### PR TITLE
[agent-b][issue #32] Make session/runtime scope invalid configurations fail closed

### DIFF
--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -36,11 +36,11 @@ type actorScopedToolExecutor interface {
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
 }
 
-func NewLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition) *LLMAgent {
+func NewLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition) (*LLMAgent, error) {
 	return newLLMAgent(cfg, modelRuntime, toolExecutor, tools, false)
 }
 
-func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition, precomposed bool) *LLMAgent {
+func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition, precomposed bool) (*LLMAgent, error) {
 	subs := make([]events.EventType, 0, len(cfg.Subscriptions))
 	for _, s := range cfg.Subscriptions {
 		if strings.TrimSpace(s) == "" {
@@ -55,7 +55,18 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 
 	maxTurns := 100
 	mode := llm.TaskScoped
-	if overrideMode, ok := parseConversationMode(cfg.ConversationMode); ok {
+	if strings.TrimSpace(cfg.ConversationMode) != "" {
+		overrideMode, ok := parseConversationMode(cfg.ConversationMode)
+		if !ok {
+			agentLabel := strings.TrimSpace(cfg.ID)
+			if agentLabel == "" {
+				agentLabel = strings.TrimSpace(cfg.Role)
+			}
+			if agentLabel == "" {
+				agentLabel = "unknown-agent"
+			}
+			return nil, fmt.Errorf("invalid conversation_mode %q for agent %s", strings.TrimSpace(cfg.ConversationMode), agentLabel)
+		}
 		mode = overrideMode
 	}
 	if cfg.MaxTurnsPerTask > 0 {
@@ -72,7 +83,7 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 		subscriptions: subs,
 		conversation:  c,
 		promptCache:   promptCache,
-	}
+	}, nil
 }
 
 func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, tools []llm.ToolDefinition, precomposed bool) []llm.ToolDefinition {
@@ -87,11 +98,11 @@ func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, 
 
 func parseConversationMode(raw string) (llm.ConversationMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "task", "task_scoped", "task-scoped", "stateless":
+	case "task", "stateless":
 		return llm.TaskScoped, true
-	case "session", "session_scoped", "session-scoped":
+	case "session":
 		return llm.SessionScoped, true
-	case "session_per_entity", "session-per-entity", "session_per_scope":
+	case "session_per_entity":
 		return llm.SessionPerEntityScoped, true
 	default:
 		return llm.TaskScoped, false
@@ -112,7 +123,7 @@ func NewLLMAgentFactory(modelRuntime llm.Runtime, toolExecutor actorScopedToolEx
 		}
 		agentTools := tools
 		agentTools = toolExecutor.ToolDefinitionsForActor(cfg)
-		return newLLMAgent(cfg, modelRuntime, toolExecutor, agentTools, true), nil
+		return newLLMAgent(cfg, modelRuntime, toolExecutor, agentTools, true)
 	}
 }
 

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -210,6 +210,24 @@ func TestParseConversationMode_AcceptsStatelessAlias(t *testing.T) {
 	}
 }
 
+func TestNewLLMAgent_RejectsInvalidConversationMode(t *testing.T) {
+	if _, err := NewLLMAgent(models.AgentConfig{
+		ID:               "agent-1",
+		ConversationMode: "session-scoped",
+	}, nil, nil, nil); err == nil {
+		t.Fatal("expected invalid conversation mode to fail closed")
+	}
+}
+
+func mustNewLLMAgent(t *testing.T, cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition) *LLMAgent {
+	t.Helper()
+	agent, err := NewLLMAgent(cfg, modelRuntime, toolExecutor, tools)
+	if err != nil {
+		t.Fatalf("NewLLMAgent: %v", err)
+	}
+	return agent
+}
+
 func TestNewLLMAgent_UsesConfiguredEmitEventsAndAllowedTools(t *testing.T) {
 	runtimetools.InitEventSchemaRegistry(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
@@ -224,7 +242,7 @@ func TestNewLLMAgent_UsesConfiguredEmitEventsAndAllowedTools(t *testing.T) {
 			},
 		},
 	}))
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:         "coordinator-1",
 			Role:       "coordinator",
