### PR TITLE
[runtime improvement] Add per-turn runtime flight recorder

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -554,83 +554,96 @@ func loadRunStatusReport(ctx context.Context, db *sql.DB, runID string, opts run
 	}
 
 	if report.RunID != "" {
-		logLevels := []string{"warn", "error"}
-		if opts.LogsAllLevels {
-			logLevels = []string{"info", "warn", "error"}
-		}
-		componentFilter := strings.TrimSpace(opts.Component)
-		if err := db.QueryRowContext(ctx, `
-			SELECT COUNT(*)
-			FROM events
-			WHERE event_name = 'platform.runtime_log'
-			  AND payload->>'run_id' = $1
-			  AND payload->>'level' = ANY($2::text[])
-			  AND ($3 = '' OR payload->>'component' = $3)
-		`, report.RunID, pq.Array(logLevels), componentFilter).Scan(&report.WarnErrorLogCount); err != nil {
-			return runStatusReport{}, fmt.Errorf("load runtime log summary: %w", err)
-		}
-		logSummaryRows, err := db.QueryContext(ctx, `
-			SELECT
-				COALESCE(payload->>'level', ''),
-				COALESCE(payload->>'component', ''),
-				COALESCE(payload->>'action', ''),
-				COUNT(*)
-			FROM events
-			WHERE event_name = 'platform.runtime_log'
-			  AND payload->>'run_id' = $1
-			  AND payload->>'level' = ANY($2::text[])
-			  AND ($3 = '' OR payload->>'component' = $3)
-			GROUP BY payload->>'level', payload->>'component', payload->>'action'
-			ORDER BY COUNT(*) DESC, payload->>'component', payload->>'action'
-			LIMIT 12
-		`, report.RunID, pq.Array(logLevels), componentFilter)
-		if err != nil {
-			return runStatusReport{}, fmt.Errorf("load runtime log rollup: %w", err)
-		}
-		defer logSummaryRows.Close()
-		for logSummaryRows.Next() {
-			var item runStatusRuntimeSummary
-			if err := logSummaryRows.Scan(&item.Level, &item.Component, &item.Action, &item.Count); err != nil {
-				return runStatusReport{}, fmt.Errorf("scan runtime log rollup: %w", err)
-			}
-			report.RuntimeLogSummary = append(report.RuntimeLogSummary, item)
-		}
-		if err := logSummaryRows.Err(); err != nil {
-			return runStatusReport{}, fmt.Errorf("read runtime log rollup: %w", err)
-		}
-		logRows, err := db.QueryContext(ctx, `
-			SELECT
-				COALESCE(payload->>'level', ''),
-				COALESCE(payload->>'component', ''),
-				COALESCE(payload->>'action', ''),
-				COALESCE(payload->>'error', ''),
-				created_at
-			FROM events
-			WHERE event_name = 'platform.runtime_log'
-			  AND payload->>'run_id' = $1
-			  AND payload->>'level' = ANY($2::text[])
-			  AND ($3 = '' OR payload->>'component' = $3)
-			ORDER BY created_at DESC
-			LIMIT $4
-		`, report.RunID, pq.Array(logLevels), componentFilter, logLimitForStatus(opts))
-		if err != nil {
-			return runStatusReport{}, fmt.Errorf("load runtime logs: %w", err)
-		}
-		defer logRows.Close()
-		for logRows.Next() {
-			var item runStatusRuntimeLog
-			if err := logRows.Scan(&item.Level, &item.Component, &item.Action, &item.Error, &item.CreatedAt); err != nil {
-				return runStatusReport{}, fmt.Errorf("scan runtime logs: %w", err)
-			}
-			report.RuntimeLogs = append(report.RuntimeLogs, item)
-		}
-		if err := logRows.Err(); err != nil {
-			return runStatusReport{}, fmt.Errorf("read runtime logs: %w", err)
+		if err := loadRunStatusRuntimeLogs(ctx, db, report.RunID, opts, &report); err != nil {
+			return runStatusReport{}, err
 		}
 	}
 	report.Heuristics = deriveRunStatusHeuristics(report)
 
 	return report, nil
+}
+
+func loadRunStatusRuntimeLogs(ctx context.Context, db *sql.DB, runID string, opts runStatusOptions, report *runStatusReport) error {
+	if db == nil {
+		return errors.New("db is required")
+	}
+	if report == nil {
+		return errors.New("report is required")
+	}
+	logLevels := []string{"warn", "error"}
+	if opts.LogsAllLevels {
+		logLevels = []string{"info", "warn", "error"}
+	}
+	componentFilter := strings.TrimSpace(opts.Component)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->'details'->>'run_id' = $1
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+	`, runID, pq.Array(logLevels), componentFilter).Scan(&report.WarnErrorLogCount); err != nil {
+		return fmt.Errorf("load runtime log summary: %w", err)
+	}
+	logSummaryRows, err := db.QueryContext(ctx, `
+		SELECT
+			COALESCE(payload->>'log_level', ''),
+			COALESCE(payload->'details'->>'component', ''),
+			COALESCE(payload->'details'->>'action', ''),
+			COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->'details'->>'run_id' = $1
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+		GROUP BY payload->>'log_level', payload->'details'->>'component', payload->'details'->>'action'
+		ORDER BY COUNT(*) DESC, payload->'details'->>'component', payload->'details'->>'action'
+		LIMIT 12
+	`, runID, pq.Array(logLevels), componentFilter)
+	if err != nil {
+		return fmt.Errorf("load runtime log rollup: %w", err)
+	}
+	defer logSummaryRows.Close()
+	for logSummaryRows.Next() {
+		var item runStatusRuntimeSummary
+		if err := logSummaryRows.Scan(&item.Level, &item.Component, &item.Action, &item.Count); err != nil {
+			return fmt.Errorf("scan runtime log rollup: %w", err)
+		}
+		report.RuntimeLogSummary = append(report.RuntimeLogSummary, item)
+	}
+	if err := logSummaryRows.Err(); err != nil {
+		return fmt.Errorf("read runtime log rollup: %w", err)
+	}
+	logRows, err := db.QueryContext(ctx, `
+		SELECT
+			COALESCE(payload->>'log_level', ''),
+			COALESCE(payload->'details'->>'component', ''),
+			COALESCE(payload->'details'->>'action', ''),
+			COALESCE(payload->'details'->>'error', ''),
+			created_at
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->'details'->>'run_id' = $1
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+		ORDER BY created_at DESC
+		LIMIT $4
+	`, runID, pq.Array(logLevels), componentFilter, logLimitForStatus(opts))
+	if err != nil {
+		return fmt.Errorf("load runtime logs: %w", err)
+	}
+	defer logRows.Close()
+	for logRows.Next() {
+		var item runStatusRuntimeLog
+		if err := logRows.Scan(&item.Level, &item.Component, &item.Action, &item.Error, &item.CreatedAt); err != nil {
+			return fmt.Errorf("scan runtime logs: %w", err)
+		}
+		report.RuntimeLogs = append(report.RuntimeLogs, item)
+	}
+	if err := logRows.Err(); err != nil {
+		return fmt.Errorf("read runtime logs: %w", err)
+	}
+	return nil
 }
 
 func logLimitForStatus(opts runStatusOptions) int {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
 )
@@ -71,6 +72,58 @@ func TestPrintRunStatusReport(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestLoadRunStatusRuntimeLogs_UsesSpecShapedPayload(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	summaryCount := sqlmock.NewRows([]string{"count"}).AddRow(2)
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM events`).
+		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor").
+		WillReturnRows(summaryCount)
+
+	rollupRows := sqlmock.NewRows([]string{"log_level", "component", "action", "count"}).
+		AddRow("warn", "tool-executor", "tool_execution_denied", 2)
+	mock.ExpectQuery(`SELECT\s+COALESCE\(payload->>'log_level', ''\)`).
+		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor").
+		WillReturnRows(rollupRows)
+
+	logRows := sqlmock.NewRows([]string{"log_level", "component", "action", "error", "created_at"}).
+		AddRow("warn", "tool-executor", "tool_execution_denied", "tool not allowed", time.Unix(1700000000, 0).UTC())
+	mock.ExpectQuery(`SELECT\s+COALESCE\(payload->>'log_level', ''\)`).
+		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor", 100).
+		WillReturnRows(logRows)
+
+	var report runStatusReport
+	err = loadRunStatusRuntimeLogs(context.Background(), db, "run-123", runStatusOptions{
+		LogsOnly:  true,
+		Component: "tool-executor",
+	}, &report)
+	if err != nil {
+		t.Fatalf("loadRunStatusRuntimeLogs: %v", err)
+	}
+	if report.WarnErrorLogCount != 2 {
+		t.Fatalf("WarnErrorLogCount = %d, want 2", report.WarnErrorLogCount)
+	}
+	if len(report.RuntimeLogSummary) != 1 {
+		t.Fatalf("RuntimeLogSummary len = %d, want 1", len(report.RuntimeLogSummary))
+	}
+	if got := report.RuntimeLogSummary[0]; got.Level != "warn" || got.Component != "tool-executor" || got.Action != "tool_execution_denied" || got.Count != 2 {
+		t.Fatalf("RuntimeLogSummary[0] = %#v", got)
+	}
+	if len(report.RuntimeLogs) != 1 {
+		t.Fatalf("RuntimeLogs len = %d, want 1", len(report.RuntimeLogs))
+	}
+	if got := report.RuntimeLogs[0]; got.Level != "warn" || got.Component != "tool-executor" || got.Action != "tool_execution_denied" || got.Error != "tool not allowed" {
+		t.Fatalf("RuntimeLogs[0] = %#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2431,9 +2431,11 @@ platform_tables:
         flow_instance or "global" depending on agent declaration.'
     agent_turns:
       description: 'Append-only per-turn agent execution audit log. Records the triggering event context, visible tools,
-        attempted tool calls, emitted event names, and sanitized request/response payloads. Used by all conversation modes.
-        For task mode, this is the primary per-turn audit record (no agent_sessions row exists). For session modes, this
-        complements the live session with a queryable historical record.'
+        attempted tool calls, emitted event names, canonical per-turn turn_blocks, and sanitized request/response payloads.
+        turn_blocks is the ordered per-turn projection/surface for the flight recorder. It is populated from the canonical
+        platform.runtime_log stream plus turn-local publish/tool transcript context. Used by all conversation modes. For
+        task mode, this is the primary per-turn audit record (no agent_sessions row exists). For session modes, this complements
+        the live session with a queryable historical record.'
       ddl: "CREATE TABLE agent_turns (\n    turn_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \             UUID REFERENCES runs(run_id),\n    agent_id           TEXT NOT NULL,\n    session_id         UUID\
         \ NOT NULL,\n    runtime_mode       TEXT NOT NULL DEFAULT 'task' CHECK (runtime_mode IN ('task', 'session', 'session_per_entity')),\n\
@@ -2441,7 +2443,7 @@ platform_tables:
         \   UUID,\n    trigger_event_type TEXT,\n    task_id            TEXT,\n    available_tools    JSONB NOT NULL DEFAULT\
         \ '[]',\n    tool_calls         JSONB NOT NULL DEFAULT '[]',\n    emitted_events     JSONB NOT NULL DEFAULT '[]',\n\
         \    mcp_servers        JSONB NOT NULL DEFAULT '{}',\n    mcp_tools_listed   JSONB NOT NULL DEFAULT '[]',\n    mcp_tools_visible\
-        \  JSONB NOT NULL DEFAULT '[]',\n    request_payload    JSONB,\n    response_payload   JSONB,\n    parse_ok      \
+        \  JSONB NOT NULL DEFAULT '[]',\n    request_payload    JSONB,\n    response_payload   JSONB,\n    turn_blocks      JSONB NOT NULL DEFAULT '[]',\n    parse_ok      \
         \     BOOLEAN NOT NULL DEFAULT FALSE,\n    latency_ms         INTEGER NOT NULL DEFAULT 0,\n    retry_count       \
         \ INTEGER NOT NULL DEFAULT 0,\n    error              TEXT,\n    created_at         TIMESTAMPTZ NOT NULL DEFAULT\
         \ NOW(),\n    INDEX idx_agent_turns_run (run_id, created_at) WHERE run_id IS NOT NULL,\n    INDEX idx_agent_turns_session\
@@ -2636,10 +2638,14 @@ platform_tables:
       produced_by_type: platform
       payload_fields:
         log_level: string (debug, info, warn, error, fatal)
-        component: string (boot, event_loop, timer_engine, agent_manager, etc.)
-        message: string
-        details: object (structured context)
+        message: human-readable summary written by the producer; not a machine key
+        details: object (structured source of truth; includes component, action, error, timing, and runtime context fields)
         stack_trace: string (for errors only)
+      design_rules:
+      - message is for humans; details is the machine-readable source of truth
+      - component and action live in details, not as top-level runtime_log fields
+      - error text lives in details.error; message may summarize the failure but is not the raw error string
+      - readers and debug UIs should filter and render structured runtime diagnostics from details
       note: 'Queryable via: SELECT * FROM events WHERE event_name = "platform.runtime_log" AND payload->>log_level = "error"'
     pipeline_transition_encoding:
       table: event_receipts

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1854,9 +1854,8 @@ CREATE TABLE schema_version (
 - `produced_by_type`: platform
 - `payload_fields`:
   - `log_level`: string (debug, info, warn, error, fatal)
-  - `component`: string (boot, event_loop, timer_engine, agent_manager, etc.)
-  - `message`: string
-  - `details`: object (structured context)
+  - `message`: human-readable summary written by the producer; not a machine key
+  - `details`: structured source of truth; includes component, action, error, timing, and runtime context fields
   - `stack_trace`: string (for errors only)
 
 - `note`: Queryable via: SELECT * FROM events WHERE event_name = "platform.runtime_log" AND payload->>log_level = "error"

--- a/internal/builder/runs.go
+++ b/internal/builder/runs.go
@@ -728,9 +728,9 @@ type runtimeLoggerHook struct {
 	hub  *runHub
 }
 
-func (h runtimeLoggerHook) Log(ctx context.Context, level, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
+func (h runtimeLoggerHook) Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
 	entry := runtimepkg.RuntimeLogEntry{
-		Level: level, Component: component, Action: action, EventID: eventID, EventType: eventType,
+		Level: level, Message: message, Component: component, Action: action, EventID: eventID, EventType: eventType,
 		AgentID: agentID, EntityID: entityID, SessionID: sessionID, Correlation: correlation,
 		Detail: detail, Error: errText, DurationUS: durationUS,
 	}

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -297,32 +297,32 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	query := fmt.Sprintf(`
 		SELECT
 			e.event_id::text,
-			COALESCE(e.payload->>'event_id', ''),
+			COALESCE(e.payload->'details'->>'event_id', ''),
 			e.created_at,
-			COALESCE(e.payload->>'level', ''),
-			COALESCE(e.payload->>'component', ''),
-			COALESCE(e.payload->>'action', ''),
-			COALESCE(e.payload->>'event_type', ''),
-			COALESCE(e.payload->>'parent_event_id', COALESCE(e.payload->'detail'->>'parent_event_id', '')),
-			COALESCE(e.payload->>'handler_id', COALESCE(e.payload->'detail'->>'handler_id', '')),
-			COALESCE(e.payload->>'error', ''),
-			COALESCE(e.payload->'detail'->>'error_code', ''),
-			COALESCE(e.payload->>'agent_id', ''),
-			COALESCE(e.payload->>'agent_id', ''),
-			COALESCE(e.payload->>'entity_id', ''),
-			COALESCE(e.payload->>'session_id', ''),
-			COALESCE(NULLIF(e.payload->>'duration_us', ''), '0')::int,
-			COALESCE(e.payload->'detail', '{}'::jsonb),
-			COALESCE(e.payload->'correlation', '{}'::jsonb),
-			COALESCE(e.payload->'detail'->>'message', COALESCE(e.payload->>'error', COALESCE(e.payload->>'action', COALESCE(e.payload->>'event_type', ''))))
+			COALESCE(e.payload->>'log_level', ''),
+			COALESCE(e.payload->'details'->>'component', ''),
+			COALESCE(e.payload->'details'->>'action', ''),
+			COALESCE(e.payload->'details'->>'event_name', COALESCE(e.payload->'details'->>'event_type', '')),
+			COALESCE(e.payload->'details'->>'parent_event_id', ''),
+			COALESCE(e.payload->'details'->>'handler_id', ''),
+			COALESCE(e.payload->'details'->>'error', ''),
+			COALESCE(e.payload->'details'->>'error_code', ''),
+			COALESCE(e.payload->'details'->>'agent_id', ''),
+			COALESCE(e.payload->'details'->>'agent_id', ''),
+			COALESCE(e.payload->'details'->>'entity_id', ''),
+			COALESCE(e.payload->'details'->>'session_id', ''),
+			COALESCE(NULLIF(e.payload->'details'->>'duration_us', ''), '0')::int,
+			COALESCE(e.payload->'details', '{}'::jsonb),
+			COALESCE(e.payload->'details'->'correlation', '{}'::jsonb),
+			COALESCE(e.payload->>'message', '')
 		FROM events e
 		WHERE e.event_name = 'platform.runtime_log'
-		  AND ($1 = '' OR COALESCE(e.payload->>'event_type', '') = $1 OR COALESCE(e.payload->>'action', '') = $1)
-		  AND ($2 = '' OR COALESCE(e.payload->>'agent_id', '') = $2)
-		  AND ($3 = '' OR COALESCE(e.payload->>'entity_id', '') = $3)
-		  AND ($4 = '' OR COALESCE(e.payload->>'component', '') = $4)
-		  AND ($5 = '' OR COALESCE(e.payload->>'level', '') = $5)
-		  AND ($6 = '' OR COALESCE(e.payload->'detail'->>'error_code', '') = $6)
+		  AND ($1 = '' OR COALESCE(e.payload->'details'->>'event_name', COALESCE(e.payload->'details'->>'event_type', '')) = $1 OR COALESCE(e.payload->'details'->>'action', '') = $1)
+		  AND ($2 = '' OR COALESCE(e.payload->'details'->>'agent_id', '') = $2)
+		  AND ($3 = '' OR COALESCE(e.payload->'details'->>'entity_id', '') = $3)
+		  AND ($4 = '' OR COALESCE(e.payload->'details'->>'component', '') = $4)
+		  AND ($5 = '' OR COALESCE(e.payload->>'log_level', '') = $5)
+		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'error_code', '') = $6)
 		  AND ($7::timestamptz IS NULL OR e.created_at > $7)
 		ORDER BY e.created_at %s
 		LIMIT $8
@@ -385,20 +385,20 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 	rows, err := r.db.QueryContext(ctx, `
 		WITH logs AS (
 			SELECT
-				COALESCE(e.payload->'detail'->>'error_code', '') AS code,
-				COALESCE(e.payload->>'component', '') AS component,
-				COALESCE(e.payload->>'level', '') AS level,
-				COALESCE(e.payload->>'agent_id', '') AS agent_id,
-				COALESCE(e.payload->>'action', '') AS action,
-				COALESCE(e.payload->>'error', COALESCE(e.payload->'detail'->>'message', '')) AS error,
+				COALESCE(e.payload->'details'->>'error_code', '') AS code,
+				COALESCE(e.payload->'details'->>'component', '') AS component,
+				COALESCE(e.payload->>'log_level', '') AS level,
+				COALESCE(e.payload->'details'->>'agent_id', '') AS agent_id,
+				COALESCE(e.payload->'details'->>'action', '') AS action,
+				COALESCE(e.payload->'details'->>'error', COALESCE(e.payload->>'message', '')) AS error,
 				e.created_at
 			FROM events e
 			WHERE e.event_name = 'platform.runtime_log'
 			  AND e.created_at >= now() - make_interval(hours => $1)
-			  AND COALESCE(e.payload->'detail'->>'error_code', '') <> ''
-			  AND ($2 = '' OR COALESCE(e.payload->>'level', '') = $2)
-			  AND ($3 = '' OR COALESCE(e.payload->>'component', '') = $3)
-			  AND ($4 = FALSE OR COALESCE(e.payload->>'component', '') LIKE 'mcp%%')
+			  AND COALESCE(e.payload->'details'->>'error_code', '') <> ''
+			  AND ($2 = '' OR COALESCE(e.payload->>'log_level', '') = $2)
+			  AND ($3 = '' OR COALESCE(e.payload->'details'->>'component', '') = $3)
+			  AND ($4 = FALSE OR COALESCE(e.payload->'details'->>'component', '') LIKE 'mcp%%')
 		)
 		SELECT
 			code,

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -253,6 +253,19 @@ func (eb *EventBus) WaitForQuiescence(ctx context.Context) error {
 	}
 }
 
+func (eb *EventBus) PendingAgentDeliveries() int {
+	if eb == nil {
+		return 0
+	}
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	pending := 0
+	for _, ch := range eb.agentChans {
+		pending += len(ch)
+	}
+	return pending
+}
+
 func (eb *EventBus) Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event {
 	ch := make(chan events.Event, 128)
 	eb.mu.Lock()

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -364,7 +364,7 @@ func (eb *EventBus) publishDeferredNoIntercept(ctx context.Context, evt events.E
 }
 
 func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, durationUS int) {
-	eb.logRuntime(ctx, "debug", "eventbus", "published", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+	eb.logRuntime(ctx, "debug", "Event was published to the event bus", "eventbus", "published", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
 		"type":            string(evt.Type),
 		"source":          evt.SourceAgent,
 		"parent_event_id": strings.TrimSpace(evt.ParentEventID),
@@ -448,7 +448,7 @@ func (eb *EventBus) logDelivery(ctx context.Context, evt events.Event, recipient
 	for k, v := range extra {
 		detail[k] = v
 	}
-	eb.logRuntime(ctx, "debug", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, detail, "", 0)
+	eb.logRuntime(ctx, "debug", "Event was delivered to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, detail, "", 0)
 }
 
 func subscriberIDs(in []Subscriber) []string {
@@ -616,7 +616,7 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	}
 	persisted = true
 	eb.deliverToAgents(ctx, evt, recipients)
-	eb.logRuntime(ctx, "debug", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
+	eb.logRuntime(ctx, "debug", "Event was delivered directly to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
 		"direct":           true,
 		"recipients_count": len(recipients),
 		"parent_event_id":  strings.TrimSpace(evt.ParentEventID),

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -161,7 +161,7 @@ type recordedLogEntry struct {
 	Detail any
 }
 
-func (h *recordingLoggerHook) Log(_ context.Context, _, _, action, _, _, _, _, _ string, _ map[string]string, detail any, _ string, _ int) {
+func (h *recordingLoggerHook) Log(_ context.Context, _, _, _, action, _, _, _, _, _ string, _ map[string]string, detail any, _ string, _ int) {
 	h.entries = append(h.entries, recordedLogEntry{Action: action, Detail: detail})
 }
 

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -92,7 +92,7 @@ func (eb *EventBus) deliverToAgents(ctx context.Context, evt events.Event, agent
 		case <-ctx.Done():
 			return
 		case <-time.After(deliverySendTimeout):
-			eb.logRuntime(ctx, "warn", "eventbus", "delivery_timeout", evt.ID, string(evt.Type), recipient.agentID, evt.EntityID(), "", nil, map[string]any{
+			eb.logRuntime(ctx, "warn", "Event delivery to a recipient timed out", "eventbus", "delivery_timeout", evt.ID, string(evt.Type), recipient.agentID, evt.EntityID(), "", nil, map[string]any{
 				"timeout_ms": int(deliverySendTimeout / time.Millisecond),
 			}, "", 0)
 		}
@@ -220,7 +220,7 @@ func filterOutEntityScopedAgentIDs(in []string, entityID string) []string {
 }
 
 func (eb *EventBus) emitContradiction(ctx context.Context, source events.Event, reason string) error {
-	eb.logRuntime(ctx, "warn", "eventbus", "contradiction", strings.TrimSpace(source.ID), strings.TrimSpace(string(source.Type)), "", strings.TrimSpace(source.EntityID()), "", nil, map[string]any{
+	eb.logRuntime(ctx, "warn", "Event routing contradiction was detected", "eventbus", "contradiction", strings.TrimSpace(source.ID), strings.TrimSpace(string(source.Type)), "", strings.TrimSpace(source.EntityID()), "", nil, map[string]any{
 		"reason": strings.TrimSpace(reason),
 	}, "", 0)
 	return nil
@@ -239,13 +239,13 @@ func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, er
 		return
 	}
 	if err := recorder.UpsertPipelineReceipt(ctx, eventID, status, errText); err != nil {
-		eb.logRuntime(ctx, "error", "eventbus", "pipeline_receipt_persist_failed", eventID, "", "", "", "", nil, map[string]any{
+		eb.logRuntime(ctx, "error", "Persisting the pipeline receipt failed", "eventbus", "pipeline_receipt_persist_failed", eventID, "", "", "", "", nil, map[string]any{
 			"status": status,
 		}, err.Error(), 0)
 	}
 }
 
-func (eb *EventBus) logRuntime(ctx context.Context, level, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
+func (eb *EventBus) logRuntime(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
 	if eb == nil {
 		return
 	}
@@ -255,9 +255,9 @@ func (eb *EventBus) logRuntime(ctx context.Context, level, component, action, ev
 	if logger == nil {
 		return
 	}
-	logger.Log(ctx, level, component, action, eventID, eventType, agentID, entityID, sessionID, correlation, detail, errText, durationUS)
+	logger.Log(ctx, level, message, component, action, eventID, eventType, agentID, entityID, sessionID, correlation, detail, errText, durationUS)
 }
 
 func (eb *EventBus) LogRuntime(ctx context.Context, entry runtimepipeline.RuntimeLogEntry) {
-	eb.logRuntime(ctx, entry.Level, entry.Component, entry.Action, entry.EventID, entry.EventType, entry.AgentID, entry.EffectiveEntityID(), entry.SessionID, entry.Correlation, entry.Detail, entry.Error, entry.DurationUS)
+	eb.logRuntime(ctx, entry.Level, entry.Message, entry.Component, entry.Action, entry.EventID, entry.EventType, entry.AgentID, entry.EffectiveEntityID(), entry.SessionID, entry.Correlation, entry.Detail, entry.Error, entry.DurationUS)
 }

--- a/internal/runtime/bus/hooks.go
+++ b/internal/runtime/bus/hooks.go
@@ -3,5 +3,5 @@ package bus
 import "context"
 
 type LoggerHook interface {
-	Log(ctx context.Context, level, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int)
+	Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int)
 }

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -102,7 +102,7 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		recipients := uniqueStrings(intent.Recipients)
 		if len(recipients) > 0 {
 			d.bus.deliverToAgents(ctx, intent.Event, recipients)
-			d.bus.logRuntime(ctx, "debug", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
+			d.bus.logRuntime(ctx, "debug", "Deferred event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
 				"direct":           true,
 				"recipients_count": len(recipients),
 			}, "", 0)

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -56,7 +56,7 @@ func (eb *EventBus) StartOutboxSweeper(ctx context.Context, cfg OutboxSweeperCon
 		}()
 		for {
 			if _, err := eb.SweepUndispatched(ctx, cfg.Lookback, cfg.Limit); err != nil {
-				eb.logRuntime(ctx, "warn", "eventbus", "outbox_sweep_failed", "", "", "", "", "", nil, map[string]any{
+				eb.logRuntime(ctx, "warn", "Outbox sweep failed", "eventbus", "outbox_sweep_failed", "", "", "", "", "", nil, map[string]any{
 					"lookback_seconds": int(cfg.Lookback / time.Second),
 					"limit":            cfg.Limit,
 				}, err.Error(), 0)

--- a/internal/runtime/bus/turn_context.go
+++ b/internal/runtime/bus/turn_context.go
@@ -2,10 +2,13 @@ package bus
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 
 	"swarm/internal/events"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/diaglog"
 )
 
 type emittedEventsContextKey struct{}
@@ -19,9 +22,24 @@ func InboundEventFromContext(ctx context.Context) (events.Event, bool) {
 }
 
 type EmittedEventsRecorder struct {
-	mu        sync.Mutex
-	events    []events.Event
-	publishes []PublishDiagnostic
+	mu             sync.Mutex
+	events         []events.Event
+	publishes      []PublishDiagnostic
+	flightRecorder []FlightRecorderEntry
+}
+
+type FlightRecorderEntry struct {
+	Kind                   string                       `json:"kind"`
+	LogLevel               string                       `json:"log_level,omitempty"`
+	Message                string                       `json:"message,omitempty"`
+	Details                any                          `json:"details,omitempty"`
+	StackTrace             string                       `json:"stack_trace,omitempty"`
+	EventID                string                       `json:"event_id,omitempty"`
+	EventType              string                       `json:"event_type,omitempty"`
+	EntityID               string                       `json:"entity_id,omitempty"`
+	ParentEventID          string                       `json:"parent_event_id,omitempty"`
+	RoutedRecipients       []PublishDiagnosticRecipient `json:"routed_recipients,omitempty"`
+	SubscriptionRecipients []string                     `json:"subscription_recipients,omitempty"`
 }
 
 type PublishDiagnosticRecipient struct {
@@ -83,8 +101,18 @@ func (r *EmittedEventsRecorder) AppendPublish(diag PublishDiagnostic) {
 	if r == nil {
 		return
 	}
+	diag = clonePublishDiagnostic(diag)
 	r.mu.Lock()
 	r.publishes = append(r.publishes, diag)
+	r.flightRecorder = append(r.flightRecorder, FlightRecorderEntry{
+		Kind:                   "publish",
+		EventID:                strings.TrimSpace(diag.EventID),
+		EventType:              strings.TrimSpace(diag.EventType),
+		EntityID:               strings.TrimSpace(diag.EntityID),
+		ParentEventID:          strings.TrimSpace(diag.ParentEventID),
+		RoutedRecipients:       append([]PublishDiagnosticRecipient(nil), diag.RoutedRecipients...),
+		SubscriptionRecipients: append([]string(nil), diag.SubscriptionRecipients...),
+	})
 	r.mu.Unlock()
 }
 
@@ -97,4 +125,124 @@ func (r *EmittedEventsRecorder) SnapshotPublishes() []PublishDiagnostic {
 	out := make([]PublishDiagnostic, len(r.publishes))
 	copy(out, r.publishes)
 	return out
+}
+
+func (r *EmittedEventsRecorder) AppendRuntimeLog(entry diaglog.RunEntry) {
+	if r == nil {
+		return
+	}
+	entry.NormalizeEntityID()
+	r.mu.Lock()
+	r.flightRecorder = append(r.flightRecorder, FlightRecorderEntry{
+		Kind:       "runtime_log",
+		LogLevel:   strings.TrimSpace(entry.Level),
+		Message:    strings.TrimSpace(entry.Message),
+		Details:    cloneJSONValue(runtimeLogDetails(entry)),
+		StackTrace: strings.TrimSpace(entry.StackTrace),
+	})
+	r.mu.Unlock()
+}
+
+func (r *EmittedEventsRecorder) SnapshotFlightRecorder() []FlightRecorderEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]FlightRecorderEntry, len(r.flightRecorder))
+	copy(out, r.flightRecorder)
+	return out
+}
+
+func clonePublishDiagnostic(diag PublishDiagnostic) PublishDiagnostic {
+	diag.EventID = strings.TrimSpace(diag.EventID)
+	diag.EventType = strings.TrimSpace(diag.EventType)
+	diag.EntityID = strings.TrimSpace(diag.EntityID)
+	diag.ParentEventID = strings.TrimSpace(diag.ParentEventID)
+	diag.RoutedRecipients = append([]PublishDiagnosticRecipient(nil), diag.RoutedRecipients...)
+	diag.SubscriptionRecipients = append([]string(nil), diag.SubscriptionRecipients...)
+	return diag
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneJSONValue(v any) any {
+	if v == nil {
+		return nil
+	}
+	raw, err := json.Marshal(v)
+	if err != nil || len(raw) == 0 {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return v
+	}
+	return out
+}
+
+func runtimeLogDetails(entry diaglog.RunEntry) map[string]any {
+	details := map[string]any{}
+	if v := strings.TrimSpace(entry.Component); v != "" {
+		details["component"] = v
+	}
+	if v := strings.TrimSpace(entry.Action); v != "" {
+		details["action"] = v
+	}
+	if v := strings.TrimSpace(entry.EventID); v != "" {
+		details["event_id"] = v
+	}
+	if v := strings.TrimSpace(entry.EventType); v != "" {
+		details["event_name"] = v
+		details["event_type"] = v
+	}
+	if v := strings.TrimSpace(entry.AgentID); v != "" {
+		details["agent_id"] = v
+	}
+	if v := strings.TrimSpace(entry.EntityID); v != "" {
+		details["entity_id"] = v
+	}
+	if v := strings.TrimSpace(entry.SessionID); v != "" {
+		details["session_id"] = v
+	}
+	if len(entry.Correlation) > 0 {
+		details["correlation"] = cloneStringMap(entry.Correlation)
+	}
+	if entry.Detail != nil {
+		if detailMap, ok := cloneJSONValue(entry.Detail).(map[string]any); ok {
+			for k, v := range detailMap {
+				key := strings.TrimSpace(k)
+				if key == "" {
+					continue
+				}
+				details[key] = v
+			}
+		} else {
+			details["raw_detail"] = cloneJSONValue(entry.Detail)
+		}
+	}
+	if v := strings.TrimSpace(entry.Error); v != "" {
+		details["error"] = v
+	}
+	if entry.DurationUS > 0 {
+		details["duration_us"] = entry.DurationUS
+	}
+	return details
 }

--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -316,7 +316,7 @@ func (h *runtimeHarness) publishConcurrentAndWait(steps []catalogTriggerStep, ti
 			h.t.Fatalf("concurrent publish failed: %v", err)
 		}
 	}
-	if err := h.rt.Bus.WaitForQuiescence(ctx); err != nil {
+	if err := h.rt.WaitForQuiescence(ctx); err != nil {
 		h.t.Fatalf("WaitForQuiescence(concurrent): %v", err)
 	}
 }
@@ -362,7 +362,7 @@ func (h *runtimeHarness) publishRuntimeEvent(eventType, sourceAgent string, payl
 	if err := h.publishBusEvent(ctx, evt); err != nil {
 		h.t.Fatalf("Publish(%s): %v", strings.TrimSpace(eventType), err)
 	}
-	if err := h.rt.Bus.WaitForQuiescence(ctx); err != nil {
+	if err := h.rt.WaitForQuiescence(ctx); err != nil {
 		h.t.Fatalf("WaitForQuiescence(%s): %v", strings.TrimSpace(eventType), err)
 	}
 }

--- a/internal/runtime/cataloge2e/tier11_probe_test.go
+++ b/internal/runtime/cataloge2e/tier11_probe_test.go
@@ -105,10 +105,10 @@ func TestTier11Probe(t *testing.T) {
 			t.Logf("events=%v", eventsDump)
 			var runtimeLogs []string
 			logRows, err := h.db.QueryContext(context.Background(), `
-				SELECT COALESCE(payload->>'component',''),
-				       COALESCE(payload->>'action',''),
-				       COALESCE(payload->>'error',''),
-				       COALESCE(payload->>'detail','')
+				SELECT COALESCE(payload->'details'->>'component',''),
+				       COALESCE(payload->'details'->>'action',''),
+				       COALESCE(payload->'details'->>'error',''),
+				       COALESCE(payload->>'message','')
 				FROM events
 				WHERE event_name = 'platform.runtime_log'
 				ORDER BY created_at ASC, event_id ASC
@@ -116,9 +116,9 @@ func TestTier11Probe(t *testing.T) {
 			if err == nil {
 				defer logRows.Close()
 				for logRows.Next() {
-					var component, action, errText, detail string
-					if scanErr := logRows.Scan(&component, &action, &errText, &detail); scanErr == nil {
-						runtimeLogs = append(runtimeLogs, component+":"+action+" error="+errText+" detail="+detail)
+					var component, action, errText, message string
+					if scanErr := logRows.Scan(&component, &action, &errText, &message); scanErr == nil {
+						runtimeLogs = append(runtimeLogs, component+":"+action+" error="+errText+" message="+message)
 					}
 				}
 			}

--- a/internal/runtime/diaglog/diaglog.go
+++ b/internal/runtime/diaglog/diaglog.go
@@ -10,6 +10,7 @@ import (
 
 type RunEntry struct {
 	Level       string
+	Message     string
 	Component   string
 	Action      string
 	EventID     string
@@ -20,6 +21,7 @@ type RunEntry struct {
 	Correlation map[string]string
 	Detail      any
 	Error       string
+	StackTrace  string
 	DurationUS  int
 }
 

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -9,12 +9,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/diaglog"
 )
 
 // RuntimeLogEntry is a structured runtime operation record (spec v2.0.14).
 type RuntimeLogEntry struct {
 	Level     string
+	Message   string
 	Component string
 	Action    string
 
@@ -27,6 +30,7 @@ type RuntimeLogEntry struct {
 
 	Detail     any
 	Error      string
+	StackTrace string
 	DurationUS int
 }
 
@@ -70,7 +74,7 @@ func NewRuntimeLogger(db *sql.DB) *RuntimeLogger {
 }
 
 func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) {
-	if l == nil || l.db == nil {
+	if l == nil {
 		return
 	}
 	level := strings.ToLower(strings.TrimSpace(e.Level))
@@ -86,6 +90,27 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) {
 		action = "unknown"
 	}
 	e.NormalizeEntityID()
+	if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && recorder != nil {
+		recorder.AppendRuntimeLog(diaglog.RunEntry{
+			Level:       e.Level,
+			Message:     e.Message,
+			Component:   e.Component,
+			Action:      e.Action,
+			EventID:     e.EventID,
+			EventType:   e.EventType,
+			AgentID:     e.AgentID,
+			EntityID:    e.EntityID,
+			SessionID:   e.SessionID,
+			Correlation: e.Correlation,
+			Detail:      e.Detail,
+			Error:       e.Error,
+			StackTrace:  e.StackTrace,
+			DurationUS:  e.DurationUS,
+		})
+	}
+	if l.db == nil {
+		return
+	}
 
 	detail := marshalJSONOrEmpty(e.Detail)
 	_ = logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, level, component, action, e, detail)
@@ -101,6 +126,7 @@ func (l *RuntimeLogger) Warn(ctx context.Context, component, action string, deta
 	}
 	l.Log(ctx, RuntimeLogEntry{
 		Level:     "warn",
+		Message:   runtimeLogHelperMessage("warn", component, action),
 		Component: strings.TrimSpace(component),
 		Action:    strings.TrimSpace(action),
 		Detail:    detail,
@@ -118,11 +144,29 @@ func (l *RuntimeLogger) Error(ctx context.Context, component, action string, det
 	}
 	l.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
+		Message:   runtimeLogHelperMessage("error", component, action),
 		Component: strings.TrimSpace(component),
 		Action:    strings.TrimSpace(action),
 		Detail:    detail,
 		Error:     errText,
 	})
+}
+
+func runtimeLogHelperMessage(level, component, action string) string {
+	component = strings.TrimSpace(component)
+	action = strings.TrimSpace(action)
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "error":
+		if component != "" {
+			return "Runtime error recorded by " + component
+		}
+		return "Runtime error recorded"
+	default:
+		if component != "" {
+			return "Runtime warning recorded by " + component
+		}
+		return "Runtime warning recorded"
+	}
 }
 
 type PipelineTransitionInput struct {
@@ -325,23 +369,7 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, level, component, acti
 	if handlerID == "" {
 		handlerID = strings.TrimSpace(asString(detailMap["handler_id"]))
 	}
-	payload := map[string]any{
-		"level":           level,
-		"component":       component,
-		"action":          action,
-		"event_id":        strings.TrimSpace(e.EventID),
-		"event_type":      strings.TrimSpace(e.EventType),
-		"agent_id":        strings.TrimSpace(e.AgentID),
-		"entity_id":       strings.TrimSpace(e.EffectiveEntityID()),
-		"session_id":      strings.TrimSpace(e.SessionID),
-		"run_id":          runID,
-		"parent_event_id": parentEventID,
-		"handler_id":      handlerID,
-		"correlation":     sanitizeStringMap(e.Correlation),
-		"detail":          json.RawMessage(detail),
-		"error":           strings.TrimSpace(e.Error),
-		"duration_us":     e.DurationUS,
-	}
+	payload := runtimeLogPayload(level, component, action, e, detailMap, runID, parentEventID, handlerID)
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -373,6 +401,66 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, level, component, acti
 		return err
 	}
 	return nil
+}
+
+func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detailMap map[string]any, runID, parentEventID, handlerID string) map[string]any {
+	details := map[string]any{}
+	for k, v := range detailMap {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		details[key] = v
+	}
+	if component = strings.TrimSpace(component); component != "" {
+		details["component"] = component
+	}
+	if action = strings.TrimSpace(action); action != "" {
+		details["action"] = action
+	}
+	if v := strings.TrimSpace(e.EventID); v != "" {
+		details["event_id"] = v
+	}
+	if v := strings.TrimSpace(e.EventType); v != "" {
+		details["event_name"] = v
+		details["event_type"] = v
+	}
+	if v := strings.TrimSpace(e.AgentID); v != "" {
+		details["agent_id"] = v
+	}
+	if v := strings.TrimSpace(e.EffectiveEntityID()); v != "" {
+		details["entity_id"] = v
+	}
+	if v := strings.TrimSpace(e.SessionID); v != "" {
+		details["session_id"] = v
+	}
+	if v := strings.TrimSpace(runID); v != "" {
+		details["run_id"] = v
+	}
+	if v := strings.TrimSpace(parentEventID); v != "" {
+		details["parent_event_id"] = v
+	}
+	if v := strings.TrimSpace(handlerID); v != "" {
+		details["handler_id"] = v
+	}
+	if corr := sanitizeStringMap(e.Correlation); len(corr) > 0 {
+		details["correlation"] = corr
+	}
+	if v := strings.TrimSpace(e.Error); v != "" {
+		details["error"] = v
+	}
+	if e.DurationUS > 0 {
+		details["duration_us"] = e.DurationUS
+	}
+	payload := map[string]any{
+		"log_level": strings.TrimSpace(level),
+		"message":   strings.TrimSpace(e.Message),
+		"details":   details,
+	}
+	if v := strings.TrimSpace(e.StackTrace); v != "" {
+		payload["stack_trace"] = v
+	}
+	return payload
 }
 
 func runtimeColumnExists(ctx context.Context, db *sql.DB, tableName, columnName string) bool {

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
+	logger := NewRuntimeLogger(nil)
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+
+	logger.Log(ctx, RuntimeLogEntry{
+		Level:      "warn",
+		Message:    "Tool execution was denied for save_entity_field",
+		Component:  "tool-executor",
+		Action:     "tool_execution_denied",
+		EventID:    "evt-1",
+		EventType:  "validation/requested",
+		AgentID:    "agent-1",
+		EntityID:   "entity-1",
+		SessionID:  "session-1",
+		Error:      "runtime_error code=cross_flow_write_forbidden",
+		DurationUS: 1200,
+		Detail: map[string]any{
+			"tool_name":     "save_entity_field",
+			"denial_layer":  "executor",
+			"denial_reason": "cross_flow_write_forbidden",
+		},
+	})
+
+	entries := recorder.SnapshotFlightRecorder()
+	if len(entries) != 1 {
+		t.Fatalf("flight recorder count = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.Kind != "runtime_log" {
+		t.Fatalf("kind = %q, want runtime_log", entry.Kind)
+	}
+	if entry.LogLevel != "warn" {
+		t.Fatalf("log_level = %q, want warn", entry.LogLevel)
+	}
+	if entry.Message != "Tool execution was denied for save_entity_field" {
+		t.Fatalf("message = %q", entry.Message)
+	}
+	details, ok := entry.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details type = %T, want map[string]any", entry.Details)
+	}
+	if details["component"] != "tool-executor" {
+		t.Fatalf("details.component = %#v", details["component"])
+	}
+	if details["action"] != "tool_execution_denied" {
+		t.Fatalf("details.action = %#v", details["action"])
+	}
+	if details["tool_name"] != "save_entity_field" {
+		t.Fatalf("details.tool_name = %#v", details["tool_name"])
+	}
+	if details["denial_layer"] != "executor" {
+		t.Fatalf("details.denial_layer = %#v", details["denial_layer"])
+	}
+	if details["error"] != "runtime_error code=cross_flow_write_forbidden" {
+		t.Fatalf("details.error = %#v", details["error"])
+	}
+}

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -75,12 +75,13 @@ type runtimeLoggerHook struct {
 	logger *RuntimeLogger
 }
 
-func (h runtimeLoggerHook) Log(ctx context.Context, level, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
+func (h runtimeLoggerHook) Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) {
 	if h.logger == nil {
 		return
 	}
 	h.logger.Log(ctx, RuntimeLogEntry{
 		Level:       level,
+		Message:     message,
 		Component:   component,
 		Action:      action,
 		EventID:     eventID,

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -158,7 +158,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		}
 		defer func() { _ = r.sessions.Release(ctx, lease) }()
 		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
-			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", s.AgentID, s.ID, entityID, map[string]any{
+			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the API session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
 				"runtime_mode": resolved.RuntimeMode,
 				"scope_key":    resolved.ScopeKey,
 			}, heartbeatErr)
@@ -272,7 +272,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		if err := r.budget.RecordEntityLLMUsage(ctx, entityID, s.AgentID, "api", usage, true, map[string]any{
 			"session_id": s.ID,
 		}); err != nil {
-			logPublisherRuntime(ctx, r.events, "warn", "record_api_llm_usage_failed", s.AgentID, s.ID, entityID, nil, err)
+			logPublisherRuntime(ctx, r.events, "warn", "record_api_llm_usage_failed", "Recording API LLM usage failed", s.AgentID, s.ID, entityID, nil, err)
 		}
 	}
 
@@ -306,7 +306,7 @@ func (r *AnthropicAPIRuntime) persistConversation(ctx context.Context, s *Sessio
 		TurnCount: s.TurnCount,
 		Status:    "active",
 	}); err != nil {
-		logPublisherRuntime(ctx, r.events, "error", "persist_api_conversation_failed", s.AgentID, s.ID, "", map[string]any{
+		logPublisherRuntime(ctx, r.events, "error", "persist_api_conversation_failed", "Persisting the API conversation failed", s.AgentID, s.ID, "", map[string]any{
 			"conversation_mode": mode,
 			"scope_key":         strings.TrimSpace(s.ScopeKey),
 		}, err)
@@ -322,7 +322,7 @@ func (r *AnthropicAPIRuntime) persistTurn(ctx context.Context, turn AgentTurnRec
 	}
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
 		// Turn telemetry should not break runtime path.
-		logPublisherRuntime(ctx, r.events, "error", "persist_api_turn_failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
+		logPublisherRuntime(ctx, r.events, "error", "persist_api_turn_failed", "Persisting the API agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -180,7 +180,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 		defer func() { _ = r.sessions.Release(ctx, lease) }()
 		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
-			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", s.AgentID, s.ID, entityID, map[string]any{
+			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the CLI session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
 				"runtime_mode": resolved.RuntimeMode,
 				"scope_key":    resolved.ScopeKey,
 			}, heartbeatErr)
@@ -394,7 +394,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		oldSessionID := strings.TrimSpace(s.ProviderSessionID)
 		if !resolved.Stateless {
 			if err := adoptRegistrySessionID(ctx, r.sessions, s.AgentID, resolved.RuntimeMode, lease.LockOwner, sid, resolved.ScopeKey); err != nil {
-				logPublisherRuntime(ctx, r.events, "warn", "adopt_cli_provider_session_failed", s.AgentID, s.ID, entityID, map[string]any{
+				logPublisherRuntime(ctx, r.events, "warn", "adopt_cli_provider_session_failed", "Adopting the CLI provider session failed", s.AgentID, s.ID, entityID, map[string]any{
 					"old_provider_session_id": oldSessionID,
 					"new_provider_session_id": sid,
 				}, err)
@@ -438,7 +438,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		if err := r.budget.RecordEntityLLMUsage(ctx, entityID, s.AgentID, "cli_test", usage, false, map[string]any{
 			"session_id": s.ID,
 		}); err != nil {
-			logPublisherRuntime(ctx, r.events, "warn", "record_cli_llm_usage_failed", s.AgentID, s.ID, entityID, nil, err)
+			logPublisherRuntime(ctx, r.events, "warn", "record_cli_llm_usage_failed", "Recording CLI LLM usage failed", s.AgentID, s.ID, entityID, nil, err)
 		}
 	}
 

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -23,7 +23,7 @@ func (r *ClaudeCLIRuntime) persistTurn(ctx context.Context, turn AgentTurnRecord
 		turn.TurnBlocks = BuildTurnBlocks(turn)
 	}
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
-		logPublisherRuntime(ctx, r.events, "error", "persist_cli_turn_failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
+		logPublisherRuntime(ctx, r.events, "error", "persist_cli_turn_failed", "Persisting the CLI agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
 	}
 }
 
@@ -49,7 +49,7 @@ func (r *ClaudeCLIRuntime) persistConversation(ctx context.Context, s *Session) 
 		TurnCount: s.TurnCount,
 		Status:    "active",
 	}); err != nil {
-		logPublisherRuntime(ctx, r.events, "error", "persist_cli_conversation_failed", s.AgentID, s.ID, "", map[string]any{
+		logPublisherRuntime(ctx, r.events, "error", "persist_cli_conversation_failed", "Persisting the CLI conversation failed", s.AgentID, s.ID, "", map[string]any{
 			"conversation_mode": mode,
 			"scope_key":         strings.TrimSpace(s.ScopeKey),
 		}, err)

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -190,7 +190,7 @@ func (r *ClaudeCLIRuntime) runWithPromptTransportFallback(ctx context.Context, a
 	resp, err = r.runWithPromptArg(ctx, args, target, prompt, meta)
 	if err == nil {
 		used.Used = true
-		logPublisherRuntime(ctx, r.events, "warn", "prompt_transport_fallback_used", "", "", "", nil, nil)
+		logPublisherRuntime(ctx, r.events, "warn", "prompt_transport_fallback_used", "CLI prompt transport fallback was used", "", "", "", nil, nil)
 	}
 	return resp, used, err
 }

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -21,6 +21,7 @@ type AgentTurnRecord struct {
 	AvailableTools     []string
 	ToolCalls          []ToolCall
 	EmittedEvents      []string
+	FlightRecorder     []runtimebus.FlightRecorderEntry
 	PublishDiagnostics []runtimebus.PublishDiagnostic
 	MCPServers         map[string]string
 	MCPToolsListed     []string
@@ -109,6 +110,11 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	if len(rec.PublishDiagnostics) == 0 {
 		if eventRec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && eventRec != nil {
 			rec.PublishDiagnostics = append([]runtimebus.PublishDiagnostic(nil), eventRec.SnapshotPublishes()...)
+		}
+	}
+	if len(rec.FlightRecorder) == 0 {
+		if eventRec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && eventRec != nil {
+			rec.FlightRecorder = append([]runtimebus.FlightRecorderEntry(nil), eventRec.SnapshotFlightRecorder()...)
 		}
 	}
 	return rec

--- a/internal/runtime/llm/runtime_logging.go
+++ b/internal/runtime/llm/runtime_logging.go
@@ -13,7 +13,7 @@ type RuntimeLogSink interface {
 	LogRuntime(ctx context.Context, entry runtimepipeline.RuntimeLogEntry)
 }
 
-func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, agentID, sessionID, entityID string, detail any, err error) {
+func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, message, agentID, sessionID, entityID string, detail any, err error) {
 	if logger == nil {
 		return
 	}
@@ -24,6 +24,7 @@ func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, ag
 	}
 	diaglog.RunLog(ctx, logger, runtimepipeline.RuntimeLogEntry{
 		Level:     strings.TrimSpace(level),
+		Message:   strings.TrimSpace(message),
 		Component: "llm-runtime",
 		Action:    strings.TrimSpace(action),
 		EventID:   strings.TrimSpace(inbound.ID),
@@ -36,7 +37,7 @@ func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, ag
 	})
 }
 
-func logPublisherRuntime(ctx context.Context, publisher EventPublisher, level, action, agentID, sessionID, entityID string, detail any, err error) {
+func logPublisherRuntime(ctx context.Context, publisher EventPublisher, level, action, message, agentID, sessionID, entityID string, detail any, err error) {
 	if publisher == nil {
 		return
 	}
@@ -44,21 +45,21 @@ func logPublisherRuntime(ctx context.Context, publisher EventPublisher, level, a
 	if !ok || logger == nil {
 		return
 	}
-	logRunRuntime(ctx, logger, level, action, agentID, sessionID, entityID, detail, err)
+	logRunRuntime(ctx, logger, level, action, message, agentID, sessionID, entityID, detail, err)
 }
 
-func logSessionRuntime(ctx context.Context, sink any, action, agentID, sessionID string, detail any) {
+func logSessionRuntime(ctx context.Context, sink any, action, message, agentID, sessionID string, detail any) {
 	if logger, ok := sink.(RuntimeLogSink); ok && logger != nil {
-		logRunRuntime(ctx, logger, "info", action, agentID, sessionID, "", detail, nil)
+		logRunRuntime(ctx, logger, "info", action, message, agentID, sessionID, "", detail, nil)
 		return
 	}
 	if publisher, ok := sink.(EventPublisher); ok && publisher != nil {
-		logPublisherRuntime(ctx, publisher, "info", action, agentID, sessionID, "", detail, nil)
+		logPublisherRuntime(ctx, publisher, "info", action, message, agentID, sessionID, "", detail, nil)
 	}
 }
 
 func LogSessionRotatedForRun(ctx context.Context, sink any, agentID, runtimeMode, oldSessionID, newSessionID, scopeKey, reason string, turnCount, parseFailures int) {
-	logSessionRuntime(ctx, sink, "session_rotated", agentID, newSessionID, map[string]any{
+	logSessionRuntime(ctx, sink, "session_rotated", "LLM session was rotated", agentID, newSessionID, map[string]any{
 		"runtime_mode":   strings.TrimSpace(runtimeMode),
 		"old_session_id": strings.TrimSpace(oldSessionID),
 		"new_session_id": strings.TrimSpace(newSessionID),
@@ -70,7 +71,7 @@ func LogSessionRotatedForRun(ctx context.Context, sink any, agentID, runtimeMode
 }
 
 func LogSessionAdoptedForRun(ctx context.Context, sink any, agentID, runtimeMode, oldSessionID, newSessionID, scopeKey string) {
-	logSessionRuntime(ctx, sink, "session_adopted", agentID, newSessionID, map[string]any{
+	logSessionRuntime(ctx, sink, "session_adopted", "LLM session was adopted", agentID, newSessionID, map[string]any{
 		"runtime_mode":   strings.TrimSpace(runtimeMode),
 		"old_session_id": strings.TrimSpace(oldSessionID),
 		"new_session_id": strings.TrimSpace(newSessionID),

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -16,7 +16,7 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 		return
 	}
 	if err := publisher.MarkDeliveryInProgress(ctx, session.AgentID, session.ID); err != nil {
-		logPublisherRuntime(ctx, publisher, "error", "mark_delivery_in_progress_failed", session.AgentID, session.ID, "", nil, err)
+		logPublisherRuntime(ctx, publisher, "error", "mark_delivery_in_progress_failed", "Marking the agent delivery in progress failed", session.AgentID, session.ID, "", nil, err)
 	}
 	actor, _ := runtimeactors.ActorFromContext(ctx)
 	payload := map[string]any{
@@ -31,7 +31,7 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {
-		logPublisherRuntime(ctx, publisher, "error", "marshal_agent_started_payload_failed", session.AgentID, session.ID, "", map[string]any{
+		logPublisherRuntime(ctx, publisher, "error", "marshal_agent_started_payload_failed", "Marshalling the agent-started payload failed", session.AgentID, session.ID, "", map[string]any{
 			"event_type": strings.TrimSpace(string(eventType)),
 		}, err)
 		return
@@ -47,7 +47,7 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 		evt = evt.WithEntityID(entityID)
 	}
 	if err := publisher.Publish(ctx, evt); err != nil {
-		logPublisherRuntime(ctx, publisher, "error", "publish_agent_started_failed", session.AgentID, session.ID, evt.EntityID(), map[string]any{
+		logPublisherRuntime(ctx, publisher, "error", "publish_agent_started_failed", "Publishing the agent-started event failed", session.AgentID, session.ID, evt.EntityID(), map[string]any{
 			"event_type": strings.TrimSpace(string(eventType)),
 		}, err)
 	}

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -12,6 +12,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/diaglog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/sessions"
 )
@@ -302,6 +303,17 @@ func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 		},
 		SubscriptionRecipients: []string{"direct-agent"},
 	})
+	recorder.AppendRuntimeLog(diaglog.RunEntry{
+		Level:     "info",
+		Message:   "Emit tool target was resolved",
+		Component: "tool-executor",
+		Action:    "emit_target_resolved",
+		AgentID:   "market-research-agent",
+		EntityID:  "22222222-2222-2222-2222-222222222222",
+		Detail: map[string]any{
+			"tool_name": "emit_category_assessed",
+		},
+	})
 	ctx = runtimebus.WithEmittedEventsRecorder(ctx, recorder)
 
 	session := &Session{
@@ -368,5 +380,11 @@ func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	}
 	if len(rec.PublishDiagnostics[0].RoutedRecipients) != 1 || rec.PublishDiagnostics[0].RoutedRecipients[0].LocalizedEvent != "category.assessed" {
 		t.Fatalf("publish_diagnostics[0].routed_recipients = %#v", rec.PublishDiagnostics[0].RoutedRecipients)
+	}
+	if len(rec.FlightRecorder) != 2 {
+		t.Fatalf("flight_recorder = %#v", rec.FlightRecorder)
+	}
+	if rec.FlightRecorder[1].Message != "Emit tool target was resolved" {
+		t.Fatalf("flight_recorder[1].message = %q", rec.FlightRecorder[1].Message)
 	}
 }

--- a/internal/runtime/llm/turn_transcript.go
+++ b/internal/runtime/llm/turn_transcript.go
@@ -3,6 +3,8 @@ package llm
 import (
 	"encoding/json"
 	"strings"
+
+	runtimebus "swarm/internal/runtime/bus"
 )
 
 type TurnBlock struct {
@@ -20,7 +22,7 @@ func BuildTurnBlocks(rec AgentTurnRecord) []TurnBlock {
 	if dispatch := buildDispatchBlock(rec); dispatch.Kind != "" {
 		blocks = append(blocks, dispatch)
 	}
-	blocks = append(blocks, buildPublishBlocks(rec)...)
+	blocks = append(blocks, buildFlightRecorderBlocks(rec)...)
 	if len(rec.ResponseRaw) == 0 {
 		return normalizeTurnBlocks(blocks)
 	}
@@ -89,6 +91,86 @@ func buildPublishBlocks(rec AgentTurnRecord) []TurnBlock {
 		})
 	}
 	return blocks
+}
+
+func buildFlightRecorderBlocks(rec AgentTurnRecord) []TurnBlock {
+	if len(rec.FlightRecorder) == 0 {
+		return buildPublishBlocks(rec)
+	}
+	blocks := make([]TurnBlock, 0, len(rec.FlightRecorder))
+	for _, entry := range rec.FlightRecorder {
+		switch strings.TrimSpace(entry.Kind) {
+		case "publish":
+			if block, ok := buildPublishBlock(entry); ok {
+				blocks = append(blocks, block)
+			}
+		case "runtime_log":
+			if block, ok := buildRuntimeLogBlock(entry); ok {
+				blocks = append(blocks, block)
+			}
+		}
+	}
+	return blocks
+}
+
+func buildPublishBlock(entry runtimebus.FlightRecorderEntry) (TurnBlock, bool) {
+	eventType := strings.TrimSpace(entry.EventType)
+	if eventType == "" {
+		return TurnBlock{}, false
+	}
+	data := map[string]any{}
+	if v := strings.TrimSpace(entry.EventID); v != "" {
+		data["event_id"] = v
+	}
+	if v := strings.TrimSpace(entry.EntityID); v != "" {
+		data["entity_id"] = v
+	}
+	if v := strings.TrimSpace(entry.ParentEventID); v != "" {
+		data["parent_event_id"] = v
+	}
+	if len(entry.RoutedRecipients) > 0 {
+		data["routed_recipients"] = entry.RoutedRecipients
+		data["routed_recipients_count"] = len(entry.RoutedRecipients)
+	}
+	if len(entry.SubscriptionRecipients) > 0 {
+		data["subscription_recipients"] = entry.SubscriptionRecipients
+		data["subscription_recipients_count"] = len(entry.SubscriptionRecipients)
+	}
+	return TurnBlock{
+		Kind:  "publish",
+		Title: eventType,
+		Data:  data,
+	}, true
+}
+
+func buildRuntimeLogBlock(entry runtimebus.FlightRecorderEntry) (TurnBlock, bool) {
+	message := strings.TrimSpace(entry.Message)
+	details, _ := entry.Details.(map[string]any)
+	if message == "" && len(details) == 0 {
+		return TurnBlock{}, false
+	}
+	data := map[string]any{}
+	if v := strings.TrimSpace(entry.LogLevel); v != "" {
+		data["log_level"] = v
+	}
+	if message != "" {
+		data["message"] = message
+	}
+	if entry.Details != nil {
+		data["details"] = entry.Details
+	}
+	if v := strings.TrimSpace(entry.StackTrace); v != "" {
+		data["stack_trace"] = v
+	}
+	title := message
+	if title == "" {
+		title = "runtime log"
+	}
+	return TurnBlock{
+		Kind:  "runtime_log",
+		Title: title,
+		Data:  data,
+	}, true
 }
 
 func parseTurnBlocksFromRaw(raw []byte) []TurnBlock {

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -81,3 +81,43 @@ func TestBuildTurnBlocks_IncludesPublishDiagnostics(t *testing.T) {
 		t.Fatalf("publish block routed_recipients = %#v", blocks[1].Data["routed_recipients"])
 	}
 }
+
+func TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries(t *testing.T) {
+	rec := AgentTurnRecord{
+		FlightRecorder: []runtimebus.FlightRecorderEntry{
+			{
+				Kind:     "runtime_log",
+				LogLevel: "warn",
+				Message:  "Tool execution was denied for save_entity_field",
+				Details: map[string]any{
+					"component":     "tool-executor",
+					"action":        "tool_execution_denied",
+					"tool_name":     "save_entity_field",
+					"denial_layer":  "executor",
+					"denial_reason": "cross_flow_write_forbidden",
+				},
+			},
+		},
+	}
+
+	blocks := BuildTurnBlocks(rec)
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %#v", blocks)
+	}
+	if blocks[0].Kind != "runtime_log" {
+		t.Fatalf("kind = %q, want runtime_log", blocks[0].Kind)
+	}
+	if blocks[0].Title != "Tool execution was denied for save_entity_field" {
+		t.Fatalf("title = %q", blocks[0].Title)
+	}
+	if got := asString(blocks[0].Data["log_level"]); got != "warn" {
+		t.Fatalf("log_level = %q", got)
+	}
+	details, ok := blocks[0].Data["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("details = %#v", blocks[0].Data["details"])
+	}
+	if details["denial_layer"] != "executor" {
+		t.Fatalf("details.denial_layer = %#v", details["denial_layer"])
+	}
+}

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -142,6 +142,33 @@ func (am *AgentManager) runtimeContext() context.Context {
 	return context.Background()
 }
 
+func (am *AgentManager) InFlightCount() int {
+	if am == nil {
+		return 0
+	}
+	am.inFlightMu.Lock()
+	defer am.inFlightMu.Unlock()
+	return len(am.inFlight)
+}
+
+func (am *AgentManager) WaitForQuiescence(ctx context.Context) error {
+	if am == nil {
+		return nil
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if am.InFlightCount() == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func (am *AgentManager) PublishEvent(ctx context.Context, evt events.Event) error {
 	if am == nil || am.bus == nil {
 		return errors.New("event bus is not configured")

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -161,6 +161,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 			if err := am.bus.Publish(context.Background(), autoEmitEvent); err != nil {
 				am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{
 					Level:     "warn",
+					Message:   "Auto-emitting the flow activation event failed",
 					Component: "flow_activation",
 					Action:    "auto_emit_failed",
 					EventType: autoEmit,

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -110,7 +110,8 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := g.authorize(r); err != nil {
 		g.logMCP(r, "warn", "tool.authorize_failed", err, map[string]any{
-			"path": strings.TrimSpace(r.URL.Path),
+			"path":         strings.TrimSpace(r.URL.Path),
+			"denial_layer": "gateway",
 		})
 		WriteJSON(w, http.StatusUnauthorized, ToolGatewayResponse{OK: false, Error: g.formatError(err)})
 		return
@@ -147,11 +148,18 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 
 	ctx, err := g.toolExecutionContext(r, actor, toolName)
 	if err != nil {
+		g.logMCP(r, "warn", "tool.context_error", err, map[string]any{
+			"tool_name": toolName,
+		})
 		WriteJSON(w, http.StatusBadRequest, ToolGatewayResponse{OK: false, Error: g.formatError(err)})
 		return
 	}
 	if !toolAllowedInContext(ctx, toolName) {
 		err := g.newRuntimeError(ErrCodeToolNotAllowed, "tool.execute.authorize_tool", false, nil, "tool is not allowed for this agent: %s", toolName)
+		g.logMCP(r, "warn", "tool.execute.denied", err, map[string]any{
+			"tool_name":    toolName,
+			"denial_layer": "gateway",
+		})
 		WriteJSON(w, http.StatusBadRequest, ToolGatewayResponse{OK: false, Error: g.formatError(err)})
 		return
 	}
@@ -183,7 +191,8 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	if err := g.authorize(r); err != nil {
 		g.logMCP(r, "warn", "mcp.authorize_failed", err, map[string]any{
-			"method": strings.TrimSpace(reqMethodForLog(r)),
+			"method":       strings.TrimSpace(reqMethodForLog(r)),
+			"denial_layer": "gateway",
 		})
 		WriteRPCError(w, nil, -32001, g.formatError(err))
 		return
@@ -248,8 +257,9 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 		if !toolAllowedInContext(ctx, toolName) {
 			err := g.newRuntimeError(ErrCodeToolNotAllowed, "mcp.tools.call.authorize_tool", false, nil, "tool is not allowed for this agent: %s", toolName)
 			g.logMCP(r, "warn", "mcp.tools.call.denied", err, map[string]any{
-				"method":    "tools/call",
-				"tool_name": toolName,
+				"method":       "tools/call",
+				"tool_name":    toolName,
+				"denial_layer": "gateway",
 			})
 			WriteRPCResult(w, req.ID, map[string]any{
 				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -485,7 +485,15 @@ func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *
 
 func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *testing.T) {
 	exec := &capabilityAwareExecutorStub{}
-	g := NewGateway(exec, "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	var loggedAction string
+	var denialLayer string
+	g := NewGateway(exec, "", GatewayHooks{
+		ResolveTurnContext: ResolveTurnContext,
+		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
+			loggedAction = action
+			denialLayer = strings.TrimSpace(asString(detail["denial_layer"]))
+		},
+	})
 
 	PutTurnContextForTest("ctx-denied-allowlist", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
@@ -517,6 +525,12 @@ func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *tes
 	}
 	if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
 		t.Fatalf("body = %s", rec.Body.String())
+	}
+	if loggedAction != "mcp.tools.call.denied" {
+		t.Fatalf("logged action = %q", loggedAction)
+	}
+	if denialLayer != "gateway" {
+		t.Fatalf("denial_layer = %q, want gateway", denialLayer)
 	}
 }
 

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -164,6 +164,7 @@ func runtimeMCPLog(logger *RuntimeLogger, ctx context.Context, level, action, ag
 	}
 	logger.Log(ctx, RuntimeLogEntry{
 		Level:     strings.ToLower(strings.TrimSpace(level)),
+		Message:   runtimeMCPMessage(action, detail, errText),
 		Component: "mcp-gateway",
 		Action:    strings.TrimSpace(action),
 		AgentID:   strings.TrimSpace(agentID),
@@ -175,4 +176,62 @@ func runtimeMCPLog(logger *RuntimeLogger, ctx context.Context, level, action, ag
 
 func runtimeMCPAfterToolSuccess(logger *RuntimeLogger, ctx context.Context, r *http.Request, toolName string) {
 	_, _, _, _ = logger, ctx, r, toolName
+}
+
+func runtimeMCPMessage(action string, detail map[string]any, errText string) string {
+	action = strings.TrimSpace(action)
+	toolName := strings.TrimSpace(runtimeMCPDetailString(detail, "tool_name"))
+	switch action {
+	case "tool.authorize_failed":
+		return "Tool gateway authorization failed"
+	case "mcp.authorize_failed":
+		return "MCP authorization failed"
+	case "mcp.tools.call.invalid":
+		return "MCP tools/call request was invalid"
+	case "tool.context_error":
+		return "Tool gateway context resolution failed"
+	case "mcp.tools.call.context_error":
+		return "MCP tool context resolution failed"
+	case "tool.execute.denied":
+		if toolName != "" {
+			return "Tool gateway denied execution for " + toolName
+		}
+		return "Tool gateway denied tool execution"
+	case "mcp.tools.call.denied":
+		if toolName != "" {
+			return "MCP tool call was denied for " + toolName
+		}
+		return "MCP tool call was denied"
+	case "mcp.tools.call.exec_error":
+		if toolName != "" {
+			return "MCP tool execution failed for " + toolName
+		}
+		return "MCP tool execution failed"
+	case "mcp.tools.call.success":
+		if toolName != "" {
+			return "MCP tool execution succeeded for " + toolName
+		}
+		return "MCP tool execution succeeded"
+	case "mcp.context.fallback_used":
+		return "MCP context fallback was used"
+	case "mcp.context.fallback_blocked":
+		return "MCP context fallback was blocked"
+	case "tool.context.fallback_used":
+		return "Tool context fallback was used"
+	case "tool.context.fallback_blocked":
+		return "Tool context fallback was blocked"
+	default:
+		if strings.TrimSpace(errText) != "" {
+			return "MCP gateway runtime log recorded an error"
+		}
+		return "MCP gateway runtime log recorded an event"
+	}
+}
+
+func runtimeMCPDetailString(detail map[string]any, key string) string {
+	if len(detail) == 0 {
+		return ""
+	}
+	value, _ := detail[strings.TrimSpace(key)].(string)
+	return strings.TrimSpace(value)
 }

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -155,6 +155,7 @@ func (pc *PipelineCoordinator) Run(ctx context.Context) {
 			if _, err := pc.handleEventResult(ctx, evt); err != nil && pc.bus != nil {
 				pc.bus.LogRuntime(ctx, RuntimeLogEntry{
 					Level:     "error",
+					Message:   "Workflow handler execution failed",
 					Component: runtimeWorkflowID,
 					Action:    "handler_error",
 					EventID:   strings.TrimSpace(evt.ID),
@@ -283,6 +284,7 @@ func (pc *PipelineCoordinator) recordWorkflowHandlerFailure(ctx context.Context,
 	if pc.bus != nil {
 		pc.bus.LogRuntime(ctx, RuntimeLogEntry{
 			Level:     "error",
+			Message:   "Workflow handler execution failed",
 			Component: runtimeWorkflowID,
 			Action:    "handler_error",
 			EventID:   strings.TrimSpace(evt.ID),
@@ -395,6 +397,7 @@ func (pc *PipelineCoordinator) logRuntimeWarn(ctx context.Context, component, ac
 		}
 		pc.bus.LogRuntime(ctx, RuntimeLogEntry{
 			Level:     "warn",
+			Message:   "Workflow runtime warning was recorded",
 			Component: strings.TrimSpace(component),
 			Action:    strings.TrimSpace(action),
 			EventID:   strings.TrimSpace(eventID),

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -227,6 +227,7 @@ func (n *systemNodeRunner) emitDeadLetter(ctx context.Context, evt events.Event,
 			if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 				logger.LogRuntime(ctx, RuntimeLogEntry{
 					Level:     "error",
+					Message:   "Persisting the system node dead letter failed",
 					Component: n.nodeID,
 					Action:    "dead_letter_persist_failed",
 					EventID:   strings.TrimSpace(evt.ID),
@@ -248,6 +249,7 @@ func (n *systemNodeRunner) emitDeadLetter(ctx context.Context, evt events.Event,
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
 				Level:     "error",
+				Message:   "Publishing the system node dead letter failed",
 				Component: n.nodeID,
 				Action:    "dead_letter_publish_failed",
 				EventID:   strings.TrimSpace(evt.ID),
@@ -336,6 +338,7 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
 				Level:     "error",
+				Message:   "Marking the system node event as processed failed",
 				Component: n.nodeID,
 				Action:    "mark_processed_failed",
 				EventID:   eventID,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -76,6 +76,8 @@ type Runtime struct {
 
 var ()
 
+const runtimeQuiescenceStableChecks = 3
+
 func runtimeControlPlaneRecipient() string {
 	if recipient := controlPlaneRecipientFromSource(runtimepipeline.DefaultWorkflowSemanticSourceOrNil()); recipient != "" {
 		return recipient
@@ -99,6 +101,44 @@ func controlPlaneRecipientFromSource(source semanticview.Source) string {
 
 func DefaultControlPlaneRecipient() string {
 	return strings.TrimSpace(runtimeControlPlaneRecipient())
+}
+
+func (rt *Runtime) WaitForQuiescence(ctx context.Context) error {
+	if rt == nil {
+		return nil
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	stable := 0
+	for {
+		if rt.Bus != nil {
+			if err := rt.Bus.WaitForQuiescence(ctx); err != nil {
+				return err
+			}
+		}
+		if rt.Manager != nil {
+			if err := rt.Manager.WaitForQuiescence(ctx); err != nil {
+				return err
+			}
+		}
+		pendingDeliveries := 0
+		if rt.Bus != nil {
+			pendingDeliveries = rt.Bus.PendingAgentDeliveries()
+		}
+		if pendingDeliveries == 0 {
+			stable++
+			if stable >= runtimeQuiescenceStableChecks {
+				return nil
+			}
+		} else {
+			stable = 0
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func runtimeThrottleSuppressPrefixes(source semanticview.Source) []string {

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -356,20 +356,13 @@ func (e *Executor) emitToolExecutionEvent(
 			action = "tool_execution_failed"
 		}
 	}
-	detail := map[string]any{
-		"tool_name":     toolName,
-		"phase":         strings.TrimSpace(phase),
-		"ok":            execErr == nil,
-		"input_summary": SafeTelemetryText(input),
-	}
+	detail := toolExecutionDiagnosticDetail(ctx, actor, toolName, input, result, execErr, phase)
 	if strings.TrimSpace(actor.Role) != "" {
 		detail["actor_role"] = strings.TrimSpace(actor.Role)
 	}
-	if result != nil {
-		detail["result_summary"] = SafeTelemetryText(result)
-	}
 	logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 		Level:      level,
+		Message:    toolExecutionMessage(toolName, execErr),
 		Component:  "tool-executor",
 		Action:     action,
 		AgentID:    strings.TrimSpace(actor.ID),
@@ -378,6 +371,95 @@ func (e *Executor) emitToolExecutionEvent(
 		Error:      toolExecErrorText(execErr),
 		DurationUS: int(latency / time.Microsecond),
 	})
+}
+
+func toolExecutionMessage(toolName string, execErr error) string {
+	toolName = strings.TrimSpace(toolName)
+	switch {
+	case execErr == nil:
+		if toolName == "" {
+			return "Tool execution succeeded"
+		}
+		return fmt.Sprintf("Tool %s executed successfully", toolName)
+	case errors.Is(execErr, ErrToolNotAllowed):
+		if toolName == "" {
+			return "Tool execution was denied"
+		}
+		return fmt.Sprintf("Tool %s execution was denied", toolName)
+	default:
+		if toolName == "" {
+			return "Tool execution failed"
+		}
+		return fmt.Sprintf("Tool %s execution failed", toolName)
+	}
+}
+
+func toolExecutionDiagnosticDetail(ctx context.Context, actor models.AgentConfig, toolName string, input any, result any, execErr error, phase string) map[string]any {
+	detail := map[string]any{
+		"tool_name":     toolName,
+		"phase":         strings.TrimSpace(phase),
+		"ok":            execErr == nil,
+		"input_summary": SafeTelemetryText(input),
+	}
+	if result != nil {
+		detail["result_summary"] = SafeTelemetryText(result)
+	}
+	if set, ok := toolcapabilities.FromContext(ctx); ok {
+		if cap, ok := set.Capability(toolName); ok {
+			if v := string(cap.Kind); v != "" {
+				detail["tool_kind"] = v
+			}
+			detail["visible"] = cap.Visible
+			detail["callable"] = cap.Callable
+			if v := string(cap.ContextRequirement); v != "" {
+				detail["context_requirement"] = v
+			}
+			if v := strings.TrimSpace(cap.AuthorizationClass); v != "" {
+				detail["authorization_class"] = v
+			}
+			if v := strings.TrimSpace(cap.DenialReason); v != "" {
+				detail["denial_reason"] = v
+			}
+			if execErr != nil && !cap.Callable {
+				detail["denial_layer"] = "executor"
+			}
+		} else {
+			decision := classifyToolAuthorization(actor, toolName)
+			detail["tool_kind"] = string(toolKindPolicy(toolName))
+			detail["context_requirement"] = string(toolContextRequirementPolicy(toolName))
+			if v := strings.TrimSpace(string(decision.class)); v != "" {
+				detail["authorization_class"] = v
+			}
+			if execErr != nil && !decision.allowed {
+				detail["denial_reason"] = "tool_not_allowed"
+				detail["denial_layer"] = "authorizer"
+			}
+		}
+	} else {
+		decision := classifyToolAuthorization(actor, toolName)
+		detail["tool_kind"] = string(toolKindPolicy(toolName))
+		detail["context_requirement"] = string(toolContextRequirementPolicy(toolName))
+		if v := strings.TrimSpace(string(decision.class)); v != "" {
+			detail["authorization_class"] = v
+		}
+		if execErr != nil && !decision.allowed {
+			detail["denial_reason"] = "tool_not_allowed"
+			detail["denial_layer"] = "authorizer"
+		}
+	}
+	if runtimeErr, ok := AsRuntimeError(execErr); ok {
+		if v := strings.TrimSpace(runtimeErr.Code); v != "" {
+			detail["runtime_error_code"] = v
+		}
+		if v := strings.TrimSpace(runtimeErr.Operation); v != "" {
+			detail["runtime_error_operation"] = v
+		}
+		if v := strings.TrimSpace(runtimeErr.Component); v != "" {
+			detail["runtime_error_component"] = v
+		}
+		detail["retryable"] = runtimeErr.Retryable
+	}
+	return detail
 }
 
 func toolExecErrorText(err error) string {
@@ -408,6 +490,17 @@ func (e *Executor) dispatchTool(ctx context.Context, actor models.AgentConfig, n
 		return nil, fmt.Errorf("tool dispatcher is not configured")
 	}
 	return e.dispatcher.Dispatch(ctx, actor, name, input)
+}
+
+func (e *Executor) runtimeLogSink() runtimeToolLogSink {
+	if e == nil || e.bus == nil {
+		return nil
+	}
+	logger, ok := e.bus.(runtimeToolLogSink)
+	if !ok || logger == nil {
+		return nil
+	}
+	return logger
 }
 
 func (e *Executor) getManager() Manager {

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -10,6 +10,7 @@ import (
 	"swarm/internal/events"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
 func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig, toolName string, input any) (any, error) {
@@ -65,6 +66,25 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		)
 	}
 
+	entityIDSource := "payload"
+	if strings.TrimSpace(asString(payloadMap["entity_id"])) == "" {
+		switch {
+		case strings.TrimSpace(actor.EffectiveEntityID()) != "":
+			entityIDSource = "actor"
+		case strings.TrimSpace(inbound.EntityID()) != "":
+			entityIDSource = "inbound_event"
+		default:
+			entityIDSource = "none"
+		}
+	}
+	taskIDSource := "payload"
+	if strings.TrimSpace(asString(payloadMap["task_id"])) == "" {
+		if strings.TrimSpace(inbound.TaskID) != "" {
+			taskIDSource = "inbound_event"
+		} else {
+			taskIDSource = "none"
+		}
+	}
 	emitted := (events.Event{
 		ID:          uuid.NewString(),
 		Type:        events.EventType(eventType),
@@ -88,6 +108,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		}
 		emitted.Payload = mustJSON(payloadMap)
 	}
+	e.logEmitTargetResolution(ctx, actor, toolName, schemaEventType, eventType, emitted, entityIDSource, taskIDSource)
 	if err := e.bus.Publish(ctx, emitted); err != nil {
 		return nil, WrapRuntimeError(
 			"event_publish_failed",
@@ -109,6 +130,38 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		"event_id":   emitted.ID,
 		"event_type": eventType,
 	}, nil
+}
+
+func (e *Executor) logEmitTargetResolution(ctx context.Context, actor models.AgentConfig, toolName, requestedEventType, resolvedEventType string, emitted events.Event, entityIDSource, taskIDSource string) {
+	if e == nil || e.bus == nil {
+		return
+	}
+	logger, ok := e.bus.(runtimeToolLogSink)
+	if !ok || logger == nil {
+		return
+	}
+	logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+		Level:     "info",
+		Message:   "Emit tool target was resolved",
+		Component: "tool-executor",
+		Action:    "emit_target_resolved",
+		AgentID:   strings.TrimSpace(actor.ID),
+		EntityID:  strings.TrimSpace(actor.EffectiveEntityID()),
+		Detail: map[string]any{
+			"tool_name":             strings.TrimSpace(toolName),
+			"requested_event_type":  strings.TrimSpace(requestedEventType),
+			"resolved_event_type":   strings.TrimSpace(resolvedEventType),
+			"emitted_event_id":      strings.TrimSpace(emitted.ID),
+			"emitted_event_type":    strings.TrimSpace(string(emitted.Type)),
+			"emitted_entity_id":     strings.TrimSpace(emitted.EntityID()),
+			"emitted_task_id":       strings.TrimSpace(emitted.TaskID),
+			"entity_id_source":      strings.TrimSpace(entityIDSource),
+			"task_id_source":        strings.TrimSpace(taskIDSource),
+			"actor_entity_id":       strings.TrimSpace(actor.EffectiveEntityID()),
+			"inbound_parent_event":  strings.TrimSpace(emitted.ParentEventID),
+			"context_entity_target": strings.TrimSpace(emitted.EntityID()),
+		},
+	})
 }
 
 func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eventType string) string {

--- a/internal/runtime/tools/executor_entity.go
+++ b/internal/runtime/tools/executor_entity.go
@@ -15,6 +15,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -114,7 +115,7 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err != nil {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.entity_id", false, err.Error())
 	}
-	if err := enforceEntityWriteOwnership(ctx, db, source, actor, entityID); err != nil {
+	if err := enforceEntityWriteOwnership(ctx, db, source, actor, entityID, e.runtimeLogSink()); err != nil {
 		return nil, err
 	}
 	fieldName := strings.TrimSpace(asString(payload["field"]))
@@ -199,7 +200,7 @@ func nullableJSONBytes(raw []byte) any {
 	return json.RawMessage(append([]byte(nil), raw...))
 }
 
-func enforceEntityWriteOwnership(ctx context.Context, db *sql.DB, source semanticview.Source, actor models.AgentConfig, entityID string) error {
+func enforceEntityWriteOwnership(ctx context.Context, db *sql.DB, source semanticview.Source, actor models.AgentConfig, entityID string, logger runtimeToolLogSink) error {
 	flowRoot := actorFlowOwnershipRoot(source, actor.ID)
 	if flowRoot == "" || db == nil {
 		return nil
@@ -214,6 +215,27 @@ func enforceEntityWriteOwnership(ctx context.Context, db *sql.DB, source semanti
 	targetFlow := strings.Trim(flowInstance.String, "/")
 	if targetFlow == "" || entityFlowOwnedBy(flowRoot, targetFlow) {
 		return nil
+	}
+	if logger != nil {
+		logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+			Level:     "warn",
+			Message:   "Entity write was denied because the target entity belongs to a different flow",
+			Component: "tool-executor",
+			Action:    "entity_write_denied",
+			AgentID:   strings.TrimSpace(actor.ID),
+			EntityID:  strings.TrimSpace(entityID),
+			Detail: map[string]any{
+				"denial_layer":       "executor",
+				"denial_reason":      "cross_flow_write_forbidden",
+				"tool_name":          "save_entity_field",
+				"actor_id":           strings.TrimSpace(actor.ID),
+				"actor_role":         strings.TrimSpace(actor.Role),
+				"turn_flow":          strings.TrimSpace(flowRoot),
+				"entity_owner_flow":  targetFlow,
+				"write_target_id":    strings.TrimSpace(entityID),
+				"ownership_relation": "foreign",
+			},
+		})
 	}
 	return NewRuntimeError(
 		"cross_flow_write_forbidden",

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -74,6 +74,9 @@ func TestExecutorTelemetry_LogsSuccess(t *testing.T) {
 	if log.Action != "tool_execution_succeeded" {
 		t.Fatalf("action = %q, want tool_execution_succeeded", log.Action)
 	}
+	if log.Message != "Tool check_domain executed successfully" {
+		t.Fatalf("message = %q", log.Message)
+	}
 	if log.AgentID != "agent-1" || log.EntityID != "entity-1" {
 		t.Fatalf("agent/entity = %q/%q", log.AgentID, log.EntityID)
 	}
@@ -106,12 +109,18 @@ func TestExecutorTelemetry_LogsDeniedExecution(t *testing.T) {
 	if log.Action != "tool_execution_denied" {
 		t.Fatalf("action = %q, want tool_execution_denied", log.Action)
 	}
+	if log.Message != "Tool workflow_custom_tool execution was denied" {
+		t.Fatalf("message = %q", log.Message)
+	}
 	detail, _ := log.Detail.(map[string]any)
 	if strings.TrimSpace(asString(detail["phase"])) != "authorize" {
 		t.Fatalf("phase = %#v, want authorize", detail["phase"])
 	}
 	if ok, _ := detail["ok"].(bool); ok {
 		t.Fatalf("ok = %#v, want false", detail["ok"])
+	}
+	if strings.TrimSpace(asString(detail["denial_layer"])) != "authorizer" {
+		t.Fatalf("denial_layer = %#v, want authorizer", detail["denial_layer"])
 	}
 }
 
@@ -158,6 +167,9 @@ func TestExecutorTelemetry_LogsExecutionFailure(t *testing.T) {
 	log := bus.logs[0]
 	if log.Action != "tool_execution_failed" {
 		t.Fatalf("action = %q, want tool_execution_failed", log.Action)
+	}
+	if log.Message != "Tool check_domain execution failed" {
+		t.Fatalf("message = %q", log.Message)
 	}
 	detail, _ := log.Detail.(map[string]any)
 	if strings.TrimSpace(asString(detail["phase"])) != "dispatch" {


### PR DESCRIPTION
## Summary

This change makes `platform.runtime_log` the canonical structured runtime diagnostic surface and projects that stream into `agent_turns.turn_blocks` as the ordered per-turn flight recorder.

It also records denial and other high-value runtime decisions at the point where they are made instead of reconstructing them later.

## What Changed

- realign `platform.runtime_log` payloads to the spec contract: `log_level`, `message`, `details`, `stack_trace`
- treat `details` as the structured source of truth, moving prior fields such as `component`, `action`, `error`, and timing under that contract
- extend the per-turn recorder so `agent_turns.turn_blocks` is populated from canonical runtime-log emissions plus turn-local publish diagnostics
- emit explicit runtime diagnostics from key runtime decision points across tools, MCP, bus routing/delivery, persistence-before-emit, and context/session handling
- add denial layer attribution for executor, authorizer, and gateway paths
- promote the approved runtime-log / flight-recorder semantic delta into the branch-local platform spec
- tighten started-runtime quiescence detection so catalog e2e waits for buffered deliveries and in-flight agent work, not only publish counters

## Why

Issue #4 asks for one primary structured per-turn diagnostic surface, with explicit runtime decisions and meaningful denial diagnostics.

This keeps the model aligned with the platform spec:
- `platform.runtime_log` is canonical
- `agent_turns.turn_blocks` is the ordered per-turn projection/surface
- the flight recorder remains a query pattern over existing persisted runtime data, not a separate telemetry store

## Validation

- `go test ./internal/runtime ./internal/runtime/bus ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime/mcp ./internal/runtime/pipeline ./internal/dashboard/server -count=1`
- `go test ./internal/runtime/cataloge2e -run TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-required-agents-child -count=1 -v`
- `go test ./... -count=1`

## Notes

- denial diagnostics now include meaningful layer attribution where the decision is made
- readers and debug UIs should treat `details` as the machine-readable source of truth
- no separate persisted flight-recorder channel was introduced

Closes #4
