### PR TITLE
[agent-c][issue #28] Replace ambient semantic-source lookup with explicit subsystem injection

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -12,7 +12,6 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -74,9 +73,6 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		store = InMemoryEventStore{}
 	}
 	semanticSource := opts.ContractBundle
-	if semanticSource == nil {
-		semanticSource = runtimepipeline.DefaultWorkflowSemanticSourceOrNil()
-	}
 	filtered := make([]EventInterceptor, 0, len(opts.Interceptors))
 	for _, it := range opts.Interceptors {
 		if it != nil {

--- a/internal/runtime/bus/semantic_source_injection_test.go
+++ b/internal/runtime/bus/semantic_source_injection_test.go
@@ -1,0 +1,61 @@
+package bus_test
+
+import (
+	"testing"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestNewEventBusWithOptions_DoesNotUseAmbientWorkflowSemanticSource(t *testing.T) {
+	scoring := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "scoring", Flow: "scoring"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"score.dimension_complete"}},
+			},
+		},
+		Path: "scoring",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"score.dimension_complete": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scoring-node": {
+				ID:           "scoring-node",
+				SubscribesTo: []string{"score.dimension_complete"},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{scoring}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"scoring": &root.Children[0],
+			},
+		},
+	}
+
+	previous := runtimepipeline.DefaultWorkflowModuleOrNil()
+	runtimepipeline.SetDefaultWorkflowModuleFactory(func() runtimepipeline.WorkflowModule {
+		return &fixtureWorkflowModule{source: semanticview.Wrap(bundle)}
+	})
+	t.Cleanup(func() {
+		if previous == nil {
+			runtimepipeline.SetDefaultWorkflowModuleFactory(nil)
+			return
+		}
+		runtimepipeline.SetDefaultWorkflowModuleFactory(func() runtimepipeline.WorkflowModule { return previous })
+	})
+
+	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if got := eb.RouteTable().Resolve("scoring/score.dimension_complete"); len(got) != 0 {
+		t.Fatalf("Resolve(scoring/score.dimension_complete) = %#v, want no ambient-derived routes", got)
+	}
+}

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -8,10 +8,11 @@ import (
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
@@ -19,6 +20,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, inte
 	return runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
 		Logger:              hook,
 		InterceptorProvider: interceptorProvider,
+		ContractBundle:      source,
 		PayloadValidator:    payloadValidator,
 	})
 }

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	llm "swarm/internal/runtime/llm"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	workspace "swarm/internal/runtime/workspace"
 )
