### PR TITLE
[agent-a][issue #27] Replace string-encoded timer and timeout identity with typed descriptors

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1326,16 +1326,28 @@ engine:
         event: Event name to fire when timer expires (e.g., timer.scan_timeout)
         delay: Duration string (e.g., 72h, 30m, 7d) or policy reference (e.g., policy.sla_timeout)
         recurring: Boolean — if true, timer re-fires at the interval until cancelled
-        start_on: State or event that starts the timer (e.g., state:assigned or event:ticket.opened)
-        cancel_on: State or event that cancels the timer (e.g., state:resolved or event:ticket.closed)
+        start_on: Trigger that starts the timer. Canonical forms are state:<name>, event:<name>, or boot.
+        cancel_on: Trigger that cancels the timer. Canonical forms are state:<name> or event:<name>. boot is invalid.
+      trigger_forms:
+        state: "state:<name> starts or cancels when the entity enters the named state"
+        event: "event:<name> starts or cancels when the named event fires for the entity"
+        boot: "start_on: boot starts a timer at platform boot. This form is only valid on start_on."
+      invalid_forms:
+      - "Unprefixed trigger values are boot errors. The platform does not infer state-vs-event intent from bare strings."
+      - "Prefixes other than state: and event: are boot errors."
     lifecycle:
-    - 1. Timer starts when the entity enters the start_on state or the start_on event fires.
+    - 1. Timer starts when the entity enters the start_on state, the start_on event fires, or start_on is boot and platform startup schedules it.
     - 2. Platform persists the timer (entity_id, timer_id, fire_at timestamp).
     - 3. When fire_at is reached, platform emits the timer event into the event loop.
     - 4. Timer event is a regular event — routed to subscribers, processed by handlers.
     - 5. If cancel_on state is reached or cancel_on event fires before fire_at, timer is cancelled.
     - 6. Recurring timers restart after firing unless cancelled.
     crash_recovery: Timers are persisted. On restart, platform checks for expired timers and fires them.
+    boot_validation:
+      start_on: start_on must match state:<name>, event:<name>, or boot. Any other form is a boot error.
+      cancel_on: cancel_on must match state:<name> or event:<name>. boot is not valid.
+      state_reference: state:<name> must reference a declared flow state. Unknown state is a boot error.
+      event_reference: event:<name> should reference an event in the flow or platform catalog. Unknown event is a boot warning.
     example: "timers:\n  - id: sla_timeout\n    event: timer.sla_breach\n    delay: \"{{sla_timeout_hours}}h\"\
       \n    start_on: state:assigned\n    cancel_on: state:resolved\n    recurring: false\n  - id: daily_report\n\
       \    event: timer.daily_report\n    delay: \"{{report_interval_hours}}h\"\n    start_on: boot\n    recurring: true"

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -13,6 +13,7 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimeengine "swarm/internal/runtime/engine"
 	runtimemcp "swarm/internal/runtime/mcp"
@@ -667,8 +668,75 @@ func (c *checkerContext) timerValidation() []Finding {
 				Location: strings.TrimSpace(timer.ID),
 			})
 		}
+		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
+		if err != nil {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s start_on %q is invalid: %v", timer.ID, timer.StartOn, err),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		} else {
+			c.validateTimerTrigger(timer, "start_on", startTrigger)
+		}
+		cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
+		if err != nil {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s cancel_on %q is invalid: %v", timer.ID, timer.CancelOn, err),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		} else {
+			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)
+		}
 	}
 	return c.timerFindings
