### PR TITLE
[agent-c][issue #10] Introduce a typed persisted runtime descriptor for agents

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2385,20 +2385,23 @@ platform_tables:
         \    INDEX idx_entity_state (current_state),\n    INDEX idx_entity_type (entity_type),\n    INDEX idx_entity_slug\
         \ (slug) WHERE slug IS NOT NULL\n);"
     agents:
-      description: 'Runtime agent registry. One row per agent instance. Carries the full runtime descriptor: role (from agents.yaml),
-        parent_agent_id (managerial hierarchy), config (agent-specific configuration from contracts), subscriptions/emit_events/tools/permissions
-        (materialized from contracts at boot for fast runtime lookup). flow_instance nullable for root-level agents not scoped
-        to any flow. entity_id nullable — set only for agents scoped to a specific entity (rare). The contract in agents.yaml
-        is the source of truth. This table is the runtime materialization. llm_backend specifies the LLM invocation backend
-        — api (production), cli_test (test harness), mock (fixture replay). This is a deployment/agent
-        property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.'
+      description: 'Runtime agent registry. One row per agent instance. Carries the full persisted runtime descriptor:
+        role/model_tier/llm_backend/conversation_mode/parent_agent_id as typed columns, subscriptions/emit_events/tools/permissions
+        as JSONB arrays, and runtime_descriptor JSONB for the remaining control-plane fields that do not already have a
+        first-class persisted column (for example type, mode, workspace_class, manager_fallback, max_turns_per_task, native_tools).
+        config is opaque agent-specific payload only; the platform stores and passes it through but does not read config
+        for runtime control semantics. flow_instance nullable for root-level agents not scoped to any flow. entity_id nullable
+        — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth and
+        permissions_bundle is resolved at boot into the persisted permissions array rather than being stored directly.
+        llm_backend specifies the LLM invocation backend — api (production), cli_test (test harness), mock (fixture replay).
+        This is a deployment/agent property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.'
       ddl: "CREATE TABLE agents (\n    agent_id          TEXT PRIMARY KEY,\n    flow_instance     TEXT,\n    role        \
         \      TEXT NOT NULL,\n    model_tier        TEXT NOT NULL,\n    llm_backend       TEXT NOT NULL DEFAULT 'api' CHECK\
         \ (llm_backend IN ('api', 'cli_test', 'mock', 'local')),\n    conversation_mode TEXT NOT NULL CHECK (conversation_mode\
         \ IN ('task', 'session', 'session_per_entity')),\n    parent_agent_id   TEXT,\n    entity_id         UUID,\n    config\
         \            JSONB NOT NULL DEFAULT '{}',\n    subscriptions     JSONB NOT NULL DEFAULT '[]',\n    emit_events   \
         \    JSONB NOT NULL DEFAULT '[]',\n    tools             JSONB NOT NULL DEFAULT '[]',\n    permissions       JSONB\
-        \ NOT NULL DEFAULT '[]',\n    status            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused',\
+        \ NOT NULL DEFAULT '[]',\n    runtime_descriptor JSONB NOT NULL DEFAULT '{}',\n    status            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused',\
         \ 'terminated')),\n    turn_count        INTEGER NOT NULL DEFAULT 0,\n    last_active_at    TIMESTAMPTZ,\n    created_at\
         \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_agents_flow (flow_instance) WHERE flow_instance IS NOT\
         \ NULL,\n    INDEX idx_agents_role (role),\n    INDEX idx_agents_status (status),\n    INDEX idx_agents_parent (parent_agent_id)\

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -55,13 +55,11 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 
 	maxTurns := 100
 	mode := llm.TaskScoped
-	if overrideMode, overrideMaxTurns := extractConversationConstraints(cfg.Config); overrideMode != nil {
-		mode = *overrideMode
-		if overrideMaxTurns > 0 {
-			maxTurns = overrideMaxTurns
-		}
-	} else if overrideMaxTurns > 0 {
-		maxTurns = overrideMaxTurns
+	if overrideMode, ok := parseConversationMode(cfg.ConversationMode); ok {
+		mode = overrideMode
+	}
+	if cfg.MaxTurnsPerTask > 0 {
+		maxTurns = cfg.MaxTurnsPerTask
 	}
 	c := llm.NewConversation(cfg.ID, "", systemPrompt, tools, mode, maxTurns, modelRuntime)
 	c.SetToolExecutor(toolExecutor)
@@ -87,42 +85,6 @@ func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, 
 	return tools
 }
 
-func extractConversationConstraints(raw json.RawMessage) (*llm.ConversationMode, int) {
-	if len(raw) == 0 || !json.Valid(raw) {
-		return nil, 0
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return nil, 0
-	}
-	var (
-		modePtr  *llm.ConversationMode
-		maxTurns int
-	)
-	if constraints, ok := obj["constraints"].(map[string]any); ok {
-		if mode, ok := parseConversationMode(sharedjson.AsString(constraints["conversation_mode"])); ok {
-			modeCopy := mode
-			modePtr = &modeCopy
-		}
-		if v := asIntFromAny(constraints["max_turns_per_task"]); v > 0 {
-			maxTurns = v
-		}
-	}
-	// Backward-compatible top-level overrides.
-	if modePtr == nil {
-		if mode, ok := parseConversationMode(sharedjson.AsString(obj["conversation_mode"])); ok {
-			modeCopy := mode
-			modePtr = &modeCopy
-		}
-	}
-	if maxTurns == 0 {
-		if v := asIntFromAny(obj["max_turns_per_task"]); v > 0 {
-			maxTurns = v
-		}
-	}
-	return modePtr, maxTurns
-}
-
 func parseConversationMode(raw string) (llm.ConversationMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "task", "task_scoped", "task-scoped", "stateless":
@@ -133,26 +95,6 @@ func parseConversationMode(raw string) (llm.ConversationMode, bool) {
 		return llm.SessionPerEntityScoped, true
 	default:
 		return llm.TaskScoped, false
-	}
-}
-
-func asIntFromAny(v any) int {
-	switch n := v.(type) {
-	case int:
-		return n
-	case int32:
-		return int(n)
-	case int64:
-		return int(n)
-	case float64:
-		return int(n)
-	case float32:
-		return int(n)
-	case json.Number:
-		i, _ := n.Int64()
-		return int(i)
-	default:
-		return 0
 	}
 }
 
