### PR TITLE
[agent-d][issue #18] Audit mutation-log completeness for entity_state writes

### DIFF
--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -24,6 +25,19 @@ type Record struct {
 	WriterType  string
 	WriterID    string
 	HandlerStep string
+}
+
+type Writer struct {
+	Type        string
+	ID          string
+	HandlerStep string
+}
+
+type EntityStateProjection struct {
+	CurrentState string
+	Fields       map[string]any
+	Gates        map[string]any
+	Accumulator  map[string]any
 }
 
 func Insert(ctx context.Context, db DBTX, rec Record) error {
@@ -74,6 +88,118 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 		)
 	`, runID, entityID, field, oldValue, newValue, causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep))
 	return err
+}
+
+func InsertEntityStateDiff(ctx context.Context, db DBTX, entityID string, before, after EntityStateProjection, writer Writer) error {
+	entityID = strings.TrimSpace(entityID)
+	if db == nil || entityID == "" {
+		return nil
+	}
+	writerType := strings.TrimSpace(writer.Type)
+	writerID := strings.TrimSpace(writer.ID)
+	if writerType == "" || writerID == "" {
+		return nil
+	}
+	if strings.TrimSpace(before.CurrentState) != strings.TrimSpace(after.CurrentState) {
+		if err := Insert(ctx, db, Record{
+			EntityID:    entityID,
+			Field:       "current_state",
+			OldValue:    stringOrNil(before.CurrentState),
+			NewValue:    stringOrNil(after.CurrentState),
+			WriterType:  writerType,
+			WriterID:    writerID,
+			HandlerStep: strings.TrimSpace(writer.HandlerStep),
+		}); err != nil {
+			return err
+		}
+	}
+	if err := insertMapDiff(ctx, db, entityID, "", before.Fields, after.Fields, writer); err != nil {
+		return err
+	}
+	if err := insertMapDiff(ctx, db, entityID, "gates.", before.Gates, after.Gates, writer); err != nil {
+		return err
+	}
+	if err := insertMapDiff(ctx, db, entityID, "accumulator.", before.Accumulator, after.Accumulator, writer); err != nil {
+		return err
+	}
+	return nil
+}
+
+func insertMapDiff(ctx context.Context, db DBTX, entityID, prefix string, before, after map[string]any, writer Writer) error {
+	keys := make([]string, 0, len(before)+len(after))
+	seen := map[string]struct{}{}
+	for key := range before {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	for key := range after {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		oldValue, oldOK := before[key]
+		newValue, newOK := after[key]
+		if !oldOK {
+			oldValue = nil
+		}
+		if !newOK {
+			newValue = nil
+		}
+		same, err := jsonValuesEqual(oldValue, newValue)
+		if err != nil {
+			return err
+		}
+		if same {
+			continue
+		}
+		if err := Insert(ctx, db, Record{
+			EntityID:    entityID,
+			Field:       strings.TrimSpace(prefix + key),
+			OldValue:    oldValue,
+			NewValue:    newValue,
+			WriterType:  strings.TrimSpace(writer.Type),
+			WriterID:    strings.TrimSpace(writer.ID),
+			HandlerStep: strings.TrimSpace(writer.HandlerStep),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jsonValuesEqual(left, right any) (bool, error) {
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return false, err
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return false, err
+	}
+	return string(leftJSON) == string(rightJSON), nil
+}
+
+func stringOrNil(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	return raw
 }
 
 func normalizeRunID(runID string) string {

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -2,6 +2,9 @@ package pipeline
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -73,5 +76,247 @@ func TestUpdateEntityState_LogsMutationRowForStateTransition(t *testing.T) {
 	}
 	if step == "" {
 		t.Fatal("mutation handler_step is empty")
+	}
+}
+
+func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLog(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := NewWorkflowInstanceStore(db)
+	entityID := uuid.NewString()
+
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "mutation-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"status": "open",
+			"gates": map[string]any{
+				"g_ready": true,
+			},
+		},
+		StateBuckets: map[string]any{
+			"evidence": map[string]any{"score": 1},
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "mutation-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "done",
+		Metadata: map[string]any{
+			"status": "closed",
+			"gates": map[string]any{
+				"g_done": true,
+			},
+		},
+		StateBuckets: map[string]any{
+			"evidence": map[string]any{"score": 2},
+			"notes":    map[string]any{"count": 1},
+		},
+	}); err != nil {
+		t.Fatalf("update workflow instance: %v", err)
+	}
+
+	fields := mutationFieldsForEntity(t, db, entityID)
+	for _, want := range []string{
+		"current_state",
+		"status",
+		"gates.g_ready",
+		"gates.g_done",
+		"accumulator.evidence",
+		"accumulator.notes",
+	} {
+		if !containsMutationField(fields, want) {
+			t.Fatalf("mutation fields missing %q: %v", want, fields)
+		}
+	}
+
+	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+}
+
+func mutationFieldsForEntity(t *testing.T, db *sql.DB, entityID string) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT field
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid
+		ORDER BY created_at ASC, mutation_id ASC
+	`, entityID)
+	if err != nil {
+		t.Fatalf("query mutation fields: %v", err)
+	}
+	defer rows.Close()
+	out := make([]string, 0, 8)
+	for rows.Next() {
+		var field string
+		if err := rows.Scan(&field); err != nil {
+			t.Fatalf("scan mutation field: %v", err)
+		}
+		out = append(out, strings.TrimSpace(field))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read mutation fields: %v", err)
+	}
+	return out
+}
+
+func assertMutationLogMatchesTrackedEntityState(t *testing.T, db *sql.DB, entityID string) {
+	t.Helper()
+	var (
+		currentState string
+		fieldsRaw    []byte
+		gatesRaw     []byte
+		accRaw       []byte
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT
+			COALESCE(current_state, ''),
+			COALESCE(fields, '{}'::jsonb),
+			COALESCE(gates, '{}'::jsonb),
+			COALESCE(accumulator, '{}'::jsonb)
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw); err != nil {
+		t.Fatalf("load entity_state projection: %v", err)
+	}
+
+	want := trackedMutationState{
+		CurrentState: strings.TrimSpace(currentState),
+		Fields:       decodeJSONMap(t, fieldsRaw),
+		Gates:        decodeJSONMap(t, gatesRaw),
+		Accumulator:  decodeJSONMap(t, accRaw),
+	}
+	got := trackedMutationState{
+		Fields:      map[string]any{},
+		Gates:       map[string]any{},
+		Accumulator: map[string]any{},
+	}
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT field, old_value, new_value
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid
+		ORDER BY created_at ASC, mutation_id ASC
+	`, entityID)
+	if err != nil {
+		t.Fatalf("query mutations: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			field    string
+			oldValue []byte
+			newValue []byte
+		)
+		if err := rows.Scan(&field, &oldValue, &newValue); err != nil {
+			t.Fatalf("scan mutation: %v", err)
+		}
+		applyTrackedMutation(&got, strings.TrimSpace(field), decodeJSONValue(t, newValue))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read mutations: %v", err)
+	}
+
+	if !trackedStatesEqual(got, want) {
+		t.Fatalf("mutation reconstruction mismatch:\n got=%s\nwant=%s", mustCanonicalJSON(t, got), mustCanonicalJSON(t, want))
+	}
+}
+
+type trackedMutationState struct {
+	CurrentState string         `json:"current_state"`
+	Fields       map[string]any `json:"fields"`
+	Gates        map[string]any `json:"gates"`
+	Accumulator  map[string]any `json:"accumulator"`
+}
+
+func applyTrackedMutation(state *trackedMutationState, field string, value any) {
+	if state == nil {
+		return
+	}
+	switch {
+	case field == "current_state":
+		state.CurrentState = strings.TrimSpace(trackedAsString(value))
+	case strings.HasPrefix(field, "gates."):
+		applyTrackedMapValue(state.Gates, strings.TrimPrefix(field, "gates."), value)
+	case strings.HasPrefix(field, "accumulator."):
+		applyTrackedMapValue(state.Accumulator, strings.TrimPrefix(field, "accumulator."), value)
+	default:
+		applyTrackedMapValue(state.Fields, field, value)
+	}
+}
+
+func applyTrackedMapValue(target map[string]any, key string, value any) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	if value == nil {
+		delete(target, key)
+		return
+	}
+	target[key] = value
+}
+
+func decodeJSONMap(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode json map: %v", err)
+	}
+	if out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func decodeJSONValue(t *testing.T, raw []byte) any {
+	t.Helper()
+	if len(raw) == 0 {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode json value: %v", err)
+	}
+	return out
+}
+
+func trackedStatesEqual(left, right trackedMutationState) bool {
+	return mustCanonicalJSONForCompare(left) == mustCanonicalJSONForCompare(right)
+}
+
+func mustCanonicalJSON(t *testing.T, value any) string {
+	t.Helper()
+	return mustCanonicalJSONForCompare(value)
+}
+
+func mustCanonicalJSONForCompare(value any) string {
+	raw, _ := json.Marshal(value)
+	return string(raw)
+}
+
+func containsMutationField(items []string, want string) bool {
+	for _, item := range items {
+		if strings.TrimSpace(item) == strings.TrimSpace(want) {
+			return true
+		}
+	}
+	return false
+}
+
+func trackedAsString(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return typed
+	default:
+		return ""
 	}
 }

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -152,16 +152,8 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 	return s.Upsert(ctx, instance)
 }
 
-func (s *WorkflowInstanceStore) Delete(ctx context.Context, instanceID string) error {
-	instanceID = strings.TrimSpace(instanceID)
-	if instanceID == "" || s == nil || s.db == nil {
-		return nil
-	}
-	keys := workflowInstanceLookupKeys(instanceID)
-	if len(keys) == 0 {
-		return nil
-	}
-	return s.deleteSpec(ctx, keys)
+func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
+	return fmt.Errorf("workflow instance deletion is unsupported: entity_state writes must stay on the mutation-logged upsert path")
 }
 
 func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string) (WorkflowInstance, bool, error) {
@@ -347,13 +339,8 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			}
 		}()
 	}
-
-	var previousState sql.NullString
-	if err := tx.QueryRowContext(ctx, `
-		SELECT current_state
-		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, rowID).Scan(&previousState); err != nil && err != sql.ErrNoRows {
+	previous, err := loadTrackedEntityStateProjection(ctx, tx, rowID)
+	if err != nil {
 		return err
 	}
 
@@ -424,18 +411,17 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	); err != nil {
 		return err
 	}
