### PR TITLE
[agent-d][issue #31] Persist canonical turn summaries instead of reconstructing dashboard views from raw transcript payloads

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2436,9 +2436,12 @@ platform_tables:
       description: 'Append-only per-turn agent execution audit log. Records the triggering event context, visible tools,
         attempted tool calls, emitted event names, canonical per-turn turn_blocks, and sanitized request/response payloads.
         turn_blocks is the ordered per-turn projection/surface for the flight recorder. It is populated from the canonical
-        platform.runtime_log stream plus turn-local publish/tool transcript context. Used by all conversation modes. For
-        task mode, this is the primary per-turn audit record (no agent_sessions row exists). For session modes, this complements
-        the live session with a queryable historical record.'
+        platform.runtime_log stream plus turn-local publish/tool transcript context. turn_blocks MUST include exactly one
+        canonical turn_summary block when assistant-visible output, outcome, reasoning blocks, progress updates, or tool
+        results are present for the turn. The turn_summary block is the canonical persisted read-model surface for dashboard/debug
+        consumers; readers MUST NOT reconstruct those fields from raw transcript payloads. Used by all conversation modes.
+        For task mode, this is the primary per-turn audit record (no agent_sessions row exists). For session modes, this
+        complements the live session with a queryable historical record.'
       ddl: "CREATE TABLE agent_turns (\n    turn_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \             UUID REFERENCES runs(run_id),\n    agent_id           TEXT NOT NULL,\n    session_id         UUID\
         \ NOT NULL,\n    runtime_mode       TEXT NOT NULL DEFAULT 'task' CHECK (runtime_mode IN ('task', 'session', 'session_per_entity')),\n\

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -464,222 +464,62 @@ func normalizeConversationTurn(item ConversationTurn) ConversationTurn {
 }
 
 func summarizeConversationTurn(item ConversationTurn) (string, string, []string, []string, []any) {
-	if len(item.TurnBlocks) > 0 {
-		return summarizeConversationTurnBlocks(item.TurnBlocks)
-	}
-	return summarizeConversationTurnResponse(item.ResponsePayload)
-}
-
-func summarizeConversationTurnResponse(payload map[string]any) (string, string, []string, []string, []any) {
-	if len(payload) == 0 {
-		return "", "", nil, nil, nil
-	}
-	assistantText := strings.TrimSpace(readString(payload["result"]))
-	if assistantText == "" {
-		assistantText = strings.TrimSpace(readString(payload["assistant_text"]))
-	}
-	outcome := assistantText
-	reasoning := []string{}
-	progress := []string{}
-	toolResults := []any{}
-
-	raw := strings.TrimSpace(readString(payload["raw"]))
-	if raw == "" {
-		return assistantText, outcome, reasoning, progress, toolResults
-	}
-	lines := strings.Split(raw, "\n")
-	assistantSeen := map[string]struct{}{}
-	reasoningSeen := map[string]struct{}{}
-	progressSeen := map[string]struct{}{}
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		obj := map[string]any{}
-		if err := json.Unmarshal([]byte(line), &obj); err != nil {
-			continue
-		}
-		switch strings.TrimSpace(readString(obj["type"])) {
-		case "assistant":
-			blocks := cliContentBlocks(obj)
-			texts, thinks := parseConversationBlocks(blocks)
-			for _, text := range texts {
-				if text == "" {
-					continue
-				}
-				if _, ok := assistantSeen[text]; ok {
-					continue
-				}
-				assistantSeen[text] = struct{}{}
-				if assistantText == "" {
-					assistantText = text
-				} else if looksLikeProgressUpdate(text) {
-					if _, ok := progressSeen[text]; !ok {
-						progressSeen[text] = struct{}{}
-						progress = append(progress, text)
-					}
-				}
-			}
-			for _, thought := range thinks {
-				if thought == "" {
-					continue
-				}
-				if _, ok := reasoningSeen[thought]; ok {
-					continue
-				}
-				reasoningSeen[thought] = struct{}{}
-				reasoning = append(reasoning, thought)
-			}
-		case "user":
-			for _, entry := range cliToolResults(obj) {
-				toolResults = append(toolResults, entry)
-			}
-		case "result":
-			if text := strings.TrimSpace(readString(obj["result"])); text != "" {
-				if assistantText == "" {
-					assistantText = text
-				}
-				outcome = text
-			}
-		}
-	}
-	if outcome == "" {
-		outcome = assistantText
-	}
-	return assistantText, outcome, reasoning, progress, toolResults
+	return summarizeConversationTurnBlocks(item.TurnBlocks)
 }
 
 func summarizeConversationTurnBlocks(blocks []any) (string, string, []string, []string, []any) {
-	assistantText := ""
-	outcome := ""
-	reasoning := []string{}
-	progress := []string{}
-	toolResults := []any{}
-	for _, raw := range blocks {
-		entry, _ := raw.(map[string]any)
-		switch strings.TrimSpace(readString(entry["kind"])) {
-		case "assistant_text":
-			if text := strings.TrimSpace(readString(entry["text"])); text != "" {
-				assistantText = text
-			}
-		case "outcome":
-			if text := strings.TrimSpace(readString(entry["text"])); text != "" {
-				outcome = text
-				if assistantText == "" {
-					assistantText = text
-				}
-			}
-		case "reasoning":
-			if text := strings.TrimSpace(readString(entry["text"])); text != "" {
-				reasoning = append(reasoning, text)
-			}
-		case "progress":
-			if text := strings.TrimSpace(readString(entry["text"])); text != "" {
-				progress = append(progress, text)
-			}
-		case "tool_result":
-			toolResults = append(toolResults, entry)
-		}
+	summary, ok := readTurnSummaryBlock(blocks)
+	if !ok {
+		return "", "", nil, nil, nil
 	}
+	assistantText := strings.TrimSpace(readString(summary["assistant_visible_output"]))
+	outcome := strings.TrimSpace(readString(summary["outcome"]))
 	if outcome == "" {
 		outcome = assistantText
 	}
+	reasoning := readStringSlice(summary["reasoning_blocks"])
+	progress := readStringSlice(summary["progress_updates"])
+	toolResults := readAnySlice(summary["tool_results"])
 	return assistantText, outcome, reasoning, progress, toolResults
 }
 
-func cliContentBlocks(obj map[string]any) []any {
-	if content, ok := obj["content"].([]any); ok {
-		return content
-	}
-	msg, _ := obj["message"].(map[string]any)
-	if content, ok := msg["content"].([]any); ok {
-		return content
-	}
-	return nil
-}
-
-func parseConversationBlocks(blocks []any) ([]string, []string) {
-	texts := []string{}
-	reasoning := []string{}
-	for _, block := range blocks {
-		entry, _ := block.(map[string]any)
-		if len(entry) == 0 {
+func readTurnSummaryBlock(blocks []any) (map[string]any, bool) {
+	for _, raw := range blocks {
+		entry, _ := raw.(map[string]any)
+		if strings.TrimSpace(readString(entry["kind"])) != "turn_summary" {
 			continue
 		}
-		switch strings.TrimSpace(readString(entry["type"])) {
-		case "text":
-			if text := strings.TrimSpace(readString(entry["text"])); text != "" {
-				texts = append(texts, text)
-			}
-		case "thinking":
-			if thought := strings.TrimSpace(firstReadableString(
-				readString(entry["thinking"]),
-				readString(entry["text"]),
-			)); thought != "" {
-				reasoning = append(reasoning, thought)
-			}
-		default:
-			if thought := strings.TrimSpace(readString(entry["thinking"])); thought != "" {
-				reasoning = append(reasoning, thought)
-			}
+		data, _ := entry["data"].(map[string]any)
+		if len(data) == 0 {
+			return map[string]any{}, false
 		}
+		return data, true
 	}
-	return texts, reasoning
+	return map[string]any{}, false
 }
 
-func cliToolResults(obj map[string]any) []any {
-	blocks := cliContentBlocks(obj)
-	if len(blocks) == 0 {
+func readStringSlice(value any) []string {
+	list, ok := value.([]any)
+	if !ok || len(list) == 0 {
 		return nil
 	}
-	out := []any{}
-	for _, item := range blocks {
-		entry, _ := item.(map[string]any)
-		if strings.TrimSpace(readString(entry["type"])) != "tool_result" {
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		text := strings.TrimSpace(readString(item))
+		if text == "" {
 			continue
 		}
-		result := map[string]any{
-			"tool_use_id": readString(entry["tool_use_id"]),
-		}
-		if content, ok := entry["content"].([]any); ok && len(content) > 0 {
-			result["content"] = content
-			if first, ok := content[0].(map[string]any); ok {
-				if text := strings.TrimSpace(readString(first["text"])); text != "" {
-					var decoded any
-					if json.Unmarshal([]byte(text), &decoded) == nil {
-						result["output"] = decoded
-					} else {
-						result["output"] = text
-					}
-				}
-			}
-		}
-		out = append(out, result)
+		out = append(out, text)
 	}
 	return out
 }
 
-func looksLikeProgressUpdate(text string) bool {
-	text = strings.TrimSpace(strings.ToLower(text))
-	if text == "" {
-		return false
+func readAnySlice(value any) []any {
+	list, _ := value.([]any)
+	if len(list) == 0 {
+		return nil
 	}
-	for _, prefix := range []string{
-		"i'll ",
-		"i will ",
-		"starting ",
-		"checking ",
-		"reviewing ",
-		"analyzing ",
-		"searching ",
-		"scheduling ",
-	} {
-		if strings.HasPrefix(text, prefix) {
-			return true
-		}
-	}
-	return false
+	return append([]any(nil), list...)
 }
 
 func firstReadableString(values ...string) string {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -469,11 +469,8 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	if !ok || lastTurn["parse_ok"] != true {
 		t.Fatalf("expected runtime_state.last_turn parse_ok=true, got %+v", item.RuntimeState)
 	}
-	if item.Turns[0].AssistantVisibleOutput != "14-day review scheduled." {
-		t.Fatalf("assistant_visible_output = %q", item.Turns[0].AssistantVisibleOutput)
-	}
-	if len(item.Turns[0].ToolResults) != 1 {
-		t.Fatalf("tool_results = %#v", item.Turns[0].ToolResults)
+	if item.Turns[0].AssistantVisibleOutput != "" || item.Turns[0].Outcome != "" || len(item.Turns[0].ToolResults) != 0 {
+		t.Fatalf("expected missing canonical summary to fail closed, got %+v", item.Turns[0])
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -503,7 +500,8 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 		{"kind":"tool_use","tool_name":"schedule","input":{"delay_seconds":1209600},"data":{"tool_use_id":"toolu_1"}},
 		{"kind":"tool_result","tool_name":"schedule","output":{"status":"scheduled"},"data":{"tool_use_id":"toolu_1"}},
 		{"kind":"assistant_text","text":"Parking for manual review."},
-		{"kind":"outcome","text":"14-day review scheduled."}
+		{"kind":"outcome","text":"14-day review scheduled."},
+		{"kind":"turn_summary","data":{"assistant_visible_output":"Parking for manual review.","outcome":"14-day review scheduled.","tool_results":[{"tool_name":"schedule","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}
 	]`
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
@@ -559,8 +557,9 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
-			Audits: store.SchemaFlavorCanonical,
-			Turns:  store.SchemaFlavorCanonical,
+			Audits:     store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
 		},
 	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
@@ -596,7 +595,7 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 		}).AddRow(
 			"turn-1", "agent-1", "audit-1", "task", "", "", "evt-1", "task.run", "task-1",
 			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
-			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[]`), true, 25, 0, "", now,
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[{"kind":"turn_summary","data":{"assistant_visible_output":"done","outcome":"done"}}]`), true, 25, 0, "", now,
 		))
 
 	item, ok, err := reader.Get(context.Background(), "audit-1")
@@ -608,6 +607,64 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 	}
 	if len(item.Messages) != 1 || len(item.Turns) != 1 || item.Turns[0].Outcome != "done" {
 		t.Fatalf("unexpected task audit payload: %+v", item)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetUsesCanonicalTurnSummaryProgress(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"brief"}`
+	messagePayload := `[{"role":"assistant","content":"hello"}]`
+	turnBlocksPayload := `[
+		{"kind":"turn_summary","data":{"assistant_visible_output":"Parking for manual review.","outcome":"14-day review scheduled.","progress_updates":["Scheduling the follow-up review."],"reasoning_blocks":["Need a manual checkpoint."]}}
+	]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "sess-1", "task", "global", "entity-1", "evt-1", "scoring/vertical.marginal", "",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"stale fallback text"}`), []byte(turnBlocksPayload), true, 92282, 0, "", now,
+		))
+
+	item, ok, err := reader.Get(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if !ok || len(item.Turns) != 1 {
+		t.Fatalf("unexpected detail: %+v", item)
+	}
+	if len(item.Turns[0].ProgressUpdates) != 1 || item.Turns[0].ProgressUpdates[0] != "Scheduling the follow-up review." {
+		t.Fatalf("progress_updates = %#v", item.Turns[0].ProgressUpdates)
+	}
+	if len(item.Turns[0].ReasoningBlocks) != 1 || item.Turns[0].ReasoningBlocks[0] != "Need a manual checkpoint." {
+		t.Fatalf("reasoning_blocks = %#v", item.Turns[0].ReasoningBlocks)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -317,9 +317,7 @@ func (r *AnthropicAPIRuntime) persistTurn(ctx context.Context, turn AgentTurnRec
 	if r.turns == nil {
 		return
 	}
-	if len(turn.TurnBlocks) == 0 {
-		turn.TurnBlocks = BuildTurnBlocks(turn)
-	}
+	turn.TurnBlocks = BuildTurnBlocks(turn)
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
 		// Turn telemetry should not break runtime path.
 		logPublisherRuntime(ctx, r.events, "error", "persist_api_turn_failed", "Persisting the API agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -19,9 +19,7 @@ func (r *ClaudeCLIRuntime) persistTurn(ctx context.Context, turn AgentTurnRecord
 	if r.turns == nil {
 		return
 	}
-	if len(turn.TurnBlocks) == 0 {
-		turn.TurnBlocks = BuildTurnBlocks(turn)
-	}
+	turn.TurnBlocks = BuildTurnBlocks(turn)
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
 		logPublisherRuntime(ctx, r.events, "error", "persist_cli_turn_failed", "Persisting the CLI agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
 	}

--- a/internal/runtime/llm/turn_transcript.go
+++ b/internal/runtime/llm/turn_transcript.go
@@ -17,7 +17,12 @@ type TurnBlock struct {
 	Data     map[string]any `json:"data,omitempty"`
 }
 
+const turnSummaryBlockKind = "turn_summary"
+
 func BuildTurnBlocks(rec AgentTurnRecord) []TurnBlock {
+	if len(rec.TurnBlocks) > 0 {
+		return normalizeTurnBlocks(rec.TurnBlocks)
+	}
 	blocks := make([]TurnBlock, 0, 8)
 	if dispatch := buildDispatchBlock(rec); dispatch.Kind != "" {
 		blocks = append(blocks, dispatch)
@@ -281,9 +286,6 @@ func parseBlocksFromContent(content []any) []TurnBlock {
 		case "text":
 			if text := strings.TrimSpace(asString(entry["text"])); text != "" {
 				blocks = append(blocks, TurnBlock{Kind: "assistant_text", Text: text})
-				if looksLikeProgressUpdate(text) {
-					blocks = append(blocks, TurnBlock{Kind: "progress", Text: text})
-				}
 			}
 		case "thinking":
 			if thought := strings.TrimSpace(firstReadableString(
@@ -428,6 +430,7 @@ func dedupeTurnBlocks(blocks []TurnBlock) []TurnBlock {
 }
 
 func normalizeTurnBlocks(blocks []TurnBlock) []TurnBlock {
+	blocks = stripTurnSummaryBlocks(blocks)
 	blocks = dedupeTurnBlocks(blocks)
 	if len(blocks) == 0 {
 		return blocks
@@ -444,12 +447,9 @@ func normalizeTurnBlocks(blocks []TurnBlock) []TurnBlock {
 		}
 		toolNamesByUseID[toolUseID] = toolName
 	}
-	if len(toolNamesByUseID) == 0 {
-		return blocks
-	}
 	out := make([]TurnBlock, 0, len(blocks))
 	for _, block := range blocks {
-		if strings.TrimSpace(block.Kind) == "tool_result" && strings.TrimSpace(block.ToolName) == "" {
+		if len(toolNamesByUseID) > 0 && strings.TrimSpace(block.Kind) == "tool_result" && strings.TrimSpace(block.ToolName) == "" {
 			if toolUseID := strings.TrimSpace(blockToolUseID(block)); toolUseID != "" {
 				if toolName := strings.TrimSpace(toolNamesByUseID[toolUseID]); toolName != "" {
 					block.ToolName = toolName
@@ -458,7 +458,109 @@ func normalizeTurnBlocks(blocks []TurnBlock) []TurnBlock {
 		}
 		out = append(out, block)
 	}
+	if summary, ok := buildTurnSummaryBlock(out); ok {
+		out = append(out, summary)
+	}
 	return out
+}
+
+func stripTurnSummaryBlocks(blocks []TurnBlock) []TurnBlock {
+	if len(blocks) == 0 {
+		return nil
+	}
+	out := make([]TurnBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Kind) == turnSummaryBlockKind {
+			continue
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+func buildTurnSummaryBlock(blocks []TurnBlock) (TurnBlock, bool) {
+	assistantVisibleOutput := ""
+	outcome := ""
+	reasoning := []string{}
+	progress := []string{}
+	toolResults := []any{}
+	reasoningSeen := map[string]struct{}{}
+	progressSeen := map[string]struct{}{}
+	for _, block := range blocks {
+		switch strings.TrimSpace(block.Kind) {
+		case "assistant_text":
+			if text := strings.TrimSpace(block.Text); text != "" {
+				assistantVisibleOutput = text
+			}
+		case "outcome":
+			if text := strings.TrimSpace(block.Text); text != "" {
+				outcome = text
+				if assistantVisibleOutput == "" {
+					assistantVisibleOutput = text
+				}
+			}
+		case "reasoning":
+			if text := strings.TrimSpace(block.Text); text != "" {
+				if _, ok := reasoningSeen[text]; ok {
+					continue
+				}
+				reasoningSeen[text] = struct{}{}
+				reasoning = append(reasoning, text)
+			}
+		case "progress":
+			if text := strings.TrimSpace(block.Text); text != "" {
+				if _, ok := progressSeen[text]; ok {
+					continue
+				}
+				progressSeen[text] = struct{}{}
+				progress = append(progress, text)
+			}
+		case "tool_result":
+			if result, ok := buildTurnSummaryToolResult(block); ok {
+				toolResults = append(toolResults, result)
+			}
+		}
+	}
+	if outcome == "" {
+		outcome = assistantVisibleOutput
+	}
+	data := map[string]any{}
+	if assistantVisibleOutput != "" {
+		data["assistant_visible_output"] = assistantVisibleOutput
+	}
+	if outcome != "" {
+		data["outcome"] = outcome
+	}
+	if len(reasoning) > 0 {
+		data["reasoning_blocks"] = reasoning
+	}
+	if len(progress) > 0 {
+		data["progress_updates"] = progress
+	}
+	if len(toolResults) > 0 {
+		data["tool_results"] = toolResults
+	}
+	if len(data) == 0 {
+		return TurnBlock{}, false
+	}
+	return TurnBlock{Kind: turnSummaryBlockKind, Data: data}, true
+}
+
+func buildTurnSummaryToolResult(block TurnBlock) (map[string]any, bool) {
+	result := map[string]any{}
+	if name := strings.TrimSpace(block.ToolName); name != "" {
+		result["tool_name"] = name
+	}
+	if toolUseID := strings.TrimSpace(blockToolUseID(block)); toolUseID != "" {
+		result["tool_use_id"] = toolUseID
+	}
+	if block.Output != nil {
+		result["output"] = block.Output
+	}
+	if len(result) == 0 {
+		return nil, false
+	}
+	return result, true
 }
 
 func blockToolUseID(block TurnBlock) string {
@@ -475,26 +577,4 @@ func firstReadableString(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func looksLikeProgressUpdate(text string) bool {
-	text = strings.TrimSpace(strings.ToLower(text))
-	if text == "" {
-		return false
-	}
-	for _, prefix := range []string{
-		"i'll ",
-		"i will ",
-		"starting ",
-		"checking ",
-		"reviewing ",
-		"analyzing ",
-		"searching ",
-		"scheduling ",
-	} {
-		if strings.HasPrefix(text, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -20,7 +20,7 @@ func TestBuildTurnBlocks_CorrelatesToolResultsWithToolUse(t *testing.T) {
 		t.Fatalf("expected multiple turn blocks, got %#v", blocks)
 	}
 
-	var sawToolUse, sawToolResult, sawOutcome bool
+	var sawToolUse, sawToolResult, sawOutcome, sawSummary bool
 	for _, block := range blocks {
 		switch block.Kind {
 		case "tool_use":
@@ -36,9 +36,11 @@ func TestBuildTurnBlocks_CorrelatesToolResultsWithToolUse(t *testing.T) {
 			if block.Text == "14-day review scheduled." {
 				sawOutcome = true
 			}
+		case turnSummaryBlockKind:
+			sawSummary = true
 		}
 	}
-	if !sawToolUse || !sawToolResult || !sawOutcome {
+	if !sawToolUse || !sawToolResult || !sawOutcome || !sawSummary {
 		t.Fatalf("blocks missing expected kinds: %#v", blocks)
 	}
 }
@@ -119,5 +121,45 @@ func TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries(t *te
 	}
 	if details["denial_layer"] != "executor" {
 		t.Fatalf("details.denial_layer = %#v", details["denial_layer"])
+	}
+}
+
+func TestBuildTurnBlocks_AppendsCanonicalSummaryForExplicitBlocks(t *testing.T) {
+	blocks := BuildTurnBlocks(AgentTurnRecord{
+		TurnBlocks: []TurnBlock{
+			{Kind: "progress", Text: "Scheduling the follow-up review."},
+			{Kind: "tool_result", ToolName: "schedule", Output: map[string]any{"status": "scheduled"}, Data: map[string]any{"tool_use_id": "toolu_1"}},
+			{Kind: "assistant_text", Text: "Parking for manual review."},
+			{Kind: "outcome", Text: "14-day review scheduled."},
+		},
+	})
+
+	var summary map[string]any
+	for _, block := range blocks {
+		if block.Kind == turnSummaryBlockKind {
+			summary = block.Data
+			break
+		}
+	}
+	if len(summary) == 0 {
+		t.Fatalf("expected turn summary block, got %#v", blocks)
+	}
+	if got := asString(summary["assistant_visible_output"]); got != "Parking for manual review." {
+		t.Fatalf("assistant_visible_output = %q", got)
+	}
+	if got := asString(summary["outcome"]); got != "14-day review scheduled." {
+		t.Fatalf("outcome = %q", got)
+	}
+	progress, _ := summary["progress_updates"].([]string)
+	if len(progress) != 1 || progress[0] != "Scheduling the follow-up review." {
+		t.Fatalf("progress_updates = %#v", summary["progress_updates"])
+	}
+	results, _ := summary["tool_results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("tool_results = %#v", summary["tool_results"])
+	}
+	result, _ := results[0].(map[string]any)
+	if result["tool_name"] != "schedule" {
+		t.Fatalf("tool_result = %#v", result)
 	}
 }

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -50,7 +50,6 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	reqPayload := normalizeJSONPayload(rec.RequestPayload)
 	respPayload := normalizeJSONPayload(rec.ResponseRaw)
 	toolCallsPayload := normalizeJSONArray(rec.ToolCalls)
-	turnBlocksPayload := normalizeJSONArray(rec.TurnBlocks)
 	availableToolsPayload := normalizeJSONArray(rec.AvailableTools)
 	emittedEventsPayload := normalizeJSONArray(rec.EmittedEvents)
 	mcpServersPayload := normalizeJSONObject(rec.MCPServers)
@@ -160,6 +159,11 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 
 	hasRunID := caps.Conversations.TurnRunID
 	hasTurnBlocks := caps.Conversations.TurnBlocks
+	turnBlocksPayload := ""
+	if hasTurnBlocks {
+		rec.TurnBlocks = runtimellm.BuildTurnBlocks(rec)
+		turnBlocksPayload = normalizeJSONArray(rec.TurnBlocks)
+	}
 
 	insertTurn := `
 		INSERT INTO agent_turns (

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1406,7 +1406,7 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 	if err := db.QueryRowContext(ctx, `SELECT COALESCE(turn_blocks::text, '[]') FROM agent_turns WHERE session_id = $1::uuid ORDER BY created_at DESC LIMIT 1`, sessionID).Scan(&got); err != nil {
 		t.Fatalf("load turn_blocks: %v", err)
 	}
-	if !strings.Contains(got, `"dispatch"`) || !strings.Contains(got, `"schedule"`) || !strings.Contains(got, `"14-day review scheduled."`) {
+	if !strings.Contains(got, `"dispatch"`) || !strings.Contains(got, `"schedule"`) || !strings.Contains(got, `"14-day review scheduled."`) || !strings.Contains(got, `"turn_summary"`) {
 		t.Fatalf("turn_blocks = %s", got)
 	}
 }


### PR DESCRIPTION
## What changed
Persisted one canonical per-turn summary surface inside `agent_turns.turn_blocks` instead of letting dashboard readers reconstruct assistant output and progress from raw transcript payloads.

The runtime now appends a canonical `turn_summary` block during turn canonicalization and persistence. Dashboard conversation readers consume that persisted summary block only and fail closed when it is missing. Reader-side parsing of `response_payload.raw`, transport-specific blob handling, and English-prefix progress heuristics were removed from the touched seam.

## Why
Conversation and debug views were still inferring assistant-visible output and progress state from raw transcript payload shape. That left the read model heuristic and fragile even after the flight-recorder work.

## Impact
Dashboard/debug surfaces now read one persisted canonical summary owner instead of reconstructing from transcript blobs. Older turns without a canonical summary block render blank summary fields rather than being heuristically reconstructed.

## Validation
- `go test ./internal/runtime/llm ./internal/dashboard/server ./internal/store -count=1`
- `go test ./... -count=1`
