### PR TITLE
[agent-b][issue #23] Move cross-flow routing to pin-based auto-wiring by default

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -542,7 +542,7 @@ func (c *checkerContext) transitionOwnership() []Finding {
 		if nodeID == "" {
 			continue
 		}
-		subs := stringSet(node.SubscribesTo)
+		subs := stringSet(c.source.NodeRuntimeSubscriptions(nodeID))
 		produces := stringSet(node.Produces)
 		for _, transitionID := range node.OwnedTransitions {
 			transitionID = strings.TrimSpace(transitionID)
@@ -810,7 +810,7 @@ func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
 			if eventType == "" {
 				continue
 			}
-			producers := crossFlowInputProducerFlows(c.source, flowID, eventType)
+			producers := c.source.ResolveFlowInputAutoWire(flowID, eventType).ProducerFlows
 			if len(producers) <= 1 {
 				continue
 			}
@@ -826,34 +826,6 @@ func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
 		}
 	}
 	return c.crossFlowPinAmbiguityFindings
-}
-
-func crossFlowInputProducerFlows(source semanticview.Source, targetFlowID, eventType string) []string {
-	targetFlowID = strings.TrimSpace(targetFlowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || targetFlowID == "" || eventType == "" {
-		return nil
-	}
-	seen := make(map[string]struct{})
-	out := make([]string, 0, 4)
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" || flowID == targetFlowID {
-			continue
-		}
-		for _, output := range scope.OutputEvents {
-			if strings.TrimSpace(output) != eventType {
-				continue
-			}
-			if _, ok := seen[flowID]; ok {
-				continue
-			}
-			seen[flowID] = struct{}{}
-			out = append(out, flowID)
-		}
-	}
-	sort.Strings(out)
-	return out
 }
 
 func flowHasScopedInputEscapeHatch(source semanticview.Source, flowID, eventType string) bool {
@@ -1554,11 +1526,11 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: nodeLabel,
 				})
 			}
-			if len(node.SubscribesTo) == 0 {
+			if len(c.source.NodeRuntimeSubscriptions(nodeID)) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
-					Message:  fmt.Sprintf("node %s missing required field subscribes_to", nodeLabel),
+					Message:  fmt.Sprintf("node %s missing declared subscription surface", nodeLabel),
 					Location: nodeLabel,
 				})
 			}
@@ -1650,11 +1622,11 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: nodeLabel,
 				})
 			}
-			if len(node.SubscribesTo) == 0 {
+			if len(c.source.NodeRuntimeSubscriptions(nodeID)) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
-					Message:  fmt.Sprintf("node %s missing required field subscribes_to", nodeLabel),
+					Message:  fmt.Sprintf("node %s missing declared subscription surface", nodeLabel),
 					Location: nodeLabel,
 				})
 			}

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -323,7 +323,11 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, flowID s
 			Type: "node",
 			Path: strings.Trim(strings.TrimSpace(basePath), "/"),
 		}
