### PR TITLE
[agent-d][issue #36] Unify store-side subscription and event matching with the canonical runtime matcher

### DIFF
--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	"swarm/internal/runtime/core/eventidentity"
 	runtimemanager "swarm/internal/runtime/manager"
 )
 
@@ -326,8 +327,11 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 	}
 	filtered := make([]events.Event, 0, len(out))
 	for _, evt := range out {
-		if matchesAnySubscription(string(evt.Type), subscriptions) {
-			filtered = append(filtered, evt)
+		for _, subscription := range subscriptions {
+			if eventidentity.MatchPattern(string(subscription), string(evt.Type)) {
+				filtered = append(filtered, evt)
+				break
+			}
 		}
 	}
 	return filtered, nil

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"swarm/internal/events"
 	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
@@ -172,26 +171,6 @@ func normalizeJSONPayload(raw []byte) string {
 	}
 	b, _ := json.Marshal(map[string]string{"raw": redactText(string(raw))})
 	return string(b)
-}
-
-func matchesAnySubscription(eventType string, patterns []events.EventType) bool {
-	for _, p := range patterns {
-		if subscriptionMatch(string(p), eventType) {
-			return true
-		}
-	}
-	return false
-}
-
-func subscriptionMatch(pattern, eventType string) bool {
-	switch {
-	case pattern == "", pattern == "*":
-		return true
-	case strings.HasSuffix(pattern, "*"):
-		return strings.HasPrefix(eventType, strings.TrimSuffix(pattern, "*"))
-	default:
-		return pattern == eventType
-	}
 }
 
 func nullable(value, fallback string) string {

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/store"
@@ -144,6 +145,76 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 	}
 	if len(evts) != 0 {
 		t.Fatalf("list subscribed pending (dead_letter): got %d events, want 0", len(evts))
+	}
+}
+
+func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+
+	deep := seedEvent(t, ctx, pg, entityID, "operating/child/grandchild/opco.launched")
+	segment := seedEvent(t, ctx, pg, entityID, "review.ready")
+	tooDeep := seedEvent(t, ctx, pg, entityID, "scoring/a/b")
+	invalidPattern := seedEvent(t, ctx, pg, entityID, "budget.alert")
+
+	since := time.Now().Add(-2 * time.Hour)
+	tests := []struct {
+		name          string
+		subscriptions []events.EventType
+		eventType     string
+		wantIDs       []string
+	}{
+		{
+			name:          "recursive wildcard matches deep scoped event",
+			subscriptions: []events.EventType{"operating/**/opco.launched"},
+			eventType:     string(deep.Type),
+			wantIDs:       []string{deep.ID},
+		},
+		{
+			name:          "segment glob matches canonical runtime semantics",
+			subscriptions: []events.EventType{"*.ready"},
+			eventType:     string(segment.Type),
+			wantIDs:       []string{segment.ID},
+		},
+		{
+			name:          "single segment wildcard does not span multiple segments",
+			subscriptions: []events.EventType{"scoring/*"},
+			eventType:     string(tooDeep.Type),
+			wantIDs:       nil,
+		},
+		{
+			name:          "invalid pattern fails closed",
+			subscriptions: []events.EventType{"["},
+			eventType:     string(invalidPattern.Type),
+			wantIDs:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimebus.RouteMatches(string(tt.subscriptions[0]), tt.eventType); got != (len(tt.wantIDs) > 0) {
+				t.Fatalf("runtime matcher parity mismatch for %q vs %q: got %v want %v", tt.subscriptions[0], tt.eventType, got, len(tt.wantIDs) > 0)
+			}
+			evts, err := pg.ListPendingSubscribedEvents(ctx, agentID, tt.subscriptions, since, 100)
+			if err != nil {
+				t.Fatalf("ListPendingSubscribedEvents: %v", err)
+			}
+			gotIDs := make([]string, 0, len(evts))
+			for _, evt := range evts {
+				gotIDs = append(gotIDs, evt.ID)
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("subscriptions=%v got=%v want=%v", tt.subscriptions, gotIDs, tt.wantIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tt.wantIDs[i] {
+					t.Fatalf("subscriptions=%v got=%v want=%v", tt.subscriptions, gotIDs, tt.wantIDs)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"github.com/google/uuid"
 	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/eventidentity"
 	llm "swarm/internal/runtime/llm"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/testutil"
-	"testing"
-	"time"
 )
 
 func resetAgentSessionsSpecTable(t *testing.T, ctx context.Context, pg *PostgresStore) {
@@ -713,30 +715,6 @@ func TestNormalizeJSONPayload_RedactsSensitiveText(t *testing.T) {
 	out = normalizeJSONPayload([]byte(`{"timestamp":"2026-02-21T02:47:05Z","notes":"at 2026-02-21T02:47:05Z"}`))
 	if strings.Contains(out, "[PHONE]") {
 		t.Fatalf("expected timestamp not redacted as phone, got %q", out)
-	}
-}
-
-func TestSubscriptionMatchPatterns(t *testing.T) {
-	if !subscriptionMatch("", "x.y") {
-		t.Fatalf("empty should match all")
-	}
-	if !subscriptionMatch("*", "x.y") {
-		t.Fatalf("* should match all")
-	}
-	if !subscriptionMatch("inbound.*", "inbound.a") {
-		t.Fatalf("prefix star should match")
-	}
-	if subscriptionMatch("inbound.*", "room.message") {
-		t.Fatalf("prefix star should not match other prefix")
-	}
-	if !subscriptionMatch("room.message", "room.message") {
-		t.Fatalf("exact should match")
-	}
-	if subscriptionMatch("room.message", "room.messages") {
-		t.Fatalf("exact should not match different")
-	}
-	if !matchesAnySubscription("inbound.a", []events.EventType{"review.*", "inbound.*"}) {
-		t.Fatalf("matchesAnySubscription expected true")
 	}
 }
 
@@ -1637,10 +1615,6 @@ func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
 	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{Config: runtimeactors.AgentConfig{}}); err == nil {
 		t.Fatalf("expected agent id required error")
 	}
-
-	if !matchesAnySubscription("inbound.a", []events.EventType{"inbound.*"}) {
-		t.Fatalf("expected matchesAnySubscription true")
-	}
 }
 
 func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
@@ -1913,10 +1887,10 @@ func TestManagerHelpers_MatchingAndRedaction(t *testing.T) {
 	if normalizeJSONPayload([]byte(`{"b":1,"a":2}`)) == "" {
 		t.Fatal("expected normalized json")
 	}
-	if !matchesAnySubscription("review.chat", []events.EventType{"review.*"}) {
+	if !eventidentity.MatchPattern("review.*", "review.chat") {
 		t.Fatal("expected subscription match")
 	}
-	if subscriptionMatch("review.*", "budget.alert") {
+	if eventidentity.MatchPattern("review.*", "budget.alert") {
 		t.Fatal("unexpected match")
 	}
 	if nullable("", "x") != "x" {


### PR DESCRIPTION
## What changed
Unified the store-side subscribed-event filtering path with the canonical runtime matcher semantics.

`ListPendingSubscribedEvents` now filters events with the same matcher used by the runtime bus/router instead of a store-local simplified prefix matcher. The old local helper matcher was removed from the store seam.

## Why
Store and receipt paths still had simpler local subscription matching semantics that could drift from runtime routing behavior. That risked persisted delivery state disagreeing with what the runtime considered matchable.

## Impact
Store-side subscribed backlog filtering now follows canonical runtime matching for recursive wildcards, single-segment wildcards, segment globs, and invalid patterns. Invalid patterns fail closed instead of being interpreted by a local simplified matcher.

## Validation
- `go test ./internal/store ./internal/runtime/bus ./internal/runtime/core/eventidentity -count=1`
- `go test ./... -count=1`
