### PR TITLE
[agent-b][issue #53] Introduce a typed event envelope for core scope and identity metadata

### DIFF
--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -85,7 +85,7 @@ func (h *runHub) startRun(ctx context.Context, runID string, inputs map[string]a
 			SourceAgent: "builder",
 			Payload:     encoded,
 			CreatedAt:   time.Now().UTC(),
-		}
+		}.WithEntityID(entityID)
 		if err := rt.Bus.Publish(ctx, evt); err != nil {
 			h.emit(runID, map[string]any{
 				"id":        uuid.NewString(),

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -1,0 +1,38 @@
+package builder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: eb}
+	hub := newRunHub(func() *runtimepkg.Runtime { return rt }, nil, nil, nil)
+	ch := eb.Subscribe("observer", "review.requested")
+
+	if err := hub.startRun(context.Background(), "run-123", map[string]any{
+		"review.requested": map[string]any{
+			"entity_id": "ent-001",
+			"name":      "Telemedicine",
+		},
+	}, nil); err != nil {
+		t.Fatalf("startRun: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if got := evt.EntityID(); got != "ent-001" {
+			t.Fatalf("event entity_id = %q, want ent-001", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected run input event to be published")
+	}
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -8,6 +8,20 @@ import (
 
 type EventType string
 
+type EventScope string
+
+const (
+	EventScopeGlobal EventScope = "global"
+	EventScopeFlow   EventScope = "flow"
+	EventScopeEntity EventScope = "entity"
+)
+
+type EventEnvelope struct {
+	EntityID     string     `json:"-"`
+	FlowInstance string     `json:"-"`
+	Scope        EventScope `json:"-"`
+}
+
 type Event struct {
 	ID            string          `json:"id"`
 	Type          EventType       `json:"type"`
@@ -17,7 +31,13 @@ type Event struct {
 	ChainDepth    int             `json:"-"`
 	RunID         string          `json:"-"`
 	ParentEventID string          `json:"-"`
+	Envelope      EventEnvelope   `json:"-"`
 	CreatedAt     time.Time       `json:"created_at"`
+}
+
+func (e Event) WithEnvelope(envelope EventEnvelope) Event {
+	e.Envelope = envelope.Normalized()
+	return e
 }
 
 func (e Event) WithEntityID(entityID string) Event {
@@ -25,25 +45,89 @@ func (e Event) WithEntityID(entityID string) Event {
 	if entityID == "" {
 		return e
 	}
+	envelope := e.Envelope.Normalized()
+	envelope.EntityID = entityID
+	envelope.Scope = inferEventScope(envelope.EntityID, envelope.FlowInstance)
+	e.Envelope = envelope
 	e.Payload = withEntityIDPayload(e.Payload, entityID)
 	return e
 }
 
-func (e Event) EntityID() string {
-	if len(e.Payload) > 0 {
-		var payload map[string]any
-		if err := json.Unmarshal(e.Payload, &payload); err == nil && payload != nil {
-			if value := strings.TrimSpace(asString(payload["entity_id"])); value != "" {
-				return value
-			}
-		}
+func (e Event) WithFlowInstance(flowInstance string) Event {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	if flowInstance == "" {
+		return e
 	}
-	return ""
+	envelope := e.Envelope.Normalized()
+	envelope.FlowInstance = flowInstance
+	envelope.Scope = inferEventScope(envelope.EntityID, envelope.FlowInstance)
+	e.Envelope = envelope
+	e.Payload = withPayloadString(e.Payload, "flow_instance", flowInstance)
+	return e
+}
+
+func (e Event) EntityID() string {
+	return strings.TrimSpace(e.Envelope.Normalized().EntityID)
+}
+
+func (e Event) FlowInstance() string {
+	return strings.TrimSpace(e.Envelope.Normalized().FlowInstance)
+}
+
+func (e Event) Scope() EventScope {
+	return e.Envelope.Normalized().Scope
+}
+
+func (e Event) NormalizedEnvelope() EventEnvelope {
+	return e.Envelope.Normalized()
+}
+
+func (e EventEnvelope) Normalized() EventEnvelope {
+	e.EntityID = strings.TrimSpace(e.EntityID)
+	e.FlowInstance = strings.Trim(strings.TrimSpace(e.FlowInstance), "/")
+	e.Scope = normalizeEventScope(e.Scope)
+	if e.Scope == "" {
+		e.Scope = inferEventScope(e.EntityID, e.FlowInstance)
+	}
+	return e
+}
+
+func inferEventScope(entityID, flowInstance string) EventScope {
+	entityID = strings.TrimSpace(entityID)
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	switch {
+	case entityID != "":
+		return EventScopeEntity
+	case flowInstance != "":
+		return EventScopeFlow
+	default:
+		return EventScopeGlobal
+	}
+}
+
+func normalizeEventScope(scope EventScope) EventScope {
+	switch strings.ToLower(strings.TrimSpace(string(scope))) {
+	case "":
+		return ""
+	case string(EventScopeEntity):
+		return EventScopeEntity
+	case string(EventScopeFlow):
+		return EventScopeFlow
+	case string(EventScopeGlobal):
+		return EventScopeGlobal
+	default:
+		return ""
+	}
 }
 
 func withEntityIDPayload(raw json.RawMessage, entityID string) json.RawMessage {
-	entityID = strings.TrimSpace(entityID)
-	if entityID == "" {
+	return withPayloadString(raw, "entity_id", entityID)
+}
+
+func withPayloadString(raw json.RawMessage, key, value string) json.RawMessage {
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
 		return raw
 	}
 	payload := map[string]any{}
@@ -52,7 +136,7 @@ func withEntityIDPayload(raw json.RawMessage, entityID string) json.RawMessage {
 			return raw
 		}
 	}
-	payload["entity_id"] = entityID
+	payload[key] = value
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return raw

--- a/internal/events/types_test.go
+++ b/internal/events/types_test.go
@@ -1,0 +1,38 @@
+package events
+
+import "testing"
+
+func TestEventEnvelopeOwnsCanonicalIdentity(t *testing.T) {
+	evt := Event{
+		Payload: []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`),
+	}.WithEnvelope(EventEnvelope{
+		EntityID:     "env-ent",
+		FlowInstance: "review/inst-1",
+	})
+
+	if got := evt.EntityID(); got != "env-ent" {
+		t.Fatalf("EntityID() = %q, want env-ent", got)
+	}
+	if got := evt.FlowInstance(); got != "review/inst-1" {
+		t.Fatalf("FlowInstance() = %q, want review/inst-1", got)
+	}
+	if got := evt.Scope(); got != EventScopeEntity {
+		t.Fatalf("Scope() = %q, want %q", got, EventScopeEntity)
+	}
+}
+
+func TestEventWithoutEnvelopeFailsClosedToGlobalScope(t *testing.T) {
+	evt := Event{
+		Payload: []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`),
+	}
+
+	if got := evt.EntityID(); got != "" {
+		t.Fatalf("EntityID() = %q, want empty without envelope metadata", got)
+	}
+	if got := evt.FlowInstance(); got != "" {
+		t.Fatalf("FlowInstance() = %q, want empty without envelope metadata", got)
+	}
+	if got := evt.Scope(); got != EventScopeGlobal {
+		t.Fatalf("Scope() = %q, want %q", got, EventScopeGlobal)
+	}
+}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -326,6 +326,41 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *test
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane", "reviewer-ent-1"})
 }
 
+func TestEventBusPublish_FiltersEntityScopedRecipientsByTypedEnvelopeNotPayload(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "reviewer-ent-1", EntityID: "ent-1"},
+			{AgentID: "reviewer-ent-2", EntityID: "ent-2"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
+	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
+
+	err = eb.Publish(context.Background(), (events.Event{
+		Type:      events.EventType("custom.trigger"),
+		Payload:   []byte(`{"entity_id":"ent-2"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEnvelope(events.EventEnvelope{EntityID: "ent-1"}))
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case evt := <-matchCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("matched event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("entity-scoped reviewer did not receive typed-envelope match")
+	}
+	waitForNoEvent(t, otherCh)
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"reviewer-ent-1"})
+}
+
 func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) {
 	store := &descriptorAwareEventStore{
 		descriptors: []runtimebus.ActiveAgentDescriptor{

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -114,7 +114,7 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 			AddRow("event_deliveries", "created_at"),
 	)
 	mock.ExpectExec("INSERT INTO events").
-		WithArgs("evt-1", "custom.emitted", "", "", "global", sqlmock.AnyArg(), 0, "", "platform", "", sqlmock.AnyArg()).
+		WithArgs("evt-1", "custom.emitted", "", "", "entity", sqlmock.AnyArg(), 0, "", "platform", "", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO event_deliveries").
 		WithArgs("evt-1", "reviewer").

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -46,6 +46,9 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 	if entityID := actor.EffectiveEntityID(); entityID != "" {
 		evt = evt.WithEntityID(entityID)
 	}
+	if flowInstance := strings.TrimSpace(asString(payload["flow_instance"])); flowInstance != "" {
+		evt = evt.WithFlowInstance(flowInstance)
+	}
 	if err := publisher.Publish(ctx, evt); err != nil {
 		logPublisherRuntime(ctx, publisher, "error", "publish_agent_started_failed", "Publishing the agent-started event failed", session.AgentID, session.ID, evt.EntityID(), map[string]any{
 			"event_type": strings.TrimSpace(string(eventType)),

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -278,12 +278,12 @@ func TestAnthropicAPIRuntime_PersistConversationFailureLogsRuntime(t *testing.T)
 
 func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), "run-123")
-	ctx = runtimebus.WithInboundEvent(ctx, events.Event{
+	ctx = runtimebus.WithInboundEvent(ctx, (events.Event{
 		ID:      "11111111-1111-1111-1111-111111111111",
 		RunID:   "run-123",
 		Type:    events.EventType("scan.requested"),
 		Payload: []byte(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`),
-	})
+	}).WithEnvelope(events.EventEnvelope{EntityID: "22222222-2222-2222-2222-222222222222"}))
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	recorder.Append(events.Event{Type: events.EventType("discovery/category.assessed")})
 	recorder.Append(events.Event{Type: events.EventType("discovery/category.assessed")})

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -149,7 +149,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 			SourceAgent: "flow-instance-activator",
 			Payload:     encoded,
 			CreatedAt:   time.Now().UTC(),
-		}).WithEntityID(flowEntityID)
+		}).WithEntityID(flowEntityID).WithFlowInstance(flowPath)
 		publishAutoEmit := func() {
 			if err := am.bus.Publish(context.Background(), autoEmitEvent); err != nil {
 				am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -289,7 +289,7 @@ func (am *AgentManager) maybeTripAuthCircuitBreaker(agentID, eventID string, err
 				"timestamp":     now.Format(time.RFC3339Nano),
 			}),
 			CreatedAt: now,
-		}.WithEntityID(entityID)
+		}.WithEntityID(entityID).WithFlowInstance(flowInstance)
 		if err := am.bus.Publish(am.runtimeContext(), authEvt); err != nil {
 			if am.bus != nil {
 				am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
@@ -453,7 +453,7 @@ func (am *AgentManager) maybeEscalateDeadLetter(ctx context.Context, eventID, ag
 			"timestamp":         time.Now().UTC().Format(time.RFC3339Nano),
 		}),
 		CreatedAt: time.Now().UTC(),
-	}); err != nil {
+	}.WithFlowInstance(flowInstance)); err != nil {
 		if am.bus != nil {
 			am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
 				Level:     "error",

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -33,6 +33,30 @@ func (*recordingReceiptBus) Store() runtimebus.EventStore                       
 func (*recordingReceiptBus) ResetInMemoryState() error                                   { return nil }
 func (*recordingReceiptBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) {}
 
+type receiptReaderStub struct {
+	receipt EventReceipt
+	found   bool
+}
+
+func (*receiptReaderStub) UpsertAgent(context.Context, PersistedAgent) error { return nil }
+func (*receiptReaderStub) LoadAgents(context.Context) ([]PersistedAgent, error) {
+	return nil, nil
+}
+func (*receiptReaderStub) MarkAgentTerminated(context.Context, string) error { return nil }
+func (*receiptReaderStub) EnsureEntitySchema(context.Context, string) error  { return nil }
+func (*receiptReaderStub) UpsertEventReceipt(context.Context, string, string, ReceiptStatus, string) error {
+	return nil
+}
+func (*receiptReaderStub) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (*receiptReaderStub) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (s *receiptReaderStub) GetEventReceipt(context.Context, string, string) (EventReceipt, bool, error) {
+	return s.receipt, s.found, nil
+}
+
 type traceRecordingAgent struct{ parent string }
 
 func (a *traceRecordingAgent) ID() string                        { return "trace-agent" }
@@ -42,6 +66,15 @@ func (a *traceRecordingAgent) OnEvent(ctx context.Context, evt events.Event) ([]
 	if inbound, ok := runtimebus.InboundEventFromContext(ctx); ok {
 		a.parent = inbound.ID
 	}
+	return nil, nil
+}
+
+type panicStubAgent struct{ id string }
+
+func (a panicStubAgent) ID() string                        { return a.id }
+func (a panicStubAgent) Type() string                      { return "llm" }
+func (a panicStubAgent) Subscriptions() []events.EventType { return nil }
+func (a panicStubAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
 	return nil, nil
 }
 
@@ -65,6 +98,12 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 	}
 	if got := authEvt.EntityID(); got != "ent-123" {
 		t.Fatalf("auth event entity_id = %q, want ent-123", got)
+	}
+	if got := authEvt.FlowInstance(); got != "review/inst-1" {
+		t.Fatalf("auth event flow_instance = %q, want review/inst-1", got)
+	}
+	if got := authEvt.Scope(); got != events.EventScopeEntity {
+		t.Fatalf("auth event scope = %q, want %q", got, events.EventScopeEntity)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(authEvt.Payload, &payload); err != nil {
@@ -114,6 +153,76 @@ func TestRecordDeadLetterEscalation_RequiresThreshold(t *testing.T) {
 		retryCount: 4,
 	}); emit {
 		t.Fatal("expected escalation to stay suppressed inside the same window")
+	}
+}
+
+func TestMaybeEscalateDeadLetter_PublishesTypedFlowInstanceEnvelope(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	store := &receiptReaderStub{
+		found: true,
+		receipt: EventReceipt{
+			EventID:    "evt-1",
+			AgentID:    "agent-a",
+			Status:     ReceiptStatusDeadLetter,
+			RetryCount: 2,
+			Error:      "boom",
+		},
+	}
+	am := NewAgentManager(bus, nil)
+	am.store = store
+	am.agentCfg["agent-a"] = runtimeactors.AgentConfig{
+		ID:       "agent-a",
+		EntityID: "ent-123",
+		FlowPath: "review/inst-1",
+	}
+
+	for i := 0; i < deadLetterEscalationThreshold; i++ {
+		am.maybeEscalateDeadLetter(context.Background(), "evt-1", "agent-a")
+	}
+
+	if len(bus.published) != 1 {
+		t.Fatalf("published events = %d, want 1", len(bus.published))
+	}
+	evt := bus.published[0]
+	if evt.Type != events.EventType("platform.dead_letter_escalation") {
+		t.Fatalf("event type = %s, want platform.dead_letter_escalation", evt.Type)
+	}
+	if got := evt.FlowInstance(); got != "review/inst-1" {
+		t.Fatalf("dead-letter escalation flow_instance = %q, want review/inst-1", got)
+	}
+	if got := evt.Scope(); got != events.EventScopeFlow {
+		t.Fatalf("dead-letter escalation scope = %q, want %q", got, events.EventScopeFlow)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got := payload["flow_instance"]; got != "review/inst-1" {
+		t.Fatalf("dead-letter escalation payload flow_instance = %#v, want review/inst-1", got)
+	}
+}
+
+func TestHandleAgentLoopPanic_PublishesTypedFlowInstanceEnvelope(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	am := NewAgentManager(bus, nil)
+	am.agentCfg["agent-a"] = runtimeactors.AgentConfig{
+		ID:       "agent-a",
+		EntityID: "ent-123",
+		FlowPath: "review/inst-1",
+	}
+
+	am.handleAgentLoopPanic(context.Background(), panicStubAgent{id: "agent-a"}, 5, "scan.requested", "boom", "stack")
+
+	if len(bus.published) != 2 {
+		t.Fatalf("published events = %d, want 2", len(bus.published))
+	}
+	for i, evt := range bus.published {
+		if got := evt.FlowInstance(); got != "review/inst-1" {
+			t.Fatalf("event %d flow_instance = %q, want review/inst-1", i, got)
+		}
+		if got := evt.Scope(); got != events.EventScopeEntity {
+			t.Fatalf("event %d scope = %q, want %q", i, got, events.EventScopeEntity)
+		}
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -823,7 +823,7 @@ func (am *AgentManager) handleAgentLoopPanic(ctx context.Context, agent Agent, c
 			"timestamp":       time.Now().UTC().Format(time.RFC3339Nano),
 		}),
 		CreatedAt: time.Now().UTC(),
-	}).WithEntityID(entityID)); err != nil {
+	}).WithEntityID(entityID).WithFlowInstance(flowInstance)); err != nil {
 		if am.bus != nil {
 			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 				Level:     "error",
@@ -866,7 +866,7 @@ func (am *AgentManager) handleAgentLoopPanic(ctx context.Context, agent Agent, c
 			"timestamp":       time.Now().UTC().Format(time.RFC3339Nano),
 		}),
 		CreatedAt: time.Now().UTC(),
-	}).WithEntityID(entityID)); err != nil {
+	}).WithEntityID(entityID).WithFlowInstance(flowInstance)); err != nil {
 		if am.bus != nil {
 			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 				Level:     "error",

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -465,6 +465,9 @@ func (pc *PipelineCoordinator) publish(ctx context.Context, eventType, entityID 
 		Payload:     mustJSON(payload),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(entityID)
+	if flowInstance := strings.Trim(strings.TrimSpace(asString(payload["flow_instance"])), "/"); flowInstance != "" {
+		emitted = emitted.WithFlowInstance(flowInstance)
+	}
 	if collector, ok := ctx.Value(pipelineEmitCollectorKey{}).(*[]events.Event); ok && collector != nil {
 		*collector = append(*collector, emitted)
 		return nil
@@ -496,6 +499,9 @@ func (pc *PipelineCoordinator) publishDirect(ctx context.Context, eventType, ent
 		Payload:     mustJSON(payload),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(entityID)
+	if flowInstance := strings.Trim(strings.TrimSpace(asString(payload["flow_instance"])), "/"); flowInstance != "" {
+		emitted = emitted.WithFlowInstance(flowInstance)
+	}
 	if collector, ok := ctx.Value(pipelineEmitCollectorKey{}).(*[]events.Event); ok && collector != nil {
 		*collector = append(*collector, emitted)
 		return nil

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -145,6 +146,45 @@ func TestExecuteNodeContractHandlerPublishesCollectedEventsWithoutParentCollecto
 	}
 	if got := bus.publishedCount(); got != 1 {
 		t.Fatalf("bus published count = %d, want 1", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerUsesTypedEnvelopeIdentityOverPayload(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+	}
+
+	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Emits: runtimecontracts.EventEmission{Single: "custom.emitted"},
+	}, workflowTriggerContext{
+		Event: (events.Event{
+			Type:      events.EventType("custom.trigger"),
+			Payload:   []byte(`{"entity_id":"payload-ent"}`),
+			CreatedAt: time.Now().UTC(),
+		}).WithEnvelope(events.EventEnvelope{EntityID: "env-ent"}),
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	if got := bus.publishedEvent(0).EntityID(); got != "env-ent" {
+		t.Fatalf("emitted event entity_id = %q, want env-ent", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
+		t.Fatalf("unmarshal emitted payload: %v", err)
+	}
+	if got := payload["entity_id"]; got != "env-ent" {
+		t.Fatalf("emitted payload entity_id = %#v, want env-ent", got)
 	}
 }
 
@@ -437,7 +477,7 @@ func TestResolveHandlerEntityIDForFlowPreservesCrossFlowEntityWithoutCreateEntit
 	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, incomingEntityID, events.Event{
 		Type:    events.EventType("vertical.discovered"),
 		Payload: mustJSON(map[string]any{"entity_id": incomingEntityID}),
-	}, &state)
+	}.WithEnvelope(events.EventEnvelope{EntityID: incomingEntityID}), &state)
 
 	if gotID != incomingEntityID {
 		t.Fatalf("entityID = %q, want preserved %q", gotID, incomingEntityID)
@@ -552,7 +592,7 @@ func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClears
 	inbound := events.Event{
 		Type:    events.EventType("vertical.discovered"),
 		Payload: mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}),
-	}
+	}.WithEnvelope(events.EventEnvelope{EntityID: inboundEntityID})
 
 	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "scoring", handler, inboundEntityID, inbound, &state)
 

--- a/internal/runtime/pipeline/scheduler.go
+++ b/internal/runtime/pipeline/scheduler.go
@@ -11,14 +11,15 @@ import (
 )
 
 type Schedule struct {
-	AgentID   string
-	EventType string
-	Mode      string // once | cron
-	Cron      string // supports "@every <duration>" and plain duration string
-	At        time.Time
-	EntityID  string
-	TaskID    string
-	Payload   []byte
+	AgentID      string
+	EventType    string
+	Mode         string // once | cron
+	Cron         string // supports "@every <duration>" and plain duration string
+	At           time.Time
+	EntityID     string
+	FlowInstance string
+	TaskID       string
+	Payload      []byte
 }
 
 func (s Schedule) EffectiveEntityID() string {
@@ -31,6 +32,17 @@ func (s *Schedule) NormalizeEntityID() {
 	}
 	entityID := s.EffectiveEntityID()
 	s.EntityID = entityID
+}
+
+func (s Schedule) EffectiveFlowInstance() string {
+	return strings.Trim(strings.TrimSpace(s.FlowInstance), "/")
+}
+
+func (s *Schedule) NormalizeFlowInstance() {
+	if s == nil {
+		return
+	}
+	s.FlowInstance = s.EffectiveFlowInstance()
 }
 
 type Scheduler struct {
@@ -65,6 +77,7 @@ func (s *Scheduler) Register(sc Schedule) error {
 		return errors.New("agent_id and event_type are required")
 	}
 	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
 	if sc.Mode == "" {
 		sc.Mode = "once"
 	}

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -41,14 +41,11 @@ type handlerExecutionPlan struct {
 }
 
 func workflowEventEntityID(evt events.Event) string {
-	return workflowEventEntityIDWithPayload(evt, parsePayloadMap(evt.Payload))
+	return workflowEventEntityIDWithPayload(evt, nil)
 }
 
 func workflowEventEntityIDWithPayload(evt events.Event, payload map[string]any) string {
-	return strings.TrimSpace(firstNonEmptyString(
-		asString(payload["entity_id"]),
-		evt.EntityID(),
-	))
+	return strings.TrimSpace(evt.EntityID())
 }
 
 func handlerGuardID(spec *runtimecontracts.GuardSpec) string {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -44,7 +44,7 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 				continue
 			}
 			timerState.Cancelled = true
-			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, timerState.FiresAt, workflowTimerPolicy(source)))
+			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
 			startTrigger, ok := workflowTimerStartTrigger(timer)
