### PR TITLE
[codex] Replace implicit store schema fallbacks with explicit capability boundary

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1244,7 +1244,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 	if stores.Postgres != nil {
 		agents = dashboardserver.NewSQLAgentReader(stores.Postgres.DB, stores.Postgres, rotateAfterTurns)
 		mailbox = stores.Postgres
-		conversations = dashboardserver.NewSQLConversationReader(stores.Postgres.DB)
+		conversations = dashboardserver.NewSQLConversationReader(stores.Postgres.DB, stores.Postgres.SchemaCapabilities())
 		observability = dashboardserver.NewSQLObservabilityReader(stores.Postgres.DB)
 	}
 	if supervisor != nil {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1038,6 +1038,9 @@ func buildStores(ctx context.Context, storeMode string, cfg *config.Config) (sto
 		if err := pg.Ping(ctx); err != nil {
 			return storeBundle{}, err
 		}
+		if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+			return storeBundle{}, err
+		}
 		return storeBundle{
 			Postgres:          pg,
 			SQLDB:             pg.DB,
@@ -1244,7 +1247,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 	if stores.Postgres != nil {
 		agents = dashboardserver.NewSQLAgentReader(stores.Postgres.DB, stores.Postgres, rotateAfterTurns)
 		mailbox = stores.Postgres
-		conversations = dashboardserver.NewSQLConversationReader(stores.Postgres.DB, stores.Postgres.SchemaCapabilities())
+		conversations = dashboardserver.NewSQLConversationReader(stores.Postgres.DB, stores.Postgres)
 		observability = dashboardserver.NewSQLObservabilityReader(stores.Postgres.DB)
 	}
 	if supervisor != nil {

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -7,17 +7,20 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"swarm/internal/store"
 )
 
 type SQLConversationReader struct {
-	db *sql.DB
+	db   *sql.DB
+	caps store.StoreSchemaCapabilities
 }
 
-func NewSQLConversationReader(db *sql.DB) *SQLConversationReader {
+func NewSQLConversationReader(db *sql.DB, caps store.StoreSchemaCapabilities) *SQLConversationReader {
 	if db == nil {
 		return nil
 	}
-	return &SQLConversationReader{db: db}
+	return &SQLConversationReader{db: db, caps: caps}
 }
 
 func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]ConversationSummary, error) {
@@ -200,7 +203,10 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 	if agentID == "" || sessionID == "" {
 		return []ConversationTurn{}, nil
 	}
-	rows, err := r.db.QueryContext(ctx, `
+	if r.caps.Conversations.Turns != store.SchemaFlavorCanonical {
+		return []ConversationTurn{}, nil
+	}
+	query := `
 		SELECT
 			turn_id::text,
 			agent_id,
@@ -229,9 +235,9 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		WHERE agent_id = $1
 		  AND session_id = $2::uuid
 		ORDER BY created_at ASC, turn_id ASC
-	`, agentID, sessionID)
-	if err != nil && shouldIgnoreConversationTurnBlocksColumn(err) {
-		rows, err = r.db.QueryContext(ctx, `
+	`
+	if !r.caps.Conversations.TurnBlocks {
+		query = `
 		SELECT
 			turn_id::text,
 			agent_id,
@@ -260,12 +266,10 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		WHERE agent_id = $1
 		  AND session_id = $2::uuid
 		ORDER BY created_at ASC, turn_id ASC
-	`, agentID, sessionID)
+		`
 	}
+	rows, err := r.db.QueryContext(ctx, query, agentID, sessionID)
 	if err != nil {
-		if shouldIgnoreConversationTurnsQuery(err) {
-			return []ConversationTurn{}, nil
-		}
 		return nil, err
 	}
 	defer rows.Close()
@@ -591,23 +595,6 @@ func firstReadableString(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func shouldIgnoreConversationTurnsQuery(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `relation "agent_turns" does not exist`) ||
-		strings.Contains(msg, `column "session_id" does not exist`)
-}
-
-func shouldIgnoreConversationTurnBlocksColumn(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `column "turn_blocks" does not exist`)
 }
 
 func compactMap(in map[string]any, keys ...string) map[string]any {

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -12,15 +12,19 @@ import (
 )
 
 type SQLConversationReader struct {
-	db   *sql.DB
-	caps store.StoreSchemaCapabilities
+	db        *sql.DB
+	capSource conversationCapabilitySource
 }
 
-func NewSQLConversationReader(db *sql.DB, caps store.StoreSchemaCapabilities) *SQLConversationReader {
+type conversationCapabilitySource interface {
+	ResolveSchemaCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error)
+}
+
+func NewSQLConversationReader(db *sql.DB, capSource conversationCapabilitySource) *SQLConversationReader {
 	if db == nil {
 		return nil
 	}
-	return &SQLConversationReader{db: db, caps: caps}
+	return &SQLConversationReader{db: db, capSource: capSource}
 }
 
 func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]ConversationSummary, error) {
@@ -203,7 +207,11 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 	if agentID == "" || sessionID == "" {
 		return []ConversationTurn{}, nil
 	}
-	if r.caps.Conversations.Turns != store.SchemaFlavorCanonical {
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caps.Conversations.Turns != store.SchemaFlavorCanonical {
 		return []ConversationTurn{}, nil
 	}
 	query := `
@@ -236,7 +244,7 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		  AND session_id = $2::uuid
 		ORDER BY created_at ASC, turn_id ASC
 	`
-	if !r.caps.Conversations.TurnBlocks {
+	if !caps.Conversations.TurnBlocks {
 		query = `
 		SELECT
 			turn_id::text,
@@ -286,6 +294,13 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		return nil, err
 	}
 	return out, nil
+}
+
+func (r *SQLConversationReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
+	if r == nil || r.capSource == nil {
+		return store.StoreSchemaCapabilities{}, nil
+	}
+	return r.capSource.ResolveSchemaCapabilities(ctx)
 }
 
 func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/store"
 )
 
 type builderRPCResponse = builderpkg.RPCResponse
@@ -390,7 +391,12 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db)
+	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: false,
+		},
+	})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief","last_turn":{"parse_ok":true},"provider_session_id":"sess-1"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
@@ -465,7 +471,12 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db)
+	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
@@ -528,7 +539,7 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db)
+	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{})
 	mock.ExpectQuery("SELECT\\s+session_id::text,.*FROM agent_sessions").
 		WithArgs("missing-agent").
 		WillReturnError(sql.ErrNoRows)
@@ -539,6 +550,39 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 	}
 	if ok {
 		t.Fatalf("expected missing conversation")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"brief"}`
+	messagePayload := `[{"role":"assistant","content":"hello"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id::text,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM agent_sessions").
+		WithArgs("agent-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+
+	item, ok, err := reader.Get(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected conversation to exist")
+	}
+	if len(item.Turns) != 0 {
+		t.Fatalf("turns = %#v", item.Turns)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -81,6 +81,15 @@ type stubObservability struct {
 	incidents   []incidentRecord
 }
 
+type stubConversationCaps struct {
+	caps store.StoreSchemaCapabilities
+	err  error
+}
+
+func (s stubConversationCaps) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return s.caps, s.err
+}
+
 func (s stubObservability) ListEvents(context.Context, EventFilter, int) ([]eventRecord, error) {
 	return s.events, nil
 }
@@ -391,12 +400,12 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Turns:      store.SchemaFlavorCanonical,
 			TurnBlocks: false,
 		},
-	})
+	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief","last_turn":{"parse_ok":true},"provider_session_id":"sess-1"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
@@ -471,12 +480,12 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Turns:      store.SchemaFlavorCanonical,
 			TurnBlocks: true,
 		},
-	})
+	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
@@ -539,7 +548,7 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{})
+	reader := NewSQLConversationReader(db, stubConversationCaps{})
 	mock.ExpectQuery("SELECT\\s+session_id::text,.*FROM agent_sessions").
 		WithArgs("missing-agent").
 		WillReturnError(sql.ErrNoRows)
@@ -563,7 +572,7 @@ func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, store.StoreSchemaCapabilities{})
+	reader := NewSQLConversationReader(db, stubConversationCaps{})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -88,8 +88,33 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectBegin()
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(
+		sqlmock.NewRows([]string{"table_name", "column_name"}).
+			AddRow("events", "event_id").
+			AddRow("events", "event_name").
+			AddRow("events", "entity_id").
+			AddRow("events", "flow_instance").
+			AddRow("events", "scope").
+			AddRow("events", "payload").
+			AddRow("events", "chain_depth").
+			AddRow("events", "produced_by").
+			AddRow("events", "produced_by_type").
+			AddRow("events", "source_event_id").
+			AddRow("events", "created_at").
+			AddRow("event_deliveries", "event_id").
+			AddRow("event_deliveries", "subscriber_type").
+			AddRow("event_deliveries", "subscriber_id").
+			AddRow("event_deliveries", "status").
+			AddRow("event_deliveries", "retry_count").
+			AddRow("event_deliveries", "reason_code").
+			AddRow("event_deliveries", "last_error").
+			AddRow("event_deliveries", "active_session_id").
+			AddRow("event_deliveries", "started_at").
+			AddRow("event_deliveries", "delivered_at").
+			AddRow("event_deliveries", "created_at"),
+	)
 	mock.ExpectExec("INSERT INTO events").
-		WithArgs("evt-1", "custom.emitted", "", "", "", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs("evt-1", "custom.emitted", "", "", "global", sqlmock.AnyArg(), 0, "", "platform", "", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO event_deliveries").
 		WithArgs("evt-1", "reviewer").

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.PersistedAgent) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if rec.Config.ID == "" {
 		return fmt.Errorf("agent id is required")
 	}
@@ -26,133 +30,35 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 	if !rec.StartedAt.IsZero() {
 		startedAt = rec.StartedAt
 	}
-
-	specErr := s.upsertAgentSpec(ctx, rec, cfgJSON, startedAt)
-	if specErr == nil {
-		return nil
+	switch caps.Agents {
+	case SchemaFlavorCanonical:
+		return s.upsertAgentSpec(ctx, rec, cfgJSON, startedAt)
+	default:
+		return unsupportedSchemaCapability("agents", caps.Agents)
 	}
-	if !shouldFallbackLegacyAgentsSchema(specErr) {
-		return fmt.Errorf("upsert agent %s: %w", rec.Config.ID, specErr)
-	}
-
-	const q = `
-		INSERT INTO agents (
-			id, type, role, mode, entity_id, parent_agent_id, status,
-			coordinator_id, config, budget_envelope, hired_by, template_version,
-			started_at, last_active_at
-		)
-		VALUES (
-			$1, $2, $3, $4, NULLIF($5,'')::uuid, NULLIF($6,''), $7,
-			NULLIF($8,''), $9::jsonb, NULLIF($10, 0), NULLIF($11,''), NULLIF($12,''),
-			COALESCE($13, now()), now()
-		)
-		ON CONFLICT (id) DO UPDATE SET
-			type = EXCLUDED.type,
-			role = EXCLUDED.role,
-			mode = EXCLUDED.mode,
-			entity_id = EXCLUDED.entity_id,
-			parent_agent_id = EXCLUDED.parent_agent_id,
-			status = EXCLUDED.status,
-			coordinator_id = EXCLUDED.coordinator_id,
-			config = EXCLUDED.config,
-			budget_envelope = EXCLUDED.budget_envelope,
-			hired_by = EXCLUDED.hired_by,
-			template_version = EXCLUDED.template_version,
-			last_active_at = now()
-	`
-	_, err = s.DB.ExecContext(ctx, q,
-		rec.Config.ID,
-		nullable(rec.Config.Type, "generic"),
-		rec.Config.Role,
-		nullable(rec.Config.Mode, "scoped"),
-		rec.Config.EffectiveEntityID(),
-		nullable(rec.ParentAgentID, rec.Config.ParentAgent),
-		nullable(rec.Status, "active"),
-		rec.CoordinatorID,
-		string(cfgJSON),
-		rec.Config.BudgetEnvelope,
-		rec.HiredBy,
-		rec.TemplateVersion,
-		startedAt,
-	)
-	if err != nil {
-		return fmt.Errorf("upsert agent %s: %w", rec.Config.ID, err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
-	agents, err := s.loadAgentsSpec(ctx)
-	if err == nil {
-		return agents, nil
-	}
-	if !shouldFallbackLegacyAgentsSchema(err) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
 		return nil, err
 	}
-
-	const q = `
-		SELECT
-			id, type, role, mode,
-			COALESCE(entity_id::text, ''),
-			COALESCE(parent_agent_id, ''),
-			COALESCE(status, 'active'),
-			COALESCE(coordinator_id, ''),
-			config,
-			COALESCE(budget_envelope, 0),
-			COALESCE(hired_by, ''),
-			COALESCE(template_version, ''),
-			COALESCE(started_at, now())
-		FROM agents
-		WHERE status NOT IN ('terminated', 'ephemeral')
-		ORDER BY started_at ASC, id ASC
-	`
-	rows, err := s.DB.QueryContext(ctx, q)
-	if err != nil {
-		return nil, fmt.Errorf("query agents: %w", err)
+	switch caps.Agents {
+	case SchemaFlavorCanonical:
+		return s.loadAgentsSpec(ctx)
+	default:
+		return nil, unsupportedSchemaCapability("agents", caps.Agents)
 	}
-	defer rows.Close()
-
-	var out []runtimemanager.PersistedAgent
-	for rows.Next() {
-		var rec runtimemanager.PersistedAgent
-		var cfgRaw []byte
-		if err := rows.Scan(
-			&rec.Config.ID,
-			&rec.Config.Type,
-			&rec.Config.Role,
-			&rec.Config.Mode,
-			&rec.Config.EntityID,
-			&rec.ParentAgentID,
-			&rec.Status,
-			&rec.CoordinatorID,
-			&cfgRaw,
-			&rec.Config.BudgetEnvelope,
-			&rec.HiredBy,
-			&rec.TemplateVersion,
-			&rec.StartedAt,
-		); err != nil {
-			return nil, fmt.Errorf("scan agent row: %w", err)
-		}
-
-		rec.Config.ParentAgent = rec.ParentAgentID
-		rec.Config.NormalizeEntityID()
-		rec.Config.Config = cfgRaw
-		rec.Config.Subscriptions = extractSubscriptions(cfgRaw)
-		rec.Config.Permissions = extractPermissions(cfgRaw)
-		out = append(out, rec)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read agents rows: %w", err)
-	}
-	return out, nil
 }
 
 func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string) error {
 	if strings.TrimSpace(agentID) == "" {
 		return fmt.Errorf("agent_id is required")
 	}
-	useSpecAgents := columnExists(ctx, s.DB, "agents", "agent_id")
-	hasLegacyConversations := tableExists(ctx, s.DB, "conversations")
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("mark agent terminated begin tx: %w", err)
@@ -165,37 +71,19 @@ func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string)
 		_ = tx.Rollback()
 	}()
 
-	const qAgentLegacy = `
-		UPDATE agents
-		SET status = 'terminated',
-		    last_active_at = now()
-		WHERE id = $1
-	`
 	const qAgentSpec = `
 			UPDATE agents
 			SET status = 'terminated',
 			    last_active_at = now()
 			WHERE agent_id = $1
 	`
-	qAgent := qAgentLegacy
-	if useSpecAgents {
-		qAgent = qAgentSpec
+	switch caps.Agents {
+	case SchemaFlavorCanonical:
+	default:
+		return unsupportedSchemaCapability("agents", caps.Agents)
 	}
-	if _, err := tx.ExecContext(ctx, qAgent, agentID); err != nil {
+	if _, err := tx.ExecContext(ctx, qAgentSpec, agentID); err != nil {
 		return fmt.Errorf("mark agent terminated: %w", err)
-	}
-
-	if hasLegacyConversations {
-		const qConversations = `
-			UPDATE conversations
-			SET status = 'terminated',
-			    updated_at = now()
-			WHERE agent_id = $1
-			  AND status = 'active'
-		`
-		if _, err := tx.ExecContext(ctx, qConversations, agentID); err != nil && !shouldIgnoreLegacyConversationTable(err) {
-			return fmt.Errorf("mark agent terminated conversations: %w", err)
-		}
 	}
 
 	const qSessions = `
@@ -469,34 +357,6 @@ func coalesce(vals ...string) string {
 	return ""
 }
 
-func shouldFallbackLegacyAgentsSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `column "agent_id"`) ||
-		strings.Contains(msg, `column "id"`) ||
-		strings.Contains(msg, `column "model_tier"`) ||
-		strings.Contains(msg, `column "conversation_mode"`) ||
-		strings.Contains(msg, `column "llm_backend"`) ||
-		strings.Contains(msg, `column "flow_instance"`) ||
-		strings.Contains(msg, `column "subscriptions"`) ||
-		strings.Contains(msg, `column "permissions"`) ||
-		strings.Contains(msg, `column "emit_events"`) ||
-		strings.Contains(msg, `column "parent_agent_id"`) ||
-		strings.Contains(msg, `column "last_active_at"`) ||
-		strings.Contains(msg, `column "created_at"`)
-}
-
-func shouldIgnoreLegacyConversationTable(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `relation "conversations" does not exist`) ||
-		strings.Contains(msg, `column "updated_at" does not exist`)
-}
-
 func (s *PostgresStore) EnsureEntitySchema(ctx context.Context, entityID string) error {
 	if strings.TrimSpace(entityID) == "" {
 		return fmt.Errorf("entity_id is required")
@@ -522,31 +382,4 @@ func (s *PostgresStore) EnsureEntitySchema(ctx context.Context, entityID string)
 		return fmt.Errorf("create entity schema %s: %w", schema, err)
 	}
 	return nil
-}
-
-func tableExists(ctx context.Context, q rowQueryer, tableName string) bool {
-	if q == nil {
-		return false
-	}
-	var exists bool
-	if err := q.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM information_schema.tables
-			WHERE table_schema = 'public'
-			  AND table_name = $1
-		)
-	`, tableName).Scan(&exists); err != nil {
-		return false
-	}
-	return exists
-}
-
-func shouldFallbackLegacyEntityState(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `relation "entity_state" does not exist`) ||
-		strings.Contains(msg, `column "slug" does not exist`)
 }

--- a/internal/store/agents_list.go
+++ b/internal/store/agents_list.go
@@ -11,20 +11,22 @@ func (s *PostgresStore) ListActiveAgentIDs(ctx context.Context) ([]string, error
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("db unavailable")
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	query := `
 		SELECT agent_id
 		FROM agents
 		WHERE COALESCE(status, '') <> 'terminated'
 		ORDER BY agent_id ASC
-	`)
-	if err != nil && shouldFallbackLegacyAgentsSchema(err) {
-		rows, err = s.DB.QueryContext(ctx, `
-			SELECT id
-			FROM agents
-			WHERE COALESCE(status, '') <> 'terminated'
-			ORDER BY id ASC
-		`)
+	`
+	switch caps.Agents {
+	case SchemaFlavorCanonical:
+	default:
+		return nil, unsupportedSchemaCapability("agents", caps.Agents)
 	}
+	rows, err := s.DB.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -14,31 +14,29 @@ import (
 )
 
 func (s *PostgresStore) MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	eventID = strings.TrimSpace(eventID)
 	agentID = strings.TrimSpace(agentID)
 	if eventID == "" || agentID == "" {
 		return fmt.Errorf("mark event delivery in progress: eventID and agentID required")
 	}
 	sessionID = sanitizeOptionalUUID(sessionID)
-	if err := s.markEventDeliveryInProgressSpec(ctx, eventID, agentID, sessionID); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return err
+	switch caps.Events.Deliveries {
+	case SchemaFlavorCanonical:
+		return s.markEventDeliveryInProgressSpec(ctx, eventID, agentID, sessionID)
+	default:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
 	}
-
-	const q = `
-		UPDATE event_deliveries
-		SET status = 'in_progress'
-		WHERE event_id = $1::uuid
-		  AND agent_id = $2
-	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID); err != nil {
-		return fmt.Errorf("mark event delivery in progress: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) UpsertEventReceipt(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	eventID = strings.TrimSpace(eventID)
 	agentID = strings.TrimSpace(agentID)
 	if eventID == "" || agentID == "" {
@@ -47,34 +45,19 @@ func (s *PostgresStore) UpsertEventReceipt(ctx context.Context, eventID, agentID
 	if status == "" {
 		return fmt.Errorf("upsert event receipt: status required")
 	}
-	if err := s.upsertAgentReceiptSpec(ctx, eventID, agentID, status, errText); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return err
+	switch caps.Events.Receipts {
+	case SchemaFlavorCanonical:
+		return s.upsertAgentReceiptSpec(ctx, eventID, agentID, status, errText)
+	default:
+		return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
 	}
-
-	const q = `
-		INSERT INTO event_receipts (event_id, agent_id, processed_at, status, retry_count, error)
-		VALUES ($1::uuid, $2, now(), $3, CASE WHEN $3 = 'error' THEN 1 ELSE 0 END, NULLIF($4,''))
-		ON CONFLICT (event_id, agent_id) DO UPDATE SET
-			processed_at = now(),
-			status = CASE
-				WHEN EXCLUDED.status = 'error' AND event_receipts.retry_count + 1 >= 2 THEN 'dead_letter'
-				ELSE EXCLUDED.status
-			END,
-			error = EXCLUDED.error,
-			retry_count = CASE
-				WHEN EXCLUDED.status = 'error' THEN event_receipts.retry_count + 1
-				ELSE event_receipts.retry_count
-			END
-	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, status, errText); err != nil {
-		return fmt.Errorf("upsert event receipt: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if agentID == "" {
 		return nil, nil
 	}
@@ -84,44 +67,17 @@ func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID s
 	if since.IsZero() {
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
-	if out, err := s.listPendingEventsForAgentSpec(ctx, agentID, since, limit); err == nil {
-		return out, nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return nil, err
+	switch {
+	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical:
+		return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case caps.Events.Receipts != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
 	}
-
-	const q = `
-		SELECT
-			e.id::text, e.type, e.source_agent,
-			COALESCE(e.task_id::text, ''),
-			COALESCE(e.entity_id::text, ''),
-			e.payload, e.created_at
-		FROM event_deliveries d
-		INNER JOIN events e ON e.id = d.event_id
-		LEFT JOIN event_receipts r
-			ON r.event_id = d.event_id
-			AND r.agent_id = d.agent_id
-		WHERE d.agent_id = $1
-		  AND e.created_at >= $2
-		  AND (
-				r.event_id IS NULL
-				OR (
-					r.status = 'error'
-					AND r.retry_count <= 1
-					AND (
-						(r.retry_count = 1 AND r.processed_at <= now() - interval '1 minute')
-					)
-				)
-			)
-		ORDER BY e.created_at ASC
-		LIMIT $3
-	`
-	rows, err := s.DB.QueryContext(ctx, q, agentID, since, limit)
-	if err != nil {
-		return nil, fmt.Errorf("query pending events for %s: %w", agentID, err)
-	}
-	defer rows.Close()
-	return scanLegacyPendingEvents(rows)
+	return nil, nil
 }
 
 func (s *PostgresStore) ListPendingSubscribedEvents(
@@ -131,6 +87,10 @@ func (s *PostgresStore) ListPendingSubscribedEvents(
 	since time.Time,
 	limit int,
 ) ([]events.Event, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if agentID == "" || len(subscriptions) == 0 {
 		return nil, nil
 	}
@@ -141,94 +101,35 @@ func (s *PostgresStore) ListPendingSubscribedEvents(
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
 
-	if out, err := s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit); err == nil {
-		return out, nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return nil, err
+	switch {
+	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical:
+		return s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case caps.Events.Receipts != SchemaFlavorCanonical:
+		return nil, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
 	}
-
-	const q = `
-		SELECT
-			e.id::text, e.type, e.source_agent,
-			COALESCE(e.task_id::text, ''),
-			COALESCE(e.entity_id::text, ''),
-			e.payload, e.created_at
-		FROM events e
-		LEFT JOIN event_receipts r
-			ON r.event_id = e.id
-			AND r.agent_id = $1
-		WHERE e.created_at >= $2
-		  AND (
-				NOT EXISTS (
-					SELECT 1
-					FROM event_deliveries d_any
-					WHERE d_any.event_id = e.id
-				)
-				OR EXISTS (
-					SELECT 1
-					FROM event_deliveries d_me
-					WHERE d_me.event_id = e.id
-					  AND d_me.agent_id = $1
-				)
-			)
-		  AND (
-				r.event_id IS NULL
-				OR (
-					r.status = 'error'
-					AND r.retry_count <= 1
-					AND (
-						(r.retry_count = 1 AND r.processed_at <= now() - interval '1 minute')
-					)
-				)
-			)
-		ORDER BY e.created_at ASC
-		LIMIT $3
-	`
-	rows, err := s.DB.QueryContext(ctx, q, agentID, since, limit)
-	if err != nil {
-		return nil, fmt.Errorf("query pending subscribed events for %s: %w", agentID, err)
-	}
-	defer rows.Close()
-
-	out, err := scanLegacyPendingEvents(rows)
-	if err != nil {
-		return nil, err
-	}
-	filtered := make([]events.Event, 0, len(out))
-	for _, evt := range out {
-		if matchesAnySubscription(string(evt.Type), subscriptions) {
-			filtered = append(filtered, evt)
-		}
-	}
-	return filtered, nil
+	return nil, nil
 }
 
 func (s *PostgresStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimemanager.EventReceipt{}, false, err
+	}
 	eventID = strings.TrimSpace(eventID)
 	agentID = strings.TrimSpace(agentID)
 	if eventID == "" || agentID == "" {
 		return runtimemanager.EventReceipt{}, false, fmt.Errorf("event_id and agent_id are required")
 	}
-	if receipt, ok, err := s.getEventReceiptSpec(ctx, eventID, agentID); err == nil {
-		return receipt, ok, nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return runtimemanager.EventReceipt{}, false, err
+	switch caps.Events.Receipts {
+	case SchemaFlavorCanonical:
+		return s.getEventReceiptSpec(ctx, eventID, agentID)
+	default:
+		return runtimemanager.EventReceipt{}, false, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
 	}
-
-	var r runtimemanager.EventReceipt
-	r.EventID = eventID
-	r.AgentID = agentID
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(status, 'processed'), COALESCE(retry_count, 0), COALESCE(error, '')
-		FROM event_receipts
-		WHERE event_id = $1::uuid AND agent_id = $2
-	`, eventID, agentID).Scan(&r.Status, &r.RetryCount, &r.Error); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return runtimemanager.EventReceipt{}, false, nil
-		}
-		return runtimemanager.EventReceipt{}, false, fmt.Errorf("get event receipt: %w", err)
-	}
-	return r, true, nil
 }
 
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -28,99 +27,39 @@ func (s *PostgresStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) {
 }
 
 func (s *PostgresStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	return withEventStoreRetry(ctx, tx, func() error {
-		evt = s.enrichEventCorrelation(ctx, chooseRowQueryer(s.DB, tx), evt)
-		if eventSchemaAvailable(ctx, chooseRowQueryer(s.DB, tx)) {
-			if err := s.appendEventSpec(ctx, tx, evt); err == nil {
-				return nil
-			} else if !shouldFallbackLegacyEventsSchema(err) {
-				return err
-			}
+		evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, tx), evt)
+		switch caps.Events.Log {
+		case SchemaFlavorCanonical:
+			return s.appendEventSpec(ctx, caps, tx, evt)
+		default:
+			return unsupportedSchemaCapability("events", caps.Events.Log)
 		}
-
-		id := evt.ID
-		if id == "" {
-			id = uuid.NewString()
-		}
-		taskID := sanitizeOptionalUUID(evt.TaskID)
-		entityID := sanitizeOptionalUUID(evt.EntityID())
-		createdAt := evt.CreatedAt
-		if createdAt.IsZero() {
-			createdAt = time.Now()
-		}
-
-		const q = `
-			INSERT INTO events (id, type, source_agent, task_id, entity_id, payload, created_at)
-			VALUES ($1::uuid, $2, $3, NULLIF($4,'')::uuid, NULLIF($5,'')::uuid, $6, $7)
-			ON CONFLICT (id) DO NOTHING
-		`
-		execFn := s.DB.ExecContext
-		if tx != nil {
-			execFn = tx.ExecContext
-		}
-		if _, err := execFn(ctx, q, id, string(evt.Type), evt.SourceAgent, taskID, entityID, evt.Payload, createdAt); err != nil {
-			return fmt.Errorf("append event: %w", err)
-		}
-		return nil
 	})
 }
 
 func (s *PostgresStore) PersistEventWithDeliveries(ctx context.Context, evt events.Event, agentIDs []string) error {
-	evt = s.enrichEventCorrelation(ctx, chooseRowQueryer(s.DB, nil), evt)
-	if err := s.persistEventWithDeliveriesSpec(ctx, evt, agentIDs); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
 		return err
 	}
-
-	id := evt.ID
-	if id == "" {
-		id = uuid.NewString()
-	}
-	taskID := sanitizeOptionalUUID(evt.TaskID)
-	entityID := sanitizeOptionalUUID(evt.EntityID())
-	createdAt := evt.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = time.Now()
-	}
-
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin event tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	const insertEvent = `
-		INSERT INTO events (id, type, source_agent, task_id, entity_id, payload, created_at)
-		VALUES ($1::uuid, $2, $3, NULLIF($4,'')::uuid, NULLIF($5,'')::uuid, $6, $7)
-		ON CONFLICT (id) DO NOTHING
-	`
-	if _, err := tx.ExecContext(ctx, insertEvent, id, string(evt.Type), evt.SourceAgent, taskID, entityID, evt.Payload, createdAt); err != nil {
-		return fmt.Errorf("append event: %w", err)
-	}
-
-	const insertDelivery = `
-		INSERT INTO event_deliveries (event_id, agent_id, created_at)
-		VALUES ($1::uuid, $2, now())
-		ON CONFLICT (event_id, agent_id) DO NOTHING
-	`
-	for _, agentID := range agentIDs {
-		agentID = strings.TrimSpace(agentID)
-		if agentID == "" {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx, insertDelivery, id, agentID); err != nil {
-			return fmt.Errorf("insert event delivery (agent=%s): %w", agentID, err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit event tx: %w", err)
+	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	switch {
+	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
+		return s.persistEventWithDeliveriesSpec(ctx, caps, evt, agentIDs)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
 	}
 	return nil
 }
 
-func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, q rowQueryer, evt events.Event) events.Event {
+func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.Event {
 	parentID := strings.TrimSpace(evt.ParentEventID)
 	if parentID == "" {
 		if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
@@ -131,7 +70,7 @@ func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, q rowQueryer
 		}
 	}
 	if strings.TrimSpace(evt.RunID) == "" && parentID != "" {
-		if runID := lookupEventRunID(ctx, q, parentID); runID != "" {
+		if runID := lookupEventRunID(ctx, caps, q, parentID); runID != "" {
 			evt.RunID = runID
 		}
 	}
@@ -158,27 +97,17 @@ func (s *PostgresStore) InsertEventDeliveriesTx(ctx context.Context, tx *sql.Tx,
 	if len(agentIDs) == 0 {
 		return nil
 	}
-	if eventDeliveriesSpecAvailable(ctx, chooseRowQueryer(s.DB, tx)) {
-		if err := s.insertEventDeliveriesSpec(ctx, tx, eventID, agentIDs); err == nil {
-			return nil
-		} else if !shouldFallbackLegacyEventsSchema(err) {
-			return err
-		}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
 	}
-
-	const q = `
-		INSERT INTO event_deliveries (event_id, agent_id, created_at)
-		VALUES ($1::uuid, $2, now())
-		ON CONFLICT (event_id, agent_id) DO NOTHING
-	`
-	execFn := s.DB.ExecContext
-	if tx != nil {
-		execFn = tx.ExecContext
-	}
-	for _, agentID := range agentIDs {
-		if _, err := execFn(ctx, q, eventID, agentID); err != nil {
-			return fmt.Errorf("insert event delivery (agent=%s): %w", agentID, err)
-		}
+	switch {
+	case caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Log == SchemaFlavorCanonical:
+		return s.insertEventDeliveriesSpec(ctx, caps, tx, eventID, agentIDs)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
 	}
 	return nil
 }
@@ -188,6 +117,10 @@ func (s *PostgresStore) UpsertPipelineReceipt(ctx context.Context, eventID, stat
 }
 
 func (s *PostgresStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return nil
@@ -199,66 +132,81 @@ func (s *PostgresStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx,
 	if strings.TrimSpace(errText) != "" && status == "processed" {
 		status = "error"
 	}
+	if caps.Events.Receipts != SchemaFlavorCanonical || caps.Events.Log != SchemaFlavorCanonical {
+		if caps.Events.Receipts != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+		}
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	}
 	return s.upsertPipelineReceiptSpec(ctx, tx, eventID, status, errText)
 }
 
 func (s *PostgresStore) ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.Event, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 200
 	}
 	if since.IsZero() {
 		since = time.Now().Add(-24 * time.Hour)
 	}
-
+	if caps.Events.Receipts != SchemaFlavorCanonical || caps.Events.Log != SchemaFlavorCanonical {
+		if caps.Events.Receipts != SchemaFlavorCanonical {
+			return nil, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+		}
+		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
+	}
 	return s.listEventsMissingPipelineReceiptSpec(ctx, since, limit)
 }
 
 func (s *PostgresStore) EventExists(ctx context.Context, eventID string) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return false, nil
 	}
 	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS(SELECT 1 FROM events WHERE event_id = $1::uuid)
-	`, eventID).Scan(&exists); err == nil {
-		return exists, nil
-	} else if !shouldFallbackLegacyEventsSchema(err) {
-		return false, fmt.Errorf("event exists lookup: %w", err)
+	query := `SELECT EXISTS(SELECT 1 FROM events WHERE event_id = $1::uuid)`
+	switch caps.Events.Log {
+	case SchemaFlavorCanonical:
+	default:
+		return false, unsupportedSchemaCapability("events", caps.Events.Log)
 	}
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS(SELECT 1 FROM events WHERE id = $1::uuid)
-	`, eventID).Scan(&exists); err != nil {
+	if err := s.DB.QueryRowContext(ctx, query, eventID).Scan(&exists); err != nil {
 		return false, fmt.Errorf("event exists lookup: %w", err)
 	}
 	return exists, nil
 }
 
 func (s *PostgresStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return nil, nil
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	query := `
 		SELECT subscriber_id
 		FROM event_deliveries
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
 		ORDER BY subscriber_id ASC
-	`, eventID)
+	`
+	switch caps.Events.Deliveries {
+	case SchemaFlavorCanonical:
+	default:
+		return nil, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	}
+	rows, err := s.DB.QueryContext(ctx, query, eventID)
 	if err != nil {
-		if !shouldFallbackLegacyEventsSchema(err) {
-			return nil, fmt.Errorf("list event delivery recipients: %w", err)
-		}
-		rows, err = s.DB.QueryContext(ctx, `
-			SELECT agent_id
-			FROM event_deliveries
-			WHERE event_id = $1::uuid
-			ORDER BY agent_id ASC
-		`, eventID)
-		if err != nil {
-			return nil, fmt.Errorf("list event delivery recipients: %w", err)
-		}
+		return nil, fmt.Errorf("list event delivery recipients: %w", err)
 	}
 	defer rows.Close()
 
@@ -279,13 +227,12 @@ func (s *PostgresStore) ListEventDeliveryRecipients(ctx context.Context, eventID
 	return recipients, nil
 }
 
-func (s *PostgresStore) appendEventSpec(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, evt events.Event) error {
 	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt := eventStorageEnvelope(evt)
 	execFn := s.DB.ExecContext
 	if tx != nil {
 		execFn = tx.ExecContext
 	}
-	hasRunID := columnExists(ctx, chooseRowQueryer(s.DB, tx), "events", "run_id")
 	q := `
 		INSERT INTO events (
 			event_id, event_name, entity_id, flow_instance, scope, payload,
@@ -298,8 +245,8 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, tx *sql.Tx, evt eve
 		ON CONFLICT (event_id) DO NOTHING
 	`
 	args := []any{id, name, entityID, flowInstance, scope, string(payload), chainDepth, producedBy, producedByType, sourceEventID, createdAt}
-	if hasRunID {
-		if err := s.ensureRunRow(ctx, tx, runID); err != nil {
+	if caps.Events.LogRunID {
+		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
 			return err
 		}
 		q = `
@@ -321,17 +268,17 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, tx *sql.Tx, evt eve
 	return nil
 }
 
-func (s *PostgresStore) persistEventWithDeliveriesSpec(ctx context.Context, evt events.Event, agentIDs []string) error {
+func (s *PostgresStore) persistEventWithDeliveriesSpec(ctx context.Context, caps StoreSchemaCapabilities, evt events.Event, agentIDs []string) error {
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("begin event tx: %w", err)
 		}
 		defer func() { _ = tx.Rollback() }()
-		if err := s.appendEventSpec(ctx, tx, evt); err != nil {
+		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
 			return err
 		}
-		if err := s.insertEventDeliveriesSpec(ctx, tx, evt.ID, agentIDs); err != nil {
+		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID, agentIDs); err != nil {
 			return err
 		}
 		if err := tx.Commit(); err != nil {
@@ -376,7 +323,7 @@ func isTransientEventStoreConnectionError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "bad connection")
 }
 
-func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, tx *sql.Tx, eventID string, agentIDs []string) error {
+func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, eventID string, agentIDs []string) error {
 	execFn := s.DB.ExecContext
 	if tx != nil {
 		execFn = tx.ExecContext
@@ -386,8 +333,7 @@ func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, tx *sql.T
 		VALUES ($1::uuid, 'agent', $2, 'matched_agent_subscription', now())
 		ON CONFLICT DO NOTHING
 	`
-	useRunID := columnExists(ctx, chooseRowQueryer(s.DB, tx), "event_deliveries", "run_id")
-	if useRunID {
+	if caps.Events.DeliveryRunID {
 		q = `
 			INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, reason_code, created_at)
 			SELECT e.run_id, e.event_id, 'agent', $2, 'matched_agent_subscription', now()
@@ -493,34 +439,6 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 	return out, nil
 }
 
-func shouldFallbackLegacyEventsSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	fallback := strings.Contains(msg, `event_id`) ||
-		strings.Contains(msg, `run_id`) ||
-		strings.Contains(msg, `event_name`) ||
-		strings.Contains(msg, `produced_by`) ||
-		strings.Contains(msg, `produced_by_type`) ||
-		strings.Contains(msg, `subscriber_type`) ||
-		strings.Contains(msg, `subscriber_id`) ||
-		strings.Contains(msg, `active_session_id`) ||
-		strings.Contains(msg, `started_at`) ||
-		strings.Contains(msg, `reason_code`) ||
-		strings.Contains(msg, `scope`) ||
-		strings.Contains(msg, `flow_instance`) ||
-		strings.Contains(msg, `outcome`) ||
-		strings.Contains(msg, `side_effects`) ||
-		strings.Contains(msg, `duration_ms`) ||
-		strings.Contains(msg, `relation "event_receipts" does not exist`) ||
-		strings.Contains(msg, `relation "event_deliveries" does not exist`)
-	if fallback {
-		log.Printf("store legacy schema fallback triggered err=%v", err)
-	}
-	return fallback
-}
-
 func chooseRowQueryer(db *sql.DB, tx *sql.Tx) rowQueryer {
 	if tx != nil {
 		return tx
@@ -528,40 +446,9 @@ func chooseRowQueryer(db *sql.DB, tx *sql.Tx) rowQueryer {
 	return db
 }
 
-func eventSchemaAvailable(ctx context.Context, q rowQueryer) bool {
-	return columnExists(ctx, q, "events", "event_id")
-}
-
-func eventDeliveriesSpecAvailable(ctx context.Context, q rowQueryer) bool {
-	return columnExists(ctx, q, "event_deliveries", "subscriber_id")
-}
-
-func eventReceiptsSpecAvailable(ctx context.Context, q rowQueryer) bool {
-	return columnExists(ctx, q, "event_receipts", "subscriber_id")
-}
-
-func columnExists(ctx context.Context, q rowQueryer, tableName, columnName string) bool {
-	if q == nil {
-		return false
-	}
-	var exists bool
-	if err := q.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM information_schema.columns
-			WHERE table_schema = 'public'
-			  AND table_name = $1
-			  AND column_name = $2
-		)
-	`, tableName, columnName).Scan(&exists); err != nil {
-		return false
-	}
-	return exists
-}
-
-func lookupEventRunID(ctx context.Context, q rowQueryer, eventID string) string {
+func lookupEventRunID(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, eventID string) string {
 	eventID = strings.TrimSpace(eventID)
-	if q == nil || eventID == "" {
+	if q == nil || eventID == "" || caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID {
 		return ""
 	}
 	var runID string
@@ -576,9 +463,9 @@ func lookupEventRunID(ctx context.Context, q rowQueryer, eventID string) string 
 	return strings.TrimSpace(runID)
 }
 
-func (s *PostgresStore) ensureRunRow(ctx context.Context, tx *sql.Tx, runID string) error {
+func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, runID string) error {
 	runID = nullUUIDString(runID)
-	if runID == "" || !columnExists(ctx, chooseRowQueryer(s.DB, tx), "runs", "run_id") {
+	if runID == "" || !caps.Events.HasRuns {
 		return nil
 	}
 	execFn := s.DB.ExecContext

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (s *PostgresStore) RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
 	if strings.TrimSpace(providerEventID) == "" {
 		return false, fmt.Errorf("provider_event_id is required")
 	}
@@ -20,6 +24,12 @@ func (s *PostgresStore) RecordInboundEvent(ctx context.Context, providerEventID,
 	}
 	if strings.TrimSpace(provider) == "" {
 		return false, fmt.Errorf("provider is required")
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
+		if caps.Events.Log != SchemaFlavorCanonical {
+			return false, unsupportedSchemaCapability("events", caps.Events.Log)
+		}
+		return false, fmt.Errorf("store: inbound event recording requires canonical events.idempotency_key support")
 	}
 	return s.recordInboundEventSpec(ctx, providerEventID, entityID, provider)
 }
@@ -58,13 +68,24 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 }
 
 func (s *PostgresStore) PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return 0, err
+	}
 	if limit <= 0 {
 		limit = 1000
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return 0, unsupportedSchemaCapability("events", caps.Events.Log)
 	}
 	return s.purgeInboundEventsSpec(ctx, before, limit)
 }
 
 func (s *PostgresStore) DeleteInboundEvent(ctx context.Context, providerEventID, entityID, provider string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(providerEventID) == "" {
 		return fmt.Errorf("provider_event_id is required")
 	}
@@ -74,8 +95,14 @@ func (s *PostgresStore) DeleteInboundEvent(ctx context.Context, providerEventID,
 	if strings.TrimSpace(provider) == "" {
 		return fmt.Errorf("provider is required")
 	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
+		if caps.Events.Log != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("events", caps.Events.Log)
+		}
+		return fmt.Errorf("store: inbound event deletion requires canonical events.idempotency_key support")
+	}
 	idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
-	_, err := s.DB.ExecContext(ctx, `
+	_, err = s.DB.ExecContext(ctx, `
 		DELETE FROM events
 		WHERE idempotency_key = $1
 		  AND event_name = 'platform.inbound_recorded'
@@ -88,6 +115,10 @@ func (s *PostgresStore) DeleteInboundEvent(ctx context.Context, providerEventID,
 }
 
 func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("begin inbound event tx: %w", err)
@@ -134,7 +165,6 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 		return false, fmt.Errorf("marshal inbound event payload: %w", err)
 	}
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
-	hasRunID := columnExists(ctx, tx, "events", "run_id")
 	insertQ := `
 		INSERT INTO events (
 			event_name, entity_id, flow_instance, scope, payload,
@@ -146,8 +176,8 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 		)
 	`
 	args := []any{entityID, string(payload), provider, idempotencyKey}
-	if hasRunID {
-		if err := s.ensureRunRow(ctx, tx, runID); err != nil {
+	if caps.Events.LogRunID {
+		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
 			return false, err
 		}
 		insertQ = `
@@ -201,17 +231,4 @@ func inboundEventIdempotencyKey(providerEventID, entityID, provider string) stri
 		strings.TrimSpace(entityID),
 		strings.TrimSpace(providerEventID),
 	}, ":")
-}
-
-func shouldFallbackLegacyInboundSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `column "event_name"`) ||
-		strings.Contains(msg, `column "idempotency_key"`) ||
-		strings.Contains(msg, `column "produced_by_type"`) ||
-		strings.Contains(msg, `column "event_id"`) ||
-		strings.Contains(msg, `relation "entity_state" does not exist`) ||
-		strings.Contains(msg, `column "slug"`)
 }

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -10,14 +10,23 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimesessions "swarm/internal/runtime/sessions"
 )
 
 func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if rec.AgentID == "" || rec.RuntimeMode == "" || rec.SessionID == "" {
 		return fmt.Errorf("agent_id, runtime_mode, and session_id are required")
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
 	}
 	runtimeMode := runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode)
 
@@ -69,8 +78,8 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		rec.RetryCount,
 		rec.Error,
 	}
-	if columnExists(ctx, s.DB, "agent_sessions", "run_id") {
-		if err := s.ensureRunRow(ctx, nil, runID); err != nil {
+	if caps.Conversations.SessionRunID {
+		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 			return err
 		}
 		updateQ = `
@@ -132,8 +141,8 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 
-	hasRunID := columnExists(ctx, s.DB, "agent_turns", "run_id")
-	hasTurnBlocks := columnExists(ctx, s.DB, "agent_turns", "turn_blocks")
+	hasRunID := caps.Conversations.TurnRunID
+	hasTurnBlocks := caps.Conversations.TurnBlocks
 
 	insertTurn := `
 		INSERT INTO agent_turns (
@@ -242,7 +251,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 	if hasRunID {
-		if err := s.ensureRunRow(ctx, nil, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 			return err
 		}
 		insertTurn = `
@@ -357,16 +366,19 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 	if _, err := s.DB.ExecContext(ctx, insertTurn, insertArgs...); err != nil {
-		var pgErr *pq.Error
-		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
-			return nil
-		}
 		return fmt.Errorf("insert agent turn: %w", err)
 	}
 	return nil
 }
 
 func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
 	scopeKey := strings.TrimSpace(rec.ScopeKey)
 	if scopeKey == "" {
 		scopeKey = strings.TrimSpace(rec.SessionID)
@@ -408,8 +420,8 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 		"global",
 		runtimesessions.RuntimeModeTask,
 	}
-	if columnExists(ctx, s.DB, "agent_sessions", "run_id") {
-		if err := s.ensureRunRow(ctx, nil, rec.RunID); err != nil {
+	if caps.Conversations.SessionRunID {
+		if err := s.ensureRunRow(ctx, caps, nil, rec.RunID); err != nil {
 			return err
 		}
 		q = `
@@ -489,6 +501,13 @@ func normalizeJSONObject(v any) string {
 }
 
 func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.ConversationRecord) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
 	if strings.TrimSpace(rec.AgentID) == "" {
 		return fmt.Errorf("agent_id is required")
 	}
@@ -573,8 +592,8 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			summary,
 			status,
 		}
-		if columnExists(ctx, s.DB, "agent_sessions", "run_id") {
-			if err := s.ensureRunRow(ctx, nil, runID); err != nil {
+		if caps.Conversations.SessionRunID {
+			if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 				return err
 			}
 			q = `
@@ -677,8 +696,8 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		status,
 		sessionID,
 	}
-	if columnExists(ctx, s.DB, "agent_sessions", "run_id") {
-		if err := s.ensureRunRow(ctx, nil, runID); err != nil {
+	if caps.Conversations.SessionRunID {
+		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 			return err
 		}
 		q = `
@@ -747,6 +766,13 @@ func nullUUIDString(raw string) string {
 }
 
 func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mode, scopeKey string) (runtimellm.ConversationRecord, bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return runtimellm.ConversationRecord{}, false, unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return runtimellm.ConversationRecord{}, false, fmt.Errorf("agent_id is required")
@@ -779,7 +805,7 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 	rec.Mode = mode
 
 	var rawMessages []byte
-	err := s.DB.QueryRowContext(ctx, q, agentID, mode, resolved.ScopeKey).Scan(
+	err = s.DB.QueryRowContext(ctx, q, agentID, mode, resolved.ScopeKey).Scan(
 		&rec.ScopeKey,
 		&rawMessages,
 		&rec.Summary,

--- a/internal/store/mailbox.go
+++ b/internal/store/mailbox.go
@@ -19,6 +19,10 @@ func (s *PostgresStore) InsertMailboxItem(ctx context.Context, item runtimetools
 	if s == nil || s.DB == nil {
 		return "", fmt.Errorf("postgres store is required")
 	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return "", err
+	}
 	if strings.TrimSpace(item.Type) == "" {
 		return "", fmt.Errorf("mailbox item type is required")
 	}
@@ -34,56 +38,22 @@ func (s *PostgresStore) InsertMailboxItem(ctx context.Context, item runtimetools
 	if len(item.Context) == 0 {
 		item.Context = []byte("{}")
 	}
-	if err := s.insertMailboxItemSpec(ctx, item); err == nil {
+	if caps.Mailbox == SchemaFlavorCanonical {
+		if err := s.insertMailboxItemSpec(ctx, item); err != nil {
+			return "", err
+		}
 		return item.ID, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return "", err
 	}
-
-	const q = `
-		INSERT INTO mailbox (
-			id, event_id, entity_id, from_agent, type, priority, status,
-			context, summary, timeout_at, created_at
-		)
-		VALUES (
-			$1::uuid,
-			NULLIF($2,'')::uuid,
-			NULLIF($3,'')::uuid,
-			NULLIF($4,''),
-			$5,
-			$6,
-			$7,
-			$8::jsonb,
-			NULLIF($9,''),
-			$10,
-			now()
-		)
-	`
-	var timeout any
-	if !item.TimeoutAt.IsZero() {
-		timeout = item.TimeoutAt
-	}
-	_, err := s.DB.ExecContext(ctx, q,
-		item.ID,
-		item.EventID,
-		coalesceMailboxEntityID(item),
-		item.FromAgent,
-		item.Type,
-		item.Priority,
-		item.Status,
-		string(item.Context),
-		item.Summary,
-		timeout,
-	)
-	if err != nil {
-		return "", fmt.Errorf("insert mailbox item: %w", err)
-	}
-	return item.ID, nil
+	return "", unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) ListMailboxItems(ctx context.Context, status string, limit int) ([]runtimetools.MailboxItem, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if limit <= 0 {
 		limit = 50
@@ -94,43 +64,19 @@ func (s *PostgresStore) ListMailboxItems(ctx context.Context, status string, lim
 	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
 		return nil, err
 	}
-	if items, err := s.listMailboxItemsSpec(ctx, status, limit); err == nil {
-		return items, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return nil, err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.listMailboxItemsSpec(ctx, status, limit)
 	}
-
-	const q = `
-		SELECT
-			id::text,
-			COALESCE(event_id::text, ''),
-			COALESCE(entity_id::text, ''),
-			COALESCE(from_agent, ''),
-			type,
-			COALESCE(priority, 'normal'),
-			COALESCE(status, 'pending'),
-			COALESCE(notified, false),
-			COALESCE(context, '{}'::jsonb),
-			COALESCE(summary, ''),
-			timeout_at,
-			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
-		FROM mailbox
-		WHERE status = $1
-		ORDER BY created_at ASC
-		LIMIT $2
-	`
-	rows, err := s.DB.QueryContext(ctx, q, status, limit)
-	if err != nil {
-		return nil, fmt.Errorf("query mailbox items: %w", err)
-	}
-	defer rows.Close()
-	return scanLegacyMailboxItems(rows)
+	return nil, unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) CountMailboxItems(ctx context.Context, status string) (int, error) {
 	if s == nil || s.DB == nil {
 		return 0, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return 0, err
 	}
 	if strings.TrimSpace(status) == "" {
 		status = "pending"
@@ -139,20 +85,22 @@ func (s *PostgresStore) CountMailboxItems(ctx context.Context, status string) (i
 		return 0, err
 	}
 	var n int
-	if err := s.countMailboxItemsSpec(ctx, status, &n); err == nil {
+	if caps.Mailbox == SchemaFlavorCanonical {
+		if err := s.countMailboxItemsSpec(ctx, status, &n); err != nil {
+			return 0, err
+		}
 		return n, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return 0, err
 	}
-	if err := s.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE status = $1`, status).Scan(&n); err != nil {
-		return 0, fmt.Errorf("count mailbox items: %w", err)
-	}
-	return n, nil
+	return 0, unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) GetMailboxItem(ctx context.Context, id string) (runtimetools.MailboxItem, error) {
 	if s == nil || s.DB == nil {
 		return runtimetools.MailboxItem{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimetools.MailboxItem{}, err
 	}
 	if strings.TrimSpace(id) == "" {
 		return runtimetools.MailboxItem{}, fmt.Errorf("mailbox id is required")
@@ -160,61 +108,19 @@ func (s *PostgresStore) GetMailboxItem(ctx context.Context, id string) (runtimet
 	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
 		return runtimetools.MailboxItem{}, err
 	}
-	if item, err := s.getMailboxItemSpec(ctx, id); err == nil {
-		return item, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return runtimetools.MailboxItem{}, err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.getMailboxItemSpec(ctx, id)
 	}
-
-	const q = `
-		SELECT
-			id::text,
-			COALESCE(event_id::text, ''),
-			COALESCE(entity_id::text, ''),
-			COALESCE(from_agent, ''),
-			type,
-			COALESCE(priority, 'normal'),
-			COALESCE(status, 'pending'),
-			COALESCE(notified, false),
-			COALESCE(context, '{}'::jsonb),
-			COALESCE(summary, ''),
-			timeout_at,
-			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
-		FROM mailbox
-		WHERE id = $1::uuid
-	`
-	var it runtimetools.MailboxItem
-	var timeout sql.NullTime
-	if err := s.DB.QueryRowContext(ctx, q, id).Scan(
-		&it.ID,
-		&it.EventID,
-		&it.EntityID,
-		&it.FromAgent,
-		&it.Type,
-		&it.Priority,
-		&it.Status,
-		&it.Notified,
-		&it.Context,
-		&it.Summary,
-		&timeout,
-		&it.Decision,
-		&it.DecisionNotes,
-	); err != nil {
-		if err == sql.ErrNoRows {
-			return runtimetools.MailboxItem{}, fmt.Errorf("mailbox item not found: %s", id)
-		}
-		return runtimetools.MailboxItem{}, fmt.Errorf("get mailbox item: %w", err)
-	}
-	if timeout.Valid {
-		it.TimeoutAt = timeout.Time
-	}
-	return it, nil
+	return runtimetools.MailboxItem{}, unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) DecideMailboxItem(ctx context.Context, id, status, decision, notes string) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
 	}
 	if strings.TrimSpace(id) == "" || strings.TrimSpace(status) == "" || strings.TrimSpace(decision) == "" {
 		return fmt.Errorf("mailbox id, status, and decision are required")
@@ -222,92 +128,36 @@ func (s *PostgresStore) DecideMailboxItem(ctx context.Context, id, status, decis
 	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
 		return err
 	}
-	if err := s.decideMailboxItemSpec(ctx, id, status, decision, notes); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.decideMailboxItemSpec(ctx, id, status, decision, notes)
 	}
-
-	switch status {
-	case "decided", "expired", "cancelled":
-	default:
-		return fmt.Errorf("invalid mailbox status: %s", status)
-	}
-	const q = `
-		UPDATE mailbox
-		SET status = $2,
-		    decision = $3,
-		    decision_notes = NULLIF($4,''),
-		    decided_at = now()
-		WHERE id = $1::uuid
-		  AND status = 'pending'
-	`
-	res, err := s.DB.ExecContext(ctx, q, id, status, decision, notes)
-	if err != nil {
-		return fmt.Errorf("decide mailbox item: %w", err)
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return fmt.Errorf("mailbox item is not pending or not found: %s", id)
-	}
-	return nil
+	return unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) ExpireMailboxItems(ctx context.Context, limit int) ([]runtimetools.MailboxItem, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required")
 	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 200
 	}
-	if items, err := s.expireMailboxItemsSpec(ctx, limit); err == nil {
-		return items, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return nil, err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.expireMailboxItemsSpec(ctx, limit)
 	}
-
-	const q = `
-		WITH due AS (
-			SELECT id
-			FROM mailbox
-			WHERE status = 'pending'
-			  AND timeout_at IS NOT NULL
-			  AND timeout_at <= now()
-			ORDER BY timeout_at ASC
-			LIMIT $1
-		)
-		UPDATE mailbox m
-		SET status = 'expired',
-		    decision = COALESCE(NULLIF(m.decision, ''), ''),
-		    decision_notes = COALESCE(NULLIF(m.decision_notes, ''), 'Timed out without human decision'),
-		    decided_at = COALESCE(m.decided_at, now())
-		FROM due
-		WHERE m.id = due.id
-		RETURNING
-			m.id::text,
-			COALESCE(m.event_id::text, ''),
-			COALESCE(m.entity_id::text, ''),
-			COALESCE(m.from_agent, ''),
-			m.type,
-			COALESCE(m.priority, 'normal'),
-			COALESCE(m.status, 'expired'),
-			COALESCE(m.notified, false),
-			COALESCE(m.context, '{}'::jsonb),
-			COALESCE(m.summary, ''),
-			m.timeout_at,
-			COALESCE(m.decision, ''),
-			COALESCE(m.decision_notes, '')
-	`
-	rows, err := s.DB.QueryContext(ctx, q, limit)
-	if err != nil {
-		return nil, fmt.Errorf("expire mailbox items: %w", err)
-	}
-	defer rows.Close()
-	return scanLegacyMailboxItems(rows)
+	return nil, unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) ListUnnotifiedCriticalMailboxItems(ctx context.Context, limit int) ([]runtimetools.MailboxItem, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if limit <= 0 {
 		limit = 50
@@ -315,40 +165,10 @@ func (s *PostgresStore) ListUnnotifiedCriticalMailboxItems(ctx context.Context, 
 	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
 		return nil, err
 	}
-	if items, err := s.listUnnotifiedCriticalMailboxItemsSpec(ctx, limit); err == nil {
-		return items, nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return nil, err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.listUnnotifiedCriticalMailboxItemsSpec(ctx, limit)
 	}
-
-	const q = `
-		SELECT
-			id::text,
-			COALESCE(event_id::text, ''),
-			COALESCE(entity_id::text, ''),
-			COALESCE(from_agent, ''),
-			type,
-			COALESCE(priority, 'normal'),
-			COALESCE(status, 'pending'),
-			COALESCE(notified, false),
-			COALESCE(context, '{}'::jsonb),
-			COALESCE(summary, ''),
-			timeout_at,
-			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
-		FROM mailbox
-		WHERE status = 'pending'
-		  AND priority = 'critical'
-		  AND COALESCE(notified, false) = false
-		ORDER BY created_at ASC
-		LIMIT $1
-	`
-	rows, err := s.DB.QueryContext(ctx, q, limit)
-	if err != nil {
-		return nil, fmt.Errorf("query unnotified critical mailbox items: %w", err)
-	}
-	defer rows.Close()
-	return scanLegacyMailboxItems(rows)
+	return nil, unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func coalesceMailboxEntityID(item runtimetools.MailboxItem) string {
@@ -359,23 +179,17 @@ func (s *PostgresStore) MarkMailboxItemNotified(ctx context.Context, id string) 
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required")
 	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(id) == "" {
 		return fmt.Errorf("mailbox id is required")
 	}
-	if err := s.markMailboxItemNotifiedSpec(ctx, id); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyMailboxSchema(err) {
-		return err
+	if caps.Mailbox == SchemaFlavorCanonical {
+		return s.markMailboxItemNotifiedSpec(ctx, id)
 	}
-	const q = `
-		UPDATE mailbox
-		SET notified = true
-		WHERE id = $1::uuid
-	`
-	if _, err := s.DB.ExecContext(ctx, q, id); err != nil {
-		return fmt.Errorf("mark mailbox item notified: %w", err)
-	}
-	return nil
+	return unsupportedSchemaCapability("mailbox", caps.Mailbox)
 }
 
 func (s *PostgresStore) insertMailboxItemSpec(ctx context.Context, item runtimetools.MailboxItem) error {
@@ -684,19 +498,4 @@ func denormalizeMailboxStatus(status, decision string) string {
 func mailboxListFilter(status string) (string, string) {
 	status = strings.TrimSpace(status)
 	return `status = $1`, status
-}
-
-func shouldFallbackLegacyMailboxSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `item_id`) ||
-		strings.Contains(msg, `item_type`) ||
-		strings.Contains(msg, `source_event_id`) ||
-		strings.Contains(msg, `severity`) ||
-		strings.Contains(msg, `payload`) ||
-		strings.Contains(msg, `expires_at`) ||
-		strings.Contains(msg, `decision_notes`) ||
-		strings.Contains(msg, `notified`)
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -54,11 +54,7 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 }
 
 func (s *PostgresStore) Ping(ctx context.Context) error {
-	if err := s.DB.PingContext(ctx); err != nil {
-		return err
-	}
-	_, err := s.BindSchemaCapabilities(ctx)
-	return err
+	return s.DB.PingContext(ctx)
 }
 
 func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -13,6 +14,10 @@ import (
 
 type PostgresStore struct {
 	DB *sql.DB
+
+	schemaCapsMu    sync.RWMutex
+	schemaCaps      StoreSchemaCapabilities
+	schemaCapsBound bool
 }
 
 func DSNFromConfig(cfg config.DatabaseConfig) string {
@@ -49,7 +54,11 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 }
 
 func (s *PostgresStore) Ping(ctx context.Context) error {
-	return s.DB.PingContext(ctx)
+	if err := s.DB.PingContext(ctx); err != nil {
+		return err
+	}
+	_, err := s.BindSchemaCapabilities(ctx)
+	return err
 }
 
 func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
@@ -97,19 +106,23 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if s == nil || s.DB == nil {
 		return nil
 	}
-	if !tableExists(ctx, s.DB, "agent_turns") {
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasTable("agent_turns") {
 		goto ensureEntityState
 	}
-	if !columnExists(ctx, s.DB, "agent_turns", "turn_blocks") {
+	if !catalog.hasColumns("agent_turns", "turn_blocks") {
 		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS turn_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`); err != nil {
 			return fmt.Errorf("ensure agent_turns.turn_blocks column: %w", err)
 		}
 	}
 ensureEntityState:
-	if !tableExists(ctx, s.DB, "entity_state") {
+	if !catalog.hasTable("entity_state") {
 		return nil
 	}
-	if !columnExists(ctx, s.DB, "entity_state", "subject_id") {
+	if !catalog.hasColumns("entity_state", "subject_id") {
 		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE entity_state ADD COLUMN IF NOT EXISTS subject_id UUID`); err != nil {
 			return fmt.Errorf("ensure entity_state.subject_id column: %w", err)
 		}
@@ -117,5 +130,6 @@ ensureEntityState:
 	if _, err := s.DB.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_entity_subject ON entity_state(subject_id) WHERE subject_id IS NOT NULL`); err != nil {
 		return fmt.Errorf("ensure entity_state.subject_id index: %w", err)
 	}
-	return nil
+	_, err = s.BindSchemaCapabilities(ctx)
+	return err
 }

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,6 +11,10 @@ import (
 )
 
 func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.Schedule) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return fmt.Errorf("agent_id and event_type are required")
 	}
@@ -21,239 +24,93 @@ func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.S
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
 
-	if err := s.upsertScheduleSpec(ctx, sc); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyTimersSchema(err) {
-		return err
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.upsertScheduleSpec(ctx, sc)
+	default:
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin schedule tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	payload := persistedSchedulePayload(sc)
-
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE schedules
-		SET active = false,
-		    cancelled_at = now()
-		WHERE agent_id = $1
-		  AND event_type = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(payload->>'__schedule_task_id', '') = $4
-		  AND active = true
-	`, sc.AgentID, sc.EventType, sc.EntityID, strings.TrimSpace(sc.TaskID)); err != nil {
-		return fmt.Errorf("deactivate previous schedule: %w", err)
-	}
-
-	var atTime any
-	var nextFire any
-	if !sc.At.IsZero() {
-		atTime = sc.At
-		nextFire = sc.At
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO schedules (
-			agent_id, entity_id, event_type, mode, cron_expr,
-			at_time, next_fire_at, payload, active, created_at
-		)
-		VALUES (
-			$1, NULLIF($2,'')::uuid, $3, $4, NULLIF($5,''),
-			$6, $7, $8::jsonb, true, now()
-		)
-	`, sc.AgentID, sc.EntityID, sc.EventType, sc.Mode, sc.Cron, atTime, nextFire, string(payload)); err != nil {
-		return fmt.Errorf("insert schedule: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit schedule tx: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) CancelSchedule(ctx context.Context, agentID, eventType string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(agentID) == "" || strings.TrimSpace(eventType) == "" {
 		return fmt.Errorf("agent_id and event_type are required")
 	}
-	if err := s.cancelScheduleSpec(ctx, agentID, eventType); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyTimersSchema(err) {
-		return err
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.cancelScheduleSpec(ctx, agentID, eventType)
+	default:
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-	_, err := s.DB.ExecContext(ctx, `
-		UPDATE schedules
-		SET active = false,
-		    cancelled_at = now()
-		WHERE agent_id = $1
-		  AND event_type = $2
-		  AND active = true
-	`, agentID, eventType)
-	if err != nil {
-		return fmt.Errorf("cancel schedule: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) CancelScheduleExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return fmt.Errorf("agent_id and event_type are required")
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
-	if err := s.cancelScheduleExactSpec(ctx, sc); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyTimersSchema(err) {
-		return err
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.cancelScheduleExactSpec(ctx, sc)
+	default:
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-	_, err := s.DB.ExecContext(ctx, `
-		UPDATE schedules
-		SET active = false,
-		    cancelled_at = now()
-		WHERE agent_id = $1
-		  AND event_type = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(payload->>'__schedule_task_id', '') = $4
-		  AND active = true
-	`, sc.AgentID, sc.EventType, entityID, strings.TrimSpace(sc.TaskID))
-	if err != nil {
-		return fmt.Errorf("cancel exact schedule: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) LoadActiveSchedules(ctx context.Context) ([]runtimepipeline.Schedule, error) {
-	schedules, err := s.loadActiveSchedulesSpec(ctx)
-	if err == nil {
-		return schedules, nil
-	}
-	if !shouldFallbackLegacyTimersSchema(err) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
 		return nil, err
 	}
-
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT
-			agent_id,
-			event_type,
-			mode,
-			COALESCE(cron_expr, ''),
-			at_time,
-			COALESCE(entity_id::text, ''),
-			payload
-		FROM schedules
-		WHERE active = true
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("query active schedules: %w", err)
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.loadActiveSchedulesSpec(ctx)
+	default:
+		return nil, unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-	defer rows.Close()
-
-	out := make([]runtimepipeline.Schedule, 0)
-	for rows.Next() {
-		var sc runtimepipeline.Schedule
-		var at sql.NullTime
-		if err := rows.Scan(
-			&sc.AgentID,
-			&sc.EventType,
-			&sc.Mode,
-			&sc.Cron,
-			&at,
-			&sc.EntityID,
-			&sc.Payload,
-		); err != nil {
-			return nil, fmt.Errorf("scan active schedule: %w", err)
-		}
-		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(sc.Payload)
-		if at.Valid {
-			sc.At = at.Time
-		}
-		out = append(out, sc)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate active schedules: %w", err)
-	}
-	return out, nil
 }
 
 func (s *PostgresStore) MarkScheduleFired(ctx context.Context, sc runtimepipeline.Schedule) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return nil
 	}
-	if err := s.markScheduleFiredSpec(ctx, sc); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyTimersSchema(err) {
-		return err
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.markScheduleFiredSpec(ctx, sc)
+	default:
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-	if sc.Mode == "once" {
-		_, err := s.DB.ExecContext(ctx, `
-			UPDATE schedules
-			SET active = false,
-			    last_fired_at = now(),
-			    next_fire_at = NULL
-			WHERE agent_id = $1
-			  AND event_type = $2
-			  AND active = true
-		`, sc.AgentID, sc.EventType)
-		if err != nil {
-			return fmt.Errorf("mark once schedule fired: %w", err)
-		}
-		return nil
-	}
-	_, err := s.DB.ExecContext(ctx, `
-		UPDATE schedules
-		SET last_fired_at = now()
-		WHERE agent_id = $1
-		  AND event_type = $2
-		  AND active = true
-	`, sc.AgentID, sc.EventType)
-	if err != nil {
-		return fmt.Errorf("mark recurring schedule fired: %w", err)
-	}
-	return nil
 }
 
 func (s *PostgresStore) MarkScheduleFiredExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return nil
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
-	if err := s.markScheduleFiredExactSpec(ctx, sc); err == nil {
-		return nil
-	} else if !shouldFallbackLegacyTimersSchema(err) {
-		return err
+	switch caps.Schedules {
+	case SchemaFlavorCanonical:
+		return s.markScheduleFiredExactSpec(ctx, sc)
+	default:
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
-	if sc.Mode == "once" {
-		_, err := s.DB.ExecContext(ctx, `
-			UPDATE schedules
-			SET active = false,
-			    last_fired_at = now(),
-			    next_fire_at = NULL
-			WHERE agent_id = $1
-			  AND event_type = $2
-			  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-			  AND COALESCE(payload->>'__schedule_task_id', '') = $4
-			  AND active = true
-		`, sc.AgentID, sc.EventType, entityID, strings.TrimSpace(sc.TaskID))
-		if err != nil {
-			return fmt.Errorf("mark exact once schedule fired: %w", err)
-		}
-		return nil
-	}
-	_, err := s.DB.ExecContext(ctx, `
-		UPDATE schedules
-		SET last_fired_at = now()
-		WHERE agent_id = $1
-		  AND event_type = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(payload->>'__schedule_task_id', '') = $4
-		  AND active = true
-	`, sc.AgentID, sc.EventType, entityID, strings.TrimSpace(sc.TaskID))
-	if err != nil {
-		return fmt.Errorf("mark exact schedule fired: %w", err)
-	}
-	return nil
 }
 
 func persistedSchedulePayload(sc runtimepipeline.Schedule) []byte {
@@ -449,20 +306,6 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 		return fmt.Errorf("mark exact timer fired: %w", err)
 	}
 	return nil
-}
-
-func shouldFallbackLegacyTimersSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, `relation "timers" does not exist`) ||
-		strings.Contains(msg, `column "owner_agent"`) ||
-		strings.Contains(msg, `column "fire_event"`) ||
-		strings.Contains(msg, `column "fire_payload"`) ||
-		strings.Contains(msg, `column "recurrence_cron"`) ||
-		strings.Contains(msg, `column "status"`) ||
-		strings.Contains(msg, `column "timer_name"`)
 }
 
 func extractPersistedScheduleTaskID(payload []byte) (string, []byte) {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+type SchemaFlavor string
+
+const (
+	SchemaFlavorUnavailable SchemaFlavor = "unavailable"
+	SchemaFlavorUnsupported SchemaFlavor = "unsupported"
+	SchemaFlavorLegacy      SchemaFlavor = "legacy"
+	SchemaFlavorCanonical   SchemaFlavor = "canonical"
+)
+
+type EventSchemaCapabilities struct {
+	Log               SchemaFlavor
+	Deliveries        SchemaFlavor
+	Receipts          SchemaFlavor
+	HasRuns           bool
+	LogRunID          bool
+	DeliveryRunID     bool
+	LogIdempotencyKey bool
+}
+
+type ConversationSchemaCapabilities struct {
+	Sessions     SchemaFlavor
+	Turns        SchemaFlavor
+	SessionRunID bool
+	TurnRunID    bool
+	TurnBlocks   bool
+}
+
+type StoreSchemaCapabilities struct {
+	Agents        SchemaFlavor
+	Schedules     SchemaFlavor
+	Mailbox       SchemaFlavor
+	Events        EventSchemaCapabilities
+	Conversations ConversationSchemaCapabilities
+}
+
+type schemaColumnCatalog struct {
+	tables map[string]map[string]struct{}
+}
+
+func (c schemaColumnCatalog) hasTable(tableName string) bool {
+	_, ok := c.tables[strings.TrimSpace(tableName)]
+	return ok
+}
+
+func (c schemaColumnCatalog) hasColumns(tableName string, columns ...string) bool {
+	table, ok := c.tables[strings.TrimSpace(tableName)]
+	if !ok {
+		return false
+	}
+	for _, column := range columns {
+		if _, ok := table[strings.TrimSpace(column)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func loadSchemaColumnCatalog(ctx context.Context, db *sql.DB) (schemaColumnCatalog, error) {
+	catalog := schemaColumnCatalog{tables: map[string]map[string]struct{}{}}
+	if db == nil {
+		return catalog, fmt.Errorf("postgres store is required")
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, column_name
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+	`)
+	if err != nil {
+		return schemaColumnCatalog{}, fmt.Errorf("inspect store schema: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName, columnName string
+		if err := rows.Scan(&tableName, &columnName); err != nil {
+			return schemaColumnCatalog{}, fmt.Errorf("scan store schema column: %w", err)
+		}
+		tableName = strings.TrimSpace(tableName)
+		columnName = strings.TrimSpace(columnName)
+		if tableName == "" || columnName == "" {
+			continue
+		}
+		if catalog.tables[tableName] == nil {
+			catalog.tables[tableName] = map[string]struct{}{}
+		}
+		catalog.tables[tableName][columnName] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return schemaColumnCatalog{}, fmt.Errorf("read store schema columns: %w", err)
+	}
+	return catalog, nil
+}
+
+func detectSchemaFlavor(catalog schemaColumnCatalog, tableName string, canonicalColumns, legacyColumns []string) SchemaFlavor {
+	switch {
+	case len(canonicalColumns) > 0 && catalog.hasColumns(tableName, canonicalColumns...):
+		return SchemaFlavorCanonical
+	case len(legacyColumns) > 0 && catalog.hasColumns(tableName, legacyColumns...):
+		return SchemaFlavorLegacy
+	case catalog.hasTable(tableName):
+		return SchemaFlavorUnsupported
+	default:
+		return SchemaFlavorUnavailable
+	}
+}
+
+func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapabilities {
+	caps := StoreSchemaCapabilities{}
+	caps.Agents = detectSchemaFlavor(catalog, "agents",
+		[]string{
+			"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
+			"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
+			"permissions", "status", "turn_count", "last_active_at", "created_at",
+		},
+		[]string{
+			"id", "type", "role", "mode", "entity_id", "parent_agent_id", "status",
+			"coordinator_id", "config", "budget_envelope", "hired_by", "template_version",
+			"started_at", "last_active_at",
+		},
+	)
+
+	caps.Events = EventSchemaCapabilities{
+		Log: detectSchemaFlavor(catalog, "events",
+			[]string{
+				"event_id", "event_name", "entity_id", "flow_instance", "scope", "payload",
+				"chain_depth", "produced_by", "produced_by_type", "source_event_id", "created_at",
+			},
+			[]string{"id", "type", "source_agent", "task_id", "entity_id", "payload", "created_at"},
+		),
+		Deliveries: detectSchemaFlavor(catalog, "event_deliveries",
+			[]string{
+				"event_id", "subscriber_type", "subscriber_id", "status", "retry_count",
+				"reason_code", "last_error", "active_session_id", "started_at", "delivered_at", "created_at",
+			},
+			[]string{"event_id", "agent_id", "status", "created_at"},
+		),
+		Receipts: detectSchemaFlavor(catalog, "event_receipts",
+			[]string{
+				"event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
+				"outcome", "reason_code", "side_effects", "processed_at",
+			},
+			[]string{"event_id", "agent_id", "processed_at", "status", "retry_count", "error"},
+		),
+		HasRuns:           catalog.hasColumns("runs", "run_id", "status"),
+		LogRunID:          catalog.hasColumns("events", "run_id"),
+		DeliveryRunID:     catalog.hasColumns("event_deliveries", "run_id"),
+		LogIdempotencyKey: catalog.hasColumns("events", "idempotency_key"),
+	}
+
+	caps.Conversations = ConversationSchemaCapabilities{
+		Sessions: detectSchemaFlavor(catalog, "agent_sessions",
+			[]string{
+				"session_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
+				"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
+				"lease_expires_at", "status", "created_at", "updated_at",
+			},
+			nil,
+		),
+		Turns: detectSchemaFlavor(catalog, "agent_turns",
+			[]string{
+				"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id",
+				"trigger_event_id", "trigger_event_type", "task_id", "available_tools", "tool_calls",
+				"emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+				"request_payload", "response_payload", "parse_ok", "latency_ms", "retry_count",
+				"error", "created_at",
+			},
+			nil,
+		),
+		SessionRunID: catalog.hasColumns("agent_sessions", "run_id"),
+		TurnRunID:    catalog.hasColumns("agent_turns", "run_id"),
+		TurnBlocks:   catalog.hasColumns("agent_turns", "turn_blocks"),
+	}
+
+	caps.Mailbox = detectSchemaFlavor(catalog, "mailbox",
+		[]string{
+			"item_id", "entity_id", "flow_instance", "scope", "item_type", "source_event_id",
+			"from_agent", "severity", "summary", "payload", "status", "decision", "decision_notes",
+			"decided_by", "decided_at", "notified", "expires_at", "created_at",
+		},
+		[]string{
+			"id", "event_id", "entity_id", "from_agent", "type", "priority", "status",
+			"context", "summary", "timeout_at", "decision", "decision_notes", "notified", "created_at",
+		},
+	)
+
+	caps.Schedules = detectSchemaFlavor(catalog, "timers",
+		[]string{
+			"timer_id", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
+			"fire_at", "recurring", "recurrence_cron", "recurrence_interval", "owner_node",
+			"owner_agent", "task_type", "status", "fired_at", "created_at",
+		},
+		nil,
+	)
+	if caps.Schedules == SchemaFlavorUnavailable {
+		caps.Schedules = detectSchemaFlavor(catalog, "schedules",
+			nil,
+			[]string{
+				"agent_id", "entity_id", "event_type", "mode", "cron_expr", "at_time",
+				"next_fire_at", "payload", "active", "cancelled_at", "last_fired_at", "created_at",
+			},
+		)
+	}
+
+	return caps
+}
+
+func (s *PostgresStore) BindSchemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
+	if s == nil || s.DB == nil {
+		return StoreSchemaCapabilities{}, fmt.Errorf("postgres store is required")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return StoreSchemaCapabilities{}, err
+	}
+	caps := detectStoreSchemaCapabilities(catalog)
+	s.schemaCapsMu.Lock()
+	s.schemaCaps = caps
+	s.schemaCapsBound = true
+	s.schemaCapsMu.Unlock()
+	return caps, nil
+}
+
+func (s *PostgresStore) schemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
+	if s == nil || s.DB == nil {
+		return StoreSchemaCapabilities{}, fmt.Errorf("postgres store is required")
+	}
+	s.schemaCapsMu.RLock()
+	if s.schemaCapsBound {
+		caps := s.schemaCaps
+		s.schemaCapsMu.RUnlock()
+		return caps, nil
+	}
+	s.schemaCapsMu.RUnlock()
+	return s.BindSchemaCapabilities(ctx)
+}
+
+func (s *PostgresStore) SchemaCapabilities() StoreSchemaCapabilities {
+	if s == nil {
+		return StoreSchemaCapabilities{}
+	}
+	s.schemaCapsMu.RLock()
+	defer s.schemaCapsMu.RUnlock()
+	return s.schemaCaps
+}
+
+func unsupportedSchemaCapability(subject string, flavor SchemaFlavor) error {
+	switch flavor {
+	case SchemaFlavorUnavailable:
+		return fmt.Errorf("store: %s schema is unavailable", strings.TrimSpace(subject))
+	case SchemaFlavorUnsupported, SchemaFlavorLegacy:
+		return fmt.Errorf("store: %s schema is unsupported by the explicit capability boundary", strings.TrimSpace(subject))
+	default:
+		return fmt.Errorf("store: %s schema capability is invalid (%s)", strings.TrimSpace(subject), strings.TrimSpace(string(flavor)))
+	}
+}

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -252,6 +252,10 @@ func (s *PostgresStore) SchemaCapabilities() StoreSchemaCapabilities {
 	return s.schemaCaps
 }
 
+func (s *PostgresStore) ResolveSchemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
+	return s.schemaCapabilities(ctx)
+}
+
 func unsupportedSchemaCapability(subject string, flavor SchemaFlavor) error {
 	switch flavor {
 	case SchemaFlavorUnavailable:

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"})
+	addColumns := func(table string, columns ...string) {
+		for _, column := range columns {
+			rows.AddRow(table, column)
+		}
+	}
+
+	addColumns("runs", "run_id", "status")
+	addColumns("agents",
+		"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
+		"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
+		"permissions", "status", "turn_count", "last_active_at", "created_at",
+	)
+	addColumns("events",
+		"event_id", "run_id", "event_name", "entity_id", "flow_instance", "scope", "payload",
+		"chain_depth", "produced_by", "produced_by_type", "source_event_id", "idempotency_key", "created_at",
+	)
+	addColumns("event_deliveries",
+		"run_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count",
+		"reason_code", "last_error", "active_session_id", "started_at", "delivered_at", "created_at",
+	)
+	addColumns("event_receipts",
+		"event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
+		"outcome", "reason_code", "side_effects", "processed_at",
+	)
+	addColumns("agent_sessions",
+		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
+		"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
+		"lease_expires_at", "status", "created_at", "updated_at",
+	)
+	addColumns("agent_turns",
+		"turn_id", "run_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id",
+		"trigger_event_id", "trigger_event_type", "task_id", "available_tools", "tool_calls",
+		"emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+		"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms",
+		"retry_count", "error", "created_at",
+	)
+	addColumns("mailbox",
+		"item_id", "entity_id", "flow_instance", "scope", "item_type", "source_event_id",
+		"from_agent", "severity", "summary", "payload", "status", "decision", "decision_notes",
+		"decided_by", "decided_at", "notified", "expires_at", "created_at",
+	)
+	addColumns("timers",
+		"timer_id", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
+		"fire_at", "recurring", "recurrence_cron", "recurrence_interval", "owner_node",
+		"owner_agent", "task_type", "status", "fired_at", "created_at",
+	)
+
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+
+	pg := &PostgresStore{DB: db}
+	caps, err := pg.BindSchemaCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	if caps.Agents != SchemaFlavorCanonical {
+		t.Fatalf("agents flavor = %s", caps.Agents)
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey {
+		t.Fatalf("events caps = %+v", caps.Events)
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		t.Fatalf("delivery caps = %+v", caps.Events)
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
+		t.Fatalf("session caps = %+v", caps.Conversations)
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical || !caps.Conversations.TurnRunID || !caps.Conversations.TurnBlocks {
+		t.Fatalf("turn caps = %+v", caps.Conversations)
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		t.Fatalf("mailbox flavor = %s", caps.Mailbox)
+	}
+	if caps.Schedules != SchemaFlavorCanonical {
+		t.Fatalf("schedules flavor = %s", caps.Schedules)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresStore_BindSchemaCapabilities_DetectsLegacyShapes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"})
+	addColumns := func(table string, columns ...string) {
+		for _, column := range columns {
+			rows.AddRow(table, column)
+		}
+	}
+
+	addColumns("agents",
+		"id", "type", "role", "mode", "entity_id", "parent_agent_id", "status",
+		"coordinator_id", "config", "budget_envelope", "hired_by", "template_version",
+		"started_at", "last_active_at",
+	)
+	addColumns("events", "id", "type", "source_agent", "task_id", "entity_id", "payload", "created_at")
+	addColumns("event_deliveries", "event_id", "agent_id", "status", "created_at")
+	addColumns("event_receipts", "event_id", "agent_id", "processed_at", "status", "retry_count", "error")
+	addColumns("mailbox",
+		"id", "event_id", "entity_id", "from_agent", "type", "priority", "status",
+		"context", "summary", "timeout_at", "decision", "decision_notes", "notified", "created_at",
+	)
+	addColumns("schedules",
+		"agent_id", "entity_id", "event_type", "mode", "cron_expr", "at_time",
+		"next_fire_at", "payload", "active", "cancelled_at", "last_fired_at", "created_at",
+	)
+
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+
+	pg := &PostgresStore{DB: db}
+	caps, err := pg.BindSchemaCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	if caps.Agents != SchemaFlavorLegacy {
+		t.Fatalf("agents flavor = %s", caps.Agents)
+	}
+	if caps.Events.Log != SchemaFlavorLegacy || caps.Events.Deliveries != SchemaFlavorLegacy || caps.Events.Receipts != SchemaFlavorLegacy {
+		t.Fatalf("events caps = %+v", caps.Events)
+	}
+	if caps.Mailbox != SchemaFlavorLegacy {
+		t.Fatalf("mailbox flavor = %s", caps.Mailbox)
+	}
+	if caps.Schedules != SchemaFlavorLegacy {
+		t.Fatalf("schedules flavor = %s", caps.Schedules)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Replaces implicit runtime schema-shape inference in store and dashboard paths with one explicit store-owned schema capability boundary.

## What Changed
- added a bound `StoreSchemaCapabilities` model in `internal/store` and wired it through store startup/schema setup
- moved store and dashboard consumers onto that explicit capability boundary instead of probing columns or retrying on SQL shape errors
- removed runtime support for older pre-spec legacy store schemas so unsupported shapes now fail closed
- added focused capability-binding tests and updated affected integration-style tests to declare canonical schema expectations explicitly

## Why
The platform spec is the authoritative source for runtime/platform semantics. Persisting schema compatibility behavior through per-call probing and SQL-error fallback was creating semantic drift, duplicated logic, and hot-path branching.

## Impact
- canonical platform schema is now the runtime baseline
- existing canonical optional capability bits such as `run_id` and `turn_blocks` are still recognized explicitly
- older pre-spec store shapes are no longer supported as runtime states

## Validation
- `go test ./internal/store ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Issue
- addresses #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * App now detects and binds DB schema capabilities at startup and will abort startup if capability binding fails.
  * Store operations are strictly gated by schema capability checks; unsupported schemas return clear errors instead of silent fallbacks.
  * Dashboard conversation reads now respect schema capabilities (turns, turn blocks, sessions).

* **Bug Fixes**
  * SQL query/column errors that previously were suppressed now propagate.

* **Tests**
  * Added tests validating schema capability detection and conversation behavior for canonical vs legacy schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->