### PR TITLE
[agent-a][issue #20] Replace legacy route materialization adapters with canonical flow-instance route identity

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -10,6 +10,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -138,7 +139,7 @@ func (eb *EventBus) RouteTable() *RouteTable {
 	return eb.routeTable
 }
 
-func (eb *EventBus) AddFlowInstance(template runtimecontracts.SystemNodeContract, instancePath string) error {
+func (eb *EventBus) AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
 	if eb == nil {
 		return errors.New("event bus is required")
 	}
@@ -148,29 +149,28 @@ func (eb *EventBus) AddFlowInstance(template runtimecontracts.SystemNodeContract
 	if table == nil {
 		return errors.New("route table is not initialized")
 	}
-	if err := table.AddFlowInstance(template, instancePath); err != nil {
+	if err := table.AddFlowInstanceRoute(template, identity); err != nil {
 		return err
 	}
 	persister, ok := eb.store.(FlowInstanceRoutePersistence)
 	if !ok {
 		return nil
 	}
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
-	routes := table.MaterializedRoutes(instancePath)
+	routes := table.MaterializedRoutes(identity)
 	if len(routes) == 0 {
 		return nil
 	}
 	for _, route := range routes {
 		if err := persister.UpsertFlowInstanceRoute(context.Background(), route); err != nil {
-			_ = persister.DeleteFlowInstanceRoute(context.Background(), route.TemplateID, route.InstanceID)
-			table.RemoveFlowInstance(route.TemplateID, route.InstanceID)
+			_ = persister.DeleteFlowInstanceRoute(context.Background(), route.Identity)
+			table.RemoveFlowInstanceRoute(route.Identity)
 			return err
 		}
 	}
 	return nil
 }
 
-func (eb *EventBus) RemoveFlowInstance(templateID, instanceID string) error {
+func (eb *EventBus) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error {
 	if eb == nil {
 		return errors.New("event bus is required")
 	}
@@ -181,11 +181,11 @@ func (eb *EventBus) RemoveFlowInstance(templateID, instanceID string) error {
 		return errors.New("route table is not initialized")
 	}
 	if persister, ok := eb.store.(FlowInstanceRoutePersistence); ok {
-		if err := persister.DeleteFlowInstanceRoute(context.Background(), templateID, instanceID); err != nil {
+		if err := persister.DeleteFlowInstanceRoute(context.Background(), identity); err != nil {
 			return err
 		}
 	}
-	table.RemoveFlowInstance(templateID, instanceID)
+	table.RemoveFlowInstanceRoute(identity)
 	return nil
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/flowmodel"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -1049,7 +1050,7 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.AddFlowInstance(runtimecontracts.SystemNodeContract{}, "child/grandchild/inst-1"); err != nil {
+	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	recorder := runtimebus.NewEmittedEventsRecorder()

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -102,15 +102,16 @@ func (rt *RouteTable) Resolve(eventType string) []Subscriber {
 	return cloneSubscribers(rt.routes[eventType])
 }
 
-func (rt *RouteTable) AddFlowInstance(template runtimecontracts.SystemNodeContract, instancePath string) error {
+func (rt *RouteTable) AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
 	if rt == nil {
 		return fmt.Errorf("route table is required")
 	}
 
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
-	if instancePath == "" {
-		return fmt.Errorf("instance path is required")
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return fmt.Errorf("flow-instance route identity is required")
 	}
+	instancePath := identity.InstancePath
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -119,14 +120,13 @@ func (rt *RouteTable) AddFlowInstance(template runtimecontracts.SystemNodeContra
 		return nil
 	}
 
-	templateScope := strings.TrimSpace(runtimeflowidentity.SemanticScopeFromInstancePath(instancePath))
+	templateScope := strings.TrimSpace(identity.ScopeKey)
 	if templateDef, ok := rt.templates[templateScope]; ok {
 		rt.instances[instancePath] = struct{}{}
 		rt.instanceEventPath[instancePath] = rt.addEventPathsLocked(instancePath, templateDef.LocalEvents)
-		instanceID := routeLastPathSegment(instancePath)
 		vars := map[string]string{
 			"flow_instance_path": instancePath,
-			"instance_id":        instanceID,
+			"instance_id":        identity.InstanceID,
 			"template_id":        templateDef.FlowID,
 			"flow_scope_key":     templateScope,
 		}
@@ -163,7 +163,7 @@ func (rt *RouteTable) AddFlowInstance(template runtimecontracts.SystemNodeContra
 	rt.instances[instancePath] = struct{}{}
 	rt.instanceEventPath[instancePath] = rt.addEventPathsLocked(instancePath, localEvents)
 	subscriber := Subscriber{
-		ID:   routeRenderTemplate(template.ID, map[string]string{"instance_id": routeLastPathSegment(instancePath)}),
+		ID:   routeRenderTemplate(template.ID, map[string]string{"instance_id": identity.InstanceID}),
 		Type: "node",
 		Path: instancePath,
 	}
@@ -184,14 +184,15 @@ func (rt *RouteTable) AddFlowInstance(template runtimecontracts.SystemNodeContra
 	return nil
 }
 
-func (rt *RouteTable) RemoveFlowInstance(templateID, instanceID string) {
+func (rt *RouteTable) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) {
 	if rt == nil {
 		return
 	}
-	instancePath := routeFlowInstancePath(templateID, instanceID)
-	if instancePath == "" {
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
 		return
 	}
+	instancePath := identity.InstancePath
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if _, exists := rt.instances[instancePath]; !exists {
@@ -213,19 +214,18 @@ func (rt *RouteTable) RemoveFlowInstance(templateID, instanceID string) {
 	rt.rebuildLocked()
 }
 
-func (rt *RouteTable) MaterializedRoutes(instancePath string) []FlowInstanceRouteRecord {
+func (rt *RouteTable) MaterializedRoutes(identity runtimeflowidentity.Route) []FlowInstanceRouteRecord {
 	if rt == nil {
 		return nil
 	}
-	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
-	if instancePath == "" {
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
 		return nil
 	}
+	instancePath := identity.InstancePath
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 
-	templateID := strings.TrimSpace(runtimeflowidentity.SemanticScopeFromInstancePath(instancePath))
-	instanceID := routeLastPathSegment(instancePath)
 	seen := make(map[string]struct{})
 	out := make([]FlowInstanceRouteRecord, 0, 8)
 	for _, pattern := range rt.patterns {
@@ -233,16 +233,14 @@ func (rt *RouteTable) MaterializedRoutes(instancePath string) []FlowInstanceRout
 			continue
 		}
 		record := FlowInstanceRouteRecord{
-			TemplateID:     templateID,
-			InstanceID:     instanceID,
-			InstancePath:   instancePath,
+			Identity:       identity,
 			EventPattern:   strings.TrimSpace(pattern.EventPattern),
 			SubscriberType: strings.TrimSpace(pattern.Subscriber.Type),
 			SubscriberID:   strings.TrimSpace(pattern.Subscriber.ID),
-			SourceFlow:     templateID,
+			SourceFlow:     identity.ScopeKey,
 		}
 		key := strings.Join([]string{
-			record.InstancePath,
+			record.Identity.InstancePath,
 			record.EventPattern,
 			record.SubscriberType,
 			record.SubscriberID,
@@ -597,18 +595,6 @@ func routeRenderTemplate(raw string, vars map[string]string) string {
 		replacements = append(replacements, "{"+key+"}", value, "{{"+key+"}}", value)
 	}
 	return strings.NewReplacer(replacements...).Replace(raw)
-}
-
-func routeLastPathSegment(raw string) string {
-	parts := eventidentity.SplitRouteSegments(raw)
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.TrimSpace(parts[len(parts)-1])
-}
-
-func routeFlowInstancePath(templateID, instanceID string) string {
-	return runtimeflowidentity.InstancePath(nil, templateID, instanceID)
 }
 
 func appendUniqueSubscriber(in []Subscriber, subscriber Subscriber) []Subscriber {

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -7,6 +7,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/flowmodel"
 	"swarm/internal/runtime/semanticview"
 )
@@ -16,17 +17,17 @@ func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstance(runtimecontracts.SystemNodeContract{
+	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
 		ID:           "reviewer-{instance_id}",
 		Produces:     []string{"task.started"},
 		SubscribesTo: []string{"task.started"},
-	}, "review/inst-1"); err != nil {
+	}, runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("review/inst-1/task.started"); len(got) != 1 || got[0].ID != "reviewer-inst-1" {
 		t.Fatalf("resolved subscribers after add = %#v", got)
 	}
-	if err := eb.RemoveFlowInstance("review", "inst-1"); err != nil {
+	if err := eb.RemoveFlowInstanceRoute(runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
 		t.Fatalf("RemoveFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("review/inst-1/task.started"); len(got) != 0 {
@@ -47,19 +48,19 @@ func (s *routePersistenceTestStore) UpsertFlowInstanceRoute(_ context.Context, r
 	if s.routes == nil {
 		s.routes = map[string]runtimebus.FlowInstanceRouteRecord{}
 	}
-	s.routes[route.TemplateID+"/"+route.InstanceID] = route
+	s.routes[route.Identity.ScopeKey+"/"+route.Identity.InstanceID] = route
 	return nil
 }
 
-func (s *routePersistenceTestStore) DeleteFlowInstanceRoute(_ context.Context, templateID, instanceID string) error {
-	delete(s.routes, templateID+"/"+instanceID)
+func (s *routePersistenceTestStore) DeleteFlowInstanceRoute(_ context.Context, identity runtimeflowidentity.Route) error {
+	delete(s.routes, identity.ScopeKey+"/"+identity.InstanceID)
 	return nil
 }
 
-func (s *routePersistenceTestStore) ListFlowInstanceRoutes(context.Context) ([]runtimebus.FlowInstanceRouteRecord, error) {
-	out := make([]runtimebus.FlowInstanceRouteRecord, 0, len(s.routes))
+func (s *routePersistenceTestStore) ListFlowInstanceRoutes(context.Context) ([]runtimeflowidentity.Route, error) {
+	out := make([]runtimeflowidentity.Route, 0, len(s.routes))
 	for _, route := range s.routes {
-		out = append(out, route)
+		out = append(out, route.Identity)
 	}
 	return out, nil
 }
@@ -70,17 +71,17 @@ func TestEventBusFlowInstanceRoutesPersistAcrossAddAndRemove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstance(runtimecontracts.SystemNodeContract{
+	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
 		ID:           "reviewer-{instance_id}",
 		Produces:     []string{"task.started"},
 		SubscribesTo: []string{"task.started"},
-	}, "review/inst-1"); err != nil {
+	}, runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if _, ok := store.routes["review/inst-1"]; !ok {
 		t.Fatalf("persisted routes = %#v, want review/inst-1", store.routes)
 	}
-	if err := eb.RemoveFlowInstance("review", "inst-1"); err != nil {
+	if err := eb.RemoveFlowInstanceRoute(runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
 		t.Fatalf("RemoveFlowInstance: %v", err)
 	}
 	if len(store.routes) != 0 {
@@ -93,17 +94,17 @@ func TestEventBusRemoveNestedFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstance(runtimecontracts.SystemNodeContract{
+	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
 		ID:           "worker-{instance_id}",
 		Produces:     []string{"micro.started"},
 		SubscribesTo: []string{"micro.started"},
-	}, "child/grandchild/inst-1"); err != nil {
+	}, runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("child/grandchild/inst-1/micro.started"); len(got) != 1 || got[0].ID != "worker-inst-1" {
 		t.Fatalf("resolved subscribers after add = %#v", got)
 	}
-	if err := eb.RemoveFlowInstance("child/grandchild", "inst-1"); err != nil {
+	if err := eb.RemoveFlowInstanceRoute(runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
 		t.Fatalf("RemoveFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("child/grandchild/inst-1/micro.started"); len(got) != 0 {
@@ -293,18 +294,19 @@ func TestDeriveRouteTable_NestedTemplateInstancesPersistSemanticScopeKey(t *test
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
-	if err := rt.AddFlowInstance(runtimecontracts.SystemNodeContract{}, "child/grandchild/inst-1"); err != nil {
+	identity := runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")
+	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, identity); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
-	routes := rt.MaterializedRoutes("child/grandchild/inst-1")
+	routes := rt.MaterializedRoutes(identity)
 	if len(routes) != 1 {
 		t.Fatalf("MaterializedRoutes = %#v, want 1 route", routes)
 	}
-	if routes[0].TemplateID != "child/grandchild" {
-		t.Fatalf("TemplateID = %q, want child/grandchild", routes[0].TemplateID)
+	if routes[0].Identity.ScopeKey != "child/grandchild" {
+		t.Fatalf("ScopeKey = %q, want child/grandchild", routes[0].Identity.ScopeKey)
 	}
-	if routes[0].InstanceID != "inst-1" {
-		t.Fatalf("InstanceID = %q, want inst-1", routes[0].InstanceID)
+	if routes[0].Identity.InstanceID != "inst-1" {
+		t.Fatalf("InstanceID = %q, want inst-1", routes[0].Identity.InstanceID)
 	}
 	if routes[0].SourceFlow != "child/grandchild" {
 		t.Fatalf("SourceFlow = %q, want child/grandchild", routes[0].SourceFlow)

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 )
 
 type EventStore interface {
@@ -14,9 +15,7 @@ type EventStore interface {
 }
 
 type FlowInstanceRouteRecord struct {
-	TemplateID     string
-	InstanceID     string
-	InstancePath   string
+	Identity       runtimeflowidentity.Route
 	EventPattern   string
 	SubscriberType string
 	SubscriberID   string
@@ -25,8 +24,8 @@ type FlowInstanceRouteRecord struct {
 
 type FlowInstanceRoutePersistence interface {
 	UpsertFlowInstanceRoute(ctx context.Context, route FlowInstanceRouteRecord) error
-	DeleteFlowInstanceRoute(ctx context.Context, templateID, instanceID string) error
-	ListFlowInstanceRoutes(ctx context.Context) ([]FlowInstanceRouteRecord, error)
+	DeleteFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error
+	ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error)
 }
 
 // ActiveAgentLister is an optional capability for broadcast-style events.

--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -21,6 +21,12 @@ type Instance struct {
 	HasStoredPath  bool
 }
 
+type Route struct {
+	ScopeKey     string
+	InstanceID   string
+	InstancePath string
+}
+
 func ScopeKey(source semanticview.Source, flowID string) string {
 	flowID = strings.TrimSpace(flowID)
 	if flowID == "" {
@@ -44,6 +50,19 @@ func InstancePath(source semanticview.Source, flowID, instanceID string) string 
 		return basePath
 	default:
 		return basePath + "/" + instanceID
+	}
+}
+
+func routePath(scopeKey, instanceID string) string {
+	scopeKey = normalizeRef(scopeKey)
+	instanceID = strings.Trim(strings.TrimSpace(instanceID), "/")
+	switch {
+	case scopeKey == "":
+		return instanceID
+	case instanceID == "":
+		return scopeKey
+	default:
+		return scopeKey + "/" + instanceID
 	}
 }
 
@@ -101,6 +120,40 @@ func Derive(source semanticview.Source, flowID, instanceID string) Instance {
 		EntityID:      entityID,
 		HasStoredPath: instancePath != "",
 	}
+}
+
+func DeriveRoute(scopeKey, instanceID string) Route {
+	return StoredRoute(scopeKey, instanceID, "")
+}
+
+func StoredRoute(scopeKey, instanceID, instancePath string) Route {
+	scopeKey = normalizeRef(scopeKey)
+	instancePath = normalizeRef(instancePath)
+	instanceID = strings.TrimSpace(instanceID)
+	if scopeKey == "" && instancePath != "" {
+		scopeKey = SemanticScope(instancePath)
+	}
+	if instanceID == "" && instancePath != "" {
+		instanceID = LogicalInstanceID(instancePath)
+	}
+	if instancePath == "" {
+		instancePath = routePath(scopeKey, instanceID)
+	}
+	return Route{
+		ScopeKey:     scopeKey,
+		InstanceID:   instanceID,
+		InstancePath: instancePath,
+	}
+}
+
+func (i Instance) Route() Route {
+	return StoredRoute(i.ScopeKey, i.InstanceID, i.InstancePath)
+}
+
+func (r Route) Valid() bool {
+	return strings.TrimSpace(r.ScopeKey) != "" &&
+		strings.TrimSpace(r.InstanceID) != "" &&
+		strings.TrimSpace(r.InstancePath) != ""
 }
 
 func SemanticScopeFromInstancePath(instancePath string) string {

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -118,6 +118,32 @@ func TestStoredCoordinates_SeparateScopeFromConcretePath(t *testing.T) {
 	}
 }
 
+func TestStoredRoute_CanonicalizesScopeInstanceAndPath(t *testing.T) {
+	route := StoredRoute("", "", "child/grandchild/inst-1")
+	if !route.Valid() {
+		t.Fatal("expected stored route from instance path to be valid")
+	}
+	if route.ScopeKey != "child/grandchild" {
+		t.Fatalf("StoredRoute scope = %q, want child/grandchild", route.ScopeKey)
+	}
+	if route.InstanceID != "inst-1" {
+		t.Fatalf("StoredRoute instance id = %q, want inst-1", route.InstanceID)
+	}
+	if route.InstancePath != "child/grandchild/inst-1" {
+		t.Fatalf("StoredRoute instance path = %q, want child/grandchild/inst-1", route.InstancePath)
+	}
+
+	derived := DeriveRoute("child/grandchild", "inst-1")
+	if derived != route {
+		t.Fatalf("DeriveRoute = %#v, want %#v", derived, route)
+	}
+
+	instance := Stored(nil, "grandchild", "child/grandchild/inst-1", "inst-1", "", "", "")
+	if got := instance.Route(); got != route {
+		t.Fatalf("Instance.Route() = %#v, want %#v", got, route)
+	}
+}
+
 func TestSemanticScopeFromInstancePath(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -24,11 +24,11 @@ type flowInstancePersistence interface {
 }
 
 type flowInstanceRouteInstaller interface {
-	AddFlowInstance(template runtimecontracts.SystemNodeContract, instancePath string) error
+	AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error
 }
 
 type flowInstanceRouteRemover interface {
-	RemoveFlowInstance(templateID, instanceID string) error
+	RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error
 }
 
 func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
@@ -114,7 +114,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		}
 	}
 	if installer, ok := am.bus.(flowInstanceRouteInstaller); ok && installer != nil {
-		if err := installer.AddFlowInstance(runtimecontracts.SystemNodeContract{}, flowPath); err != nil {
+		if err := installer.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, instance.Route()); err != nil {
 			return err
 		}
 	} else {
@@ -253,9 +253,9 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 		return fmt.Errorf("template_id, instance_id, flow_path, and entity_id are required")
 	}
 	flowEntityID := entityID
-	scopeKey := strings.TrimSpace(instance.ScopeKey)
-	if scopeKey == "" {
-		return fmt.Errorf("derive scope key for flow path %s", flowPath)
+	routeIdentity := instance.Route()
+	if !routeIdentity.Valid() {
+		return fmt.Errorf("derive route identity for flow path %s", flowPath)
 	}
 	am.mu.RLock()
 	agentIDs := make([]string, 0, len(am.agentCfg))
@@ -273,7 +273,7 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 		}
 	}
 	if remover, ok := am.bus.(flowInstanceRouteRemover); ok && remover != nil {
-		return remover.RemoveFlowInstance(scopeKey, instanceID)
+		return remover.RemoveFlowInstanceRoute(routeIdentity)
 	}
 	return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", flowPath)
 }

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -70,13 +70,13 @@ func (*flowActivationTestBus) Store() runtimebus.EventStore                     
 func (*flowActivationTestBus) ResetInMemoryState() error                                   { return nil }
 func (*flowActivationTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) {}
 
-func (b *flowActivationTestBus) AddFlowInstance(_ runtimecontracts.SystemNodeContract, instancePath string) error {
-	b.addedPaths = append(b.addedPaths, instancePath)
+func (b *flowActivationTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+	b.addedPaths = append(b.addedPaths, identity.InstancePath)
 	return nil
 }
 
-func (b *flowActivationTestBus) RemoveFlowInstance(templateID, instanceID string) error {
-	b.removedPairs = append(b.removedPairs, templateID+"/"+instanceID)
+func (b *flowActivationTestBus) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error {
+	b.removedPairs = append(b.removedPairs, identity.ScopeKey+"/"+identity.InstanceID)
 	return nil
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -10,6 +10,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
@@ -35,12 +36,18 @@ func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time
 func (b *recoveryTestBus) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {
 	return nil
 }
-func (b *recoveryTestBus) DeleteFlowInstanceRoute(context.Context, string, string) error { return nil }
-func (b *recoveryTestBus) ListFlowInstanceRoutes(context.Context) ([]runtimebus.FlowInstanceRouteRecord, error) {
-	return append([]runtimebus.FlowInstanceRouteRecord(nil), b.storedRoutes...), nil
+func (b *recoveryTestBus) DeleteFlowInstanceRoute(context.Context, runtimeflowidentity.Route) error {
+	return nil
 }
-func (b *recoveryTestBus) AddFlowInstance(_ runtimecontracts.SystemNodeContract, instancePath string) error {
-	b.restored = append(b.restored, instancePath)
+func (b *recoveryTestBus) ListFlowInstanceRoutes(context.Context) ([]runtimeflowidentity.Route, error) {
+	out := make([]runtimeflowidentity.Route, 0, len(b.storedRoutes))
+	for _, route := range b.storedRoutes {
+		out = append(out, route.Identity)
+	}
+	return out, nil
+}
+func (b *recoveryTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+	b.restored = append(b.restored, identity.InstancePath)
 	return nil
 }
 
@@ -67,9 +74,7 @@ func (s *recoveryTestStore) ListPendingSubscribedEvents(context.Context, string,
 func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
 	bus := &recoveryTestBus{
 		storedRoutes: []runtimebus.FlowInstanceRouteRecord{{
-			TemplateID:   "review",
-			InstanceID:   "inst-1",
-			InstancePath: "review/inst-1",
+			Identity: runtimeflowidentity.DeriveRoute("review", "inst-1"),
 		}},
 	}
 	store := &recoveryTestStore{

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -444,8 +444,8 @@ func (am *AgentManager) restoreFlowInstanceRoutes(ctx context.Context) error {
 		return fmt.Errorf("list persisted flow instance routes: %w", err)
 	}
 	for _, route := range routes {
-		if err := installer.AddFlowInstance(runtimecontracts.SystemNodeContract{}, route.InstancePath); err != nil {
-			return fmt.Errorf("restore flow instance route %s/%s: %w", route.TemplateID, route.InstanceID, err)
+		if err := installer.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, route); err != nil {
+			return fmt.Errorf("restore flow instance route %s/%s: %w", route.ScopeKey, route.InstanceID, err)
 		}
 	}
 	return nil

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -6,17 +6,20 @@ import (
 	"strings"
 
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 )
 
 func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for flow instance routes")
 	}
-	route.TemplateID = strings.TrimSpace(route.TemplateID)
-	route.InstanceID = strings.TrimSpace(route.InstanceID)
-	route.InstancePath = strings.Trim(strings.TrimSpace(route.InstancePath), "/")
-	if route.TemplateID == "" || route.InstanceID == "" || route.InstancePath == "" {
-		return fmt.Errorf("template_id, instance_id, and instance_path are required")
+	route.Identity = runtimeflowidentity.StoredRoute(route.Identity.ScopeKey, route.Identity.InstanceID, route.Identity.InstancePath)
+	if !route.Identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
+	}
+	sourceFlow := strings.TrimSpace(route.SourceFlow)
+	if sourceFlow == "" {
+		sourceFlow = route.Identity.ScopeKey
 	}
 	var materializedFrom any
 	if strings.TrimSpace(route.EventPattern) != "" && strings.TrimSpace(route.SubscriberType) != "" && strings.TrimSpace(route.SubscriberID) != "" {
@@ -28,11 +31,11 @@ func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runti
 			  AND subscriber_id = $3
 			  AND COALESCE(source_flow, '') = $4
 			  AND is_wildcard = true
-			  AND is_materialized = false
-			  AND status = 'active'
-			ORDER BY created_at ASC
-			LIMIT 1
-		`, route.EventPattern, route.SubscriberType, route.SubscriberID, strings.TrimSpace(route.SourceFlow)).Scan(&materializedFrom)
+				  AND is_materialized = false
+				  AND status = 'active'
+				ORDER BY created_at ASC
+				LIMIT 1
+			`, route.EventPattern, route.SubscriberType, route.SubscriberID, sourceFlow).Scan(&materializedFrom)
 	}
 	_, err := s.DB.ExecContext(ctx, `
 		WITH updated AS (
@@ -59,84 +62,73 @@ func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runti
 			status,
 			created_at
 		)
-		SELECT
-			$1,
-			$2,
-			$3,
-			NULLIF($4,''),
+			SELECT
+				$1,
+				$2,
+				$3,
+				NULLIF($4,''),
 			NULLIF($5,''),
 			false,
 			true,
 			$6,
-			'active',
-			now()
-		WHERE NOT EXISTS (SELECT 1 FROM updated)
-	`, route.EventPattern, route.SubscriberType, route.SubscriberID, route.InstancePath, route.SourceFlow, materializedFrom)
+				'active',
+				now()
+			WHERE NOT EXISTS (SELECT 1 FROM updated)
+		`, route.EventPattern, route.SubscriberType, route.SubscriberID, route.Identity.InstancePath, sourceFlow, materializedFrom)
 	if err != nil {
-		return fmt.Errorf("upsert flow instance route %s/%s: %w", route.TemplateID, route.InstanceID, err)
+		return fmt.Errorf("upsert flow instance route %s/%s: %w", route.Identity.ScopeKey, route.Identity.InstanceID, err)
 	}
 	return nil
 }
 
-func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, templateID, instanceID string) error {
+func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for flow instance routes")
 	}
-	templateID = strings.TrimSpace(templateID)
-	instanceID = strings.TrimSpace(instanceID)
-	if templateID == "" || instanceID == "" {
-		return fmt.Errorf("template_id and instance_id are required")
-	}
-	instancePath := strings.Trim(strings.TrimSpace(templateID), "/")
-	if trimmedInstanceID := strings.Trim(strings.TrimSpace(instanceID), "/"); trimmedInstanceID != "" {
-		if instancePath != "" {
-			instancePath += "/"
-		}
-		instancePath += trimmedInstanceID
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
 	}
 	if _, err := s.DB.ExecContext(ctx, `
-		UPDATE routing_rules
-		SET status = 'inactive'
-		WHERE flow_instance = $1
-		  AND is_materialized = true
-		  AND status = 'active'
-	`, instancePath); err != nil {
-		return fmt.Errorf("delete flow instance route %s/%s: %w", templateID, instanceID, err)
+			UPDATE routing_rules
+			SET status = 'inactive'
+			WHERE flow_instance = $1
+			  AND is_materialized = true
+			  AND status = 'active'
+		`, identity.InstancePath); err != nil {
+		return fmt.Errorf("delete flow instance route %s/%s: %w", identity.ScopeKey, identity.InstanceID, err)
 	}
 	return nil
 }
 
-func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimebus.FlowInstanceRouteRecord, error) {
+func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required for flow instance routes")
 	}
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT
-			COALESCE(NULLIF(source_flow, ''), regexp_replace(flow_instance, '/[^/]+$', '')),
-			split_part(flow_instance, '/', array_length(string_to_array(flow_instance, '/'), 1)),
-			flow_instance
-		FROM routing_rules
-		WHERE is_materialized = true
-		  AND status = 'active'
-		  AND flow_instance IS NOT NULL
-		GROUP BY flow_instance, source_flow
-		ORDER BY flow_instance ASC
+			SELECT
+				COALESCE(NULLIF(source_flow, ''), ''),
+				flow_instance
+			FROM routing_rules
+			WHERE is_materialized = true
+			  AND status = 'active'
+			  AND flow_instance IS NOT NULL
+			GROUP BY flow_instance, source_flow
+			ORDER BY flow_instance ASC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list flow instance routes: %w", err)
 	}
 	defer rows.Close()
 
-	out := []runtimebus.FlowInstanceRouteRecord{}
+	out := []runtimeflowidentity.Route{}
 	for rows.Next() {
-		var route runtimebus.FlowInstanceRouteRecord
-		if err := rows.Scan(&route.TemplateID, &route.InstanceID, &route.InstancePath); err != nil {
+		var sourceFlow, instancePath string
+		if err := rows.Scan(&sourceFlow, &instancePath); err != nil {
 			return nil, fmt.Errorf("scan flow instance route: %w", err)
 		}
-		route.TemplateID = strings.TrimSpace(route.TemplateID)
-		route.InstanceID = strings.TrimSpace(route.InstanceID)
-		route.InstancePath = strings.Trim(strings.TrimSpace(route.InstancePath), "/")
-		if route.TemplateID == "" || route.InstanceID == "" || route.InstancePath == "" {
+		route := runtimeflowidentity.StoredRoute(sourceFlow, "", instancePath)
+		if !route.Valid() {
 			continue
 		}
 		out = append(out, route)

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -6,6 +6,7 @@ import (
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/testutil"
 )
 
@@ -35,9 +36,7 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	}
 
 	route := runtimebus.FlowInstanceRouteRecord{
-		TemplateID:     "review",
-		InstanceID:     "inst-1",
-		InstancePath:   "review/inst-1",
+		Identity:       runtimeflowidentity.DeriveRoute("review", "inst-1"),
 		EventPattern:   "review/inst-1/task.started",
 		SubscriberType: "node",
 		SubscriberID:   "reviewer-inst-1",
@@ -50,15 +49,11 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFlowInstanceRoutes: %v", err)
 	}
-	want := runtimebus.FlowInstanceRouteRecord{
-		TemplateID:   route.TemplateID,
-		InstanceID:   route.InstanceID,
-		InstancePath: route.InstancePath,
-	}
+	want := route.Identity
 	if len(routes) != 1 || routes[0] != want {
 		t.Fatalf("listed routes = %#v, want %#v", routes, want)
 	}
-	if err := pg.DeleteFlowInstanceRoute(ctx, route.TemplateID, route.InstanceID); err != nil {
+	if err := pg.DeleteFlowInstanceRoute(ctx, route.Identity); err != nil {
 		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
 	}
 	routes, err = pg.ListFlowInstanceRoutes(ctx)
@@ -96,9 +91,7 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	}
 
 	route := runtimebus.FlowInstanceRouteRecord{
-		TemplateID:     "child/grandchild",
-		InstanceID:     "inst-1",
-		InstancePath:   "child/grandchild/inst-1",
+		Identity:       runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1"),
 		EventPattern:   "child/grandchild/inst-1/micro.started",
 		SubscriberType: "node",
 		SubscriberID:   "worker-inst-1",
@@ -111,15 +104,11 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFlowInstanceRoutes: %v", err)
 	}
-	want := runtimebus.FlowInstanceRouteRecord{
-		TemplateID:   route.TemplateID,
-		InstanceID:   route.InstanceID,
-		InstancePath: route.InstancePath,
-	}
+	want := route.Identity
 	if len(routes) != 1 || routes[0] != want {
 		t.Fatalf("listed routes = %#v, want %#v", routes, want)
 	}
-	if err := pg.DeleteFlowInstanceRoute(ctx, route.TemplateID, route.InstanceID); err != nil {
+	if err := pg.DeleteFlowInstanceRoute(ctx, route.Identity); err != nil {
 		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
 	}
 	routes, err = pg.ListFlowInstanceRoutes(ctx)


### PR DESCRIPTION
## What changed

This change replaces the remaining route materialization adapters with one canonical flow-instance route identity.

`internal/runtime/core/flowidentity` now owns a dedicated route descriptor carrying `scope_key`, `instance_id`, and `instance_path`. The bus, manager recovery/activation paths, and route persistence now pass that descriptor directly instead of reconstructing route identity from raw paths or template/instance pairs.

## Why

Route persistence and deletion were still carrying a second identity model separate from the canonical flow-instance identity work. Different layers were re-parsing instance paths or rebuilding paths from template and instance fragments, which kept route semantics duplicated and fragile.

This PR centralizes route identity so materialization, deletion, and restore all use the same explicit model.

## Impact

- Route persistence and deletion now use one canonical flow-instance route identity.
- Manager activation/deactivation and route restore stop reconstructing template/instance identity from raw paths.
- Store listing/deletion no longer rely on SQL/path parsing adapters to recover route identity.

## Validation

- `go test ./internal/runtime/pipeline ./internal/runtime/manager -count=1`
- `go test ./internal/runtime/core/flowidentity -count=1`
- `go test ./... -count=1`
- `gofmt -l .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured flow instance routing to use unified route identity objects
  * Updated route persistence and retrieval mechanisms across the runtime engine
  * Simplified internal route management interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->