@@ -66,7 +66,7 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 				StartedBy: "state:" + nextStage,
 				Recurring: timer.Recurring,
 			})
-			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, fireAt, workflowTimerPolicy(source)))
+			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source)))
 		}
 	}); err != nil {
 		return err
@@ -129,7 +129,7 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 				continue
 			}
 			timerState.Cancelled = true
-			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, timerState.FiresAt, workflowTimerPolicy(source)))
+			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
 			startTrigger, ok := workflowTimerStartTrigger(timer)
@@ -151,7 +151,7 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 				StartedBy: "event:" + sourceEvent,
 				Recurring: timer.Recurring,
 			})
-			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, fireAt, workflowTimerPolicy(source)))
+			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source)))
 		}
 	}); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_event_timer_projection_failed", "", sourceEvent, runtimeWorkflowID, entityID, map[string]any{
@@ -191,7 +191,7 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	if !ok {
 		return nil
 	}
-	sc := accumulationTimeoutSchedule(entityID, bucketRef, time.Time{}, spec.TimeoutMS)
+	sc := accumulationTimeoutSchedule(entityID, evt.FlowInstance(), bucketRef, time.Time{}, spec.TimeoutMS)
 	if isAccumulationTimeoutEvent(evt.Type) || !waiting {
 		pc.persistWorkflowTimerCancellation(ctx, sc)
 		return nil
@@ -244,16 +244,17 @@ func accumulationTimeoutStartedAt(stateBuckets map[string]any, bucketRef timerid
 	return parsed.UTC(), true
 }
 
-func accumulationTimeoutSchedule(entityID string, bucketRef timeridentity.AccumulatorBucketRef, fireAt time.Time, timeoutMS int) Schedule {
+func accumulationTimeoutSchedule(entityID, flowInstance string, bucketRef timeridentity.AccumulatorBucketRef, fireAt time.Time, timeoutMS int) Schedule {
 	handle := timeridentity.AccumulationTimeoutHandle(bucketRef)
 	return Schedule{
-		AgentID:   runtimeWorkflowID,
-		EventType: "accumulate.timeout",
-		Mode:      "once",
-		At:        fireAt,
-		EntityID:  strings.TrimSpace(entityID),
-		TaskID:    handle.TaskID(),
-		Payload:   mustJSON(accumulationTimeoutPayload(handle, timeoutMS)),
+		AgentID:      runtimeWorkflowID,
+		EventType:    "accumulate.timeout",
+		Mode:         "once",
+		At:           fireAt,
+		EntityID:     strings.TrimSpace(entityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(flowInstance), "/"),
+		TaskID:       handle.TaskID(),
+		Payload:      mustJSON(accumulationTimeoutPayload(handle, timeoutMS)),
 	}
 }
 
@@ -327,16 +328,17 @@ func workflowTimerPolicy(source semanticview.Source) map[string]any {
 	return policyDocumentToMap(source.ResolvedPolicyForFlow(""))
 }
 
-func workflowTimerSchedule(timer runtimecontracts.WorkflowTimerContract, entityID string, fireAt time.Time, policy map[string]any) Schedule {
+func workflowTimerSchedule(timer runtimecontracts.WorkflowTimerContract, entityID, flowInstance string, fireAt time.Time, policy map[string]any) Schedule {
 	handle := timeridentity.WorkflowTimerHandle(timer.ID)
 	sc := Schedule{
-		AgentID:   strings.TrimSpace(timer.Owner),
-		EventType: strings.TrimSpace(timer.Event),
-		Mode:      "once",
-		At:        fireAt,
-		EntityID:  strings.TrimSpace(entityID),
-		TaskID:    handle.TaskID(),
-		Payload:   mustJSON(handle.PayloadMetadata()),
+		AgentID:      strings.TrimSpace(timer.Owner),
+		EventType:    strings.TrimSpace(timer.Event),
+		Mode:         "once",
+		At:           fireAt,
+		EntityID:     strings.TrimSpace(entityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(flowInstance), "/"),
+		TaskID:       handle.TaskID(),
+		Payload:      mustJSON(handle.PayloadMetadata()),
 	}
 	if timer.Recurring {
 		if cronSpec, ok := workflowTimerRecurringSpec(timer, policy); ok {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -298,15 +298,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	rt.Scheduler = runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		callbackCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		payload := scheduleEventPayload(sc)
-		if err := rt.Bus.Publish(callbackCtx, (events.Event{
-			ID:          uuid.NewString(),
-			Type:        events.EventType(sc.EventType),
-			SourceAgent: sc.AgentID,
-			TaskID:      sc.TaskID,
-			Payload:     payload,
-			CreatedAt:   time.Now(),
-		}).WithEntityID(sc.EffectiveEntityID())); err != nil {
+		if err := rt.Bus.Publish(callbackCtx, scheduledEvent(sc)); err != nil {
 			if rt.Logger != nil {
 				rt.Logger.Error(callbackCtx, "scheduler", "publish_failed", map[string]any{
 					"agent_id":   sc.AgentID,
@@ -497,11 +489,31 @@ func scheduleEventPayload(sc runtimepipeline.Schedule) []byte {
 			decoded["entity_id"] = entityID
 		}
 	}
+	flowInstance := strings.TrimSpace(sc.EffectiveFlowInstance())
+	if _, ok := decoded["flow_instance"]; !ok {
+		if flowInstance != "" {
+			decoded["flow_instance"] = flowInstance
+		}
+	}
 	encoded, err := json.Marshal(decoded)
 	if err != nil {
 		return payload
 	}
 	return encoded
+}
+
+func scheduledEvent(sc runtimepipeline.Schedule) events.Event {
+	return (events.Event{
+		ID:          uuid.NewString(),
+		Type:        events.EventType(sc.EventType),
+		SourceAgent: sc.AgentID,
+		TaskID:      sc.TaskID,
+		Payload:     scheduleEventPayload(sc),
+		CreatedAt:   time.Now(),
+	}).WithEnvelope(events.EventEnvelope{
+		EntityID:     sc.EffectiveEntityID(),
+		FlowInstance: sc.EffectiveFlowInstance(),
+	})
 }
 
 func (rt *Runtime) Start(ctx context.Context) error {
@@ -777,13 +789,14 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 				continue
 			}
 			sc := runtimepipeline.Schedule{
-				AgentID:   owner,
-				EventType: eventType,
-				Mode:      "once",
-				At:        timerState.FiresAt,
-				EntityID:  entityID,
-				TaskID:    timeridentity.WorkflowTimerHandle(timerID).TaskID(),
-				Payload:   recurringWorkflowTimerPayload(timer),
+				AgentID:      owner,
+				EventType:    eventType,
+				Mode:         "once",
+				At:           timerState.FiresAt,
+				EntityID:     entityID,
+				FlowInstance: strings.TrimSpace(instance.StorageRef),
+				TaskID:       timeridentity.WorkflowTimerHandle(timerID).TaskID(),
+				Payload:      recurringWorkflowTimerPayload(timer),
 			}
 			if err := store.UpsertSchedule(ctx, sc); err != nil {
 				return err

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -62,6 +63,36 @@ func TestScheduleEventPayloadPreservesAccumulationTimeoutHandle(t *testing.T) {
 	}
 	if got := decoded["entity_id"]; got != "ent-001" {
 		t.Fatalf("entity_id = %#v, want %q", got, "ent-001")
+	}
+}
+
+func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
+	evt := scheduledEvent(runtimepipeline.Schedule{
+		AgentID:      "runtime",
+		EventType:    "timer.check",
+		EntityID:     "ent-001",
+		FlowInstance: "review/inst-1",
+		Payload:      []byte(`{"entity_id":"payload-entity","flow_instance":"payload-flow"}`),
+	})
+
+	if got := evt.EntityID(); got != "ent-001" {
+		t.Fatalf("event entity_id = %q, want ent-001", got)
+	}
+	if got := evt.FlowInstance(); got != "review/inst-1" {
+		t.Fatalf("event flow_instance = %q, want review/inst-1", got)
+	}
+	if got := evt.Scope(); got != events.EventScopeEntity {
+		t.Fatalf("event scope = %q, want %q", got, events.EventScopeEntity)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		t.Fatalf("Unmarshal(payload): %v", err)
+	}
+	if got := payload["entity_id"]; got != "payload-entity" {
+		t.Fatalf("payload entity_id = %#v, want payload-entity", got)
+	}
+	if got := payload["flow_instance"]; got != "payload-flow" {
+		t.Fatalf("payload flow_instance = %#v, want payload-flow", got)
 	}
 }
 

--- a/internal/runtime/tools/executor_agents.go
+++ b/internal/runtime/tools/executor_agents.go
@@ -194,14 +194,15 @@ func (e *Executor) execSchedule(ctx context.Context, actor models.AgentConfig, i
 	}
 
 	schedule := Schedule{
-		AgentID:   in.AgentID,
-		EventType: in.EventType,
-		Mode:      in.Mode,
-		Cron:      in.Cron,
-		At:        at,
-		EntityID:  entityID,
-		TaskID:    in.TaskID,
-		Payload:   payload,
+		AgentID:      in.AgentID,
+		EventType:    in.EventType,
+		Mode:         in.Mode,
+		Cron:         in.Cron,
+		At:           at,
+		EntityID:     entityID,
+		FlowInstance: actor.CanonicalFlowPath(),
+		TaskID:       in.TaskID,
+		Payload:      payload,
 	}
 	if err := e.scheduler.Register(schedule); err != nil {
 		return nil, err

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -93,6 +93,9 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		Payload:     mustJSON(payloadMap),
 		CreatedAt:   time.Now(),
 	}).WithEntityID(strings.TrimSpace(asString(payloadMap["entity_id"])))
+	if flowInstance := strings.Trim(strings.TrimSpace(asString(payloadMap["flow_instance"])), "/"); flowInstance != "" {
+		emitted = emitted.WithFlowInstance(flowInstance)
+	}
 	if emitted.EntityID() == "" {
 		emitted = emitted.WithEntityID(strings.TrimSpace(actor.EffectiveEntityID()))
 	}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -245,7 +245,8 @@ func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agent
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, ''), e.payload, e.created_at,
+			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
+			e.payload, e.created_at,
 			COALESCE(e.source_event_id::text, '')
 		FROM event_deliveries d
 		INNER JOIN events e ON e.event_id = d.event_id
@@ -281,7 +282,8 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, ''), e.payload, e.created_at,
+			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
+			e.payload, e.created_at,
 			COALESCE(e.source_event_id::text, '')
 		FROM events e
 		LEFT JOIN event_receipts r
@@ -393,7 +395,7 @@ func scanLegacyPendingEvents(rows *sql.Rows) ([]events.Event, error) {
 		); err != nil {
 			return nil, fmt.Errorf("scan pending event: %w", err)
 		}
-		evt = evt.WithEntityID(legacyEntityID)
+		evt = evt.WithEnvelope(events.EventEnvelope{EntityID: legacyEntityID})
 		out = append(out, evt)
 	}
 	if err := rows.Err(); err != nil {
@@ -406,20 +408,26 @@ func scanSpecPendingEvents(rows *sql.Rows) ([]events.Event, error) {
 	out := make([]events.Event, 0)
 	for rows.Next() {
 		var evt events.Event
-		var entityID string
+		var entityID, flowInstance, scope string
 		if err := rows.Scan(
 			&evt.ID,
 			&evt.RunID,
 			&evt.Type,
 			&evt.SourceAgent,
 			&entityID,
+			&flowInstance,
+			&scope,
 			&evt.Payload,
 			&evt.CreatedAt,
 			&evt.ParentEventID,
 		); err != nil {
 			return nil, fmt.Errorf("scan pending event: %w", err)
 		}
-		evt = evt.WithEntityID(entityID)
+		evt = evt.WithEnvelope(events.EventEnvelope{
+			EntityID:     entityID,
+			FlowInstance: flowInstance,
+			Scope:        events.EventScope(scope),
+		})
 		out = append(out, evt)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -400,7 +400,8 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
 			e.event_id::text, e.event_name, COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, ''), e.payload, e.created_at
+			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
+			e.payload, e.created_at
 		FROM events e
 		LEFT JOIN event_receipts r
 			ON r.event_id = e.event_id
@@ -419,18 +420,24 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 	out := make([]events.Event, 0, limit)
 	for rows.Next() {
 		var evt events.Event
-		var entityID string
+		var entityID, flowInstance, scope string
 		if err := rows.Scan(
 			&evt.ID,
 			&evt.Type,
 			&evt.SourceAgent,
 			&entityID,
+			&flowInstance,
+			&scope,
 			&evt.Payload,
 			&evt.CreatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan missing pipeline receipt event: %w", err)
 		}
-		evt = evt.WithEntityID(entityID)
+		evt = evt.WithEnvelope(events.EventEnvelope{
+			EntityID:     entityID,
+			FlowInstance: flowInstance,
+			Scope:        events.EventScope(scope),
+		})
 		out = append(out, evt)
 	}
 	if err := rows.Err(); err != nil {
@@ -497,13 +504,12 @@ func eventStorageEnvelope(evt events.Event) (id string, runID string, eventName 
 	runID = runIDOrEventID(evt.RunID, id)
 	eventName = strings.TrimSpace(string(evt.Type))
 	payload = eventPayloadForStorage(evt)
-	entityID = sanitizeOptionalUUID(evt.EntityID())
-	flowInstance = eventPayloadString(payload, "flow_instance")
-	scope = "global"
-	if entityID != "" {
-		scope = "entity"
-	} else if flowInstance != "" {
-		scope = "flow"
+	envelope := evt.NormalizedEnvelope()
+	entityID = sanitizeOptionalUUID(envelope.EntityID)
+	flowInstance = envelope.FlowInstance
+	scope = string(envelope.Scope)
+	if scope == "" {
+		scope = string(events.EventScopeGlobal)
 	}
 	chainDepth = evt.ChainDepth
 	if chainDepth < 0 {
@@ -544,18 +550,6 @@ func eventPayloadForStorage(evt events.Event) []byte {
 		return evt.Payload
 	}
 	return encoded
-}
-
-func eventPayloadString(raw []byte, key string) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil || payload == nil {
-		return ""
-	}
-	value, _ := payload[strings.TrimSpace(key)].(string)
-	return strings.TrimSpace(value)
 }
 
 func mapPipelineStatusToOutcome(status string) string {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -925,6 +925,38 @@ func TestSchedules_ExactIdentityUsesTaskID(t *testing.T) {
 	}
 }
 
+func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	entityID := uuid.NewString()
+
+	sc := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-a",
+		Payload:      []byte(`{"timer_id":"timer-a"}`),
+	}
+	if err := pg.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("upsert schedule: %v", err)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("active schedules = %d, want 1", len(active))
+	}
+	if got := active[0].FlowInstance; got != "review/inst-1" {
+		t.Fatalf("loaded flow_instance = %q, want review/inst-1", got)
+	}
+}
+
 func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -407,6 +407,51 @@ func TestPostgresStore_ListPendingEventsForAgentSpec_PreservesRunID(t *testing.T
 	}
 }
 
+func TestPostgresStore_ListPendingEventsForAgentSpec_UsesTypedEnvelopeMetadata(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	entityID := uuid.NewString()
+	const flowInstance = "review/inst-1"
+	seedSpecAgent(t, ctx, pg, "analysis-agent", "", "scoring.requested")
+
+	eventID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		Type:        events.EventType("scoring.requested"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEnvelope(events.EventEnvelope{
+		EntityID:     entityID,
+		FlowInstance: flowInstance,
+	})
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"analysis-agent"}); err != nil {
+		t.Fatalf("InsertEventDeliveries: %v", err)
+	}
+
+	got, err := pg.ListPendingEventsForAgent(ctx, "analysis-agent", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("pending events = %d, want 1", len(got))
+	}
+	if got := got[0].EntityID(); got != entityID {
+		t.Fatalf("pending event entity_id = %q, want %q", got, entityID)
+	}
+	if got := got[0].FlowInstance(); got != flowInstance {
+		t.Fatalf("pending event flow_instance = %q, want %q", got, flowInstance)
+	}
+	if got := got[0].Scope(); got != events.EventScopeEntity {
+		t.Fatalf("pending event scope = %q, want %q", got, events.EventScopeEntity)
+	}
+}
+
 func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -957,6 +957,94 @@ func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	}
 }
 
+func TestSchedules_MarkScheduleFiredExact_PreservesRecurringReplayAndFiresOnceSchedules(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	entityID := uuid.NewString()
+
+	recurring := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "cron",
+		Cron:         "@every 30m",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-recurring",
+		Payload:      []byte(`{"timer_id":"timer-recurring"}`),
+	}
+	once := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(60 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-once",
+		Payload:      []byte(`{"timer_id":"timer-once"}`),
+	}
+	if err := pg.UpsertSchedule(ctx, recurring); err != nil {
+		t.Fatalf("upsert recurring schedule: %v", err)
+	}
+	if err := pg.UpsertSchedule(ctx, once); err != nil {
+		t.Fatalf("upsert once schedule: %v", err)
+	}
+
+	if err := pg.MarkScheduleFiredExact(ctx, recurring); err != nil {
+		t.Fatalf("MarkScheduleFiredExact(recurring): %v", err)
+	}
+	if err := pg.MarkScheduleFiredExact(ctx, once); err != nil {
+		t.Fatalf("MarkScheduleFiredExact(once): %v", err)
+	}
+
+	var recurringStatus, onceStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM timers
+		WHERE owner_agent = $1
+		  AND fire_event = $2
+		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $3
+	`, recurring.AgentID, recurring.EventType, recurring.TaskID).Scan(&recurringStatus); err != nil {
+		t.Fatalf("query recurring timer status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM timers
+		WHERE owner_agent = $1
+		  AND fire_event = $2
+		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $3
+	`, once.AgentID, once.EventType, once.TaskID).Scan(&onceStatus); err != nil {
+		t.Fatalf("query once timer status: %v", err)
+	}
+	if recurringStatus != "active" {
+		t.Fatalf("recurring timer status = %q, want active", recurringStatus)
+	}
+	if onceStatus != "fired" {
+		t.Fatalf("once timer status = %q, want fired", onceStatus)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	var recurringFound, onceFound bool
+	for _, sc := range active {
+		if sc.AgentID == recurring.AgentID && sc.EventType == recurring.EventType && sc.TaskID == recurring.TaskID {
+			recurringFound = true
+		}
+		if sc.AgentID == once.AgentID && sc.EventType == once.EventType && sc.TaskID == once.TaskID {
+			onceFound = true
+		}
+	}
+	if !recurringFound {
+		t.Fatal("expected recurring exact schedule to remain active after firing")
+	}
+	if onceFound {
+		t.Fatal("expected once exact schedule to be absent from active schedule restore after firing")
+	}
+}
+
 func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -23,6 +23,8 @@ func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.S
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	flowInstance := sc.EffectiveFlowInstance()
+	sc.FlowInstance = flowInstance
 
 	switch caps.Schedules {
 	case SchemaFlavorCanonical:
@@ -58,6 +60,8 @@ func (s *PostgresStore) CancelScheduleExact(ctx context.Context, sc runtimepipel
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	flowInstance := sc.EffectiveFlowInstance()
+	sc.FlowInstance = flowInstance
 	switch caps.Schedules {
 	case SchemaFlavorCanonical:
 		return s.cancelScheduleExactSpec(ctx, sc)
@@ -105,6 +109,8 @@ func (s *PostgresStore) MarkScheduleFiredExact(ctx context.Context, sc runtimepi
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	flowInstance := sc.EffectiveFlowInstance()
+	sc.FlowInstance = flowInstance
 	switch caps.Schedules {
 	case SchemaFlavorCanonical:
 		return s.markScheduleFiredExactSpec(ctx, sc)
@@ -148,9 +154,10 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 		WHERE owner_agent = $1
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $4
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
+		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, strings.TrimSpace(sc.TaskID)); err != nil {
+	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)); err != nil {
 		return fmt.Errorf("deactivate previous timer: %w", err)
 	}
 
@@ -177,11 +184,11 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 			owner_node, owner_agent, task_type, status
 		)
 		VALUES (
-			$1, NULLIF($2,'')::uuid, NULL, $3, $4::jsonb,
-			$5, $6, NULLIF($7,''), NULL,
-			NULL, $8, $9, 'active'
+			$1, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5::jsonb,
+			$6, $7, NULLIF($8,''), NULL,
+			NULL, $9, $10, 'active'
 		)
-	`, timerName, sc.EntityID, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, taskType)
+	`, timerName, sc.EntityID, sc.FlowInstance, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, taskType)
 	if err != nil {
 		return fmt.Errorf("insert timer: %w", err)
 	}
@@ -212,9 +219,10 @@ func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimep
 		WHERE owner_agent = $1
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $4
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
+		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, strings.TrimSpace(sc.TaskID))
+	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
 	if err != nil {
 		return fmt.Errorf("cancel exact timer: %w", err)
 	}
