### PR TITLE
[agent-a][issue #12] Separate semantic flow scope from concrete flow-instance path

### DIFF
--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -18,6 +18,11 @@ type Identity struct {
 	EntityID     string
 }
 
+type Coordinates struct {
+	ScopeKey     string
+	InstancePath string
+}
+
 func ScopeKey(source semanticview.Source, flowID string) string {
 	flowID = strings.TrimSpace(flowID)
 	if flowID == "" {
@@ -85,17 +90,27 @@ func LogicalInstanceID(instancePath string) string {
 func Derive(source semanticview.Source, flowID, instanceID string) Identity {
 	flowID = strings.TrimSpace(flowID)
 	instanceID = strings.TrimSpace(instanceID)
-	instancePath := InstancePath(source, flowID, instanceID)
+	coordinates := DerivedCoordinates(source, flowID, instanceID)
+	instancePath := coordinates.InstancePath
 	entityID := strings.TrimSpace(instanceID)
 	if instancePath != "" {
 		entityID = EntityID(instancePath)
 	}
 	return Identity{
 		TemplateID:   flowID,
-		ScopeKey:     ScopeKey(source, flowID),
+		ScopeKey:     coordinates.ScopeKey,
 		InstanceID:   instanceID,
 		InstancePath: instancePath,
 		EntityID:     entityID,
+	}
+}
+
+func DerivedCoordinates(source semanticview.Source, flowID, instanceID string) Coordinates {
+	scopeKey := normalizeRef(ScopeKey(source, flowID))
+	instancePath := normalizeRef(InstancePath(source, flowID, instanceID))
+	return Coordinates{
+		ScopeKey:     scopeKey,
+		InstancePath: instancePath,
 	}
 }
 
@@ -111,21 +126,39 @@ func SemanticScopeFromInstancePath(instancePath string) string {
 	return strings.TrimSpace(instancePath[:idx])
 }
 
-func InstanceScopeKey(source semanticview.Source, workflowName, flowPath, fallbackFlowID string) string {
-	if workflowName = strings.TrimSpace(workflowName); workflowName != "" {
-		if scopeKey := strings.TrimSpace(ScopeKey(source, workflowName)); scopeKey != "" {
-			return scopeKey
-		}
+func SemanticScope(instancePath string) string {
+	instancePath = normalizeRef(instancePath)
+	if instancePath == "" {
+		return ""
 	}
-	if scopeKey := strings.TrimSpace(SemanticScopeFromInstancePath(flowPath)); scopeKey != "" {
+	if scopeKey := SemanticScopeFromInstancePath(instancePath); scopeKey != "" {
 		return scopeKey
 	}
-	return strings.TrimSpace(ScopeKey(source, fallbackFlowID))
+	return instancePath
+}
+
+func StoredCoordinates(source semanticview.Source, workflowName, materializedPath string) Coordinates {
+	instancePath := normalizeRef(materializedPath)
+	if instancePath == "" {
+		instancePath = normalizeRef(ScopeKey(source, workflowName))
+	}
+	return Coordinates{
+		ScopeKey:     normalizeRef(storedScopeKey(source, workflowName, instancePath)),
+		InstancePath: instancePath,
+	}
+}
+
+func StoredScopeKey(source semanticview.Source, workflowName, materializedPath string) string {
+	return StoredCoordinates(source, workflowName, materializedPath).ScopeKey
+}
+
+func StoredInstancePath(source semanticview.Source, workflowName, materializedPath string) string {
+	return StoredCoordinates(source, workflowName, materializedPath).InstancePath
 }
 
 func IsDescendant(scopeKey, instancePath string) bool {
-	scopeKey = strings.Trim(strings.TrimSpace(scopeKey), "/")
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
+	scopeKey = normalizeRef(scopeKey)
+	instancePath = normalizeRef(instancePath)
 	if scopeKey == "" || instancePath == "" || instancePath == scopeKey {
 		return false
 	}
@@ -145,12 +178,20 @@ func OwnedByFlow(source semanticview.Source, ownerFlowID, targetInstancePath str
 }
 
 func OwnedByScope(ownerScope, targetInstancePath string) bool {
-	ownerScope = strings.TrimSpace(ownerScope)
-	targetScope := strings.TrimSpace(SemanticScopeFromInstancePath(targetInstancePath))
+	ownerScope = normalizeRef(ownerScope)
+	targetScope := SemanticScope(targetInstancePath)
 	if ownerScope == "" || strings.TrimSpace(targetInstancePath) == "" {
 		return true
 	}
 	return ownerScope == targetScope
+}
+
+func storedScopeKey(source semanticview.Source, workflowName, instancePath string) string {
+	instancePath = normalizeRef(instancePath)
+	if instancePath != "" {
+		return SemanticScope(instancePath)
+	}
+	return normalizeRef(ScopeKey(source, workflowName))
 }
 
 func contains(items []string, target string) bool {

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -62,6 +62,59 @@ func TestLookupKeys_UsesCanonicalEntityID(t *testing.T) {
 	}
 }
 
+func TestSemanticScope_DistinguishesStaticAndInstancedPaths(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{path: "", want: ""},
+		{path: "child", want: "child"},
+		{path: "child/inst-1", want: "child"},
+		{path: "child/grandchild/inst-1", want: "child/grandchild"},
+	}
+	for _, tc := range cases {
+		if got := SemanticScope(tc.path); got != tc.want {
+			t.Fatalf("SemanticScope(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestStoredCoordinates_SeparateScopeFromConcretePath(t *testing.T) {
+	cases := []struct {
+		name         string
+		workflowName string
+		flowPath     string
+		wantScope    string
+		wantPath     string
+	}{
+		{
+			name:         "static flow row uses semantic scope as path",
+			workflowName: "child",
+			wantScope:    "child",
+			wantPath:     "child",
+		},
+		{
+			name:         "template flow row keeps concrete path",
+			workflowName: "grandchild",
+			flowPath:     "child/grandchild/inst-1",
+			wantScope:    "child/grandchild",
+			wantPath:     "child/grandchild/inst-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StoredCoordinates(nil, tc.workflowName, tc.flowPath)
+			if got.ScopeKey != tc.wantScope {
+				t.Fatalf("StoredCoordinates(%q, %q).ScopeKey = %q, want %q", tc.workflowName, tc.flowPath, got.ScopeKey, tc.wantScope)
+			}
+			if got.InstancePath != tc.wantPath {
+				t.Fatalf("StoredCoordinates(%q, %q).InstancePath = %q, want %q", tc.workflowName, tc.flowPath, got.InstancePath, tc.wantPath)
+			}
+		})
+	}
+}
+
 func TestSemanticScopeFromInstancePath(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -802,14 +802,12 @@ func workflowInstanceOwnedByFlow(source semanticview.Source, instance WorkflowIn
 	if flowID == "" {
 		return true
 	}
-	if strings.TrimSpace(instance.WorkflowName) == flowID {
-		return true
-	}
-	targetPath := workflowInstancePath(instance)
-	if targetPath == "" {
+	ownerScope := runtimeflowidentity.ScopeKey(source, flowID)
+	targetScope := workflowInstanceScopeKey(source, instance)
+	if ownerScope == "" || targetScope == "" {
 		return false
 	}
-	return runtimeflowidentity.OwnedByFlow(source, flowID, targetPath)
+	return ownerScope == targetScope
 }
 
 func workflowStateGatesForScope(source semanticview.Source, flowID string, metadata map[string]any) map[string]bool {

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -323,9 +323,9 @@ func resolveHandlerEntityIDForFlow(
 	}
 	entityID, evt = ensureHandlerEntityID(source, handler, entityID, evt)
 	if flowID != "" && state != nil {
-		currentFlowPath := strings.TrimSpace(workflowScopeKey(source, flowID))
-		inboundFlowPath := strings.Trim(strings.TrimSpace(asString(state.Metadata["flow_path"])), "/")
-		if isDescendantFlowInstance(currentFlowPath, inboundFlowPath) {
+		currentScopeKey := strings.TrimSpace(workflowScopeKey(source, flowID))
+		inboundInstancePath := strings.Trim(strings.TrimSpace(asString(state.Metadata["flow_path"])), "/")
+		if isDescendantFlowInstance(currentScopeKey, inboundInstancePath) {
 			if parentEntityID := strings.TrimSpace(asString(state.Metadata["parent_entity_id"])); parentEntityID != "" {
 				entityID = parentEntityID
 				state.EntityID = parentEntityID

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -31,23 +31,20 @@ func deriveFlowInstanceIdentity(source semanticview.Source, flowID, instanceID s
 	return DeriveFlowInstanceIdentity(source, flowID, instanceID)
 }
 
-func workflowInstanceScopeKey(source semanticview.Source, instance WorkflowInstance, fallbackFlowID string) string {
-	return runtimeflowidentity.InstanceScopeKey(
+func workflowInstanceCoordinates(source semanticview.Source, instance WorkflowInstance) runtimeflowidentity.Coordinates {
+	return runtimeflowidentity.StoredCoordinates(
 		source,
 		strings.TrimSpace(instance.WorkflowName),
-		workflowInstancePath(instance),
-		fallbackFlowID,
+		workflowInstanceMaterializedPath(instance),
 	)
 }
 
-func workflowInstancePath(instance WorkflowInstance) string {
-	if flowPath := strings.Trim(strings.TrimSpace(asString(instance.Metadata["flow_path"])), "/"); flowPath != "" {
-		return flowPath
-	}
-	if storageRef := strings.Trim(strings.TrimSpace(instance.StorageRef), "/"); storageRef != "" {
-		return storageRef
-	}
-	return strings.Trim(strings.TrimSpace(asString(instance.Metadata["storage_ref"])), "/")
+func workflowInstanceScopeKey(source semanticview.Source, instance WorkflowInstance) string {
+	return workflowInstanceCoordinates(source, instance).ScopeKey
+}
+
+func workflowInstancePath(source semanticview.Source, instance WorkflowInstance) string {
+	return workflowInstanceCoordinates(source, instance).InstancePath
 }
 
 func workflowInstanceMaterializedPath(instance WorkflowInstance) string {
@@ -58,7 +55,7 @@ func workflowInstanceLogicalIDFromInstance(instance WorkflowInstance) string {
 	if instanceID := strings.TrimSpace(asString(instance.Metadata["instance_id"])); instanceID != "" {
 		return instanceID
 	}
-	return runtimeflowidentity.LogicalInstanceID(workflowInstancePath(instance))
+	return runtimeflowidentity.LogicalInstanceID(workflowInstanceMaterializedPath(instance))
 }
 
 func workflowInstanceMaterializedIdentity(instance WorkflowInstance) (flowPath string, instanceID string, ok bool) {

--- a/internal/runtime/pipeline/flow_instance_identity_test.go
+++ b/internal/runtime/pipeline/flow_instance_identity_test.go
@@ -134,6 +134,61 @@ func TestFlowInstanceIdentity_ResolveEmittedEntityID(t *testing.T) {
 	}
 }
 
+func TestWorkflowInstanceCoordinates_SeparateStaticScopeFromGenericStorageRef(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-gates-in-child-flow")
+
+	instance := WorkflowInstance{
+		WorkflowName: "child",
+		StorageRef:   "22222222-2222-2222-2222-222222222222",
+		Metadata: map[string]any{
+			"storage_ref": "22222222-2222-2222-2222-222222222222",
+		},
+	}
+
+	if got := workflowInstanceScopeKey(source, instance); got != "child" {
+		t.Fatalf("workflowInstanceScopeKey(static child) = %q, want child", got)
+	}
+	if got := workflowInstancePath(source, instance); got != "child" {
+		t.Fatalf("workflowInstancePath(static child) = %q, want child", got)
+	}
+}
+
+func TestWorkflowInstanceCoordinates_KeepNestedInstancePathDistinctFromScope(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
+
+	instance := WorkflowInstance{
+		WorkflowName: "grandchild",
+		Metadata: map[string]any{
+			"flow_path": "child/grandchild/inst-1",
+		},
+	}
+
+	if got := workflowInstanceScopeKey(source, instance); got != "child/grandchild" {
+		t.Fatalf("workflowInstanceScopeKey(nested) = %q, want child/grandchild", got)
+	}
+	if got := workflowInstancePath(source, instance); got != "child/grandchild/inst-1" {
+		t.Fatalf("workflowInstancePath(nested) = %q, want child/grandchild/inst-1", got)
+	}
+}
+
+func TestWorkflowInstanceOwnedByFlow_UsesExactSemanticScope(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
+
+	instance := WorkflowInstance{
+		WorkflowName: "grandchild",
+		Metadata: map[string]any{
+			"flow_path": "child/grandchild/inst-1",
+		},
+	}
+
+	if workflowInstanceOwnedByFlow(source, instance, "child") {
+		t.Fatal("did not expect child to own child/grandchild/inst-1")
+	}
+	if !workflowInstanceOwnedByFlow(source, instance, "grandchild") {
+		t.Fatal("expected grandchild to own child/grandchild/inst-1")
+	}
+}
+
 func mustEvent(eventType, entityID string) Event {
 	return Event{
 		Type: events.EventType(eventType),

--- a/internal/runtime/pipeline/workflow_state_persistence.go
+++ b/internal/runtime/pipeline/workflow_state_persistence.go
@@ -138,13 +138,7 @@ func (pc *PipelineCoordinator) projectWorkflowSubjectGates(ctx context.Context, 
 	if subjectID == "" || subjectID == entityID {
 		return nil
 	}
-	scopeKey := workflowInstanceScopeKey(pc.SemanticSource(), instance, strings.TrimSpace(pipelineFlowScope(ctx)))
-	if scopeKey == "" {
-		flowID := strings.TrimSpace(pipelineFlowScope(ctx))
-		if flowID != "" {
-			scopeKey = strings.TrimSpace(workflowScopeKey(pc.SemanticSource(), flowID))
-		}
-	}
+	scopeKey := workflowInstanceScopeKey(pc.SemanticSource(), instance)
 	if scopeKey == "" {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- make `internal/runtime/core/flowidentity` the canonical owner for separating semantic flow scope from concrete flow-instance path
- remove remaining pipeline seams that derived semantic scope from generic row plumbing or treated scope and path as interchangeable
- add focused nested child/grandchild tests for stored coordinates, exact ownership, and scope-safe gate projection inputs

## Why
The platform spec explicitly says `flow_scope_key` and `flow_instance_path` are distinct and not interchangeable. A few runtime seams were still reconstructing semantic scope from loosely related row fields, which kept scope ownership and instance-path behavior coupled in ways that only happened to work for some paths.

This change makes the split explicit in the shared `flowidentity` model and routes the touched runtime call sites through that single owner.

## Validation
- `gofmt -l .`
- `go vet ./...`
- `go test ./internal/runtime/pipeline ./internal/runtime/core/flowidentity -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workflow instance scope and identity resolution to accurately track ownership relationships and identify descendant flows in nested and templated workflow configurations
  * Standardized scope key computation across instance derivation paths for enhanced consistency

* **Tests**
  * Added comprehensive tests validating semantic scope resolution, instance coordinate handling, and ownership determination logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->