-	if strings.TrimSpace(previousState.String) != strings.TrimSpace(instance.CurrentState) {
-		if err := runtimemutationlog.Insert(ctx, tx, runtimemutationlog.Record{
-			EntityID:    rowID,
-			Field:       "current_state",
-			OldValue:    nullStringValue(previousState),
-			NewValue:    strings.TrimSpace(instance.CurrentState),
-			WriterType:  "platform",
-			WriterID:    "workflow_instance_store",
-			HandlerStep: "current_state",
-		}); err != nil {
-			return err
-		}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rowID, previous, runtimemutationlog.EntityStateProjection{
+		CurrentState: strings.TrimSpace(instance.CurrentState),
+		Fields:       fields,
+		Gates:        gates,
+		Accumulator:  cloneStringAnyMap(instance.StateBuckets),
+	}, runtimemutationlog.Writer{
+		Type:        "platform",
+		ID:          "workflow_instance_store",
+		HandlerStep: "upsert",
+	}); err != nil {
+		return err
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM timers WHERE entity_id = $1::uuid AND flow_instance = $2`, rowID, storageRef); err != nil {
 		return err
@@ -477,66 +463,6 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	return nil
 }
 
-func nullStringValue(v sql.NullString) any {
-	if !v.Valid {
-		return nil
-	}
-	return strings.TrimSpace(v.String)
-}
-
-func (s *WorkflowInstanceStore) deleteSpec(ctx context.Context, keys []string) error {
-	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	committed := !ownedTx
-	if ownedTx {
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
-			}
-		}()
-	}
-	rows, err := tx.QueryContext(ctx, `SELECT COALESCE(flow_instance, '') FROM entity_state WHERE entity_id = ANY($1::uuid[])`, pqStringArray(keys))
-	if err != nil {
-		return err
-	}
-	flowInstances := make([]string, 0, len(keys))
-	for rows.Next() {
-		var flowInstance string
-		if err := rows.Scan(&flowInstance); err != nil {
-			rows.Close()
-			return err
-		}
-		if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
-			flowInstances = append(flowInstances, flowInstance)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return err
-	}
-	rows.Close()
-	if _, err := tx.ExecContext(ctx, `DELETE FROM timers WHERE entity_id = ANY($1::uuid[])`, pqStringArray(keys)); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM entity_state WHERE entity_id = ANY($1::uuid[])`, pqStringArray(keys)); err != nil {
-		return err
-	}
-	if len(flowInstances) > 0 {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM flow_instances WHERE instance_id = ANY($1::text[])`, pq.Array(flowInstances)); err != nil {
-			return err
-		}
-	}
-	if ownedTx {
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		committed = true
-	}
-	return nil
-}
-
 func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, error) {
 	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
 		return tx, false, nil
@@ -546,6 +472,54 @@ func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, er
 		return nil, false, err
 	}
 	return tx, true, nil
+}
+
+func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, entityID string) (runtimemutationlog.EntityStateProjection, error) {
+	if tx == nil || strings.TrimSpace(entityID) == "" {
+		return runtimemutationlog.EntityStateProjection{}, nil
+	}
+	var (
+		currentState sql.NullString
+		fieldsRaw    []byte
+		gatesRaw     []byte
+		accRaw       []byte
+	)
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			current_state,
+			COALESCE(fields, '{}'::jsonb),
+			COALESCE(gates, '{}'::jsonb),
+			COALESCE(accumulator, '{}'::jsonb)
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+		FOR UPDATE
+	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw)
+	if err == sql.ErrNoRows {
+		return runtimemutationlog.EntityStateProjection{}, nil
+	}
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	return runtimemutationlog.EntityStateProjection{
+		CurrentState: strings.TrimSpace(currentState.String),
+		Fields:       jsonObjectMap(fieldsRaw),
+		Gates:        jsonObjectMap(gatesRaw),
+		Accumulator:  jsonObjectMap(accRaw),
+	}, nil
+}
+
+func jsonObjectMap(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, entityID string) ([]WorkflowTimerState, error) {

--- a/internal/runtime/tools/executor_entity.go
+++ b/internal/runtime/tools/executor_entity.go
@@ -170,13 +170,17 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	`, entityID, fieldName, string(valueJSON)).Scan(&revision); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.update", true, err, "save entity field %s", fieldName)
 	}
