### PR TITLE
[codex] separate live session state from audit persistence

### DIFF
--- a/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
+++ b/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
@@ -1443,19 +1443,19 @@ Likely causes:
 
 Current mitigations:
 
-- `runtime_mode` and synthetic scope values
-- dashboard-side filtering/reconstruction
+- issue `#3` introduces a first-class audit persistence surface for task-mode conversation snapshots
+- dashboard readers now label live-session versus turn-audit rows explicitly instead of inferring from `agent_sessions`
 
 Still brittle because:
 
-- one table is carrying two incompatible concepts
-- downstream readers must remember hidden exceptions
+- the authoritative YAML platform spec still needs an explicit update to describe the split model
+- older databases may still contain pre-split task rows until migrated forward
 
 Improvement items:
 
-- separate live session state from turn/transcript audit state
-- or introduce an explicit persisted session kind with dedicated reader APIs
-- stop treating stateless audit rows as leaseable/live session records
+- keep `agent_sessions` reserved for live leaseable session state only
+- keep task-mode snapshots in the dedicated audit persistence surface
+- remove remaining stale documentation/spec drift describing the mixed model
 
 ### Timer and accumulation-timeout identity still depends on string mini-languages
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1118,18 +1118,25 @@ engine:
       universal_tools: 'The following tools are auto-granted to all agents without explicit tools listing: agent_message,
         mailbox_send, get_entity, save_entity_field, query_entities, query_metrics, search_entities. These are "universal"
         tools. See tool_model.agent_tool_filtering.universal_tools for the authoritative list.'
-    task_mode_audit: 'Agents in task conversation_mode DO get an agent_sessions row. The conversation transcript (reasoning,
-      tool calls, results) is persisted after each invocation for audit and debugging. However, the transcript is write-only —
-      it is NEVER loaded back for subsequent invocations. Each event invocation starts with a fresh context. Task mode means
-      "no memory between invocations", not "no record of what happened." The persisted transcript enables the builder Run tab
-      to show agent reasoning details regardless of conversation_mode. Rows may be archived per retention policy.'
-    provider_session_ids: External LLM provider session IDs (e.g., Anthropic conversation ID) are stored in agent_sessions.runtime_state.provider_session_id,
-      NOT in session_id. session_id is the platform-owned UUID primary key. The provider ID is an implementation detail that
-      may change if the provider is swapped.
+    task_mode_audit: 'Agents in task conversation_mode do NOT create agent_sessions rows. Task mode is
+      stateless — no live session, no session lookup, no session persistence. The conversation transcript
+      (reasoning, tool calls, results) is persisted after each invocation to agent_conversation_audits
+      (write-only audit table) and agent_turns (per-turn append-only log). The transcript is NEVER loaded
+      back for subsequent invocations. Each event invocation starts with a fresh context. Task mode means
+      "no memory between invocations" AND "no live session row." The persisted audit snapshot enables the
+      builder Run tab to show agent reasoning details. Rows may be archived per retention policy.'
+    provider_session_ids: 'External LLM provider session IDs (e.g., Anthropic conversation ID) are stored in
+      runtime_state.provider_session_id — in agent_sessions for session/session_per_entity modes, in
+      agent_conversation_audits for task mode. NOT in session_id or audit_id. Those are platform-owned
+      UUID primary keys. The provider ID is an implementation detail that may change if the provider is swapped.'
     conversation_mode_values:
-      task: Stateless between invocations. Transcript persisted (write-only) for audit. Never reloaded. Each invocation starts fresh.
-      session: Persistent session across events. Conversation history maintained and reused. Agent accumulates context.
-      session_per_entity: One session per agent × entity. Context preserved and reused per entity.
+      task: 'Stateless between invocations. No agent_sessions row. Audit snapshot persisted to
+        agent_conversation_audits (write-only). Per-turn history in agent_turns. Never reloaded.
+        Each invocation starts fresh.'
+      session: 'Persistent session across events. Live session row in agent_sessions. Conversation
+        history maintained and reused. Agent accumulates context.'
+      session_per_entity: 'One session per agent × entity. Live session row in agent_sessions per entity.
+        Context preserved and reused per entity.'
       stateless: Alias for task. Accepted by the loader, normalized to task internally.
     native_tools:
       description: Optional agent contract field. Declares which host-level capabilities the agent may use. Default all false
@@ -2397,17 +2404,17 @@ platform_tables:
         \ NULL,\n    INDEX idx_agents_role (role),\n    INDEX idx_agents_status (status),\n    INDEX idx_agents_parent (parent_agent_id)\
         \ WHERE parent_agent_id IS NOT NULL\n);"
     agent_sessions:
-      description: 'Agent conversation sessions. Supports three scopes: entity (one session per agent × entity), flow (one
-        session per agent × flow instance), global (one session per agent, shared across all entities). scope_key is the lookup
-        key used by the runtime: for entity scope it is the entity_id, for flow scope it is the flow_instance path, for global
-        scope it is the literal "global". runtime_mode matches the agent conversation_mode from contracts. lease_holder/lease_expires_at
-        for distributed session locking.'
+      description: 'Live reusable agent conversation sessions. Used ONLY by session and session_per_entity
+        conversation modes. Task mode does NOT create rows here — task-mode audit goes to
+        agent_conversation_audits instead. Supports three scopes: entity (one session per agent × entity),
+        flow (one session per agent × flow instance), global (one session per agent, shared across all
+        entities). scope_key is the lookup key. lease_holder/lease_expires_at for distributed session locking.'
       ddl: "CREATE TABLE agent_sessions (\n    session_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \            UUID REFERENCES runs(run_id),\n    agent_id          TEXT NOT NULL REFERENCES agents(agent_id),\n\
         \    entity_id         UUID,\n    flow_instance     TEXT,\n    scope_key         TEXT NOT NULL,\n    scope         \
         \    TEXT NOT NULL DEFAULT 'entity' CHECK (scope IN ('entity', 'flow', 'global')),\n    conversation      JSONB NOT\
-        \ NULL DEFAULT '[]',\n    turn_count        INTEGER NOT NULL DEFAULT 0,\n    runtime_mode      TEXT NOT NULL DEFAULT\
-        \ 'task' CHECK (runtime_mode IN ('task', 'session', 'session_per_entity')),\n    runtime_state     JSONB NOT NULL\
+        \ NULL DEFAULT '[]',\n    turn_count        INTEGER NOT NULL DEFAULT 0,\n    runtime_mode      TEXT NOT NULL\
+        \ CHECK (runtime_mode IN ('session', 'session_per_entity')),\n    runtime_state     JSONB NOT NULL\
         \ DEFAULT '{}',\n    lease_holder      TEXT,\n    lease_expires_at  TIMESTAMPTZ,\n    status            TEXT NOT\
         \ NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'terminated')),\n    created_at        TIMESTAMPTZ\
         \ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (agent_id, scope_key),\n\
@@ -2418,13 +2425,15 @@ platform_tables:
         entity: entity_id NOT NULL, flow_instance NOT NULL, scope_key = entity_id. One session per agent per entity.
         flow: entity_id NULL, flow_instance NOT NULL, scope_key = flow_instance. One session per agent per flow instance.
         global: entity_id NULL, flow_instance NULL, scope_key = "global". One session per agent across the entire system.
-      lookup_pattern: 'Runtime acquires sessions via (agent_id, scope_key). The scope_key is derived from runtime_mode: task
-        → no session (stateless), session_per_entity → scope_key = entity_id, session → scope_key = flow_instance or "global"
-        depending on agent declaration.'
+      lookup_pattern: 'Runtime acquires sessions via (agent_id, scope_key). The scope_key is derived from
+        conversation_mode: task → no session lookup, no agent_sessions row (audit goes to
+        agent_conversation_audits). session_per_entity → scope_key = entity_id. session → scope_key =
+        flow_instance or "global" depending on agent declaration.'
     agent_turns:
       description: 'Append-only per-turn agent execution audit log. Records the triggering event context, visible tools,
-        attempted tool calls, emitted event names, and sanitized request/response payloads. Complements agent_sessions.runtime_state.last_turn
-        with a queryable historical record.'
+        attempted tool calls, emitted event names, and sanitized request/response payloads. Used by all conversation modes.
+        For task mode, this is the primary per-turn audit record (no agent_sessions row exists). For session modes, this
+        complements the live session with a queryable historical record.'
       ddl: "CREATE TABLE agent_turns (\n    turn_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \             UUID REFERENCES runs(run_id),\n    agent_id           TEXT NOT NULL,\n    session_id         UUID\
         \ NOT NULL,\n    runtime_mode       TEXT NOT NULL DEFAULT 'task' CHECK (runtime_mode IN ('task', 'session', 'session_per_entity')),\n\
@@ -2438,6 +2447,38 @@ platform_tables:
         \ NOW(),\n    INDEX idx_agent_turns_run (run_id, created_at) WHERE run_id IS NOT NULL,\n    INDEX idx_agent_turns_session\
         \ (session_id, created_at),\n    INDEX idx_agent_turns_agent (agent_id, created_at),\n    INDEX idx_agent_turns_event\
         \ (trigger_event_id) WHERE trigger_event_id IS NOT NULL\n);"
