### PR TITLE
[agent-e][issue #40] Add invariant tests for completed seams

### DIFF
--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -672,6 +672,28 @@ func TestSQLConversationReader_GetUsesCanonicalTurnSummaryProgress(t *testing.T)
 	}
 }
 
+func TestSummarizeConversationTurnBlocks_FailsClosedOnEmptyCanonicalSummary(t *testing.T) {
+	blocks := []any{
+		map[string]any{"kind": "assistant_text", "text": "stale fallback text"},
+		map[string]any{"kind": "outcome", "text": "stale outcome"},
+		map[string]any{"kind": "turn_summary", "data": map[string]any{}},
+	}
+
+	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(blocks)
+	if assistantText != "" || outcome != "" {
+		t.Fatalf("expected empty canonical summary strings, got assistant=%q outcome=%q", assistantText, outcome)
+	}
+	if reasoning != nil {
+		t.Fatalf("expected nil reasoning blocks, got %#v", reasoning)
+	}
+	if progress != nil {
+		t.Fatalf("expected nil progress updates, got %#v", progress)
+	}
+	if toolResults != nil {
+		t.Fatalf("expected nil tool results, got %#v", toolResults)
+	}
+}
+
 func TestSQLConversationReader_GetUsesSessionIDNotAgentID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/core/eventidentity/eventidentity_test.go
+++ b/internal/runtime/core/eventidentity/eventidentity_test.go
@@ -86,6 +86,24 @@ func TestScopeResolveEvent_ExternalizesLocalAndDescendantEvents(t *testing.T) {
 	}
 }
 
+func TestScopeResolveEvent_LeavesUndeclaredDescendantEventUnchanged(t *testing.T) {
+	scope := Scope{
+		Path:        "child",
+		LocalEvents: []string{"step.result"},
+	}
+	descendants := []DescendantScope{{
+		Path:        "child/grandchild",
+		LocalEvents: []string{"micro.done"},
+	}}
+
+	if got := scope.ResolveEvent("grandchild/not-local", descendants); got != "grandchild/not-local" {
+		t.Fatalf("ResolveEvent(non-local descendant) = %q, want grandchild/not-local", got)
+	}
+	if got := scope.ResolveSubscriptionPattern("grandchild/not-local", descendants); got != "grandchild/not-local" {
+		t.Fatalf("ResolveSubscriptionPattern(non-local descendant) = %q, want grandchild/not-local", got)
+	}
+}
+
 func TestScopeMatches_TreatsLocalAndScopedInputEventsAsEquivalent(t *testing.T) {
 	scope := Scope{
 		Path:        "discovery",

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -119,3 +119,62 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 		t.Fatalf("listed routes after delete = %#v, want none", routes)
 	}
 }