@@ -26,6 +27,7 @@ type AgentManager struct {
 	factory                  AgentFactory
 	store                    ManagerPersistence
 	sessions                 sessions.Registry
+	semanticSource           semanticview.Source
 	budget                   BudgetGuard
 	runtimeMode              string
 	throttleSuppressPrefixes []string
@@ -95,6 +97,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		store:                    store,
 		workspaces:               opts.Workspaces,
 		sessions:                 opts.Sessions,
+		semanticSource:           opts.SemanticSource,
 		runtimeMode:              strings.TrimSpace(opts.RuntimeMode),
 		budget:                   opts.Budget,
 		throttleSuppressPrefixes: throttleSuppressPrefixes,

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -193,7 +193,7 @@ func (am *AgentManager) defaultManagerAgentID(cfg runtimeactors.AgentConfig) str
 	if managerID := normalizedManagerFallback(cfg, cfg.ManagerFallback); managerID != "" {
 		return managerID
 	}
-	if source := runtimepipeline.DefaultWorkflowSemanticSourceOrNil(); source != nil {
+	if source := am.semanticSource; source != nil {
 		if _, entry, ok := semanticview.ResolveAgentRegistryEntry(source, cfg); ok {
 			if managerID := normalizedManagerFallback(cfg, strings.TrimSpace(entry.ManagerFallback)); managerID != "" {
 				return managerID

--- a/internal/runtime/manager/semantic_source_test.go
+++ b/internal/runtime/manager/semantic_source_test.go
@@ -1,0 +1,94 @@
+package manager
+
+import (
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+)
+
+type managerSemanticSourceTestModule struct {
+	source semanticview.Source
+}
+
+func (m managerSemanticSourceTestModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func (managerSemanticSourceTestModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return nil
+}
+
+func (managerSemanticSourceTestModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return nil
+}
+
+func (managerSemanticSourceTestModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return nil
+}
+
+func (managerSemanticSourceTestModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return nil
+}
+
+func TestDefaultManagerAgentID_UsesInjectedSemanticSource(t *testing.T) {
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "ops", Flow: "ops"},
+		Path:  "ops",
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": {Role: "worker", ManagerFallback: "control-injected"},
+		},
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"ops": &flow,
+			},
+		},
+	})
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{SemanticSource: source})
+
+	got := am.defaultManagerAgentID(runtimeactors.AgentConfig{ID: "worker-1", Role: "worker"})
+	if got != "control-injected" {
+		t.Fatalf("defaultManagerAgentID = %q, want control-injected", got)
+	}
+}
+
+func TestDefaultManagerAgentID_DoesNotUseAmbientWorkflowSemanticSource(t *testing.T) {
+	previous := runtimepipeline.DefaultWorkflowModuleOrNil()
+	runtimepipeline.SetDefaultWorkflowModuleFactory(func() runtimepipeline.WorkflowModule {
+		flow := runtimecontracts.FlowContractView{
+			Paths: runtimecontracts.FlowContractPaths{ID: "ops", Flow: "ops"},
+			Path:  "ops",
+			Agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {Role: "worker", ManagerFallback: "control-ambient"},
+			},
+		}
+		return managerSemanticSourceTestModule{
+			source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+				FlowTree: runtimecontracts.FlowTree{
+					Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}},
+					ByID: map[string]*runtimecontracts.FlowContractView{
+						"ops": &flow,
+					},
+				},
+			}),
+		}
+	})
+	t.Cleanup(func() {
+		if previous == nil {
+			runtimepipeline.SetDefaultWorkflowModuleFactory(nil)
+			return
+		}
+		runtimepipeline.SetDefaultWorkflowModuleFactory(func() runtimepipeline.WorkflowModule { return previous })
+	})
+
+	am := NewAgentManager(nil, nil)
+	got := am.defaultManagerAgentID(runtimeactors.AgentConfig{ID: "worker-1", Role: "worker"})
+	if got != "" {
+		t.Fatalf("defaultManagerAgentID = %q, want empty without injected semantic source", got)
+	}
+}

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -10,6 +10,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	models "swarm/internal/runtime/core/actors"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	workspace "swarm/internal/runtime/workspace"
 )