+    agent_conversation_audits:
+      description: 'Write-only audit table for task-mode conversation snapshots. One row per task-mode
+        agent invocation. The conversation transcript is persisted here after each invocation for debugging
+        and the builder Run tab. This table is NEVER read back for subsequent invocations — it is purely
+        for audit/debug. Dashboard/readers distinguish live sessions (agent_sessions) from task audits
+        (agent_conversation_audits) by table, not by convention.'
+      ddl: "CREATE TABLE agent_conversation_audits (\n    session_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n\
+        \    run_id            UUID REFERENCES runs(run_id),\n    agent_id          TEXT NOT NULL,\n    entity_id\
+        \         UUID,\n    flow_instance     TEXT,\n    scope_key         TEXT,\n    scope             TEXT\
+        \ NOT NULL DEFAULT 'global' CHECK (scope IN ('entity', 'flow', 'global')),\n    conversation      JSONB NOT NULL\
+        \ DEFAULT '[]',\n    turn_count        INTEGER NOT NULL DEFAULT 0,\n    runtime_mode      TEXT NOT NULL DEFAULT\
+        \ 'task' CHECK (runtime_mode = 'task'),\n    runtime_state     JSONB NOT NULL DEFAULT '{}',\n    status\
+        \            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'terminated')),\n    created_at\
+        \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n\
+        \    INDEX idx_audits_run (run_id, created_at) WHERE run_id IS NOT NULL,\n    INDEX idx_audits_agent (agent_id,\
+        \ created_at),\n    INDEX idx_audits_entity (entity_id) WHERE entity_id IS NOT NULL\n);"
+      primary_key: 'session_id — shared identifier with agent_turns.session_id. Task-mode turns reference
+        the audit row via the same session_id, matching the runtime''s existing linking model.'
+      status_lifecycle: 'Task audit rows remain active for dashboard/reader visibility. The status values
+        (active, suspended, terminated) match the agent_sessions status model for consistency. Dashboard
+        readers query status = active to find visible task-mode audit records. The runtime does NOT
+        transition task audits to completed/failed — they stay active as part of the visible audit surface.'
+      scope_model: 'scope_key is nullable. scope defaults to global. Task-mode invocations may produce
+        audit rows without a specific scope key (e.g., root-level agents with no entity or flow context).
+        When entity_id or flow_instance is available, the runtime sets scope_key and scope accordingly.'
+      write_only: 'This table is append/update only from the runtime perspective. The runtime writes the
+        audit row after each task-mode invocation. It is NEVER read back to construct agent context.
+        Readers are: dashboard API, flight recorder queries, debug tools.'
+      relationship_to_agent_turns: 'agent_conversation_audits holds the full conversation snapshot per
+        invocation. agent_turns holds the per-turn structured execution log. Both are audit surfaces.
+        agent_turns is more granular (one row per turn). agent_conversation_audits captures the complete
+        conversation context (all messages, all tool results) in one row.'
     routing_rules:
       description: 'Unified routing table for both contract-defined patterns and materialized instance routes. Replaces the
         need for a separate flow_instance_routes table. At boot: contract subscriptions inserted as pattern rows (is_wildcard
@@ -2689,6 +2730,7 @@ run_model:
       - events.run_id
       - event_deliveries.run_id
       - agent_sessions.run_id
+      - agent_conversation_audits.run_id
       - agent_turns.run_id
       - entity_mutations.run_id
       propagation_rule: 'Child event run_id = parent event run_id. The bus publish path reads run_id from

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -966,10 +966,10 @@ Specification for the platform engine — how it loads, validates, and executes 
   - `behavior`: Each emit tool accepts a payload object matching the event's schema in events.yaml. The platform validates the payload, attaches sender context, and publishes the event.
   - `universal_tools`: Some tools are auto-granted to all agents without explicit tools_tier2 listing: agent_message, mailbox_send. These are "universal" tools.
 
-- `task_mode_stateless`: Agents in task conversation_mode do NOT get an agent_sessions row. Each event invocation is independent. No conversation history persisted. Debugging traces for task invocations: spend_ledger (cost per invocation) + events (what the agent emitted). Provider session IDs for task invocations are ephemeral and not stored.
+- `task_mode_audit`: Agents in task conversation_mode do NOT get an agent_sessions row. Each event invocation is independent at runtime, but the sanitized conversation snapshot and per-turn telemetry are still persisted for audit/debugging. Task-mode conversation snapshots live in a dedicated audit persistence surface and are never reloaded as live session state.
 - `provider_session_ids`: External LLM provider session IDs (e.g., Anthropic conversation ID) are stored in agent_sessions.runtime_state.provider_session_id, NOT in session_id. session_id is the platform-owned UUID primary key. The provider ID is an implementation detail that may change if the provider is swapped.
 - `conversation_mode_values`:
-  - `task`: Stateless. No session persisted. Each invocation is independent.
+  - `task`: Stateless live execution. No `agent_sessions` row is created. Audit snapshots may still be persisted separately.
   - `session`: Persistent session across events. Conversation history maintained.
   - `session_per_entity`: One session per agent × entity. Context preserved per entity.
   - `stateless`: Alias for task. Accepted by the loader, normalized to task internally.
@@ -1600,7 +1600,7 @@ CREATE TABLE agents (
 
 ### agent_sessions
 
-- `description`: Agent conversation sessions. Supports three scopes: entity (one session per agent × entity), flow (one session per agent × flow instance), global (one session per agent, shared across all entities). scope_key is the lookup key used by the runtime: for entity scope it is the entity_id, for flow scope it is the flow_instance path, for global scope it is the literal "global". runtime_mode matches the agent conversation_mode from contracts. lease_holder/lease_expires_at for distributed session locking.
+- `description`: Live agent conversation sessions only. Supports three scopes: entity (one session per agent × entity), flow (one session per agent × flow instance), global (one session per agent, shared across all entities). scope_key is the lookup key used by the runtime: for entity scope it is the entity_id, for flow scope it is the flow_instance path, for global scope it is the literal "global". lease_holder/lease_expires_at provide distributed session locking. Task-mode audit snapshots are not stored here.
 ### ddl
 
 ```sql
@@ -1634,6 +1634,34 @@ CREATE TABLE agent_sessions (
 - `flow`: entity_id NULL, flow_instance NOT NULL, scope_key = flow_instance. One session per agent per flow instance.
 - `global`: entity_id NULL, flow_instance NULL, scope_key = "global". One session per agent across the entire system.
 - `lookup_pattern`: Runtime acquires sessions via (agent_id, scope_key). The scope_key is derived from runtime_mode: task → no session (stateless), session_per_entity → scope_key = entity_id, session → scope_key = flow_instance or "global" depending on agent declaration.
+
+### agent_conversation_audits
+
+- `description`: Stateless/task-mode conversation snapshot store. Holds write-only audit snapshots and summary/runtime_state for turns that must remain observable but must not be treated as live, leaseable sessions. Session-shaped identifiers here are audit correlation keys, not live session ownership records.
+### ddl
+
+```sql
+CREATE TABLE agent_conversation_audits (
+    session_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id            UUID REFERENCES runs(run_id),
+    agent_id          TEXT NOT NULL REFERENCES agents(agent_id),
+    entity_id         UUID,
+    flow_instance     TEXT,
+    scope_key         TEXT,
+    scope             TEXT NOT NULL DEFAULT 'global',
+    conversation      JSONB NOT NULL DEFAULT '[]',
+    turn_count        INTEGER NOT NULL DEFAULT 0,
+    runtime_mode      TEXT NOT NULL DEFAULT 'task' CHECK (runtime_mode = 'task'),
+    runtime_state     JSONB NOT NULL DEFAULT '{}',
+    status            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'terminated')),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    INDEX idx_agent_conversation_audits_run (run_id, updated_at) WHERE run_id IS NOT NULL,
+    INDEX idx_agent_conversation_audits_agent (agent_id, updated_at),
+    INDEX idx_agent_conversation_audits_entity (entity_id) WHERE entity_id IS NOT NULL,
+    INDEX idx_agent_conversation_audits_status (status, updated_at)
+);
+```
 ### routing_rules
 
 - `description`: Unified routing table for both contract-defined patterns and materialized instance routes. Replaces the need for a separate flow_instance_routes table. At boot: contract subscriptions inserted as pattern rows (is_wildcard may be true). On create_flow_instance: wildcard patterns expanded into concrete rows (is_materialized = true, materialized_from = parent rule_id). On flow instance termination: materialized rows set to inactive. Event dispatch: match concrete routes first (is_materialized = true, exact match), fall back to wildcard patterns.

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimesessions "swarm/internal/runtime/sessions"
 )
 
 type SQLAgentReader struct {
@@ -117,6 +118,7 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 			FROM agent_sessions
 			WHERE agent_id = a.agent_id
 			  AND status = 'active'
+			  AND runtime_mode IN ($1, $2)
 			ORDER BY updated_at DESC, created_at DESC
 			LIMIT 1
 		) sess ON true
@@ -148,7 +150,7 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 		) f ON true
 		WHERE a.status NOT IN ('terminated', 'ephemeral')
 		ORDER BY a.created_at ASC, a.agent_id ASC
-	`)
+	`, runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
 	if err != nil {
 		return nil, fmt.Errorf("query agent aggregates: %w", err)
 	}

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -11,6 +11,11 @@ import (
 	"swarm/internal/store"
 )
 
+const (
+	conversationKindLiveSession = "live_session"
+	conversationKindTurnAudit   = "turn_audit"
+)
+
 type SQLConversationReader struct {
 	db        *sql.DB
 	capSource conversationCapabilitySource
@@ -34,9 +39,19 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := r.db.QueryContext(ctx, `
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sources := conversationQuerySources(caps)
+	if len(sources) == 0 {
+		return []ConversationSummary{}, nil
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
+			session_id,
 			agent_id,
+			kind,
 			COALESCE(scope_key, ''),
 			COALESCE(scope, ''),
 			COALESCE(runtime_mode, ''),
@@ -44,11 +59,12 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 			COALESCE(turn_count, 0),
 			COALESCE(runtime_state, '{}'::jsonb),
 			updated_at
-		FROM agent_sessions
-		WHERE status = 'active'
+		FROM (
+			%s
+		) conversations
 		ORDER BY updated_at DESC, agent_id ASC
 		LIMIT $1
-	`, limit)
+	`, strings.Join(sources, "\nUNION ALL\n")), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
 	}
