### PR TITLE
[agent-a][issue #68] Eliminate post-construction dependency setters

### DIFF
--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -115,14 +115,6 @@ func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *S
 	})
 }
 
-func (r *ClaudeCLIRuntime) SetWorkspaceResolver(resolver workspace.Resolver) {
-	r.workspaces = resolver
-}
-
-func (r *ClaudeCLIRuntime) SetMonitorSink(sink MonitorSink) {
-	r.monitor = sink
-}
-
 func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
 	scope := sessions.ScopeFromContext(ctx)
 	resolved, err := resolvedSessionScope(ctx, scope.ConversationMode, scope.ScopeKey)

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -101,6 +101,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		sessions:                 opts.Sessions,
 		semanticSource:           opts.SemanticSource,
 		promptResolver:           opts.PromptResolver,
+		workflowInstances:        opts.WorkflowInstances,
 		runtimeMode:              strings.TrimSpace(opts.RuntimeMode),
 		budget:                   opts.Budget,
 		resetRuntimeOwnedState:   opts.ResetRuntimeOwnedState,
@@ -113,27 +114,6 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		deadLetterWindows:        make(map[string][]deadLetterEscalationSample),
 		deadLetterLastRaised:     make(map[string]time.Time),
 	}
-}
-
-// SetSessionRegistry enables spec v2.0 session rotation behavior on reconfigure.
-// runtimeMode should match the LLM runtime (e.g. "api" or "cli_test").
-func (am *AgentManager) SetSessionRegistry(sessions sessions.Registry, runtimeMode string) {
-	am.mu.Lock()
-	defer am.mu.Unlock()
-	am.sessions = sessions
-	am.runtimeMode = strings.TrimSpace(runtimeMode)
-}
-
-func (am *AgentManager) SetBudgetTracker(tracker BudgetGuard) {
-	am.mu.Lock()
-	defer am.mu.Unlock()
-	am.budget = tracker
-}
-
-func (am *AgentManager) SetWorkflowInstanceStore(store flowInstancePersistence) {
-	am.mu.Lock()
-	defer am.mu.Unlock()
-	am.workflowInstances = store
 }
 
 func (am *AgentManager) runtimeContext() context.Context {

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -38,6 +38,9 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if req.ContractBundle == nil {
 		return fmt.Errorf("contract bundle is required")
 	}
+	if am.workflowInstances == nil {
+		return fmt.Errorf("workflow instance store is required")
+	}
 	instance := req.Instance
 	templateID := strings.TrimSpace(instance.TemplateID)
 	instanceID := strings.TrimSpace(instance.InstanceID)
@@ -58,32 +61,30 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		return fmt.Errorf("derive flow entity id for %s", flowPath)
 	}
 	sourceEntityID := strings.TrimSpace(instance.SubjectID)