-	if err := runtimemutationlog.Insert(ctx, tx, runtimemutationlog.Record{
-		EntityID:    entityID,
-		Field:       fieldName,
-		OldValue:    nullableJSONBytes(oldValue),
-		NewValue:    json.RawMessage(valueJSON),
-		WriterType:  "agent",
-		WriterID:    strings.TrimSpace(actor.ID),
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{
+			fieldName: nullableJSONBytes(oldValue),
+		},
+	}, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{
+			fieldName: json.RawMessage(valueJSON),
+		},
+	}, runtimemutationlog.Writer{
+		Type:        "agent",
+		ID:          strings.TrimSpace(actor.ID),
 		HandlerStep: "save_entity_field",
 	}); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.mutation_log", true, err, "record entity mutation %s", fieldName)
@@ -335,7 +339,17 @@ func (e *Executor) execCreateEntity(ctx context.Context, _ models.AgentConfig, i
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_create_entity.fields", false, err, "marshal fields")
 	}
 	now := time.Now().UTC()
-	if _, err := db.ExecContext(ctx, `
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.begin", true, err, "begin create entity tx")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO entity_state (
 			entity_id, subject_id, flow_instance, entity_type, name,
 			current_state, gates, fields, accumulator, revision,
@@ -349,6 +363,20 @@ func (e *Executor) execCreateEntity(ctx context.Context, _ models.AgentConfig, i
 	`, entityID, subjectID, flowInstance, entityType, name, currentState, string(fieldsJSON), now); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.insert", false, err, "create entity %s", entityID)
 	}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
