### PR TITLE
[agent-d][issue #51] Make conversation last_turn and agent_turn persistence atomic

### DIFF
--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -46,6 +46,16 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 		}
 	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("append agent turn begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
 
 	reqPayload := normalizeJSONPayload(rec.RequestPayload)
 	respPayload := normalizeJSONPayload(rec.ResponseRaw)
@@ -95,7 +105,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		rec.Error,
 	}
 	if hasConversationRunID {
-		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
 			return err
 		}
 		updateQ = fmt.Sprintf(`
@@ -134,7 +144,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			rec.Error,
 		}
 	}
-	res, err := s.DB.ExecContext(ctx, updateQ,
+	res, err := tx.ExecContext(ctx, updateQ,
 		updateArgs...,
 	)
 	if err != nil {
@@ -143,10 +153,10 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		if runtimeMode == runtimesessions.RuntimeModeTask {
-			if err := s.ensureTaskConversationAuditRow(ctx, rec); err != nil {
+			if err := s.ensureTaskConversationAuditRowTx(ctx, tx, caps, rec); err != nil {
 				return err
 			}
-			res, err = s.DB.ExecContext(ctx, updateQ, updateArgs...)
+			res, err = tx.ExecContext(ctx, updateQ, updateArgs...)
 			if err != nil {
 				return fmt.Errorf("append agent turn: %w", err)
 			}
@@ -272,7 +282,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 	if hasRunID {
-		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
 			return err
 		}
 		insertTurn = `
@@ -386,23 +396,39 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			}
 		}
 	}
