### PR TITLE
[agent-d][issue #62] Replace loose dashboard JSON projection with typed canonical read-model projection

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -276,29 +276,12 @@ func enrichAgentAggregateFromLatestTurn(aggregate *agentRuntimeAggregate, taskID
 		return nil
 	}
 	aggregate.CurrentTaskID = strings.TrimSpace(taskID)
-	turnBlocks, err := decodeJSONArray(turnBlocksRaw)
+	summary, ok, err := decodeTurnSummaryProjection(turnBlocksRaw)
 	if err != nil {
-		return fmt.Errorf("decode latest agent turn turn_blocks: %w", err)
+		return fmt.Errorf("decode latest agent turn turn_summary: %w", err)
 	}
-	summary, ok := readTurnSummaryBlock(turnBlocks)
-	if !ok {
-		return nil
-	}
-	toolResults := readAnySlice(summary["tool_results"])
-	if len(toolResults) == 0 {
-		return nil
-	}
-	lastResult, _ := toolResults[len(toolResults)-1].(map[string]any)
-	toolName := strings.TrimSpace(readString(lastResult["tool_name"]))
-	if toolName == "" {
-		return nil
-	}
-	aggregate.LastTool = map[string]any{
-		"name": toolName,
-		"ok":   parseOK,
-	}
-	if output, ok := lastResult["output"]; ok && output != nil {
-		aggregate.LastTool["result"] = output
+	if ok {
+		aggregate.LastTool = summary.lastToolMap(parseOK)
 	}
 	return nil
 }

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -158,12 +158,12 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 	); err != nil {
 		return ConversationSummary{}, err
 	}
-	runtimeState, err := decodeJSONMap(runtimeStateRaw)
+	runtimeState, err := decodeConversationRuntimeStateProjection(runtimeStateRaw)
 	if err != nil {
 		return ConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
-	item.Summary = readString(runtimeState["summary"])
-	item.Metadata = compactMap(runtimeState, "summary", "last_turn")
+	item.Summary = runtimeState.Summary
+	item.Metadata = runtimeState.metadataMap()
 	return item, nil
 }
 
@@ -188,12 +188,12 @@ func scanConversationDetail(scanner rowScanner) (ConversationDetail, error) {
 	); err != nil {
 		return ConversationDetail{}, err
 	}
-	runtimeState, err := decodeJSONMap(runtimeStateRaw)
+	runtimeState, err := decodeConversationRuntimeStateProjection(runtimeStateRaw)
 	if err != nil {
 		return ConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
-	item.Summary = readString(runtimeState["summary"])
-	item.RuntimeState = runtimeState
+	item.Summary = runtimeState.Summary
+	item.RuntimeState = runtimeState.runtimeStateMap()
 	item.Messages, err = decodeJSONArray(messagesRaw)
 	if err != nil {
 		return ConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)
@@ -427,6 +427,10 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 	}
 	item.CreatedAt = createdAt.Format(time.RFC3339Nano)
 	var err error
+	summary, hasSummary, err := decodeTurnSummaryProjection(turnBlocksRaw)
+	if err != nil {
+		return ConversationTurn{}, err
+	}
 	if item.AvailableTools, err = decodeJSONArray(availableToolsRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn available_tools: %w", err)
 	}
@@ -456,83 +460,22 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 			return ConversationTurn{}, fmt.Errorf("decode turn turn_blocks: %w", err)
 		}
 	}
