### PR TITLE
[agent-a][issue #64] Remove MCP turn-context globals and process-wide hook state

### DIFF
--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -25,6 +25,7 @@ type ClaudeCLIRuntime struct {
 	workspaces    workspace.Resolver
 	monitor       MonitorSink
 	events        EventPublisher
+	mcpTurns      MCPTurnContextStore
 }
 
 var ErrClaudeAuthRequired = errors.New("claude auth required")
@@ -33,6 +34,11 @@ var ErrClaudeWorkspaceRequired = errors.New("claude workspace target required")
 type promptTransportFallback struct {
 	Attempted bool
 	Used      bool
+}
+
+type ClaudeCLIRuntimeOptions struct {
+	MonitorSink         MonitorSink
+	MCPTurnContextStore MCPTurnContextStore
 }
 
 func NewClaudeCLIRuntime(
@@ -45,6 +51,24 @@ func NewClaudeCLIRuntime(
 	conversations ConversationPersistence,
 	publisher EventPublisher,
 ) *ClaudeCLIRuntime {
+	return NewClaudeCLIRuntimeWithOptions(cfg, sessions, lockOwner, turns, budget, workspaces, conversations, publisher, ClaudeCLIRuntimeOptions{})
+}
+
+func NewClaudeCLIRuntimeWithOptions(
+	cfg *config.Config,
+	sessions sessions.Registry,
+	lockOwner string,
+	turns TurnPersistence,
+	budget BudgetGuard,
+	workspaces workspace.Resolver,
+	conversations ConversationPersistence,
+	publisher EventPublisher,
+	opts ClaudeCLIRuntimeOptions,
+) *ClaudeCLIRuntime {
+	monitor := opts.MonitorSink
+	if monitor == nil {
+		monitor = NewFileMonitorSink(DefaultMonitorDir())
+	}
 	return &ClaudeCLIRuntime{
 		cfg:           cfg,
 		sessions:      sessions,
@@ -53,8 +77,9 @@ func NewClaudeCLIRuntime(
 		budget:        budget,
 		lockOwner:     lockOwner,
 		workspaces:    workspaces,
-		monitor:       NewFileMonitorSink(DefaultMonitorDir()),
+		monitor:       monitor,
 		events:        publisher,
+		mcpTurns:      opts.MCPTurnContextStore,
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -52,6 +52,9 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 	if strings.TrimSpace(actor.ID) == "" {
 		return "", "", false, nil
 	}
+	if r.mcpTurns == nil {
+		return "", "", false, errors.New("mcp turn context store is required for MCP bridge")
+	}
 
 	gatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
 	if gatewayURL == "" {
@@ -74,7 +77,7 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 	if token := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); token != "" {
 		headers["Authorization"] = "Bearer " + token
 	}
-	contextToken = mcpTurnContextRegister(ctx, r.mcpContextTokenTTL(ctx))
+	contextToken = r.mcpTurns.RegisterTurnContextWithTTL(ctx, r.mcpContextTokenTTL(ctx))
 	if contextToken != "" {
 		headers[mcpContextTokenHeader] = contextToken
 	}
@@ -91,7 +94,7 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 	raw, marshalErr := json.Marshal(cfg)
 	if marshalErr != nil {
 		if contextToken != "" {
-			mcpTurnContextUnregister(contextToken)
+			r.mcpTurns.UnregisterTurnContext(contextToken)
 			contextToken = ""
 		}
 		return "", "", false, marshalErr

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -12,6 +12,24 @@ import (
 	models "swarm/internal/runtime/core/actors"
 )
 
+type mcpTurnContextStoreStub struct {
+	register   func(context.Context, time.Duration) string
+	unregister func(string)
+}
+
+func (s mcpTurnContextStoreStub) RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
+	if s.register == nil {
+		return ""
+	}
+	return s.register(ctx, ttl)
+}
+
+func (s mcpTurnContextStoreStub) UnregisterTurnContext(token string) {
+	if s.unregister != nil {
+		s.unregister(token)
+	}
+}
+
 func TestShouldUseMCPBridge_DefaultsOn(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
 	if !shouldUseMCPBridge() {
@@ -96,15 +114,13 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:18082")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 
-	r := &ClaudeCLIRuntime{cfg: &config.Config{}}
-	prevRegister := mcpTurnContextRegister
-	prevUnregister := mcpTurnContextUnregister
-	mcpTurnContextRegister = func(context.Context, time.Duration) string { return "ctx-token-123" }
-	mcpTurnContextUnregister = func(string) {}
-	defer func() {
-		mcpTurnContextRegister = prevRegister
-		mcpTurnContextUnregister = prevUnregister
-	}()
+	r := &ClaudeCLIRuntime{
+		cfg: &config.Config{},
+		mcpTurns: mcpTurnContextStoreStub{
+			register:   func(context.Context, time.Duration) string { return "ctx-token-123" },
+			unregister: func(string) {},
+		},
+	}
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
 		ID:   "market-research-agent",
 		Role: "market_research",
@@ -146,5 +162,25 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	legacyTraceQuery := "trace" + "_id="
 	if strings.Contains(urlRaw, legacyTraceQuery) {
 		t.Fatalf("url %q should not propagate legacy trace query params", urlRaw)
+	}
+}
+
+func TestBuildMCPConfigArg_FailsClosedWithoutTurnContextStore(t *testing.T) {
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:18082")
+
+	r := &ClaudeCLIRuntime{cfg: &config.Config{}}
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:   "market-research-agent",
+		Role: "market_research",
+	})
+	s := &Session{
+		AgentID: "market-research-agent",
+		Tools:   []ToolDefinition{{Name: "query_entities"}},
+	}
+
+	_, _, _, err := r.buildMCPConfigArg(ctx, s)
+	if err == nil || !strings.Contains(err.Error(), "mcp turn context store is required") {
+		t.Fatalf("buildMCPConfigArg err = %v, want missing store error", err)
 	}
 }

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -21,6 +21,7 @@ type RuntimeFactory struct {
 	LockOwner     string
 	Workspaces    workspace.Resolver
 	Events        EventPublisher
+	MCPTurns      MCPTurnContextStore
 }
 
 func (f RuntimeFactory) Build() (Runtime, error) {
@@ -35,7 +36,9 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 	case "api":
 		return NewAnthropicAPIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events), nil
 	case "cli_test":
-		return NewClaudeCLIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events), nil
+		return NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
+			MCPTurnContextStore: f.MCPTurns,
+		}), nil
 	default:
 		return nil, fmt.Errorf("unsupported llm runtime mode: %s", f.Cfg.LLM.RuntimeMode)
 	}