@@ -76,11 +92,20 @@ func (r *SQLConversationReader) Get(ctx context.Context, agentID string) (Conver
 	if agentID == "" {
 		return ConversationDetail{}, false, nil
 	}
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return ConversationDetail{}, false, err
+	}
+	sources := conversationQuerySources(caps)
+	if len(sources) == 0 {
+		return ConversationDetail{}, false, nil
+	}
 
-	row := r.db.QueryRowContext(ctx, `
+	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT
-			session_id::text,
+			session_id,
 			agent_id,
+			kind,
 			COALESCE(scope_key, ''),
 			COALESCE(scope, ''),
 			COALESCE(runtime_mode, ''),
@@ -89,12 +114,13 @@ func (r *SQLConversationReader) Get(ctx context.Context, agentID string) (Conver
 			COALESCE(runtime_state, '{}'::jsonb),
 			COALESCE(conversation, '[]'::jsonb),
 			updated_at
-		FROM agent_sessions
+		FROM (
+			%s
+		) conversations
 		WHERE agent_id = $1
-		  AND status = 'active'
 		ORDER BY updated_at DESC, created_at DESC
 		LIMIT 1
-	`, agentID)
+	`, strings.Join(sources, "\nUNION ALL\n")), agentID)
 
 	item, err := scanConversationDetail(row)
 	if err == sql.ErrNoRows {
@@ -120,7 +146,9 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 		runtimeStateRaw []byte
 	)
 	if err := scanner.Scan(
+		&item.SessionID,
 		&item.AgentID,
+		&item.Kind,
 		&item.ScopeKey,
 		&item.Scope,
 		&item.RuntimeMode,
@@ -149,6 +177,7 @@ func scanConversationDetail(scanner rowScanner) (ConversationDetail, error) {
 	if err := scanner.Scan(
 		&item.SessionID,
 		&item.AgentID,
+		&item.Kind,
 		&item.ScopeKey,
 		&item.Scope,
 		&item.RuntimeMode,
@@ -298,9 +327,60 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 
 func (r *SQLConversationReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
 	if r == nil || r.capSource == nil {
-		return store.StoreSchemaCapabilities{}, nil
+		return store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Audits:     store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		}, nil
 	}
 	return r.capSource.ResolveSchemaCapabilities(ctx)
+}
+
+func conversationQuerySources(caps store.StoreSchemaCapabilities) []string {
+	sources := []string{}
+	if caps.Conversations.Sessions == store.SchemaFlavorCanonical {
+		sources = append(sources, `
+			SELECT
+				session_id::text AS session_id,
+				agent_id,
+				'live_session' AS kind,
+				scope_key,
+				scope,
+				runtime_mode,
+				status,
+				turn_count,
+				runtime_state,
+				conversation,
+				updated_at,
+				created_at
+			FROM agent_sessions
+			WHERE status = 'active'
+			  AND runtime_mode IN ('session', 'session_per_entity')
+		`)
+	}
+	if caps.Conversations.Audits == store.SchemaFlavorCanonical {
+		sources = append(sources, `
+			SELECT
+				session_id::text AS session_id,
+				agent_id,
+				'turn_audit' AS kind,
+				scope_key,
+				scope,
+				runtime_mode,
+				status,
+				turn_count,
+				runtime_state,
+				conversation,
+				updated_at,
+				created_at
+			FROM agent_conversation_audits
+			WHERE status = 'active'
+		`)
+	}
+	return sources
 }
 
 func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -84,12 +84,12 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 	return out, nil
 }
 
-func (r *SQLConversationReader) Get(ctx context.Context, agentID string) (ConversationDetail, bool, error) {
+func (r *SQLConversationReader) Get(ctx context.Context, sessionID string) (ConversationDetail, bool, error) {
 	if r == nil || r.db == nil {
 		return ConversationDetail{}, false, nil
 	}
-	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
 		return ConversationDetail{}, false, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -117,10 +117,9 @@ func (r *SQLConversationReader) Get(ctx context.Context, agentID string) (Conver
 		FROM (
 			%s
 		) conversations
-		WHERE agent_id = $1
-		ORDER BY updated_at DESC, created_at DESC
+		WHERE session_id = $1
 		LIMIT 1
-	`, strings.Join(sources, "\nUNION ALL\n")), agentID)
+	`, strings.Join(sources, "\nUNION ALL\n")), sessionID)
 
 	item, err := scanConversationDetail(row)
 	if err == sql.ErrNoRows {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -33,7 +33,9 @@ type InstanceReader interface {
 }
 
 type ConversationSummary struct {
+	SessionID   string         `json:"session_id,omitempty"`
 	AgentID     string         `json:"agent_id"`
+	Kind        string         `json:"kind,omitempty"`
 	ScopeKey    string         `json:"scope_key,omitempty"`
 	Scope       string         `json:"scope,omitempty"`
 	RuntimeMode string         `json:"runtime_mode,omitempty"`
@@ -47,6 +49,7 @@ type ConversationSummary struct {
 type ConversationDetail struct {
 	AgentID      string             `json:"agent_id"`
 	SessionID    string             `json:"session_id,omitempty"`
+	Kind         string             `json:"kind,omitempty"`
 	ScopeKey     string             `json:"scope_key,omitempty"`
 	Scope        string             `json:"scope,omitempty"`
 	RuntimeMode  string             `json:"runtime_mode,omitempty"`

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -95,7 +95,7 @@ type ConversationTurn struct {
 
 type ConversationReader interface {
 	List(ctx context.Context, limit int) ([]ConversationSummary, error)
-	Get(ctx context.Context, agentID string) (ConversationDetail, bool, error)
+	Get(ctx context.Context, sessionID string) (ConversationDetail, bool, error)
 }
 
 type ObservabilityReader interface {
@@ -166,7 +166,7 @@ func NewHandler(opts Options) http.Handler {
 	mux.HandleFunc("POST /api/agents/{id}/actions/restart", h.handleAgentRestart)
 	mux.HandleFunc("POST /api/agents/{id}/actions/replay", h.handleAgentReplay)
 	mux.HandleFunc("GET /api/conversations", h.handleConversations)
-	mux.HandleFunc("GET /api/conversations/{agentID}", h.handleConversationDetail)
+	mux.HandleFunc("GET /api/conversations/{sessionID}", h.handleConversationDetail)
 	mux.HandleFunc("GET /api/events", h.handleEvents)
 	mux.HandleFunc("GET /api/events/flow", h.handleFlowEvents)
 	mux.HandleFunc("GET /api/events/{id}", h.handleEventDetail)
@@ -432,12 +432,12 @@ func (h *Handler) handleConversationDetail(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusNotImplemented, errors.New("conversation reader is not configured"))
 		return
 	}
-	agentID := strings.TrimSpace(r.PathValue("agentID"))
-	if agentID == "" {
-		writeJSONError(w, http.StatusBadRequest, errors.New("agent id is required"))
+	sessionID := strings.TrimSpace(r.PathValue("sessionID"))
+	if sessionID == "" {
+		writeJSONError(w, http.StatusBadRequest, errors.New("session id is required"))
 		return
 	}
-	row, ok, err := h.conversations.Get(r.Context(), agentID)
+	row, ok, err := h.conversations.Get(r.Context(), sessionID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -402,6 +402,7 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
 			Turns:      store.SchemaFlavorCanonical,
 			TurnBlocks: false,
 		},
@@ -412,11 +413,11 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	toolCallsPayload := `[{"name":"schedule","arguments":{"delay_seconds":1209600}}]`
 	responsePayload := `{"result":"14-day review scheduled.","raw":"{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"status\\\":\\\"scheduled\\\"}\"}]}]}}\n{\"type\":\"result\",\"result\":\"14-day review scheduled.\"}"}`
 
-	mock.ExpectQuery("SELECT\\s+agent_id,.*FROM agent_sessions").
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
 		WithArgs(25).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("agent-1", "global", "global", "session", "active", 3, []byte(summaryState), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), now))
 
 	items, err := reader.List(context.Background(), 25)
 	if err != nil {
@@ -425,15 +426,18 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	if len(items) != 1 || items[0].AgentID != "agent-1" || items[0].Summary != "brief" {
 		t.Fatalf("unexpected summaries: %+v", items)
 	}
+	if items[0].SessionID != "sess-1" || items[0].Kind != "live_session" {
+		t.Fatalf("unexpected summary identity: %+v", items[0])
+	}
 	if items[0].Metadata["provider_session_id"] != "sess-1" {
 		t.Fatalf("expected metadata to retain provider_session_id: %+v", items[0].Metadata)
 	}
 
-	mock.ExpectQuery("SELECT\\s+session_id::text,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM agent_sessions").
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
 		WithArgs("agent-1").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
-		}).AddRow("sess-1", "agent-1", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
 
 	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
 		WithArgs("agent-1", "sess-1").
@@ -456,6 +460,9 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 	if item.AgentID != "agent-1" || item.SessionID != "sess-1" || len(item.Messages) != 1 || len(item.Turns) != 1 {
 		t.Fatalf("unexpected detail: %+v", item)
+	}
+	if item.Kind != "live_session" {
+		t.Fatalf("expected live_session detail kind, got %+v", item)
 	}
 	lastTurn, ok := item.RuntimeState["last_turn"].(map[string]any)
 	if !ok || lastTurn["parse_ok"] != true {
@@ -482,6 +489,7 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
 			Turns:      store.SchemaFlavorCanonical,
 			TurnBlocks: true,
 		},
@@ -497,11 +505,11 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 		{"kind":"outcome","text":"14-day review scheduled."}
 	]`
 