-	if am.workflowInstances != nil {
-		initialState := strings.TrimSpace(schema.InitialState)
-		if initialState == "" {
-			initialState = strings.TrimSpace(req.InitialState)
-		}
-		if initialState == "" {
-			initialState = "pending"
-		}
-		if err := am.workflowInstances.Upsert(ctx, runtimepipeline.WorkflowInstance{
-			InstanceID:      instanceID,
-			SubjectID:       strings.TrimSpace(sourceEntityID),
-			StorageRef:      flowPath,
-			WorkflowName:    templateID,
-			WorkflowVersion: strings.TrimSpace(req.ContractBundle.WorkflowVersion()),
-			CurrentState:    initialState,
-			Config:          cloneFlowConfig(req.Config),
-			Metadata: map[string]any{
-				"entity_id":        flowEntityID,
-				"instance_id":      instanceID,
-				"flow_path":        flowPath,
-				"subject_id":       strings.TrimSpace(sourceEntityID),
-				"parent_entity_id": strings.TrimSpace(instance.ParentEntityID),
-			},
-		}); err != nil {
-			return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
-		}
+	initialState := strings.TrimSpace(schema.InitialState)
+	if initialState == "" {
+		initialState = strings.TrimSpace(req.InitialState)
+	}
+	if initialState == "" {
+		initialState = "pending"
+	}
+	if err := am.workflowInstances.Upsert(ctx, runtimepipeline.WorkflowInstance{
+		InstanceID:      instanceID,
+		SubjectID:       strings.TrimSpace(sourceEntityID),
+		StorageRef:      flowPath,
+		WorkflowName:    templateID,
+		WorkflowVersion: strings.TrimSpace(req.ContractBundle.WorkflowVersion()),
+		CurrentState:    initialState,
+		Config:          cloneFlowConfig(req.Config),
+		Metadata: map[string]any{
+			"entity_id":        flowEntityID,
+			"instance_id":      instanceID,
+			"flow_path":        flowPath,
+			"subject_id":       strings.TrimSpace(sourceEntityID),
+			"parent_entity_id": strings.TrimSpace(instance.ParentEntityID),
+		},
+	}); err != nil {
+		return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
 	}
 
 	vars := flowActivationVars(req)

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -28,6 +28,12 @@ type flowActivationTestStore struct {
 	upserts []PersistedAgent
 }
 
+func newFlowActivationManager(bus Bus, instances flowInstancePersistence, stores ...ManagerPersistence) *AgentManager {
+	return NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		WorkflowInstances: instances,
+	}, stores...)
+}
+
 func (s *flowActivationTestInstanceStore) Upsert(_ context.Context, instance runtimepipeline.WorkflowInstance) error {
 	s.upserts = append(s.upserts, instance)
 	return nil
@@ -228,7 +234,7 @@ func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, temp
 
 func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("")
 
 	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
@@ -251,7 +257,7 @@ func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 
 func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
@@ -275,7 +281,7 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 
 func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
 	postCommit := make([]func(), 0, 1)
 	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
@@ -329,8 +335,7 @@ func TestNormalizedFlowAgentEmitEvents_ExternalizesInstanceLocalEvents(t *testin
 func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	instances := &flowActivationTestInstanceStore{}
-	am := NewAgentManager(bus, nil)
-	am.SetWorkflowInstanceStore(instances)
+	am := newFlowActivationManager(bus, instances)
 	bundle := testFlowBundle("task.started")
 
 	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
@@ -365,7 +370,7 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 
 func TestActivateFlowInstanceResolvesAgentPermissions(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("")
 	reviewFlow := bundle.FlowTree.ByID["review"]
 	reviewFlow.Policy = runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
@@ -399,7 +404,7 @@ func TestActivateFlowInstanceResolvesAgentPermissions(t *testing.T) {
 
 func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("")
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
@@ -419,7 +424,7 @@ func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 
 func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testNestedFlowBundle()
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "grandchild", "inst-1", "ent-1", "child/grandchild/inst-1"))
@@ -463,7 +468,7 @@ func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t 
 func TestEnsureStaticFlowRequiredAgentsRegistersStaticFlowSubscriptions(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	store := &flowActivationTestStore{}
-	am := NewAgentManager(bus, nil, store)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{}, store)
 	bundle := testStaticFlowBundle()
 
 	if err := am.EnsureStaticFlowRequiredAgents(context.Background(), semanticview.Wrap(bundle)); err != nil {
@@ -489,7 +494,7 @@ func TestEnsureStaticFlowRequiredAgentsRegistersStaticFlowSubscriptions(t *testi
 
 func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := NewAgentManager(bus, nil)
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			Version: "v-test",
@@ -538,6 +543,16 @@ func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.
 	}
 	if len(flowCfg.Subscriptions) != 1 || flowCfg.Subscriptions[0] != "ops-flow/work.requested" {
 		t.Fatalf("flow subscriptions = %#v, want [ops-flow/work.requested]", flowCfg.Subscriptions)
+	}
+}
+
+func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := NewAgentManager(bus, nil)
+
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(testFlowBundle(""), "review", "inst-1", "ent-1", "review/inst-1"))
+	if err == nil || !strings.Contains(err.Error(), "workflow instance store is required") {
+		t.Fatalf("ActivateFlowInstance err = %v, want workflow instance store error", err)
 	}
 }
 

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -128,6 +128,7 @@ type AgentManagerOptions struct {
 	Sessions                  sessions.Registry
 	SemanticSource            semanticview.Source
 	PromptResolver            runtimecontracts.PromptResolver
+	WorkflowInstances         flowInstancePersistence
 	RuntimeMode               string
 	Budget                    BudgetGuard
 	ResetRuntimeOwnedState    func()

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -65,6 +65,8 @@ type PipelineCoordinatorOptions struct {
 	Module              WorkflowModule
 	InstanceActivator   FlowInstanceActivator
 	InstanceDeactivator FlowInstanceDeactivator
+	TimerScheduler      *Scheduler
+	TimerScheduleStore  SchedulePersistence
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -83,6 +85,8 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		expressionEval:      newWorkflowExpressionEvaluator(),
 		instanceActivator:   opts.InstanceActivator,
 		instanceDeactivator: opts.InstanceDeactivator,
+		timerScheduler:      opts.TimerScheduler,
+		timerScheduleStore:  opts.TimerScheduleStore,
 		entityLocks:         make(map[string]*sync.Mutex),
 	}
 }
