### PR TITLE
[runtime improvement] Unify flow-instance entity-id derivation across runtime and store layers

### DIFF
--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -8,6 +8,8 @@ import (
 	"swarm/internal/runtime/semanticview"
 )
 
+var flowInstanceEntityNamespace = uuid.NewSHA1(uuid.NameSpaceOID, []byte("flow-instance-entity"))
+
 type Identity struct {
 	TemplateID   string
 	ScopeKey     string
@@ -42,17 +44,38 @@ func InstancePath(source semanticview.Source, flowID, instanceID string) string 
 	}
 }
 
-func EntityID(instancePath string) string {
-	ref := strings.Trim(strings.TrimSpace(instancePath), "/")
+func normalizeRef(ref string) string {
+	return strings.Trim(strings.TrimSpace(ref), "/")
+}
+
+func EntityID(ref string) string {
+	ref = normalizeRef(ref)
 	if ref == "" {
 		return ""
 	}
-	namespace := uuid.NewSHA1(uuid.NameSpaceOID, []byte("flow-instance-entity"))
-	return uuid.NewSHA1(namespace, []byte(ref)).String()
+	if parsed, err := uuid.Parse(ref); err == nil {
+		return parsed.String()
+	}
+	return uuid.NewSHA1(flowInstanceEntityNamespace, []byte(ref)).String()
+}
+
+func LookupKeys(ref string) []string {
+	ref = normalizeRef(ref)
+	if ref == "" {
+		return nil
+	}
+	keys := make([]string, 0, 2)
+	if parsed, err := uuid.Parse(ref); err == nil {
+		keys = append(keys, parsed.String())
+	}
+	if entityID := EntityID(ref); entityID != "" && !contains(keys, entityID) {
+		keys = append(keys, entityID)
+	}
+	return keys
 }
 
 func LogicalInstanceID(instancePath string) string {
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
+	instancePath = normalizeRef(instancePath)
 	if instancePath == "" {
 		return ""
 	}
@@ -77,7 +100,7 @@ func Derive(source semanticview.Source, flowID, instanceID string) Identity {
 }
 
 func SemanticScopeFromInstancePath(instancePath string) string {
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
+	instancePath = normalizeRef(instancePath)
 	if instancePath == "" {
 		return ""
 	}
@@ -128,4 +151,14 @@ func OwnedByScope(ownerScope, targetInstancePath string) bool {
 		return true
 	}
 	return ownerScope == targetScope
+}
+
+func contains(items []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, item := range items {
+		if strings.TrimSpace(item) == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -5,6 +5,63 @@ import (
 	"testing"
 )
 
+func TestEntityID_UsesCanonicalRefDerivation(t *testing.T) {
+	const uuidRef = "11111111-1111-1111-1111-111111111111"
+	if got := EntityID(uuidRef); got != uuidRef {
+		t.Fatalf("EntityID(%q) = %q, want preserved uuid", uuidRef, got)
+	}
+
+	if got := EntityID("child"); got == "" || got == "child" {
+		t.Fatalf("EntityID(child) = %q, want canonical hashed id", got)
+	}
+
+	pathID := EntityID("child/inst-1")
+	if pathID == "" || pathID == "child/inst-1" {
+		t.Fatalf("EntityID(child/inst-1) = %q, want canonical hashed id", pathID)
+	}
+	if got := EntityID("/child/inst-1/"); got != pathID {
+		t.Fatalf("EntityID(/child/inst-1/) = %q, want %q", got, pathID)
+	}
+}
+
+func TestLookupKeys_UsesCanonicalEntityID(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+		want []string
+	}{
+		{
+			name: "uuid ref",
+			ref:  "11111111-1111-1111-1111-111111111111",
+			want: []string{"11111111-1111-1111-1111-111111111111"},
+		},
+		{
+			name: "bare non-uuid ref",
+			ref:  "child",
+			want: []string{EntityID("child")},
+		},
+		{
+			name: "path ref",
+			ref:  "child/inst-1",
+			want: []string{EntityID("child/inst-1")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LookupKeys(tc.ref)
+			if len(got) != len(tc.want) {
+				t.Fatalf("LookupKeys(%q) len = %d, want %d (%v)", tc.ref, len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("LookupKeys(%q)[%d] = %q, want %q", tc.ref, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestSemanticScopeFromInstancePath(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -315,7 +315,7 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 		item.StorageRef = strings.TrimSpace(flowInstance)
 		item.InstanceID = workflowInstanceLogicalID(item.InstanceID, item.Metadata)
 		item.TransitionHistory = workflowInstanceTransitionHistory(item.Metadata)
-		timers, err := s.loadWorkflowTimersSpec(ctx, workflowInstanceRowID(item.StorageRef))
+		timers, err := s.loadWorkflowTimersSpec(ctx, runtimeflowidentity.EntityID(item.StorageRef))
 		if err != nil {
 			return nil, err
 		}
@@ -763,38 +763,15 @@ func workflowInstanceLogicalID(fallback string, metadata map[string]any) string 
 }
 
 func workflowInstanceLookupKeys(ref string) []string {
-	ref = strings.TrimSpace(ref)
-	if ref == "" {
-		return nil
-	}
-	keys := make([]string, 0, 2)
-	if parsed, err := uuid.Parse(ref); err == nil {
-		keys = append(keys, parsed.String())
-	}
-	if rowID := workflowInstanceRowID(ref); rowID != "" && !containsString(keys, rowID) {
-		keys = append(keys, rowID)
-	}
-	return keys
+	return runtimeflowidentity.LookupKeys(ref)
 }
 
 func workflowInstanceRowID(ref string) string {
-	ref = strings.TrimSpace(ref)
-	if ref == "" {
-		return ""
-	}
-	if strings.Contains(ref, "/") {
-		return runtimeflowidentity.EntityID(ref)
-	}
-	if !strings.Contains(ref, "/") {
-		if parsed, err := uuid.Parse(ref); err == nil {
-			return parsed.String()
-		}
-	}
-	return uuid.NewSHA1(workflowInstancePathNamespace, []byte(ref)).String()
+	return runtimeflowidentity.EntityID(ref)
 }
 
 func FlowInstanceEntityID(ref string) string {
-	return workflowInstanceRowID(ref)
+	return runtimeflowidentity.EntityID(ref)
 }
 
 func containsString(items []string, target string) bool {

--- a/internal/runtime/pipeline/workflow_instance_store_identity_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_identity_test.go
@@ -1,0 +1,41 @@
+package pipeline
+
+import (
+	"testing"
+
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+)
+
+func TestWorkflowInstanceStoreIdentityUsesCanonicalFlowIdentityOwner(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+	}{
+		{name: "uuid ref", ref: "11111111-1111-1111-1111-111111111111"},
+		{name: "bare non-uuid ref", ref: "child"},
+		{name: "path ref", ref: "child/inst-1"},
+		{name: "trimmed path ref", ref: "/child/inst-1/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := workflowInstanceRowID(tc.ref), runtimeflowidentity.EntityID(tc.ref); got != want {
+				t.Fatalf("workflowInstanceRowID(%q) = %q, want %q", tc.ref, got, want)
+			}
+			if got, want := FlowInstanceEntityID(tc.ref), runtimeflowidentity.EntityID(tc.ref); got != want {
+				t.Fatalf("FlowInstanceEntityID(%q) = %q, want %q", tc.ref, got, want)
+			}
+
+			got := workflowInstanceLookupKeys(tc.ref)
+			want := runtimeflowidentity.LookupKeys(tc.ref)
+			if len(got) != len(want) {
+				t.Fatalf("workflowInstanceLookupKeys(%q) len = %d, want %d (%v)", tc.ref, len(got), len(want), got)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("workflowInstanceLookupKeys(%q)[%d] = %q, want %q", tc.ref, i, got[i], want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- make `internal/runtime/core/flowidentity` the single owner for flow-instance entity-id derivation and lookup-key expansion
- remove the alternate namespace/hash derivation path from `internal/runtime/pipeline/workflow_instance_store.go`
- add focused tests for UUID refs, bare non-UUID refs, path-shaped refs, and canonical equality across runtime/store call sites

## Why
Runtime and store still had separate flow-instance entity-id derivation models. The store-side row-id path used a different namespace branch for some refs, which let edge cases disagree with the centralized flow identity model.

This change deletes that alternate path and routes both runtime and store through the same canonical owner.

## Validation
- `gofmt -l .`
- `go vet ./...`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated flow identity and reference handling logic into a centralized package to improve consistency across the runtime.
  * Streamlined internal reference normalization and lookup mechanisms.

* **Tests**
  * Added validation tests for canonicalized reference derivation and lookup key consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->