-	mock.ExpectQuery("SELECT\\s+session_id::text,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM agent_sessions").
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
 		WithArgs("agent-1").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
-		}).AddRow("sess-1", "agent-1", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
 
 	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
 		WithArgs("agent-1", "sess-1").
@@ -541,6 +549,71 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	}
 }
 
+func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Audits: store.SchemaFlavorCanonical,
+			Turns:  store.SchemaFlavorCanonical,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"one-shot","last_turn":{"parse_ok":true}}`
+	messagePayload := `[{"role":"assistant","content":"done"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+		WithArgs(10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
+		}).AddRow("audit-1", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), now))
+
+	items, err := reader.List(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("list conversations: %v", err)
+	}
+	if len(items) != 1 || items[0].Kind != "turn_audit" || items[0].RuntimeMode != "task" || items[0].SessionID != "audit-1" {
+		t.Fatalf("unexpected audit summaries: %+v", items)
+	}
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("agent-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("audit-1", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "audit-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "audit-1", "task", "", "", "evt-1", "task.run", "task-1",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[]`), true, 25, 0, "", now,
+		))
+
+	item, ok, err := reader.Get(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if !ok || item.Kind != "turn_audit" || item.RuntimeMode != "task" || item.SessionID != "audit-1" {
+		t.Fatalf("unexpected task audit detail: %+v", item)
+	}
+	if len(item.Messages) != 1 || len(item.Turns) != 1 || item.Turns[0].Outcome != "done" {
+		t.Fatalf("unexpected task audit payload: %+v", item)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetMissing(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -548,8 +621,13 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, stubConversationCaps{})
-	mock.ExpectQuery("SELECT\\s+session_id::text,.*FROM agent_sessions").
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+			Audits:   store.SchemaFlavorCanonical,
+		},
+	}})
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
 		WithArgs("missing-agent").
 		WillReturnError(sql.ErrNoRows)
 
@@ -572,16 +650,20 @@ func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
 	}
 	defer db.Close()
 
-	reader := NewSQLConversationReader(db, stubConversationCaps{})
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+		},
+	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
 
-	mock.ExpectQuery("SELECT\\s+session_id::text,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM agent_sessions").
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
 		WithArgs("agent-1").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
-		}).AddRow("sess-1", "agent-1", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
 
 	item, ok, err := reader.Get(context.Background(), "agent-1")
 	if err != nil {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -61,16 +61,16 @@ func (s stubInstances) Load(_ context.Context, instanceID string) (runtimepipeli
 }
 
 type stubConversations struct {
-	list    []ConversationSummary
-	byAgent map[string]ConversationDetail
+	list      []ConversationSummary
+	bySession map[string]ConversationDetail
 }
 
 func (s stubConversations) List(context.Context, int) ([]ConversationSummary, error) {
 	return s.list, nil
 }
 
-func (s stubConversations) Get(_ context.Context, agentID string) (ConversationDetail, bool, error) {
-	item, ok := s.byAgent[agentID]
+func (s stubConversations) Get(_ context.Context, sessionID string) (ConversationDetail, bool, error) {
+	item, ok := s.bySession[sessionID]
 	return item, ok, nil
 }
 
@@ -210,9 +210,10 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 				Summary:   "summarized",
 				UpdatedAt: now.Format(time.RFC3339),
 			}},
-			byAgent: map[string]ConversationDetail{
-				"agent-1": {
+			bySession: map[string]ConversationDetail{
+				"sess-1": {
 					AgentID:   "agent-1",
+					SessionID: "sess-1",
 					UpdatedAt: now.Format(time.RFC3339),
 					Messages:  []any{map[string]any{"role": "assistant", "content": "hi"}},
 					Turns: []ConversationTurn{{
@@ -277,7 +278,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/api/conversations/agent-1", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/conversations/sess-1", nil)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("conversation detail status=%d body=%s", rec.Code, rec.Body.String())
@@ -434,7 +435,7 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
-		WithArgs("agent-1").
+		WithArgs("sess-1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
 		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
@@ -451,7 +452,7 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 			[]byte(`{"message":{"content":"dispatch"}}`), []byte(responsePayload), []byte(`[]`), true, 92282, 0, "", now,
 		))
 
-	item, ok, err := reader.Get(context.Background(), "agent-1")
+	item, ok, err := reader.Get(context.Background(), "sess-1")
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}
@@ -506,7 +507,7 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	]`
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
-		WithArgs("agent-1").
+		WithArgs("sess-1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
 		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
@@ -523,7 +524,7 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"stale fallback text"}`), []byte(turnBlocksPayload), true, 92282, 0, "", now,
 		))
 
-	item, ok, err := reader.Get(context.Background(), "agent-1")
+	item, ok, err := reader.Get(context.Background(), "sess-1")
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}
@@ -581,7 +582,7 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 	}
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
-		WithArgs("agent-1").
+		WithArgs("audit-1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
 		}).AddRow("audit-1", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), []byte(messagePayload), now))
@@ -598,7 +599,7 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[]`), true, 25, 0, "", now,
 		))
 
