### PR TITLE
[agent-c][issue #35] Replace string-suffix agent/entity scope inference with explicit metadata

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -415,7 +415,16 @@ func (eb *EventBus) buildDeliveryPlan(ctx context.Context, evt events.Event) (ev
 	if direct := uniqueStrings(plan.SubscribedRecipients); len(direct) > 0 {
 		plan.ExtraDetail["subscription_recipients"] = direct
 	}
-	plan.PersistedRecipients = eb.persistableRecipients(ctx, plan.Recipients)
+	descriptors, ok, err := eb.activeAgentDescriptors(ctx)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	if ok {
+		plan.Recipients = filterRecipientsForExplicitAgentScope(evt, plan.Recipients, descriptors)
+		plan.PersistedRecipients = append([]string(nil), plan.Recipients...)
+	} else {
+		plan.PersistedRecipients = uniqueStrings(plan.Recipients)
+	}
 	eb.recordPublishDiagnostic(ctx, evt, plan)
 	return plan, nil
 }

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -166,6 +168,60 @@ func (h *recordingLoggerHook) Log(_ context.Context, _, _, _, action, _, _, _, _
 	h.entries = append(h.entries, recordedLogEntry{Action: action, Detail: detail})
 }
 
+type descriptorAwareEventStore struct {
+	mu          sync.Mutex
+	descriptors []runtimebus.ActiveAgentDescriptor
+	deliveries  []string
+	listErr     error
+}
+
+func (*descriptorAwareEventStore) AppendEvent(context.Context, events.Event) error { return nil }
+
+func (s *descriptorAwareEventStore) InsertEventDeliveries(_ context.Context, _ string, agentIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveries = append([]string(nil), agentIDs...)
+	return nil
+}
+
+func (s *descriptorAwareEventStore) ListActiveAgentDescriptors(context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return append([]runtimebus.ActiveAgentDescriptor(nil), s.descriptors...), nil
+}
+
+func (s *descriptorAwareEventStore) persistedDeliveries() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deliveries...)
+}
+
+func waitForNoEvent(t *testing.T, ch <-chan events.Event) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Fatalf("unexpected event delivered: %#v", evt)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func assertSortedStringsEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	slices.Sort(got)
+	slices.Sort(want)
+	if len(got) != len(want) {
+		t.Fatalf("strings = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("strings = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestEventBusPublish_UsesPayloadValidator(t *testing.T) {
 	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
 		PayloadValidator: func(eventType string, payload []byte) error {
@@ -222,6 +278,106 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 	}, []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
+	}
+}
+
+func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "control-plane"},
+			{AgentID: "reviewer-ent-1", EntityID: "ent-1"},
+			{AgentID: "reviewer-ent-2", EntityID: "ent-2"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controlCh := eb.Subscribe("control-plane", events.EventType("custom.trigger"))
+	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
+	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
+
+	if err := eb.Publish(context.Background(), events.Event{
+		Type:      events.EventType("custom.trigger"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case evt := <-controlCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("control event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("control-plane did not receive event")
+	}
+	select {
+	case evt := <-matchCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("matched event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("entity-scoped reviewer did not receive matching event")
+	}
+	waitForNoEvent(t, otherCh)
+
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane", "reviewer-ent-1"})
+}
+
+func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "control-plane"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controlCh := eb.Subscribe("control-plane", events.EventType("custom.trigger"))
+	missingCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
+
+	if err := eb.Publish(context.Background(), events.Event{
+		Type:      events.EventType("custom.trigger"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-controlCh:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("control-plane did not receive event")
+	}
+	waitForNoEvent(t, missingCh)
+
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane"})
+}
+
+func TestEventBusPublish_FailsClosedWhenDescriptorLookupFails(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		listErr: errors.New("descriptor lookup failed"),
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
+
+	err = eb.Publish(context.Background(), events.Event{
+		Type:      events.EventType("custom.trigger"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1"))
+	if err == nil || !strings.Contains(err.Error(), "descriptor lookup failed") {
+		t.Fatalf("Publish error = %v, want descriptor lookup failure", err)
+	}
+	waitForNoEvent(t, ch)
+	if got := store.persistedDeliveries(); len(got) != 0 {
+		t.Fatalf("persisted deliveries = %v, want none", got)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -9,38 +9,51 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
-func (eb *EventBus) persistableRecipients(ctx context.Context, recipients []string) []string {
+func (eb *EventBus) activeAgentDescriptors(ctx context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+	lister, ok := eb.store.(ActiveAgentDescriptorLister)
+	if !ok {
+		return nil, false, nil
+	}
+	descriptors, err := lister.ListActiveAgentDescriptors(ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	set := make(map[string]ActiveAgentDescriptor, len(descriptors))
+	for _, descriptor := range descriptors {
+		descriptor = descriptor.Normalized()
+		if descriptor.AgentID == "" {
+			continue
+		}
+		set[descriptor.AgentID] = descriptor
+	}
+	return set, true, nil
+}
+
+func filterRecipientsForExplicitAgentScope(evt events.Event, recipients []string, descriptors map[string]ActiveAgentDescriptor) []string {
 	recipients = uniqueStrings(recipients)
 	if len(recipients) == 0 {
 		return nil
 	}
-	lister, ok := eb.store.(ActiveAgentLister)
-	if !ok {
-		return recipients
-	}
-	ids, err := lister.ListActiveAgentIDs(ctx)
-	if err != nil {
-		return recipients
-	}
-	if len(ids) == 0 {
+	if len(descriptors) == 0 {
 		return nil
 	}
-	set := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			set[id] = struct{}{}
-		}
-	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
 	out := make([]string, 0, len(recipients))
 	for _, r := range recipients {
 		r = strings.TrimSpace(r)
 		if r == "" {
 			continue
 		}
-		if _, ok := set[r]; ok {
-			out = append(out, r)
+		descriptor, ok := descriptors[r]
+		if !ok {
+			continue
 		}
+		if descriptor.EntityID != "" {
+			if eventEntityID == "" || descriptor.EntityID != eventEntityID {
+				continue
+			}
+		}
+		out = append(out, r)
 	}
 	return out
 }
@@ -197,26 +210,6 @@ func ensurePublishEpoch(ctx context.Context) error {
 
 func filterOutAgentIDs(in []string, disallow []string) []string {
 	return FilterOutAgentIDs(in, disallow)
-}
-
-func filterOutEntityScopedAgentIDs(in []string, entityID string) []string {
-	entityID = strings.TrimSpace(entityID)
-	if len(in) == 0 || entityID == "" {
-		return in
-	}
-	suffix := "-" + entityID
-	out := make([]string, 0, len(in))
-	for _, v := range in {
-		v = strings.TrimSpace(v)
-		if v == "" {
-			continue
-		}
-		if strings.HasSuffix(v, suffix) {
-			continue
-		}
-		out = append(out, v)
-	}
-	return out
 }
 
 func (eb *EventBus) emitContradiction(ctx context.Context, source events.Event, reason string) error {

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"swarm/internal/events"
@@ -28,10 +29,24 @@ type FlowInstanceRoutePersistence interface {
 	ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error)
 }
 
-// ActiveAgentLister is an optional capability for broadcast-style events.
-// PostgresStore implements this; InMemoryEventStore does not.
-type ActiveAgentLister interface {
-	ListActiveAgentIDs(ctx context.Context) ([]string, error)
+type ActiveAgentDescriptor struct {
+	AgentID      string
+	EntityID     string
+	FlowInstance string
+}
+
+func (d ActiveAgentDescriptor) Normalized() ActiveAgentDescriptor {
+	return ActiveAgentDescriptor{
+		AgentID:      strings.TrimSpace(d.AgentID),
+		EntityID:     strings.TrimSpace(d.EntityID),
+		FlowInstance: strings.TrimSpace(d.FlowInstance),
+	}
+}
+
+// ActiveAgentDescriptorLister is an optional capability for runtime delivery
+// planning. PostgresStore implements this; InMemoryEventStore does not.
+type ActiveAgentDescriptorLister interface {
+	ListActiveAgentDescriptors(ctx context.Context) ([]ActiveAgentDescriptor, error)
 }
 
 // PipelineReceiptPersistence is an optional capability for marking whether

--- a/internal/store/agents_list.go
+++ b/internal/store/agents_list.go
@@ -3,11 +3,13 @@ package store
 import (
 	"context"
 	"fmt"
+
+	runtimebus "swarm/internal/runtime/bus"
 )
 
-// ListActiveAgentIDs implements runtime.ActiveAgentLister for broadcast-style events
-// such as budget.*.
-func (s *PostgresStore) ListActiveAgentIDs(ctx context.Context) ([]string, error) {
+// ListActiveAgentDescriptors implements runtime.ActiveAgentDescriptorLister for
+// explicit runtime delivery planning against persisted agent metadata.
+func (s *PostgresStore) ListActiveAgentDescriptors(ctx context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("db unavailable")
 	}
@@ -16,7 +18,10 @@ func (s *PostgresStore) ListActiveAgentIDs(ctx context.Context) ([]string, error
 		return nil, err
 	}
 	query := `
-		SELECT agent_id
+		SELECT
+			agent_id,
+			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, '')
 		FROM agents
 		WHERE COALESCE(status, '') <> 'terminated'
 		ORDER BY agent_id ASC
@@ -32,14 +37,14 @@ func (s *PostgresStore) ListActiveAgentIDs(ctx context.Context) ([]string, error
 	}
 	defer rows.Close()
 
-	out := make([]string, 0, 64)
+	out := make([]runtimebus.ActiveAgentDescriptor, 0, 64)
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
+		var descriptor runtimebus.ActiveAgentDescriptor
+		if err := rows.Scan(&descriptor.AgentID, &descriptor.EntityID, &descriptor.FlowInstance); err != nil {
 			return nil, err
 		}
-		if id != "" {
-			out = append(out, id)
+		if descriptor.AgentID != "" {
+			out = append(out, descriptor.Normalized())
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -117,18 +117,27 @@ func TestPostgresStore_HelpersAndDigest(t *testing.T) {
 		t.Fatalf("ListInstanceDigestRows err=%v len=%d", err, len(rows))
 	}
 
-	// Active agent ids.
+	// Active agent descriptors.
 	_ = pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
-		Config: runtimeactors.AgentConfig{ID: "a", Role: "a", Mode: "global", Type: "stub", Config: []byte(`{}`)},
+		Config: runtimeactors.AgentConfig{ID: "a", Role: "a", Mode: "global", Type: "stub", FlowPath: "review/inst-1", EntityID: entityID, Config: []byte(`{}`)},
 		Status: "active", HiredBy: "test", StartedAt: time.Now().UTC(),
 	})
 	_ = pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
 		Config: runtimeactors.AgentConfig{ID: "t", Role: "t", Mode: "global", Type: "stub", Config: []byte(`{}`)},
 		Status: "terminated", HiredBy: "test", StartedAt: time.Now().UTC(),
 	})
-	ids, err := pg.ListActiveAgentIDs(ctx)
-	if err != nil || len(ids) == 0 {
-		t.Fatalf("ListActiveAgentIDs err=%v ids=%v", err, ids)
+	descriptors, err := pg.ListActiveAgentDescriptors(ctx)
+	if err != nil || len(descriptors) == 0 {
+		t.Fatalf("ListActiveAgentDescriptors err=%v descriptors=%v", err, descriptors)
+	}
+	if got := descriptors[0].AgentID; got != "a" {
+		t.Fatalf("descriptor agent_id = %q, want a", got)
+	}
+	if got := descriptors[0].EntityID; got != entityID {
+		t.Fatalf("descriptor entity_id = %q, want %q", got, entityID)
+	}
+	if got := descriptors[0].FlowInstance; got != "review/inst-1" {
+		t.Fatalf("descriptor flow_instance = %q, want review/inst-1", got)
 	}
 
 }


### PR DESCRIPTION
## What changed
- replaced the event-bus active-agent lookup with a typed `ActiveAgentDescriptor` contract carrying `agent_id`, `entity_id`, and `flow_instance`
- filtered publish-time recipients against explicit persisted agent metadata instead of string-suffix agent-id inference
- removed the last suffix-based entity-scope helper from the touched bus routing seam
- updated store coverage to assert the typed descriptor path and added focused bus tests for matching, missing, and failed descriptor lookup behavior

## Why
The runtime still had a hidden scope convention where entity association could leak through agent ids ending with `-{entityID}`. That made routing semantics depend on naming rather than one canonical runtime contract.

## Impact
- entity-scoped routing in the touched seam now depends only on persisted agent metadata
- stale or missing active-agent metadata no longer falls through to hidden id parsing
- descriptor lookup failures now fail closed in publish-time planning instead of silently reconstructing scope

## Root cause
The bus/store seam exposed only bare active agent ids, so the only available scope discriminator in that path was an old string-suffix heuristic.

## Validation
- `go test ./internal/runtime/bus ./internal/store -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Events now filter recipients more accurately based on agent descriptors and entity scope; added error handling for descriptor lookup failures.

* **Refactor**
  * Enhanced agent descriptor retrieval and event delivery routing logic.

* **Tests**
  * Expanded test coverage for entity-scoped event filtering, agent descriptor validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->