+}
+
+func (c *checkerContext) validateTimerTrigger(timer runtimecontracts.WorkflowTimerContract, field string, trigger timeridentity.Trigger) {
+	if !trigger.Valid() {
+		return
+	}
+	switch trigger.Kind {
+	case timeridentity.TriggerKindState:
+		if !containsString(flowStatesForTimer(c.source, timer.FlowID), trigger.Name) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s %s references unknown state %s", timer.ID, field, trigger.Name),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		}
+	case timeridentity.TriggerKindEvent:
+		if !eventExists(c.source, trigger.Name) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "warning",
+				Message:  fmt.Sprintf("timer %s %s references unknown event %s", timer.ID, field, trigger.Name),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		}
+	}
+}
+
+func flowStatesForTimer(source semanticview.Source, flowID string) []string {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil {
+		return nil
+	}
+	if flowID != "" {
+		return source.FlowStates(flowID)
+	}
+	stages := source.WorkflowStages()
+	out := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		name := strings.TrimSpace(stage.ID)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func (c *checkerContext) writePinOwnership() []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -791,6 +791,46 @@ func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsErrorForUnprefixedTimerStartOn(t *testing.T) {
+	root := writeTimerValidationFixture(t, "ticket.opened", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "start_on") {
+		t.Fatalf("expected timer_validation start_on error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelOnBoot(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "boot")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on") {
+		t.Fatalf("expected timer_validation cancel_on error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForUnknownTimerTriggerState(t *testing.T) {
+	root := writeTimerValidationFixture(t, "state:missing_state", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "unknown state") {
+		t.Fatalf("expected timer_validation unknown state error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsWarningForUnknownTimerTriggerEvent(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.unknown", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Warnings(), "timer_validation", "unknown event") {
+		t.Fatalf("expected timer_validation unknown event warning, got %#v", report.Warnings())
+	}
+}
+
 func repoRootForBootverifyTest(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()
@@ -808,6 +848,83 @@ func writeBootverifyFixtureFile(t *testing.T, path, contents string) {
 	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func writeTimerValidationFixture(t *testing.T, startOn, cancelOn string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: timer-validation
+version: "1.0.0"
+platform: ">=1.6.0"
+entity_schema:
+  groups:
+    - name: ticket
+      fields:
+        - name: ticket_id
+          type: string
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: timer-validation\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+terminal_states: [done]
+states: [waiting, active, done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+ticket.opened:
+  payload:
+    properties:
+      entity_id:
+        type: string
+ticket.closed:
+  payload:
+    properties:
+      entity_id:
+        type: string
+timer.reminder:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	timerBlock := `
+    - id: reminder
+      event: timer.reminder
+      delay: 1m
+      start_on: ` + startOn + "\n"
+	if strings.TrimSpace(cancelOn) != "" {
+		timerBlock += "      cancel_on: " + cancelOn + "\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.opened
+    - ticket.closed
+    - timer.reminder
+  timers:
+`+timerBlock+`  event_handlers:
+    ticket.opened:
+      create_entity: true
+      advances_to: active
+    ticket.closed:
+      advances_to: done
+    timer.reminder:
+      advances_to: done
+`)
+	return root
 }
 
 func writeCrossFlowPinAmbiguityFixture(t *testing.T, scoped bool) string {

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -1,0 +1,267 @@
+package timeridentity
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TriggerKind string
+
+const (
+	TriggerKindState TriggerKind = "state"
+	TriggerKindEvent TriggerKind = "event"
+	TriggerKindBoot  TriggerKind = "boot"
+)
+
+type Trigger struct {
+	Kind TriggerKind
+	Name string
+}
+
+type TimerHandleKind string
+
+const (
+	TimerHandleWorkflowTimer       TimerHandleKind = "workflow_timer"
+	TimerHandleAccumulationTimeout TimerHandleKind = "accumulation_timeout"
+	timerHandlePayloadKey                          = "timer_handle"
+	accumulationTimeoutTaskPrefix                  = "accumulate_timeout:"
+)
+
+type TimerHandle struct {
+	Kind    TimerHandleKind
+	TimerID string
+	Bucket  AccumulatorBucketRef
+}
+
+type AccumulatorBucketRef struct {
+	NodeID    string
+	EventType string
+}
+
+func ParseStartTrigger(raw string) (Trigger, error) {
+	return parseTrigger(raw, true)
+}
+
+func ParseCancelTrigger(raw string) (Trigger, error) {
+	return parseTrigger(raw, false)
+}
+
+func parseTrigger(raw string, allowBoot bool) (Trigger, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Trigger{}, nil
+	}
+	if raw == string(TriggerKindBoot) {
+		if !allowBoot {
+			return Trigger{}, fmt.Errorf("boot is not valid here")
+		}
+		return Trigger{Kind: TriggerKindBoot}, nil
+	}
+	prefix, value, ok := strings.Cut(raw, ":")
+	if !ok {
+		return Trigger{}, fmt.Errorf("trigger %q must use state:<name>, event:<name>, or boot", raw)
+	}
+	prefix = strings.TrimSpace(prefix)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return Trigger{}, fmt.Errorf("trigger %q is missing a target name", raw)
+	}
+	switch TriggerKind(prefix) {
+	case TriggerKindState:
+		return Trigger{Kind: TriggerKindState, Name: value}, nil
+	case TriggerKindEvent:
+		return Trigger{Kind: TriggerKindEvent, Name: value}, nil
+	default:
+		return Trigger{}, fmt.Errorf("trigger %q uses unsupported prefix %q", raw, prefix)
+	}
+}
+
+func (t Trigger) Valid() bool {
+	switch t.Kind {
+	case TriggerKindState, TriggerKindEvent:
+		return strings.TrimSpace(t.Name) != ""
+	case TriggerKindBoot:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t Trigger) IsBoot() bool {
+	return t.Kind == TriggerKindBoot
+}
+
+func (t Trigger) MatchesStage(stage string) bool {
+	return t.Kind == TriggerKindState && strings.TrimSpace(t.Name) == strings.TrimSpace(stage)
+}
+
+func (t Trigger) MatchesEvent(eventType string) bool {
+	return t.Kind == TriggerKindEvent && strings.TrimSpace(t.Name) == strings.TrimSpace(eventType)
+}
+
+func (t Trigger) String() string {
+	switch t.Kind {
+	case TriggerKindState, TriggerKindEvent:
+		if name := strings.TrimSpace(t.Name); name != "" {
+			return string(t.Kind) + ":" + name
+		}
+	case TriggerKindBoot:
+		return string(TriggerKindBoot)
+	}
+	return ""
+}
+
+func WorkflowTimerHandle(timerID string) TimerHandle {
+	return TimerHandle{
+		Kind:    TimerHandleWorkflowTimer,
+		TimerID: strings.TrimSpace(timerID),
+	}
+}
+
+func AccumulationTimeoutHandle(bucket AccumulatorBucketRef) TimerHandle {
+	return TimerHandle{
+		Kind:   TimerHandleAccumulationTimeout,
+		Bucket: bucket.Normalize(),
+	}
+}
+
+func (h TimerHandle) Valid() bool {
+	switch h.Kind {
+	case TimerHandleWorkflowTimer:
+		return strings.TrimSpace(h.TimerID) != ""
+	case TimerHandleAccumulationTimeout:
+		return h.Bucket.Valid()
+	default:
+		return false
+	}
+}
+
+func (h TimerHandle) TaskID() string {
+	switch h.Kind {
+	case TimerHandleWorkflowTimer:
+		return strings.TrimSpace(h.TimerID)
+	case TimerHandleAccumulationTimeout:
+		if !h.Bucket.Valid() {
+			return ""
+		}
+		return accumulationTimeoutTaskPrefix + h.Bucket.Key()
+	default:
+		return ""
+	}
+}
+
+func (h TimerHandle) PayloadMetadata() map[string]any {
+	if !h.Valid() {
+		return nil
+	}
+	handle := map[string]any{
+		"kind": string(h.Kind),
+	}
+	switch h.Kind {
+	case TimerHandleWorkflowTimer:
+		handle["timer_id"] = strings.TrimSpace(h.TimerID)
+	case TimerHandleAccumulationTimeout:
+		handle["bucket"] = h.Bucket.PayloadValue()
+	}
+	return map[string]any{
+		timerHandlePayloadKey: handle,
+	}
+}
+
+func ParseTimerHandle(payload map[string]any) (TimerHandle, bool) {
+	handleMap, ok := stringAnyMap(payload[timerHandlePayloadKey])
+	if !ok {
+		return TimerHandle{}, false
+	}
+	switch TimerHandleKind(strings.TrimSpace(asString(handleMap["kind"]))) {
+	case TimerHandleWorkflowTimer:
+		handle := WorkflowTimerHandle(asString(handleMap["timer_id"]))
+		return handle, handle.Valid()
+	case TimerHandleAccumulationTimeout:
+		bucket, ok := bucketFromAny(handleMap["bucket"])
+		if !ok {
+			return TimerHandle{}, false
+		}
+		handle := AccumulationTimeoutHandle(bucket)
+		return handle, handle.Valid()
+	default:
+		return TimerHandle{}, false
+	}
+}
+
+func NewAccumulatorBucketRef(nodeID, eventType string) AccumulatorBucketRef {
+	return AccumulatorBucketRef{
+		NodeID:    strings.TrimSpace(nodeID),
+		EventType: strings.TrimSpace(eventType),
+	}
+}
+
+func ParseAccumulatorBucketRef(payload map[string]any) (AccumulatorBucketRef, bool) {
+	handle, ok := ParseTimerHandle(payload)
+	if !ok || handle.Kind != TimerHandleAccumulationTimeout {
+		return AccumulatorBucketRef{}, false
+	}
+	return handle.Bucket, handle.Bucket.Valid()
+}
+
+func ParseAccumulatorBucketKey(key string) (AccumulatorBucketRef, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return AccumulatorBucketRef{}, false
+	}
+	nodeID, eventType, ok := strings.Cut(key, ":")
+	if !ok {
+		return AccumulatorBucketRef{}, false
+	}
+	bucket := NewAccumulatorBucketRef(nodeID, eventType)
+	return bucket, bucket.Valid()
+}
+
+func (r AccumulatorBucketRef) Normalize() AccumulatorBucketRef {
+	return NewAccumulatorBucketRef(r.NodeID, r.EventType)
+}
+
+func (r AccumulatorBucketRef) Valid() bool {
+	return strings.TrimSpace(r.NodeID) != "" && strings.TrimSpace(r.EventType) != ""
+}
+
+func (r AccumulatorBucketRef) Key() string {
+	r = r.Normalize()
+	if !r.Valid() {
+		return ""
+	}
+	return r.NodeID + ":" + r.EventType
+}
+
+func (r AccumulatorBucketRef) PayloadValue() map[string]any {
+	r = r.Normalize()
+	if !r.Valid() {
+		return nil
+	}
+	return map[string]any{
+		"node_id":    r.NodeID,
+		"event_type": r.EventType,
+	}
+}
+
+func stringAnyMap(value any) (map[string]any, bool) {
+	typed, ok := value.(map[string]any)
+	if !ok || typed == nil {
+		return nil, false
+	}
+	return typed, true
+}
+
+func bucketFromAny(value any) (AccumulatorBucketRef, bool) {
+	payload, ok := stringAnyMap(value)
+	if !ok {
+		return AccumulatorBucketRef{}, false
+	}
+	bucket := NewAccumulatorBucketRef(asString(payload["node_id"]), asString(payload["event_type"]))
+	return bucket, bucket.Valid()
+}
+
+func asString(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}

--- a/internal/runtime/core/timeridentity/timeridentity_test.go
+++ b/internal/runtime/core/timeridentity/timeridentity_test.go
@@ -1,0 +1,70 @@
+package timeridentity
+
+import "testing"
+
+func TestParseStartTrigger(t *testing.T) {
+	trigger, err := ParseStartTrigger("state:active")
+	if err != nil {
+		t.Fatalf("ParseStartTrigger: %v", err)
+	}
+	if trigger.Kind != TriggerKindState || trigger.Name != "active" {
+		t.Fatalf("trigger = %#v", trigger)
+	}
+	if !trigger.MatchesStage("active") {
+		t.Fatal("expected state trigger to match stage")
+	}
+}
+
+func TestParseTriggerRejectsUnprefixedValues(t *testing.T) {
+	if _, err := ParseStartTrigger("ticket.opened"); err == nil {
+		t.Fatal("expected unprefixed trigger to be rejected")
+	}
+}
+
+func TestParseCancelTriggerRejectsBoot(t *testing.T) {
+	if _, err := ParseCancelTrigger("boot"); err == nil {
+		t.Fatal("expected cancel_on boot to be rejected")
+	}
+}
+
+func TestTimerHandlePayloadRoundTrip(t *testing.T) {
+	handle := WorkflowTimerHandle("check_timer")
+	parsed, ok := ParseTimerHandle(handle.PayloadMetadata())
+	if !ok {
+		t.Fatal("expected workflow timer handle payload to round trip")
+	}
+	if parsed.Kind != TimerHandleWorkflowTimer || parsed.TimerID != "check_timer" {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+	if parsed.TaskID() != "check_timer" {
+		t.Fatalf("TaskID() = %q", parsed.TaskID())
+	}
+}
+
+func TestAccumulationTimeoutHandleRoundTrip(t *testing.T) {
+	bucket := NewAccumulatorBucketRef("collector", "item.arrived")
+	handle := AccumulationTimeoutHandle(bucket)
+	parsedHandle, ok := ParseTimerHandle(handle.PayloadMetadata())
+	if !ok {
+		t.Fatal("expected accumulation timeout handle payload to round trip")
+	}
+	if parsedHandle.Kind != TimerHandleAccumulationTimeout {
+		t.Fatalf("parsedHandle = %#v", parsedHandle)
+	}
+	if parsedHandle.Bucket != bucket {
+		t.Fatalf("parsed bucket = %#v, want %#v", parsedHandle.Bucket, bucket)
+	}
+	if got := parsedHandle.TaskID(); got != "accumulate_timeout:collector:item.arrived" {
+		t.Fatalf("TaskID() = %q", got)
+	}
+}
+
+func TestParseAccumulatorBucketKey(t *testing.T) {
+	bucket, ok := ParseAccumulatorBucketKey("collector:item.arrived")
+	if !ok {
+		t.Fatal("expected accumulator bucket key to parse")
+	}
+	if bucket.NodeID != "collector" || bucket.EventType != "item.arrived" {
+		t.Fatalf("bucket = %#v", bucket)
+	}
+}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -13,6 +13,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/core/values"
 )
 
@@ -465,11 +466,15 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	if spec == nil {
 		return false, nil
 	}
-	bucketEventType := frame.req.Event.Type
-	acc, ok := loadAccumulator(frame.state.State, frame.req.NodeID, bucketEventType)
-	if !ok && isAccumulationTimeoutEvent(frame.req.Event.Type) {
-		acc, bucketEventType, ok = loadNodeAccumulatorForTimeout(frame.state.State, frame.req.NodeID)
+	bucketRef := timeridentity.NewAccumulatorBucketRef(frame.req.NodeID.String(), string(frame.req.Event.Type))
+	if isAccumulationTimeoutEvent(frame.req.Event.Type) {
+		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
+		if !ok || parsed.NodeID != frame.req.NodeID.String() {
+			return false, nil
+		}
+		bucketRef = parsed
 	}
+	acc, ok := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	if !ok {
 		acc = &Accumulator{}
 	}
@@ -506,7 +511,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	acc.LastEventType = strings.TrimSpace(string(frame.req.Event.Type))
 	acc.LastSource = strings.TrimSpace(frame.req.Event.SourceAgent)
 	acc.LastReceivedAt = frame.req.Event.CreatedAt.UTC().Format(time.RFC3339Nano)
-	storeAccumulator(&frame.state.State, frame.req.NodeID, bucketEventType, acc)
+	storeAccumulatorForBucket(&frame.state.State, bucketRef, acc)
 	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateBuckets)
 	frame.state.Accumulated = accumulatorExpressionValue(acc)
 	if isAccumulationTimeoutEvent(frame.req.Event.Type) && spec.OnTimeout != nil {

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -277,6 +277,15 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 		Event: events.Event{
 			ID:   "timeout-1",
 			Type: events.EventType("accumulate.timeout"),
+			Payload: mustEncodeJSON(t, map[string]any{
+				"timer_handle": map[string]any{
+					"kind": "accumulation_timeout",
+					"bucket": map[string]any{
+						"node_id":    "node-1",
+						"event_type": "item.arrived",
+					},
+				},
+			}),
 		},
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Accumulate: &runtimecontracts.AccumulateSpec{
@@ -301,6 +310,15 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 	if repo.snapshot.CurrentState != "partial" {
 		t.Fatalf("persisted CurrentState = %q", repo.snapshot.CurrentState)
 	}
+}
+
+func mustEncodeJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%#v): %v", value, err)
+	}
+	return encoded
 }
 
 func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -15,6 +15,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/core/values"
 )
 
@@ -323,21 +324,21 @@ func nextChainDepth(current, max int) (int, error) {
 	return next, nil
 }
 
-func accumulatorBucketID(nodeID identity.NodeID, eventType events.EventType) string {
-	nodeName := nodeID.String()
-	eventName := strings.TrimSpace(string(eventType))
-	if nodeName == "" {
-		return eventName
-	}
-	return nodeName + ":" + eventName
+func accumulatorBucketRef(nodeID identity.NodeID, eventType events.EventType) timeridentity.AccumulatorBucketRef {
+	return timeridentity.NewAccumulatorBucketRef(nodeID.String(), string(eventType))
 }
 
 func loadAccumulator(state StateSnapshot, nodeID identity.NodeID, eventType events.EventType) (*Accumulator, bool) {
-	if nodeID.IsZero() {
+	return loadAccumulatorForBucket(state, accumulatorBucketRef(nodeID, eventType))
+}
+
+func loadAccumulatorForBucket(state StateSnapshot, bucketRef timeridentity.AccumulatorBucketRef) (*Accumulator, bool) {
+	bucketRef = bucketRef.Normalize()
+	if !bucketRef.Valid() {
 		return nil, false
 	}
 	root := state.EnsureStateBucketsBucket()
-	bucket, ok := root.Map(nodeID.String())
+	bucket, ok := root.Map(bucketRef.NodeID)
 	if !ok {
 		return nil, false
 	}
@@ -345,7 +346,7 @@ func loadAccumulator(state StateSnapshot, nodeID identity.NodeID, eventType even
 	if !ok {
 		return nil, false
 	}
-	raw, ok := rawAccumulators.Map(accumulatorBucketID(nodeID, eventType))
+	raw, ok := rawAccumulators.Map(bucketRef.Key())
 	if !ok {
 		return nil, false
 	}
@@ -369,11 +370,16 @@ func loadAccumulator(state StateSnapshot, nodeID identity.NodeID, eventType even
 }
 
 func storeAccumulator(state *StateSnapshot, nodeID identity.NodeID, eventType events.EventType, acc *Accumulator) {
-	if state == nil || acc == nil || nodeID.IsZero() {
+	storeAccumulatorForBucket(state, accumulatorBucketRef(nodeID, eventType), acc)
+}
+
+func storeAccumulatorForBucket(state *StateSnapshot, bucketRef timeridentity.AccumulatorBucketRef, acc *Accumulator) {
+	bucketRef = bucketRef.Normalize()
+	if state == nil || acc == nil || !bucketRef.Valid() {
 		return
 	}
 	root := state.EnsureStateBucketsBucket()
-	bucket := root.EnsureMap(nodeID.String())
+	bucket := root.EnsureMap(bucketRef.NodeID)
 	accumulators := bucket.EnsureMap(handlerAccumulatorBucketKey)
 	received := map[string]any{}
 	keys := make([]string, 0, len(acc.Received))
@@ -388,7 +394,7 @@ func storeAccumulator(state *StateSnapshot, nodeID identity.NodeID, eventType ev
 	for _, item := range acc.Items {
 		items = append(items, cloneStringAnyMap(item))
 	}
-	accumulators.Set(accumulatorBucketID(nodeID, eventType), map[string]any{
+	accumulators.Set(bucketRef.Key(), map[string]any{
 		"expected":         append([]string{}, acc.Expected...),
 		"expected_count":   acc.ExpectedCount,
 		"received":         received,
@@ -406,59 +412,8 @@ func isAccumulationTimeoutEvent(eventType events.EventType) bool {
 	return strings.HasSuffix(eventName, ".timeout") || strings.EqualFold(eventName, "accumulate.timeout")
 }
 
-func loadNodeAccumulatorForTimeout(state StateSnapshot, nodeID identity.NodeID) (*Accumulator, events.EventType, bool) {
-	if nodeID.IsZero() {
-		return nil, "", false
-	}
-	root := state.EnsureStateBucketsBucket()
-	bucket, ok := root.Map(nodeID.String())
-	if !ok {
-		return nil, "", false
-	}
-	rawAccumulators, ok := bucket.Map(handlerAccumulatorBucketKey)
-	if !ok {
-		return nil, "", false
-	}
-	var (
-		bestAcc     *Accumulator
-		bestEvent   events.EventType
-		bestSortKey string
-	)
-	for _, bucketID := range rawAccumulators.Keys() {
-		raw, ok := rawAccumulators.Map(bucketID)
-		if !ok {
-			continue
-		}
-		acc := &Accumulator{
-			Expected:       normalizeStrings(stringSliceFromAny(raw.Raw()["expected"])),
-			ExpectedCount:  raw.Int("expected_count"),
-			Received:       map[string]bool{},
-			Items:          sliceOfMapsFromAny(raw.Raw()["items"]),
-			StartedAt:      raw.String("started_at"),
-			LastEventID:    raw.String("last_event_id"),
-			LastEventType:  raw.String("last_event_type"),
-			LastSource:     raw.String("last_source"),
-			LastReceivedAt: raw.String("last_received_at"),
-		}
-		if received, ok := raw.Map("received"); ok {
-			for _, key := range received.Keys() {
-				acc.Received[strings.TrimSpace(key)] = received.Bool(key)
-			}
-		}
-		sortKey := strings.TrimSpace(firstNonEmpty(acc.LastReceivedAt, acc.StartedAt, bucketID))
-		if bestAcc == nil || sortKey > bestSortKey {
-			bestAcc = acc
-			bestSortKey = sortKey
-			bestEvent = events.EventType(strings.TrimSpace(raw.String("last_event_type")))
-			if bestEvent == "" {
-				bestEvent = events.EventType(strings.TrimSpace(strings.TrimPrefix(bucketID, nodeID.String()+":")))
-			}
-		}
-	}
-	if bestAcc == nil {
-		return nil, "", false
-	}
-	return bestAcc, bestEvent, true
+func accumulationTimeoutBucketRefFromPayload(payload map[string]any) (timeridentity.AccumulatorBucketRef, bool) {
+	return timeridentity.ParseAccumulatorBucketRef(payload)
 }
 
 func expectedAccumulatorTargets(base BaseContext, state ExecutionState, parsed paths.Path, raw string) ([]string, int) {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimeengine "swarm/internal/runtime/engine"
 )
@@ -240,7 +241,10 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	}
 	handler, ok := source.NodeEventHandler(nodeID, trigger)
 	if !ok && isAccumulationTimeoutEvent(events.EventType(trigger)) {
-		handler, ok = findAccumulationTimeoutHandlerForNode(source, nodeID, trigger)
+		bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload))
+		if bucketOK && strings.TrimSpace(bucket.NodeID) == nodeID {
+			handler, ok = findAccumulationTimeoutHandlerForBucket(source, bucket)
+		}
 	}
 	if !ok {
 		return false, nil

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -9,6 +9,7 @@ import (
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
@@ -82,20 +83,10 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 		matched = true
 	}
 	if !matched && isAccumulationTimeoutEvent(events.EventType(trigger)) {
-		payload := parsePayloadMap(evt.Payload)
-		hintNodeID := strings.TrimSpace(asString(payload["node_id"]))
-		if hintNodeID != "" {
-			timeoutHandler, ok := findAccumulationTimeoutHandlerForNode(source, hintNodeID, trigger)
+		if bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); ok {
+			timeoutHandler, ok := findAccumulationTimeoutHandlerForBucket(source, bucket)
 			if ok {
-				nodeID = hintNodeID
-				handler = timeoutHandler
-				matched = true
-			}
-		}
-		if !matched {
-			timeoutNodeID, timeoutHandler, ok := findAccumulationTimeoutHandler(source, trigger)
-			if ok {
-				nodeID = timeoutNodeID
+				nodeID = bucket.NodeID
 				handler = timeoutHandler
 				matched = true
 			}
@@ -112,68 +103,34 @@ func isAccumulationTimeoutEvent(eventType events.EventType) bool {
 	return strings.HasSuffix(eventName, ".timeout") || strings.EqualFold(eventName, "accumulate.timeout")
 }
 
-func findAccumulationTimeoutHandler(source interface {
+func findAccumulationTimeoutHandlerForBucket(source interface {
 	NodeEntries() map[string]runtimecontracts.SystemNodeContract
 	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
-}, trigger string) (string, runtimecontracts.SystemNodeEventHandler, bool) {
-	trigger = strings.TrimSpace(trigger)
-	if source == nil || trigger == "" {
-		return "", runtimecontracts.SystemNodeEventHandler{}, false
-	}
-	var (
-		nodeID  string
-		handler runtimecontracts.SystemNodeEventHandler
-		matched bool
-	)
-	for candidateNodeID, node := range source.NodeEntries() {
-		if !containsString(node.SubscribesTo, trigger) {
-			continue
-		}
-		for _, candidate := range source.NodeEventHandlers(candidateNodeID) {
-			if candidate.Accumulate == nil {
-				continue
-			}
-			if candidate.Accumulate.Completion.Mode != runtimecontracts.AccumulateModeTimeout && candidate.Accumulate.OnTimeout == nil {
-				continue
-			}
-			if matched {
-				return "", runtimecontracts.SystemNodeEventHandler{}, false
-			}
-			nodeID = strings.TrimSpace(candidateNodeID)
-			handler = candidate
-			matched = true
-			break
-		}
-	}
-	if !matched {
-		return "", runtimecontracts.SystemNodeEventHandler{}, false
-	}
-	return nodeID, handler, true
-}
-
-func findAccumulationTimeoutHandlerForNode(source interface {
-	NodeEntries() map[string]runtimecontracts.SystemNodeContract
-	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
-}, nodeID, trigger string) (runtimecontracts.SystemNodeEventHandler, bool) {
-	nodeID = strings.TrimSpace(nodeID)
-	trigger = strings.TrimSpace(trigger)
-	if source == nil || nodeID == "" || trigger == "" {
+}, bucket timeridentity.AccumulatorBucketRef) (runtimecontracts.SystemNodeEventHandler, bool) {
+	bucket = bucket.Normalize()
+	if source == nil || !bucket.Valid() {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
-	node, ok := source.NodeEntries()[nodeID]
-	if !ok || !containsString(node.SubscribesTo, trigger) {
+	node, ok := source.NodeEntries()[bucket.NodeID]
+	if !ok || !containsString(node.SubscribesTo, "accumulate.timeout") {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
-	for _, candidate := range source.NodeEventHandlers(nodeID) {
-		if candidate.Accumulate == nil {
+	for eventType, candidate := range source.NodeEventHandlers(bucket.NodeID) {
+		if strings.TrimSpace(eventType) != bucket.EventType {
 			continue
 		}
-		if candidate.Accumulate.Completion.Mode != runtimecontracts.AccumulateModeTimeout && candidate.Accumulate.OnTimeout == nil {
-			continue
+		if accumulationTimeoutHandler(candidate) {
+			return candidate, true
 		}
-		return candidate, true
 	}
 	return runtimecontracts.SystemNodeEventHandler{}, false
+}
+
+func accumulationTimeoutHandler(handler runtimecontracts.SystemNodeEventHandler) bool {
+	if handler.Accumulate == nil {
+		return false
+	}
+	return handler.Accumulate.Completion.Mode == runtimecontracts.AccumulateModeTimeout || handler.Accumulate.OnTimeout != nil
 }
 
 func (pc *PipelineCoordinator) executeNodeContractHandler(

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -10,6 +10,7 @@ import (
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
 )
@@ -76,6 +77,11 @@ func (n *declarativeWorkflowNode) InterceptPolicy(eventType string, evt events.E
 		eventType = strings.TrimSpace(string(evt.Type))
 	}
 	policy, ok := workflowNodeEventPolicy(n.NodeID(), eventType)
+	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
+		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); bucketOK && bucket.NodeID == n.NodeID() {
+			policy, ok = workflowNodeEventPolicy(n.NodeID(), bucket.EventType)
+		}
+	}
 	if !ok {
 		return false, false
 	}
@@ -126,6 +132,11 @@ func (n *DeclarativeNode) InterceptPolicy(eventType string, evt events.Event) (b
 		eventType = strings.TrimSpace(string(evt.Type))
 	}
 	policy, ok := workflowNodeEventPolicy(n.NodeID(), eventType)
+	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
+		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); bucketOK && bucket.NodeID == n.NodeID() {
+			policy, ok = workflowNodeEventPolicy(n.NodeID(), bucket.EventType)
+		}
+	}
 	if !ok {
 		return false, false
 	}
@@ -159,16 +170,18 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 		}
 	}
 	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) && containsString(n.contract.SubscribesTo, eventType) {
-		for _, candidate := range n.contract.EventHandlers {
-			if candidate.Accumulate == nil {
-				continue
+		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); bucketOK && bucket.NodeID == n.NodeID() {
+			for candidateEventType, candidate := range n.contract.EventHandlers {
+				if strings.TrimSpace(candidateEventType) != bucket.EventType {
+					continue
+				}
+				if !accumulationTimeoutHandler(candidate) {
+					continue
+				}
+				handler = candidate
+				ok = true
+				break
 			}
-			if candidate.Accumulate.Completion.Mode != runtimecontracts.AccumulateModeTimeout && candidate.Accumulate.OnTimeout == nil {
-				continue
-			}
-			handler = candidate
-			ok = true
-			break
 		}
 	}
 	if !ok {

--- a/internal/runtime/pipeline/on_timeout_pipeline_test.go
+++ b/internal/runtime/pipeline/on_timeout_pipeline_test.go
@@ -8,6 +8,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
@@ -45,7 +46,7 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 		StateBuckets: map[string]any{
 			"test-node": map[string]any{
 				"handler_accumulators": map[string]any{
-					"test-node:item.arrived": map[string]any{
+					timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived").Key(): map[string]any{
 						"expected":       []string{},
 						"expected_count": 3,
 						"received": map[string]any{
@@ -71,8 +72,17 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 	}
 
 	timeoutEvt := events.Event{
-		ID:        "timeout-1",
-		Type:      events.EventType("accumulate.timeout"),
+		ID:   "timeout-1",
+		Type: events.EventType("accumulate.timeout"),
+		Payload: mustJSON(map[string]any{
+			"timer_handle": map[string]any{
+				"kind": "accumulation_timeout",
+				"bucket": map[string]any{
+					"node_id":    "test-node",
+					"event_type": "item.arrived",
+				},
+			},
+		}),
 		CreatedAt: time.Now().UTC(),
 	}.WithEntityID("ent-001")
 	result, err := pc.executeAuthoritativeNodeHandler(context.Background(), timeoutEvt, workflowTriggerContext{

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -8,6 +8,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -22,7 +23,7 @@ func (r *recordingExecutionEngine) ExecuteHandlerSteps(_ context.Context, handle
 	return &HandlerOutcome{Handled: true}, nil
 }
 
-func TestFindAccumulationTimeoutHandler_OnTimeoutFixture(t *testing.T) {
+func TestFindAccumulationTimeoutHandlerForBucket_OnTimeoutFixture(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier2-accumulation", "test-accumulate-on-timeout")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -30,12 +31,10 @@ func TestFindAccumulationTimeoutHandler_OnTimeoutFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load bundle: %v", err)
 	}
-	nodeID, handler, ok := findAccumulationTimeoutHandler(semanticview.Wrap(bundle), "accumulate.timeout")
+	bucket := timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived")
+	handler, ok := findAccumulationTimeoutHandlerForBucket(semanticview.Wrap(bundle), bucket)
 	if !ok {
 		t.Fatal("expected timeout handler")
-	}
-	if nodeID != "test-node" {
-		t.Fatalf("nodeID = %q", nodeID)
 	}
 	if handler.Accumulate == nil || handler.Accumulate.OnTimeout == nil {
 		t.Fatalf("handler missing accumulate on_timeout: %#v", handler.Accumulate)
@@ -58,7 +57,18 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, engine, nil)
-	handled := node.Handle(context.Background(), events.Event{Type: "accumulate.timeout"})
+	handled := node.Handle(context.Background(), events.Event{
+		Type: "accumulate.timeout",
+		Payload: mustJSON(map[string]any{
+			"timer_handle": map[string]any{
+				"kind": "accumulation_timeout",
+				"bucket": map[string]any{
+					"node_id":    "test-node",
+					"event_type": "item.arrived",
+				},
+			},
+		}),
+	})
 	if !handled {
 		t.Fatal("expected timeout event to be handled")
 	}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -552,6 +553,25 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(eventType string, evt
 						policy = candidate
 						ok = true
 						break
+					}
+				}
+			}
+		}
+		if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
+			if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); bucketOK && bucket.NodeID == strings.TrimSpace(node.ID) {
+				if node.Policies != nil {
+					policy, ok = node.Policies[bucket.EventType]
+					if !ok {
+						for pattern, candidate := range node.Policies {
+							if strings.TrimSpace(pattern) == bucket.EventType {
+								continue
+							}
+							if runtimecontractsHandlerPatternMatches(pattern, bucket.EventType) {
+								policy = candidate
+								ok = true
+								break
+							}
+						}
 					}
 				}
 			}

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -38,14 +39,16 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 				continue
 			}
 			timer, ok := source.WorkflowTimerByID(timerState.TimerID)
-			if !ok || !workflowTimerLifecycleMatches(timer.CancelOn, nextStage, sourceEvent) {
+			cancelTrigger, ok := workflowTimerCancelTrigger(timer)
+			if !ok || !workflowTimerLifecycleMatches(cancelTrigger, nextStage, sourceEvent) {
 				continue
 			}
 			timerState.Cancelled = true
 			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
-			if !workflowTimerLifecycleMatches(timer.StartOn, nextStage, sourceEvent) {
+			startTrigger, ok := workflowTimerStartTrigger(timer)
+			if !ok || !workflowTimerLifecycleMatches(startTrigger, nextStage, sourceEvent) {
 				continue
 			}
 			if workflowTimerStateActive(instance.TimerState, timer.ID) {
@@ -121,14 +124,16 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 				continue
 			}
 			timer, ok := source.WorkflowTimerByID(timerState.TimerID)
-			if !ok || !workflowTimerLifecycleMatches(timer.CancelOn, "", sourceEvent) {
+			cancelTrigger, ok := workflowTimerCancelTrigger(timer)
+			if !ok || !workflowTimerLifecycleMatches(cancelTrigger, "", sourceEvent) {
 				continue
 			}
 			timerState.Cancelled = true
 			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
-			if !workflowTimerLifecycleMatches(timer.StartOn, "", sourceEvent) {
+			startTrigger, ok := workflowTimerStartTrigger(timer)
+			if !ok || !workflowTimerLifecycleMatches(startTrigger, "", sourceEvent) {
 				continue
 			}
 			if workflowTimerStateActive(instance.TimerState, timer.ID) {
@@ -182,16 +187,16 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	if entityID == "" || nodeID == "" {
 		return nil
 	}
-	bucketEventType := accumulationTimeoutBucketEventType(evt, stateBuckets, nodeID)
-	if strings.TrimSpace(bucketEventType) == "" {
+	bucketRef, ok := accumulationTimeoutBucketRef(evt, nodeID)
+	if !ok {
 		return nil
 	}
-	sc := accumulationTimeoutSchedule(entityID, nodeID, bucketEventType, time.Time{}, spec.TimeoutMS)
+	sc := accumulationTimeoutSchedule(entityID, bucketRef, time.Time{}, spec.TimeoutMS)
 	if isAccumulationTimeoutEvent(evt.Type) || !waiting {
 		pc.persistWorkflowTimerCancellation(ctx, sc)
 		return nil
 	}
-	startedAt, ok := accumulationTimeoutStartedAt(stateBuckets, nodeID, bucketEventType)
+	startedAt, ok := accumulationTimeoutStartedAt(stateBuckets, bucketRef)
 	if !ok {
 		return nil
 	}
@@ -200,54 +205,31 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	return nil
 }
 
-func workflowTimerLifecycleMatches(trigger, stage, sourceEvent string) bool {
-	trigger = strings.TrimSpace(trigger)
-	stage = strings.TrimSpace(stage)
-	sourceEvent = strings.TrimSpace(sourceEvent)
-	if trigger == "" {
-		return false
-	}
-	switch {
-	case strings.HasPrefix(trigger, "state:"):
-		return strings.TrimSpace(strings.TrimPrefix(trigger, "state:")) == stage
-	case strings.HasPrefix(trigger, "event:"):
-		return strings.TrimSpace(strings.TrimPrefix(trigger, "event:")) == sourceEvent
-	default:
-		return trigger == stage || trigger == sourceEvent
-	}
+func workflowTimerLifecycleMatches(trigger timeridentity.Trigger, stage, sourceEvent string) bool {
+	return trigger.MatchesStage(stage) || trigger.MatchesEvent(sourceEvent)
 }
 
-func accumulationTimeoutBucketEventType(evt Event, stateBuckets map[string]any, nodeID string) string {
-	payload := parsePayloadMap(evt.Payload)
-	if raw := strings.TrimSpace(asString(payload["bucket_event_type"])); raw != "" {
-		return raw
+func accumulationTimeoutBucketRef(evt Event, nodeID string) (timeridentity.AccumulatorBucketRef, bool) {
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "" {
+		return timeridentity.AccumulatorBucketRef{}, false
 	}
 	if !isAccumulationTimeoutEvent(evt.Type) {
-		return strings.TrimSpace(string(evt.Type))
+		bucket := timeridentity.NewAccumulatorBucketRef(nodeID, string(evt.Type))
+		return bucket, bucket.Valid()
 	}
-	nodeBucket, _ := stateBuckets[strings.TrimSpace(nodeID)].(map[string]any)
-	accumulators, _ := nodeBucket["handler_accumulators"].(map[string]any)
-	var (
-		bestBucket string
-		bestTime   string
-	)
-	for bucketID, raw := range accumulators {
-		bucket, _ := raw.(map[string]any)
-		sortKey := strings.TrimSpace(firstNonEmptyString(asString(bucket["last_received_at"]), asString(bucket["started_at"]), bucketID))
-		if bestBucket == "" || sortKey > bestTime {
-			bestBucket = strings.TrimSpace(bucketID)
-			bestTime = sortKey
-		}
+	bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload))
+	if !ok || strings.TrimSpace(bucket.NodeID) != nodeID {
+		return timeridentity.AccumulatorBucketRef{}, false
 	}
-	prefix := strings.TrimSpace(nodeID) + ":"
-	return strings.TrimSpace(strings.TrimPrefix(bestBucket, prefix))
+	return bucket, true
 }
 
-func accumulationTimeoutStartedAt(stateBuckets map[string]any, nodeID, bucketEventType string) (time.Time, bool) {
-	nodeBucket, _ := stateBuckets[strings.TrimSpace(nodeID)].(map[string]any)
+func accumulationTimeoutStartedAt(stateBuckets map[string]any, bucketRef timeridentity.AccumulatorBucketRef) (time.Time, bool) {
+	bucketRef = bucketRef.Normalize()
+	nodeBucket, _ := stateBuckets[bucketRef.NodeID].(map[string]any)
 	accumulators, _ := nodeBucket["handler_accumulators"].(map[string]any)
-	bucketID := strings.TrimSpace(nodeID) + ":" + strings.TrimSpace(bucketEventType)
-	raw, ok := accumulators[bucketID].(map[string]any)
+	raw, ok := accumulators[bucketRef.Key()].(map[string]any)
 	if !ok {
 		return time.Time{}, false
 	}
@@ -262,27 +244,26 @@ func accumulationTimeoutStartedAt(stateBuckets map[string]any, nodeID, bucketEve
 	return parsed.UTC(), true
 }
 
-func accumulationTimeoutSchedule(entityID, nodeID, bucketEventType string, fireAt time.Time, timeoutMS int) Schedule {
-	taskID := accumulationTimeoutTaskID(nodeID, bucketEventType)
+func accumulationTimeoutSchedule(entityID string, bucketRef timeridentity.AccumulatorBucketRef, fireAt time.Time, timeoutMS int) Schedule {
+	handle := timeridentity.AccumulationTimeoutHandle(bucketRef)
 	return Schedule{
 		AgentID:   runtimeWorkflowID,
 		EventType: "accumulate.timeout",
 		Mode:      "once",
 		At:        fireAt,
 		EntityID:  strings.TrimSpace(entityID),
-		TaskID:    taskID,
-		Payload: mustJSON(map[string]any{
-			"timer_id":          taskID,
-			"trigger_reason":    "accumulate_timeout",
-			"node_id":           strings.TrimSpace(nodeID),
-			"bucket_event_type": strings.TrimSpace(bucketEventType),
-			"timeout_ms":        timeoutMS,
-		}),
+		TaskID:    handle.TaskID(),
+		Payload:   mustJSON(accumulationTimeoutPayload(handle, timeoutMS)),
 	}
 }
 
-func accumulationTimeoutTaskID(nodeID, bucketEventType string) string {
-	return "accumulate_timeout:" + strings.TrimSpace(nodeID) + ":" + strings.TrimSpace(bucketEventType)
+func accumulationTimeoutPayload(handle timeridentity.TimerHandle, timeoutMS int) map[string]any {
+	payload := handle.PayloadMetadata()
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload["timeout_ms"] = timeoutMS
+	return payload
 }
 
 func workflowTimerStateActive(items []WorkflowTimerState, timerID string) bool {
@@ -347,14 +328,15 @@ func workflowTimerPolicy(source semanticview.Source) map[string]any {
 }
 
 func workflowTimerSchedule(timer runtimecontracts.WorkflowTimerContract, entityID string, fireAt time.Time, policy map[string]any) Schedule {
+	handle := timeridentity.WorkflowTimerHandle(timer.ID)
 	sc := Schedule{
 		AgentID:   strings.TrimSpace(timer.Owner),
 		EventType: strings.TrimSpace(timer.Event),
 		Mode:      "once",
 		At:        fireAt,
 		EntityID:  strings.TrimSpace(entityID),
-		TaskID:    strings.TrimSpace(timer.ID),
-		Payload:   mustJSON(map[string]any{"timer_id": strings.TrimSpace(timer.ID), "trigger_reason": strings.TrimSpace(timer.ID)}),
+		TaskID:    handle.TaskID(),
+		Payload:   mustJSON(handle.PayloadMetadata()),
 	}
 	if timer.Recurring {
 		if cronSpec, ok := workflowTimerRecurringSpec(timer, policy); ok {
@@ -364,6 +346,16 @@ func workflowTimerSchedule(timer runtimecontracts.WorkflowTimerContract, entityI
 		}
 	}
 	return sc
+}
+
+func workflowTimerStartTrigger(timer runtimecontracts.WorkflowTimerContract) (timeridentity.Trigger, bool) {
+	trigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
+	return trigger, err == nil && trigger.Valid()
+}
+
+func workflowTimerCancelTrigger(timer runtimecontracts.WorkflowTimerContract) (timeridentity.Trigger, bool) {
+	trigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
+	return trigger, err == nil && trigger.Valid()
 }
 
 func workflowTimerRecurringSpec(timer runtimecontracts.WorkflowTimerContract, policy map[string]any) (string, bool) {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/testutil"
 )
 
@@ -102,6 +103,11 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 	}
 	if got.TaskID != "check_timer" {
 		t.Fatalf("scheduled task_id = %q, want check_timer", got.TaskID)
+	}
+	payload := parsePayloadMap(got.Payload)
+	handle, ok := timeridentity.ParseTimerHandle(payload)
+	if !ok || handle.Kind != timeridentity.TimerHandleWorkflowTimer || handle.TimerID != "check_timer" {
+		t.Fatalf("scheduled payload handle = %#v", payload)
 	}
 }
 
@@ -297,7 +303,8 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	if got.AgentID != runtimeWorkflowID {
 		t.Fatalf("scheduled agent_id = %q, want %q", got.AgentID, runtimeWorkflowID)
 	}
-	if got.TaskID != accumulationTimeoutTaskID("test-node", "item.arrived") {
+	wantHandle := timeridentity.AccumulationTimeoutHandle(timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived"))
+	if got.TaskID != wantHandle.TaskID() {
 		t.Fatalf("scheduled task_id = %q", got.TaskID)
 	}
 	if got.EntityID != "ent-001" {
@@ -307,7 +314,11 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 		t.Fatalf("scheduled at = %s, want about %s", got.At.Format(time.RFC3339Nano), start.Add(5*time.Second).Format(time.RFC3339Nano))
 	}
 	payload := parsePayloadMap(got.Payload)
-	if asString(payload["node_id"]) != "test-node" || asString(payload["bucket_event_type"]) != "item.arrived" {
+	handle, ok := timeridentity.ParseTimerHandle(payload)
+	if !ok || handle.Kind != timeridentity.TimerHandleAccumulationTimeout {
+		t.Fatalf("scheduled payload = %#v", payload)
+	}
+	if handle.Bucket.NodeID != "test-node" || handle.Bucket.EventType != "item.arrived" {
 		t.Fatalf("scheduled payload = %#v", payload)
 	}
 }
@@ -362,9 +373,14 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		Type:        events.EventType("accumulate.timeout"),
 		SourceAgent: runtimeWorkflowID,
 		Payload: mustJSON(map[string]any{
-			"entity_id":         "ent-001",
-			"node_id":           "test-node",
-			"bucket_event_type": "item.arrived",
+			"entity_id": "ent-001",
+			"timer_handle": map[string]any{
+				"kind": "accumulation_timeout",
+				"bucket": map[string]any{
+					"node_id":    "test-node",
+					"event_type": "item.arrived",
+				},
+			},
 		}),
 		CreatedAt: time.Now().UTC(),
 	}.WithEntityID("ent-001")
@@ -374,7 +390,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	if len(store.cancels) != 1 {
 		t.Fatalf("cancelled schedules = %d, want 1", len(store.cancels))
 	}
-	if got := store.cancels[0].TaskID; got != accumulationTimeoutTaskID("test-node", "item.arrived") {
+	if got := store.cancels[0].TaskID; got != timeridentity.AccumulationTimeoutHandle(timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived")).TaskID() {
 		t.Fatalf("cancelled task_id = %q", got)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -21,6 +21,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/timeridentity"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	llm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -431,8 +432,9 @@ func scheduleEventPayload(sc runtimepipeline.Schedule) []byte {
 		return payload
 	}
 	delete(decoded, "__schedule_task_id")
-	delete(decoded, "timer_id")
-	delete(decoded, "trigger_reason")
+	if handle, ok := timeridentity.ParseTimerHandle(decoded); ok && handle.Kind == timeridentity.TimerHandleWorkflowTimer {
+		delete(decoded, "timer_handle")
+	}
 	entityID := strings.TrimSpace(sc.EffectiveEntityID())
 	if _, ok := decoded["entity_id"]; !ok {
 		if entityID != "" {
@@ -649,7 +651,12 @@ func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline
 		if !timer.Recurring {
 			continue
 		}
-		if strings.TrimSpace(timer.StartOn) != "" || strings.TrimSpace(timer.CancelOn) != "" {
+		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
+		if err != nil || !startTrigger.IsBoot() {
+			continue
+		}
+		cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
+		if err != nil || cancelTrigger.Valid() {
 			continue
 		}
 		owner := strings.TrimSpace(timer.Owner)
@@ -719,8 +726,8 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 				Mode:      "once",
 				At:        timerState.FiresAt,
 				EntityID:  entityID,
-				TaskID:    timerID,
-				Payload:   mustJSON(map[string]any{"timer_id": timerID, "trigger_reason": timerID}),
+				TaskID:    timeridentity.WorkflowTimerHandle(timerID).TaskID(),
+				Payload:   recurringWorkflowTimerPayload(timer),
 			}
 			if err := store.UpsertSchedule(ctx, sc); err != nil {
 				return err
@@ -753,11 +760,11 @@ func recurringWorkflowTimerSpec(timer runtimecontracts.WorkflowTimerContract) (s
 }
 
 func recurringWorkflowTimerPayload(timer runtimecontracts.WorkflowTimerContract) []byte {
-	timerID := strings.TrimSpace(timer.ID)
-	if timerID == "" {
+	handle := timeridentity.WorkflowTimerHandle(timer.ID)
+	if !handle.Valid() {
 		return mustJSON(map[string]any{})
 	}
-	return mustJSON(map[string]any{"trigger_reason": timerID})
+	return mustJSON(handle.PayloadMetadata())
 }
 
 func runtimeEnvBool(key string, fallback bool) bool {

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -14,7 +14,7 @@ import (
 func TestScheduleEventPayloadInjectsEntityID(t *testing.T) {
 	payload := scheduleEventPayload(runtimepipeline.Schedule{
 		EntityID: "ent-001",
-		Payload:  []byte(`{"timer_id":"check_timer","trigger_reason":"check_timer"}`),
+		Payload:  []byte(`{"timer_handle":{"kind":"workflow_timer","timer_id":"check_timer"}}`),
 	})
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
@@ -23,18 +23,15 @@ func TestScheduleEventPayloadInjectsEntityID(t *testing.T) {
 	if got := decoded["entity_id"]; got != "ent-001" {
 		t.Fatalf("entity_id = %#v, want %q", got, "ent-001")
 	}
-	if _, ok := decoded["timer_id"]; ok {
-		t.Fatalf("timer_id should be stripped from published payload, got %#v", decoded["timer_id"])
-	}
-	if _, ok := decoded["trigger_reason"]; ok {
-		t.Fatalf("trigger_reason should be stripped from published payload, got %#v", decoded["trigger_reason"])
+	if _, ok := decoded["timer_handle"]; ok {
+		t.Fatalf("timer_handle should be stripped from published workflow timer payload, got %#v", decoded["timer_handle"])
 	}
 }
 
 func TestScheduleEventPayloadPreservesExistingEntityID(t *testing.T) {
 	payload := scheduleEventPayload(runtimepipeline.Schedule{
 		EntityID: "ent-001",
-		Payload:  []byte(`{"entity_id":"payload-entity","timer_id":"check_timer","__schedule_task_id":"timer-1"}`),
+		Payload:  []byte(`{"entity_id":"payload-entity","timer_handle":{"kind":"workflow_timer","timer_id":"check_timer"},"__schedule_task_id":"timer-1"}`),
 	})
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
@@ -43,11 +40,28 @@ func TestScheduleEventPayloadPreservesExistingEntityID(t *testing.T) {
 	if got := decoded["entity_id"]; got != "payload-entity" {
 		t.Fatalf("entity_id = %#v, want %q", got, "payload-entity")
 	}
-	if _, ok := decoded["timer_id"]; ok {
-		t.Fatalf("timer_id should be stripped from published payload, got %#v", decoded["timer_id"])
+	if _, ok := decoded["timer_handle"]; ok {
+		t.Fatalf("timer_handle should be stripped from published workflow timer payload, got %#v", decoded["timer_handle"])
 	}
 	if _, ok := decoded["__schedule_task_id"]; ok {
 		t.Fatalf("__schedule_task_id should be stripped from published payload, got %#v", decoded["__schedule_task_id"])
+	}
+}
+
+func TestScheduleEventPayloadPreservesAccumulationTimeoutHandle(t *testing.T) {
+	payload := scheduleEventPayload(runtimepipeline.Schedule{
+		EntityID: "ent-001",
+		Payload:  []byte(`{"timer_handle":{"kind":"accumulation_timeout","bucket":{"node_id":"collector","event_type":"item.arrived"}}}`),
+	})
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("Unmarshal(payload): %v", err)
+	}
+	if _, ok := decoded["timer_handle"]; !ok {
+		t.Fatalf("expected accumulation timeout handle to remain in published payload, got %#v", decoded)
+	}
+	if got := decoded["entity_id"]; got != "ent-001" {
+		t.Fatalf("entity_id = %#v, want %q", got, "ent-001")
 	}
 }
 
@@ -107,5 +121,33 @@ func TestEnsureRecurringWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *
 	}
 	if len(store.schedules) != 0 {
 		t.Fatalf("startup recurring schedules = %#v, want none for start_on recurring timers", store.schedules)
+	}
+}
+
+func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing.T) {
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:        "daily_report",
+				Owner:     "runtime",
+				Event:     "timer.daily_report",
+				Delay:     "24h",
+				StartOn:   "boot",
+				Recurring: true,
+			}},
+		},
+	}
+	err := ensureRecurringWorkflowSchedules(context.Background(), store, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	})
+	if err != nil {
+		t.Fatalf("ensureRecurringWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("startup recurring schedules = %#v, want 1 boot schedule", store.schedules)
+	}
+	if got := store.schedules[0].EventType; got != "timer.daily_report" {
+		t.Fatalf("scheduled event = %q, want timer.daily_report", got)
 	}
 }

--- a/internal/runtime/swarmflowtest/catalog_runner_phase5_conformance_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_phase5_conformance_test.go
@@ -68,7 +68,7 @@ func TestCatalogRunner_TimerEventRequiresActiveNodeTimer(t *testing.T) {
 		"task-node": {
 			Timers: []catalogNodeTimerContract{{
 				ID:      "task_timer",
-				StartOn: "task.started",
+				StartOn: "event:task.started",
 				Emits:   "timer.task_timeout",
 			}},
 		},

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/timeridentity"
 )
 
 type catalogTriggerStep struct {
@@ -2168,10 +2169,10 @@ func applyCatalogNodeTimers(nodeID string, node catalogNodeContract, event strin
 		return
 	}
 	for _, timer := range node.Timers {
-		if strings.EqualFold(strings.TrimSpace(timer.StartOn), event) {
+		if trigger, err := timeridentity.ParseStartTrigger(timer.StartOn); err == nil && trigger.MatchesEvent(event) {
 			activeTimers[catalogNodeTimerKey(nodeID, timer)] = timer
 		}
-		if strings.EqualFold(strings.TrimSpace(timer.CancelOn), event) {
+		if trigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn); err == nil && trigger.MatchesEvent(event) {
 			delete(activeTimers, catalogNodeTimerKey(nodeID, timer))
 		}
 	}

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/expected.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/expected.yaml
@@ -5,7 +5,13 @@ trigger:
     - event: item.arrived
       payload: { entity_id: ent-001, item_id: b }
     - event: accumulate.timeout
-      payload: { entity_id: ent-001 }
+      payload:
+        entity_id: ent-001
+        timer_handle:
+          kind: accumulation_timeout
+          bucket:
+            node_id: test-node
+            event_type: item.arrived
   entity_fields_before:
     expected_count: 3
 

--- a/tests/tier2-accumulation/test-accumulate-timeout/expected.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/expected.yaml
@@ -5,7 +5,13 @@ trigger:
     - event: item.arrived
       payload: { entity_id: ent-001, item_id: b }
     - event: accumulate.timeout
-      payload: { entity_id: ent-001 }
+      payload:
+        entity_id: ent-001
+        timer_handle:
+          kind: accumulation_timeout
+          bucket:
+            node_id: test-node
+            event_type: item.arrived
   entity_fields_before:
     expected_count: 5
 

--- a/tests/tier5-flow-lifecycle/test-timer-fire/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-fire/nodes.yaml
@@ -7,7 +7,7 @@ test-node:
     - id: check_timer
       event: timer.check
       delay: 1s
-      start_on: timer.scheduled
+      start_on: event:timer.scheduled
   event_handlers:
     timer.scheduled:
       advances_to: waiting

--- a/tests/tier5-flow-lifecycle/test-timer-recurring/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-recurring/nodes.yaml
@@ -7,7 +7,7 @@ test-node:
     - id: tick_timer
       event: timer.tick
       delay: 1s
-      start_on: monitor.started
+      start_on: event:monitor.started
       recurring: true
   event_handlers:
     monitor.started:

--- a/tests/tier5-flow-lifecycle/test-timer-start-on/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-start-on/nodes.yaml
@@ -7,7 +7,7 @@ task-node:
     - id: task_timer
       event: timer.task_timeout
       delay: 1h
-      start_on: task.started
+      start_on: event:task.started
   event_handlers:
     task.started:
       advances_to: active


### PR DESCRIPTION
## Summary
- introduce a canonical typed timer identity owner for timer triggers, workflow timer handles, and accumulation-timeout bucket targeting
- remove unprefixed timer-trigger inference and timeout bucket fallback routing from runtime hot paths
- align boot validation, fixtures, and the in-branch authoritative platform spec with the reviewed explicit trigger semantics

## Testing
- `go test ./internal/runtime/core/timeridentity ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict trigger validation for timer configurations with explicit format requirements (`event:<name>`, `state:<name>`, `boot`).
  * Enhanced accumulation timeout handling with structured payload metadata.

* **Bug Fixes**
  * Improved timer trigger reference validation to detect unknown states and events.

* **Tests**
  * Updated timer test configurations to use new trigger format with explicit prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->