--- a/internal/runtime/llm/helpers_runtime.go
+++ b/internal/runtime/llm/helpers_runtime.go
@@ -37,16 +37,7 @@ func asString(v any) string {
 	return runtimesharedjson.AsString(v)
 }
 
-var mcpTurnContextRegister = func(context.Context, time.Duration) string { return "" }
-var mcpTurnContextUnregister = func(string) {}
-
-func SetMCPTurnContextHooks(register func(context.Context, time.Duration) string, unregister func(string)) {
-	if register == nil {
-		register = func(context.Context, time.Duration) string { return "" }
-	}
-	if unregister == nil {
-		unregister = func(string) {}
-	}
-	mcpTurnContextRegister = register
-	mcpTurnContextUnregister = unregister
+type MCPTurnContextStore interface {
+	RegisterTurnContextWithTTL(context.Context, time.Duration) string
+	UnregisterTurnContext(string)
 }

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -30,6 +30,7 @@ type AgentManager struct {
 	semanticSource           semanticview.Source
 	promptResolver           runtimecontracts.PromptResolver
 	budget                   BudgetGuard
+	resetRuntimeOwnedState   func()
 	runtimeMode              string
 	throttleSuppressPrefixes []string
 	inFlightMu               sync.Mutex
@@ -102,6 +103,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		promptResolver:           opts.PromptResolver,
 		runtimeMode:              strings.TrimSpace(opts.RuntimeMode),
 		budget:                   opts.Budget,
+		resetRuntimeOwnedState:   opts.ResetRuntimeOwnedState,
 		throttleSuppressPrefixes: throttleSuppressPrefixes,
 		inFlight:                 make(map[string]struct{}),
 		loopCancel:               make(map[string]context.CancelFunc),

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -16,7 +16,6 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
-	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
@@ -594,7 +593,9 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 			return fmt.Errorf("kill workspace orphan processes: %w", err)
 		}
 	}