@@ -342,7 +360,7 @@ func (actorScopedFactoryToolExec) ToolDefinitionsForActor(cfg models.AgentConfig
 }
 
 func TestBoardStep_ReturnsErrorWhenDirectiveDoesNotAct(t *testing.T) {
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{ID: "coordinator-1", Role: "coordinator"},
 		&boardTestRuntime{
 			steps: []*llm.Response{
@@ -364,7 +382,7 @@ func TestBoardStep_ReturnsErrorWhenDirectiveDoesNotAct(t *testing.T) {
 }
 
 func TestBoardStep_RemediatesAndSucceedsWhenDirectiveEmits(t *testing.T) {
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{ID: "coordinator-1", Role: "coordinator"},
 		&boardTestRuntime{
 			steps: []*llm.Response{
@@ -392,7 +410,7 @@ func TestBoardStep_RemediatesAndSucceedsWhenDirectiveEmits(t *testing.T) {
 }
 
 func TestNewLLMAgent_DefaultsToTaskConversationMode(t *testing.T) {
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:       "entity-agent-1",
 			Role:     "operator",
@@ -467,7 +485,7 @@ func (r *taskRetryRuntime) ContinueSession(_ context.Context, _ *llm.Session, _ 
 
 func TestLLMAgent_TaskScopedFatalCLIErrorResetsConversationAndRetries(t *testing.T) {
 	rt := &taskRetryRuntime{}
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:               "spec-reviewer",
 			Role:             "spec_reviewer",
@@ -514,7 +532,7 @@ func (r *runIDCaptureRuntime) ContinueSession(ctx context.Context, _ *llm.Sessio
 
 func TestLLMAgent_OnEvent_SeedsRunIDIntoConversationContext(t *testing.T) {
 	rt := &runIDCaptureRuntime{}
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:       "analysis-agent",
 			Role:     "analysis_agent",
@@ -563,7 +581,7 @@ func (s nativeCapabilityRuntimeStub) NativeToolCapabilities() llm.NativeToolCapa
 }
 
 func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testing.T) {
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:   "researcher-1",
 			Role: "researcher",
@@ -589,7 +607,7 @@ func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testi
 }
 
 func TestNewLLMAgent_DoesNotInjectNativeFallbackToolsWhenProviderSupportsCapability(t *testing.T) {
-	agent := NewLLMAgent(
+	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:   "ops-1",
 			Role: "ops",

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -18,6 +18,7 @@ import (
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 )
 
@@ -1570,6 +1571,13 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Message:  fmt.Sprintf("agent %s missing required field conversation_mode", agentLabel),
 					Location: agentLabel,
 				})
+			} else if _, err := sessions.ParseConversationRuntimeMode(agent.ConversationMode); err != nil {
+				c.invalidFindings = append(c.invalidFindings, Finding{
+					CheckID:  "invalid_field_detection",
+					Severity: "error",
+					Message:  fmt.Sprintf("agent %s has invalid conversation_mode: %v", agentLabel, err),
+					Location: agentLabel,
+				})
 			}
 			if len(agent.Subscriptions) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
@@ -1664,6 +1672,13 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
 					Message:  fmt.Sprintf("agent %s missing required field conversation_mode", agentLabel),
+					Location: agentLabel,
+				})
+			} else if _, err := sessions.ParseConversationRuntimeMode(agent.ConversationMode); err != nil {
+				c.invalidFindings = append(c.invalidFindings, Finding{
+					CheckID:  "invalid_field_detection",
+					Severity: "error",
+					Message:  fmt.Sprintf("agent %s has invalid conversation_mode: %v", agentLabel, err),
 					Location: agentLabel,
 				})
 			}

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -58,9 +58,9 @@ func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s
 	if r.conversations == nil || s == nil {
 		return nil
 	}
-	mode := strings.TrimSpace(s.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	mode, err := sessions.ParseConversationRuntimeMode(s.ConversationMode)
+	if err != nil {
+		return err
 	}
 	if !shouldPersistConversationMode(mode) {
 		return nil
@@ -80,15 +80,13 @@ func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s
 
 func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
 	scope := sessions.ScopeFromContext(ctx)
-	mode := strings.TrimSpace(scope.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	resolved, err := resolvedSessionScope(ctx, scope.ConversationMode, scope.ScopeKey)
+	if err != nil {
+		return nil, err
 	}
-	resolved := resolvedSessionScope(mode, scope.ScopeKey)
 
 	var lease *sessions.Lease
 	if !resolved.Stateless {
-		var err error
 		lease, err = r.sessions.Acquire(ctx, agentID, resolved.RuntimeMode, r.lockOwner, resolved.ScopeKey)
 		if err != nil {
 			return nil, err
@@ -107,7 +105,7 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 		}()),
 		AgentID:          agentID,
 		RuntimeMode:      resolved.RuntimeMode,
-		ConversationMode: mode,
+		ConversationMode: resolved.RuntimeMode,
 		ScopeKey:         resolved.ScopeKey,
 		ProviderSessionID: func() string {
 			if lease != nil {
@@ -120,7 +118,7 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 		Messages:     nil,
 	}
 	if r.conversations != nil && !resolved.Stateless {
-		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, mode, resolved.ScopeKey); err == nil && ok {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode, resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
 		}
@@ -148,9 +146,11 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		}
 	}
 
-	resolved := resolvedSessionScope(s.ConversationMode, s.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, coalesce(s.ConversationMode, s.RuntimeMode), s.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
 	var lease *sessions.Lease
-	var err error
 	if !resolved.Stateless {
 		lease, err = r.sessions.Acquire(ctx, s.AgentID, resolved.RuntimeMode, r.lockOwner, resolved.ScopeKey)
 		if err != nil {
@@ -289,9 +289,14 @@ func (r *AnthropicAPIRuntime) persistConversation(ctx context.Context, s *Sessio
 	if r.conversations == nil || s == nil {
 		return
 	}
-	mode := strings.TrimSpace(s.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	mode, err := sessions.ParseConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode))
+	if err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_api_conversation_invalid_mode", "Persisting the API conversation was skipped because the session mode was invalid", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": strings.TrimSpace(s.ConversationMode),
+			"runtime_mode":      strings.TrimSpace(s.RuntimeMode),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+		return
 	}
 	if !shouldPersistConversationMode(mode) {
 		return

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -70,9 +70,9 @@ func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *S
 	if r.conversations == nil || s == nil {
 		return nil
 	}
-	mode := strings.TrimSpace(s.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	mode, err := sessions.ParseConversationRuntimeMode(s.ConversationMode)
+	if err != nil {
+		return err
 	}
 	if !shouldPersistConversationMode(mode) {
 		return nil
@@ -100,15 +100,13 @@ func (r *ClaudeCLIRuntime) SetMonitorSink(sink MonitorSink) {
 
 func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
 	scope := sessions.ScopeFromContext(ctx)
-	mode := strings.TrimSpace(scope.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	resolved, err := resolvedSessionScope(ctx, scope.ConversationMode, scope.ScopeKey)
+	if err != nil {
+		return nil, err
 	}
-	resolved := resolvedSessionScope(mode, scope.ScopeKey)
 
 	var lease *sessions.Lease
 	if !resolved.Stateless {
-		var err error
 		lease, err = r.sessions.Acquire(ctx, agentID, resolved.RuntimeMode, r.lockOwner, resolved.ScopeKey)
 		if err != nil {
 			return nil, err
@@ -133,14 +131,14 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 		}(),
 		AgentID:          agentID,
 		RuntimeMode:      resolved.RuntimeMode,
-		ConversationMode: mode,
+		ConversationMode: resolved.RuntimeMode,
 		ScopeKey:         resolved.ScopeKey,
 		SystemPrompt:     augmentCLISystemPrompt(systemPrompt, tools),
 		Tools:            tools,
 		Messages:         nil,
 	}
 	if r.conversations != nil && !resolved.Stateless {
-		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, mode, resolved.ScopeKey); err == nil && ok {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode, resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
 		}
@@ -170,9 +168,11 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 	}
 
-	resolved := resolvedSessionScope(s.ConversationMode, s.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, coalesce(s.ConversationMode, s.RuntimeMode), s.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
 	var lease *sessions.Lease
-	var err error
 	if !resolved.Stateless {
 		lease, err = r.sessions.Acquire(ctx, s.AgentID, resolved.RuntimeMode, r.lockOwner, resolved.ScopeKey)
 		if err != nil {

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -29,9 +29,14 @@ func (r *ClaudeCLIRuntime) persistConversation(ctx context.Context, s *Session) 
 	if r.conversations == nil || s == nil {
 		return
 	}
-	mode := strings.TrimSpace(s.ConversationMode)
-	if mode == "" {
-		mode = sessions.RuntimeModeSession
+	mode, err := sessions.ParseConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode))
+	if err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_cli_conversation_invalid_mode", "Persisting the CLI conversation was skipped because the session mode was invalid", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": strings.TrimSpace(s.ConversationMode),
+			"runtime_mode":      strings.TrimSpace(s.RuntimeMode),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+		return
 	}
 	if !shouldPersistConversationMode(mode) {
 		return

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -68,11 +68,13 @@ type Conversation struct {
 func ConversationModeString(mode ConversationMode) string {
 	switch mode {
 	case TaskScoped:
-		return "task"
+		return sessions.RuntimeModeTask
+	case SessionScoped:
+		return sessions.RuntimeModeSession
 	case SessionPerEntityScoped:
-		return "session_per_entity"
+		return sessions.RuntimeModeSessionPerEntity
 	default:
-		return "session"
+		return ""
 	}
 }
 
@@ -142,21 +144,20 @@ func (c *Conversation) ensureSession(ctx context.Context) error {
 	if c.Session != nil {
 		return nil
 	}
-	scopeKey := ""
-	switch c.Mode {
-	case TaskScoped, SessionPerEntityScoped:
-		scopeKey = strings.TrimSpace(c.TaskID)
+	scope := sessions.ScopeFromContext(ctx)
+	if strings.TrimSpace(scope.ConversationMode) == "" {
+		scope.ConversationMode = ConversationModeString(c.Mode)
 	}
-	ctx = sessions.WithScope(ctx, ConversationModeString(c.Mode), scopeKey)
+	if strings.TrimSpace(scope.ScopeKey) == "" {
+		switch c.Mode {
+		case TaskScoped, SessionPerEntityScoped:
+			scope.ScopeKey = strings.TrimSpace(c.TaskID)
+		}
+	}
+	ctx = sessions.WithScope(ctx, scope.ConversationMode, scope.ScopeKey)
 	s, err := c.runtime.StartSession(ctx, c.AgentID, c.SystemPrompt, c.Tools)
 	if err != nil {
 		return err
-	}
-	if strings.TrimSpace(s.ConversationMode) == "" {
-		s.ConversationMode = ConversationModeString(c.Mode)
-	}
-	if strings.TrimSpace(s.ScopeKey) == "" {
-		s.ScopeKey = scopeKey
 	}
 	c.Session = s
 	return nil

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -148,8 +148,9 @@ func TestClaudeCLIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 
 func TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools(t *testing.T) {
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask, "task-1")
 
-	s, err := runtime.StartSession(context.Background(), "agent-2", "base prompt", []ToolDefinition{
+	s, err := runtime.StartSession(ctx, "agent-2", "base prompt", []ToolDefinition{
 		{Name: "emit_market_research_scan_complete"},
 		{Name: "read_file"},
 	})

--- a/internal/runtime/llm/session_helpers.go
+++ b/internal/runtime/llm/session_helpers.go
@@ -1,14 +1,15 @@
 package llm
 
 import (
+	"context"
 	"strings"
 
 	"github.com/google/uuid"
 	"swarm/internal/runtime/sessions"
 )
 
-func resolvedSessionScope(mode, scopeKey string) sessions.ResolvedScope {
-	return sessions.ResolveScope(mode, scopeKey)
+func resolvedSessionScope(ctx context.Context, mode, scopeKey string) (sessions.ResolvedScope, error) {
+	return sessions.ResolveScope(ctx, mode, scopeKey)
 }
 
 func ensurePlatformSessionID(id string) string {

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -34,12 +34,15 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID, runtimeMode, l
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
-	if resolved.Stateless {
-		return nil, errors.New("task-scoped sessions are stateless")
-	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
 	}
 
 	tx, err := sr.db.BeginTx(ctx, &sql.TxOptions{})
@@ -192,6 +195,10 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	mode, err := ParseConversationRuntimeMode(lease.RuntimeMode)
+	if err != nil {
+		return err
+	}
 	res, err := sr.db.ExecContext(ctx, `
 		UPDATE agent_sessions
 		SET lease_holder = NULL,
@@ -203,7 +210,7 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 		  AND scope_key = $4
 		  AND lease_holder = $5
 		  AND status = 'active'
-	`, lease.AgentID, NormalizeConversationRuntimeMode(lease.RuntimeMode), lease.SessionID, strings.TrimSpace(lease.ScopeKey), lease.LockOwner)
+	`, lease.AgentID, mode, lease.SessionID, strings.TrimSpace(lease.ScopeKey), lease.LockOwner)
 	if err != nil {
 		return fmt.Errorf("release lease: %w", err)
 	}
@@ -218,12 +225,15 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID, runtimeMode, lo
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
-	if resolved.Stateless {
-		return nil, errors.New("task-scoped sessions are stateless")
-	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
 	}
 
 	tx, err := sr.db.BeginTx(ctx, &sql.TxOptions{})
@@ -299,7 +309,10 @@ func (sr *PostgresRegistry) IncrementTurn(ctx context.Context, agentID, runtimeM
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return err
+	}
 	res, err := sr.db.ExecContext(ctx, `
 		UPDATE agent_sessions
 		SET turn_count = turn_count + 1,
@@ -327,12 +340,15 @@ func (sr *PostgresRegistry) AdoptSessionID(ctx context.Context, agentID, runtime
 	if agentID == "" || runtimeMode == "" || lockOwner == "" || newSessionID == "" {
 		return errors.New("agentID, runtimeMode, lockOwner, and newSessionID are required")
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
-	if resolved.Stateless {
-		return nil
-	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return err
+	}
+	if resolved.Stateless {
+		return nil
 	}
 
 	tx, err := sr.db.BeginTx(ctx, &sql.TxOptions{})
@@ -401,9 +417,6 @@ func (sr *PostgresRegistry) ScopeKeyEnabledForTest() bool {
 
 func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
 	runtimeMode = strings.TrimSpace(runtimeMode)
-	if runtimeMode != "" && IsStatelessRuntimeMode(runtimeMode) {
-		return nil
-	}
 	if runtimeMode == "" {
 		_, err := sr.db.Exec(`
 			UPDATE agent_sessions
@@ -419,14 +432,21 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
 		}
 		return nil
 	}
-	_, err := sr.db.Exec(`
+	mode, err := ParseConversationRuntimeMode(runtimeMode)
+	if err != nil {
+		return err
+	}
+	if mode == RuntimeModeTask {
+		return nil
+	}
+	_, err = sr.db.Exec(`
 		UPDATE agent_sessions
 		SET status = 'terminated',
 		    lease_holder = NULL,
 		    lease_expires_at = NULL,
 		    updated_at = now()
 		WHERE status = 'active' AND runtime_mode = $1
-	`, NormalizeConversationRuntimeMode(runtimeMode))
+	`, mode)
 	if err != nil {
 		return fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode, err)
 	}

--- a/internal/runtime/sessions/postgres_test.go
+++ b/internal/runtime/sessions/postgres_test.go
@@ -29,7 +29,7 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "lease_expires_at"}).AddRow("sess-1", "global", fixedNow.Add(30*time.Second)))
 	mock.ExpectCommit()
 
-	lease, err := sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "")
+	lease, err := sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "global")
 	if err != nil {
 		t.Fatalf("Acquire new: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"lease_expires_at"}).AddRow(fixedNow.Add(30 * time.Second)))
 	mock.ExpectCommit()
 
-	lease2, err := sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "")
+	lease2, err := sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "global")
 	if err != nil {
 		t.Fatalf("Acquire existing: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestPostgresSessionRegistry_AcquireLeasedByOtherReturnsErrLeased(t *testing
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "global", "active", nil, "someone-else", fixedNow.Add(10*time.Second)))
 
-	_, err = sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "")
+	_, err = sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", "global")
 	if err != ErrSessionLeased {
 		t.Fatalf("expected ErrSessionLeased, got %v", err)
 	}
@@ -121,7 +121,7 @@ func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"lease_expires_at"}).AddRow(fixedNow.Add(30 * time.Second)))
 	mock.ExpectCommit()
 
-	lease, err := sr.Rotate(context.Background(), "a1", RuntimeModeSession, "owner-1", "sum", "")
+	lease, err := sr.Rotate(context.Background(), "a1", RuntimeModeSession, "owner-1", "sum", "global")
 	if err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
@@ -132,14 +132,14 @@ func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 	mock.ExpectExec("UPDATE agent_sessions\\s+SET turn_count = turn_count \\+ 1").
 		WithArgs("a1", RuntimeModeSession, lease.SessionID, "global").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	if err := sr.IncrementTurn(context.Background(), "a1", RuntimeModeSession, lease.SessionID, ""); err != nil {
+	if err := sr.IncrementTurn(context.Background(), "a1", RuntimeModeSession, lease.SessionID, "global"); err != nil {
 		t.Fatalf("IncrementTurn: %v", err)
 	}
 
 	mock.ExpectExec("UPDATE agent_sessions\\s+SET turn_count = turn_count \\+ 1").
 		WithArgs("a1", RuntimeModeSession, "missing", "global").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	if err := sr.IncrementTurn(context.Background(), "a1", RuntimeModeSession, "missing", ""); err == nil {
+	if err := sr.IncrementTurn(context.Background(), "a1", RuntimeModeSession, "missing", "global"); err == nil {
 		t.Fatal("expected IncrementTurn to error on missing session")
 	}
 
@@ -169,7 +169,7 @@ func TestPostgresSessionRegistry_AdoptSessionID(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	if err := sr.AdoptSessionID(context.Background(), "a1", RuntimeModeSession, "owner-1", "claude-session-1", ""); err != nil {
+	if err := sr.AdoptSessionID(context.Background(), "a1", RuntimeModeSession, "owner-1", "claude-session-1", "global"); err != nil {
 		t.Fatalf("AdoptSessionID: %v", err)
 	}
 
@@ -188,6 +188,19 @@ func TestPostgresSessionRegistry_TaskModeIsStateless(t *testing.T) {
 	sr := NewPostgresRegistry(db, 30*time.Second)
 	if _, err := sr.Acquire(context.Background(), "a1", RuntimeModeTask, "owner-1", "task-1"); err == nil {
 		t.Fatal("expected task mode acquire to reject stateless sessions")
+	}
+}
+
+func TestPostgresSessionRegistry_SessionScopeRequiresExplicitDeclaration(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sr := NewPostgresRegistry(db, 30*time.Second)
+	if _, err := sr.Acquire(context.Background(), "a1", RuntimeModeSession, "owner-1", ""); err == nil {
+		t.Fatal("expected session acquire without explicit scope to fail closed")
 	}
 }
 

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -72,11 +72,14 @@ func registryKey(agentID, runtimeMode, scopeKey string) string {
 	return strings.TrimSpace(agentID) + "|" + strings.TrimSpace(runtimeMode) + "|" + strings.TrimSpace(scopeKey)
 }
 
-func (sr *InMemoryRegistry) Acquire(_ context.Context, agentID, runtimeMode, lockOwner, scopeKey string) (*Lease, error) {
+func (sr *InMemoryRegistry) Acquire(ctx context.Context, agentID, runtimeMode, lockOwner, scopeKey string) (*Lease, error) {
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return nil, err
+	}
 	if resolved.Stateless {
 		return nil, errors.New("task-scoped sessions are stateless")
 	}
@@ -140,8 +143,11 @@ func (sr *InMemoryRegistry) Release(_ context.Context, lease *Lease) error {
 	return nil
 }
 
-func (sr *InMemoryRegistry) Rotate(_ context.Context, agentID, runtimeMode, lockOwner, summary, scopeKey string) (*Lease, error) {
-	resolved := ResolveScope(runtimeMode, scopeKey)
+func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID, runtimeMode, lockOwner, summary, scopeKey string) (*Lease, error) {
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return nil, err
+	}
 	if resolved.Stateless {
 		return nil, errors.New("task-scoped sessions are stateless")
 	}
@@ -181,8 +187,11 @@ func (sr *InMemoryRegistry) Rotate(_ context.Context, agentID, runtimeMode, lock
 	}, nil
 }
 
-func (sr *InMemoryRegistry) IncrementTurn(_ context.Context, agentID, runtimeMode, sessionID, scopeKey string) error {
-	resolved := ResolveScope(runtimeMode, scopeKey)
+func (sr *InMemoryRegistry) IncrementTurn(ctx context.Context, agentID, runtimeMode, sessionID, scopeKey string) error {
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return err
+	}
 	if resolved.Stateless {
 		return errors.New("task-scoped sessions are stateless")
 	}
@@ -201,7 +210,7 @@ func (sr *InMemoryRegistry) IncrementTurn(_ context.Context, agentID, runtimeMod
 	return fmt.Errorf("session for agent %s not found", agentID)
 }
 
-func (sr *InMemoryRegistry) AdoptSessionID(_ context.Context, agentID, runtimeMode, lockOwner, newSessionID, scopeKey string) error {
+func (sr *InMemoryRegistry) AdoptSessionID(ctx context.Context, agentID, runtimeMode, lockOwner, newSessionID, scopeKey string) error {
 	agentID = strings.TrimSpace(agentID)
 	runtimeMode = strings.TrimSpace(runtimeMode)
 	lockOwner = strings.TrimSpace(lockOwner)
@@ -209,7 +218,10 @@ func (sr *InMemoryRegistry) AdoptSessionID(_ context.Context, agentID, runtimeMo
 	if agentID == "" || runtimeMode == "" || lockOwner == "" || newSessionID == "" {
 		return errors.New("agentID, runtimeMode, lockOwner, and newSessionID are required")
 	}
-	resolved := ResolveScope(runtimeMode, scopeKey)
+	resolved, err := ResolveScope(ctx, runtimeMode, scopeKey)
+	if err != nil {
+		return err
+	}
 	if resolved.Stateless {
 		return nil
 	}
@@ -270,13 +282,17 @@ func (sr *InMemoryRegistry) Snapshot(agentID string) (*Record, bool) {
 
 func (sr *InMemoryRegistry) ResetAll(runtimeMode string) error {
 	runtimeMode = strings.TrimSpace(runtimeMode)
-	if runtimeMode != "" && IsStatelessRuntimeMode(runtimeMode) {
-		return nil
-	}
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	if runtimeMode == "" {
 		sr.byKey = make(map[string]*Record)
+		return nil
+	}
+	mode, err := ParseConversationRuntimeMode(runtimeMode)
+	if err != nil {
+		return err
+	}
+	if mode == RuntimeModeTask {
 		return nil
 	}
 	for key, rec := range sr.byKey {
@@ -284,7 +300,7 @@ func (sr *InMemoryRegistry) ResetAll(runtimeMode string) error {
 			delete(sr.byKey, key)
 			continue
 		}
-		if strings.TrimSpace(rec.RuntimeMode) == runtimeMode {
+		if strings.TrimSpace(rec.RuntimeMode) == mode {
 			delete(sr.byKey, key)
 		}
 	}

--- a/internal/runtime/sessions/registry_test.go
+++ b/internal/runtime/sessions/registry_test.go
@@ -8,12 +8,12 @@ import (
 func TestInMemorySessionRegistryLeaseConflictAndRelease(t *testing.T) {
 	sr := NewInMemoryRegistry(0)
 
-	leaseA, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "")
+	leaseA, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "global")
 	if err != nil {
 		t.Fatalf("acquire A: %v", err)
 	}
 
-	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-b", ""); err == nil {
+	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-b", "global"); err == nil {
 		t.Fatalf("expected lease conflict for worker-b")
 	}
 
@@ -21,7 +21,7 @@ func TestInMemorySessionRegistryLeaseConflictAndRelease(t *testing.T) {
 		t.Fatalf("release A: %v", err)
 	}
 
-	leaseB, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-b", "")
+	leaseB, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-b", "global")
 	if err != nil {
 		t.Fatalf("acquire B after release: %v", err)
 	}
@@ -33,13 +33,13 @@ func TestInMemorySessionRegistryLeaseConflictAndRelease(t *testing.T) {
 func TestInMemorySessionRegistryRotate(t *testing.T) {
 	sr := NewInMemoryRegistry(0)
 
-	lease, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "")
+	lease, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "global")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
 	old := lease.SessionID
 
-	rotated, err := sr.Rotate(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "checkpoint", "")
+	rotated, err := sr.Rotate(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "checkpoint", "global")
 	if err != nil {
 		t.Fatalf("rotate: %v", err)
 	}
@@ -50,11 +50,11 @@ func TestInMemorySessionRegistryRotate(t *testing.T) {
 
 func TestInMemorySessionRegistryAdoptSessionID(t *testing.T) {
 	sr := NewInMemoryRegistry(0)
-	_, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "")
+	_, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "global")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
-	if err := sr.AdoptSessionID(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "claude-session-1", ""); err != nil {
+	if err := sr.AdoptSessionID(context.Background(), "agent-a", RuntimeModeSession, "worker-a", "claude-session-1", "global"); err != nil {
 		t.Fatalf("adopt: %v", err)
 	}
 	rec, ok := sr.Snapshot("agent-a")
@@ -73,5 +73,12 @@ func TestInMemorySessionRegistry_TaskModeIsStateless(t *testing.T) {
 	}
 	if err := sr.ResetAll(RuntimeModeTask); err != nil {
 		t.Fatalf("ResetAll(task): %v", err)
+	}
+}
+
+func TestInMemorySessionRegistry_SessionScopeRequiresExplicitDeclaration(t *testing.T) {
+	sr := NewInMemoryRegistry(0)
+	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "worker-a", ""); err == nil {
+		t.Fatal("expected session acquire without explicit scope to fail closed")
 	}
 }

--- a/internal/runtime/sessions/scope.go
+++ b/internal/runtime/sessions/scope.go
@@ -2,7 +2,10 @@ package sessions
 
 import (
 	"context"
+	"fmt"
 	"strings"
+
+	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
 const (
@@ -29,7 +32,7 @@ type scopeContextKey struct{}
 
 func WithScope(ctx context.Context, mode, scopeKey string) context.Context {
 	payload := ScopeContext{
-		ConversationMode: NormalizeConversationRuntimeMode(mode),
+		ConversationMode: strings.TrimSpace(mode),
 		ScopeKey:         strings.TrimSpace(scopeKey),
 	}
 	return context.WithValue(ctx, scopeContextKey{}, payload)
@@ -37,42 +40,66 @@ func WithScope(ctx context.Context, mode, scopeKey string) context.Context {
 
 func ScopeFromContext(ctx context.Context) ScopeContext {
 	if ctx == nil {
-		return ScopeContext{ConversationMode: RuntimeModeTask}
+		return ScopeContext{}
 	}
 	v := ctx.Value(scopeContextKey{})
 	payload, ok := v.(ScopeContext)
 	if !ok {
-		return ScopeContext{ConversationMode: RuntimeModeTask}
+		return ScopeContext{}
 	}
-	payload.ConversationMode = NormalizeConversationRuntimeMode(payload.ConversationMode)
+	payload.ConversationMode = strings.TrimSpace(payload.ConversationMode)
 	payload.ScopeKey = strings.TrimSpace(payload.ScopeKey)
 	return payload
 }
 
-func NormalizeConversationRuntimeMode(raw string) string {
+func canonicalConversationRuntimeMode(raw string) (string, bool) {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
 	case RuntimeModeTask, "stateless":
-		return RuntimeModeTask
+		return RuntimeModeTask, true
 	case RuntimeModeSession:
-		return RuntimeModeSession
+		return RuntimeModeSession, true
 	case RuntimeModeSessionPerEntity:
-		return RuntimeModeSessionPerEntity
+		return RuntimeModeSessionPerEntity, true
 	default:
-		return RuntimeModeTask
+		return "", false
 	}
 }
 
+func NormalizeConversationRuntimeMode(raw string) string {
+	mode, _ := canonicalConversationRuntimeMode(raw)
+	return mode
+}
+
+func ParseConversationRuntimeMode(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("conversation mode is required")
+	}
+	mode, ok := canonicalConversationRuntimeMode(raw)
+	if !ok {
+		return "", fmt.Errorf("invalid conversation mode %q", raw)
+	}
+	return mode, nil
+}
+
 func IsStatelessRuntimeMode(raw string) bool {
-	return NormalizeConversationRuntimeMode(raw) == RuntimeModeTask
+	mode, ok := canonicalConversationRuntimeMode(raw)
+	return ok && mode == RuntimeModeTask
 }
 
 func IsLiveSessionRuntimeMode(raw string) bool {
-	return !IsStatelessRuntimeMode(raw)
+	mode, ok := canonicalConversationRuntimeMode(raw)
+	return ok && mode != RuntimeModeTask
 }
 
-func ResolveScope(runtimeMode, scopeKey string) ResolvedScope {
-	mode := NormalizeConversationRuntimeMode(runtimeMode)
+func ResolveScope(ctx context.Context, runtimeMode, scopeKey string) (ResolvedScope, error) {
+	mode, err := ParseConversationRuntimeMode(runtimeMode)
+	if err != nil {
+		return ResolvedScope{}, err
+	}
 	scopeKey = strings.TrimSpace(scopeKey)
+	actor, _ := runtimeactors.ActorFromContext(ctx)
+	flowPath := actor.CanonicalFlowPath()
 
 	out := ResolvedScope{
 		RuntimeMode: mode,
@@ -82,18 +109,41 @@ func ResolveScope(runtimeMode, scopeKey string) ResolvedScope {
 	switch mode {
 	case RuntimeModeTask:
 		out.Stateless = true
+		return out, nil
 	case RuntimeModeSessionPerEntity:
+		if scopeKey == "" {
+			return ResolvedScope{}, fmt.Errorf("session_per_entity requires entity scope key")
+		}
+		if flowPath == "" {
+			return ResolvedScope{}, fmt.Errorf("session_per_entity requires actor flow path")
+		}
 		out.Scope = "entity"
 		out.EntityID = scopeKey
-	default:
-		if scopeKey == "" {
+		out.FlowInstance = flowPath
+		return out, nil
+	case RuntimeModeSession:
+		switch {
+		case scopeKey == "global":
 			out.Scope = "global"
 			out.ScopeKey = "global"
-			break
+			return out, nil
+		case scopeKey != "":
+			out.Scope = "flow"
+			out.FlowInstance = scopeKey
+			return out, nil
+		case flowPath != "":
+			out.Scope = "flow"
+			out.ScopeKey = flowPath
+			out.FlowInstance = flowPath
+			return out, nil
+		case strings.TrimSpace(actor.ID) != "":
+			out.Scope = "global"
+			out.ScopeKey = "global"
+			return out, nil
+		default:
+			return ResolvedScope{}, fmt.Errorf("session requires explicit scope key or actor declaration")
 		}
-		out.Scope = "flow"
-		out.FlowInstance = scopeKey
 	}
 
-	return out
+	return ResolvedScope{}, fmt.Errorf("unsupported conversation mode %q", runtimeMode)
 }

--- a/internal/runtime/sessions/scope_heartbeat_test.go
+++ b/internal/runtime/sessions/scope_heartbeat_test.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
 func TestScopeFromContext_DefaultsToTask(t *testing.T) {
 	scope := ScopeFromContext(nil)
-	if scope.ConversationMode != "task" || scope.ScopeKey != "" {
+	if scope.ConversationMode != "" || scope.ScopeKey != "" {
 		t.Fatalf("unexpected nil-context scope: %+v", scope)
 	}
 
 	ctx := WithScope(context.Background(), "TASK", "  abc  ")
 	scope = ScopeFromContext(ctx)
-	if scope.ConversationMode != "task" || scope.ScopeKey != "abc" {
+	if scope.ConversationMode != "TASK" || scope.ScopeKey != "abc" {
 		t.Fatalf("unexpected scoped context: %+v", scope)
 	}
 }
@@ -23,9 +25,49 @@ func TestNormalizeConversationRuntimeMode_AcceptsStatelessAlias(t *testing.T) {
 	if got := NormalizeConversationRuntimeMode("stateless"); got != RuntimeModeTask {
 		t.Fatalf("NormalizeConversationRuntimeMode(stateless) = %q, want %q", got, RuntimeModeTask)
 	}
-	scope := ResolveScope("stateless", "ignored")
+	scope, err := ResolveScope(context.Background(), "stateless", "ignored")
+	if err != nil {
+		t.Fatalf("ResolveScope(stateless): %v", err)
+	}
 	if scope.RuntimeMode != RuntimeModeTask || !scope.Stateless {
 		t.Fatalf("ResolveScope(stateless) = %+v, want task/stateless", scope)
+	}
+}
+
+func TestResolveScope_SessionUsesActorDeclaration(t *testing.T) {
+	flowCtx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID:       "flow-agent",
+		FlowPath: "review/inst-1",
+	})
+	flowScope, err := ResolveScope(flowCtx, RuntimeModeSession, "")
+	if err != nil {
+		t.Fatalf("ResolveScope(flow session): %v", err)
+	}
+	if flowScope.Scope != "flow" || flowScope.ScopeKey != "review/inst-1" || flowScope.FlowInstance != "review/inst-1" {
+		t.Fatalf("unexpected flow scope: %+v", flowScope)
+	}
+
+	globalCtx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "global-agent",
+	})
+	globalScope, err := ResolveScope(globalCtx, RuntimeModeSession, "")
+	if err != nil {
+		t.Fatalf("ResolveScope(global session): %v", err)
+	}
+	if globalScope.Scope != "global" || globalScope.ScopeKey != "global" {
+		t.Fatalf("unexpected global scope: %+v", globalScope)
+	}
+}
+
+func TestResolveScope_InvalidSessionConfigurationsFailClosed(t *testing.T) {
+	if _, err := ResolveScope(context.Background(), RuntimeModeSession, ""); err == nil {
+		t.Fatal("expected session scope without declaration to fail")
+	}
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "entity-agent",
+	})
+	if _, err := ResolveScope(ctx, RuntimeModeSessionPerEntity, "entity-1"); err == nil {
+		t.Fatal("expected session_per_entity without flow path to fail")
 	}
 }
 

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -535,8 +535,14 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if err != nil {
 		return err
 	}
-	mode := runtimesessions.NormalizeConversationRuntimeMode(rec.Mode)
-	resolved := runtimesessions.ResolveScope(mode, rec.ScopeKey)
+	mode, err := runtimesessions.ParseConversationRuntimeMode(rec.Mode)
+	if err != nil {
+		return err
+	}
+	resolved, err := runtimesessions.ResolveScope(context.Background(), mode, rec.ScopeKey)
+	if err != nil {
+		return err
+	}
 
 	status := strings.TrimSpace(strings.ToLower(rec.Status))
 	if status == "" {
@@ -805,8 +811,14 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 		return runtimellm.ConversationRecord{}, false, fmt.Errorf("agent_id is required")
 	}
 
-	mode = runtimesessions.NormalizeConversationRuntimeMode(mode)
-	resolved := runtimesessions.ResolveScope(mode, scopeKey)
+	mode, err := runtimesessions.ParseConversationRuntimeMode(mode)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
+	resolved, err := runtimesessions.ResolveScope(context.Background(), mode, scopeKey)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
 	if resolved.Stateless {
 		return runtimellm.ConversationRecord{}, false, nil
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1216,8 +1216,9 @@ func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
 	seedSpecAgent(t, ctx, pg, "a1", "", "")
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
-		AgentID: "a1",
-		Mode:    "session",
+		AgentID:  "a1",
+		Mode:     "session",
+		ScopeKey: "global",
 		Messages: []llm.Message{
 			{Role: "user", Content: "reach me at a@example.com"},
 		},
@@ -1225,7 +1226,7 @@ func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertConversation: %v", err)
 	}
-	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "")
+	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global")
 	if err != nil || !ok {
 		t.Fatalf("LoadActiveConversation ok=%v err=%v", ok, err)
 	}
@@ -1789,6 +1790,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 		AgentID:   ceoID,
 		TaskID:    "",
 		Mode:      "session",
+		ScopeKey:  "global",
 		Messages:  []llm.Message{{Role: "user", Content: "hi"}},
 		Summary:   "sum",
 		TurnCount: 1,
@@ -1796,7 +1798,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertConversation: %v", err)
 	}
-	if rec, ok, err := pg.LoadActiveConversation(ctx, ceoID, "session", ""); err != nil || !ok || rec.AgentID != ceoID {
+	if rec, ok, err := pg.LoadActiveConversation(ctx, ceoID, "session", "global"); err != nil || !ok || rec.AgentID != ceoID {
 		t.Fatalf("LoadActiveConversation ok=%v err=%v rec=%+v", ok, err, rec)
 	}
 
@@ -1848,6 +1850,7 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
 		AgentID:   "agent-cleanup-1",
 		Mode:      "session",
+		ScopeKey:  "global",
 		Messages:  []llm.Message{{Role: "user", Content: "hello"}},
 		Summary:   "x",
 		TurnCount: 1,


### PR DESCRIPTION
## What Changed
- made `internal/runtime/sessions` the canonical owner for conversation mode parsing and session scope resolution
- removed silent normalization of invalid or incomplete session/runtime scope inputs to permissive task/global behavior
- updated LLM runtime, agent construction, boot verification, and store persistence paths to consume the strict shared validator/resolver
- added focused regressions for invalid mode aliases, missing session scope, canonical flow/global session scope, and store persistence expectations

## Why
Invalid or incomplete scope configuration was being silently normalized in several runtime paths. That hid configuration errors and let behavior drift based on local fallback rules rather than one explicit semantic owner.

## Impact
- invalid `conversation_mode` values now fail explicitly instead of collapsing to `task`
- `session` scope now requires an explicit canonical basis: `global`, an explicit scope key, or actor declaration data
- `session_per_entity` now fails closed when the required entity/flow scope semantics are incomplete
- boot verification now rejects invalid agent conversation modes earlier

## Validation
- `go test ./... -count=1`
