### PR TITLE
[agent-b][issue #17] Canonicalize event identity across local, scoped, and emitted forms

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -534,10 +534,12 @@ func (eb *EventBus) localizedSubscriberEvent(eventType string, subscriber Subscr
 	if eb != nil && eb.semanticSource != nil {
 		flowID := strings.TrimSpace(routeFlowIDForPath(eb.semanticSource, subscriber.Path))
 		if flowID != "" {
-			flowPath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
-			inputs := eventidentity.NormalizeList(eb.semanticSource.FlowInputEvents(flowID))
+			scope := eventidentity.Scope{
+				Path:        strings.Trim(strings.TrimSpace(subscriber.Path), "/"),
+				InputEvents: append([]string{}, eb.semanticSource.FlowInputEvents(flowID)...),
+			}
 			for _, candidate := range candidates {
-				if localized := eventidentity.LocalizeForFlow(flowPath, inputs, candidate); localized != "" && localized != eventidentity.Normalize(candidate) {
+				if localized := scope.LocalizeInput(candidate); localized != "" && localized != eventidentity.Normalize(candidate) {
 					return localized
 				}
 			}

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -278,8 +278,9 @@ func newRouteTable(source semanticview.Source) *RouteTable {
 
 func (rt *RouteTable) addEventPathsLocked(basePath string, localEvents map[string]struct{}) []string {
 	added := make([]string, 0, len(localEvents))
+	scope := routeEventIdentityScope(basePath, localEvents, nil)
 	for _, eventType := range sortedStringKeys(localEvents) {
-		absolute := routeResolvePattern(basePath, localEvents, eventType)
+		absolute := scope.ResolveEvent(eventType, nil)
 		if absolute == "" || strings.Contains(absolute, "*") {
 			continue
 		}
@@ -379,27 +380,10 @@ func routeFlowLocalEventSet(source semanticview.Source, scope semanticview.FlowS
 }
 
 func routeFlowInputHasExternalProducer(source semanticview.Source, flowID, eventType string) bool {
-	flowID = strings.TrimSpace(flowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || flowID == "" || eventType == "" {
+	if source == nil {
 		return false
 	}
-	for _, scope := range semanticview.ProjectScopes(source) {
-		if _, ok := scope.Events[eventType]; ok {
-			return true
-		}
-	}
-	for _, scope := range source.FlowScopes() {
-		if strings.TrimSpace(scope.ID) == flowID {
-			continue
-		}
-		for _, candidate := range scope.OutputEvents {
-			if strings.TrimSpace(candidate) == eventType {
-				return true
-			}
-		}
-	}
-	return false
+	return len(source.FlowInputProducerPatterns(flowID, eventType)) > 0
 }
 
 func routeNodeLocalEventSet(node runtimecontracts.SystemNodeContract) map[string]struct{} {
@@ -493,14 +477,6 @@ func routeFlowIDForPath(source semanticview.Source, flowPath string) string {
 	return ""
 }
 
-func routeResolvePattern(basePath string, localEvents map[string]struct{}, raw string) string {
-	return eventidentity.ResolvePattern(basePath, localEvents, raw)
-}
-
-func routeIsLocalEvent(localEvents map[string]struct{}, raw string) bool {
-	return eventidentity.IsLocalEvent(localEvents, raw)
-}
-
 func routeResolvedPatternsForList(source semanticview.Source, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, patterns []string) []routeResolvedPattern {
 	out := make([]routeResolvedPattern, 0, len(patterns))
 	for _, raw := range patterns {
@@ -515,25 +491,14 @@ func routeResolveSubscriberPatterns(source semanticview.Source, flowID string, i
 	if raw == "" {
 		return nil
 	}
-	if flowID != "" && strings.Contains(raw, "/") {
-		if absolute, ok := routeResolveDescendantPattern(source, flowID, raw); ok {
-			return []routeResolvedPattern{{EventPattern: absolute, RouteSource: "subscription"}}
-		}
-	}
-	if flowID == "" || strings.Contains(raw, "://") || strings.HasPrefix(raw, "*/") || strings.HasPrefix(raw, "**/") || strings.Contains(raw, "/") || routeIsLocalEvent(localEvents, raw) {
-		pattern := routeResolvePattern(basePath, localEvents, raw)
-		if pattern == "" {
-			return nil
-		}
-		return []routeResolvedPattern{{EventPattern: pattern, RouteSource: "subscription"}}
-	}
-	if routeFlowHasInputEvent(inputEvents, raw) {
+	if flowID != "" && source != nil && source.FlowHasInputEvent(flowID, raw) {
 		patterns := routeInputProducerPatterns(source, flowID, raw)
 		if len(patterns) > 0 {
 			return patterns
 		}
 	}
-	pattern := routeResolvePattern(basePath, localEvents, raw)
+	scope := routeEventIdentityScope(basePath, localEvents, inputEvents)
+	pattern := scope.ResolveSubscriptionPattern(raw, routeDescendantScopes(source, flowID))
 	if pattern == "" {
 		return nil
 	}
@@ -541,41 +506,7 @@ func routeResolveSubscriberPatterns(source semanticview.Source, flowID string, i
 }
 
 func routeFlowHasInputEvent(inputEvents []string, eventType string) bool {
-	eventType = strings.TrimSpace(eventType)
-	if eventType == "" {
-		return false
-	}
-	for _, input := range inputEvents {
-		if strings.TrimSpace(input) == eventType {
-			return true
-		}
-	}
-	return false
-}
-
-func routeResolveDescendantPattern(source semanticview.Source, flowID, eventType string) (string, bool) {
-	flowID = strings.TrimSpace(flowID)
-	eventType = eventidentity.Normalize(eventType)
-	if source == nil || flowID == "" || eventType == "" || !strings.Contains(eventType, "/") {
-		return "", false
-	}
-	flowPath := routeFlowPath(source, flowID)
-	if flowPath == "" {
-		return "", false
-	}
-	descendants := make(map[string]map[string]struct{})
-	for _, scope := range source.FlowScopes() {
-		descendantPath := strings.Trim(strings.TrimSpace(scope.Path), "/")
-		if descendantPath == "" {
-			continue
-		}
-		local := workflowScopeLocalEvents(scope)
-		if len(local) == 0 {
-			continue
-		}
-		descendants[descendantPath] = local
-	}
-	return eventidentity.ExternalizeDescendantForFlow(flowPath, eventType, descendants)
+	return eventidentity.Scope{InputEvents: inputEvents}.HasInput(eventType)
 }
 
 func workflowScopeLocalEvents(scope semanticview.FlowScope) map[string]struct{} {
@@ -599,46 +530,56 @@ func workflowScopeLocalEvents(scope semanticview.FlowScope) map[string]struct{} 
 }
 
 func routeInputProducerPatterns(source semanticview.Source, targetFlowID, eventType string) []routeResolvedPattern {
-	targetFlowID = strings.TrimSpace(targetFlowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || targetFlowID == "" || eventType == "" {
+	if source == nil {
 		return nil
 	}
-	seen := make(map[string]struct{})
-	out := make([]routeResolvedPattern, 0, 4)
-	appendPattern := func(value string) {
-		value = eventidentity.Normalize(value)
-		if value == "" {
-			return
+	patterns := source.FlowInputProducerPatterns(targetFlowID, eventType)
+	out := make([]routeResolvedPattern, 0, len(patterns))
+	for _, pattern := range patterns {
+		pattern = eventidentity.Normalize(pattern)
+		if pattern == "" {
+			continue
 		}
-		if _, ok := seen[value]; ok {
-			return
-		}
-		seen[value] = struct{}{}
 		out = append(out, routeResolvedPattern{
-			EventPattern: value,
+			EventPattern: pattern,
 			RouteSource:  "pin_auto_wire",
 		})
 	}
-	for _, scope := range semanticview.ProjectScopes(source) {
-		if _, ok := scope.Events[eventType]; ok {
-			appendPattern(eventType)
-		}
+	return out
+}
+
+func routeEventIdentityScope(basePath string, localEvents map[string]struct{}, inputEvents []string) eventidentity.Scope {
+	return eventidentity.Scope{
+		Path:        strings.Trim(strings.TrimSpace(basePath), "/"),
+		LocalEvents: sortedStringKeys(localEvents),
+		InputEvents: append([]string{}, inputEvents...),
 	}
+}
+
+func routeDescendantScopes(source semanticview.Source, flowID string) []eventidentity.DescendantScope {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return nil
+	}
+	parentPath := eventidentity.Normalize(source.FlowPath(flowID))
+	if parentPath == "" {
+		return nil
+	}
+	out := make([]eventidentity.DescendantScope, 0)
 	for _, scope := range source.FlowScopes() {
-		if strings.TrimSpace(scope.ID) == targetFlowID {
+		descendantPath := eventidentity.Normalize(scope.Path)
+		if descendantPath == "" || !strings.HasPrefix(descendantPath, parentPath+"/") {
 			continue
 		}
-		for _, output := range scope.OutputEvents {
-			if strings.TrimSpace(output) != eventType {
-				continue
-			}
-			appendPattern(routeFlowPath(source, scope.ID) + "/" + eventType)
+		localEvents := sortedStringKeys(workflowScopeLocalEvents(scope))
+		if len(localEvents) == 0 {
+			continue
 		}
+		out = append(out, eventidentity.DescendantScope{
+			Path:        descendantPath,
+			LocalEvents: localEvents,
+		})
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].EventPattern < out[j].EventPattern
-	})
 	return out
 }
 

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -376,70 +376,62 @@ func (b *WorkflowContractBundle) FlowWritePins(flowID string) []string {
 	}
 	return append([]string{}, b.Semantics.FlowWrites[strings.TrimSpace(flowID)]...)
 }
-func (b *WorkflowContractBundle) ResolveFlowEventReference(flowID, eventType string) string {
-	if b == nil {
-		return eventidentity.Normalize(eventType)
-	}
-	flowID = strings.TrimSpace(flowID)
+func (b *WorkflowContractBundle) FlowHasInputEvent(flowID, eventType string) bool {
+	return b.flowEventScope(flowID).HasInput(eventType)
+}
+func (b *WorkflowContractBundle) FlowHasOutputEvent(flowID, eventType string) bool {
+	return b.flowEventScope(flowID).HasOutput(eventType)
+}
+func (b *WorkflowContractBundle) FlowInputProducerPatterns(targetFlowID, eventType string) []string {
+	targetFlowID = strings.TrimSpace(targetFlowID)
 	eventType = eventidentity.Normalize(eventType)
-	if flowID == "" || eventType == "" {
-		return eventType
+	if b == nil || targetFlowID == "" || eventType == "" {
+		return nil
 	}
-	if strings.Contains(eventType, "/") {
-		if absolute, ok := b.externalizeDescendantEventType(flowID, eventType); ok {
-			return absolute
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 4)
+	appendPattern := func(value string) {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			return
 		}
-		return eventType
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
+	for _, view := range b.ProjectViews() {
+		if _, ok := view.Events[eventType]; ok {
+			appendPattern(eventType)
+		}
 	}
-	return eventidentity.ExternalizeForFlow(flowPath, b.flowLocalEvents(flowID), eventType)
+	for _, view := range b.FlowViews() {
+		flowID := strings.TrimSpace(view.Paths.ID)
+		if flowID == "" || flowID == targetFlowID {
+			continue
+		}
+		for _, output := range view.Schema.Pins.Outputs.Events {
+			if eventidentity.Normalize(output) != eventType {
+				continue
+			}
+			appendPattern(b.ResolveFlowEventReference(flowID, eventType))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+func (b *WorkflowContractBundle) ResolveFlowEventReference(flowID, eventType string) string {
+	scope := b.flowEventScope(flowID)
+	return scope.ResolveEvent(eventType, b.flowEventDescendants(flowID))
 }
 func (b *WorkflowContractBundle) ResolveFlowEventPattern(flowID, pattern string) string {
-	if b == nil {
-		return eventidentity.Normalize(pattern)
-	}
-	flowID = strings.TrimSpace(flowID)
-	pattern = eventidentity.Normalize(pattern)
-	if flowID == "" || pattern == "" {
-		return pattern
-	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	localEvents := make(map[string]struct{})
-	for _, eventType := range b.flowLocalEvents(flowID) {
-		localEvents[eventidentity.Normalize(eventType)] = struct{}{}
-	}
-	return eventidentity.ResolvePattern(flowPath, localEvents, pattern)
+	scope := b.flowEventScope(flowID)
+	return scope.ResolveSubscriptionPattern(pattern, b.flowEventDescendants(flowID))
 }
 func (b *WorkflowContractBundle) FlowEventMatches(flowID, subscription, eventType string) bool {
-	if b == nil {
-		return false
-	}
-	subscription = eventidentity.Normalize(subscription)
-	eventType = eventidentity.Normalize(eventType)
-	if subscription == "" || eventType == "" {
-		return false
-	}
-	if strings.Contains(subscription, "*") {
-		return eventidentity.MatchPattern(b.ResolveFlowEventPattern(flowID, subscription), eventType)
-	}
-	if eventType == subscription || eventType == b.ResolveFlowEventReference(flowID, subscription) {
-		return true
-	}
-	flowID = strings.TrimSpace(flowID)
-	if flowID == "" {
-		return false
-	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	return eventidentity.LocalizeForFlow(flowPath, b.FlowInputEvents(flowID), eventType) == subscription
+	scope := b.flowEventScope(flowID)
+	return scope.Matches(subscription, eventType, b.flowEventDescendants(flowID))
 }
 func (b *WorkflowContractBundle) FlowRequiredAgents(flowID string) []FlowRequiredAgent {
 	if b == nil {
@@ -484,6 +476,12 @@ func (b *WorkflowContractBundle) AgentContractSource(agentID string) (ContractIt
 	}
 	source, ok := b.agentSources[strings.TrimSpace(agentID)]
 	return source, ok
+}
+func (b *WorkflowContractBundle) ResolveNodeEventReference(nodeID, eventType string) string {
+	if b == nil {
+		return eventidentity.Normalize(eventType)
+	}
+	return b.nodeEventScope(nodeID).ResolveEvent(eventType, b.flowEventDescendants(b.nodeFlowID(nodeID)))
 }
 func (b *WorkflowContractBundle) ScopedAgentEntries() map[string]AgentRegistryEntry {
 	if b == nil {
@@ -597,74 +595,11 @@ func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 }
 
 func (b *WorkflowContractBundle) localizeNodeEventType(nodeID, eventType string) string {
-	if b == nil {
-		return strings.TrimSpace(eventType)
-	}
-	flowID := b.nodeFlowID(nodeID)
-	if flowID == "" {
-		return strings.TrimSpace(eventType)
-	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	return eventidentity.LocalizeForFlow(flowPath, b.FlowInputEvents(flowID), eventType)
+	return b.nodeEventScope(nodeID).LocalizeInput(eventType)
 }
 
 func (b *WorkflowContractBundle) externalizeNodeEventType(nodeID, eventType string) string {
-	if b == nil {
-		return strings.TrimSpace(eventType)
-	}
-	flowID := b.nodeFlowID(nodeID)
-	if flowID == "" {
-		return strings.TrimSpace(eventType)
-	}
-	eventType = eventidentity.Normalize(eventType)
-	if eventType == "" {
-		return eventType
-	}
-	if strings.Contains(eventType, "/") {
-		if absolute, ok := b.externalizeDescendantEventType(flowID, eventType); ok {
-			return absolute
-		}
-		return eventType
-	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	return eventidentity.ExternalizeForFlow(flowPath, b.flowLocalEvents(flowID), eventType)
-}
-
-func (b *WorkflowContractBundle) externalizeDescendantEventType(flowID, eventType string) (string, bool) {
-	if b == nil {
-		return "", false
-	}
-	flowID = strings.TrimSpace(flowID)
-	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
-	if flowID == "" || eventType == "" {
-		return "", false
-	}
-	flowPath := strings.Trim(strings.TrimSpace(b.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	descendants := make(map[string]map[string]struct{})
-	for _, view := range b.FlowViews() {
-		descendantPath := strings.Trim(strings.TrimSpace(view.Path), "/")
-		if descendantPath == "" {
-			continue
-		}
-		localEvents := make(map[string]struct{})
-		for _, candidate := range b.flowLocalEvents(strings.TrimSpace(view.Paths.ID)) {
-			localEvents[strings.TrimSpace(candidate)] = struct{}{}
-		}
-		if len(localEvents) == 0 {
-			continue
-		}
-		descendants[descendantPath] = localEvents
-	}
-	return eventidentity.ExternalizeDescendantForFlow(flowPath, eventType, descendants)
+	return b.ResolveNodeEventReference(nodeID, eventType)
 }
 
 func (b *WorkflowContractBundle) flowLocalEvents(flowID string) []string {
@@ -683,10 +618,76 @@ func (b *WorkflowContractBundle) flowLocalEvents(flowID string) []string {
 			out = append(out, eventType)
 		}
 	}
+	for _, eventType := range view.Schema.Pins.Outputs.Events {
+		eventType = strings.TrimSpace(eventType)
+		if eventType != "" {
+			out = append(out, eventType)
+		}
+	}
 	if autoEmit := strings.TrimSpace(view.Schema.AutoEmitOnCreate.Event); autoEmit != "" {
 		out = append(out, autoEmit)
 	}
 	return out
+}
+
+func (b *WorkflowContractBundle) flowEventScope(flowID string) eventidentity.Scope {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil || flowID == "" {
+		return eventidentity.Scope{}
+	}
+	view, ok := b.FlowViewByID(flowID)
+	if !ok || view == nil {
+		return eventidentity.Scope{Path: b.FlowPath(flowID)}
+	}
+	return eventidentity.Scope{
+		Path:         strings.Trim(strings.TrimSpace(view.Path), "/"),
+		LocalEvents:  b.flowLocalEvents(flowID),
+		InputEvents:  append([]string{}, view.Schema.Pins.Inputs.Events...),
+		OutputEvents: append([]string{}, view.Schema.Pins.Outputs.Events...),
+	}
+}
+
+func (b *WorkflowContractBundle) flowEventDescendants(flowID string) []eventidentity.DescendantScope {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil || flowID == "" {
+		return nil
+	}
+	scope := b.flowEventScope(flowID)
+	parentPath := eventidentity.Normalize(scope.Path)
+	if parentPath == "" {
+		return nil
+	}
+	out := make([]eventidentity.DescendantScope, 0)
+	for _, view := range b.FlowViews() {
+		descendantFlowID := strings.TrimSpace(view.Paths.ID)
+		if descendantFlowID == "" || descendantFlowID == flowID {
+			continue
+		}
+		descendantPath := eventidentity.Normalize(view.Path)
+		if descendantPath == "" || !strings.HasPrefix(descendantPath, parentPath+"/") {
+			continue
+		}
+		localEvents := b.flowLocalEvents(descendantFlowID)
+		if len(localEvents) == 0 {
+			continue
+		}
+		out = append(out, eventidentity.DescendantScope{
+			Path:        descendantPath,
+			LocalEvents: localEvents,
+		})
+	}
+	return out
+}
+
+func (b *WorkflowContractBundle) nodeEventScope(nodeID string) eventidentity.Scope {
+	if b == nil {
+		return eventidentity.Scope{}
+	}
+	flowID := b.nodeFlowID(nodeID)
+	if flowID == "" {
+		return eventidentity.Scope{}
+	}
+	return b.flowEventScope(flowID)
 }
 
 func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler SystemNodeEventHandler) SystemNodeEventHandler {

--- a/internal/runtime/core/eventidentity/eventidentity.go
+++ b/internal/runtime/core/eventidentity/eventidentity.go
@@ -5,6 +5,18 @@ import (
 	"strings"
 )
 
+type Scope struct {
+	Path         string
+	LocalEvents  []string
+	InputEvents  []string
+	OutputEvents []string
+}
+
+type DescendantScope struct {
+	Path        string
+	LocalEvents []string
+}
+
 func Normalize(raw string) string {
 	return strings.Trim(strings.TrimSpace(raw), "/")
 }
@@ -49,6 +61,82 @@ func IsLocalEvent(localEvents map[string]struct{}, raw string) bool {
 	}
 	_, ok := localEvents[Normalize(raw)]
 	return ok
+}
+
+func (s Scope) ResolveEvent(raw string, descendants []DescendantScope) string {
+	raw = Normalize(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.Contains(raw, "/") {
+		if absolute, ok := ExternalizeDescendantForFlow(s.Path, raw, descendantLocalEventSets(descendants)); ok {
+			return absolute
+		}
+		return raw
+	}
+	return ExternalizeForFlow(s.Path, s.LocalEvents, raw)
+}
+
+func (s Scope) ResolveSubscriptionPattern(raw string, descendants []DescendantScope) string {
+	raw = Normalize(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.Contains(raw, "/") && !strings.Contains(raw, "://") {
+		if absolute, ok := ExternalizeDescendantForFlow(s.Path, raw, descendantLocalEventSets(descendants)); ok {
+			return absolute
+		}
+	}
+	return ResolvePattern(s.Path, localEventSet(s.LocalEvents), raw)
+}
+
+func (s Scope) LocalizeInput(raw string) string {
+	return LocalizeForFlow(s.Path, s.InputEvents, raw)
+}
+
+func (s Scope) LocalizeOutput(raw string) string {
+	return LocalizeForFlow(s.Path, s.OutputEvents, raw)
+}
+
+func (s Scope) HasInput(raw string) bool {
+	local := Normalize(s.LocalizeInput(raw))
+	if local == "" {
+		return false
+	}
+	for _, input := range NormalizeList(s.InputEvents) {
+		if input == local {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Scope) HasOutput(raw string) bool {
+	local := Normalize(s.LocalizeOutput(raw))
+	if local == "" {
+		return false
+	}
+	for _, output := range NormalizeList(s.OutputEvents) {
+		if output == local {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Scope) Matches(subscription, eventName string, descendants []DescendantScope) bool {
+	subscription = Normalize(subscription)
+	eventName = Normalize(eventName)
+	if subscription == "" || eventName == "" {
+		return false
+	}
+	if strings.Contains(subscription, "*") {
+		return MatchPattern(s.ResolveSubscriptionPattern(subscription, descendants), eventName)
+	}
+	if eventName == subscription || eventName == s.ResolveEvent(subscription, descendants) {
+		return true
+	}
+	return Normalize(s.LocalizeInput(eventName)) == subscription
 }
 
 func ResolvePattern(basePath string, localEvents map[string]struct{}, raw string) string {
@@ -181,4 +269,31 @@ func ExternalizeDescendantForFlow(flowPath, eventName string, descendantLocalEve
 		return flowPath + "/" + eventName, true
 	}
 	return "", false
+}
+
+func localEventSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range NormalizeList(values) {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func descendantLocalEventSets(descendants []DescendantScope) map[string]map[string]struct{} {
+	if len(descendants) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]struct{}, len(descendants))
+	for _, descendant := range descendants {
+		path := Normalize(descendant.Path)
+		if path == "" {
+			continue
+		}
+		local := localEventSet(descendant.LocalEvents)
+		if len(local) == 0 {
+			continue
+		}
+		out[path] = local
+	}
+	return out
 }

--- a/internal/runtime/core/eventidentity/eventidentity_test.go
+++ b/internal/runtime/core/eventidentity/eventidentity_test.go
@@ -67,3 +67,49 @@ func TestSplitRouteSegments_NormalizesInput(t *testing.T) {
 		t.Fatalf("SplitRouteSegments = %#v", got)
 	}
 }
+
+func TestScopeResolveEvent_ExternalizesLocalAndDescendantEvents(t *testing.T) {
+	scope := Scope{
+		Path:        "child",
+		LocalEvents: []string{"step.result"},
+	}
+	descendants := []DescendantScope{{
+		Path:        "child/grandchild",
+		LocalEvents: []string{"micro.done"},
+	}}
+
+	if got := scope.ResolveEvent("step.result", descendants); got != "child/step.result" {
+		t.Fatalf("ResolveEvent(local) = %q, want child/step.result", got)
+	}
+	if got := scope.ResolveEvent("grandchild/micro.done", descendants); got != "child/grandchild/micro.done" {
+		t.Fatalf("ResolveEvent(descendant) = %q, want child/grandchild/micro.done", got)
+	}
+}
+
+func TestScopeMatches_TreatsLocalAndScopedInputEventsAsEquivalent(t *testing.T) {
+	scope := Scope{
+		Path:        "discovery",
+		InputEvents: []string{"scan.requested"},
+	}
+
+	if !scope.Matches("scan.requested", "producer/scan.requested", nil) {
+		t.Fatal("expected local subscription to match scoped event")
+	}
+	if !scope.Matches("scan.requested", "scan.requested", nil) {
+		t.Fatal("expected local subscription to match local event")
+	}
+}
+
+func TestScopeLocalizeOutput_MapsScopedOutputBackToLocalName(t *testing.T) {
+	scope := Scope{
+		Path:         "child",
+		OutputEvents: []string{"child.done"},
+	}
+
+	if got := scope.LocalizeOutput("child/child.done"); got != "child.done" {
+		t.Fatalf("LocalizeOutput = %q, want child.done", got)
+	}
+	if !scope.HasOutput("child/child.done") {
+		t.Fatal("expected scoped output event to be recognized as flow output")
+	}
+}

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
-	"swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/semanticview"
@@ -202,27 +201,11 @@ func (pc *PipelineCoordinator) handlerEmitPayload(ctx context.Context, triggerCt
 }
 
 func workflowEmitTargetsParentEntity(source semanticview.Source, flowID, eventType string) bool {
-	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
 	flowID = strings.TrimSpace(flowID)
-	if source == nil || eventType == "" || flowID == "" {
+	if source == nil || flowID == "" {
 		return false
 	}
-	scope, ok := source.FlowScopeByID(flowID)
-	if !ok {
-		return false
-	}
-	return workflowFlowScopeHasOutputEvent(scope, eventType)
-}
-
-func workflowFlowScopeHasOutputEvent(scope semanticview.FlowScope, eventType string) bool {
-	localEvent := eventidentity.LocalizeForFlow(scope.Path, scope.OutputEvents, eventType)
-	localEvent = strings.Trim(strings.TrimSpace(localEvent), "/")
-	for _, candidate := range scope.OutputEvents {
-		if strings.TrimSpace(candidate) == localEvent {
-			return true
-		}
-	}
-	return false
+	return source.FlowHasOutputEvent(flowID, eventType)
 }
 
 func workflowEntityMetadataPayload(source semanticview.Source, metadata map[string]any) map[string]any {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -179,7 +179,7 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 		}
 		out = append(out, value)
 	}
-	appendAlias(workflowNodeExternalEventType(source, nodeID, eventType))
+	appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 	contractSource, ok := source.NodeContractSource(nodeID)
 	if !ok {
 		return out
@@ -188,10 +188,10 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 	if flowID == "" {
 		return out
 	}
-	if !workflowFlowHasInputEvent(source, flowID, eventType) {
+	if !source.FlowHasInputEvent(flowID, eventType) {
 		return out
 	}
-	for _, pattern := range workflowFlowInputProducerAliases(source, flowID, eventType) {
+	for _, pattern := range source.FlowInputProducerPatterns(flowID, eventType) {
 		appendAlias(pattern)
 	}
 	appendAlias(eventType)
@@ -199,60 +199,17 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 }
 
 func workflowFlowInputProducerAliases(source semanticview.Source, targetFlowID, eventType string) []string {
-	targetFlowID = strings.TrimSpace(targetFlowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || targetFlowID == "" || eventType == "" {
+	if source == nil {
 		return nil
 	}
-	seen := make(map[string]struct{})
-	out := make([]string, 0, 4)
-	appendAlias := func(value string) {
-		value = eventidentity.Normalize(value)
-		if value == "" {
-			return
-		}
-		if _, ok := seen[value]; ok {
-			return
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	for _, scope := range semanticview.ProjectScopes(source) {
-		if _, ok := scope.Events[eventType]; ok {
-			appendAlias(eventType)
-		}
-	}
-	for _, scope := range source.FlowScopes() {
-		if strings.TrimSpace(scope.ID) == targetFlowID {
-			continue
-		}
-		flowPath := strings.Trim(strings.TrimSpace(scope.Path), "/")
-		if flowPath == "" {
-			continue
-		}
-		for _, output := range scope.OutputEvents {
-			if strings.TrimSpace(output) != eventType {
-				continue
-			}
-			appendAlias(flowPath + "/" + eventType)
-		}
-	}
-	sort.Strings(out)
-	return out
+	return source.FlowInputProducerPatterns(targetFlowID, eventType)
 }
 
 func workflowFlowHasInputEvent(source semanticview.Source, flowID, eventType string) bool {
-	flowID = strings.TrimSpace(flowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || flowID == "" || eventType == "" {
+	if source == nil {
 		return false
 	}
-	for _, candidate := range source.FlowInputEvents(flowID) {
-		if strings.TrimSpace(candidate) == eventType {
-			return true
-		}
-	}
-	return false
+	return source.FlowHasInputEvent(flowID, eventType)
 }
 
 func workflowRuntimeNodeIDs(source semanticview.Source) []string {
@@ -429,115 +386,10 @@ func workflowNodeRuntimePolicyEvents(source semanticview.Source, nodeID string, 
 }
 
 func workflowNodeExternalEventType(source semanticview.Source, nodeID, eventType string) string {
-	nodeID = strings.TrimSpace(nodeID)
-	eventType = eventidentity.Normalize(eventType)
-	if nodeID == "" || eventType == "" || source == nil {
-		return eventType
+	if source == nil {
+		return eventidentity.Normalize(eventType)
 	}
-	if strings.Contains(eventType, "/") {
-		if absolute, ok := workflowNodeExternalDescendantEventType(source, nodeID, eventType); ok {
-			return absolute
-		}
-		return eventType
-	}
-	contractSource, ok := source.NodeContractSource(nodeID)
-	if !ok {
-		return eventType
-	}
-	flowID := strings.TrimSpace(contractSource.FlowID)
-	if flowID == "" {
-		return eventType
-	}
-	flowPath := strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
-	}
-	return eventidentity.ExternalizeForFlow(flowPath, workflowFlowLocalEvents(source, flowID), eventType)
-}
-
-func workflowNodeExternalDescendantEventType(source semanticview.Source, nodeID, eventType string) (string, bool) {
-	nodeID = strings.TrimSpace(nodeID)
-	eventType = eventidentity.Normalize(eventType)
-	if nodeID == "" || eventType == "" || source == nil {
-		return "", false
-	}
-	contractSource, ok := source.NodeContractSource(nodeID)
-	if !ok {
-		return "", false
-	}
-	flowID := strings.TrimSpace(contractSource.FlowID)
-	if flowID == "" {
-		return "", false
-	}
-	flowPath := strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
-	if flowPath == "" {
-		flowPath = strings.Trim(flowID, "/")
-	}
-	descendants := make(map[string]map[string]struct{})
-	for _, scope := range source.FlowScopes() {
-		descendantPath := strings.Trim(strings.TrimSpace(scope.Path), "/")
-		if descendantPath == "" {
-			continue
-		}
-		localEvents := workflowFlowLocalEventSet(scope)
-		if len(localEvents) == 0 {
-			continue
-		}
-		descendants[descendantPath] = localEvents
-	}
-	return eventidentity.ExternalizeDescendantForFlow(flowPath, eventType, descendants)
-}
-
-func workflowFlowLocalEventSet(scope semanticview.FlowScope) map[string]struct{} {
-	out := make(map[string]struct{}, len(scope.Events)+1)
-	for eventType := range scope.Events {
-		eventType = strings.TrimSpace(eventType)
-		if eventType != "" {
-			out[eventType] = struct{}{}
-		}
-	}
-	if autoEmit := strings.TrimSpace(scope.AutoEmitEvent); autoEmit != "" {
-		out[autoEmit] = struct{}{}
-	}
-	return out
-}
-
-func workflowFlowHasLocalEvent(source semanticview.Source, flowID, eventType string) bool {
-	flowID = strings.TrimSpace(flowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || flowID == "" || eventType == "" {
-		return false
-	}
-	scope, ok := source.FlowScopeByID(flowID)
-	if !ok {
-		return false
-	}
-	if _, ok := scope.Events[eventType]; ok {
-		return true
-	}
-	return strings.TrimSpace(scope.AutoEmitEvent) == eventType
-}
-
-func workflowFlowLocalEvents(source semanticview.Source, flowID string) []string {
-	flowID = strings.TrimSpace(flowID)
-	if source == nil || flowID == "" {
-		return nil
-	}
-	scope, ok := source.FlowScopeByID(flowID)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(scope.Events)+1)
-	for eventType := range scope.Events {
-		eventType = strings.TrimSpace(eventType)
-		if eventType != "" {
-			out = append(out, eventType)
-		}
-	}
-	if autoEmit := strings.TrimSpace(scope.AutoEmitEvent); autoEmit != "" {
-		out = append(out, autoEmit)
-	}
-	return out
+	return source.ResolveNodeEventReference(nodeID, eventType)
 }
 
 func workflowNodeTransitionTriggers(source semanticview.Source, nodeID string) map[string]bool {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"path/filepath"
 	"testing"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -96,4 +97,18 @@ func TestWorkflowFlowInputProducerAliases_AutoWireCrossFlowInputPinsToProducerSc
 		}
 	}
 	t.Fatalf("aliases = %#v, want scoring/vertical.shortlisted", aliases)
+}
+
+func TestWorkflowNodeExternalEventType_ExternalizesLocalFlowOutputs(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-child-flow-pin-wiring")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	if got := workflowNodeExternalEventType(semanticview.Wrap(bundle), "child-worker", "work.completed"); got != "child/work.completed" {
+		t.Fatalf("workflowNodeExternalEventType = %q, want child/work.completed", got)
+	}
 }

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -159,6 +159,15 @@ func (s bundleSource) FlowOutputEvents(flowID string) []string {
 }
 func (s bundleSource) FlowWritePins(flowID string) []string { return s.bundle.FlowWritePins(flowID) }
 func (s bundleSource) WritePinOwners(pin string) []string   { return s.bundle.WritePinOwners(pin) }
+func (s bundleSource) FlowHasInputEvent(flowID, eventType string) bool {
+	return s.bundle.FlowHasInputEvent(flowID, eventType)
+}
+func (s bundleSource) FlowHasOutputEvent(flowID, eventType string) bool {
+	return s.bundle.FlowHasOutputEvent(flowID, eventType)
+}
+func (s bundleSource) FlowInputProducerPatterns(flowID, eventType string) []string {
+	return s.bundle.FlowInputProducerPatterns(flowID, eventType)
+}
 func (s bundleSource) ResolveFlowEventReference(flowID, eventType string) string {
 	return s.bundle.ResolveFlowEventReference(flowID, eventType)
 }
@@ -197,6 +206,9 @@ func (s bundleSource) NodeContractSource(nodeID string) (runtimecontracts.Contra
 }
 func (s bundleSource) AgentContractSource(agentID string) (runtimecontracts.ContractItemSource, bool) {
 	return s.bundle.AgentContractSource(agentID)
+}
+func (s bundleSource) ResolveNodeEventReference(nodeID, eventType string) string {
+	return s.bundle.ResolveNodeEventReference(nodeID, eventType)
 }
 func (s bundleSource) NodeHandlerSubscriptions(nodeID string) []string {
 	return s.bundle.NodeHandlerSubscriptions(nodeID)

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -33,6 +33,9 @@ type Source interface {
 	FlowOutputEvents(flowID string) []string
 	FlowWritePins(flowID string) []string
 	WritePinOwners(pin string) []string
+	FlowHasInputEvent(flowID, eventType string) bool
+	FlowHasOutputEvent(flowID, eventType string) bool
+	FlowInputProducerPatterns(flowID, eventType string) []string
 	ResolveFlowEventReference(flowID, eventType string) string
 	ResolveFlowEventPattern(flowID, pattern string) string
 	FlowEventMatches(flowID, subscription, eventType string) bool
@@ -46,6 +49,7 @@ type Source interface {
 	RuntimeEventOwners(eventType string) []string
 	NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool)
 	AgentContractSource(agentID string) (runtimecontracts.ContractItemSource, bool)
+	ResolveNodeEventReference(nodeID, eventType string) string
 	NodeHandlerSubscriptions(nodeID string) []string
 	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
 	NodeEventHandler(nodeID, eventType string) (runtimecontracts.SystemNodeEventHandler, bool)


### PR DESCRIPTION
## Summary
- make `internal/runtime/core/eventidentity` the canonical owner for local, scoped, and emitted event identity
- route bus and pipeline event handling through shared contracts/semanticview accessors instead of re-deriving localization and externalization rules locally
- add focused coverage for local/scoped equivalence and emitted event identity correctness

## Why
Issue #17 is about removing drift-prone event identity semantics across runtime layers. Before this change, bus, pipeline, and contracts each re-derived parts of local, scoped, and emitted event behavior independently, which risks semantic drift.

## Impact
- one canonical event-identity owner now serves the touched runtime seams
- drift-prone local routing and emit-time identity logic is removed from bus and pipeline paths
- emitted flow output events now externalize through the same model used for matching and localization

## Validation
- `go test ./internal/runtime/core/eventidentity ./internal/runtime/bus ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

Closes #17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event identity resolution system with a new scope-based abstraction for enhanced clarity and maintainability.
  * Streamlined event routing and pattern matching logic to reduce complexity and improve consistency.
  * Consolidated event resolution operations to use unified scope methods.

* **Tests**
  * Added comprehensive unit tests for event scope resolution and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->