-	runtimemcp.ResetTurnContexts()
+	if am.resetRuntimeOwnedState != nil {
+		am.resetRuntimeOwnedState()
+	}
 	if resetter, ok := am.sessions.(sessions.Resetter); ok && resetter != nil {
 		if err := resetter.ResetAll(am.runtimeMode); err != nil {
 			if am.bus != nil {

--- a/internal/runtime/manager/runtime_reset_test.go
+++ b/internal/runtime/manager/runtime_reset_test.go
@@ -1,0 +1,43 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemcp "swarm/internal/runtime/mcp"
+)
+
+func TestResetRuntimeState_OnlyResetsOwnedTurnContextRegistry(t *testing.T) {
+	registryA := runtimemcp.NewTurnContextRegistry(nil)
+	registryB := runtimemcp.NewTurnContextRegistry(nil)
+
+	registryA.PutTurnContextForTest("ctx-shared", runtimemcp.TurnContext{
+		Actor:     runtimeactors.AgentConfig{ID: "agent-a"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	registryB.PutTurnContextForTest("ctx-shared", runtimemcp.TurnContext{
+		Actor:     runtimeactors.AgentConfig{ID: "agent-b"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{
+		ResetRuntimeOwnedState: registryA.Reset,
+	})
+	if err := am.ResetRuntimeState(); err != nil {
+		t.Fatalf("ResetRuntimeState: %v", err)
+	}
+
+	if _, ok := registryA.ResolveTurnContext("ctx-shared"); ok {
+		t.Fatal("registryA should be empty after reset")
+	}
+	turn, ok := registryB.ResolveTurnContext("ctx-shared")
+	if !ok {
+		t.Fatal("registryB should retain its turn context")
+	}
+	if turn.Actor.ID != "agent-b" {
+		t.Fatalf("registryB actor id = %q, want agent-b", turn.Actor.ID)
+	}
+}

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -130,6 +130,7 @@ type AgentManagerOptions struct {
 	PromptResolver            runtimecontracts.PromptResolver
 	RuntimeMode               string
 	Budget                    BudgetGuard
+	ResetRuntimeOwnedState    func()
 	ThrottleSuppressPrefixes  []string
 	DisableSpinupControl      bool
 	EnableLegacySpinupControl bool

--- a/internal/runtime/mcp/context.go
+++ b/internal/runtime/mcp/context.go
@@ -14,8 +14,6 @@ import (
 
 type actorResolverFn func(context.Context) (models.AgentConfig, bool)
 
-var actorResolver actorResolverFn
-
 type TurnContext struct {
 	Actor      models.AgentConfig
 	Inbound    events.Event
@@ -27,42 +25,39 @@ type TurnContext struct {
 	ExpiresAt  time.Time
 }
 
-type mcpTurnRegistry struct {
+type TurnContextRegistry struct {
 	mu   sync.RWMutex
 	data map[string]TurnContext
+
+	actorResolver actorResolverFn
+	defaultTTL    time.Duration
 }
 
-func newMCPTurnRegistry() *mcpTurnRegistry {
-	return &mcpTurnRegistry{
-		data: make(map[string]TurnContext),
+func NewTurnContextRegistry(resolve actorResolverFn) *TurnContextRegistry {
+	return &TurnContextRegistry{
+		data:          make(map[string]TurnContext),
+		actorResolver: resolve,
+		defaultTTL:    2 * time.Hour,
 	}
 }
 
-var globalMCPTurnRegistry = newMCPTurnRegistry()
-var defaultMCPTurnContextTTL = 2 * time.Hour
-
-func init() {
-	runtimebus.SetRuntimeResetHook(ResetTurnContexts)
-}
-
-func SetActorResolver(resolve actorResolverFn) {
-	actorResolver = resolve
-}
-
-func RegisterTurnContext(ctx context.Context) string {
-	return RegisterTurnContextWithTTL(ctx, defaultMCPTurnContextTTL)
-}
-
-func RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
-	if actorResolver == nil {
+func (r *TurnContextRegistry) RegisterTurnContext(ctx context.Context) string {
+	if r == nil {
 		return ""
 	}
-	actor, ok := actorResolver(ctx)
+	return r.RegisterTurnContextWithTTL(ctx, r.defaultTTL)
+}
+
+func (r *TurnContextRegistry) RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
+	if r == nil || r.actorResolver == nil {
+		return ""
+	}
+	actor, ok := r.actorResolver(ctx)
 	if !ok || strings.TrimSpace(actor.ID) == "" {
 		return ""
 	}
 	if ttl <= 0 {
-		ttl = defaultMCPTurnContextTTL
+		ttl = r.defaultTTL
 	}
 	now := time.Now().UTC()
 	token := uuid.NewString()
@@ -72,7 +67,7 @@ func RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
 	if scoped, ok := runtimebus.RuntimeEpochFromContext(ctx); ok && scoped > 0 {
 		epoch = scoped
 	}
-	globalMCPTurnRegistry.put(token, TurnContext{
+	r.put(token, TurnContext{
 		Actor:      actor,
 		Inbound:    inbound,
 		HasInbound: hasInbound,
@@ -84,37 +79,58 @@ func RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
 	return token
 }
 
-func ResolveTurnContext(token string) (TurnContext, bool) {
-	return globalMCPTurnRegistry.get(strings.TrimSpace(token))
+func (r *TurnContextRegistry) ResolveTurnContext(token string) (TurnContext, bool) {
+	if r == nil {
+		return TurnContext{}, false
+	}
+	return r.get(strings.TrimSpace(token))
 }
 
-func MarkEmitUsed(token string) bool {
-	return globalMCPTurnRegistry.markEmitKeyUsed(strings.TrimSpace(token), "__default__")
+func (r *TurnContextRegistry) MarkEmitUsed(token string) bool {
+	if r == nil {
+		return false
+	}
+	return r.markEmitKeyUsed(strings.TrimSpace(token), "__default__")
 }
 
-func MarkEmitKeyUsed(token, key string) bool {
-	return globalMCPTurnRegistry.markEmitKeyUsed(strings.TrimSpace(token), strings.TrimSpace(key))
+func (r *TurnContextRegistry) MarkEmitKeyUsed(token, key string) bool {
+	if r == nil {
+		return false
+	}
+	return r.markEmitKeyUsed(strings.TrimSpace(token), strings.TrimSpace(key))
 }
 
-func UnregisterTurnContext(token string) {
-	globalMCPTurnRegistry.delete(strings.TrimSpace(token))
+func (r *TurnContextRegistry) UnregisterTurnContext(token string) {
+	if r == nil {
+		return
+	}
+	r.delete(strings.TrimSpace(token))
 }
 
-func ResetTurnContexts() {
-	globalMCPTurnRegistry.reset()
+func (r *TurnContextRegistry) Reset() {
+	if r == nil {
+		return
+	}
+	r.reset()
 }
 
-func PutTurnContextForTest(token string, data TurnContext) {
-	globalMCPTurnRegistry.put(strings.TrimSpace(token), data)
+func (r *TurnContextRegistry) PutTurnContextForTest(token string, data TurnContext) {
+	if r == nil {
+		return
+	}
+	r.put(strings.TrimSpace(token), data)
 }
 
-func PruneTurnContextsBefore(now time.Time) {
-	globalMCPTurnRegistry.mu.Lock()
-	defer globalMCPTurnRegistry.mu.Unlock()
-	globalMCPTurnRegistry.pruneLocked(now)
+func (r *TurnContextRegistry) PruneTurnContextsBefore(now time.Time) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked(now)
 }
 
-func (r *mcpTurnRegistry) put(token string, data TurnContext) {
+func (r *TurnContextRegistry) put(token string, data TurnContext) {
 	if strings.TrimSpace(token) == "" {
 		return
 	}
@@ -123,7 +139,7 @@ func (r *mcpTurnRegistry) put(token string, data TurnContext) {
 		data.CreatedAt = now
 	}
 	if data.ExpiresAt.IsZero() {
-		data.ExpiresAt = data.CreatedAt.Add(defaultMCPTurnContextTTL)
+		data.ExpiresAt = data.CreatedAt.Add(r.defaultTTL)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -131,7 +147,7 @@ func (r *mcpTurnRegistry) put(token string, data TurnContext) {
 	r.data[token] = data
 }
 
-func (r *mcpTurnRegistry) get(token string) (TurnContext, bool) {
+func (r *TurnContextRegistry) get(token string) (TurnContext, bool) {
 	if strings.TrimSpace(token) == "" {
 		return TurnContext{}, false
 	}
@@ -143,7 +159,7 @@ func (r *mcpTurnRegistry) get(token string) (TurnContext, bool) {
 	return v, ok
 }
 
-func (r *mcpTurnRegistry) markEmitKeyUsed(token, key string) bool {
+func (r *TurnContextRegistry) markEmitKeyUsed(token, key string) bool {
 	if strings.TrimSpace(token) == "" {
 		return false
 	}
@@ -169,7 +185,7 @@ func (r *mcpTurnRegistry) markEmitKeyUsed(token, key string) bool {
 	return false
 }
 
-func (r *mcpTurnRegistry) delete(token string) {
+func (r *TurnContextRegistry) delete(token string) {
 	if strings.TrimSpace(token) == "" {
 		return
 	}
@@ -178,13 +194,13 @@ func (r *mcpTurnRegistry) delete(token string) {
 	delete(r.data, token)
 }
 
-func (r *mcpTurnRegistry) reset() {
+func (r *TurnContextRegistry) reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.data = make(map[string]TurnContext)
 }
 
-func (r *mcpTurnRegistry) pruneLocked(now time.Time) {
+func (r *TurnContextRegistry) pruneLocked(now time.Time) {
 	for k, v := range r.data {
 		if !v.ExpiresAt.IsZero() {
 			if !v.ExpiresAt.After(now) {
@@ -192,7 +208,7 @@ func (r *mcpTurnRegistry) pruneLocked(now time.Time) {
 			}
 			continue
 		}
-		if v.CreatedAt.Before(now.Add(-defaultMCPTurnContextTTL)) {
+		if v.CreatedAt.Before(now.Add(-r.defaultTTL)) {
 			delete(r.data, k)
 		}
 	}

--- a/internal/runtime/mcp/context.go
+++ b/internal/runtime/mcp/context.go
@@ -20,7 +20,6 @@ type TurnContext struct {
 	HasInbound bool
 	Recorder   *runtimebus.EmittedEventsRecorder
 	Emitted    map[string]struct{}
-	Epoch      int64
 	CreatedAt  time.Time
 	ExpiresAt  time.Time
 }
@@ -63,16 +62,11 @@ func (r *TurnContextRegistry) RegisterTurnContextWithTTL(ctx context.Context, tt
 	token := uuid.NewString()
 	recorder, _ := runtimebus.EmittedEventsRecorderFromContext(ctx)
 	inbound, hasInbound := runtimebus.InboundEventFromContext(ctx)
-	epoch := runtimebus.CurrentRuntimeEpoch()
-	if scoped, ok := runtimebus.RuntimeEpochFromContext(ctx); ok && scoped > 0 {
-		epoch = scoped
-	}
 	r.put(token, TurnContext{
 		Actor:      actor,
 		Inbound:    inbound,
 		HasInbound: hasInbound,
 		Recorder:   recorder,
-		Epoch:      epoch,
 		CreatedAt:  now,
 		ExpiresAt:  now.Add(ttl),
 	})

--- a/internal/runtime/mcp/context_test.go
+++ b/internal/runtime/mcp/context_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	models "swarm/internal/runtime/core/actors"
+)
+
+func TestTurnContextRegistry_ResetIsScopedToRegistry(t *testing.T) {
+	registryA := NewTurnContextRegistry(nil)
+	registryB := NewTurnContextRegistry(nil)
+
+	registryA.PutTurnContextForTest("ctx-shared", TurnContext{
+		Actor:     models.AgentConfig{ID: "agent-a"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	registryB.PutTurnContextForTest("ctx-shared", TurnContext{
+		Actor:     models.AgentConfig{ID: "agent-b"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	registryA.Reset()
+
+	if _, ok := registryA.ResolveTurnContext("ctx-shared"); ok {
+		t.Fatal("registryA should be empty after reset")
+	}
+	turn, ok := registryB.ResolveTurnContext("ctx-shared")
+	if !ok {
+		t.Fatal("registryB should retain its turn context")
+	}
+	if turn.Actor.ID != "agent-b" {
+		t.Fatalf("registryB actor id = %q, want agent-b", turn.Actor.ID)
+	}
+}

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -26,9 +26,7 @@ type GatewayHooks struct {
 	WithActor                 func(context.Context, models.AgentConfig) context.Context
 	ActorFromContext          func(context.Context) (models.AgentConfig, bool)
 	ResolveActorConfig        func(string) (models.AgentConfig, bool)
-	WithRuntimeEpoch          func(context.Context, int64) context.Context
 	WithCurrentRuntimeEpoch   func(context.Context) context.Context
-	IsCurrentRuntimeEpoch     func(int64) bool
 	WithInboundEvent          func(context.Context, events.Event) context.Context
 	WithEmittedEventsRecorder func(context.Context, *runtimebus.EmittedEventsRecorder) context.Context
 	ResolveTurnContext        func(string) (TurnContext, bool)
@@ -329,15 +327,12 @@ func (g *Gateway) mcpExecutionContext(r *http.Request, toolName string) (context
 	if token := ContextTokenFromRequest(r); token != "" {
 		if g.hooks.ResolveTurnContext != nil {
 			if turn, ok := g.hooks.ResolveTurnContext(token); ok {
-				if g.hooks.IsCurrentRuntimeEpoch != nil && !g.hooks.IsCurrentRuntimeEpoch(turn.Epoch) {
-					return nil, g.newRuntimeError(ErrCodeContextStale, "mcp.context.resolve", false, nil, "stale mcp context token")
-				}
 				ctx := context.Background()
 				if g.hooks.WithActor != nil {
 					ctx = g.hooks.WithActor(ctx, g.hydrateActor(turn.Actor))
 				}
-				if g.hooks.WithRuntimeEpoch != nil {
-					ctx = g.hooks.WithRuntimeEpoch(ctx, turn.Epoch)
+				if g.hooks.WithCurrentRuntimeEpoch != nil {
+					ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
 				}
 				ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
 				if turn.HasInbound && g.hooks.WithInboundEvent != nil {
@@ -404,15 +399,12 @@ func (g *Gateway) toolExecutionContext(r *http.Request, actor models.AgentConfig
 	if token := ContextTokenFromRequest(r); token != "" {
 		if g.hooks.ResolveTurnContext != nil {
 			if turn, ok := g.hooks.ResolveTurnContext(token); ok {
-				if g.hooks.IsCurrentRuntimeEpoch != nil && !g.hooks.IsCurrentRuntimeEpoch(turn.Epoch) {
-					return nil, g.newRuntimeError(ErrCodeContextStale, "tool.context.resolve", false, nil, "stale mcp context token")
-				}
 				ctx := r.Context()
 				if g.hooks.WithActor != nil {
 					ctx = g.hooks.WithActor(ctx, g.hydrateActor(turn.Actor))
 				}
-				if g.hooks.WithRuntimeEpoch != nil {
-					ctx = g.hooks.WithRuntimeEpoch(ctx, turn.Epoch)
+				if g.hooks.WithCurrentRuntimeEpoch != nil {
+					ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
 				}
 				ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
 				if turn.HasInbound && g.hooks.WithInboundEvent != nil {

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -32,6 +32,7 @@ type GatewayHooks struct {
 	WithInboundEvent          func(context.Context, events.Event) context.Context
 	WithEmittedEventsRecorder func(context.Context, *runtimebus.EmittedEventsRecorder) context.Context
 	ResolveTurnContext        func(string) (TurnContext, bool)
+	MarkEmitKeyUsed           func(string, string) bool
 	EmitToolsForActor         func(models.AgentConfig) []llm.ToolDefinition
 	EmitTools                 func(string) []llm.ToolDefinition
 	EmitSchemaForTool         func(string) (description string, schema any, ok bool)
@@ -268,7 +269,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if toolIsKindInContext(ctx, toolName, toolcapabilities.KindEmit) {
-			if token := ContextTokenFromRequest(r); token != "" && MarkEmitKeyUsed(token, emitTurnDedupeKey(toolName, req.Params["arguments"])) {
+			if token := ContextTokenFromRequest(r); token != "" && g.hooks.MarkEmitKeyUsed != nil && g.hooks.MarkEmitKeyUsed(token, emitTurnDedupeKey(toolName, req.Params["arguments"])) {
 				WriteRPCResult(w, req.ID, map[string]any{
 					"content": []map[string]any{{
 						"type": "text",

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -150,6 +150,18 @@ func (s *capabilityAwareExecutorStub) ToolCapabilitiesForActor(_ models.AgentCon
 	return toolcapabilities.NewSet(caps)
 }
 
+func newTestTurnContextRegistry() *TurnContextRegistry {
+	return NewTurnContextRegistry(nil)
+}
+
+func putTestTurnContext(t testing.TB, registry *TurnContextRegistry, token string, turn TurnContext) {
+	t.Helper()
+	registry.PutTurnContextForTest(token, turn)
+	t.Cleanup(func() {
+		registry.UnregisterTurnContext(token)
+	})
+}
+
 func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
 	g := NewGateway(nil, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
@@ -252,6 +264,7 @@ func TestGatewayMCPToolsForRequest_UsesHydratedActorRoleForEmitTools(t *testing.
 }
 
 func TestGatewayMCPToolsForRequest_KeepsEmitToolsForDirectMCPContext(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(nil, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			if agentID != "campaign-coordinator" {
@@ -272,14 +285,14 @@ func TestGatewayMCPToolsForRequest_KeepsEmitToolsForDirectMCPContext(t *testing.
 				Schema:      map[string]any{"type": "object"},
 			}}
 		},
+		ResolveTurnContext: registry.ResolveTurnContext,
 	})
 
-	PutTurnContextForTest("ctx-1", TurnContext{
+	putTestTurnContext(t, registry, "ctx-1", TurnContext{
 		Actor:     models.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-1") })
 
 	req := httptest.NewRequest("POST", "/mcp?agent_id=campaign-coordinator&ctx_token=ctx-1", nil)
 	tools := g.mcpToolsForRequest(req)
@@ -359,53 +372,56 @@ func TestGatewayMCPToolsForRequest_DoesNotInventUnknownAllowedToolEntries(t *tes
 }
 
 func TestMarkEmitUsed(t *testing.T) {
-	PutTurnContextForTest("ctx-emit", TurnContext{
+	registry := newTestTurnContextRegistry()
+	putTestTurnContext(t, registry, "ctx-emit", TurnContext{
 		Actor:     models.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-emit") })
 
-	if already := MarkEmitUsed("ctx-emit"); already {
+	if already := registry.MarkEmitUsed("ctx-emit"); already {
 		t.Fatal("first emit use should not report already used")
 	}
-	if already := MarkEmitUsed("ctx-emit"); !already {
+	if already := registry.MarkEmitUsed("ctx-emit"); !already {
 		t.Fatal("second emit use should report already used")
 	}
 }
 
 func TestMarkEmitKeyUsed_AllowsDistinctKeysPerTurn(t *testing.T) {
-	PutTurnContextForTest("ctx-emit-keys", TurnContext{
+	registry := newTestTurnContextRegistry()
+	putTestTurnContext(t, registry, "ctx-emit-keys", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-emit-keys") })
 
-	if already := MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"one\"}"); already {
+	if already := registry.MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"one\"}"); already {
 		t.Fatal("first unique emit key should not report already used")
 	}
-	if already := MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"two\"}"); already {
+	if already := registry.MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"two\"}"); already {
 		t.Fatal("second distinct emit key should be allowed")
 	}
-	if already := MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"one\"}"); !already {
+	if already := registry.MarkEmitKeyUsed("ctx-emit-keys", "emit_a\n{\"dimension\":\"one\"}"); !already {
 		t.Fatal("duplicate emit key should report already used")
 	}
 }
 
 func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	}), "", GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
+	})
 
-	PutTurnContextForTest("ctx-emit-gateway", TurnContext{
+	putTestTurnContext(t, registry, "ctx-emit-gateway", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-emit-gateway") })
 
 	handler := g.Handler()
 	makeReq := func(arguments any) *httptest.ResponseRecorder {
@@ -447,15 +463,18 @@ func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
 }
 
 func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	exec := &capabilityAwareExecutorStub{}
-	g := NewGateway(exec, "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	g := NewGateway(exec, "", GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
+	})
 
-	PutTurnContextForTest("ctx-prefixed-emit", TurnContext{
+	putTestTurnContext(t, registry, "ctx-prefixed-emit", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-prefixed-emit") })
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -484,23 +503,24 @@ func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *
 }
 
 func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	exec := &capabilityAwareExecutorStub{}
 	var loggedAction string
 	var denialLayer string
 	g := NewGateway(exec, "", GatewayHooks{
-		ResolveTurnContext: ResolveTurnContext,
+		ResolveTurnContext: registry.ResolveTurnContext,
+		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
 			loggedAction = action
 			denialLayer = strings.TrimSpace(asString(detail["denial_layer"]))
 		},
 	})
 
-	PutTurnContextForTest("ctx-denied-allowlist", TurnContext{
+	putTestTurnContext(t, registry, "ctx-denied-allowlist", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-denied-allowlist") })
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -539,7 +559,7 @@ func TestGatewayHandleMCP_RejectsMutatingToolWhenContextTokenMisses(t *testing.T
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	}), "", GatewayHooks{})
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -568,7 +588,7 @@ func TestGatewayHandleMCP_RejectsMutatingToolWhenContextTokenMisses(t *testing.T
 }
 
 func TestGatewayMCPExecutionContext_RejectsPrefixedMutatingToolOnContextMiss(t *testing.T) {
-	g := NewGateway(nil, "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	g := NewGateway(nil, "", GatewayHooks{})
 	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", nil)
 	if _, err := g.mcpExecutionContext(req, "mcp__runtime-tools__emit_score_dimension_complete"); err == nil {
 		t.Fatal("expected context miss error for prefixed mutating tool")
@@ -576,8 +596,9 @@ func TestGatewayMCPExecutionContext_RejectsPrefixedMutatingToolOnContextMiss(t *
 }
 
 func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(nil, "", GatewayHooks{
-		ResolveTurnContext: ResolveTurnContext,
+		ResolveTurnContext: registry.ResolveTurnContext,
 		WithActor: func(ctx context.Context, actor models.AgentConfig) context.Context {
 			return models.WithActor(ctx, actor)
 		},
@@ -588,14 +609,13 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 			return runtimebus.WithInboundEvent(ctx, evt)
 		},
 	})
-	PutTurnContextForTest("ctx-trace", TurnContext{
+	putTestTurnContext(t, registry, "ctx-trace", TurnContext{
 		Actor:      models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		Inbound:    events.Event{ID: "evt-1", RunID: "run-1"},
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
 	})
-	t.Cleanup(func() { UnregisterTurnContext("ctx-trace") })
 
 	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-trace", nil)
 	ctx, err := g.mcpExecutionContext(req, "get_entity")
@@ -610,7 +630,7 @@ func TestGatewayHandleMCP_AllowsReadOnlyToolWhenContextTokenMisses(t *testing.T)
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	}), "", GatewayHooks{})
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -643,7 +663,7 @@ func TestGatewayHandleTool_RejectsMutatingToolWithoutContextToken(t *testing.T) 
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	}), "", GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
 		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
@@ -672,7 +692,7 @@ func TestGatewayHandleTool_AllowsReadOnlyToolWithoutContextToken(t *testing.T) {
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{ResolveTurnContext: ResolveTurnContext})
+	}), "", GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
 		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
@@ -699,7 +719,6 @@ func TestGatewayHandleMCP_LogsFallbackUsedReason(t *testing.T) {
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
 	}), "", GatewayHooks{
-		ResolveTurnContext: ResolveTurnContext,
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
 			actions = append(actions, action)
 			if reason, _ := detail["reason"].(string); strings.TrimSpace(reason) != "" {
@@ -740,7 +759,6 @@ func TestGatewayHandleTool_LogsFallbackBlockedReason(t *testing.T) {
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
 	}), "", GatewayHooks{
-		ResolveTurnContext: ResolveTurnContext,
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
 			actions = append(actions, action)
 			if reason, _ := detail["reason"].(string); strings.TrimSpace(reason) != "" {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -602,8 +602,8 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 		WithActor: func(ctx context.Context, actor models.AgentConfig) context.Context {
 			return models.WithActor(ctx, actor)
 		},
-		WithRuntimeEpoch: func(ctx context.Context, epoch int64) context.Context {
-			return ctx
+		WithCurrentRuntimeEpoch: func(ctx context.Context) context.Context {
+			return runtimebus.WithCurrentRuntimeEpoch(ctx)
 		},
 		WithInboundEvent: func(ctx context.Context, evt events.Event) context.Context {
 			return runtimebus.WithInboundEvent(ctx, evt)
@@ -623,6 +623,36 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 		t.Fatalf("mcpExecutionContext: %v", err)
 	}
 	_ = ctx
+}
+
+func TestGatewayMCPExecutionContext_KeepsOtherRegistryTokensValidAfterGlobalEpochBump(t *testing.T) {
+	registryA := newTestTurnContextRegistry()
+	registryB := newTestTurnContextRegistry()
+	registryB.PutTurnContextForTest("ctx-b", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	t.Cleanup(func() { registryB.UnregisterTurnContext("ctx-b") })
+
+	gatewayB := NewGateway(nil, "", GatewayHooks{
+		ResolveTurnContext:      registryB.ResolveTurnContext,
+		WithActor:               models.WithActor,
+		WithCurrentRuntimeEpoch: runtimebus.WithCurrentRuntimeEpoch,
+	})
+
+	registryA.Reset()
+	runtimebus.EnterRuntimeResetMode()
+	runtimebus.ExitRuntimeResetMode()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-b", nil)
+	ctx, err := gatewayB.mcpExecutionContext(req, "query_entities")
+	if err != nil {
+		t.Fatalf("mcpExecutionContext after unrelated reset: %v", err)
+	}
+	if epoch, ok := runtimebus.RuntimeEpochFromContext(ctx); !ok || epoch != runtimebus.CurrentRuntimeEpoch() {
+		t.Fatalf("context epoch = %d ok=%v, want current epoch %d", epoch, ok, runtimebus.CurrentRuntimeEpoch())
+	}
 }
 
 func TestGatewayHandleMCP_AllowsReadOnlyToolWhenContextTokenMisses(t *testing.T) {

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"sync"
-	"time"
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -13,15 +11,6 @@ import (
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimetools "swarm/internal/runtime/tools"
 )
-
-type mcpTurnContext = runtimemcp.TurnContext
-
-type mcpTurnRegistry struct {
-	mu sync.Mutex
-}
-
-var globalMCPTurnRegistry = newMCPTurnRegistry()
-var defaultMCPTurnContextTTL = 2 * time.Hour
 
 const (
 	ErrCodeMCPAuthMissingBearer = runtimemcp.ErrCodeAuthMissingBearer
@@ -35,55 +24,6 @@ const (
 	ErrCodeMCPInvalidRequest    = runtimemcp.ErrCodeInvalidRequest
 )
 
-func init() {
-	runtimemcp.SetActorResolver(runtimeactors.ActorFromContext)
-	llm.SetMCPTurnContextHooks(runtimemcp.RegisterTurnContextWithTTL, runtimemcp.UnregisterTurnContext)
-}
-
-func newMCPTurnRegistry() *mcpTurnRegistry {
-	return &mcpTurnRegistry{}
-}
-
-func registerMCPTurnContext(ctx context.Context) string {
-	return runtimemcp.RegisterTurnContext(ctx)
-}
-
-func registerMCPTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
-	return runtimemcp.RegisterTurnContextWithTTL(ctx, ttl)
-}
-
-func resolveMCPTurnContext(token string) (mcpTurnContext, bool) {
-	return runtimemcp.ResolveTurnContext(token)
-}
-
-func unregisterMCPTurnContext(token string) {
-	runtimemcp.UnregisterTurnContext(token)
-}
-
-func resetMCPTurnContexts() {
-	runtimemcp.ResetTurnContexts()
-}
-
-func (r *mcpTurnRegistry) put(token string, data mcpTurnContext) {
-	runtimemcp.PutTurnContextForTest(token, data)
-}
-
-func (r *mcpTurnRegistry) get(token string) (mcpTurnContext, bool) {
-	return runtimemcp.ResolveTurnContext(token)
-}
-
-func (r *mcpTurnRegistry) delete(token string) {
-	runtimemcp.UnregisterTurnContext(token)
-}
-
-func (r *mcpTurnRegistry) reset() {
-	runtimemcp.ResetTurnContexts()
-}
-
-func (r *mcpTurnRegistry) pruneLocked(now time.Time) {
-	runtimemcp.PruneTurnContextsBefore(now)
-}
-
 func newMCPRuntimeError(code, operation string, retryable bool, cause error, format string, args ...any) error {
 	return WrapRuntimeError(code, "mcp-gateway", operation, retryable, cause, format, args...)
 }
@@ -96,7 +36,7 @@ func runtimeErrorEnvelope(raw string) string {
 	return runtimemcp.RuntimeErrorEnvelope(raw)
 }
 
-func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), emitRegistry *runtimetools.EmitRegistry) runtimemcp.GatewayHooks {
+func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
 	if emitRegistry == nil {
 		emitRegistry = runtimetools.NewEmitRegistry(nil, nil)
 	}
@@ -113,7 +53,18 @@ func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(strin
 		IsCurrentRuntimeEpoch:     runtimebus.IsCurrentRuntimeEpoch,
 		WithInboundEvent:          runtimebus.WithInboundEvent,
 		WithEmittedEventsRecorder: runtimebus.WithEmittedEventsRecorder,
-		ResolveTurnContext:        resolveMCPTurnContext,
+		ResolveTurnContext: func(token string) (runtimemcp.TurnContext, bool) {
+			if turnContexts == nil {
+				return runtimemcp.TurnContext{}, false
+			}
+			return turnContexts.ResolveTurnContext(token)
+		},
+		MarkEmitKeyUsed: func(token, key string) bool {
+			if turnContexts == nil {
+				return false
+			}
+			return turnContexts.MarkEmitKeyUsed(token, key)
+		},
 		EmitToolsForActor: func(actor runtimeactors.AgentConfig) []llm.ToolDefinition {
 			return emitRegistry.GenerateEmitToolsForActor(actor, processWarnOnce)
 		},

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -48,9 +48,7 @@ func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(strin
 		WithActor:                 runtimeactors.WithActor,
 		ActorFromContext:          runtimeactors.ActorFromContext,
 		ResolveActorConfig:        resolveActorConfig,
-		WithRuntimeEpoch:          runtimebus.WithRuntimeEpoch,
 		WithCurrentRuntimeEpoch:   runtimebus.WithCurrentRuntimeEpoch,
-		IsCurrentRuntimeEpoch:     runtimebus.IsCurrentRuntimeEpoch,
 		WithInboundEvent:          runtimebus.WithInboundEvent,
 		WithEmittedEventsRecorder: runtimebus.WithEmittedEventsRecorder,
 		ResolveTurnContext: func(token string) (runtimemcp.TurnContext, bool) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -73,6 +73,7 @@ type Runtime struct {
 	Manager        *runtimemanager.AgentManager
 	InboundGateway *InboundGateway
 	ToolGateway    *runtimemcp.Gateway
+	MCPTurns       *runtimemcp.TurnContextRegistry
 	Authority      runtimeauthority.Provider
 	EmitRegistry   *runtimetools.EmitRegistry
 	PromptResolver runtimecontracts.PromptResolver
@@ -236,6 +237,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if err != nil {
 		return nil, fmt.Errorf("build prompt resolver: %w", err)
 	}
+	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	authorityProvider := runtimeauthority.NewSourceProvider(source)
 	emitRegistry := runtimetools.NewEmitRegistry(source, authorityProvider)
 	if warnings, err := runtimetools.ValidateToolImplementations(source); err != nil {
@@ -259,6 +261,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		Stores:         stores,
 		Options:        opts,
 		Workspace:      opts.WorkspaceLifecycle,
+		MCPTurns:       mcpTurns,
 		Authority:      authorityProvider,
 		EmitRegistry:   emitRegistry,
 		PromptResolver: promptResolver,
@@ -349,6 +352,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			Budget:        rt.Budget,
 			Workspaces:    rt.Workspace,
 			Events:        rt.Bus,
+			MCPTurns:      rt.MCPTurns,
 		}.Build()
 		if err != nil {
 			return nil, fmt.Errorf("build runtime: %w", err)
@@ -430,12 +434,17 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		EmitRegistry:      rt.EmitRegistry,
 	})
 	rt.Manager = runtimemanager.NewAgentManagerWithOptions(rt.Bus, factory, runtimemanager.AgentManagerOptions{
-		Workspaces:               rt.Workspace,
-		Sessions:                 stores.SessionRegistry,
-		SemanticSource:           source,
-		PromptResolver:           rt.PromptResolver,
-		RuntimeMode:              cfg.LLM.RuntimeMode,
-		Budget:                   rt.Budget,
+		Workspaces:     rt.Workspace,
+		Sessions:       stores.SessionRegistry,
+		SemanticSource: source,
+		PromptResolver: rt.PromptResolver,
+		RuntimeMode:    cfg.LLM.RuntimeMode,
+		Budget:         rt.Budget,
+		ResetRuntimeOwnedState: func() {
+			if rt.MCPTurns != nil {
+				rt.MCPTurns.Reset()
+			}
+		},
 		ThrottleSuppressPrefixes: runtimeThrottleSuppressPrefixes(source),
 		DisableSpinupControl:     true,
 	}, stores.ManagerStore)
@@ -463,7 +472,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 				return runtimeactors.AgentConfig{}, false
 			}
 			return rt.Manager.GetAgentConfig(strings.TrimSpace(agentID))
-		}, rt.EmitRegistry))
+		}, rt.EmitRegistry, rt.MCPTurns))
 	}
 
 	return rt, nil

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -152,7 +152,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_AcceptsVisibleTools(t *testing.T
 	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
-	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil))
+	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil))
 
 	if err := validateClaudeMCPToolsForManagedAgents(cfg, gateway, "gateway-token", manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
@@ -170,7 +170,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsWhenRequiredEmitToolsMissin
 	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
-	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil))
+	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil))
 
 	err := validateClaudeMCPToolsForManagedAgents(cfg, gateway, "gateway-token", manager)
 	if err == nil || !strings.Contains(err.Error(), "missing required emit tools") {


### PR DESCRIPTION
## What changed

This removes the remaining MCP turn-context globals and process-wide hook state from the runtime path.

The canonical owner is now a runtime-owned `mcp.TurnContextRegistry` created during runtime construction and injected explicitly into:
- the Claude CLI runtime
- MCP gateway hooks
- runtime reset ownership in the agent manager

The touched seams no longer use package-level mutable MCP registries or cross-package setter hooks.

## Why

The previous implementation still depended on:
- a package-global MCP turn-context registry
- `mcp.SetActorResolver(...)`
- `llm.SetMCPTurnContextHooks(...)`
- manager reset clearing global MCP state for the whole process

That meant one runtime instance could invalidate turn context for another and left MCP/LLM ownership split across ambient mutable state.

## Impact

- MCP gateway and Claude CLI transport now share one explicit runtime-owned turn-context store.
- Runtime resets clear only the registry owned by that runtime instance.
- CLI MCP bridge now fails closed if MCP is enabled without an injected turn-context store.
- Focused tests now cover multi-runtime coexistence and reset isolation.

## Validation

- `go test ./internal/runtime/mcp ./internal/runtime/llm ./internal/runtime/manager ./internal/runtime -count=1`
- `go test ./... -count=1`