@@ -606,25 +548,12 @@ func extractSystemPrompt(cfg models.AgentConfig) string {
 
 func extractAllowedToolSet(cfg models.AgentConfig) (map[string]struct{}, bool) {
 	allowed := make(map[string]struct{})
-	if len(cfg.Config) == 0 || !json.Valid(cfg.Config) {
-		return allowed, false
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(cfg.Config, &obj); err != nil {
+	if len(cfg.Tools) == 0 {
 		return allowed, false
 	}
 	found := false
-	raw, ok := obj["tools"]
-	if !ok {
-		return allowed, false
-	}
-	arr, ok := raw.([]any)
-	if !ok {
-		return allowed, false
-	}
-	for _, item := range arr {
-		name, _ := item.(string)
-		name = strings.TrimSpace(name)
+	for _, item := range cfg.Tools {
+		name := strings.TrimSpace(item)
 		if name == "" {
 			continue
 		}
@@ -635,34 +564,14 @@ func extractAllowedToolSet(cfg models.AgentConfig) (map[string]struct{}, bool) {
 }
 
 func extractNativeToolConfig(cfg models.AgentConfig) map[string]bool {
-	if len(cfg.Config) == 0 || !json.Valid(cfg.Config) {
+	if !cfg.NativeTools.Any() {
 		return nil
 	}
-	var obj map[string]any
-	if err := json.Unmarshal(cfg.Config, &obj); err != nil {
-		return nil
+	return map[string]bool{
+		"bash":       cfg.NativeTools.Bash,
+		"web_search": cfg.NativeTools.WebSearch,
+		"file_io":    cfg.NativeTools.FileIO,
 	}
-	raw, ok := obj["native_tools"]
-	if !ok {
-		return nil
-	}
-	items, ok := raw.(map[string]any)
-	if !ok {
-		return nil
-	}
-	out := make(map[string]bool, len(items))
-	for key, value := range items {
-		key = strings.TrimSpace(key)
-		flag, ok := value.(bool)
-		if key == "" || !ok || !flag {
-			continue
-		}
-		out[key] = true
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 func supportedNativeToolCapabilities(runtime llm.Runtime) llm.NativeToolCapabilities {
@@ -722,30 +631,7 @@ func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runt
 }
 
 func extractEmitEvents(cfg models.AgentConfig) []string {
-	if len(cfg.Config) == 0 || !json.Valid(cfg.Config) {
-		return nil
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(cfg.Config, &obj); err != nil {
-		return nil
-	}
-	raw, ok := obj["emit_events"]
-	if !ok {
-		return nil
-	}
-	arr, ok := raw.([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(arr))
-	for _, item := range arr {
-		eventType := strings.TrimSpace(sharedjson.AsString(item))
-		if eventType == "" {
-			continue
-		}
-		out = append(out, eventType)
-	}
-	return uniqueStrings(out)
+	return uniqueStrings(cfg.EmitEvents)
 }
 
 func emitToolDefinitions(cfg models.AgentConfig) []llm.ToolDefinition {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -23,12 +23,10 @@ import (
 
 func TestFormatEventForAgent_UsesConfiguredToolSummary(t *testing.T) {
 	cfg := models.AgentConfig{
-		ID:   "agent-1",
-		Role: "operator",
-		Mode: "task",
-		Config: mustAgentConfigJSON(t, map[string]any{
-			"tools": []string{"schedule", "get_entity", "emit_example"},
-		}),
+		ID:    "agent-1",
+		Role:  "operator",
+		Mode:  "task",
+		Tools: []string{"schedule", "get_entity", "emit_example"},
 	}
 	evt := (events.Event{
 		ID:          "evt-1",
@@ -46,9 +44,7 @@ func TestFormatEventForAgent_UsesConfiguredToolSummary(t *testing.T) {
 
 func TestFilterTools_RetainsUniversalEntityToolsWhenConstrained(t *testing.T) {
 	allowed, constrained := extractAllowedToolSet(models.AgentConfig{
-		Config: mustAgentConfigJSON(t, map[string]any{
-			"tools": []string{"emit_example"},
-		}),
+		Tools: []string{"emit_example"},
 	})
 	if !constrained {
 		t.Fatal("expected constrained tool set")
@@ -230,12 +226,10 @@ func TestNewLLMAgent_UsesConfiguredEmitEventsAndAllowedTools(t *testing.T) {
 	}))
 	agent := NewLLMAgent(
 		models.AgentConfig{
-			ID:   "coordinator-1",
-			Role: "coordinator",
-			Config: mustAgentConfigJSON(t, map[string]any{
-				"tools":       []string{"schedule"},
-				"emit_events": []string{"coord.done"},
-			}),
+			ID:         "coordinator-1",
+			Role:       "coordinator",
+			Tools:      []string{"schedule"},
+			EmitEvents: []string{"coord.done"},
 		},
 		nil,
 		nil,
@@ -418,10 +412,10 @@ func TestNewLLMAgentFactory_PrefersActorScopedToolDefinitions(t *testing.T) {
 		{Name: "global_only"},
 	})
 	agent, err := factory(models.AgentConfig{
-		ID: "analysis-agent",
+		ID:    "analysis-agent",
+		Tools: []string{"query_entities"},
 		Config: mustAgentConfigJSON(t, map[string]any{
 			"system_prompt": "You are here.",
-			"tools":         []string{"query_entities"},
 		}),
 	})
 	if err != nil {
@@ -475,12 +469,10 @@ func TestLLMAgent_TaskScopedFatalCLIErrorResetsConversationAndRetries(t *testing
 	rt := &taskRetryRuntime{}
 	agent := NewLLMAgent(
 		models.AgentConfig{
-			ID:       "spec-reviewer",
-			Role:     "spec_reviewer",
-			EntityID: "ent-1",
-			Config: mustAgentConfigJSON(t, map[string]any{
-				"conversation_mode": "stateless",
-			}),
+			ID:               "spec-reviewer",
+			Role:             "spec_reviewer",
+			EntityID:         "ent-1",
+			ConversationMode: "stateless",
 		},
 		rt,
 		nil,
@@ -575,13 +567,11 @@ func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testi
 		models.AgentConfig{
 			ID:   "researcher-1",
 			Role: "researcher",
-			Config: mustAgentConfigJSON(t, map[string]any{
-				"native_tools": map[string]any{
-					"bash":       true,
-					"web_search": true,
-					"file_io":    true,
-				},
-			}),
+			NativeTools: models.NativeToolConfig{
+				Bash:      true,
+				WebSearch: true,
+				FileIO:    true,
+			},
 		},
 		nativeCapabilityRuntimeStub{},
 		nil,
@@ -603,13 +593,11 @@ func TestNewLLMAgent_DoesNotInjectNativeFallbackToolsWhenProviderSupportsCapabil
 		models.AgentConfig{
 			ID:   "ops-1",
 			Role: "ops",
-			Config: mustAgentConfigJSON(t, map[string]any{
-				"native_tools": map[string]any{
-					"bash":       true,
-					"web_search": true,
-					"file_io":    true,
-				},
-			}),
+			NativeTools: models.NativeToolConfig{
+				Bash:      true,
+				WebSearch: true,
+				FileIO:    true,
+			},
 		},
 		nativeCapabilityRuntimeStub{caps: llm.NativeToolCapabilities{
 			Bash:      true,

--- a/internal/runtime/authority/source_provider.go
+++ b/internal/runtime/authority/source_provider.go
@@ -1,7 +1,6 @@
 package authority
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -152,7 +151,7 @@ func (p *sourceProvider) UpsertManagedAgent(cfg models.AgentConfig) {
 	}
 	parent := strings.TrimSpace(cfg.ParentAgent)
 	if parent == "" {
-		parent = ManagerFallbackFromConfig(cfg.Config)
+		parent = strings.TrimSpace(cfg.ManagerFallback)
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -427,56 +426,15 @@ func appendUniqueSortedEvent(events []string, eventType string) []string {
 }
 
 func SameFlowInstance(actor, target models.AgentConfig) bool {
-	actorFlow := flowPathFromConfig(actor.Config)
-	targetFlow := flowPathFromConfig(target.Config)
+	actorFlow := actor.CanonicalFlowPath()
+	targetFlow := target.CanonicalFlowPath()
 	return actorFlow != "" && actorFlow == targetFlow
 }
 
 func PeerManagerFallback(actor, target models.AgentConfig) bool {
-	actorFallback := managerFallbackFromConfig(actor.Config)
-	targetFallback := managerFallbackFromConfig(target.Config)
+	actorFallback := strings.TrimSpace(actor.ManagerFallback)
+	targetFallback := strings.TrimSpace(target.ManagerFallback)
 	return actorFallback != "" && actorFallback == targetFallback
-}
-
-func FlowPathFromConfig(raw []byte) string {
-	return flowPathFromConfig(raw)
-}
-
-func flowPathFromConfig(raw []byte) string {
-	payload := decodeConfigMap(raw)
-	if payload == nil {
-		return ""
-	}
-	if value, ok := payload["flow_path"].(string); ok {
-		return strings.Trim(strings.TrimSpace(value), "/")
-	}
-	return ""
-}
-
-func ManagerFallbackFromConfig(raw []byte) string {
-	return managerFallbackFromConfig(raw)
-}
-
-func managerFallbackFromConfig(raw []byte) string {
-	payload := decodeConfigMap(raw)
-	if payload == nil {
-		return ""
-	}
-	if value, ok := payload["manager_fallback"].(string); ok {
-		return strings.TrimSpace(value)
-	}
-	return ""
-}
-
-func decodeConfigMap(raw []byte) map[string]any {
-	if len(raw) == 0 {
-		return nil
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return nil
-	}
-	return payload
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/runtime/authority/source_provider_test.go
+++ b/internal/runtime/authority/source_provider_test.go
@@ -1,7 +1,6 @@
 package authority
 
 import (
-	"encoding/json"
 	"testing"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -144,19 +143,14 @@ func TestSourceProvider_ManagedAgentGraphUpdates(t *testing.T) {
 }
 
 func testAgentConfig(id, role string, permissions []string, entityID, flowPath, managerFallback string) models.AgentConfig {
-	payload := map[string]any{
-		"flow_path": flowPath,
-	}
-	if managerFallback != "" {
-		payload["manager_fallback"] = managerFallback
-	}
-	raw, _ := json.Marshal(payload)
 	return models.AgentConfig{
-		ID:          id,
-		Role:        role,
-		Permissions: permissions,
-		EntityID:    entityID,
-		ParentAgent: managerFallback,
-		Config:      raw,
+		ID:              id,
+		Role:            role,
+		Permissions:     permissions,
+		Tools:           permissions,
+		EntityID:        entityID,
+		ParentAgent:     managerFallback,
+		ManagerFallback: managerFallback,
+		FlowPath:        flowPath,
 	}
 }

--- a/internal/runtime/contracts/prompts.go
+++ b/internal/runtime/contracts/prompts.go
@@ -460,10 +460,8 @@ func promptRuntimeTokens(cfg models.AgentConfig) map[string]any {
 		"current_date": time.Now().In(time.Local).Format("2006-01-02"),
 		"agent_id":     strings.TrimSpace(cfg.ID),
 	}
-	if config := parsePromptConfig(cfg.Config); len(config) > 0 {
-		if flowPath := strings.TrimSpace(asPromptString(config["flow_path"])); flowPath != "" {
-			out["flow_instance_path"] = flowPath
-		}
+	if flowPath := cfg.CanonicalFlowPath(); flowPath != "" {
+		out["flow_instance_path"] = flowPath
 	}
 	return out
 }

--- a/internal/runtime/contracts/prompts_test.go
+++ b/internal/runtime/contracts/prompts_test.go
@@ -99,10 +99,10 @@ func TestPromptVariableValues_UsesSpecResolutionOrder(t *testing.T) {
 		}},
 	}
 	cfg := models.AgentConfig{
-		ID: "agent-42",
+		ID:       "agent-42",
+		FlowPath: "flows/demo/inst-1",
 		Config: mustPromptJSON(t, map[string]any{
 			"team_name": "instance",
-			"flow_path": "flows/demo/inst-1",
 			"fields": map[string]any{
 				"team_name": "entity",
 				"score":     7,

--- a/internal/runtime/core/actors/agent_config.go
+++ b/internal/runtime/core/actors/agent_config.go
@@ -3,24 +3,71 @@ package actors
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 )
+
+type NativeToolConfig struct {
+	Bash      bool `json:"bash,omitempty"`
+	WebSearch bool `json:"web_search,omitempty"`
+	FileIO    bool `json:"file_io,omitempty"`
+}
+
+func (cfg NativeToolConfig) Enabled(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "bash":
+		return cfg.Bash
+	case "web_search":
+		return cfg.WebSearch
+	case "file_io":
+		return cfg.FileIO
+	default:
+		return false
+	}
+}
+
+func (cfg NativeToolConfig) Any() bool {
+	return cfg.Bash || cfg.WebSearch || cfg.FileIO
+}
+
+func (cfg NativeToolConfig) Names() []string {
+	names := make([]string, 0, 3)
+	if cfg.Bash {
+		names = append(names, "bash")
+	}
+	if cfg.WebSearch {
+		names = append(names, "web_search")
+	}
+	if cfg.FileIO {
+		names = append(names, "file_io")
+	}
+	return names
+}
 
 // AgentConfig is the runtime-owned actor descriptor used by manager, tools,
 // LLM, and semantic/runtime contract resolution. It is intentionally distinct
 // from persistence-row ownership even when stored verbatim.
 type AgentConfig struct {
-	ID             string          `json:"id"`
-	Type           string          `json:"type"`
-	Role           string          `json:"role"`
-	Mode           string          `json:"mode"`
-	LLMBackend     string          `json:"llm_backend,omitempty"`
-	Subscriptions  []string        `json:"subscriptions,omitempty"`
-	Permissions    []string        `json:"permissions,omitempty"`
-	EntityID       string          `json:"entity_id,omitempty"`
-	ParentAgent    string          `json:"parent_agent_id,omitempty"`
-	Config         json.RawMessage `json:"config,omitempty"`
-	BudgetEnvelope float64         `json:"budget_envelope,omitempty"`
+	ID               string           `json:"id"`
+	Type             string           `json:"type"`
+	Role             string           `json:"role"`
+	Mode             string           `json:"mode"`
+	ModelTier        string           `json:"model_tier,omitempty"`
+	LLMBackend       string           `json:"llm_backend,omitempty"`
+	ConversationMode string           `json:"conversation_mode,omitempty"`
+	MaxTurnsPerTask  int              `json:"max_turns_per_task,omitempty"`
+	Subscriptions    []string         `json:"subscriptions,omitempty"`
+	EmitEvents       []string         `json:"emit_events,omitempty"`
+	Tools            []string         `json:"tools,omitempty"`
+	Permissions      []string         `json:"permissions,omitempty"`
+	NativeTools      NativeToolConfig `json:"native_tools,omitempty"`
+	WorkspaceClass   string           `json:"workspace_class,omitempty"`
+	ManagerFallback  string           `json:"manager_fallback,omitempty"`
+	FlowPath         string           `json:"flow_path,omitempty"`
+	EntityID         string           `json:"entity_id,omitempty"`
+	ParentAgent      string           `json:"parent_agent_id,omitempty"`
+	Config           json.RawMessage  `json:"config,omitempty"`
+	BudgetEnvelope   float64          `json:"budget_envelope,omitempty"`
 }
 
 func (cfg AgentConfig) EffectiveEntityID() string { return strings.TrimSpace(cfg.EntityID) }
@@ -33,6 +80,55 @@ func (cfg *AgentConfig) NormalizeEntityID() {
 	if strings.TrimSpace(cfg.EntityID) == "" {
 		cfg.EntityID = entityID
 	}
+}
+
+func (cfg AgentConfig) CanonicalFlowPath() string {
+	return strings.Trim(strings.TrimSpace(cfg.FlowPath), "/")
+}
+
+func (cfg *AgentConfig) NormalizeRuntimeDescriptor() {
+	if cfg == nil {
+		return
+	}
+	cfg.ID = strings.TrimSpace(cfg.ID)
+	cfg.Type = strings.TrimSpace(cfg.Type)
+	cfg.Role = strings.TrimSpace(cfg.Role)
+	cfg.Mode = strings.TrimSpace(cfg.Mode)
+	cfg.ModelTier = strings.TrimSpace(cfg.ModelTier)
+	cfg.LLMBackend = strings.TrimSpace(cfg.LLMBackend)
+	cfg.ConversationMode = strings.TrimSpace(cfg.ConversationMode)
+	cfg.WorkspaceClass = strings.TrimSpace(cfg.WorkspaceClass)
+	cfg.ManagerFallback = strings.TrimSpace(cfg.ManagerFallback)
+	cfg.FlowPath = cfg.CanonicalFlowPath()
+	cfg.ParentAgent = strings.TrimSpace(cfg.ParentAgent)
+	cfg.Subscriptions = normalizeStringList(cfg.Subscriptions)
+	cfg.EmitEvents = normalizeStringList(cfg.EmitEvents)
+	cfg.Tools = normalizeStringList(cfg.Tools)
+	cfg.Permissions = normalizeStringList(cfg.Permissions)
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	slices.Sort(out)
+	return out
 }
 
 type actorContextKey struct{}

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -227,23 +227,16 @@ var claudeProviderBuiltinToolNames = []string{
 
 func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig) string {
 	allowed := map[string]struct{}{}
-	if len(actor.Config) != 0 && json.Valid(actor.Config) {
-		var parsed map[string]any
-		if err := json.Unmarshal(actor.Config, &parsed); err == nil {
-			if raw, ok := parsed["native_tools"].(map[string]any); ok {
-				if enabled, _ := raw["bash"].(bool); enabled {
-					allowed["Bash"] = struct{}{}
-				}
-				if enabled, _ := raw["web_search"].(bool); enabled {
-					allowed["WebSearch"] = struct{}{}
-				}
-				if enabled, _ := raw["file_io"].(bool); enabled {
-					allowed["Read"] = struct{}{}
-					allowed["Write"] = struct{}{}
-					allowed["Edit"] = struct{}{}
-				}
-			}
-		}
+	if actor.NativeTools.Bash {
+		allowed["Bash"] = struct{}{}
+	}
+	if actor.NativeTools.WebSearch {
+		allowed["WebSearch"] = struct{}{}
+	}
+	if actor.NativeTools.FileIO {
+		allowed["Read"] = struct{}{}
+		allowed["Write"] = struct{}{}
+		allowed["Edit"] = struct{}{}
 	}
 	names := make([]string, 0, len(claudeProviderBuiltinToolNames))
 	for _, name := range claudeProviderBuiltinToolNames {
@@ -274,23 +267,16 @@ func claudeAllowedToolsArgForActor(actor models.AgentConfig, tools []ToolDefinit
 		add(tool.Name)
 	}
 	add("ExitPlanMode")
-	if len(actor.Config) != 0 && json.Valid(actor.Config) {
-		var parsed map[string]any
-		if err := json.Unmarshal(actor.Config, &parsed); err == nil {
-			if raw, ok := parsed["native_tools"].(map[string]any); ok {
-				if enabled, _ := raw["bash"].(bool); enabled {
-					add("Bash")
-				}
-				if enabled, _ := raw["web_search"].(bool); enabled {
-					add("WebSearch")
-				}
-				if enabled, _ := raw["file_io"].(bool); enabled {
-					add("Read")
-					add("Write")
-					add("Edit")
-				}
-			}
-		}
+	if actor.NativeTools.Bash {
+		add("Bash")
+	}
+	if actor.NativeTools.WebSearch {
+		add("WebSearch")
+	}
+	if actor.NativeTools.FileIO {
+		add("Read")
+		add("Write")
+		add("Edit")
 	}
 	if len(allowed) == 0 {
 		return ""

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -42,17 +42,13 @@ func TestClaudeDisallowedBuiltinToolsArgForActor_DefaultsToAllKnownBuiltins(t *t
 }
 
 func TestClaudeDisallowedBuiltinToolsArgForActor_MapsNativeCapabilities(t *testing.T) {
-	raw, err := json.Marshal(map[string]any{
-		"native_tools": map[string]any{
-			"bash":       true,
-			"web_search": true,
-			"file_io":    true,
+	got := claudeDisallowedBuiltinToolsArgForActor(models.AgentConfig{
+		NativeTools: models.NativeToolConfig{
+			Bash:      true,
+			WebSearch: true,
+			FileIO:    true,
 		},
 	})
-	if err != nil {
-		t.Fatalf("marshal config: %v", err)
-	}
-	got := claudeDisallowedBuiltinToolsArgForActor(models.AgentConfig{Config: raw})
 	gotNames := strings.Split(got, ",")
 	for _, name := range []string{"Bash", "Read", "Write", "Edit", "WebSearch"} {
 		if slices.Contains(gotNames, name) {
@@ -67,15 +63,9 @@ func TestClaudeDisallowedBuiltinToolsArgForActor_MapsNativeCapabilities(t *testi
 }
 
 func TestClaudeAllowedToolsArgForActor_IncludesContractAndNativeTools(t *testing.T) {
-	raw, err := json.Marshal(map[string]any{
-		"native_tools": map[string]any{
-			"file_io": true,
-		},
-	})
-	if err != nil {
-		t.Fatalf("marshal config: %v", err)
-	}
-	got := claudeAllowedToolsArgForActor(models.AgentConfig{Config: raw}, []ToolDefinition{
+	got := claudeAllowedToolsArgForActor(models.AgentConfig{
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	}, []ToolDefinition{
 		{Name: "emit_category_assessed"},
 		{Name: "emit_market_research_scan_complete"},
 		{Name: "query_entities"},

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -54,16 +54,11 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 }
 
 func sessionModelTier(actor runtimeactors.AgentConfig) string {
-	if modelTier := strings.TrimSpace(actor.Type); modelTier != "" {
+	if modelTier := strings.TrimSpace(actor.ModelTier); modelTier != "" {
 		return modelTier
 	}
-	if len(actor.Config) > 0 {
-		var parsed map[string]any
-		if json.Unmarshal(actor.Config, &parsed) == nil {
-			if modelTier, _ := parsed["model_tier"].(string); strings.TrimSpace(modelTier) != "" {
-				return strings.TrimSpace(modelTier)
-			}
-		}
+	if modelTier := strings.TrimSpace(actor.Type); modelTier != "" {
+		return modelTier
 	}
 	return ""
 }

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -318,33 +318,6 @@ func buildFlowAgentConfig(
 			cfgPayload[k] = v
 		}
 	}
-	if workspaceClass := strings.TrimSpace(entry.WorkspaceClass); workspaceClass != "" {
-		cfgPayload["workspace_class"] = workspaceClass
-	}
-	if flowPath != "" {
-		cfgPayload["flow_path"] = strings.Trim(flowPath, "/")
-	}
-	if managerFallback := strings.TrimSpace(entry.ManagerFallback); managerFallback != "" {
-		cfgPayload["manager_fallback"] = managerFallback
-	}
-	if modelTier := strings.TrimSpace(entry.ModelTier); modelTier != "" {
-		cfgPayload["model_tier"] = modelTier
-	}
-	if conversationMode := strings.TrimSpace(entry.ConversationMode); conversationMode != "" {
-		cfgPayload["conversation_mode"] = conversationMode
-	}
-	if maxTurns := entry.MaxTurnsPerTask; maxTurns > 0 {
-		cfgPayload["max_turns_per_task"] = maxTurns
-	}
-	if tools := normalizedConfiguredToolList(entry.ConfiguredTools()); len(tools) > 0 {
-		cfgPayload["tools"] = append([]string{}, tools...)
-	}
-	if nativeTools := normalizedConfiguredNativeTools(entry.NativeTools); len(nativeTools) > 0 {
-		cfgPayload["native_tools"] = nativeTools
-	}
-	if emitEvents := normalizedFlowAgentEmitEvents(entry.EmitEvents, vars, localEvents, strings.Trim(flowPath, "/"), templateID, instanceID); len(emitEvents) > 0 {
-		cfgPayload["emit_events"] = append([]string{}, emitEvents...)
-	}
 	rawConfig, err := json.Marshal(cfgPayload)
 	if err != nil {
 		return models.AgentConfig{}, err
@@ -354,17 +327,29 @@ func buildFlowAgentConfig(
 		return models.AgentConfig{}, fmt.Errorf("flow agent %s permissions: %w", key, err)
 	}
 
-	return models.AgentConfig{
-		ID:            agentID,
-		Type:          strings.TrimSpace(entry.Type),
-		Role:          strings.TrimSpace(entry.Role),
-		Mode:          templateID,
-		LLMBackend:    "",
-		Permissions:   permissions,
-		EntityID:      entityID,
-		Subscriptions: rendered,
-		Config:        rawConfig,
-	}, nil
+	cfg := models.AgentConfig{
+		ID:               agentID,
+		Type:             strings.TrimSpace(entry.Type),
+		Role:             strings.TrimSpace(entry.Role),
+		Mode:             templateID,
+		ModelTier:        strings.TrimSpace(entry.ModelTier),
+		LLMBackend:       "",
+		ConversationMode: strings.TrimSpace(entry.ConversationMode),
+		MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+		Subscriptions:    rendered,
+		EmitEvents:       normalizedFlowAgentEmitEvents(entry.EmitEvents, vars, localEvents, strings.Trim(flowPath, "/"), templateID, instanceID),
+		Tools:            normalizedConfiguredToolList(entry.ConfiguredTools()),
+		Permissions:      permissions,
+		NativeTools:      nativeToolConfigFromMap(normalizedConfiguredNativeTools(entry.NativeTools)),
+		WorkspaceClass:   strings.TrimSpace(entry.WorkspaceClass),
+		ManagerFallback:  strings.TrimSpace(entry.ManagerFallback),
+		FlowPath:         strings.Trim(flowPath, "/"),
+		EntityID:         entityID,
+		ParentAgent:      strings.TrimSpace(entry.ManagerFallback),
+		Config:           rawConfig,
+	}
+	cfg.NormalizeRuntimeDescriptor()
+	return cfg, nil
 }
 
 func (am *AgentManager) ensureStaticRequiredAgentsForScope(
@@ -478,33 +463,6 @@ func buildStaticFlowAgentConfig(
 	rendered = dedupeStrings(rendered)
 
 	cfgPayload := map[string]any{}
-	if flowPath != "" {
-		cfgPayload["flow_path"] = flowPath
-	}
-	if workspaceClass := strings.TrimSpace(entry.WorkspaceClass); workspaceClass != "" {
-		cfgPayload["workspace_class"] = workspaceClass
-	}
-	if managerFallback := strings.TrimSpace(entry.ManagerFallback); managerFallback != "" {
-		cfgPayload["manager_fallback"] = managerFallback
-	}
-	if modelTier := strings.TrimSpace(entry.ModelTier); modelTier != "" {
-		cfgPayload["model_tier"] = modelTier
-	}
-	if conversationMode := strings.TrimSpace(entry.ConversationMode); conversationMode != "" {
-		cfgPayload["conversation_mode"] = conversationMode
-	}
-	if maxTurns := entry.MaxTurnsPerTask; maxTurns > 0 {
-		cfgPayload["max_turns_per_task"] = maxTurns
-	}
-	if tools := normalizedConfiguredToolList(entry.ConfiguredTools()); len(tools) > 0 {
-		cfgPayload["tools"] = append([]string{}, tools...)
-	}
-	if nativeTools := normalizedConfiguredNativeTools(entry.NativeTools); len(nativeTools) > 0 {
-		cfgPayload["native_tools"] = nativeTools
-	}
-	if emitEvents := normalizedStaticFlowEmitEvents(entry.EmitEvents, vars, localEvents, flowPath); len(emitEvents) > 0 {
-		cfgPayload["emit_events"] = append([]string{}, emitEvents...)
-	}
 	if _, ok := cfgPayload["system_prompt"]; !ok {
 		role := strings.TrimSpace(entry.Role)
 		if role == "" {
@@ -531,17 +489,29 @@ func buildStaticFlowAgentConfig(
 	if role == "" {
 		role = strings.TrimSpace(logicalID)
 	}
-	return models.AgentConfig{
-		ID:            agentID,
-		Type:          strings.TrimSpace(entry.Type),
-		Role:          role,
-		Mode:          flowID,
-		LLMBackend:    "",
-		Permissions:   permissions,
-		EntityID:      "",
-		Subscriptions: rendered,
-		Config:        rawConfig,
-	}, nil
+	cfg := models.AgentConfig{
+		ID:               agentID,
+		Type:             strings.TrimSpace(entry.Type),
+		Role:             role,
+		Mode:             flowID,
+		ModelTier:        strings.TrimSpace(entry.ModelTier),
+		LLMBackend:       "",
+		ConversationMode: strings.TrimSpace(entry.ConversationMode),
+		MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+		Subscriptions:    rendered,
+		EmitEvents:       normalizedStaticFlowEmitEvents(entry.EmitEvents, vars, localEvents, flowPath),
+		Tools:            normalizedConfiguredToolList(entry.ConfiguredTools()),
+		Permissions:      permissions,
+		NativeTools:      nativeToolConfigFromMap(normalizedConfiguredNativeTools(entry.NativeTools)),
+		WorkspaceClass:   strings.TrimSpace(entry.WorkspaceClass),
+		ManagerFallback:  strings.TrimSpace(entry.ManagerFallback),
+		FlowPath:         flowPath,
+		EntityID:         "",
+		ParentAgent:      strings.TrimSpace(entry.ManagerFallback),
+		Config:           rawConfig,
+	}
+	cfg.NormalizeRuntimeDescriptor()
+	return cfg, nil
 }
 
 func resolveRequiredAgentEntry(agents map[string]runtimecontracts.AgentRegistryEntry, required runtimecontracts.FlowRequiredAgent) (string, runtimecontracts.AgentRegistryEntry, bool) {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -480,11 +479,7 @@ func TestEnsureStaticFlowRequiredAgentsRegistersStaticFlowSubscriptions(t *testi
 	if len(cfg.Subscriptions) != 1 || cfg.Subscriptions[0] != "analyzer-flow/analysis.requested" {
 		t.Fatalf("subscriptions = %#v, want [analyzer-flow/analysis.requested]", cfg.Subscriptions)
 	}
-	var payload map[string]any
-	if err := json.Unmarshal(cfg.Config, &payload); err != nil {
-		t.Fatalf("json.Unmarshal(config): %v", err)
-	}
-	if got := anySliceToStrings(payload["emit_events"]); len(got) != 1 || got[0] != "analyzer-flow/analysis.done" {
+	if got := cfg.EmitEvents; len(got) != 1 || got[0] != "analyzer-flow/analysis.done" {
 		t.Fatalf("emit_events = %#v, want [analyzer-flow/analysis.done]", got)
 	}
 	if len(store.upserts) != 1 || store.upserts[0].Config.ID != "analyzer" {
@@ -570,35 +565,16 @@ func TestBuildFlowAgentConfig_PassesContractToolsAndEmitEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildFlowAgentConfig: %v", err)
 	}
-	var payload map[string]any
-	if err := json.Unmarshal(cfg.Config, &payload); err != nil {
-		t.Fatalf("json.Unmarshal(config): %v", err)
+	if got := cfg.MaxTurnsPerTask; got != 7 {
+		t.Fatalf("max_turns_per_task = %d, want 7", got)
 	}
-	if got := payload["max_turns_per_task"]; got != float64(7) {
-		t.Fatalf("max_turns_per_task = %#v, want 7", got)
+	if got := cfg.Tools; len(got) != 2 || got[0] != "check_status" || got[1] != "schedule" {
+		t.Fatalf("tools = %#v, want [check_status schedule]", got)
 	}
-	if got := anySliceToStrings(payload["tools"]); len(got) != 2 || got[0] != "schedule" || got[1] != "check_status" {
-		t.Fatalf("tools = %#v, want [schedule check_status]", got)
+	if got := cfg.EmitEvents; len(got) != 2 || got[0] != "review/inst-1/review.failed" || got[1] != "review/inst-1/task.completed" {
+		t.Fatalf("emit_events = %#v, want [review/inst-1/review.failed review/inst-1/task.completed]", got)
 	}
-	if got := anySliceToStrings(payload["emit_events"]); len(got) != 2 || got[0] != "review/inst-1/task.completed" || got[1] != "review/inst-1/review.failed" {
-		t.Fatalf("emit_events = %#v, want [review/inst-1/task.completed review/inst-1/review.failed]", got)
+	if !cfg.NativeTools.Bash || !cfg.NativeTools.FileIO {
+		t.Fatalf("native_tools = %#v, want bash/file_io true", cfg.NativeTools)
 	}
-	nativeTools, ok := payload["native_tools"].(map[string]any)
-	if !ok || nativeTools["bash"] != true || nativeTools["file_io"] != true {
-		t.Fatalf("native_tools = %#v, want bash/file_io true", payload["native_tools"])
-	}
-}
-
-func anySliceToStrings(raw any) []string {
-	items, ok := raw.([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(items))
-	for _, item := range items {
-		if s, ok := item.(string); ok {
-			out = append(out, s)
-		}
-	}
-	return out
 }

--- a/internal/runtime/manager/generic_agent_support.go
+++ b/internal/runtime/manager/generic_agent_support.go
@@ -19,16 +19,7 @@ func newGenericAgent(cfg runtimeactors.AgentConfig) Agent {
 	if cfg.Type == "" {
 		cfg.Type = "generic"
 	}
-	merged := make([]string, 0, len(cfg.Subscriptions))
-	merged = append(merged, cfg.Subscriptions...)
-	if len(cfg.Config) > 0 {
-		var aux struct {
-			Subscriptions []string `json:"subscriptions"`
-		}
-		if err := json.Unmarshal(cfg.Config, &aux); err == nil {
-			merged = append(merged, aux.Subscriptions...)
-		}
-	}
+	merged := append([]string(nil), cfg.Subscriptions...)
 
 	uniq := make(map[string]struct{})
 	subs := make([]events.EventType, 0, len(merged))

--- a/internal/runtime/manager/helpers.go
+++ b/internal/runtime/manager/helpers.go
@@ -141,17 +141,44 @@ func MergeAgentConfig(base, patch runtimeactors.AgentConfig) runtimeactors.Agent
 	if patch.LLMBackend != "" {
 		out.LLMBackend = patch.LLMBackend
 	}
+	if patch.ModelTier != "" {
+		out.ModelTier = patch.ModelTier
+	}
+	if patch.ConversationMode != "" {
+		out.ConversationMode = patch.ConversationMode
+	}
+	if patch.MaxTurnsPerTask > 0 {
+		out.MaxTurnsPerTask = patch.MaxTurnsPerTask
+	}
 	if patch.EntityID != "" {
 		out.EntityID = patch.EntityID
 	}
 	if patch.ParentAgent != "" {
 		out.ParentAgent = patch.ParentAgent
 	}
+	if patch.WorkspaceClass != "" {
+		out.WorkspaceClass = patch.WorkspaceClass
+	}
+	if patch.ManagerFallback != "" {
+		out.ManagerFallback = patch.ManagerFallback
+	}
+	if patch.FlowPath != "" {
+		out.FlowPath = patch.FlowPath
+	}
 	if len(patch.Subscriptions) > 0 {
 		out.Subscriptions = patch.Subscriptions
 	}
+	if len(patch.EmitEvents) > 0 {
+		out.EmitEvents = patch.EmitEvents
+	}
+	if len(patch.Tools) > 0 {
+		out.Tools = patch.Tools
+	}
 	if len(patch.Permissions) > 0 {
 		out.Permissions = patch.Permissions
+	}
+	if patch.NativeTools.Any() {
+		out.NativeTools = patch.NativeTools
 	}
 	if len(patch.Config) > 0 {
 		out.Config = patch.Config
@@ -160,6 +187,7 @@ func MergeAgentConfig(base, patch runtimeactors.AgentConfig) runtimeactors.Agent
 		out.BudgetEnvelope = patch.BudgetEnvelope
 	}
 	out.NormalizeEntityID()
+	out.NormalizeRuntimeDescriptor()
 	return out
 }
 
@@ -249,6 +277,14 @@ func DeterministicOutputEventID(inbound events.Event, agentID string, index int,
 		strings.TrimSpace(out.EntityID()),
 	}, "|")
 	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed)).String()
+}
+
+func nativeToolConfigFromMap(values map[string]bool) runtimeactors.NativeToolConfig {
+	return runtimeactors.NativeToolConfig{
+		Bash:      values["bash"],
+		WebSearch: values["web_search"],
+		FileIO:    values["file_io"],
+	}
 }
 
 func ExtractDirectiveText(payload []byte) string {

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -521,7 +521,7 @@ func (am *AgentManager) resolveManagerAgentID(agentID string) string {
 		if p := strings.TrimSpace(cfg.ParentAgent); p != "" {
 			return p
 		}
-		if managerID := normalizedManagerFallback(cfg, managerFallbackFromConfig(cfg)); managerID != "" {
+		if managerID := normalizedManagerFallback(cfg, cfg.ManagerFallback); managerID != "" {
 			return managerID
 		}
 	}

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -51,9 +51,7 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 	am.agentCfg["agent-a"] = runtimeactors.AgentConfig{
 		ID:       "agent-a",
 		EntityID: "ent-123",
-		Config: mustJSON(map[string]any{
-			"flow_path": "review/inst-1",
-		}),
+		FlowPath: "review/inst-1",
 	}
 
 	am.maybeTripAuthCircuitBreaker("agent-a", "evt-1", errors.New("claude auth required"))

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -190,7 +190,7 @@ func deterministicOutputEventID(inbound events.Event, agentID string, index int,
 }
 
 func (am *AgentManager) defaultManagerAgentID(cfg runtimeactors.AgentConfig) string {
-	if managerID := normalizedManagerFallback(cfg, managerFallbackFromConfig(cfg)); managerID != "" {
+	if managerID := normalizedManagerFallback(cfg, cfg.ManagerFallback); managerID != "" {
 		return managerID
 	}
 	if source := runtimepipeline.DefaultWorkflowSemanticSourceOrNil(); source != nil {
@@ -199,20 +199,6 @@ func (am *AgentManager) defaultManagerAgentID(cfg runtimeactors.AgentConfig) str
 				return managerID
 			}
 		}
-	}
-	return ""
-}
-
-func managerFallbackFromConfig(cfg runtimeactors.AgentConfig) string {
-	if len(cfg.Config) == 0 {
-		return ""
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(cfg.Config, &payload); err != nil {
-		return ""
-	}
-	if value, ok := payload["manager_fallback"].(string); ok {
-		return strings.TrimSpace(value)
 	}
 	return ""
 }
@@ -226,17 +212,7 @@ func normalizedManagerFallback(cfg runtimeactors.AgentConfig, managerID string) 
 }
 
 func flowPathFromAgentConfig(cfg runtimeactors.AgentConfig) string {
-	if len(cfg.Config) == 0 {
-		return ""
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(cfg.Config, &payload); err != nil {
-		return ""
-	}
-	if value, ok := payload["flow_path"].(string); ok {
-		return strings.Trim(strings.TrimSpace(value), "/")
-	}
-	return ""
+	return cfg.CanonicalFlowPath()
 }
 
 type eventExistenceReader interface {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -162,7 +162,7 @@ func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
 				Mode:        "discovery",
 				EntityID:    "entity-1",
 				Permissions: []string{"schedule"},
-				Config:      []byte(`{"emit_events":["category.assessed","market_research.scan_complete"]}`),
+				EmitEvents:  []string{"category.assessed", "market_research.scan_complete"},
 			}, true
 		},
 	})
@@ -172,8 +172,8 @@ func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
 		Role: "market_research",
 	})
 
-	if string(hydrated.Config) == "" {
-		t.Fatal("expected hydrated actor config")
+	if len(hydrated.EmitEvents) != 2 {
+		t.Fatalf("emit_events = %#v, want two resolved events", hydrated.EmitEvents)
 	}
 	if hydrated.Mode != "discovery" {
 		t.Fatalf("mode = %q, want discovery", hydrated.Mode)

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -126,7 +126,7 @@ func validateClaudeMCPToolsForManagedAgents(cfg *config.Config, gateway *runtime
 			toolNames[name] = struct{}{}
 		}
 		missingEmitTools := make([]string, 0)
-		for _, eventType := range configuredEmitEventsForStartup(agentCfg.Config) {
+		for _, eventType := range agentCfg.EmitEvents {
 			name := runtimetools.EmitToolName(eventType)
 			if _, ok := toolNames[name]; ok {
 				continue
@@ -139,37 +139,4 @@ func validateClaudeMCPToolsForManagedAgents(cfg *config.Config, gateway *runtime
 		}
 	}
 	return nil
-}
-
-func configuredEmitEventsForStartup(raw json.RawMessage) []string {
-	if len(raw) == 0 || !json.Valid(raw) {
-		return nil
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return nil
-	}
-	eventsRaw, ok := payload["emit_events"]
-	if !ok {
-		return nil
-	}
-	items, ok := eventsRaw.([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(items))
-	seen := make(map[string]struct{}, len(items))
-	for _, item := range items {
-		eventType := strings.TrimSpace(asString(item))
-		if eventType == "" {
-			continue
-		}
-		if _, exists := seen[eventType]; exists {
-			continue
-		}
-		seen[eventType] = struct{}{}
-		out = append(out, eventType)
-	}
-	sort.Strings(out)
-	return out
 }

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -164,9 +164,9 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsWhenRequiredEmitToolsMissin
 	cfg.LLM.RuntimeMode = "cli_test"
 	manager := runtimemanager.NewAgentManager(nil, nil)
 	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
-		ID:     "market-research-agent",
-		Role:   "market_research",
-		Config: json.RawMessage(`{"emit_events":["discovery/category.assessed","discovery/market_research.scan_complete"]}`),
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		EmitEvents: []string{"discovery/category.assessed", "discovery/market_research.scan_complete"},
 	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}

--- a/internal/runtime/tools/authorizer_permission_test.go
+++ b/internal/runtime/tools/authorizer_permission_test.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -71,15 +70,9 @@ func TestToolAuthorizer_PermissionGatedTools(t *testing.T) {
 	})
 
 	t.Run("actor config still allows explicitly listed workflow tool", func(t *testing.T) {
-		raw, err := json.Marshal(map[string]any{
-			"tools": []string{"workflow_custom_tool"},
-		})
-		if err != nil {
-			t.Fatalf("json.Marshal: %v", err)
-		}
 		authErr := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-			ID:     "ops-7",
-			Config: raw,
+			ID:    "ops-7",
+			Tools: []string{"workflow_custom_tool"},
 		}, "workflow_custom_tool")
 		if authErr != nil {
 			t.Fatalf("expected listed workflow tool to be allowed: %v", authErr)
@@ -87,17 +80,9 @@ func TestToolAuthorizer_PermissionGatedTools(t *testing.T) {
 	})
 
 	t.Run("provider native read allowed when file_io enabled", func(t *testing.T) {
-		raw, err := json.Marshal(map[string]any{
-			"native_tools": map[string]any{
-				"file_io": true,
-			},
-		})
-		if err != nil {
-			t.Fatalf("json.Marshal: %v", err)
-		}
 		authErr := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-			ID:     "ops-8",
-			Config: raw,
+			ID:          "ops-8",
+			NativeTools: models.NativeToolConfig{FileIO: true},
 		}, "Read")
 		if authErr != nil {
 			t.Fatalf("expected provider native Read to be allowed: %v", authErr)
@@ -105,15 +90,9 @@ func TestToolAuthorizer_PermissionGatedTools(t *testing.T) {
 	})
 
 	t.Run("actor config tool aliases are canonicalized", func(t *testing.T) {
-		raw, err := json.Marshal(map[string]any{
-			"tools": []string{"Read"},
-		})
-		if err != nil {
-			t.Fatalf("json.Marshal: %v", err)
-		}
 		authErr := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-			ID:     "ops-9",
-			Config: raw,
+			ID:    "ops-9",
+			Tools: []string{"Read"},
 		}, "read_file")
 		if authErr != nil {
 			t.Fatalf("expected aliased configured tool to be allowed: %v", authErr)
@@ -253,15 +232,9 @@ func TestToolAuthorizer_ExplicitEmitEventsAllowEmitTool(t *testing.T) {
 			},
 		},
 	}))
-	raw, err := json.Marshal(map[string]any{
-		"emit_events": []string{"coord.done"},
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
-	err = NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-		ID:     "coordinator-1",
-		Config: raw,
+	err := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
+		ID:         "coordinator-1",
+		EmitEvents: []string{"coord.done"},
 	}, "emit_coord_done")
 	if err != nil {
 		t.Fatalf("expected configured emit tool to be allowed: %v", err)
@@ -280,15 +253,9 @@ func TestToolAuthorizer_ScopedEmitEventsAllowLocalEmitTool(t *testing.T) {
 			},
 		},
 	}))
-	raw, err := json.Marshal(map[string]any{
-		"emit_events": []string{"discovery/category.assessed"},
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
-	err = NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-		ID:     "market-research-agent",
-		Config: raw,
+	err := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
+		ID:         "market-research-agent",
+		EmitEvents: []string{"discovery/category.assessed"},
 	}, "emit_category_assessed")
 	if err != nil {
 		t.Fatalf("expected scoped configured emit tool to be allowed: %v", err)
@@ -307,15 +274,9 @@ func TestToolAuthorizer_AllowsMCPPrefixedEmitToolAlias(t *testing.T) {
 			},
 		},
 	}))
-	raw, err := json.Marshal(map[string]any{
-		"emit_events": []string{"market_research.scan_complete"},
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
-	err = NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
-		ID:     "market-research-agent",
-		Config: raw,
+	err := NewToolAuthorizer(nil).Authorize(context.Background(), models.AgentConfig{
+		ID:         "market-research-agent",
+		EmitEvents: []string{"market_research.scan_complete"},
 	}, "mcp__runtime-tools__emit_market_research_scan_complete")
 	if err != nil {
 		t.Fatalf("expected MCP-prefixed emit tool alias to be allowed: %v", err)

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"sort"
 	"strings"
 	"sync"
@@ -154,12 +153,8 @@ func GenerateEmitToolsForEvents(eventTypes []string, warn func(string, string, s
 	return tools
 }
 
-func GenerateEmitToolsForConfig(raw json.RawMessage, warn func(string, string, string, ...any)) []llm.ToolDefinition {
-	return GenerateEmitToolsForEvents(configuredEmitEvents(raw), warn)
-}
-
 func GenerateEmitToolsForActor(actor models.AgentConfig, warn func(string, string, string, ...any)) []llm.ToolDefinition {
-	if configured := configuredEmitEvents(actor.Config); len(configured) > 0 {
+	if configured := UniqueNonEmpty(actor.EmitEvents); len(configured) > 0 {
 		return GenerateEmitToolsForEvents(configured, warn)
 	}
 	return GenerateEmitToolsForRole(actor.Role, warn)
@@ -202,12 +197,12 @@ func IsEmitToolAllowedForRole(role, toolName string) bool {
 	return false
 }
 
-func IsEmitToolAllowedForConfig(raw json.RawMessage, toolName string) bool {
+func IsEmitToolAllowedForActor(actor models.AgentConfig, toolName string) bool {
 	eventType, ok := eventTypeFromEmitToolName(toolName)
 	if !ok {
 		return false
 	}
-	for _, configured := range configuredEmitEvents(raw) {
+	for _, configured := range actor.EmitEvents {
 		if emitEventTypesEquivalent(configured, eventType) {
 			return true
 		}
@@ -262,33 +257,6 @@ func emitSchemaForEventTypeLocal(eventType string) (EmitSchema, bool) {
 	}
 	schema, ok := activeSchemas[local]
 	return schema, ok
-}
-
-func configuredEmitEvents(raw json.RawMessage) []string {
-	if len(raw) == 0 || !json.Valid(raw) {
-		return nil
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return nil
-	}
-	eventsRaw, ok := payload["emit_events"]
-	if !ok {
-		return nil
-	}
-	items, ok := eventsRaw.([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(items))
-	for _, item := range items {
-		eventType := strings.TrimSpace(asString(item))
-		if eventType == "" {
-			continue
-		}
-		out = append(out, eventType)
-	}
-	return UniqueNonEmpty(out)
 }
 
 func InboundEventFromContext(ctx context.Context) (events.Event, bool) {

--- a/internal/runtime/tools/executor_agents_test.go
+++ b/internal/runtime/tools/executor_agents_test.go
@@ -60,14 +60,16 @@ func TestAuthorizeManage_AllowsAncestorManagerChain(t *testing.T) {
 		agents: map[string]models.AgentConfig{
 			"control": {ID: "control"},
 			"reviewer": {
-				ID:          "reviewer",
-				ParentAgent: "control",
-				Config:      []byte(`{"flow_path":"review/inst-1","manager_fallback":"control"}`),
+				ID:              "reviewer",
+				ParentAgent:     "control",
+				FlowPath:        "review/inst-1",
+				ManagerFallback: "control",
 			},
 			"worker": {
-				ID:          "worker",
-				ParentAgent: "reviewer",
-				Config:      []byte(`{"flow_path":"review/inst-1","manager_fallback":"reviewer"}`),
+				ID:              "worker",
+				ParentAgent:     "reviewer",
+				FlowPath:        "review/inst-1",
+				ManagerFallback: "reviewer",
 			},
 		},
 	}
@@ -75,7 +77,7 @@ func TestAuthorizeManage_AllowsAncestorManagerChain(t *testing.T) {
 		ID:          "control",
 		Role:        "control",
 		Permissions: []string{"agent_fire"},
-		Config:      []byte(`{"flow_path":"review/inst-1"}`),
+		FlowPath:    "review/inst-1",
 	}
 	target := manager.agents["worker"]
 
@@ -105,10 +107,11 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	manager := managerStub{
 		agents: map[string]models.AgentConfig{
 			"target-1": {
-				ID:       "target-1",
-				Role:     "reviewer",
-				EntityID: "entity-b",
-				Config:   []byte(`{"flow_path":"review/inst-1","manager_fallback":"control"}`),
+				ID:              "target-1",
+				Role:            "reviewer",
+				EntityID:        "entity-b",
+				FlowPath:        "review/inst-1",
+				ManagerFallback: "control",
 			},
 		},
 	}
@@ -118,7 +121,7 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 		Role:        "control",
 		Permissions: []string{"message_flow"},
 		EntityID:    "entity-a",
-		Config:      []byte(`{"flow_path":"review/inst-1"}`),
+		FlowPath:    "review/inst-1",
 	})
 
 	if _, err := exec.execAgentMessage(ctx, models.AgentConfig{
@@ -126,7 +129,7 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 		Role:        "control",
 		Permissions: []string{"message_flow"},
 		EntityID:    "entity-a",
-		Config:      []byte(`{"flow_path":"review/inst-1"}`),
+		FlowPath:    "review/inst-1",
 	}, map[string]any{
 		"target_agent_id": "target-1",
 		"message":         "hello",

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -169,7 +168,7 @@ func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eve
 	if eventType == "" || strings.Contains(eventType, "/") {
 		return eventType
 	}
-	configured := configuredEmitEvents(actor.Config)
+	configured := UniqueNonEmpty(actor.EmitEvents)
 	for _, candidate := range configured {
 		if strings.Contains(candidate, "/") && eventidentity.LeafName(candidate) == eventType {
 			return strings.TrimSpace(candidate)
@@ -179,8 +178,7 @@ func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eve
 	if flowID == "" {
 		return eventType
 	}
-	flowPath := strings.TrimSpace(configString(actor.Config, "flow_path"))
-	flowPath = strings.Trim(flowPath, "/")
+	flowPath := actor.CanonicalFlowPath()
 	if flowPath == "" {
 		return eventType
 	}
@@ -200,16 +198,4 @@ func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eve
 		localEvents = append(localEvents, candidate)
 	}
 	return eventidentity.ExternalizeForFlow(flowPath, localEvents, eventType)
-}
-
-func configString(raw json.RawMessage, key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" || len(raw) == 0 || !json.Valid(raw) {
-		return ""
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(asString(payload[key]))
 }

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -63,21 +63,15 @@ func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
 
 	bus := &publishBusCapture{}
 	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
-	actorConfig, err := json.Marshal(map[string]any{
-		"flow_path":   "discovery",
-		"emit_events": []string{"category.assessed"},
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal actor config: %v", err)
-	}
 	actor := models.AgentConfig{
-		ID:     "market-research-agent",
-		Role:   "market_research",
-		Mode:   "discovery",
-		Config: actorConfig,
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		Mode:       "discovery",
+		FlowPath:   "discovery",
+		EmitEvents: []string{"category.assessed"},
 	}
 
-	_, err = exec.handleEmitTool(context.Background(), actor, "emit_category_assessed", map[string]any{
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_category_assessed", map[string]any{
 		"category":  "AP automation",
 		"signal_id": "sig-1",
 	})
@@ -141,21 +135,15 @@ func TestHandleEmitTool_KeepsFlowOutputPinAtParentScope(t *testing.T) {
 
 	bus := &publishBusCapture{}
 	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
-	actorConfig, err := json.Marshal(map[string]any{
-		"flow_path":   "discovery",
-		"emit_events": []string{"vertical.discovered"},
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal actor config: %v", err)
-	}
 	actor := models.AgentConfig{
-		ID:     "discovery-coordinator",
-		Role:   "discovery_coordinator",
-		Mode:   "discovery",
-		Config: actorConfig,
+		ID:         "discovery-coordinator",
+		Role:       "discovery_coordinator",
+		Mode:       "discovery",
+		FlowPath:   "discovery",
+		EmitEvents: []string{"vertical.discovered"},
 	}
 
-	_, err = exec.handleEmitTool(context.Background(), actor, "emit_vertical_discovered", map[string]any{
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_vertical_discovered", map[string]any{
 		"name": "Law firm AP automation",
 	})
 	if err != nil {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -531,11 +531,9 @@ func TestEntityTools_GetSubjectStatusAllTerminalTrueWhenAllFlowsTerminal(t *test
 		},
 	}
 	ctx, exec := newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_subject_status"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_subject_status"},
 	}, bundle)
 	subjectID := uuid.NewString()
 	for _, row := range []struct {
@@ -605,11 +603,9 @@ func TestEntityTools_GetSubjectStatusSingleFlowSubject(t *testing.T) {
 func TestEntityTools_GetSubjectStatusPrefersDeeperFlowOnEqualEnteredStateAt(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-nested-three-levels")
 	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_subject_status"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_subject_status"},
 	}, bundle)
 	subjectID := uuid.NewString()
 	childID := uuid.NewString()
@@ -701,11 +697,9 @@ func TestEntityTools_CreateEntityDuplicate(t *testing.T) {
 
 func TestEntityTools_ConstrainedAllowedToolsStillPermitOnlyUniversalEntityTools(t *testing.T) {
 	ctx, exec := newEntityToolTestExecutorWithActor(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"emit_something"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"emit_something"},
 	})
 	entityID := uuid.NewString()
 	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
@@ -726,11 +720,9 @@ func TestEntityTools_ConstrainedAllowedToolsStillPermitOnlyUniversalEntityTools(
 
 func TestEntityTools_NoSchemaAcceptsArbitraryFieldNames(t *testing.T) {
 	ctx, exec := newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "save_entity_field", "get_entity"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
 	}, &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			InitialStage: "queued",
@@ -758,11 +750,9 @@ func TestEntityTools_NoSchemaAcceptsArbitraryFieldNames(t *testing.T) {
 func TestEntityTools_SaveEntityFieldRejectsCrossFlowWrite(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-required-agents-child")
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "analyzer",
-		Role: "analyzer",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "save_entity_field", "get_entity"},
-		}),
+		ID:    "analyzer",
+		Role:  "analyzer",
+		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
 	}, bundle)
 	entityID := uuid.NewString()
 	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
@@ -789,11 +779,9 @@ func TestEntityTools_SaveEntityFieldRejectsCrossFlowWrite(t *testing.T) {
 func TestEntityTools_SaveEntityFieldAllowsSameFlowWrite(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-required-agents-child")
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "analyzer",
-		Role: "analyzer",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "save_entity_field", "get_entity"},
-		}),
+		ID:    "analyzer",
+		Role:  "analyzer",
+		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
 	}, bundle)
 	entityID := uuid.NewString()
 	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
@@ -818,11 +806,9 @@ func TestEntityTools_SaveEntityFieldAllowsSameFlowWrite(t *testing.T) {
 func TestEntityTools_SaveEntityFieldAllowsSameFlowWriteWithForeignSubject(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-required-agents-child")
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "analyzer",
-		Role: "analyzer",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "save_entity_field", "get_entity"},
-		}),
+		ID:    "analyzer",
+		Role:  "analyzer",
+		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
 	}, bundle)
 	entityID := uuid.NewString()
 	subjectID := uuid.NewString()
@@ -849,11 +835,9 @@ func TestEntityTools_SaveEntityFieldAllowsSameFlowWriteWithForeignSubject(t *tes
 func TestEntityTools_GetEntityAllowsCrossFlowRead(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-required-agents-child")
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "analyzer",
-		Role: "analyzer",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_entity"},
-		}),
+		ID:    "analyzer",
+		Role:  "analyzer",
+		Tools: []string{"create_entity", "get_entity"},
 	}, bundle)
 	entityID := uuid.NewString()
 	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
@@ -886,11 +870,9 @@ func TestEntityTools_GetEntityAllowsCrossFlowRead(t *testing.T) {
 func TestEntityTools_FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity(t *testing.T) {
 	bundle := loadEntityToolFixtureBundle(t, "tests/tier11-flow-composition/test-required-agents-child")
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
-		ID:   "analyzer",
-		Role: "analyzer",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_entity", "save_entity_field"},
-		}),
+		ID:    "analyzer",
+		Role:  "analyzer",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
 	}, bundle)
 
 	scoringID := uuid.NewString()
@@ -945,11 +927,9 @@ func TestEntityTools_FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity(t *test
 func newEntityToolTestExecutor(t *testing.T) (context.Context, *runtimetools.Executor) {
 	t.Helper()
 	ctx, exec, _ := newEntityToolTestHarnessWithActor(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_entity", "get_subject_status", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "get_subject_status", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
 	})
 	return ctx, exec
 }
@@ -986,11 +966,9 @@ func newEntityToolTestExecutorWithBundle(t *testing.T, actor models.AgentConfig,
 func newEntityToolTestHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
 	return newEntityToolTestHarnessWithActor(t, models.AgentConfig{
-		ID:   "tester",
-		Role: "operator",
-		Config: mustJSONRaw(t, map[string]any{
-			"tools": []string{"create_entity", "get_entity", "get_subject_status", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
-		}),
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "get_subject_status", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
 	})
 }
 

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -61,7 +61,7 @@ func TestExecutorTelemetry_LogsSuccess(t *testing.T) {
 		ID:       "agent-1",
 		Role:     "analysis",
 		EntityID: "entity-1",
-		Config:   mustToolConfigJSON(t, map[string]any{"tools": []string{"check_domain"}}),
+		Tools:    []string{"check_domain"},
 	})
 
 	if _, err := exec.Execute(ctx, "check_domain", map[string]any{"domain": "example.com"}); err != nil {
@@ -155,7 +155,7 @@ func TestExecutorTelemetry_LogsExecutionFailure(t *testing.T) {
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
 		ID:       "agent-3",
 		EntityID: "entity-3",
-		Config:   mustToolConfigJSON(t, map[string]any{"tools": []string{"check_domain"}}),
+		Tools:    []string{"check_domain"},
 	})
 
 	if _, err := exec.Execute(ctx, "check_domain", map[string]any{"domain": "example.com"}); err == nil {

--- a/internal/runtime/tools/native_tools.go
+++ b/internal/runtime/tools/native_tools.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"encoding/json"
 	"strings"
 
 	models "swarm/internal/runtime/core/actors"
@@ -72,19 +71,10 @@ func nativeFallbackRegisteredTool(actor models.AgentConfig, name string) (Regist
 
 func nativeToolCapabilityEnabledForActor(actor models.AgentConfig, capability string) bool {
 	capability = strings.TrimSpace(capability)
-	if capability == "" || len(actor.Config) == 0 || !json.Valid(actor.Config) {
+	if capability == "" {
 		return false
 	}
-	var parsed map[string]any
-	if err := json.Unmarshal(actor.Config, &parsed); err != nil {
-		return false
-	}
-	items, ok := parsed["native_tools"].(map[string]any)
-	if !ok {
-		return false
-	}
-	flag, ok := items[capability].(bool)
-	return ok && flag
+	return actor.NativeTools.Enabled(capability)
 }
 
 func normalizeNativeToolName(name string) string {

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -108,7 +108,7 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 	for name := range entries {
 		candidates[strings.TrimSpace(name)] = struct{}{}
 	}
-	if allowed, _ := extractAllowedToolsFromConfig(actor); len(allowed) > 0 {
+	if allowed, _ := extractAllowedTools(actor); len(allowed) > 0 {
 		for name := range allowed {
 			candidates[strings.TrimSpace(name)] = struct{}{}
 		}

--- a/internal/runtime/tools/tool_capability_policy.go
+++ b/internal/runtime/tools/tool_capability_policy.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"encoding/json"
 	"strings"
 
 	models "swarm/internal/runtime/core/actors"
@@ -44,7 +43,7 @@ func classifyToolAuthorization(actor models.AgentConfig, toolName string) toolAu
 		decision.allowed = true
 		return decision
 	}
-	allowed, constrained := extractAllowedToolsFromConfig(actor)
+	allowed, constrained := extractAllowedTools(actor)
 	decision.constrained = constrained
 	if _, ok := allowed[toolName]; ok {
 		decision.class = toolAuthorizationActorConfig
@@ -55,7 +54,7 @@ func classifyToolAuthorization(actor models.AgentConfig, toolName string) toolAu
 }
 
 func toolEmitAllowed(actor models.AgentConfig, toolName string) bool {
-	return IsEmitToolAllowedForRole(actor.Role, toolName) || IsEmitToolAllowedForConfig(actor.Config, toolName)
+	return IsEmitToolAllowedForRole(actor.Role, toolName) || IsEmitToolAllowedForActor(actor, toolName)
 }
 
 func toolKindPolicy(toolName string) toolcapabilities.ToolKind {
@@ -74,26 +73,14 @@ func toolContextRequirementPolicy(toolName string) toolcapabilities.ContextRequi
 	}
 }
 
-func extractAllowedToolsFromConfig(actor models.AgentConfig) (map[string]struct{}, bool) {
+func extractAllowedTools(actor models.AgentConfig) (map[string]struct{}, bool) {
 	allowed := make(map[string]struct{})
-	if len(actor.Config) == 0 || !json.Valid(actor.Config) {
-		return allowed, false
-	}
-	var parsed map[string]any
-	if err := json.Unmarshal(actor.Config, &parsed); err != nil {
+	if len(actor.Tools) == 0 {
 		return allowed, false
 	}
 	found := false
-	raw, ok := parsed["tools"]
-	if !ok {
-		return allowed, false
-	}
-	arr, ok := raw.([]any)
-	if !ok {
-		return allowed, false
-	}
-	for _, item := range arr {
-		name := normalizeNativeToolName(asString(item))
+	for _, item := range actor.Tools {
+		name := normalizeNativeToolName(item)
 		if name == "" {
 			continue
 		}

--- a/internal/runtime/tools/tool_input_normalization.go
+++ b/internal/runtime/tools/tool_input_normalization.go
@@ -108,10 +108,31 @@ func canonicalRuntimeToolInput(name string, input any) any {
 			if entityID := strings.TrimSpace(asString(payload["entity_id"])); entityID != "" {
 				config["entity_id"] = entityID
 			}
-			rawConfig := map[string]any{}
 			if modelTier := strings.TrimSpace(asString(payload["model_tier"])); modelTier != "" {
-				rawConfig["model_tier"] = modelTier
+				config["model_tier"] = modelTier
 			}
+			if conversationMode := strings.TrimSpace(asString(payload["conversation_mode"])); conversationMode != "" {
+				config["conversation_mode"] = conversationMode
+			}
+			if maxTurns := asInt(payload["max_turns_per_task"]); maxTurns > 0 {
+				config["max_turns_per_task"] = maxTurns
+			}
+			if tools, ok := payload["tools"]; ok && tools != nil {
+				config["tools"] = tools
+			}
+			if emitEvents, ok := payload["emit_events"]; ok && emitEvents != nil {
+				config["emit_events"] = emitEvents
+			}
+			if nativeTools, ok := payload["native_tools"]; ok && nativeTools != nil {
+				config["native_tools"] = nativeTools
+			}
+			if workspaceClass := strings.TrimSpace(asString(payload["workspace_class"])); workspaceClass != "" {
+				config["workspace_class"] = workspaceClass
+			}
+			if managerFallback := strings.TrimSpace(asString(payload["manager_fallback"])); managerFallback != "" {
+				config["manager_fallback"] = managerFallback
+			}
+			rawConfig := map[string]any{}
 			if systemPrompt := strings.TrimSpace(asString(payload["system_prompt"])); systemPrompt != "" {
 				rawConfig["system_prompt"] = systemPrompt
 			}
@@ -130,11 +151,33 @@ func canonicalRuntimeToolInput(name string, input any) any {
 			if modelTier := strings.TrimSpace(asString(payload["model_tier"])); modelTier != "" {
 				config["model_tier"] = modelTier
 			}
-			if systemPrompt := strings.TrimSpace(asString(payload["system_prompt"])); systemPrompt != "" {
-				config["system_prompt"] = systemPrompt
+			if conversationMode := strings.TrimSpace(asString(payload["conversation_mode"])); conversationMode != "" {
+				config["conversation_mode"] = conversationMode
 			}
 			if maxTurns := asInt(payload["max_turns_per_task"]); maxTurns > 0 {
 				config["max_turns_per_task"] = maxTurns
+			}
+			if tools, ok := payload["tools"]; ok && tools != nil {
+				config["tools"] = tools
+			}
+			if emitEvents, ok := payload["emit_events"]; ok && emitEvents != nil {
+				config["emit_events"] = emitEvents
+			}
+			if nativeTools, ok := payload["native_tools"]; ok && nativeTools != nil {
+				config["native_tools"] = nativeTools
+			}
+			if workspaceClass := strings.TrimSpace(asString(payload["workspace_class"])); workspaceClass != "" {
+				config["workspace_class"] = workspaceClass
+			}
+			if managerFallback := strings.TrimSpace(asString(payload["manager_fallback"])); managerFallback != "" {
+				config["manager_fallback"] = managerFallback
+			}
+			rawConfig := map[string]any{}
+			if systemPrompt := strings.TrimSpace(asString(payload["system_prompt"])); systemPrompt != "" {
+				rawConfig["system_prompt"] = systemPrompt
+			}
+			if len(rawConfig) > 0 {
+				config["config"] = rawConfig
 			}
 			payload["config"] = config
 		}

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -59,10 +59,8 @@ func TestExecutor_HTTPToolExecutesTemplateAndResponseMapping(t *testing.T) {
 
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
-		ID: "agent-1",
-		Config: mustToolConfigJSON(t, map[string]any{
-			"tools": []string{"check_domain"},
-		}),
+		ID:    "agent-1",
+		Tools: []string{"check_domain"},
 	})
 	out, err := exec.Execute(ctx, "check_domain", map[string]any{"domain": "example.com"})
 	if err != nil {
@@ -135,10 +133,8 @@ func TestExecutor_MCPToolExecutesDiscoveredServerTool(t *testing.T) {
 
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
-		ID: "agent-1",
-		Config: mustToolConfigJSON(t, map[string]any{
-			"tools": []string{"infra.ping"},
-		}),
+		ID:    "agent-1",
+		Tools: []string{"infra.ping"},
 	})
 	out, err := exec.Execute(ctx, "infra.ping", map[string]any{"target": "svc"})
 	if err != nil {
@@ -172,13 +168,9 @@ func TestExecutor_ToolDefinitionsForActor_UsesSharedActorRegistry(t *testing.T) 
 
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
 	defs := exec.ToolDefinitionsForActor(models.AgentConfig{
-		ID: "agent-1",
-		Config: mustToolConfigJSON(t, map[string]any{
-			"tools": []string{"check_domain"},
-			"native_tools": map[string]any{
-				"file_io": true,
-			},
-		}),
+		ID:          "agent-1",
+		Tools:       []string{"check_domain"},
+		NativeTools: models.NativeToolConfig{FileIO: true},
 	})
 
 	names := make([]string, 0, len(defs))

--- a/internal/runtime/tools/tool_semantics_guardrails_test.go
+++ b/internal/runtime/tools/tool_semantics_guardrails_test.go
@@ -141,8 +141,8 @@ func TestToolDefinitionsForActor_IncludesEnabledNativeTools(t *testing.T) {
 
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
 	defs := exec.ToolDefinitionsForActor(models.AgentConfig{
-		ID:     "analysis-agent",
-		Config: []byte(`{"native_tools":{"file_io":true}}`),
+		ID:          "analysis-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true},
 	})
 
 	names := make([]string, 0, len(defs))

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -375,7 +375,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 }
 
 func WorkspaceClass(actor models.AgentConfig) string {
-	if cfgClass := configString(actor.Config, "workspace_class"); cfgClass != "" {
+	if cfgClass := strings.TrimSpace(actor.WorkspaceClass); cfgClass != "" {
 		return cfgClass
 	}
 	if source := runtimepipeline.DefaultWorkflowSemanticSourceOrNil(); source != nil {
@@ -447,7 +447,7 @@ func (m *DockerManager) workspaceScopeForActor(actor models.AgentConfig) (string
 		}
 		return scope, agentID, nil
 	case "per-flow-instance":
-		flowPath := strings.Trim(strings.TrimSpace(configString(actor.Config, "flow_path")), "/")
+		flowPath := actor.CanonicalFlowPath()
 		if flowPath == "" {
 			return "", "", fmt.Errorf("workspace resolution failed: per-flow-instance workspace for agent %s requires flow_path", strings.TrimSpace(actor.ID))
 		}
@@ -653,18 +653,6 @@ func validateReadableDir(path, prefix string) error {
 		return fmt.Errorf("%s %s is not a directory", prefix, path)
 	}
 	return nil
-}
-
-func configString(raw []byte, key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" || len(raw) == 0 || !json.Valid(raw) {
-		return ""
-	}
-	var parsed map[string]any
-	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(asString(parsed[key]))
 }
 
 func asString(v any) string {

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,10 +105,9 @@ func TestResolveWorkspace_PerAgentMountsStandardPaths(t *testing.T) {
 			return "", nil
 		}
 	})
-	raw, _ := json.Marshal(map[string]any{"workspace_class": "dedicated"})
 	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
-		ID:     "dedicated-agent",
-		Config: raw,
+		ID:             "dedicated-agent",
+		WorkspaceClass: "dedicated",
 	})
 	if err != nil {
 		t.Fatalf("ResolveWorkspace: %v", err)
@@ -166,13 +164,10 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 			return "", nil
 		}
 	})
-	raw, _ := json.Marshal(map[string]any{
-		"workspace_class": "shared_flow",
-		"flow_path":       "shared/work-001",
-	})
 	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
-		ID:     "shared-work-lead",
-		Config: raw,
+		ID:             "shared-work-lead",
+		WorkspaceClass: "shared_flow",
+		FlowPath:       "shared/work-001",
 	})
 	if err != nil {
 		t.Fatalf("ResolveWorkspace: %v", err)

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -13,6 +13,9 @@ import (
 )
 
 func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.PersistedAgent) error {
+	if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+		return err
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -21,9 +24,14 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 		return fmt.Errorf("agent id is required")
 	}
 	rec.Config.NormalizeEntityID()
+	rec.Config.NormalizeRuntimeDescriptor()
 	cfgJSON, err := mergeAgentConfigJSON(rec.Config)
 	if err != nil {
 		return fmt.Errorf("marshal agent config: %w", err)
+	}
+	runtimeDescriptorJSON, err := marshalPersistedAgentRuntimeDescriptor(rec.Config)
+	if err != nil {
+		return fmt.Errorf("marshal agent runtime descriptor: %w", err)
 	}
 
 	var startedAt any
@@ -32,13 +40,16 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 	}
 	switch caps.Agents {
 	case SchemaFlavorCanonical:
-		return s.upsertAgentSpec(ctx, rec, cfgJSON, startedAt)
+		return s.upsertAgentSpec(ctx, rec, cfgJSON, runtimeDescriptorJSON, startedAt)
 	default:
 		return unsupportedSchemaCapability("agents", caps.Agents)
 	}
 }
 
 func (s *PostgresStore) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
+	if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+		return nil, err
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return nil, err
@@ -118,11 +129,11 @@ func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string)
 	return nil
 }
 
-func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.PersistedAgent, cfgJSON []byte, startedAt any) error {
+func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.PersistedAgent, cfgJSON, runtimeDescriptorJSON []byte, startedAt any) error {
 	modelTier := agentModelTier(rec.Config)
 	conversationMode := agentConversationMode(rec.Config)
-	emitEvents := extractStringListField(cfgJSON, "emit_events")
-	tools := extractStringListField(cfgJSON, "tools")
+	emitEvents := rec.Config.EmitEvents
+	tools := rec.Config.Tools
 	permissions := rec.Config.Permissions
 	subscriptions := rec.Config.Subscriptions
 	flowInstance := agentFlowInstance(rec.Config)
@@ -132,12 +143,12 @@ func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.
 		INSERT INTO agents (
 			agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
 			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
-			status, turn_count, last_active_at, created_at
+			runtime_descriptor, status, turn_count, last_active_at, created_at
 		)
 		VALUES (
 			$1, NULLIF($2,''), $3, $4, $5, $6,
 			NULLIF($7,''), NULLIF($8,'')::uuid, $9::jsonb, $10::jsonb, $11::jsonb, $12::jsonb, $13::jsonb,
-			$14, 0, now(), COALESCE($15, now())
+			$14::jsonb, $15, 0, now(), COALESCE($16, now())
 		)
 		ON CONFLICT (agent_id) DO UPDATE SET
 			flow_instance = EXCLUDED.flow_instance,
@@ -152,6 +163,7 @@ func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.
 			emit_events = EXCLUDED.emit_events,
 			tools = EXCLUDED.tools,
 			permissions = EXCLUDED.permissions,
+			runtime_descriptor = EXCLUDED.runtime_descriptor,
 			status = EXCLUDED.status,
 			last_active_at = now()
 	`
@@ -169,6 +181,7 @@ func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.
 		mustJSONString(emitEvents),
 		mustJSONString(tools),
 		mustJSONString(permissions),
+		string(runtimeDescriptorJSON),
 		agentPersistedStatus(rec.Status),
 		startedAt,
 	)
@@ -187,7 +200,10 @@ func (s *PostgresStore) loadAgentsSpec(ctx context.Context) ([]runtimemanager.Pe
 			COALESCE(parent_agent_id, ''),
 			COALESCE(entity_id::text, ''),
 			config,
+			COALESCE(runtime_descriptor, '{}'::jsonb),
 			COALESCE(subscriptions, '[]'::jsonb),
+			COALESCE(emit_events, '[]'::jsonb),
+			COALESCE(tools, '[]'::jsonb),
 			COALESCE(permissions, '[]'::jsonb),
 			COALESCE(status, 'active'),
 			COALESCE(created_at, now())
@@ -210,7 +226,10 @@ func (s *PostgresStore) loadAgentsSpec(ctx context.Context) ([]runtimemanager.Pe
 			llmBackend        string
 			conversationMode  string
 			cfgRaw            []byte
+			runtimeDescriptor []byte
 			subscriptionsJSON []byte
+			emitEventsJSON    []byte
+			toolsJSON         []byte
 			permissionsJSON   []byte
 		)
 		if err := rows.Scan(
@@ -223,30 +242,35 @@ func (s *PostgresStore) loadAgentsSpec(ctx context.Context) ([]runtimemanager.Pe
 			&rec.ParentAgentID,
 			&rec.Config.EntityID,
 			&cfgRaw,
+			&runtimeDescriptor,
 			&subscriptionsJSON,
+			&emitEventsJSON,
+			&toolsJSON,
 			&permissionsJSON,
 			&rec.Status,
 			&rec.StartedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent row: %w", err)
 		}
+		desc := decodePersistedAgentRuntimeDescriptor(runtimeDescriptor)
 		rec.Config.ParentAgent = rec.ParentAgentID
 		rec.Config.NormalizeEntityID()
 		rec.Config.Config = cfgRaw
-		rec.Config.Type = coalesce(extractStringField(cfgRaw, "type"), modelTier)
-		rec.Config.Mode = extractStringField(cfgRaw, "mode")
+		rec.Config.Type = coalesce(desc.Type, modelTier)
+		rec.Config.Mode = desc.Mode
+		rec.Config.ModelTier = strings.TrimSpace(modelTier)
 		rec.Config.LLMBackend = llmBackend
-		rec.Config.Subscriptions = coalesceStringList(decodeJSONStringList(subscriptionsJSON), extractSubscriptions(cfgRaw))
-		rec.Config.Permissions = coalesceStringList(decodeJSONStringList(permissionsJSON), extractPermissions(cfgRaw))
-		if rec.Config.Mode == "" && flowInstance != "" {
-			rec.Config.Mode = flowInstance
-		}
-		if extractStringField(cfgRaw, "conversation_mode") == "" && conversationMode != "" {
-			rec.Config.Config = withConfigString(cfgRaw, "conversation_mode", conversationMode)
-		}
-		if extractStringField(cfgRaw, "model_tier") == "" && modelTier != "" {
-			rec.Config.Config = withConfigString(rec.Config.Config, "model_tier", modelTier)
-		}
+		rec.Config.ConversationMode = strings.TrimSpace(conversationMode)
+		rec.Config.MaxTurnsPerTask = desc.MaxTurnsPerTask
+		rec.Config.Subscriptions = decodeJSONStringList(subscriptionsJSON)
+		rec.Config.EmitEvents = decodeJSONStringList(emitEventsJSON)
+		rec.Config.Tools = decodeJSONStringList(toolsJSON)
+		rec.Config.Permissions = decodeJSONStringList(permissionsJSON)
+		rec.Config.NativeTools = desc.NativeTools
+		rec.Config.WorkspaceClass = desc.WorkspaceClass
+		rec.Config.ManagerFallback = desc.ManagerFallback
+		rec.Config.FlowPath = strings.Trim(strings.TrimSpace(flowInstance), "/")
+		rec.Config.NormalizeRuntimeDescriptor()
 		out = append(out, rec)
 	}
 	if err := rows.Err(); err != nil {
@@ -256,7 +280,7 @@ func (s *PostgresStore) loadAgentsSpec(ctx context.Context) ([]runtimemanager.Pe
 }
 
 func agentModelTier(cfg runtimeactors.AgentConfig) string {
-	if v := extractStringField(cfg.Config, "model_tier"); v != "" {
+	if v := strings.TrimSpace(cfg.ModelTier); v != "" {
 		return v
 	}
 	if v := strings.TrimSpace(cfg.Type); v != "" {
@@ -266,18 +290,8 @@ func agentModelTier(cfg runtimeactors.AgentConfig) string {
 }
 
 func agentConversationMode(cfg runtimeactors.AgentConfig) string {
-	if v := extractStringField(cfg.Config, "conversation_mode"); v != "" {
+	if v := strings.TrimSpace(cfg.ConversationMode); v != "" {
 		return runtimesessions.NormalizeConversationRuntimeMode(v)
-	}
-	if len(cfg.Config) > 0 && json.Valid(cfg.Config) {
-		var obj map[string]any
-		if json.Unmarshal(cfg.Config, &obj) == nil {
-			if constraints, ok := obj["constraints"].(map[string]any); ok {
-				if raw, _ := constraints["conversation_mode"].(string); strings.TrimSpace(raw) != "" {
-					return runtimesessions.NormalizeConversationRuntimeMode(raw)
-				}
-			}
-		}
 	}
 	if cfg.EffectiveEntityID() == "" {
 		return runtimesessions.RuntimeModeTask
@@ -286,10 +300,7 @@ func agentConversationMode(cfg runtimeactors.AgentConfig) string {
 }
 
 func agentFlowInstance(cfg runtimeactors.AgentConfig) string {
-	if v := extractStringField(cfg.Config, "flow_instance"); v != "" {
-		return v
-	}
-	if v := extractStringField(cfg.Config, "flow_path"); v != "" {
+	if v := strings.TrimSpace(cfg.FlowPath); v != "" {
 		return v
 	}
 	return ""
@@ -297,9 +308,6 @@ func agentFlowInstance(cfg runtimeactors.AgentConfig) string {
 
 func agentLLMBackend(cfg runtimeactors.AgentConfig) string {
 	if v := strings.TrimSpace(cfg.LLMBackend); v != "" {
-		return v
-	}
-	if v := extractStringField(cfg.Config, "llm_backend"); v != "" {
 		return v
 	}
 	return "api"
@@ -340,24 +348,6 @@ func coalesceStringList(primary, fallback []string) []string {
 		return primary
 	}
 	return fallback
-}
-
-func withConfigString(raw []byte, key, value string) []byte {
-	key = strings.TrimSpace(key)
-	value = strings.TrimSpace(value)
-	if key == "" || value == "" {
-		return raw
-	}
-	obj := map[string]any{}
-	if len(raw) > 0 && json.Valid(raw) {
-		_ = json.Unmarshal(raw, &obj)
-	}
-	obj[key] = value
-	b, err := json.Marshal(obj)
-	if err != nil {
-		return raw
-	}
-	return b
 }
 
 func coalesce(vals ...string) string {

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -9,33 +9,88 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
+type persistedAgentRuntimeDescriptor struct {
+	Type            string                         `json:"type,omitempty"`
+	Mode            string                         `json:"mode,omitempty"`
+	MaxTurnsPerTask int                            `json:"max_turns_per_task,omitempty"`
+	NativeTools     runtimeactors.NativeToolConfig `json:"native_tools,omitempty"`
+	WorkspaceClass  string                         `json:"workspace_class,omitempty"`
+	ManagerFallback string                         `json:"manager_fallback,omitempty"`
+}
+
+var runtimeConfigKeys = map[string]struct{}{
+	"type":               {},
+	"mode":               {},
+	"model_tier":         {},
+	"llm_backend":        {},
+	"conversation_mode":  {},
+	"max_turns_per_task": {},
+	"subscriptions":      {},
+	"emit_events":        {},
+	"tools":              {},
+	"permissions":        {},
+	"native_tools":       {},
+	"workspace_class":    {},
+	"manager_fallback":   {},
+	"flow_path":          {},
+	"flow_instance":      {},
+}
+
 func mergeAgentConfigJSON(cfg runtimeactors.AgentConfig) ([]byte, error) {
+	return sanitizeOpaqueAgentConfig(cfg.Config)
+}
+
+func sanitizeOpaqueAgentConfig(raw json.RawMessage) ([]byte, error) {
 	obj := map[string]any{}
-	if len(cfg.Config) > 0 && json.Valid(cfg.Config) {
-		_ = json.Unmarshal(cfg.Config, &obj)
+	if len(raw) > 0 && json.Valid(raw) {
+		_ = json.Unmarshal(raw, &obj)
 	}
-	if len(cfg.Subscriptions) > 0 {
-		obj["subscriptions"] = cfg.Subscriptions
+	for key := range runtimeConfigKeys {
+		delete(obj, key)
 	}
-	if len(cfg.Permissions) > 0 {
-		obj["permissions"] = cfg.Permissions
-	}
-	if _, ok := obj["role"]; !ok && cfg.Role != "" {
-		obj["role"] = cfg.Role
-	}
-	if _, ok := obj["mode"]; !ok && cfg.Mode != "" {
-		obj["mode"] = cfg.Mode
-	}
-	if _, ok := obj["type"]; !ok && cfg.Type != "" {
-		obj["type"] = cfg.Type
-	}
-	if _, ok := obj["llm_backend"]; !ok && cfg.LLMBackend != "" {
-		obj["llm_backend"] = cfg.LLMBackend
+	if constraints, ok := obj["constraints"].(map[string]any); ok {
+		delete(constraints, "conversation_mode")
+		delete(constraints, "max_turns_per_task")
+		if len(constraints) == 0 {
+			delete(obj, "constraints")
+		} else {
+			obj["constraints"] = constraints
+		}
 	}
 	if len(obj) == 0 {
 		obj = map[string]any{}
 	}
 	return json.Marshal(obj)
+}
+
+func marshalPersistedAgentRuntimeDescriptor(cfg runtimeactors.AgentConfig) ([]byte, error) {
+	desc := persistedAgentRuntimeDescriptor{
+		Type:            strings.TrimSpace(cfg.Type),
+		Mode:            strings.TrimSpace(cfg.Mode),
+		MaxTurnsPerTask: cfg.MaxTurnsPerTask,
+		NativeTools:     cfg.NativeTools,
+		WorkspaceClass:  strings.TrimSpace(cfg.WorkspaceClass),
+		ManagerFallback: strings.TrimSpace(cfg.ManagerFallback),
+	}
+	if !desc.NativeTools.Any() {
+		desc.NativeTools = runtimeactors.NativeToolConfig{}
+	}
+	return json.Marshal(desc)
+}
+
+func decodePersistedAgentRuntimeDescriptor(raw []byte) persistedAgentRuntimeDescriptor {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return persistedAgentRuntimeDescriptor{}
+	}
+	var desc persistedAgentRuntimeDescriptor
+	if err := json.Unmarshal(raw, &desc); err != nil {
+		return persistedAgentRuntimeDescriptor{}
+	}
+	desc.Type = strings.TrimSpace(desc.Type)
+	desc.Mode = strings.TrimSpace(desc.Mode)
+	desc.WorkspaceClass = strings.TrimSpace(desc.WorkspaceClass)
+	desc.ManagerFallback = strings.TrimSpace(desc.ManagerFallback)
+	return desc
 }
 
 func extractSubscriptions(raw []byte) []string {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"swarm/internal/config"
+	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
 type PostgresStore struct {
@@ -107,7 +109,7 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 		return err
 	}
 	if !catalog.hasTable("agent_turns") {
-		goto ensureEntityState
+		goto ensureAgents
 	}
 	if !catalog.hasColumns("agent_turns", "turn_blocks") {
 		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS turn_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`); err != nil {
@@ -117,7 +119,10 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if err := s.ensureConversationAuditTable(ctx); err != nil {
 		return err
 	}
-ensureEntityState:
+ensureAgents:
+	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
+		return err
+	}
 	if !catalog.hasTable("entity_state") {
 		return nil
 	}
@@ -131,6 +136,192 @@ ensureEntityState:
 	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *PostgresStore) ensureAgentRuntimeDescriptorColumn(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasTable("agents") {
+		return nil
+	}
+	if !catalog.hasColumns("agents", "runtime_descriptor") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN IF NOT EXISTS runtime_descriptor JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
+			return fmt.Errorf("ensure agents.runtime_descriptor column: %w", err)
+		}
+	}
+	if err := s.migrateLegacyAgentRuntimeDescriptors(ctx); err != nil {
+		return err
+	}
+	_, err = s.BindSchemaCapabilities(ctx)
+	return err
+}
+
+func (s *PostgresStore) migrateLegacyAgentRuntimeDescriptors(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT agent_id, COALESCE(config, '{}'::jsonb), COALESCE(runtime_descriptor, '{}'::jsonb)
+		FROM agents
+	`)
+	if err != nil {
+		return fmt.Errorf("query agent runtime descriptor migration rows: %w", err)
+	}
+	defer rows.Close()
+
+	type rowUpdate struct {
+		agentID           string
+		config            []byte
+		runtimeDescriptor []byte
+	}
+	updates := make([]rowUpdate, 0)
+	for rows.Next() {
+		var (
+			agentID           string
+			configRaw         []byte
+			runtimeDescriptor []byte
+		)
+		if err := rows.Scan(&agentID, &configRaw, &runtimeDescriptor); err != nil {
+			return fmt.Errorf("scan agent runtime descriptor migration row: %w", err)
+		}
+		desc := decodePersistedAgentRuntimeDescriptor(runtimeDescriptor)
+		legacy := decodeLegacyAgentRuntimeConfig(configRaw)
+		if desc.Type == "" {
+			desc.Type = legacy.Type
+		}
+		if desc.Mode == "" {
+			desc.Mode = legacy.Mode
+		}
+		if desc.MaxTurnsPerTask == 0 {
+			desc.MaxTurnsPerTask = legacy.MaxTurnsPerTask
+		}
+		if !desc.NativeTools.Any() {
+			desc.NativeTools = legacy.NativeTools
+		}
+		if desc.WorkspaceClass == "" {
+			desc.WorkspaceClass = legacy.WorkspaceClass
+		}
+		if desc.ManagerFallback == "" {
+			desc.ManagerFallback = legacy.ManagerFallback
+		}
+		sanitizedConfig, err := sanitizeOpaqueAgentConfig(configRaw)
+		if err != nil {
+			return fmt.Errorf("sanitize legacy agent config for %s: %w", strings.TrimSpace(agentID), err)
+		}
+		nextDescriptor, err := json.Marshal(desc)
+		if err != nil {
+			return fmt.Errorf("marshal runtime descriptor for %s: %w", strings.TrimSpace(agentID), err)
+		}
+		updates = append(updates, rowUpdate{
+			agentID:           agentID,
+			config:            sanitizedConfig,
+			runtimeDescriptor: nextDescriptor,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read agent runtime descriptor migration rows: %w", err)
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin agent runtime descriptor migration tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, update := range updates {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE agents
+			SET config = $2::jsonb,
+			    runtime_descriptor = $3::jsonb
+			WHERE agent_id = $1
+		`, update.agentID, string(update.config), string(update.runtimeDescriptor)); err != nil {
+			return fmt.Errorf("update agent runtime descriptor for %s: %w", strings.TrimSpace(update.agentID), err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit agent runtime descriptor migration tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func decodeLegacyAgentRuntimeConfig(raw []byte) persistedAgentRuntimeDescriptor {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return persistedAgentRuntimeDescriptor{}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return persistedAgentRuntimeDescriptor{}
+	}
+	desc := persistedAgentRuntimeDescriptor{
+		Type:            strings.TrimSpace(stringValue(payload["type"])),
+		Mode:            strings.TrimSpace(stringValue(payload["mode"])),
+		MaxTurnsPerTask: intValue(payload["max_turns_per_task"]),
+		NativeTools:     nativeToolConfigValue(payload["native_tools"]),
+		WorkspaceClass:  strings.TrimSpace(stringValue(payload["workspace_class"])),
+		ManagerFallback: strings.TrimSpace(stringValue(payload["manager_fallback"])),
+	}
+	if desc.MaxTurnsPerTask == 0 {
+		if constraints, ok := payload["constraints"].(map[string]any); ok {
+			desc.MaxTurnsPerTask = intValue(constraints["max_turns_per_task"])
+		}
+	}
+	return desc
+}
+
+func stringValue(v any) string {
+	if value, ok := v.(string); ok {
+		return value
+	}
+	return ""
+}
+
+func intValue(v any) int {
+	switch typed := v.(type) {
+	case int:
+		return typed
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case float32:
+		return int(typed)
+	case json.Number:
+		out, _ := typed.Int64()
+		return int(out)
+	default:
+		return 0
+	}
+}
+
+func nativeToolConfigValue(v any) runtimeactors.NativeToolConfig {
+	items, ok := v.(map[string]any)
+	if !ok {
+		return runtimeactors.NativeToolConfig{}
+	}
+	return runtimeactors.NativeToolConfig{
+		Bash:      boolValue(items["bash"]),
+		WebSearch: boolValue(items["web_search"]),
+		FileIO:    boolValue(items["file_io"]),
+	}
+}
+
+func boolValue(v any) bool {
+	value, _ := v.(bool)
+	return value
 }
 
 func (s *PostgresStore) ensureConversationAuditTable(ctx context.Context) error {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -121,7 +121,7 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 		[]string{
 			"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
 			"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
-			"permissions", "status", "turn_count", "last_active_at", "created_at",
+			"permissions", "runtime_descriptor", "status", "turn_count", "last_active_at", "created_at",
 		},
 		[]string{
 			"id", "type", "role", "mode", "entity_id", "parent_agent_id", "status",

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -25,7 +25,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	addColumns("agents",
 		"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
 		"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
-		"permissions", "status", "turn_count", "last_active_at", "created_at",
+		"permissions", "runtime_descriptor", "status", "turn_count", "last_active_at", "created_at",
 	)
 	addColumns("events",
 		"event_id", "run_id", "event_name", "entity_id", "flow_instance", "scope", "payload",


### PR DESCRIPTION
## What changed

This PR introduces a typed persisted runtime descriptor for agents and makes it the single canonical owner for runtime control semantics.

Key changes:
- adds `agents.runtime_descriptor` as the persisted home for runtime control fields that were previously only recoverable from `config`
- keeps `agents.config` as opaque payload only
- extends the typed runtime agent model so manager, authority, workspace, tool, LLM, and MCP paths read control semantics from typed fields instead of re-decoding `config`
- updates runtime materialization, store load/save paths, and forward migration logic so legacy control fields are moved out of opaque config into the persisted descriptor
- promotes the approved platform spec delta into this branch's `platform-spec.yaml`

## Why this changed

Issue #10 requires one typed canonical owner for persisted runtime control semantics and forbids adding more local JSON re-decode helpers.

Before this change, runtime behavior was split across typed columns, array columns, and opaque `config`, which forced multiple subsystems to reconstruct core semantics like:
- allowed tools
- emit events
- native tools
- workspace class
- manager fallback
- conversation mode / max turns
- flow path

This PR removes that duplicate semantic model.

## Impact

Runtime behavior is now simpler and more explicit:
- persisted control semantics come from the typed descriptor, not opaque config
- `permissions` remains the canonical persisted post-boot value; `permissions_bundle` is not persisted
- store compatibility performs a forward rewrite for legacy rows so old runtime-control keys are migrated out of `config`
- tests and runtime readers were updated to the typed model end to end

## Root cause

The root issue was semantic ownership drift: the platform allowed core runtime control semantics to exist partly in typed persistence and partly inside opaque JSON, so readers implemented local reconstruction rules instead of consuming one canonical descriptor.

## Validation

- `go test ./internal/runtime/manager ./internal/store ./internal/runtime/authority ./internal/runtime/workspace ./internal/runtime/agents ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime/mcp -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured agent configuration from opaque JSON format to strongly-typed fields for improved consistency and maintainability.
  * Added persistent storage for agent runtime descriptors in the database.
  * Introduced native tool configuration with explicit boolean toggles for supported capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->