### PR TITLE
[agent-e][issue #41] Remove obsolete read-model compatibility code

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -316,7 +316,13 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, normalizeConversationTurn(item))
+		assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(item.TurnBlocks)
+		item.AssistantVisibleOutput = assistantText
+		item.Outcome = outcome
+		item.ReasoningBlocks = reasoning
+		item.ProgressUpdates = progress
+		item.ToolResults = toolResults
+		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -453,20 +459,6 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 	return item, nil
 }
 
-func normalizeConversationTurn(item ConversationTurn) ConversationTurn {
-	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurn(item)
-	item.AssistantVisibleOutput = assistantText
-	item.Outcome = outcome
-	item.ReasoningBlocks = reasoning
-	item.ProgressUpdates = progress
-	item.ToolResults = toolResults
-	return item
-}
-
-func summarizeConversationTurn(item ConversationTurn) (string, string, []string, []string, []any) {
-	return summarizeConversationTurnBlocks(item.TurnBlocks)
-}
-
 func summarizeConversationTurnBlocks(blocks []any) (string, string, []string, []string, []any) {
 	summary, ok := readTurnSummaryBlock(blocks)
 	if !ok {
@@ -520,15 +512,6 @@ func readAnySlice(value any) []any {
 		return nil
 	}
 	return append([]any(nil), list...)
-}
-
-func firstReadableString(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
 }
 
 func compactMap(in map[string]any, keys ...string) map[string]any {

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -10,30 +10,29 @@ import (
 )
 
 type AgentTurnRecord struct {
-	AgentID            string
-	RuntimeMode        string
-	SessionID          string
-	ScopeKey           string
-	RunID              string
-	EntityID           string
-	TriggerEventID     string
-	TriggerEventType   string
-	AvailableTools     []string
-	ToolCalls          []ToolCall
-	EmittedEvents      []string
-	FlightRecorder     []runtimebus.FlightRecorderEntry
-	PublishDiagnostics []runtimebus.PublishDiagnostic
-	MCPServers         map[string]string
-	MCPToolsListed     []string
-	MCPToolsVisible    []string
-	TaskID             string
-	RequestPayload     []byte
-	ResponseRaw        []byte
-	TurnBlocks         []TurnBlock
-	ParseOK            bool
-	Latency            time.Duration
-	RetryCount         int
-	Error              string
+	AgentID          string
+	RuntimeMode      string
+	SessionID        string
+	ScopeKey         string
+	RunID            string
+	EntityID         string
+	TriggerEventID   string
+	TriggerEventType string
+	AvailableTools   []string
+	ToolCalls        []ToolCall
+	EmittedEvents    []string
+	FlightRecorder   []runtimebus.FlightRecorderEntry
+	MCPServers       map[string]string
+	MCPToolsListed   []string
+	MCPToolsVisible  []string
+	TaskID           string
+	RequestPayload   []byte
+	ResponseRaw      []byte
+	TurnBlocks       []TurnBlock
+	ParseOK          bool
+	Latency          time.Duration
+	RetryCount       int
+	Error            string
 }
 
 type TurnPersistence interface {
@@ -105,11 +104,6 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 				seen[name] = struct{}{}
 				rec.EmittedEvents = append(rec.EmittedEvents, name)
 			}
-		}
-	}
-	if len(rec.PublishDiagnostics) == 0 {
-		if eventRec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && eventRec != nil {
-			rec.PublishDiagnostics = append([]runtimebus.PublishDiagnostic(nil), eventRec.SnapshotPublishes()...)
 		}
 	}
 	if len(rec.FlightRecorder) == 0 {

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -373,17 +373,11 @@ func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	if len(rec.EmittedEvents) != 2 || rec.EmittedEvents[0] != "discovery/category.assessed" || rec.EmittedEvents[1] != "discovery/scan_complete" {
 		t.Fatalf("emitted_events = %#v", rec.EmittedEvents)
 	}
-	if len(rec.PublishDiagnostics) != 1 {
-		t.Fatalf("publish_diagnostics = %#v", rec.PublishDiagnostics)
-	}
-	if rec.PublishDiagnostics[0].EventType != "discovery/category.assessed" {
-		t.Fatalf("publish_diagnostics[0].event_type = %q", rec.PublishDiagnostics[0].EventType)
-	}
-	if len(rec.PublishDiagnostics[0].RoutedRecipients) != 1 || rec.PublishDiagnostics[0].RoutedRecipients[0].LocalizedEvent != "category.assessed" {
-		t.Fatalf("publish_diagnostics[0].routed_recipients = %#v", rec.PublishDiagnostics[0].RoutedRecipients)
-	}
 	if len(rec.FlightRecorder) != 2 {
 		t.Fatalf("flight_recorder = %#v", rec.FlightRecorder)
+	}
+	if rec.FlightRecorder[0].Kind != "publish" || rec.FlightRecorder[0].EventType != "discovery/category.assessed" {
+		t.Fatalf("flight_recorder[0] = %#v", rec.FlightRecorder[0])
 	}
 	if rec.FlightRecorder[1].Message != "Emit tool target was resolved" {
 		t.Fatalf("flight_recorder[1].message = %q", rec.FlightRecorder[1].Message)

--- a/internal/runtime/llm/turn_transcript.go
+++ b/internal/runtime/llm/turn_transcript.go
@@ -61,46 +61,9 @@ func buildDispatchBlock(rec AgentTurnRecord) TurnBlock {
 	}
 }
 
-func buildPublishBlocks(rec AgentTurnRecord) []TurnBlock {
-	if len(rec.PublishDiagnostics) == 0 {
-		return nil
-	}
-	blocks := make([]TurnBlock, 0, len(rec.PublishDiagnostics))
-	for _, diag := range rec.PublishDiagnostics {
-		eventType := strings.TrimSpace(diag.EventType)
-		if eventType == "" {
-			continue
-		}
-		data := map[string]any{}
-		if v := strings.TrimSpace(diag.EventID); v != "" {
-			data["event_id"] = v
-		}
-		if v := strings.TrimSpace(diag.EntityID); v != "" {
-			data["entity_id"] = v
-		}
-		if v := strings.TrimSpace(diag.ParentEventID); v != "" {
-			data["parent_event_id"] = v
-		}
-		if len(diag.RoutedRecipients) > 0 {
-			data["routed_recipients"] = diag.RoutedRecipients
-			data["routed_recipients_count"] = len(diag.RoutedRecipients)
-		}
-		if len(diag.SubscriptionRecipients) > 0 {
-			data["subscription_recipients"] = diag.SubscriptionRecipients
-			data["subscription_recipients_count"] = len(diag.SubscriptionRecipients)
-		}
-		blocks = append(blocks, TurnBlock{
-			Kind:  "publish",
-			Title: eventType,
-			Data:  data,
-		})
-	}
-	return blocks
-}
-
 func buildFlightRecorderBlocks(rec AgentTurnRecord) []TurnBlock {
 	if len(rec.FlightRecorder) == 0 {
-		return buildPublishBlocks(rec)
+		return nil
 	}
 	blocks := make([]TurnBlock, 0, len(rec.FlightRecorder))
 	for _, entry := range rec.FlightRecorder {

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -45,12 +45,13 @@ func TestBuildTurnBlocks_CorrelatesToolResultsWithToolUse(t *testing.T) {
 	}
 }
 
-func TestBuildTurnBlocks_IncludesPublishDiagnostics(t *testing.T) {
+func TestBuildTurnBlocks_IncludesPublishEntriesFromFlightRecorder(t *testing.T) {
 	rec := AgentTurnRecord{
 		TriggerEventType: "scan.requested",
 		EntityID:         "ent-1",
-		PublishDiagnostics: []runtimebus.PublishDiagnostic{
+		FlightRecorder: []runtimebus.FlightRecorderEntry{
 			{
+				Kind:      "publish",
 				EventID:   "evt-1",
 				EventType: "scoring/vertical.shortlisted",
 				EntityID:  "ent-1",


### PR DESCRIPTION
## Summary
Removes dead helpers and obsolete compatibility code from completed read-model seams without changing canonical behavior.

## What Changed
- removed the obsolete `PublishDiagnostics` shadow path from `internal/runtime/llm`; turn-block publish entries now come only from the canonical flight-recorder surface
- deleted redundant dashboard turn-summary wrappers/helpers in `internal/dashboard/server` so the canonical turn-summary reader is easier to identify
- updated focused tests to assert the surviving canonical owners directly

## Impact
This is maintenance-only cleanup in already-completed seams. The touched code is simpler, the canonical read-model owner is clearer in both the LLM turn pipeline and the dashboard reader, and no runtime semantics changed.

## Validation
- `go test ./internal/runtime/llm ./internal/dashboard/server ./internal/store`
- `go test ./... -count=1`

## Semantic Issues Found
No real semantic issue was uncovered. The removed code paths were compatibility leftovers around already-completed canonical read-model surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal diagnostic data processing and event recording mechanisms to improve system efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->