### PR TITLE
[agent-a][issue #16] Introduce a first-class flow-instance model

### DIFF
--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -10,17 +10,15 @@ import (
 
 var flowInstanceEntityNamespace = uuid.NewSHA1(uuid.NameSpaceOID, []byte("flow-instance-entity"))
 
-type Identity struct {
-	TemplateID   string
-	ScopeKey     string
-	InstanceID   string
-	InstancePath string
-	EntityID     string
-}
-
-type Coordinates struct {
-	ScopeKey     string
-	InstancePath string
+type Instance struct {
+	TemplateID     string
+	ScopeKey       string
+	InstanceID     string
+	InstancePath   string
+	EntityID       string
+	SubjectID      string
+	ParentEntityID string
+	HasStoredPath  bool
 }
 
 func ScopeKey(source semanticview.Source, flowID string) string {
@@ -87,30 +85,21 @@ func LogicalInstanceID(instancePath string) string {
 	return strings.TrimSpace(path.Base(instancePath))
 }
 
-func Derive(source semanticview.Source, flowID, instanceID string) Identity {
-	flowID = strings.TrimSpace(flowID)
+func Derive(source semanticview.Source, flowID, instanceID string) Instance {
+	scopeKey := normalizeRef(ScopeKey(source, flowID))
+	instancePath := normalizeRef(InstancePath(source, flowID, instanceID))
 	instanceID = strings.TrimSpace(instanceID)
-	coordinates := DerivedCoordinates(source, flowID, instanceID)
-	instancePath := coordinates.InstancePath
 	entityID := strings.TrimSpace(instanceID)
 	if instancePath != "" {
 		entityID = EntityID(instancePath)
 	}
-	return Identity{
-		TemplateID:   flowID,
-		ScopeKey:     coordinates.ScopeKey,
-		InstanceID:   instanceID,
-		InstancePath: instancePath,
-		EntityID:     entityID,
-	}
-}
-
-func DerivedCoordinates(source semanticview.Source, flowID, instanceID string) Coordinates {
-	scopeKey := normalizeRef(ScopeKey(source, flowID))
-	instancePath := normalizeRef(InstancePath(source, flowID, instanceID))
-	return Coordinates{
-		ScopeKey:     scopeKey,
-		InstancePath: instancePath,
+	return Instance{
+		TemplateID:    strings.TrimSpace(flowID),
+		ScopeKey:      scopeKey,
+		InstanceID:    instanceID,
+		InstancePath:  instancePath,
+		EntityID:      entityID,
+		HasStoredPath: instancePath != "",
 	}
 }
 
@@ -137,23 +126,37 @@ func SemanticScope(instancePath string) string {
 	return instancePath
 }
 
-func StoredCoordinates(source semanticview.Source, workflowName, materializedPath string) Coordinates {
-	instancePath := normalizeRef(materializedPath)
+func Stored(
+	source semanticview.Source,
+	workflowName,
+	materializedPath,
+	instanceID,
+	entityID,
+	subjectID,
+	parentEntityID string,
+) Instance {
+	workflowName = strings.TrimSpace(workflowName)
+	materializedPath = normalizeRef(materializedPath)
+	instancePath := materializedPath
 	if instancePath == "" {
 		instancePath = normalizeRef(ScopeKey(source, workflowName))
 	}
-	return Coordinates{
-		ScopeKey:     normalizeRef(storedScopeKey(source, workflowName, instancePath)),
-		InstancePath: instancePath,
+	if strings.TrimSpace(instanceID) == "" && materializedPath != "" {
+		instanceID = LogicalInstanceID(materializedPath)
 	}
-}
-
-func StoredScopeKey(source semanticview.Source, workflowName, materializedPath string) string {
-	return StoredCoordinates(source, workflowName, materializedPath).ScopeKey
-}
-
-func StoredInstancePath(source semanticview.Source, workflowName, materializedPath string) string {
-	return StoredCoordinates(source, workflowName, materializedPath).InstancePath
+	if strings.TrimSpace(entityID) == "" && instancePath != "" {
+		entityID = EntityID(instancePath)
+	}
+	return Instance{
+		TemplateID:     workflowName,
+		ScopeKey:       normalizeRef(storedScopeKey(source, workflowName, instancePath)),
+		InstanceID:     strings.TrimSpace(instanceID),
+		InstancePath:   instancePath,
+		EntityID:       strings.TrimSpace(entityID),
+		SubjectID:      strings.TrimSpace(subjectID),
+		ParentEntityID: strings.TrimSpace(parentEntityID),
+		HasStoredPath:  materializedPath != "",
+	}
 }
 
 func IsDescendant(scopeKey, instancePath string) bool {

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -104,12 +104,15 @@ func TestStoredCoordinates_SeparateScopeFromConcretePath(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := StoredCoordinates(nil, tc.workflowName, tc.flowPath)
+			got := Stored(nil, tc.workflowName, tc.flowPath, "", "", "", "")
 			if got.ScopeKey != tc.wantScope {
-				t.Fatalf("StoredCoordinates(%q, %q).ScopeKey = %q, want %q", tc.workflowName, tc.flowPath, got.ScopeKey, tc.wantScope)
+				t.Fatalf("Stored(%q, %q).ScopeKey = %q, want %q", tc.workflowName, tc.flowPath, got.ScopeKey, tc.wantScope)
 			}
 			if got.InstancePath != tc.wantPath {
-				t.Fatalf("StoredCoordinates(%q, %q).InstancePath = %q, want %q", tc.workflowName, tc.flowPath, got.InstancePath, tc.wantPath)
+				t.Fatalf("Stored(%q, %q).InstancePath = %q, want %q", tc.workflowName, tc.flowPath, got.InstancePath, tc.wantPath)
+			}
+			if got.HasStoredPath != (tc.flowPath != "") {
+				t.Fatalf("Stored(%q, %q).HasStoredPath = %v, want %v", tc.workflowName, tc.flowPath, got.HasStoredPath, tc.flowPath != "")
 			}
 		})
 	}

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -38,10 +38,12 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if req.ContractBundle == nil {
 		return fmt.Errorf("contract bundle is required")
 	}
-	templateID := strings.TrimSpace(req.TemplateID)
-	instanceID := strings.TrimSpace(req.InstanceID)
-	entityID := strings.TrimSpace(req.EntityID)
-	if templateID == "" || instanceID == "" || entityID == "" {
+	instance := req.Instance
+	templateID := strings.TrimSpace(instance.TemplateID)
+	instanceID := strings.TrimSpace(instance.InstanceID)
+	flowEntityID := strings.TrimSpace(instance.EntityID)
+	flowPath := strings.TrimSpace(instance.InstancePath)
+	if templateID == "" || instanceID == "" || flowEntityID == "" || flowPath == "" {
 		return fmt.Errorf("template_id, instance_id, and entity_id are required")
 	}
 	scope, ok := semanticview.FlowScopeByID(req.ContractBundle, templateID)
@@ -52,19 +54,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if !ok {
 		return fmt.Errorf("flow schema not found: %s", templateID)
 	}
-	flowPath := strings.Trim(strings.TrimSpace(req.FlowPath), "/")
-	identity := runtimepipeline.DeriveFlowInstanceIdentity(req.ContractBundle, templateID, instanceID)
-	if flowPath == "" {
-		flowPath = identity.InstancePath
-	}
-	sourceEntityID := entityID
-	flowEntityID := strings.TrimSpace(identity.EntityID)
-	if strings.TrimSpace(flowPath) != strings.TrimSpace(identity.InstancePath) {
-		flowEntityID = strings.TrimSpace(runtimepipeline.FlowInstanceEntityID(flowPath))
-	}
 	if flowEntityID == "" {
 		return fmt.Errorf("derive flow entity id for %s", flowPath)
 	}
+	sourceEntityID := strings.TrimSpace(instance.SubjectID)
 	if am.workflowInstances != nil {
 		initialState := strings.TrimSpace(schema.InitialState)
 		if initialState == "" {
@@ -83,10 +76,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 			Config:          cloneFlowConfig(req.Config),
 			Metadata: map[string]any{
 				"entity_id":        flowEntityID,
-				"instance_id":      identity.InstanceID,
+				"instance_id":      instanceID,
 				"flow_path":        flowPath,
 				"subject_id":       strings.TrimSpace(sourceEntityID),
-				"parent_entity_id": strings.TrimSpace(sourceEntityID),
+				"parent_entity_id": strings.TrimSpace(instance.ParentEntityID),
 			},
 		}); err != nil {
 			return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
@@ -131,11 +124,11 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		eventType := eventidentity.ExternalizeForFlow(flowPath, []string{autoEmit}, autoEmit)
 		payload := map[string]any{
 			"entity_id":        flowEntityID,
-			"instance_id":      identity.InstanceID,
+			"instance_id":      instanceID,
 			"template_id":      templateID,
 			"flow_path":        flowPath,
 			"subject_id":       strings.TrimSpace(sourceEntityID),
-			"parent_entity_id": strings.TrimSpace(sourceEntityID),
+			"parent_entity_id": strings.TrimSpace(instance.ParentEntityID),
 		}
 		for key, value := range req.Config {
 			key = strings.TrimSpace(key)
@@ -239,15 +232,28 @@ func (am *AgentManager) DeactivateFlowInstance(ctx context.Context, templateID, 
 	if am == nil {
 		return fmt.Errorf("agent manager is required")
 	}
-	templateID = strings.TrimSpace(templateID)
-	instanceID = strings.TrimSpace(instanceID)
-	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
-	entityID = strings.TrimSpace(entityID)
+	if canonicalEntityID := runtimeflowidentity.EntityID(flowPath); canonicalEntityID != "" {
+		entityID = canonicalEntityID
+	}
+	return am.DeactivateFlowInstanceModel(ctx, runtimepipeline.FlowInstanceDeactivationRequest{
+		Instance: runtimeflowidentity.Stored(nil, templateID, flowPath, instanceID, entityID, "", ""),
+	})
+}
+
+func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
+	if am == nil {
+		return fmt.Errorf("agent manager is required")
+	}
+	instance := req.Instance
+	templateID := strings.TrimSpace(instance.TemplateID)
+	instanceID := strings.TrimSpace(instance.InstanceID)
+	flowPath := strings.TrimSpace(instance.InstancePath)
+	entityID := strings.TrimSpace(instance.EntityID)
 	if templateID == "" || instanceID == "" || flowPath == "" || entityID == "" {
 		return fmt.Errorf("template_id, instance_id, flow_path, and entity_id are required")
 	}
-	flowEntityID := strings.TrimSpace(runtimepipeline.FlowInstanceEntityID(flowPath))
-	scopeKey := strings.TrimSpace(runtimeflowidentity.SemanticScopeFromInstancePath(flowPath))
+	flowEntityID := entityID
+	scopeKey := strings.TrimSpace(instance.ScopeKey)
 	if scopeKey == "" {
 		return fmt.Errorf("derive scope key for flow path %s", flowPath)
 	}
@@ -609,8 +615,8 @@ func staticFlowLocalEventSet(agents map[string]runtimecontracts.AgentRegistryEnt
 
 func flowActivationVars(req runtimepipeline.FlowInstanceActivationRequest) map[string]string {
 	vars := map[string]string{
-		"entity_id":   strings.TrimSpace(req.EntityID),
-		"instance_id": strings.TrimSpace(req.InstanceID),
+		"entity_id":   strings.TrimSpace(req.Instance.EntityID),
+		"instance_id": strings.TrimSpace(req.Instance.InstanceID),
 	}
 	for key, value := range req.Config {
 		key = strings.TrimSpace(key)

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -10,6 +10,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -210,19 +211,30 @@ func testStaticFlowBundle() *runtimecontracts.WorkflowContractBundle {
 	}
 }
 
+func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, templateID, instanceID, sourceEntityID, flowPath string) runtimepipeline.FlowInstanceActivationRequest {
+	instance := runtimeflowidentity.Stored(
+		semanticview.Wrap(bundle),
+		templateID,
+		flowPath,
+		instanceID,
+		runtimepipeline.FlowInstanceEntityID(flowPath),
+		sourceEntityID,
+		sourceEntityID,
+	)
+	return runtimepipeline.FlowInstanceActivationRequest{
+		ContractBundle: semanticview.Wrap(bundle),
+		Instance:       instance,
+	}
+}
+
 func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := NewAgentManager(bus, nil)
 	bundle := testFlowBundle("")
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-		InitialState:   "queued",
-	})
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.InitialState = "queued"
+	err := am.ActivateFlowInstance(context.Background(), req)
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -243,13 +255,7 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	am := NewAgentManager(bus, nil)
 	bundle := testFlowBundle("task.started")
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-	})
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -275,13 +281,7 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	postCommit := make([]func(), 0, 1)
 	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
 
-	err := am.ActivateFlowInstance(ctx, runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-	})
+	err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -334,17 +334,12 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	am.SetWorkflowInstanceStore(instances)
 	bundle := testFlowBundle("task.started")
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-		Config: map[string]any{
-			"name":     "alpha",
-			"priority": 1,
-		},
-	})
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"name":     "alpha",
+		"priority": 1,
+	}
+	err := am.ActivateFlowInstance(context.Background(), req)
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -390,13 +385,7 @@ func TestActivateFlowInstanceResolvesAgentPermissions(t *testing.T) {
 	reviewFlow.Agents["reviewer"] = entry
 	bundle.FlowTree.Root.Children[0].Agents["reviewer"] = entry
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-	})
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -414,13 +403,7 @@ func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 	am := NewAgentManager(bus, nil)
 	bundle := testFlowBundle("")
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "review/inst-1",
-	})
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -440,13 +423,7 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 	am := NewAgentManager(bus, nil)
 	bundle := testNestedFlowBundle()
 