@@ -106,34 +110,6 @@ func (pc *PipelineCoordinator) SetTestEntityStateHook(fn func(entityID, state st
 	}
 	pc.mu.Lock()
 	pc.testEntityStateHook = fn
-	pc.mu.Unlock()
-}
-
-func (pc *PipelineCoordinator) SetInstanceActivator(activator FlowInstanceActivator) {
-	if pc == nil {
-		return
-	}
-	pc.mu.Lock()
-	pc.instanceActivator = activator
-	pc.mu.Unlock()
-}
-
-func (pc *PipelineCoordinator) SetInstanceDeactivator(deactivator FlowInstanceDeactivator) {
-	if pc == nil {
-		return
-	}
-	pc.mu.Lock()
-	pc.instanceDeactivator = deactivator
-	pc.mu.Unlock()
-}
-
-func (pc *PipelineCoordinator) SetTimerScheduling(scheduler *Scheduler, store SchedulePersistence) {
-	if pc == nil {
-		return
-	}
-	pc.mu.Lock()
-	pc.timerScheduler = scheduler
-	pc.timerScheduleStore = store
 	pc.mu.Unlock()
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -194,16 +194,16 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 			"root": {},
 		},
 	}
+	deactivated := false
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
 		Module: &pipelineFixtureWorkflowModule{
 			source:   semanticview.Wrap(bundle),
 			workflow: NewWorkflowDefinition("root", []WorkflowStage{{Name: "pending"}, {Name: "done", Terminal: true}}, nil),
 		},
-	})
-	deactivated := false
-	pc.SetInstanceDeactivator(func(context.Context, FlowInstanceDeactivationRequest) error {
-		deactivated = true
-		return nil
+		InstanceDeactivator: func(context.Context, FlowInstanceDeactivationRequest) error {
+			deactivated = true
+			return nil
+		},
 	})
 
 	const entityID = "11111111-1111-1111-1111-111111111111"

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -44,6 +45,15 @@ func (s *recordingSchedulePersistence) MarkScheduleFiredExact(context.Context, S
 	return nil
 }
 
+func newTimerLifecycleCoordinator(bus Bus, db *sql.DB, module WorkflowModule, store SchedulePersistence) *PipelineCoordinator {
+	opts := PipelineCoordinatorOptions{Module: module}
+	if store != nil {
+		opts.TimerScheduler = NewScheduler()
+		opts.TimerScheduleStore = store
+	}
+	return NewPipelineCoordinatorWithOptions(bus, db, opts)
+}
+
 func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier5-flow-lifecycle", "test-timer-fire")
@@ -59,14 +69,11 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
-	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
-	})
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	store := &recordingSchedulePersistence{}
-	pc.SetTimerScheduling(NewScheduler(), store)
 
 	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
 		InstanceID:      "ent-001",
@@ -123,14 +130,11 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
-	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
-	})
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	store := &recordingSchedulePersistence{}
-	pc.SetTimerScheduling(NewScheduler(), store)
 
 	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
 		InstanceID:      "ent-001",
@@ -253,14 +257,11 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
-	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
-	})
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	store := &recordingSchedulePersistence{}
-	pc.SetTimerScheduling(NewScheduler(), store)
 
 	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
 		InstanceID:      "ent-001",
@@ -329,14 +330,11 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
-	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
-	})
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	store := &recordingSchedulePersistence{}
-	pc.SetTimerScheduling(NewScheduler(), store)
 
 	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
 		InstanceID:      "ent-001",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -286,15 +286,8 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		return nil, fmt.Errorf("build event bus: %w", err)
 	}
 	rt.Bus = bus