-	item, ok, err := reader.Get(context.Background(), "agent-1")
+	item, ok, err := reader.Get(context.Background(), "audit-1")
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}
@@ -607,6 +608,54 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 	}
 	if len(item.Messages) != 1 || len(item.Turns) != 1 || item.Turns[0].Outcome != "done" {
 		t.Fatalf("unexpected task audit payload: %+v", item)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetUsesSessionIDNotAgentID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Audits: store.SchemaFlavorCanonical,
+			Turns:  store.SchemaFlavorCanonical,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"older audit"}`
+	messagePayload := `[{"role":"assistant","content":"older"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("audit-older").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("audit-older", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "audit-older").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "audit-older", "task", "", "", "evt-1", "task.run", "task-1",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"older"}`), []byte(`[]`), true, 25, 0, "", now,
+		))
+
+	item, ok, err := reader.Get(context.Background(), "audit-older")
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if !ok || item.SessionID != "audit-older" || item.Summary != "older audit" {
+		t.Fatalf("unexpected detail: %+v", item)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -628,10 +677,10 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 		},
 	}})
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
-		WithArgs("missing-agent").
+		WithArgs("missing-session").
 		WillReturnError(sql.ErrNoRows)
 
-	_, ok, err := reader.Get(context.Background(), "missing-agent")
+	_, ok, err := reader.Get(context.Background(), "missing-session")
 	if err != nil {
 		t.Fatalf("expected nil error for missing conversation, got %v", err)
 	}
@@ -660,12 +709,12 @@ func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
-		WithArgs("agent-1").
+		WithArgs("sess-1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
 		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
 
-	item, ok, err := reader.Get(context.Background(), "agent-1")
+	item, ok, err := reader.Get(context.Background(), "sess-1")
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -68,10 +68,11 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID, runtimeMode, l
 		FROM agent_sessions
 		WHERE agent_id = $1
 		  AND scope_key = $2
+		  AND runtime_mode = $3
 		ORDER BY created_at DESC
 		LIMIT 1
 		FOR UPDATE
-	`, agentID, resolved.ScopeKey).Scan(
+	`, agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(
 		&r.sessionID,
 		&r.scopeKey,
 		&r.status,
@@ -135,8 +136,9 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID, runtimeMode, l
 			    updated_at = now()
 			WHERE agent_id = $8
 			  AND scope_key = $9
+			  AND runtime_mode = $10
 			RETURNING session_id::text, scope_key, lease_expires_at
-		`, sessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, lockOwner, now.Add(sr.lockTTL), agentID, resolved.ScopeKey).Scan(&r.sessionID, &r.scopeKey, &expires); err != nil {
+		`, sessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, lockOwner, now.Add(sr.lockTTL), agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(&r.sessionID, &r.scopeKey, &expires); err != nil {
 			return nil, fmt.Errorf("reactivate session row: %w", err)
 		}
 		if err := tx.Commit(); err != nil {
@@ -240,11 +242,12 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID, runtimeMode, lo
 		FROM agent_sessions
 		WHERE agent_id = $1
 		  AND scope_key = $2
+		  AND runtime_mode = $3
 		  AND status = 'active'
 		ORDER BY created_at DESC
 		LIMIT 1
 		FOR UPDATE
-	`, agentID, resolved.ScopeKey).Scan(&currentSessionID, &existingOwner, &existingExpiry); err != nil {
+	`, agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(&currentSessionID, &existingOwner, &existingExpiry); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("no active session to rotate for agent=%s", agentID)
 		}
@@ -348,11 +351,12 @@ func (sr *PostgresRegistry) AdoptSessionID(ctx context.Context, agentID, runtime
 		FROM agent_sessions
 		WHERE agent_id = $1
 		  AND scope_key = $2
+		  AND runtime_mode = $3
 		  AND status = 'active'
 		ORDER BY created_at DESC
 		LIMIT 1
 		FOR UPDATE
-	`, agentID, resolved.ScopeKey).Scan(&sessionID, &existingOwner, &existingExpiry); err != nil {
+	`, agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(&sessionID, &existingOwner, &existingExpiry); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("no active session to adopt for agent=%s", agentID)
 		}
@@ -397,6 +401,9 @@ func (sr *PostgresRegistry) ScopeKeyEnabledForTest() bool {
 
 func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
 	runtimeMode = strings.TrimSpace(runtimeMode)
+	if runtimeMode != "" && IsStatelessRuntimeMode(runtimeMode) {
+		return nil
+	}
 	if runtimeMode == "" {
 		_, err := sr.db.Exec(`
 			UPDATE agent_sessions
@@ -405,6 +412,7 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
 			    lease_expires_at = NULL,
 			    updated_at = now()
 			WHERE status = 'active'
+			  AND runtime_mode IN ('session', 'session_per_entity')
 		`)
 		if err != nil {
 			return fmt.Errorf("reset all sessions: %w", err)

--- a/internal/runtime/sessions/postgres_test.go
+++ b/internal/runtime/sessions/postgres_test.go
@@ -22,7 +22,7 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
-		WithArgs("a1", "global").
+		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("INSERT INTO agent_sessions").
 		WithArgs(sqlmock.AnyArg(), "a1", "", "", "global", "global", "session", "owner-1", fixedNow.Add(30*time.Second)).
@@ -39,7 +39,7 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
-		WithArgs("a1", "global").
+		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "global", "active", nil, "owner-1", fixedNow.Add(30*time.Second)))
 	mock.ExpectQuery("UPDATE agent_sessions\\s+SET lease_holder = \\$1,").
@@ -86,7 +86,7 @@ func TestPostgresSessionRegistry_AcquireLeasedByOtherReturnsErrLeased(t *testing
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
-		WithArgs("a1", "global").
+		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "global", "active", nil, "someone-else", fixedNow.Add(10*time.Second)))
 
@@ -113,7 +113,7 @@ func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT session_id::text, lease_holder, lease_expires_at\\s+FROM agent_sessions").
-		WithArgs("a1", "global").
+		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "owner-1", fixedNow.Add(10*time.Second)))
 	mock.ExpectQuery("UPDATE agent_sessions\\s+SET session_id = \\$1::uuid,").
@@ -161,7 +161,7 @@ func TestPostgresSessionRegistry_AdoptSessionID(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT session_id::text, lease_holder, lease_expires_at\\s+FROM agent_sessions").
-		WithArgs("a1", "global").
+		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "owner-1", fixedNow.Add(10*time.Second)))
 	mock.ExpectExec("UPDATE agent_sessions\\s+SET runtime_state = COALESCE").
@@ -199,13 +199,13 @@ func TestPostgresSessionRegistry_ResetAll_TerminatesActiveSessions(t *testing.T)
 	defer db.Close()
 
 	sr := NewPostgresRegistry(db, 30*time.Second)
-	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'").
+	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'.*runtime_mode IN \\('session', 'session_per_entity'\\)").
 		WillReturnResult(sqlmock.NewResult(0, 2))
 	if err := sr.ResetAll(""); err != nil {
 		t.Fatalf("ResetAll(all runtimes): %v", err)
 	}
 
-	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'").
+	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'.*runtime_mode = \\$1").
 		WithArgs(RuntimeModeSession).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	if err := sr.ResetAll(RuntimeModeSession); err != nil {

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -76,20 +76,23 @@ func (sr *InMemoryRegistry) Acquire(_ context.Context, agentID, runtimeMode, loc
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
-	scopeKey = strings.TrimSpace(scopeKey)
+	resolved := ResolveScope(runtimeMode, scopeKey)
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
+	}
 
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
 	now := time.Now()
-	key := registryKey(agentID, runtimeMode, scopeKey)
+	key := registryKey(agentID, resolved.RuntimeMode, resolved.ScopeKey)
 	rec, ok := sr.byKey[key]
 	if !ok || rec.Status != "active" {
 		rec = &Record{
 			SessionID:   uuid.NewString(),
 			AgentID:     agentID,
-			RuntimeMode: runtimeMode,
-			ScopeKey:    scopeKey,
+			RuntimeMode: resolved.RuntimeMode,
+			ScopeKey:    resolved.ScopeKey,
 			Status:      "active",
 		}
 		sr.byKey[key] = rec
@@ -138,11 +141,15 @@ func (sr *InMemoryRegistry) Release(_ context.Context, lease *Lease) error {
 }
 
 func (sr *InMemoryRegistry) Rotate(_ context.Context, agentID, runtimeMode, lockOwner, summary, scopeKey string) (*Lease, error) {
+	resolved := ResolveScope(runtimeMode, scopeKey)
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
+	}
+
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
-	scopeKey = strings.TrimSpace(scopeKey)
-	key := registryKey(agentID, runtimeMode, scopeKey)
+	key := registryKey(agentID, resolved.RuntimeMode, resolved.ScopeKey)
 	rec, ok := sr.byKey[key]
 	if !ok {
 		return nil, fmt.Errorf("session for agent %s not found", agentID)
@@ -175,9 +182,14 @@ func (sr *InMemoryRegistry) Rotate(_ context.Context, agentID, runtimeMode, lock
 }
 
 func (sr *InMemoryRegistry) IncrementTurn(_ context.Context, agentID, runtimeMode, sessionID, scopeKey string) error {
+	resolved := ResolveScope(runtimeMode, scopeKey)
+	if resolved.Stateless {
+		return errors.New("task-scoped sessions are stateless")
+	}
+
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
-	key := registryKey(agentID, runtimeMode, strings.TrimSpace(scopeKey))
+	key := registryKey(agentID, resolved.RuntimeMode, resolved.ScopeKey)
 	if rec, ok := sr.byKey[key]; ok {
 		if rec.SessionID != sessionID {
 			return fmt.Errorf("session mismatch: have=%s want=%s", rec.SessionID, sessionID)
@@ -197,7 +209,10 @@ func (sr *InMemoryRegistry) AdoptSessionID(_ context.Context, agentID, runtimeMo
 	if agentID == "" || runtimeMode == "" || lockOwner == "" || newSessionID == "" {
 		return errors.New("agentID, runtimeMode, lockOwner, and newSessionID are required")
 	}
-	scopeKey = strings.TrimSpace(scopeKey)
+	resolved := ResolveScope(runtimeMode, scopeKey)
+	if resolved.Stateless {
+		return nil
+	}
 
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
@@ -210,10 +225,10 @@ func (sr *InMemoryRegistry) AdoptSessionID(_ context.Context, agentID, runtimeMo
 		if candidate == nil {
 			continue
 		}
-		if candidate.AgentID != agentID || candidate.RuntimeMode != runtimeMode {
+		if candidate.AgentID != agentID || candidate.RuntimeMode != resolved.RuntimeMode {
 			continue
 		}
-		if scopeKey != "" && candidate.ScopeKey != scopeKey {
+		if resolved.ScopeKey != "" && candidate.ScopeKey != resolved.ScopeKey {
 			continue
 		}
 		if candidate.LockOwner == lockOwner {
@@ -255,6 +270,9 @@ func (sr *InMemoryRegistry) Snapshot(agentID string) (*Record, bool) {
 
 func (sr *InMemoryRegistry) ResetAll(runtimeMode string) error {
 	runtimeMode = strings.TrimSpace(runtimeMode)
+	if runtimeMode != "" && IsStatelessRuntimeMode(runtimeMode) {
+		return nil
+	}
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	if runtimeMode == "" {

--- a/internal/runtime/sessions/registry_test.go
+++ b/internal/runtime/sessions/registry_test.go
@@ -65,3 +65,13 @@ func TestInMemorySessionRegistryAdoptSessionID(t *testing.T) {
 		t.Fatalf("expected adopted provider session id, got %q", rec.ProviderSessionID)
 	}
 }
+
+func TestInMemorySessionRegistry_TaskModeIsStateless(t *testing.T) {
+	sr := NewInMemoryRegistry(0)
+	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeTask, "worker-a", ""); err == nil {
+		t.Fatal("expected task mode acquire to reject stateless sessions")
+	}
+	if err := sr.ResetAll(RuntimeModeTask); err != nil {
+		t.Fatalf("ResetAll(task): %v", err)
+	}
+}

--- a/internal/runtime/sessions/scope.go
+++ b/internal/runtime/sessions/scope.go
@@ -62,6 +62,14 @@ func NormalizeConversationRuntimeMode(raw string) string {
 	}
 }
 
+func IsStatelessRuntimeMode(raw string) bool {
+	return NormalizeConversationRuntimeMode(raw) == RuntimeModeTask
+}
+
+func IsLiveSessionRuntimeMode(raw string) bool {
+	return !IsStatelessRuntimeMode(raw)
+}
+
 func ResolveScope(runtimeMode, scopeKey string) ResolvedScope {
 	mode := NormalizeConversationRuntimeMode(runtimeMode)
 	scopeKey = strings.TrimSpace(scopeKey)

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -98,6 +98,18 @@ func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string)
 	if _, err := tx.ExecContext(ctx, qSessions, agentID); err != nil {
 		return fmt.Errorf("mark agent terminated sessions: %w", err)
 	}
+	if caps.Conversations.Audits == SchemaFlavorCanonical {
+		const qConversationAudits = `
+			UPDATE agent_conversation_audits
+			SET status = 'terminated',
+			    updated_at = now()
+			WHERE agent_id = $1
+			  AND status = 'active'
+		`
+		if _, err := tx.ExecContext(ctx, qConversationAudits, agentID); err != nil {
+			return fmt.Errorf("mark agent terminated conversation audits: %w", err)
+		}
+	}
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("mark agent terminated commit: %w", err)

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -22,13 +22,30 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	if rec.AgentID == "" || rec.RuntimeMode == "" || rec.SessionID == "" {
 		return fmt.Errorf("agent_id, runtime_mode, and session_id are required")
 	}
-	if caps.Conversations.Sessions != SchemaFlavorCanonical {
-		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
-	}
 	if caps.Conversations.Turns != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
 	}
 	runtimeMode := runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode)
+	targetTable := "agent_sessions"
+	hasConversationRunID := caps.Conversations.SessionRunID
+	if runtimesessions.IsStatelessRuntimeMode(runtimeMode) {
+		if err := s.ensureConversationAuditTable(ctx); err != nil {
+			return err
+		}
+		caps, err = s.schemaCapabilities(ctx)
+		if err != nil {
+			return err
+		}
+		if caps.Conversations.Audits != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
+		}
+		targetTable = "agent_conversation_audits"
+		hasConversationRunID = caps.Conversations.AuditRunID
+	} else {
+		if caps.Conversations.Sessions != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+		}
+	}
 
 	reqPayload := normalizeJSONPayload(rec.RequestPayload)
 	respPayload := normalizeJSONPayload(rec.ResponseRaw)
@@ -45,8 +62,8 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	}
 	runID := strings.TrimSpace(rec.RunID)
 
-	updateQ := `
-		UPDATE agent_sessions
+	updateQ := fmt.Sprintf(`
+		UPDATE %s
 		SET runtime_state = COALESCE(runtime_state, '{}'::jsonb) || jsonb_build_object(
 				'last_turn',
 				jsonb_build_object(
@@ -65,7 +82,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		  AND runtime_mode = $2
 		  AND session_id = $3::uuid
 		  AND status = 'active'
-	`
+	`, targetTable)
 	updateArgs := []any{
 		rec.AgentID,
 		runtimeMode,
@@ -78,12 +95,12 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		rec.RetryCount,
 		rec.Error,
 	}
-	if caps.Conversations.SessionRunID {
+	if hasConversationRunID {
 		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 			return err
 		}
-		updateQ = `
-			UPDATE agent_sessions
+		updateQ = fmt.Sprintf(`
+			UPDATE %s
 			SET runtime_state = COALESCE(runtime_state, '{}'::jsonb) || jsonb_build_object(
 					'last_turn',
 					jsonb_build_object(
@@ -103,7 +120,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			  AND runtime_mode = $2
 			  AND session_id = $3::uuid
 			  AND status = 'active'
-		`
+		`, targetTable)
 		updateArgs = []any{
 			rec.AgentID,
 			runtimeMode,
@@ -127,7 +144,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		if runtimeMode == runtimesessions.RuntimeModeTask {
-			if err := s.ensureTaskAuditSessionRow(ctx, rec); err != nil {
+			if err := s.ensureTaskConversationAuditRow(ctx, rec); err != nil {
 				return err
 			}
 			res, err = s.DB.ExecContext(ctx, updateQ, updateArgs...)
@@ -137,7 +154,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			n, _ = res.RowsAffected()
 		}
 		if n == 0 {
-			return fmt.Errorf("no active session row found for agent=%s runtime=%s session=%s", rec.AgentID, rec.RuntimeMode, rec.SessionID)
+			return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, rec.RuntimeMode, rec.SessionID)
 		}
 	}
 
@@ -371,20 +388,24 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	return nil
 }
 
-func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
+func (s *PostgresStore) ensureTaskConversationAuditRow(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
 	}
-	if caps.Conversations.Sessions != SchemaFlavorCanonical {
-		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	if err := s.ensureConversationAuditTable(ctx); err != nil {
+		return err
+	}
+	caps, err = s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Audits != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 	}
 	scopeKey := strings.TrimSpace(rec.ScopeKey)
-	if scopeKey == "" {
-		scopeKey = strings.TrimSpace(rec.SessionID)
-	}
 	q := `
-		INSERT INTO agent_sessions (
+		INSERT INTO agent_conversation_audits (
 			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
 			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
 		)
@@ -393,7 +414,7 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 			$2,
 			NULLIF($3,'')::uuid,
 			NULL,
-			$4,
+			NULLIF($4, ''),
 			$5,
 			'[]'::jsonb,
 			0,
@@ -406,6 +427,7 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 		ON CONFLICT (session_id) DO UPDATE SET
 			agent_id = EXCLUDED.agent_id,
 			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
 			scope_key = EXCLUDED.scope_key,
 			scope = EXCLUDED.scope,
 			runtime_mode = EXCLUDED.runtime_mode,
@@ -420,12 +442,12 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 		"global",
 		runtimesessions.RuntimeModeTask,
 	}
-	if caps.Conversations.SessionRunID {
+	if caps.Conversations.AuditRunID {
 		if err := s.ensureRunRow(ctx, caps, nil, rec.RunID); err != nil {
 			return err
 		}
 		q = `
-			INSERT INTO agent_sessions (
+			INSERT INTO agent_conversation_audits (
 				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
 				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
 			)
@@ -435,7 +457,7 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 				$3,
 				NULLIF($4,'')::uuid,
 				NULL,
-				$5,
+				NULLIF($5, ''),
 				$6,
 				'[]'::jsonb,
 				0,
@@ -446,9 +468,10 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 				now()
 			)
 			ON CONFLICT (session_id) DO UPDATE SET
-				run_id = COALESCE(EXCLUDED.run_id, agent_sessions.run_id),
+				run_id = COALESCE(EXCLUDED.run_id, agent_conversation_audits.run_id),
 				agent_id = EXCLUDED.agent_id,
 				entity_id = EXCLUDED.entity_id,
+				flow_instance = EXCLUDED.flow_instance,
 				scope_key = EXCLUDED.scope_key,
 				scope = EXCLUDED.scope,
 				runtime_mode = EXCLUDED.runtime_mode,
@@ -468,7 +491,7 @@ func (s *PostgresStore) ensureTaskAuditSessionRow(ctx context.Context, rec runti
 	if _, err := s.DB.ExecContext(ctx, q,
 		args...,
 	); err != nil {
-		return fmt.Errorf("ensure task audit session row: %w", err)
+		return fmt.Errorf("ensure task conversation audit row: %w", err)
 	}
 	return nil
 }
@@ -501,15 +524,12 @@ func normalizeJSONObject(v any) string {
 }
 
 func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.ConversationRecord) error {
+	if strings.TrimSpace(rec.AgentID) == "" {
+		return fmt.Errorf("agent_id is required")
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
-	}
-	if caps.Conversations.Sessions != SchemaFlavorCanonical {
-		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
-	}
-	if strings.TrimSpace(rec.AgentID) == "" {
-		return fmt.Errorf("agent_id is required")
 	}
 	mode := runtimesessions.NormalizeConversationRuntimeMode(rec.Mode)
 	resolved := runtimesessions.ResolveScope(mode, rec.ScopeKey)
@@ -538,16 +558,23 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	runID := nullUUIDString(rec.RunID)
 
 	if resolved.Stateless {
-		scopeKey := strings.TrimSpace(rec.ScopeKey)
-		if scopeKey == "" {
-			scopeKey = sessionID
+		if err := s.ensureConversationAuditTable(ctx); err != nil {
+			return err
 		}
+		caps, err = s.schemaCapabilities(ctx)
+		if err != nil {
+			return err
+		}
+		if caps.Conversations.Audits != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
+		}
+		scopeKey := strings.TrimSpace(rec.ScopeKey)
 		scope := strings.TrimSpace(resolved.Scope)
 		if scope == "" {
 			scope = "global"
 		}
 		q := `
-			INSERT INTO agent_sessions (
+			INSERT INTO agent_conversation_audits (
 				session_id, agent_id, entity_id, flow_instance, scope_key, scope,
 				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
 			)
@@ -575,7 +602,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				conversation = EXCLUDED.conversation,
 				turn_count = EXCLUDED.turn_count,
 				runtime_mode = EXCLUDED.runtime_mode,
-				runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($10,'')),
+				runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($10,'')),
 				status = EXCLUDED.status,
 				updated_at = now()
 		`
@@ -592,12 +619,12 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			summary,
 			status,
 		}
-		if caps.Conversations.SessionRunID {
+		if caps.Conversations.AuditRunID {
 			if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 				return err
 			}
 			q = `
-				INSERT INTO agent_sessions (
+				INSERT INTO agent_conversation_audits (
 					session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
 					conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
 				)
@@ -618,7 +645,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 					now()
 				)
 				ON CONFLICT (session_id) DO UPDATE SET
-					run_id = COALESCE(EXCLUDED.run_id, agent_sessions.run_id),
+					run_id = COALESCE(EXCLUDED.run_id, agent_conversation_audits.run_id),
 					agent_id = EXCLUDED.agent_id,
 					entity_id = EXCLUDED.entity_id,
 					flow_instance = EXCLUDED.flow_instance,
@@ -627,7 +654,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 					conversation = EXCLUDED.conversation,
 					turn_count = EXCLUDED.turn_count,
 					runtime_mode = EXCLUDED.runtime_mode,
-					runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($11,'')),
+					runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($11,'')),
 					status = EXCLUDED.status,
 					updated_at = now()
 			`
@@ -650,6 +677,9 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			return fmt.Errorf("insert stateless conversation: %w", err)
 		}
 		return nil
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 	}
 
 	q := `
@@ -766,13 +796,6 @@ func nullUUIDString(raw string) string {
 }
 
 func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mode, scopeKey string) (runtimellm.ConversationRecord, bool, error) {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return runtimellm.ConversationRecord{}, false, err
-	}
-	if caps.Conversations.Sessions != SchemaFlavorCanonical {
-		return runtimellm.ConversationRecord{}, false, unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
-	}
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return runtimellm.ConversationRecord{}, false, fmt.Errorf("agent_id is required")
@@ -782,6 +805,13 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 	resolved := runtimesessions.ResolveScope(mode, scopeKey)
 	if resolved.Stateless {
 		return runtimellm.ConversationRecord{}, false, nil
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return runtimellm.ConversationRecord{}, false, unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 	}
 
 	const q = `

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -114,6 +114,9 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return fmt.Errorf("ensure agent_turns.turn_blocks column: %w", err)
 		}
 	}
+	if err := s.ensureConversationAuditTable(ctx); err != nil {
+		return err
+	}
 ensureEntityState:
 	if !catalog.hasTable("entity_state") {
 		return nil
@@ -128,4 +131,130 @@ ensureEntityState:
 	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *PostgresStore) ensureConversationAuditTable(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	hasAuditTable := catalog.hasTable("agent_conversation_audits")
+	hasAuditRunID := catalog.hasColumns("agent_conversation_audits", "run_id")
+	hasRunsTable := catalog.hasColumns("runs", "run_id")
+	if !hasAuditTable {
+		if _, err := s.DB.ExecContext(ctx, `
+			CREATE TABLE IF NOT EXISTS agent_conversation_audits (
+				session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				agent_id TEXT NOT NULL,
+				entity_id UUID,
+				flow_instance TEXT,
+				scope_key TEXT,
+				scope TEXT NOT NULL DEFAULT 'global',
+				conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+				turn_count INTEGER NOT NULL DEFAULT 0,
+				runtime_mode TEXT NOT NULL DEFAULT 'task',
+				runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+				status TEXT NOT NULL DEFAULT 'active',
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				CHECK (runtime_mode = 'task')
+			)
+		`); err != nil {
+			return fmt.Errorf("ensure agent_conversation_audits table: %w", err)
+		}
+		hasAuditTable = true
+	}
+	if hasRunsTable && !hasAuditRunID {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agent_conversation_audits ADD COLUMN IF NOT EXISTS run_id UUID REFERENCES runs(run_id)`); err != nil {
+			return fmt.Errorf("ensure agent_conversation_audits.run_id column: %w", err)
+		}
+		hasAuditRunID = true
+	}
+	for _, stmt := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_agent_conversation_audits_agent ON agent_conversation_audits(agent_id, updated_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_agent_conversation_audits_status ON agent_conversation_audits(status, updated_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_agent_conversation_audits_entity ON agent_conversation_audits(entity_id) WHERE entity_id IS NOT NULL`,
+	} {
+		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure agent_conversation_audits indexes: %w", err)
+		}
+	}
+	if hasAuditRunID {
+		if _, err := s.DB.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_agent_conversation_audits_run ON agent_conversation_audits(run_id, updated_at) WHERE run_id IS NOT NULL`); err != nil {
+			return fmt.Errorf("ensure agent_conversation_audits.run_id index: %w", err)
+		}
+	}
+	if err := s.migrateLegacyTaskConversationAudits(ctx); err != nil {
+		return err
+	}
+	_, err = s.BindSchemaCapabilities(ctx)
+	return err
+}
+
+func (s *PostgresStore) migrateLegacyTaskConversationAudits(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasTable("agent_sessions") || !catalog.hasTable("agent_conversation_audits") {
+		return nil
+	}
+	sessionHasRunID := catalog.hasColumns("agent_sessions", "run_id")
+	auditHasRunID := catalog.hasColumns("agent_conversation_audits", "run_id")
+	insert := `
+		INSERT INTO agent_conversation_audits (
+			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		SELECT
+			session_id, agent_id, entity_id, flow_instance, NULLIF(scope_key, ''), scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		FROM agent_sessions
+		WHERE runtime_mode = 'task'
+	`
+	if sessionHasRunID && auditHasRunID {
+		insert = `
+			INSERT INTO agent_conversation_audits (
+				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+			)
+			SELECT
+				session_id, run_id, agent_id, entity_id, flow_instance, NULLIF(scope_key, ''), scope,
+				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+			FROM agent_sessions
+			WHERE runtime_mode = 'task'
+		`
+	}
+	insert += `
+		ON CONFLICT (session_id) DO UPDATE SET
+			agent_id = EXCLUDED.agent_id,
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			scope_key = EXCLUDED.scope_key,
+			scope = EXCLUDED.scope,
+			conversation = EXCLUDED.conversation,
+			turn_count = EXCLUDED.turn_count,
+			runtime_mode = EXCLUDED.runtime_mode,
+			runtime_state = EXCLUDED.runtime_state,
+			status = EXCLUDED.status,
+			updated_at = EXCLUDED.updated_at
+	`
+	if auditHasRunID {
+		insert += `,
+			run_id = COALESCE(EXCLUDED.run_id, agent_conversation_audits.run_id)
+		`
+	}
+	if _, err := s.DB.ExecContext(ctx, insert); err != nil {
+		return fmt.Errorf("migrate task conversation audits: %w", err)
+	}
+	if _, err := s.DB.ExecContext(ctx, `DELETE FROM agent_sessions WHERE runtime_mode = 'task'`); err != nil {
+		return fmt.Errorf("delete legacy task sessions: %w", err)
+	}
+	return nil
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1348,8 +1348,8 @@ func TestManagerStore_Conversations_AndAgentTurns_PersistRunIDWhenColumnsExist(t
 	}
 
 	var gotSessionRunID, gotTurnRunID string
-	if err := db.QueryRowContext(ctx, `SELECT COALESCE(run_id::text, '') FROM agent_sessions WHERE session_id = $1::uuid`, sessionID).Scan(&gotSessionRunID); err != nil {
-		t.Fatalf("load session run_id: %v", err)
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(run_id::text, '') FROM agent_conversation_audits WHERE session_id = $1::uuid`, sessionID).Scan(&gotSessionRunID); err != nil {
+		t.Fatalf("load audit run_id: %v", err)
 	}
 	if err := db.QueryRowContext(ctx, `SELECT COALESCE(run_id::text, '') FROM agent_turns WHERE session_id = $1::uuid ORDER BY created_at DESC LIMIT 1`, sessionID).Scan(&gotTurnRunID); err != nil {
 		t.Fatalf("load turn run_id: %v", err)
@@ -1438,8 +1438,8 @@ func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *test
 	}
 
 	var count int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_sessions WHERE agent_id = 'a1' AND runtime_mode = 'task'`).Scan(&count); err != nil {
-		t.Fatalf("count task sessions: %v", err)
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_conversation_audits WHERE agent_id = 'a1' AND runtime_mode = 'task'`).Scan(&count); err != nil {
+		t.Fatalf("count task audits: %v", err)
 	}
 	if count != 1 {
 		t.Fatalf("expected one persisted task audit row, got %d", count)
@@ -1460,7 +1460,7 @@ func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *test
 	var parseOK bool
 	if err := db.QueryRowContext(ctx, `
 		SELECT COALESCE((runtime_state->'last_turn'->>'parse_ok')::boolean, false)
-		FROM agent_sessions
+		FROM agent_conversation_audits
 		WHERE session_id = $1::uuid
 	`, sessionID).Scan(&parseOK); err != nil {
 		t.Fatalf("load task runtime_state: %v", err)
@@ -1514,7 +1514,7 @@ func TestManagerStore_TaskConversationUpsertIsIdempotentBySessionID(t *testing.T
 	var count, turnCount int
 	if err := db.QueryRowContext(ctx, `
 		SELECT COUNT(*), COALESCE(MAX(turn_count), 0)
-		FROM agent_sessions
+		FROM agent_conversation_audits
 		WHERE session_id = $1::uuid
 	`, sessionID).Scan(&count, &turnCount); err != nil {
 		t.Fatalf("load task audit row: %v", err)
@@ -1550,8 +1550,8 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	var scope, scopeKey string
 	var parseOK bool
 	if err := db.QueryRowContext(ctx, `
-		SELECT scope, scope_key, COALESCE((runtime_state->'last_turn'->>'parse_ok')::boolean, false)
-		FROM agent_sessions
+		SELECT scope, COALESCE(scope_key, ''), COALESCE((runtime_state->'last_turn'->>'parse_ok')::boolean, false)
+		FROM agent_conversation_audits
 		WHERE session_id = $1::uuid
 	`, sessionID).Scan(&scope, &scopeKey, &parseOK); err != nil {
 		t.Fatalf("load synthesized task audit row: %v", err)
@@ -1559,8 +1559,8 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	if scope != "global" {
 		t.Fatalf("expected synthesized task audit scope=global, got %q", scope)
 	}
-	if scopeKey != sessionID {
-		t.Fatalf("expected synthesized task scope_key=%q, got %q", sessionID, scopeKey)
+	if scopeKey != "" {
+		t.Fatalf("expected synthesized task scope_key to stay empty, got %q", scopeKey)
 	}
 	if !parseOK {
 		t.Fatal("expected synthesized task audit row to record last_turn telemetry")
@@ -1584,7 +1584,7 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 		SELECT
 			COUNT(*),
 			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid AND runtime_mode = 'task')
-		FROM agent_sessions
+		FROM agent_conversation_audits
 		WHERE session_id = $1::uuid
 	`, sessionID).Scan(&count, &turns); err != nil {
 		t.Fatalf("count synthesized task persistence: %v", err)
@@ -1855,6 +1855,17 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed conversation: %v", err)
 	}
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: uuid.NewString(),
+		AgentID:   "agent-cleanup-1",
+		Mode:      "task",
+		Messages:  []llm.Message{{Role: "assistant", Content: "done"}},
+		Summary:   "task",
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("seed task audit: %v", err)
+	}
 	if err := pg.MarkAgentTerminated(ctx, "agent-cleanup-1"); err != nil {
 		t.Fatalf("MarkAgentTerminated: %v", err)
 	}