-	err := am.ActivateFlowInstance(context.Background(), runtimepipeline.FlowInstanceActivationRequest{
-		ContractBundle: semanticview.Wrap(bundle),
-		TemplateID:     "grandchild",
-		InstanceID:     "inst-1",
-		EntityID:       "ent-1",
-		FlowPath:       "child/grandchild/inst-1",
-	})
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "grandchild", "inst-1", "ent-1", "child/grandchild/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -672,7 +672,7 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 		instance.Metadata = cloneStringAnyMap(mutation.Metadata)
 	}
 	if instance.Metadata != nil && strings.TrimSpace(instance.SubjectID) == "" {
-		instance.SubjectID = strings.TrimSpace(asString(instance.Metadata["subject_id"]))
+		instance.SubjectID = workflowInstanceIdentity(source, *instance).SubjectID
 	}
 	if mutation.StateBuckets != nil {
 		instance.StateBuckets = cloneStringAnyMap(mutation.StateBuckets)
@@ -724,16 +724,13 @@ func (pc *PipelineCoordinator) maybeDeactivateTerminalFlowInstance(ctx context.C
 			return nil
 		}
 	}
-	flowPath, instanceID, ok := workflowInstanceMaterializedIdentity(instance)
-	if !ok {
+	instanceIdentity := workflowInstanceIdentity(source, instance)
+	if !instanceIdentity.HasStoredPath {
 		return nil
 	}
 	return pc.instanceDeactivator(ctx, FlowInstanceDeactivationRequest{
 		ContractBundle: source,
-		TemplateID:     templateID,
-		InstanceID:     instanceID,
-		EntityID:       entityID,
-		FlowPath:       flowPath,
+		Instance:       instanceIdentity,
 		FinalState:     nextState,
 	})
 }

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -228,7 +228,7 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 	}
 }
 
