### PR TITLE
[agent-d][issue #56] Remove remaining raw-response summary inference from agent and status readers

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -3,13 +3,13 @@ package server
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
+	"swarm/internal/store"
 )
 
 type SQLAgentReader struct {
@@ -96,7 +96,15 @@ type agentRuntimeAggregate struct {
 }
 
 func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRuntimeAggregate, error) {
-	rows, err := r.db.QueryContext(ctx, `
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	latestTurnBlocksExpr := `'[]'::jsonb`
+	if caps.Conversations.TurnBlocks {
+		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			a.agent_id,
 			COALESCE(sess.turn_count, 0),
@@ -107,14 +115,15 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 			COALESCE(f.failures_24h, 0),
 			COALESCE(f.dead_letters_24h, 0),
 			0,
-			COALESCE(sess.runtime_state, '{}'::jsonb)
+			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.turn_blocks, '[]'::jsonb)
 		FROM agents a
 		LEFT JOIN LATERAL (
 			SELECT
 				turn_count,
 				lease_holder,
-				lease_expires_at,
-				runtime_state
+				lease_expires_at
 			FROM agent_sessions
 			WHERE agent_id = a.agent_id
 			  AND status = 'active'
@@ -122,6 +131,16 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 			ORDER BY updated_at DESC, created_at DESC
 			LIMIT 1
 		) sess ON true
+		LEFT JOIN LATERAL (
+			SELECT
+				COALESCE(task_id, '') AS task_id,
+				parse_ok,
+				%s AS turn_blocks
+			FROM agent_turns
+			WHERE agent_id = a.agent_id
+			ORDER BY created_at DESC, turn_id DESC
+			LIMIT 1
+		) latest_turn ON true
 		LEFT JOIN LATERAL (
 			SELECT
 				COUNT(*)::int AS pending_count,
@@ -150,7 +169,7 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 		) f ON true
 		WHERE a.status NOT IN ('terminated', 'ephemeral')
 		ORDER BY a.created_at ASC, a.agent_id ASC
-	`, runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
+	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
 	if err != nil {
 		return nil, fmt.Errorf("query agent aggregates: %w", err)
 	}
@@ -159,10 +178,12 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 	out := map[string]agentRuntimeAggregate{}
 	for rows.Next() {
 		var (
-			id              string
-			aggregate       agentRuntimeAggregate
-			lockExpiresAt   sql.NullTime
-			runtimeStateRaw []byte
+			id            string
+			aggregate     agentRuntimeAggregate
+			lockExpiresAt sql.NullTime
+			latestTaskID  string
+			latestParseOK bool
+			latestTurnRaw []byte
 		)
 		if err := rows.Scan(
 			&id,
@@ -174,7 +195,9 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 			&aggregate.Failures24h,
 			&aggregate.DeadLetters24h,
 			&aggregate.Turns24h,
-			&runtimeStateRaw,
+			&latestTaskID,
+			&latestParseOK,
+			&latestTurnRaw,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent aggregate: %w", err)
 		}
@@ -184,13 +207,31 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 				aggregate.InFlightTurn = true
 			}
 		}
-		enrichAgentAggregateFromRuntimeState(&aggregate, runtimeStateRaw)
+		if err := enrichAgentAggregateFromLatestTurn(&aggregate, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
+			return nil, err
+		}
 		out[strings.TrimSpace(id)] = aggregate
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read agent aggregate rows: %w", err)
 	}
 	return out, nil