@@ -1862,6 +1873,7 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	var (
 		agentStatus string
 		sessStatus  string
+		auditStatus string
 	)
 	if err := db.QueryRowContext(ctx, `SELECT status FROM agents WHERE agent_id = $1`, "agent-cleanup-1").Scan(&agentStatus); err != nil {
 		t.Fatalf("read agent status: %v", err)
@@ -1869,11 +1881,17 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	if err := db.QueryRowContext(ctx, `SELECT status FROM agent_sessions WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1`, "agent-cleanup-1").Scan(&sessStatus); err != nil {
 		t.Fatalf("read session status: %v", err)
 	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM agent_conversation_audits WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1`, "agent-cleanup-1").Scan(&auditStatus); err != nil {
+		t.Fatalf("read audit status: %v", err)
+	}
 	if agentStatus != "terminated" {
 		t.Fatalf("expected terminated agent status, got %q", agentStatus)
 	}
 	if sessStatus != "terminated" {
 		t.Fatalf("expected terminated session status, got %q", sessStatus)
+	}
+	if auditStatus != "terminated" {
+		t.Fatalf("expected terminated audit status, got %q", auditStatus)
 	}
 }
 

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -28,8 +28,10 @@ type EventSchemaCapabilities struct {
 
 type ConversationSchemaCapabilities struct {
 	Sessions     SchemaFlavor
+	Audits       SchemaFlavor
 	Turns        SchemaFlavor
 	SessionRunID bool
+	AuditRunID   bool
 	TurnRunID    bool
 	TurnBlocks   bool
 }
@@ -165,6 +167,14 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			},
 			nil,
 		),
+		Audits: detectSchemaFlavor(catalog, "agent_conversation_audits",
+			[]string{
+				"session_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
+				"conversation", "turn_count", "runtime_mode", "runtime_state", "status",
+				"created_at", "updated_at",
+			},
+			nil,
+		),
 		Turns: detectSchemaFlavor(catalog, "agent_turns",
 			[]string{
 				"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id",
@@ -176,6 +186,7 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			nil,
 		),
 		SessionRunID: catalog.hasColumns("agent_sessions", "run_id"),
+		AuditRunID:   catalog.hasColumns("agent_conversation_audits", "run_id"),
 		TurnRunID:    catalog.hasColumns("agent_turns", "run_id"),
 		TurnBlocks:   catalog.hasColumns("agent_turns", "turn_blocks"),
 	}

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -44,6 +44,10 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
 		"lease_expires_at", "status", "created_at", "updated_at",
 	)
+	addColumns("agent_conversation_audits",
+		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
+		"conversation", "turn_count", "runtime_mode", "runtime_state", "status", "created_at", "updated_at",
+	)
 	addColumns("agent_turns",
 		"turn_id", "run_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id",
 		"trigger_event_id", "trigger_event_type", "task_id", "available_tools", "tool_calls",
@@ -80,6 +84,9 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	}
 	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
 		t.Fatalf("session caps = %+v", caps.Conversations)
+	}
+	if caps.Conversations.Audits != SchemaFlavorCanonical || !caps.Conversations.AuditRunID {
+		t.Fatalf("audit caps = %+v", caps.Conversations)
 	}
 	if caps.Conversations.Turns != SchemaFlavorCanonical || !caps.Conversations.TurnRunID || !caps.Conversations.TurnBlocks {
 		t.Fatalf("turn caps = %+v", caps.Conversations)


### PR DESCRIPTION
## What changed

This separates live session state from stateless audit persistence.

- `agent_sessions` now represents live session state only
- task mode no longer creates `agent_sessions` rows
- task-mode conversation snapshots now persist in `agent_conversation_audits`
- dashboard conversation readers query explicit live-session and audit sources instead of reconstructing meaning from mixed `agent_sessions` rows
- the branch platform spec and Markdown docs now reflect the split model

## Why

The previous model conflated two different concepts in `agent_sessions`:

- real live sessions
- task-mode observability/audit shims

That forced readers to infer row meaning from runtime mode and scope conventions. Issue #3 requires a clean semantic split so readers do not need hidden inference rules.

## Impact

- runtime/session semantics are explicit and simpler
- task mode is stateless in the session registry layer
- audit persistence is first-class instead of piggybacking on live-session storage
- dashboard readers expose explicit conversation `kind` semantics
- legacy task rows are migrated forward from `agent_sessions` into `agent_conversation_audits`

## Root cause removed

The old design stored both live session state and task-mode audit state in `agent_sessions`, then downstream readers reconstructed which rows were "real" sessions. This PR removes that mixed model rather than documenting or wrapping it.

## Validation

- `go test ./internal/runtime/sessions ./internal/store ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Notes

- This branch updates `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` from the reviewed `platform-spec.session-audit-split.yaml` draft to match the implemented semantics.
- The main migration risk is forward migration of legacy task-mode rows out of `agent_sessions` and into `agent_conversation_audits` on existing databases.