-func TestProjectWorkflowSubjectGatesFallsBackToFlowPathStorageRef(t *testing.T) {
+func TestProjectWorkflowSubjectGatesRequiresCanonicalEntityID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	store := NewWorkflowInstanceStore(db)
 	subjectID := "11111111-1111-1111-1111-111111111111"
@@ -277,8 +277,7 @@ func TestProjectWorkflowSubjectGatesFallsBackToFlowPathStorageRef(t *testing.T) 
 			},
 		},
 	}
-	ctx := withPipelineFlowScope(context.Background(), "child")
-	if err := pc.projectWorkflowSubjectGates(ctx, logicalChildID); err != nil {
+	if err := pc.projectWorkflowSubjectGates(context.Background(), logicalChildID); err != nil {
 		t.Fatalf("projectWorkflowSubjectGates: %v", err)
 	}
 
@@ -290,8 +289,8 @@ func TestProjectWorkflowSubjectGatesFallsBackToFlowPathStorageRef(t *testing.T) 
 		t.Fatal("subject entity missing after projection")
 	}
 	gates := workflowStateGatesAsBools(subject.Metadata)
-	if !gates["child/g_validated"] {
-		t.Fatalf("subject gates missing projected child gate via flow-path fallback: %#v", gates)
+	if gates["child/g_validated"] {
+		t.Fatalf("subject gates unexpectedly projected from logical instance id lookup: %#v", gates)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -293,47 +293,47 @@ func resolveHandlerEntityIDForFlow(
 	if handler.CreateEntity {
 		sourceEntityID := strings.TrimSpace(firstNonEmptyString(entityID, evt.EntityID()))
 		instanceID := uuid.NewString()
-		identity := deriveFlowInstanceIdentity(source, flowID, instanceID)
-		subjectID := ""
+		instance := deriveFlowInstanceIdentity(source, flowID, instanceID)
+		instance.ParentEntityID = sourceEntityID
 		if state != nil && state.Metadata != nil {
-			subjectID = strings.TrimSpace(asString(state.Metadata["subject_id"]))
+			instance.SubjectID = strings.TrimSpace(asString(state.Metadata["subject_id"]))
 		}
-		if subjectID == "" {
-			subjectID = sourceEntityID
+		if instance.SubjectID == "" {
+			instance.SubjectID = sourceEntityID
 		}
-		if subjectID == "" {
-			subjectID = identity.EntityID
+		if instance.SubjectID == "" {
+			instance.SubjectID = instance.EntityID
 		}
-		entityID = identity.EntityID
+		entityID = instance.EntityID
 		if state != nil {
 			state.EntityID = entityID
 			state.Stage = ""
 			state.Status = ""
-			state.Metadata = map[string]any{"subject_id": subjectID}
-			if identity.InstancePath != "" {
-				state.Metadata["flow_path"] = identity.InstancePath
-				state.Metadata["storage_ref"] = identity.InstancePath
+			state.Metadata = map[string]any{"subject_id": instance.SubjectID}
+			if instance.InstancePath != "" {
+				state.Metadata["flow_path"] = instance.InstancePath
+				state.Metadata["storage_ref"] = instance.InstancePath
 			}
-			state.Metadata["instance_id"] = identity.InstanceID
-			if sourceEntityID != "" {
-				state.Metadata["parent_entity_id"] = sourceEntityID
+			state.Metadata["instance_id"] = instance.InstanceID
+			if instance.ParentEntityID != "" {
+				state.Metadata["parent_entity_id"] = instance.ParentEntityID
 			}
 		}
 		return entityID, evt
 	}
 	entityID, evt = ensureHandlerEntityID(source, handler, entityID, evt)
 	if flowID != "" && state != nil {
+		inboundInstance := workflowStateIdentity(source, flowID, *state)
 		currentScopeKey := strings.TrimSpace(workflowScopeKey(source, flowID))
-		inboundInstancePath := strings.Trim(strings.TrimSpace(asString(state.Metadata["flow_path"])), "/")
-		if isDescendantFlowInstance(currentScopeKey, inboundInstancePath) {
-			if parentEntityID := strings.TrimSpace(asString(state.Metadata["parent_entity_id"])); parentEntityID != "" {
+		if isDescendantFlowInstance(currentScopeKey, inboundInstance.InstancePath) {
+			if parentEntityID := strings.TrimSpace(inboundInstance.ParentEntityID); parentEntityID != "" {
 				entityID = parentEntityID
 				state.EntityID = parentEntityID
 			}
 		}
 	}
 	if strings.TrimSpace(flowID) == "" && state != nil {
-		subjectID := strings.TrimSpace(asString(state.Metadata["subject_id"]))
+		subjectID := strings.TrimSpace(workflowStateIdentity(source, "", *state).SubjectID)
 		if subjectID != "" && subjectID != entityID {
 			entityID = subjectID
 			state.EntityID = subjectID

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -9,68 +9,56 @@ import (
 )
 
 type FlowInstanceIdentity struct {
-	TemplateID   string
-	ScopeKey     string
-	InstanceID   string
-	InstancePath string
-	EntityID     string
+	runtimeflowidentity.Instance
 }
 
 func DeriveFlowInstanceIdentity(source semanticview.Source, flowID, instanceID string) FlowInstanceIdentity {
-	identity := runtimeflowidentity.Derive(source, flowID, instanceID)
-	return FlowInstanceIdentity{
-		TemplateID:   identity.TemplateID,
-		ScopeKey:     identity.ScopeKey,
-		InstanceID:   identity.InstanceID,
-		InstancePath: identity.InstancePath,
-		EntityID:     identity.EntityID,
-	}
+	return FlowInstanceIdentity{Instance: runtimeflowidentity.Derive(source, flowID, instanceID)}
 }
 
 func deriveFlowInstanceIdentity(source semanticview.Source, flowID, instanceID string) FlowInstanceIdentity {
 	return DeriveFlowInstanceIdentity(source, flowID, instanceID)
 }
 
-func workflowInstanceCoordinates(source semanticview.Source, instance WorkflowInstance) runtimeflowidentity.Coordinates {
-	return runtimeflowidentity.StoredCoordinates(
+func StoredFlowInstance(source semanticview.Source, instance WorkflowInstance) runtimeflowidentity.Instance {
+	materializedPath := strings.Trim(strings.TrimSpace(asString(instance.Metadata["flow_path"])), "/")
+	entityID := strings.TrimSpace(asString(instance.Metadata["entity_id"]))
+	if entityID == "" && materializedPath == "" {
+		entityID = strings.TrimSpace(instance.InstanceID)
+	}
+	return runtimeflowidentity.Stored(
 		source,
 		strings.TrimSpace(instance.WorkflowName),
-		workflowInstanceMaterializedPath(instance),
+		materializedPath,
+		strings.TrimSpace(firstNonEmptyString(asString(instance.Metadata["instance_id"]), instance.InstanceID)),
+		entityID,
+		strings.TrimSpace(firstNonEmptyString(instance.SubjectID, asString(instance.Metadata["subject_id"]))),
+		strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
 	)
 }
 
+func workflowInstanceIdentity(source semanticview.Source, instance WorkflowInstance) runtimeflowidentity.Instance {
+	return StoredFlowInstance(source, instance)
+}
+
 func workflowInstanceScopeKey(source semanticview.Source, instance WorkflowInstance) string {
-	return workflowInstanceCoordinates(source, instance).ScopeKey
+	return workflowInstanceIdentity(source, instance).ScopeKey
 }
 
 func workflowInstancePath(source semanticview.Source, instance WorkflowInstance) string {
-	return workflowInstanceCoordinates(source, instance).InstancePath
+	return workflowInstanceIdentity(source, instance).InstancePath
 }
 
-func workflowInstanceMaterializedPath(instance WorkflowInstance) string {
-	return strings.Trim(strings.TrimSpace(asString(instance.Metadata["flow_path"])), "/")
-}
-
-func workflowInstanceLogicalIDFromInstance(instance WorkflowInstance) string {
-	if instanceID := strings.TrimSpace(asString(instance.Metadata["instance_id"])); instanceID != "" {
-		return instanceID
-	}
-	return runtimeflowidentity.LogicalInstanceID(workflowInstanceMaterializedPath(instance))
-}
-
-func workflowInstanceMaterializedIdentity(instance WorkflowInstance) (flowPath string, instanceID string, ok bool) {
-	flowPath = workflowInstanceMaterializedPath(instance)
-	if flowPath == "" {
-		return "", "", false
-	}
-	instanceID = strings.TrimSpace(asString(instance.Metadata["instance_id"]))
-	if instanceID == "" {
-		instanceID = runtimeflowidentity.LogicalInstanceID(flowPath)
-	}
-	if instanceID == "" {
-		return "", "", false
-	}
-	return flowPath, instanceID, true
+func workflowStateIdentity(source semanticview.Source, flowID string, state WorkflowState) runtimeflowidentity.Instance {
+	return runtimeflowidentity.Stored(
+		source,
+		strings.TrimSpace(flowID),
+		asString(state.Metadata["flow_path"]),
+		asString(state.Metadata["instance_id"]),
+		strings.TrimSpace(state.EntityID),
+		asString(state.Metadata["subject_id"]),
+		asString(state.Metadata["parent_entity_id"]),
+	)
 }
 
 func isDescendantFlowInstance(scopeKey, instancePath string) bool {
@@ -85,9 +73,10 @@ func resolveEmittedEntityID(
 	currentEntityID string,
 	inboundEntityID string,
 ) string {
+	instance := workflowStateIdentity(source, flowID, state)
 	entityID := strings.TrimSpace(firstNonEmptyString(
 		currentEntityID,
-		state.EntityID,
+		instance.EntityID,
 		inboundEntityID,
 		workflowEventEntityID(trigger),
 		trigger.EntityID(),
@@ -95,11 +84,11 @@ func resolveEmittedEntityID(
 	if !workflowEmitTargetsParentEntity(source, flowID, eventType) {
 		return entityID
 	}
-	if strings.TrimSpace(asString(state.Metadata["flow_path"])) == "" {
+	if !instance.HasStoredPath {
 		return entityID
 	}
 	return strings.TrimSpace(firstNonEmptyString(
-		asString(state.Metadata["parent_entity_id"]),
+		instance.ParentEntityID,
 		trigger.EntityID(),
 		entityID,
 	))

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -16,10 +16,7 @@ import (
 
 type FlowInstanceActivationRequest struct {
 	ContractBundle semanticview.Source
-	TemplateID     string
-	InstanceID     string
-	EntityID       string
-	FlowPath       string
+	Instance       runtimeflowidentity.Instance
 	InitialState   string
 	Config         map[string]any
 	TriggerEvent   events.Event
@@ -29,10 +26,7 @@ type FlowInstanceActivator func(context.Context, FlowInstanceActivationRequest) 
 
 type FlowInstanceDeactivationRequest struct {
 	ContractBundle semanticview.Source
-	TemplateID     string
-	InstanceID     string
-	EntityID       string
-	FlowPath       string
+	Instance       runtimeflowidentity.Instance
 	FinalState     string
 }
 
@@ -64,12 +58,19 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 	if instanceID == "" {
 		instanceID = uuid.NewString()
 	}
+	sourceEntityID := strings.TrimSpace(entityID)
+	instance := runtimeflowidentity.Derive(pc.SemanticSource(), templateID, instanceID)
+	instance.ParentEntityID = sourceEntityID
+	instance.SubjectID = strings.TrimSpace(asString(triggerCtx.State.Metadata["subject_id"]))
+	if instance.SubjectID == "" {
+		instance.SubjectID = sourceEntityID
+	}
+	if instance.SubjectID == "" {
+		instance.SubjectID = instance.EntityID
+	}
 	req := FlowInstanceActivationRequest{
 		ContractBundle: pc.SemanticSource(),
-		TemplateID:     templateID,
-		InstanceID:     instanceID,
-		EntityID:       entityID,
-		FlowPath:       DeriveFlowInstancePath(pc.SemanticSource(), templateID, instanceID),
+		Instance:       instance,
 		InitialState:   strings.TrimSpace(plan.AdvancesTo),
 		Config:         map[string]any{},
 		TriggerEvent:   triggerCtx.Event,

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -33,8 +33,14 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 	if ok != nil {
 		t.Fatalf("expected createFlowInstance to succeed: %v", ok)
 	}
-	if captured.InstanceID != "inst-42" {
-		t.Fatalf("instance id = %q, want inst-42", captured.InstanceID)
+	if captured.Instance.InstanceID != "inst-42" {
+		t.Fatalf("instance id = %q, want inst-42", captured.Instance.InstanceID)
+	}
+	if captured.Instance.InstancePath != "review/inst-42" {
+		t.Fatalf("instance path = %q, want review/inst-42", captured.Instance.InstancePath)
+	}
+	if captured.Instance.EntityID != FlowInstanceEntityID("review/inst-42") {
+		t.Fatalf("entity id = %q, want %q", captured.Instance.EntityID, FlowInstanceEntityID("review/inst-42"))
 	}
 }
 
@@ -70,6 +76,9 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 	}
 	if captured.Config["priority"] != float64(1) && captured.Config["priority"] != 1 {
 		t.Fatalf("config priority = %#v, want 1", captured.Config["priority"])
+	}
+	if captured.Instance.SubjectID != "ent-1" {
+		t.Fatalf("subject id = %q, want ent-1", captured.Instance.SubjectID)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_state_persistence.go
+++ b/internal/runtime/pipeline/workflow_state_persistence.go
@@ -115,30 +115,14 @@ func (pc *PipelineCoordinator) projectWorkflowSubjectGates(ctx context.Context, 
 	}
 	instance, ok, err := pc.workflowStore.Load(ctx, entityID)
 	if err != nil || !ok {
-		if err != nil {
-			return err
-		}
-		flowID := strings.TrimSpace(pipelineFlowScope(ctx))
-		if flowID == "" || pc.SemanticSource() == nil {
-			return nil
-		}
-		flowPath := strings.Trim(strings.TrimSpace(pc.SemanticSource().FlowPath(flowID)), "/")
-		if flowPath == "" {
-			flowPath = flowID
-		}
-		if flowPath == "" {
-			return nil
-		}
-		instance, ok, err = pc.workflowStore.Load(ctx, flowPath)
-		if err != nil || !ok {
-			return err
-		}
+		return err
 	}
-	subjectID := strings.TrimSpace(firstNonEmptyString(instance.SubjectID, asString(instance.Metadata["subject_id"]), entityID))
+	instanceIdentity := workflowInstanceIdentity(pc.SemanticSource(), instance)
+	subjectID := strings.TrimSpace(firstNonEmptyString(instanceIdentity.SubjectID, entityID))
 	if subjectID == "" || subjectID == entityID {
 		return nil
 	}
-	scopeKey := workflowInstanceScopeKey(pc.SemanticSource(), instance)
+	scopeKey := strings.TrimSpace(instanceIdentity.ScopeKey)
 	if scopeKey == "" {
 		return nil
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -423,7 +423,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		rt.Manager.SetWorkflowInstanceStore(rt.Pipeline.WorkflowInstanceStore())
 		rt.Pipeline.SetInstanceActivator(rt.Manager.ActivateFlowInstance)
 		rt.Pipeline.SetInstanceDeactivator(func(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
-			return rt.Manager.DeactivateFlowInstance(ctx, req.TemplateID, req.InstanceID, req.FlowPath, req.EntityID)
+			return rt.Manager.DeactivateFlowInstanceModel(ctx, req)
 		})
 	}
 	if rt.Pipeline != nil {
@@ -715,7 +715,11 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 		return err
 	}
 	for _, instance := range instances {
-		entityID := strings.TrimSpace(instance.InstanceID)
+		instanceIdentity := runtimepipeline.StoredFlowInstance(source, instance)
+		entityID := strings.TrimSpace(instanceIdentity.EntityID)
+		if entityID == "" {
+			continue
+		}
 		for _, timerState := range instance.TimerState {
 			if timerState.Cancelled {
 				continue


### PR DESCRIPTION
## What changed

This change introduces a first-class flow-instance descriptor in `internal/runtime/core/flowidentity` and threads it through the touched runtime seams.

The canonical model now carries the flow template, semantic scope key, concrete instance path, entity id, subject id, and parent entity id together instead of reconstructing them from loosely-related strings and metadata fragments.

## Why

Runtime lifecycle paths still disagreed about flow identity. Different seams were independently interpreting `instance_id`, `entity_id`, `flow_path`, `storage_ref`, and subject metadata, which allowed logical ids and persistence transport fields to leak back into semantic identity decisions.

This PR centralizes those semantics behind one model and removes the remaining non-canonical reconstruction in the touched paths.

## Impact

- Activation, deactivation, bridge, and persistence paths now consume the same flow-instance descriptor.
- Gate projection now requires canonical flow-instance identity instead of falling back through logical id and flow-path lookup shortcuts.
- Flow-instance deactivation and lifecycle timer restoration now derive entity identity from the canonical instance model instead of trusting loose row strings.

## Validation

- `go test ./internal/runtime/pipeline ./internal/runtime/core/flowidentity -count=1`
- `go test ./internal/runtime/manager -count=1`
- `go test ./... -count=1`
- `gofmt -l .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal flow instance identity management and metadata handling to improve consistency and reduce redundant code paths.
  * Simplified instance activation and deactivation workflows by unifying identity data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->