-	if stores.SQLDB != nil {
-		rt.Pipeline = runtimepipeline.NewPipelineCoordinatorWithOptions(rt.Bus, stores.SQLDB, runtimepipeline.PipelineCoordinatorOptions{
-			Module: opts.WorkflowModule,
-		})
-		if rt.Pipeline != nil {
-			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)
-		}
-	}
 
+	var managerRef *runtimemanager.AgentManager
 	rt.Scheduler = runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		callbackCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
@@ -337,6 +330,28 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			}
 		}
 	})
+	if stores.SQLDB != nil {
+		rt.Pipeline = runtimepipeline.NewPipelineCoordinatorWithOptions(rt.Bus, stores.SQLDB, runtimepipeline.PipelineCoordinatorOptions{
+			Module: opts.WorkflowModule,
+			InstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+				if managerRef == nil {
+					return fmt.Errorf("flow instance activator is required")
+				}
+				return managerRef.ActivateFlowInstance(ctx, req)
+			},
+			InstanceDeactivator: func(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
+				if managerRef == nil {
+					return fmt.Errorf("flow instance deactivator is required")
+				}
+				return managerRef.DeactivateFlowInstanceModel(ctx, req)
+			},
+			TimerScheduler:     rt.Scheduler,
+			TimerScheduleStore: stores.ScheduleStore,
+		})
+		if rt.Pipeline != nil {
+			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)
+		}
+	}
 
 	if stores.SQLDB != nil {
 		rt.Budget = NewBudgetTracker(stores.SQLDB, rt.Bus, cfg, stores.MailboxStore, rt.Logger, source)
@@ -375,14 +390,12 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		}
 	}
 
-	var managerRef *runtimemanager.AgentManager
 	rt.ToolExecutor = runtimetools.NewExecutorWithOptions(rt.Bus, rt.Scheduler, runtimetools.ExecutorOptions{
 		Config:            cfg,
 		Credentials:       rt.Credentials,
 		MailboxStore:      stores.MailboxStore,
 		SQLDB:             stores.SQLDB,
 		WorkflowSource:    source,
-		FlowActivator:     nil,
 		WorkspaceResolver: rt.Workspace,
 		AuthorityProvider: rt.Authority,
 		EmitRegistry:      rt.EmitRegistry,
@@ -433,13 +446,18 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		AuthorityProvider: rt.Authority,
 		EmitRegistry:      rt.EmitRegistry,
 	})