+}
+
+func (r *SQLAgentReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
+	if r != nil {
+		if source, ok := r.base.(conversationCapabilitySource); ok && source != nil {
+			return source.ResolveSchemaCapabilities(ctx)
+		}
+	}
+	return store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Audits:     store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}, nil
 }
 
 func applyAggregate(agent *genericAgent, aggregate agentRuntimeAggregate, turnLimit int) {
@@ -230,35 +271,36 @@ func deriveGenericAgentState(agent genericAgent, aggregate agentRuntimeAggregate
 	return "idle"
 }
 
-func enrichAgentAggregateFromRuntimeState(aggregate *agentRuntimeAggregate, raw []byte) {
-	if aggregate == nil || len(raw) == 0 {
-		return
+func enrichAgentAggregateFromLatestTurn(aggregate *agentRuntimeAggregate, taskID string, parseOK bool, turnBlocksRaw []byte) error {
+	if aggregate == nil {
+		return nil
 	}
-	var state map[string]any
-	if err := json.Unmarshal(raw, &state); err != nil {
-		return
+	aggregate.CurrentTaskID = strings.TrimSpace(taskID)
+	turnBlocks, err := decodeJSONArray(turnBlocksRaw)
+	if err != nil {
+		return fmt.Errorf("decode latest agent turn turn_blocks: %w", err)
 	}
-	lastTurn, _ := state["last_turn"].(map[string]any)
-	if len(lastTurn) == 0 {
-		return
+	summary, ok := readTurnSummaryBlock(turnBlocks)
+	if !ok {
+		return nil
 	}
-	aggregate.CurrentTaskID = readString(lastTurn["task_id"])
-	responsePayload, _ := lastTurn["response_payload"].(map[string]any)
-	if len(responsePayload) == 0 {
-		return
+	toolResults := readAnySlice(summary["tool_results"])
+	if len(toolResults) == 0 {
+		return nil
 	}
-	if calls, ok := responsePayload["tool_calls"].([]any); ok && len(calls) > 0 {
-		first, _ := calls[0].(map[string]any)
-		aggregate.LastTool = map[string]any{
-			"name": readString(first["name"]),
-			"ok":   lastTurn["parse_ok"] == true,
-		}
-		if result := readString(responsePayload["result"]); result != "" {
-			aggregate.LastTool["result"] = result
-		} else if result := readString(responsePayload["assistant_text"]); result != "" {
-			aggregate.LastTool["result"] = result
-		}
+	lastResult, _ := toolResults[len(toolResults)-1].(map[string]any)
+	toolName := strings.TrimSpace(readString(lastResult["tool_name"]))
+	if toolName == "" {
+		return nil
 	}
+	aggregate.LastTool = map[string]any{
+		"name": toolName,
+		"ok":   parseOK,
+	}
+	if output, ok := lastResult["output"]; ok && output != nil {
+		aggregate.LastTool["result"] = output
+	}
+	return nil
 }
 
 func maxInt(v, floor int) int {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 )
@@ -87,6 +88,20 @@ type stubConversationCaps struct {
 }
 
 func (s stubConversationCaps) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return s.caps, s.err
+}
+
+type stubSQLAgents struct {
+	rows []runtimemanager.PersistedAgent
+	caps store.StoreSchemaCapabilities
+	err  error
+}
+
+func (s stubSQLAgents) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return s.rows, nil
+}
+
+func (s stubSQLAgents) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
 	return s.caps, s.err
 }
 
@@ -473,6 +488,119 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 		t.Fatalf("expected missing canonical summary to fail closed, got %+v", item.Turns[0])
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		},
+	}, 12)
+
+	turnBlocksPayload := `[
+		{"kind":"tool_result","tool_name":"schedule","output":{"status":"scheduled"},"data":{"tool_use_id":"toolu_1"}},
+		{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"schedule","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}
+	]`
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(turnBlocksPayload)))
+
+	items, err := reader.ListGenericAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].CurrentTaskID != "task-1" {
+		t.Fatalf("current_task_id = %q", items[0].CurrentTaskID)
+	}
+	if items[0].LastTool["name"] != "schedule" {
+		t.Fatalf("last_tool = %#v", items[0].LastTool)
+	}
+	if items[0].LastTool["ok"] != true {
+		t.Fatalf("last_tool.ok = %#v", items[0].LastTool["ok"])
+	}
+	result, _ := items[0].LastTool["result"].(map[string]any)
+	if result["status"] != "scheduled" {
+		t.Fatalf("last_tool.result = %#v", items[0].LastTool["result"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+
+	items, err := reader.ListGenericAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].CurrentTaskID != "task-1" {
+		t.Fatalf("current_task_id = %q", items[0].CurrentTaskID)
+	}
+	if items[0].LastTool != nil {
+		t.Fatalf("expected missing canonical summary to fail closed, got last_tool=%#v", items[0].LastTool)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}


### PR DESCRIPTION
## What changed
- removed the remaining agent reader summary inference from `runtime_state.last_turn.response_payload`
- made the dashboard agent aggregate path consume the latest persisted `agent_turns.turn_blocks` row and parse the canonical `turn_summary` block
- added focused tests proving canonical summary consumption and fail-closed behavior when the summary block is missing

## Why it changed
Conversation readers already consume canonical persisted turn summaries, but the agent/status reader still derived `last_tool` state from raw response payload blobs. That kept a second weaker summary model alive and allowed reader-side drift.

## Impact
- touched agent/status readers now use canonical persisted summaries as the only semantic source in this seam
- missing canonical summary blocks no longer trigger reader-side reconstruction from stale response payloads
- `current_task_id` still comes from the latest persisted turn row, while `last_tool` comes only from canonical `turn_summary.tool_results`

## Validation
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_ListGenericAgents_(UsesCanonicalTurnSummary|FailsClosedWithoutCanonicalTurnSummary)' -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./... -count=1`