@@ -124,6 +125,7 @@ type StrategicContext = json.RawMessage
 type AgentManagerOptions struct {
 	Workspaces                workspace.Lifecycle
 	Sessions                  sessions.Registry
+	SemanticSource            semanticview.Source
 	RuntimeMode               string
 	Budget                    BudgetGuard
 	ThrottleSuppressPrefixes  []string

--- a/internal/runtime/pipeline/module.go
+++ b/internal/runtime/pipeline/module.go
@@ -34,11 +34,3 @@ func defaultWorkflowModuleOrNil() WorkflowModule {
 func DefaultWorkflowModuleOrNil() WorkflowModule {
 	return defaultWorkflowModuleOrNil()
 }
-
-func DefaultWorkflowSemanticSourceOrNil() semanticview.Source {
-	module := defaultWorkflowModuleOrNil()
-	if module == nil {
-		return nil
-	}
-	return module.SemanticSource()
-}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -78,31 +78,6 @@ var ()
 
 const runtimeQuiescenceStableChecks = 3
 
-func runtimeControlPlaneRecipient() string {
-	if recipient := controlPlaneRecipientFromSource(runtimepipeline.DefaultWorkflowSemanticSourceOrNil()); recipient != "" {
-		return recipient
-	}
-	return ""
-}
-
-func controlPlaneRecipientFromSource(source semanticview.Source) string {
-	if source == nil {
-		return ""
-	}
-	for _, key := range []string{"control_plane_agent_id", "manager_fallback_agent_id"} {
-		if value, ok := semanticview.PolicyValueForFlow(source, "", key); ok {
-			if agentID := strings.TrimSpace(asString(value.Value)); agentID != "" {
-				return agentID
-			}
-		}
-	}
-	return ""
-}
-
-func DefaultControlPlaneRecipient() string {
-	return strings.TrimSpace(runtimeControlPlaneRecipient())
-}
-
 func (rt *Runtime) WaitForQuiescence(ctx context.Context) error {
 	if rt == nil {
 		return nil
@@ -256,7 +231,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		rt.Logger = NewRuntimeLogger(stores.SQLDB)
 	}
 	payloadValidator := newRuntimePayloadValidator(runtimeEnvBool("SWARM_STRICT_PAYLOAD_VALIDATION", false), rt.Logger)
-	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, func() []runtimebus.EventInterceptor {
+	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil
 		}
@@ -410,6 +385,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	rt.Manager = runtimemanager.NewAgentManagerWithOptions(rt.Bus, factory, runtimemanager.AgentManagerOptions{
 		Workspaces:               rt.Workspace,
 		Sessions:                 stores.SessionRegistry,
+		SemanticSource:           source,
 		RuntimeMode:              cfg.LLM.RuntimeMode,
 		Budget:                   rt.Budget,
 		ThrottleSuppressPrefixes: runtimeThrottleSuppressPrefixes(source),

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -323,7 +323,11 @@ func (m *DockerManager) RuntimeWorkspaceContainers(ctx context.Context) ([]strin
 }
 
 func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.AgentConfig) (*Target, error) {
-	switch workspaceRouteClass(WorkspaceClass(actor)) {
+	class, err := m.workspaceClass(actor)
+	if err != nil {
+		return nil, err
+	}
+	switch workspaceRouteClass(class) {
 	case "scaffold":
 		if err := m.EnsureContainerRunning(ctx, m.cfg.ScaffoldContainer, []string{
 			"-v", fmt.Sprintf("%s:%s", m.cfg.ScaffoldVolume, m.cfg.ScaffoldWorkdir),
@@ -374,29 +378,18 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 	}, nil
 }
 
-func WorkspaceClass(actor models.AgentConfig) string {
+func (m *DockerManager) workspaceClass(actor models.AgentConfig) (string, error) {
 	if cfgClass := strings.TrimSpace(actor.WorkspaceClass); cfgClass != "" {
-		return cfgClass
+		return cfgClass, nil
 	}
-	if source := runtimepipeline.DefaultWorkflowSemanticSourceOrNil(); source != nil {
-		if entry, ok := workflowAgentRegistryEntry(source, actor.ID, actor.Role); ok {
-			return strings.TrimSpace(entry.WorkspaceClass)
-		}
+	source := m.semanticSource()
+	if source == nil {
+		return "", nil
 	}
-	return ""
-}
-
-func RoleWorkspaceClass(role string) string {
-	role = strings.TrimSpace(role)
-	if role == "" {
-		return ""
+	if _, entry, ok := semanticview.ResolveAgentRegistryEntry(source, actor); ok {
+		return strings.TrimSpace(entry.WorkspaceClass), nil
 	}
-	if source := runtimepipeline.DefaultWorkflowSemanticSourceOrNil(); source != nil {
-		if entry, ok := workflowAgentRegistryEntry(source, "", role); ok {
-			return strings.TrimSpace(entry.WorkspaceClass)
-		}
-	}
-	return ""
+	return "", nil
 }
 
 func workspaceRouteClass(class string) string {
@@ -410,27 +403,25 @@ func workspaceRouteClass(class string) string {
 	}
 }
 
-func RoleWorkspaceRouteClass(role string) string {
-	return workspaceRouteClass(RoleWorkspaceClass(role))
-}
-
-func workflowAgentRegistryEntry(source semanticview.Source, agentID, role string) (runtimecontracts.AgentRegistryEntry, bool) {
-	entry, ok := semanticview.FindAgentEntry(source, agentID, role)
-	return entry, ok
-}
-
 func (m *DockerManager) semanticSource() semanticview.Source {
-	if m != nil && m.source != nil {
-		return m.source
+	if m == nil {
+		return nil
 	}
-	return runtimepipeline.DefaultWorkflowSemanticSourceOrNil()
+	return m.source
 }
 
 func (m *DockerManager) workspaceScopeForActor(actor models.AgentConfig) (string, string, error) {
-	class := WorkspaceClass(actor)
+	class, err := m.workspaceClass(actor)
+	if err != nil {
+		return "", "", err
+	}
 	scope := "per-agent"
 	if class != "" {
-		resolved, ok, err := workspaceClassScope(m.semanticSource(), class)
+		source := m.semanticSource()
+		if source == nil {
+			return "", "", fmt.Errorf("workspace resolution failed: semantic source is required for workspace_class %q", class)
+		}
+		resolved, ok, err := workspaceClassScope(source, class)
 		if err != nil {
 			return "", "", err
 		}

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -181,6 +181,81 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspace_UsesInjectedSemanticSourceForRoleLookup(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.SharedDataSource = dataDir
+	cfg.ContractsSource = contractsDir
+	cfg.WorkspaceNetwork = ""
+	cfg.WorkspaceImage = "test-image"
+	manager.SetConfig(cfg)
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"workspace_classes": {
+				Value: map[string]any{
+					"shared_flow": map[string]any{"workspace_scope": "per-flow-instance"},
+				},
+			},
+		}},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": {Role: "worker", WorkspaceClass: "shared_flow"},
+		},
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{{
+				Paths: runtimecontracts.FlowContractPaths{ID: "ops", Flow: "ops"},
+				Path:  "ops",
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{
+					"worker": {Role: "worker", WorkspaceClass: "shared_flow"},
+				},
+			}}},
+			ByID: map[string]*runtimecontracts.FlowContractView{},
+		},
+	})
+	if err := manager.ValidateSource(context.Background(), source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		switch args[0] {
+		case "inspect":
+			return "", fmt.Errorf("no such object")
+		case "create", "start":
+			return "", nil
+		default:
+			return "", nil
+		}
+	})
+
+	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+		ID:       "worker-1",
+		Role:     "worker",
+		FlowPath: "ops/instance-1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	if target == nil || target.Container != "swarm-flow-ops-instance-1" {
+		t.Fatalf("target = %#v, want swarm-flow-ops-instance-1", target)
+	}
+}
+
+func TestResolveWorkspace_FailsClosedWithoutInjectedSourceForWorkspaceClassScope(t *testing.T) {
+	manager := NewDockerManager(nil)
+	_, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+		ID:             "worker-1",
+		WorkspaceClass: "dedicated",
+	})
+	if err == nil || !strings.Contains(err.Error(), `semantic source is required for workspace_class "dedicated"`) {
+		t.Fatalf("expected missing semantic source error, got %v", err)
+	}
+}
+
 func TestEnsurePrereqs_CreatesMissingNetworkAndBuildsMissingImage(t *testing.T) {
 	manager := NewDockerManager(nil)
 	cfg := DefaultDockerConfig()


### PR DESCRIPTION
## Summary
- replace ambient semantic-source reads in runtime wiring with explicit constructor injection for the event bus and agent manager
- make workspace resolution depend on its injected semantic source instead of package-level lookup, and fail closed when workspace-class scope resolution lacks that source
- add focused regression tests proving the injected path is canonical and ambient workflow globals are ignored in the touched seams

## Why
Issue #28 requires semantic ownership to be explicit, local, and testable. The runtime had package-level semantic-source access that let subsystems recover semantics indirectly from pipeline globals, which obscured ownership and made constructor behavior harder to reason about.

## Impact
- touched runtime subsystems now receive semantic source explicitly from runtime wiring
- ambient semantic-source lookup is removed from production runtime, manager, workspace, and event-bus paths touched here
- missing injected semantic source now fails closed for workspace-class scope resolution instead of silently depending on process-global state

## Validation
- `go test ./internal/runtime/bus ./internal/runtime/manager ./internal/runtime/workspace -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./... -count=1`

Closes #28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace class resolution to use explicitly configured semantic sources instead of ambient defaults, ensuring correct workspace configuration.

* **Chores**
  * Removed unused control plane recipient helper functions.
  * Refactored semantic source handling for improved dependency injection clarity.

* **Tests**
  * Added tests validating semantic source isolation and workspace configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->