+		CurrentState: currentState,
+		Fields:       normalizedFields,
+	}, runtimemutationlog.Writer{
+		Type:        "platform",
+		ID:          "create_entity",
+		HandlerStep: "create_entity",
+	}); err != nil {
+		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.mutation_log", true, err, "record initial entity mutations")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.commit", true, err, "commit create entity")
+	}
+	committed = true
 	return map[string]any{
 		"entity_id":     entityID,
 		"subject_id":    subjectID,

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -272,6 +272,59 @@ func TestEntityTools_SaveEntityField_LogsMutationRow(t *testing.T) {
 	}
 }
 
+func TestEntityTools_CreateEntity_LogsInitialMutationRows(t *testing.T) {
+	ctx, exec, db := newEntityToolTestHarness(t)
+	entityID := uuid.NewString()
+	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
+		"entity_id":     entityID,
+		"flow_instance": "review/inst-1",
+		"fields": map[string]any{
+			"status": "open",
+			"score":  10.0,
+		},
+	}); err != nil {
+		t.Fatalf("create_entity: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT field, COALESCE(writer_type, ''), COALESCE(writer_id, ''), COALESCE(handler_step, '')
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid
+		ORDER BY created_at ASC, mutation_id ASC
+	`, entityID)
+	if err != nil {
+		t.Fatalf("query entity mutations: %v", err)
+	}
+	defer rows.Close()
+
+	fields := map[string][3]string{}
+	for rows.Next() {
+		var (
+			field       string
+			writerType  string
+			writerID    string
+			handlerStep string
+		)
+		if err := rows.Scan(&field, &writerType, &writerID, &handlerStep); err != nil {
+			t.Fatalf("scan entity mutation: %v", err)
+		}
+		fields[strings.TrimSpace(field)] = [3]string{writerType, writerID, handlerStep}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read entity mutations: %v", err)
+	}
+
+	for _, want := range []string{"current_state", "score", "status"} {
+		meta, ok := fields[want]
+		if !ok {
+			t.Fatalf("missing mutation field %q in %#v", want, fields)
+		}
+		if meta[0] != "platform" || meta[1] != "create_entity" || meta[2] != "create_entity" {
+			t.Fatalf("mutation metadata for %q = %#v, want platform/create_entity/create_entity", want, meta)
+		}
+	}
+}
+
 func TestEntityTools_GetEntityReturnsStoredCurrentState(t *testing.T) {
 	ctx, exec, db := newEntityToolTestHarness(t)
 	entityID := uuid.NewString()


### PR DESCRIPTION
## What changed

This PR audits the runtime/store `entity_state` write paths and makes mutation logging transactionally coupled instead of relying on path-specific behavior.

- added a shared tracked-state diff helper in `internal/runtime/mutationlog`
- moved `WorkflowInstanceStore.Upsert` onto a canonical path that writes `entity_state` and matching `entity_mutations` rows in the same transaction
- aligned `create_entity` and `save_entity_field` with that shared mutation logging path
- removed the residual exported delete path that could bypass mutation logging by making it fail closed
- added conformance-style tests that reconstruct tracked state from `entity_mutations` and fail if writes drift from the log

## Why

Issue #18 requires proving that every touched `entity_state` write emits a matching `entity_mutations` row in the same transactional path, and removing any remaining bypass that can mutate tracked state without mutation logging.

The previous runtime surface still had split write semantics:
- `create_entity` could write `entity_state` without initial mutation rows
- tracked state diffs were implemented in multiple places
- the exported workflow store delete path could remove `entity_state` without any mutation logging contract

This change consolidates those semantics into one canonical mutation-coupled write model.

## Impact

- tracked `entity_state` writes in the runtime/store surface now emit matching mutation rows at write time in the same transaction
- mutation-log completeness is enforced by focused regression tests rather than post-facto heuristics
- unsupported delete behavior now fails explicitly instead of silently drifting from the mutation log

## Validation

- `go test ./internal/store ./internal/runtime/... -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced entity state mutation tracking now captures detailed changes across current state, individual fields, workflow gates, and state accumulator buckets with deterministic ordering for comprehensive audit visibility.

* **Breaking Changes**
  * Entity deletion functionality is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->