+	var workflowInstances runtimepipeline.WorkflowInstancePersistence
+	if rt.Pipeline != nil {
+		workflowInstances = rt.Pipeline.WorkflowInstanceStore()
+	}
 	rt.Manager = runtimemanager.NewAgentManagerWithOptions(rt.Bus, factory, runtimemanager.AgentManagerOptions{
-		Workspaces:     rt.Workspace,
-		Sessions:       stores.SessionRegistry,
-		SemanticSource: source,
-		PromptResolver: rt.PromptResolver,
-		RuntimeMode:    cfg.LLM.RuntimeMode,
-		Budget:         rt.Budget,
+		Workspaces:        rt.Workspace,
+		Sessions:          stores.SessionRegistry,
+		SemanticSource:    source,
+		PromptResolver:    rt.PromptResolver,
+		WorkflowInstances: workflowInstances,
+		RuntimeMode:       cfg.LLM.RuntimeMode,
+		Budget:            rt.Budget,
 		ResetRuntimeOwnedState: func() {
 			if rt.MCPTurns != nil {
 				rt.MCPTurns.Reset()
@@ -449,19 +467,6 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		DisableSpinupControl:     true,
 	}, stores.ManagerStore)
 	managerRef = rt.Manager
-	if rt.ToolExecutor != nil && rt.Manager != nil {
-		rt.ToolExecutor.SetFlowActivator(rt.Manager.ActivateFlowInstance)
-	}
-	if rt.Pipeline != nil && rt.Manager != nil {
-		rt.Manager.SetWorkflowInstanceStore(rt.Pipeline.WorkflowInstanceStore())
-		rt.Pipeline.SetInstanceActivator(rt.Manager.ActivateFlowInstance)
-		rt.Pipeline.SetInstanceDeactivator(func(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
-			return rt.Manager.DeactivateFlowInstanceModel(ctx, req)
-		})
-	}
-	if rt.Pipeline != nil {
-		rt.Pipeline.SetTimerScheduling(rt.Scheduler, stores.ScheduleStore)
-	}
 
 	if stores.InboundStore != nil {
 		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, stores.InboundStore)

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -47,7 +47,6 @@ type ExecutorOptions struct {
 	MCPClient         *runtimemcp.Client
 	SQLDB             *sql.DB
 	WorkflowSource    semanticview.Source
-	FlowActivator     runtimepipeline.FlowInstanceActivator
 	WorkspaceResolver workspace.Resolver
 	AuthorityProvider runtimeauthority.Provider
 	EmitRegistry      *EmitRegistry

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -38,7 +38,6 @@ type Executor struct {
 	httpClient      *http.Client
 	mcpClient       *runtimemcp.Client
 	workflowSource  semanticview.Source
-	flowActivator   runtimepipeline.FlowInstanceActivator
 	workspaces      workspace.Resolver
 	authority       runtimeauthority.Provider
 	emitRegistry    *EmitRegistry
@@ -75,7 +74,6 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		httpClient:      &http.Client{Timeout: 30 * time.Second},
 		mcpClient:       opts.MCPClient,
 		workflowSource:  opts.WorkflowSource,
-		flowActivator:   opts.FlowActivator,
 		workspaces:      opts.WorkspaceResolver,
 		authority:       runtimeauthority.ProviderOrNoop(opts.AuthorityProvider),
 		oneShotEmits:    make(map[string]struct{}),
@@ -128,49 +126,6 @@ func (e *Executor) contractDefinitions() ([]llm.ToolDefinition, error) {
 		discovered = client.DiscoveredTools()
 	}
 	return toolDefinitionsForRuntime(source, discovered)
-}
-
-func (e *Executor) SetWorkflowSource(source semanticview.Source) {
-	e.mu.Lock()
-	e.workflowSource = source
-	client := e.mcpClient
-	e.emitRegistry = NewEmitRegistry(source, e.authority)
-	e.mu.Unlock()
-	if client != nil {
-		for _, err := range client.Refresh(context.Background(), source) {
-			processWarn("tool-executor", "mcp discovery warning: %v", err)
-		}
-	}
-}
-
-func (e *Executor) SetManager(manager Manager) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if manager == nil {
-		e.manager = nil
-		return
-	}
-	e.manager = manager
-	e.managerProvider = nil
-}
-
-func (e *Executor) SetFlowActivator(activator runtimepipeline.FlowInstanceActivator) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.flowActivator = activator
-}
-
-func (e *Executor) SetConfig(cfg *config.Config) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.cfg = cfg
-}
-
-func (e *Executor) SetAuthorityProvider(provider runtimeauthority.Provider) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.authority = runtimeauthority.ProviderOrNoop(provider)
-	e.emitRegistry = NewEmitRegistry(e.workflowSource, e.authority)
 }
 
 func (e *Executor) resolveRegisteredTool(actor models.AgentConfig, name string) (RegisteredTool, bool, error) {


### PR DESCRIPTION
## What changed
- moved manager workflow-instance persistence ownership into `AgentManagerOptions` instead of mutating it after construction
- moved pipeline activator, deactivator, and timer scheduling ownership into `PipelineCoordinatorOptions`
- removed setter-based mutation from the touched manager, pipeline, executor, and CLI runtime seams
- made flow activation fail closed when the workflow-instance store is missing

## Why
Issue #68 is about eliminating post-construction dependency setters in the runtime layer. The canonical construction path now owns these dependencies up front instead of constructing partially configured objects and patching them later.

## Impact
- runtime-owned objects in the touched seams no longer rely on setter mutation for normal operation
- missing required runtime dependencies now fail closed instead of degrading silently
- focused tests now exercise both valid constructor wiring and missing-dependency behavior

## Validation
- `go test ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime -count=1`
- `go test ./internal/runtime/manager -run 'TestActivateFlowInstance(FailsWithoutWorkflowInstanceStore|PersistsFlowInstanceConfig)$' -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure required runtime dependencies are properly initialized, preventing failures downstream.

* **Refactor**
  * Improved dependency management by requiring configuration at initialization time rather than after construction, enhancing system reliability and reducing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->