-	if _, err := s.DB.ExecContext(ctx, insertTurn, insertArgs...); err != nil {
+	if _, err := tx.ExecContext(ctx, insertTurn, insertArgs...); err != nil {
 		return fmt.Errorf("insert agent turn: %w", err)
 	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("append agent turn commit: %w", err)
+	}
+	committed = true
 	return nil
 }
 
 func (s *PostgresStore) ensureTaskConversationAuditRow(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
+	return s.ensureTaskConversationAuditRowTx(ctx, nil, StoreSchemaCapabilities{}, rec)
+}
+
+func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx *sql.Tx, caps StoreSchemaCapabilities, rec runtimellm.AgentTurnRecord) error {
+	if caps.Conversations.Audits == "" {
+		var err error
+		caps, err = s.schemaCapabilities(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	if err := s.ensureConversationAuditTable(ctx); err != nil {
-		return err
-	}
-	caps, err = s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
+	if tx == nil {
+		if err := s.ensureConversationAuditTable(ctx); err != nil {
+			return err
+		}
+		if caps.Conversations.Audits == "" {
+			var err error
+			caps, err = s.schemaCapabilities(ctx)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if caps.Conversations.Audits != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
@@ -447,7 +473,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRow(ctx context.Context, rec 
 		runtimesessions.RuntimeModeTask,
 	}
 	if caps.Conversations.AuditRunID {
-		if err := s.ensureRunRow(ctx, caps, nil, rec.RunID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID); err != nil {
 			return err
 		}
 		q = `
@@ -492,7 +518,11 @@ func (s *PostgresStore) ensureTaskConversationAuditRow(ctx context.Context, rec 
 			runtimesessions.RuntimeModeTask,
 		}
 	}
-	if _, err := s.DB.ExecContext(ctx, q,
+	execFn := s.DB.ExecContext
+	if tx != nil {
+		execFn = tx.ExecContext
+	}
+	if _, err := execFn(ctx, q,
 		args...,
 	); err != nil {
 		return fmt.Errorf("ensure task conversation audit row: %w", err)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -107,6 +107,40 @@ type execer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
+func installFailAgentTurnInsertTrigger(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION fail_agent_turn_insert()
+		RETURNS trigger
+		AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced agent_turn insert failure';
+		END;
+		$$ LANGUAGE plpgsql
+	`); err != nil {
+		t.Fatalf("create fail_agent_turn_insert function: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TRIGGER IF EXISTS fail_agent_turn_insert_trigger ON agent_turns`); err != nil {
+		t.Fatalf("drop existing fail_agent_turn_insert trigger: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER fail_agent_turn_insert_trigger
+		BEFORE INSERT ON agent_turns
+		FOR EACH ROW
+		EXECUTE FUNCTION fail_agent_turn_insert()
+	`); err != nil {
+		t.Fatalf("create fail_agent_turn_insert trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := db.ExecContext(context.Background(), `DROP TRIGGER IF EXISTS fail_agent_turn_insert_trigger ON agent_turns`); err != nil {
+			t.Fatalf("cleanup fail_agent_turn_insert trigger: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `DROP FUNCTION IF EXISTS fail_agent_turn_insert()`); err != nil {
+			t.Fatalf("cleanup fail_agent_turn_insert function: %v", err)
+		}
+	})
+}
+
 func TestPostgresStore_AppendEvent_NormalizesInvalidOptionalUUIDs(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1387,6 +1421,110 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 	}
 	if !strings.Contains(got, `"dispatch"`) || !strings.Contains(got, `"schedule"`) || !strings.Contains(got, `"14-day review scheduled."`) || !strings.Contains(got, `"turn_summary"`) {
 		t.Fatalf("turn_blocks = %s", got)
+	}
+}
+
+func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		AgentID:   "a1",
+		Mode:      "session",
+		ScopeKey:  "global",
+		Messages:  []llm.Message{{Role: "assistant", Content: "done"}},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(session): %v", err)
+	}
+
+	var sessionID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT session_id::text
+		FROM agent_sessions
+		WHERE agent_id = 'a1' AND scope_key = 'global'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&sessionID); err != nil {
+		t.Fatalf("load seeded agent_session: %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "session",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"session"}`),
+		ResponseRaw:    []byte(`{"result":"done"}`),
+		ParseOK:        true,
+		Latency:        10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn: %v", err)
+	}
+
+	var parseOK bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE((runtime_state->'last_turn'->>'parse_ok')::boolean, false)
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&parseOK); err != nil {
+		t.Fatalf("load session runtime_state: %v", err)
+	}
+	if !parseOK {
+		t.Fatal("expected session last_turn telemetry to be persisted")
+	}
+
+	var turnCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_turns
+		WHERE agent_id = 'a1' AND session_id = $1::uuid AND runtime_mode = 'session'
+	`, sessionID).Scan(&turnCount); err != nil {
+		t.Fatalf("count agent_turns(session): %v", err)
+	}
+	if turnCount != 1 {
+		t.Fatalf("expected one session-mode agent_turn row, got %d", turnCount)
+	}
+}
+
+func TestManagerStore_AppendAgentTurn_RollsBackTaskAuditAndTurnRowWhenTurnInsertFails(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	installFailAgentTurnInsertTrigger(t, ctx, db)
+
+	sessionID := uuid.NewString()
+	err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected AppendAgentTurn to fail when agent_turns insert fails")
+	}
+
+	var auditCount, turnCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM agent_conversation_audits WHERE session_id = $1::uuid),
+			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid)
+	`, sessionID).Scan(&auditCount, &turnCount); err != nil {
+		t.Fatalf("count rolled back task persistence: %v", err)
+	}
+	if auditCount != 0 {
+		t.Fatalf("expected synthesized task audit row rollback, got %d rows", auditCount)
+	}
+	if turnCount != 0 {
+		t.Fatalf("expected agent_turn insert rollback, got %d rows", turnCount)
 	}
 }
 


### PR DESCRIPTION
## What changed
- wrapped `AppendAgentTurn` in one SQL transaction so `runtime_state.last_turn` updates, synthesized task audit rows, and `agent_turns` inserts succeed or fail together
- added a tx-aware task audit helper so task-mode append stays on the same transactional path instead of splitting writes across separate DB calls
- added focused store tests for atomic success and forced insert rollback

## Why it changed
The previous store seam could persist `last_turn` before the `agent_turns` insert completed. If the second write failed, canonical conversation read models could drift. This change makes the store fail closed at write time instead of relying on repair or reader-side compensation.

## Impact
- conversation/session `last_turn` and `agent_turns` persistence are now atomic in the canonical store path
- task-mode synthesized audit rows also roll back when the turn insert fails
- readers in this seam no longer depend on a boundary that can partially persist

## Validation
- `go test ./internal/store -run 'TestManagerStore_AppendAgentTurn_(AtomicallyPersistsSessionLastTurnAndTurnRow|RollsBackTaskAuditAndTurnRowWhenTurnInsertFails)' -count=1 -timeout 60s -v`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`