-		for _, rawPattern := range normalizeStringList(entry.SubscribesTo) {
+		patterns := normalizeStringList(entry.SubscribesTo)
+		if source != nil {
+			patterns = source.NodeRuntimeSubscriptions(nodeID)
+		}
+		for _, rawPattern := range patterns {
 			for _, resolved := range routeResolveSubscriberPatterns(source, flowID, inputEvents, basePath, localEvents, rawPattern) {
 				if strings.TrimSpace(resolved.EventPattern) == "" {
 					continue
@@ -381,7 +385,7 @@ func routeFlowInputHasExternalProducer(source semanticview.Source, flowID, event
 	if source == nil {
 		return false
 	}
-	return len(source.FlowInputProducerPatterns(flowID, eventType)) > 0
+	return len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
 }
 
 func routeNodeLocalEventSet(node runtimecontracts.SystemNodeContract) map[string]struct{} {
@@ -423,13 +427,16 @@ func routeSubscriberTemplates(source semanticview.Source, scope semanticview.Flo
 	}
 	for _, key := range sortedStringKeys(scope.Nodes) {
 		entry := scope.Nodes[key]
-		patterns := normalizeStringList(entry.SubscribesTo)
-		if len(patterns) == 0 {
-			continue
-		}
 		nodeID := strings.TrimSpace(entry.ID)
 		if nodeID == "" {
 			nodeID = strings.TrimSpace(key)
+		}
+		patterns := normalizeStringList(entry.SubscribesTo)
+		if source != nil {
+			patterns = source.NodeRuntimeSubscriptions(nodeID)
+		}
+		if len(patterns) == 0 {
+			continue
 		}
 		out = append(out, routeSubscriberTemplate{
 			IDTemplate:  nodeID,
@@ -490,7 +497,7 @@ func routeResolveSubscriberPatterns(source semanticview.Source, flowID string, i
 		return nil
 	}
 	if flowID != "" && source != nil && source.FlowHasInputEvent(flowID, raw) {
-		patterns := routeInputProducerPatterns(source, flowID, raw)
+		patterns := routeInputProducerPatterns(source.ResolveFlowInputAutoWire(flowID, raw))
 		if len(patterns) > 0 {
 			return patterns
 		}
@@ -527,13 +534,9 @@ func workflowScopeLocalEvents(scope semanticview.FlowScope) map[string]struct{} 
 	return out
 }
 
-func routeInputProducerPatterns(source semanticview.Source, targetFlowID, eventType string) []routeResolvedPattern {
-	if source == nil {
-		return nil
-	}
-	patterns := source.FlowInputProducerPatterns(targetFlowID, eventType)
-	out := make([]routeResolvedPattern, 0, len(patterns))
-	for _, pattern := range patterns {
+func routeInputProducerPatterns(resolution runtimecontracts.FlowInputAutoWireResolution) []routeResolvedPattern {
+	out := make([]routeResolvedPattern, 0, len(resolution.Patterns))
+	for _, pattern := range resolution.Patterns {
 		pattern = eventidentity.Normalize(pattern)
 		if pattern == "" {
 			continue

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -163,6 +163,126 @@ func TestDeriveRouteTable_InputPinsAutoWireFromProducerOutput(t *testing.T) {
 	}
 }
 
+func TestDeriveRouteTable_HandlerOnlyInputPinsAutoWireFromProducerOutput(t *testing.T) {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "producer",
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": {
+				ID: "consumer-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"scan.requested": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, consumer}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"consumer": &root.Children[1],
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"consumer-node": {
+					"scan.requested": {},
+				},
+			},
+		},
+	}
+	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	got := rt.Resolve("producer/scan.requested")
+	if len(got) != 1 || got[0].ID != "consumer-node" {
+		t.Fatalf("Resolve(producer/scan.requested) = %#v, want consumer-node", got)
+	}
+}
+
+func TestDeriveRouteTable_AmbiguousInputPinsFailClosedWithoutEscapeHatch(t *testing.T) {
+	producerA := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer_a", Flow: "producer_a"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "producer_a",
+	}
+	producerB := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer_b", Flow: "producer_b"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "producer_b",
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": {
+				ID: "consumer-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"ticket.ready": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producerA, producerB, consumer}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer_a": &root.Children[0],
+				"producer_b": &root.Children[1],
+				"consumer":   &root.Children[2],
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"consumer-node": {
+					"ticket.ready": {},
+				},
+			},
+		},
+	}
+	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if got := rt.Resolve("producer_a/ticket.ready"); len(got) != 0 {
+		t.Fatalf("Resolve(producer_a/ticket.ready) = %#v, want none", got)
+	}
+	if got := rt.Resolve("producer_b/ticket.ready"); len(got) != 0 {
+		t.Fatalf("Resolve(producer_b/ticket.ready) = %#v, want none", got)
+	}
+}
+
 func TestDeriveRouteTable_InputPinsStayLocalWithoutExternalProducer(t *testing.T) {
 	scoring := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "scoring", Flow: "scoring"},

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -142,6 +142,20 @@ func (b *WorkflowContractBundle) NodeEntries() map[string]SystemNodeContract {
 	if b == nil {
 		return nil
 	}
+	if len(b.Nodes) == 0 {
+		out := make(map[string]SystemNodeContract)
+		for _, view := range b.ProjectViews() {
+			for key, entry := range view.Nodes {
+				out[key] = entry
+			}
+		}
+		for _, view := range b.FlowViews() {
+			for key, entry := range view.Nodes {
+				out[key] = entry
+			}
+		}
+		return out
+	}
 	return cloneSystemNodeContractMap(b.Nodes)
 }
 func (b *WorkflowContractBundle) NodeEntry(id string) (SystemNodeContract, bool) {
@@ -382,44 +396,55 @@ func (b *WorkflowContractBundle) FlowHasInputEvent(flowID, eventType string) boo
 func (b *WorkflowContractBundle) FlowHasOutputEvent(flowID, eventType string) bool {
 	return b.flowEventScope(flowID).HasOutput(eventType)
 }
-func (b *WorkflowContractBundle) FlowInputProducerPatterns(targetFlowID, eventType string) []string {
+func (b *WorkflowContractBundle) ResolveFlowInputAutoWire(targetFlowID, eventType string) FlowInputAutoWireResolution {
 	targetFlowID = strings.TrimSpace(targetFlowID)
 	eventType = eventidentity.Normalize(eventType)
-	if b == nil || targetFlowID == "" || eventType == "" {
-		return nil
+	if b == nil || targetFlowID == "" || eventType == "" || !b.FlowHasInputEvent(targetFlowID, eventType) {
+		return FlowInputAutoWireResolution{EventType: eventType}
 	}
-	seen := make(map[string]struct{})
-	out := make([]string, 0, 4)
+
+	out := FlowInputAutoWireResolution{EventType: eventType}
+	seenPatterns := make(map[string]struct{})
 	appendPattern := func(value string) {
 		value = eventidentity.Normalize(value)
 		if value == "" {
 			return
 		}
-		if _, ok := seen[value]; ok {
+		if _, ok := seenPatterns[value]; ok {
 			return
 		}
-		seen[value] = struct{}{}
-		out = append(out, value)
+		seenPatterns[value] = struct{}{}
+		out.Patterns = append(out.Patterns, value)
 	}
+
 	for _, view := range b.ProjectViews() {
 		if _, ok := view.Events[eventType]; ok {
 			appendPattern(eventType)
 		}
 	}
+
+	seenFlows := make(map[string]struct{})
 	for _, view := range b.FlowViews() {
 		flowID := strings.TrimSpace(view.Paths.ID)
-		if flowID == "" || flowID == targetFlowID {
+		if flowID == "" || flowID == targetFlowID || !b.FlowHasOutputEvent(flowID, eventType) {
 			continue
 		}
-		for _, output := range view.Schema.Pins.Outputs.Events {
-			if eventidentity.Normalize(output) != eventType {
-				continue
-			}
-			appendPattern(b.ResolveFlowEventReference(flowID, eventType))
+		if _, ok := seenFlows[flowID]; ok {
+			continue
 		}
+		seenFlows[flowID] = struct{}{}
+		out.ProducerFlows = append(out.ProducerFlows, flowID)
 	}
-	sort.Strings(out)
+
+	sort.Strings(out.ProducerFlows)
+	if len(out.ProducerFlows) == 1 {
+		appendPattern(b.ResolveFlowEventReference(out.ProducerFlows[0], eventType))
+	}
+	sort.Strings(out.Patterns)
 	return out
+}
+func (b *WorkflowContractBundle) FlowInputProducerPatterns(targetFlowID, eventType string) []string {
+	return append([]string{}, b.ResolveFlowInputAutoWire(targetFlowID, eventType).Patterns...)
 }
 func (b *WorkflowContractBundle) ResolveFlowEventReference(flowID, eventType string) string {
 	scope := b.flowEventScope(flowID)
@@ -460,8 +485,35 @@ func (b *WorkflowContractBundle) NodeContractSource(nodeID string) (ContractItem
 	if b == nil {
 		return ContractItemSource{}, false
 	}
-	source, ok := b.nodeSources[strings.TrimSpace(nodeID)]
-	return source, ok
+	nodeID = strings.TrimSpace(nodeID)
+	source, ok := b.nodeSources[nodeID]
+	if ok {
+		return source, true
+	}
+	for _, view := range b.ProjectViews() {
+		for key, entry := range view.Nodes {
+			if strings.TrimSpace(key) != nodeID && strings.TrimSpace(entry.ID) != nodeID {
+				continue
+			}
+			return ContractItemSource{
+				PackageKey: strings.TrimSpace(view.Paths.Key),
+				Layer:      "project",
+			}, true
+		}
+	}
+	for _, view := range b.FlowViews() {
+		for key, entry := range view.Nodes {
+			if strings.TrimSpace(key) != nodeID && strings.TrimSpace(entry.ID) != nodeID {
+				continue
+			}
+			return ContractItemSource{
+				PackageKey: strings.TrimSpace(view.Paths.PackageKey),
+				FlowID:     strings.TrimSpace(view.Paths.ID),
+				Layer:      "flow",
+			}, true
+		}
+	}
+	return ContractItemSource{}, false
 }
 func (b *WorkflowContractBundle) EventContractSource(eventType string) (ContractItemSource, bool) {
 	if b == nil {
@@ -483,6 +535,37 @@ func (b *WorkflowContractBundle) ResolveNodeEventReference(nodeID, eventType str
 	}
 	return b.nodeEventScope(nodeID).ResolveEvent(eventType, b.flowEventDescendants(b.nodeFlowID(nodeID)))
 }
+func (b *WorkflowContractBundle) NodeRuntimeSubscriptions(nodeID string) []string {
+	nodeID = strings.TrimSpace(nodeID)
+	if b == nil || nodeID == "" {
+		return nil
+	}
+	entry, ok := b.nodeContract(nodeID)
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(entry.SubscribesTo)+len(entry.EventHandlers))
+	appendSubscription := func(value string) {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	for _, eventType := range entry.SubscribesTo {
+		appendSubscription(eventType)
+	}
+	for _, eventType := range b.NodeHandlerSubscriptions(nodeID) {
+		appendSubscription(eventType)
+	}
+	sort.Strings(out)
+	return out
+}
 func (b *WorkflowContractBundle) ScopedAgentEntries() map[string]AgentRegistryEntry {
 	if b == nil {
 		return nil
@@ -501,8 +584,12 @@ func (b *WorkflowContractBundle) NodeEventHandlers(nodeID string) map[string]Sys
 	}
 	nodeID = strings.TrimSpace(nodeID)
 	handlers, ok := b.Semantics.NodeHandlers[nodeID]
-	if !ok {
-		return nil
+	if !ok || len(handlers) == 0 {
+		entry, ok := b.nodeContract(nodeID)
+		if !ok || len(entry.EventHandlers) == 0 {
+			return nil
+		}
+		handlers = entry.EventHandlers
 	}
 	out := make(map[string]SystemNodeEventHandler, len(handlers))
 	for eventType, handler := range handlers {
@@ -511,12 +598,8 @@ func (b *WorkflowContractBundle) NodeEventHandlers(nodeID string) map[string]Sys
 	return out
 }
 func (b *WorkflowContractBundle) NodeHandlerSubscriptions(nodeID string) []string {
-	if b == nil {
-		return nil
-	}
-	nodeID = strings.TrimSpace(nodeID)
-	handlers, ok := b.Semantics.NodeHandlers[nodeID]
-	if !ok {
+	handlers := b.NodeEventHandlers(nodeID)
+	if len(handlers) == 0 {
 		return nil
 	}
 	out := make([]string, 0, len(handlers))
@@ -528,6 +611,42 @@ func (b *WorkflowContractBundle) NodeHandlerSubscriptions(nodeID string) []strin
 	}
 	sort.Strings(out)
 	return out
+}
+
+func (b *WorkflowContractBundle) nodeContract(nodeID string) (SystemNodeContract, bool) {
+	nodeID = strings.TrimSpace(nodeID)
+	if b == nil || nodeID == "" {
+		return SystemNodeContract{}, false
+	}
+	if entry, ok := b.Nodes[nodeID]; ok {
+		return entry, true
+	}
+	for _, entry := range b.Nodes {
+		if strings.TrimSpace(entry.ID) == nodeID {
+			return entry, true
+		}
+	}
+	for _, view := range b.ProjectViews() {
+		if entry, ok := view.Nodes[nodeID]; ok {
+			return entry, true
+		}
+		for _, entry := range view.Nodes {
+			if strings.TrimSpace(entry.ID) == nodeID {
+				return entry, true
+			}
+		}
+	}
+	for _, view := range b.FlowViews() {
+		if entry, ok := view.Nodes[nodeID]; ok {
+			return entry, true
+		}
+		for _, entry := range view.Nodes {
+			if strings.TrimSpace(entry.ID) == nodeID {
+				return entry, true
+			}
+		}
+	}
+	return SystemNodeContract{}, false
 }
 func (b *WorkflowContractBundle) NodeEventHandler(nodeID, eventType string) (SystemNodeEventHandler, bool) {
 	if b == nil {

--- a/internal/runtime/contracts/workflow_contract_accessors_test.go
+++ b/internal/runtime/contracts/workflow_contract_accessors_test.go
@@ -1,0 +1,95 @@
+package contracts
+
+import (
+	"testing"
+
+	"swarm/internal/runtime/flowmodel"
+)
+
+func TestResolveFlowInputAutoWire_ReturnsScopedProducerForUniquePinMatch(t *testing.T) {
+	producer := FlowContractView{
+		Paths: FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Outputs: FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "producer",
+	}
+	consumer := FlowContractView{
+		Paths: FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Inputs: FlowInputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "consumer",
+	}
+	root := FlowContractView{Children: []FlowContractView{producer, consumer}}
+	bundle := &WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[FlowContractView]{
+			Root: &root,
+			ByID: map[string]*FlowContractView{
+				"producer": &root.Children[0],
+				"consumer": &root.Children[1],
+			},
+		},
+	}
+
+	resolution := bundle.ResolveFlowInputAutoWire("consumer", "scan.requested")
+	if got, want := resolution.ProducerFlows, []string{"producer"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("ProducerFlows = %#v, want %#v", got, want)
+	}
+	if got, want := resolution.Patterns, []string{"producer/scan.requested"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Patterns = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveFlowInputAutoWire_FailsClosedOnAmbiguousPinMatch(t *testing.T) {
+	producerA := FlowContractView{
+		Paths: FlowContractPaths{ID: "producer_a", Flow: "producer_a"},
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Outputs: FlowOutputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "producer_a",
+	}
+	producerB := FlowContractView{
+		Paths: FlowContractPaths{ID: "producer_b", Flow: "producer_b"},
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Outputs: FlowOutputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "producer_b",
+	}
+	consumer := FlowContractView{
+		Paths: FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Inputs: FlowInputPins{Events: []string{"ticket.ready"}},
+			},
+		},
+		Path: "consumer",
+	}
+	root := FlowContractView{Children: []FlowContractView{producerA, producerB, consumer}}
+	bundle := &WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[FlowContractView]{
+			Root: &root,
+			ByID: map[string]*FlowContractView{
+				"producer_a": &root.Children[0],
+				"producer_b": &root.Children[1],
+				"consumer":   &root.Children[2],
+			},
+		},
+	}
+
+	resolution := bundle.ResolveFlowInputAutoWire("consumer", "ticket.ready")
+	if got, want := resolution.ProducerFlows, []string{"producer_a", "producer_b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("ProducerFlows = %#v, want %#v", got, want)
+	}
+	if len(resolution.Patterns) != 0 {
+		t.Fatalf("Patterns = %#v, want none for ambiguous auto-wire", resolution.Patterns)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -89,6 +89,12 @@ type WorkflowSemanticView struct {
 	HandlerTransitions     []HandlerTransitionSemantic
 	HandlerTransitionIndex map[string]map[string]HandlerTransitionSemantic
 }
+
+type FlowInputAutoWireResolution struct {
+	EventType     string
+	Patterns      []string
+	ProducerFlows []string
+}
 type HandlerTransitionSemantic struct {
 	ID               string
 	NodeID           string

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -187,8 +187,6 @@ validation.started:
 validation-orchestrator:
   id: validation-orchestrator
   execution_type: system_node
-  subscribes_to:
-    - scoring/vertical.shortlisted
   produces:
     - validation.started
   event_handlers:

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -124,8 +124,9 @@ func LoadWorkflowNodes(source semanticview.Source) ([]WorkflowNode, error) {
 		if !ok {
 			return nil, fmt.Errorf("system node %q missing from %s", nodeID, path)
 		}
-		subscriptions := make([]events.EventType, 0, len(entry.SubscribesTo))
-		for _, evt := range entry.SubscribesTo {
+		runtimeSubscriptions := source.NodeRuntimeSubscriptions(nodeID)
+		subscriptions := make([]events.EventType, 0, len(runtimeSubscriptions))
+		for _, evt := range runtimeSubscriptions {
 			for _, resolved := range workflowNodeSubscriptionAliases(source, nodeID, evt) {
 				if resolved == "" {
 					continue
@@ -202,7 +203,7 @@ func workflowFlowInputProducerAliases(source semanticview.Source, targetFlowID, 
 	if source == nil {
 		return nil
 	}
-	return source.FlowInputProducerPatterns(targetFlowID, eventType)
+	return append([]string{}, source.ResolveFlowInputAutoWire(targetFlowID, eventType).Patterns...)
 }
 
 func workflowFlowHasInputEvent(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -112,3 +112,75 @@ func TestWorkflowNodeExternalEventType_ExternalizesLocalFlowOutputs(t *testing.T
 		t.Fatalf("workflowNodeExternalEventType = %q, want child/work.completed", got)
 	}
 }
+
+func TestLoadWorkflowNodes_UsesHandlerKeysForCrossFlowPinAutoWire(t *testing.T) {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "producer",
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": {
+				ID:       "consumer-node",
+				Produces: []string{"scan.completed"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"scan.requested": {
+						Emits: runtimecontracts.EventEmission{Single: "scan.completed"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.completed": {OwningNode: "consumer-node"},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, consumer}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"consumer": &root.Children[1],
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"consumer-node": {
+					"scan.requested": {},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": consumer.Nodes["consumer-node"],
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"consumer/scan.completed": {OwningNode: "consumer-node"},
+		},
+	}
+
+	nodes, err := LoadWorkflowNodes(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("LoadWorkflowNodes returned %d nodes, want 1", len(nodes))
+	}
+	for _, subscription := range nodes[0].Subscriptions {
+		if string(subscription) == "producer/scan.requested" {
+			return
+		}
+	}
+	t.Fatalf("Subscriptions = %#v, want producer/scan.requested", nodes[0].Subscriptions)
+}

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -165,6 +165,9 @@ func (s bundleSource) FlowHasInputEvent(flowID, eventType string) bool {
 func (s bundleSource) FlowHasOutputEvent(flowID, eventType string) bool {
 	return s.bundle.FlowHasOutputEvent(flowID, eventType)
 }
+func (s bundleSource) ResolveFlowInputAutoWire(flowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
+	return s.bundle.ResolveFlowInputAutoWire(flowID, eventType)
+}
 func (s bundleSource) FlowInputProducerPatterns(flowID, eventType string) []string {
 	return s.bundle.FlowInputProducerPatterns(flowID, eventType)
 }
@@ -209,6 +212,9 @@ func (s bundleSource) AgentContractSource(agentID string) (runtimecontracts.Cont
 }
 func (s bundleSource) ResolveNodeEventReference(nodeID, eventType string) string {
 	return s.bundle.ResolveNodeEventReference(nodeID, eventType)
+}
+func (s bundleSource) NodeRuntimeSubscriptions(nodeID string) []string {
+	return s.bundle.NodeRuntimeSubscriptions(nodeID)
 }
 func (s bundleSource) NodeHandlerSubscriptions(nodeID string) []string {
 	return s.bundle.NodeHandlerSubscriptions(nodeID)

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -35,6 +35,7 @@ type Source interface {
 	WritePinOwners(pin string) []string
 	FlowHasInputEvent(flowID, eventType string) bool
 	FlowHasOutputEvent(flowID, eventType string) bool
+	ResolveFlowInputAutoWire(flowID, eventType string) runtimecontracts.FlowInputAutoWireResolution
 	FlowInputProducerPatterns(flowID, eventType string) []string
 	ResolveFlowEventReference(flowID, eventType string) string
 	ResolveFlowEventPattern(flowID, pattern string) string
@@ -50,6 +51,7 @@ type Source interface {
 	NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool)
 	AgentContractSource(agentID string) (runtimecontracts.ContractItemSource, bool)
 	ResolveNodeEventReference(nodeID, eventType string) string
+	NodeRuntimeSubscriptions(nodeID string) []string
 	NodeHandlerSubscriptions(nodeID string) []string
 	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
 	NodeEventHandler(nodeID, eventType string) (runtimecontracts.SystemNodeEventHandler, bool)


### PR DESCRIPTION
## Summary
- make the compiled contracts layer the canonical owner of default cross-flow pin auto-wiring and node runtime subscription surfaces
- route bus and pipeline cross-flow delivery through those compiled accessors instead of re-deriving the common case from explicit topology wiring
- fail closed on ambiguous pin matches unless the contract uses an explicit scoped subscription escape hatch

## Why
Issue #23 is about making pin-based auto-wiring the default cross-flow routing model when the contract interface is unambiguous. The previous runtime path still depended on explicit `subscribes_to` topology in the common case, which leaked routing topology into authoring and duplicated semantics across layers.

## Impact
- unambiguous flow input pins now auto-wire to a single producer flow by default
- handler keys participate in a node's effective runtime subscription surface, so common pin-wired flows no longer require duplicate explicit topology wiring
- ambiguous cross-flow pin matches no longer produce default routes; boot verification and runtime both consume the same compiled ambiguity result

## Validation
- `go test ./internal/runtime/contracts ./internal/runtime/bus ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`

Closes #23