+	if hasSummary {
+		item.AssistantVisibleOutput, item.Outcome, item.ReasoningBlocks, item.ProgressUpdates, item.ToolResults = summary.conversationFields()
+	}
 	return item, nil
 }
 
 func summarizeConversationTurnBlocks(blocks []any) (string, string, []string, []string, []any) {
-	summary, ok := readTurnSummaryBlock(blocks)
-	if !ok {
+	raw, err := json.Marshal(blocks)
+	if err != nil {
 		return "", "", nil, nil, nil
 	}
-	assistantText := strings.TrimSpace(readString(summary["assistant_visible_output"]))
-	outcome := strings.TrimSpace(readString(summary["outcome"]))
-	if outcome == "" {
-		outcome = assistantText
+	summary, ok, err := decodeTurnSummaryProjection(raw)
+	if err != nil || !ok {
+		return "", "", nil, nil, nil
 	}
-	reasoning := readStringSlice(summary["reasoning_blocks"])
-	progress := readStringSlice(summary["progress_updates"])
-	toolResults := readAnySlice(summary["tool_results"])
-	return assistantText, outcome, reasoning, progress, toolResults
-}
-
-func readTurnSummaryBlock(blocks []any) (map[string]any, bool) {
-	for _, raw := range blocks {
-		entry, _ := raw.(map[string]any)
-		if strings.TrimSpace(readString(entry["kind"])) != "turn_summary" {
-			continue
-		}
-		data, _ := entry["data"].(map[string]any)
-		if len(data) == 0 {
-			return map[string]any{}, false
-		}
-		return data, true
-	}
-	return map[string]any{}, false
-}
-
-func readStringSlice(value any) []string {
-	list, ok := value.([]any)
-	if !ok || len(list) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(list))
-	for _, item := range list {
-		text := strings.TrimSpace(readString(item))
-		if text == "" {
-			continue
-		}
-		out = append(out, text)
-	}
-	return out
-}
-
-func readAnySlice(value any) []any {
-	list, _ := value.([]any)
-	if len(list) == 0 {
-		return nil
-	}
-	return append([]any(nil), list...)
-}
-
-func compactMap(in map[string]any, keys ...string) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
-	drop := map[string]struct{}{}
-	for _, key := range keys {
-		drop[key] = struct{}{}
-	}
-	out := map[string]any{}
-	for key, value := range in {
-		if _, skip := drop[key]; skip {
-			continue
-		}
-		out[key] = value
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return summary.conversationFields()
 }
 
 func readString(value any) string {

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -1,0 +1,224 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type projectedConversationRuntimeState struct {
+	Summary  string
+	LastTurn *projectedConversationLastTurn
+	raw      map[string]any
+}
+
+type projectedConversationLastTurn struct {
+	TaskID  string `json:"task_id,omitempty"`
+	ParseOK bool   `json:"parse_ok,omitempty"`
+}
+
+func decodeConversationRuntimeStateProjection(raw []byte) (projectedConversationRuntimeState, error) {
+	if len(raw) == 0 {
+		return projectedConversationRuntimeState{raw: map[string]any{}}, nil
+	}
+	var projected projectedConversationRuntimeState
+	if err := json.Unmarshal(raw, &projected.raw); err != nil {
+		return projectedConversationRuntimeState{}, err
+	}
+	var typed struct {
+		Summary  string                         `json:"summary"`
+		LastTurn *projectedConversationLastTurn `json:"last_turn,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &typed); err != nil {
+		return projectedConversationRuntimeState{}, err
+	}
+	projected.Summary = strings.TrimSpace(typed.Summary)
+	projected.LastTurn = typed.LastTurn
+	return projected, nil
+}
+
+func (p projectedConversationRuntimeState) metadataMap() map[string]any {
+	return omitKnownKeys(p.raw, "summary", "last_turn")
+}
+
+func (p projectedConversationRuntimeState) runtimeStateMap() map[string]any {
+	return cloneAnyMap(p.raw)
+}
+
+type projectedTurnSummary struct {
+	AssistantVisibleOutput string                         `json:"assistant_visible_output,omitempty"`
+	Outcome                string                         `json:"outcome,omitempty"`
+	ReasoningBlocks        []string                       `json:"reasoning_blocks,omitempty"`
+	ProgressUpdates        []string                       `json:"progress_updates,omitempty"`
+	ToolResults            []projectedTurnSummaryToolItem `json:"tool_results,omitempty"`
+}
+
+type projectedTurnSummaryToolItem struct {
+	ToolName  string `json:"tool_name,omitempty"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Output    any    `json:"output,omitempty"`
+}
+
+type projectedTurnBlockEnvelope struct {
+	Kind string          `json:"kind"`
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+func decodeTurnSummaryProjection(raw []byte) (projectedTurnSummary, bool, error) {
+	if len(raw) == 0 {
+		return projectedTurnSummary{}, false, nil
+	}
+	var blocks []projectedTurnBlockEnvelope
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return projectedTurnSummary{}, false, err
+	}
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Kind) != "turn_summary" {
+			continue
+		}
+		data := bytes.TrimSpace(block.Data)
+		if len(data) == 0 || bytes.Equal(data, []byte("null")) || bytes.Equal(data, []byte("{}")) {
+			return projectedTurnSummary{}, false, nil
+		}
+		var summary projectedTurnSummary
+		if err := json.Unmarshal(data, &summary); err != nil {
+			return projectedTurnSummary{}, false, fmt.Errorf("decode canonical turn_summary: %w", err)
+		}
+		summary = normalizeProjectedTurnSummary(summary)
+		if summary.isZero() {
+			return projectedTurnSummary{}, false, nil
+		}
+		return summary, true, nil
+	}
+	return projectedTurnSummary{}, false, nil
+}
+
+func normalizeProjectedTurnSummary(summary projectedTurnSummary) projectedTurnSummary {
+	summary.AssistantVisibleOutput = strings.TrimSpace(summary.AssistantVisibleOutput)
+	summary.Outcome = strings.TrimSpace(summary.Outcome)
+	summary.ReasoningBlocks = trimStringSlice(summary.ReasoningBlocks)
+	summary.ProgressUpdates = trimStringSlice(summary.ProgressUpdates)
+	if len(summary.ToolResults) == 0 {
+		summary.ToolResults = nil
+	} else {
+		out := make([]projectedTurnSummaryToolItem, 0, len(summary.ToolResults))
+		for _, item := range summary.ToolResults {
+			item.ToolName = strings.TrimSpace(item.ToolName)
+			item.ToolUseID = strings.TrimSpace(item.ToolUseID)
+			out = append(out, item)
+		}
+		summary.ToolResults = out
+	}
+	if summary.Outcome == "" {
+		summary.Outcome = summary.AssistantVisibleOutput
+	}
+	return summary
+}
+
+func (p projectedTurnSummary) isZero() bool {
+	return p.AssistantVisibleOutput == "" &&
+		p.Outcome == "" &&
+		len(p.ReasoningBlocks) == 0 &&
+		len(p.ProgressUpdates) == 0 &&
+		len(p.ToolResults) == 0
+}
+
+func (p projectedTurnSummary) conversationFields() (string, string, []string, []string, []any) {
+	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), p.toolResultsAny()
+}
+
+func (p projectedTurnSummary) toolResultsAny() []any {
+	if len(p.ToolResults) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(p.ToolResults))
+	for _, item := range p.ToolResults {
+		row := map[string]any{
+			"tool_name": item.ToolName,
+		}
+		if item.ToolUseID != "" {
+			row["tool_use_id"] = item.ToolUseID
+		}
+		if item.Output != nil {
+			row["output"] = item.Output
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func (p projectedTurnSummary) lastToolMap(parseOK bool) map[string]any {
+	if len(p.ToolResults) == 0 {
+		return nil
+	}
+	last := p.ToolResults[len(p.ToolResults)-1]
+	if last.ToolName == "" {
+		return nil
+	}
+	out := map[string]any{
+		"name": last.ToolName,
+		"ok":   parseOK,
+	}
+	if last.Output != nil {
+		out["result"] = last.Output
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func omitKnownKeys(in map[string]any, keys ...string) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	drop := map[string]struct{}{}
+	for _, key := range keys {
+		drop[key] = struct{}{}
+	}
+	out := map[string]any{}
+	for key, value := range in {
+		if _, skip := drop[key]; skip {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func trimStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]string(nil), in...)
+}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -606,6 +606,48 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	}
 }
 
+func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
+		t.Fatal("expected malformed canonical turn summary to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -819,6 +861,79 @@ func TestSummarizeConversationTurnBlocks_FailsClosedOnEmptyCanonicalSummary(t *t
 	}
 	if toolResults != nil {
 		t.Fatalf("expected nil tool results, got %#v", toolResults)
+	}
+}
+
+func TestSQLConversationReader_ListFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+		WithArgs(10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":123}`), time.Now().UTC()))
+
+	if _, err := reader.List(context.Background(), 10); err == nil {
+		t.Fatal("expected malformed canonical runtime_state to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetFailsOnMalformedCanonicalTurnSummary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"brief"}`
+	messagePayload := `[{"role":"assistant","content":"hello"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), []byte(messagePayload), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "sess-1", "task", "global", "entity-1", "evt-1", "scoring/vertical.marginal", "",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"stale fallback text"}`), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`), true, 92282, 0, "", now,
+		))
+
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil {
+		t.Fatal("expected malformed canonical turn summary to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed
- added one shared typed dashboard projection helper for canonical conversation `runtime_state` summaries and canonical `turn_summary` blocks
- switched the conversation and agent SQL readers to consume that typed projection boundary instead of repeatedly parsing canonical JSON through ad hoc maps and slices
- added focused malformed-data tests so canonical read-model readers now fail explicitly when required canonical data is malformed

## Why it changed
The dashboard readers were still decoding canonical persisted surfaces into loose `map[string]any` and `[]any` structures in multiple places. That kept the projection logic duplicated and made semantic drift cheap. This change centralizes the canonical read-model projection in one typed owner while preserving the outward reader behavior.

## Impact
- canonical conversation summary fields and canonical turn summaries now have one typed projection owner in the dashboard layer
- conversation and agent readers share the same typed summary projection path
- malformed canonical `runtime_state` and malformed canonical `turn_summary` data now fail closed instead of being tolerated through loose map parsing

## Validation
- `go test ./internal/dashboard/server ./... -count=1`