@@ -230,6 +238,7 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			COALESCE(recurrence_cron, ''),
 			fire_at,
 			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
 			fire_payload
 		FROM timers
 		WHERE status = 'active'
@@ -254,6 +263,7 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			&sc.Cron,
 			&fireAt,
 			&sc.EntityID,
+			&sc.FlowInstance,
 			&payload,
 		); err != nil {
 			return nil, fmt.Errorf("scan active timer: %w", err)
@@ -299,9 +309,10 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 		WHERE owner_agent = $1
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $4
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
+		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, strings.TrimSpace(sc.TaskID), status)
+	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
 	if err != nil {
 		return fmt.Errorf("mark exact timer fired: %w", err)
 	}

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -304,7 +304,7 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	}
 	_, err := s.DB.ExecContext(ctx, `
 		UPDATE timers
-		SET status = $5,
+		SET status = $6,
 		    fired_at = now()
 		WHERE owner_agent = $1
 		  AND fire_event = $2


### PR DESCRIPTION
## What changed

- Introduced a typed event envelope on runtime events for canonical entity, flow, and scope metadata.

- Switched store round-trips, bus routing, and pipeline execution in the touched seams to consume the typed envelope instead of payload-carried identity.

- Added focused regression coverage for envelope-owned routing, persistence round-trip, and execution behavior.

## Why
- Canonical event identity was still being recovered from payload JSON in several runtime paths, which let routing and execution semantics drift away from the spec-defined persisted event columns.

- This change makes the envelope the single semantic owner in the touched seams while keeping payload metadata only as mirrored contract data where needed.

## Impact

- Runtime routing and execution now fail closed unless canonical event identity is stamped on the typed envelope.

- Store reads no longer reconstruct identity by mutating payload JSON on load.
- Payload entity or flow fields may still exist, but they are no longer the semantic owner in the touched runtime seams.

## Validation

- go test ./... -count=1






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Events now carry structured metadata (entity ID, flow instance, scope) for improved routing and filtering.
  * Scheduler now tracks workflow instance context alongside event triggers.

* **Bug Fixes**
  * Event recipient matching now uses canonical envelope metadata instead of payload fields, ensuring consistent event delivery.

* **Tests**
  * Added comprehensive test coverage for event envelope handling and scheduler flow context preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->