+
+func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules`); err != nil {
+		t.Fatalf("drop legacy routing_rules: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"routing_rules": {
+			DDL: "CREATE TABLE routing_rules (\n    rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    event_pattern TEXT NOT NULL,\n    subscriber_type TEXT NOT NULL,\n    subscriber_id TEXT NOT NULL,\n    flow_instance TEXT,\n    source_flow TEXT,\n    is_wildcard BOOLEAN NOT NULL DEFAULT FALSE,\n    is_materialized BOOLEAN NOT NULL DEFAULT FALSE,\n    materialized_from UUID,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+
+	instancePath := "child/grandchild/inst-1"
+	route := runtimebus.FlowInstanceRouteRecord{
+		Identity: runtimeflowidentity.Route{
+			InstancePath: instancePath,
+		},
+		EventPattern:   instancePath + "/micro.started",
+		SubscriberType: "node",
+		SubscriberID:   "worker-inst-1",
+	}
+	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
+		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
+	}
+
+	routes, err := pg.ListFlowInstanceRoutes(ctx)
+	if err != nil {
+		t.Fatalf("ListFlowInstanceRoutes: %v", err)
+	}
+	want := runtimeflowidentity.StoredRoute("", "", instancePath)
+	if len(routes) != 1 || routes[0] != want {
+		t.Fatalf("listed routes = %#v, want %#v", routes, want)
+	}
+
+	if err := pg.DeleteFlowInstanceRoute(ctx, runtimeflowidentity.Route{InstancePath: instancePath}); err != nil {
+		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
+	}
+	routes, err = pg.ListFlowInstanceRoutes(ctx)
+	if err != nil {
+		t.Fatalf("ListFlowInstanceRoutes after delete: %v", err)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("listed routes after delete = %#v, want none", routes)
+	}
+}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1461,6 +1461,68 @@ func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *test
 	}
 }
 
+func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	if err := pg.ensureConversationAuditTable(ctx); err != nil {
+		t.Fatalf("ensureConversationAuditTable: %v", err)
+	}
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		AgentID:  "a1",
+		Mode:     "session",
+		ScopeKey: "global",
+		Messages: []llm.Message{
+			{Role: "user", Content: "hello"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(session): %v", err)
+	}
+
+	var sessionID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT session_id::text
+		FROM agent_sessions
+		WHERE agent_id = 'a1' AND runtime_mode = 'session'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&sessionID); err != nil {
+		t.Fatalf("load session row: %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "session",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"session"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(session): %v", err)
+	}
+
+	var auditCount, turnCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM agent_conversation_audits WHERE agent_id = 'a1'),
+			(SELECT COUNT(*) FROM agent_turns WHERE agent_id = 'a1' AND session_id = $1::uuid AND runtime_mode = 'session')
+	`, sessionID).Scan(&auditCount, &turnCount); err != nil {
+		t.Fatalf("count persisted rows: %v", err)
+	}
+	if auditCount != 0 {
+		t.Fatalf("expected no audit rows for session-mode persistence, got %d", auditCount)
+	}
+	if turnCount != 1 {
+		t.Fatalf("expected one session-mode turn row, got %d", turnCount)
+	}
+}
+
 func TestManagerStore_TaskConversationUpsertIsIdempotentBySessionID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1573,6 +1635,59 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	}
 	if turns != 1 {
 		t.Fatalf("expected one task agent_turn row after synthesized append, got %d", turns)
+	}
+}
+
+func TestManagerStore_TaskConversationDoesNotPersistLiveSessionRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "assistant", Content: "done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task): %v", err)
+	}
+
+	var sessionCount, auditCount, turnCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM agent_sessions WHERE agent_id = 'a1'),
+			(SELECT COUNT(*) FROM agent_conversation_audits WHERE agent_id = 'a1' AND session_id = $1::uuid AND runtime_mode = 'task'),
+			(SELECT COUNT(*) FROM agent_turns WHERE agent_id = 'a1' AND session_id = $1::uuid AND runtime_mode = 'task')
+	`, sessionID).Scan(&sessionCount, &auditCount, &turnCount); err != nil {
+		t.Fatalf("count persisted rows: %v", err)
+	}
+	if sessionCount != 0 {
+		t.Fatalf("expected no live session rows for task-mode persistence, got %d", sessionCount)
+	}
+	if auditCount != 1 {
+		t.Fatalf("expected one task audit row, got %d", auditCount)
+	}
+	if turnCount != 1 {
+		t.Fatalf("expected one task turn row, got %d", turnCount)
 	}
 }
 

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -156,3 +156,67 @@ func TestPostgresStore_BindSchemaCapabilities_DetectsLegacyShapes(t *testing.T) 
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestPostgresStore_BindSchemaCapabilities_FailsClosedOnPartialCanonicalShapes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"})
+	addColumns := func(table string, columns ...string) {
+		for _, column := range columns {
+			rows.AddRow(table, column)
+		}
+	}
+
+	addColumns("events",
+		"event_id", "event_name", "entity_id", "flow_instance", "scope", "payload",
+		"chain_depth", "produced_by", "produced_by_type", "created_at",
+	)
+	addColumns("agent_sessions",
+		"session_id", "agent_id", "scope_key", "scope", "conversation",
+		"turn_count", "runtime_mode", "status", "created_at", "updated_at",
+	)
+	addColumns("agent_turns",
+		"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key",
+		"request_payload", "response_payload", "parse_ok", "latency_ms", "created_at",
+	)
+	addColumns("timers", "timer_id")
+
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+
+	pg := &PostgresStore{DB: db}
+	caps, err := pg.BindSchemaCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	if caps.Events.Log != SchemaFlavorUnsupported {
+		t.Fatalf("events log flavor = %s, want %s", caps.Events.Log, SchemaFlavorUnsupported)
+	}
+	if caps.Conversations.Sessions != SchemaFlavorUnsupported {
+		t.Fatalf("sessions flavor = %s, want %s", caps.Conversations.Sessions, SchemaFlavorUnsupported)
+	}
+	if caps.Conversations.Turns != SchemaFlavorUnsupported {
+		t.Fatalf("turns flavor = %s, want %s", caps.Conversations.Turns, SchemaFlavorUnsupported)
+	}
+	if caps.Schedules != SchemaFlavorUnsupported {
+		t.Fatalf("schedules flavor = %s, want %s", caps.Schedules, SchemaFlavorUnsupported)
+	}
+	if caps.Conversations.Audits != SchemaFlavorUnavailable {
+		t.Fatalf("audits flavor = %s, want %s", caps.Conversations.Audits, SchemaFlavorUnavailable)
+	}
+	if caps.Mailbox != SchemaFlavorUnavailable {
+		t.Fatalf("mailbox flavor = %s, want %s", caps.Mailbox, SchemaFlavorUnavailable)
+	}
+	if caps.Events.LogIdempotencyKey {
+		t.Fatalf("expected partial canonical events table to report missing idempotency_key: %+v", caps.Events)
+	}
+	if caps.Conversations.TurnBlocks {
+		t.Fatalf("expected partial canonical turns table to report missing turn_blocks: %+v", caps.Conversations)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds maintenance-only invariant coverage for completed canonical identity and read-model seams so regressions fail on focused tests instead of only showing up through larger issue-local coverage.

## What Changed
- added schema-capability boundary tests that fail closed on partial canonical table shapes
- added session/audit split tests proving session-mode writes stay in `agent_sessions` and task-mode writes stay in `agent_conversation_audits`
- added flow-instance route identity tests proving store-side route operations canonicalize from instance-path identity
- added event-identity tests proving undeclared descendant-relative events are not externalized by the canonical resolver helpers
- added dashboard read-model tests proving empty canonical `turn_summary` blocks fail closed instead of reconstructing output from non-canonical blocks

## Impact
This hardens the completed seams without changing runtime semantics or production code. The new tests protect the explicit schema-capability boundary, the live-session vs audit split, canonical flow-instance identity at the store seam, canonical event identity externalization, and the canonical turn-summary read model consumed by the dashboard.

## Validation
- `go test ./internal/store/...`
- `go test ./internal/runtime/core/eventidentity`
- `go test ./internal/dashboard/server`
- `go test ./...`

## Semantic Issues Found
No real seam bug was discovered. After rebasing on `origin/main`, one new test needed an explicit session `scope_key` to match the current session-mode precondition; that was adjusted in the test only.