### PR TITLE
[agent-b][issue #70] Unify schema capability ownership and remove runtime-side schema introspection

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -108,7 +108,7 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 
 	entityID := uuid.NewString()
 	parentEventID := uuid.NewString()
-	logger := runtimepkg.NewRuntimeLogger(db)
+	logger := runtimepkg.NewRuntimeLogger(db, pg)
 	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
 		Level:      "warn",
 		Message:    "Tool execution was denied for save_entity_field",

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -47,7 +47,12 @@ func (e *RuntimeLogEntry) NormalizeEntityID() {
 }
 
 type RuntimeLogger struct {
-	db *sql.DB
+	db           *sql.DB
+	capabilities runtimeLogCapabilityResolver
+}
+
+type runtimeLogCapabilityResolver interface {
+	CanonicalRuntimeLogCapability(context.Context) (bool, bool, error)
 }
 
 type InstanceDigestRow struct {
@@ -69,8 +74,8 @@ type deferredPipelineTransition struct {
 
 type pipelineTransitionCollectorKey struct{}
 
-func NewRuntimeLogger(db *sql.DB) *RuntimeLogger {
-	return &RuntimeLogger{db: db}
+func NewRuntimeLogger(db *sql.DB, capabilities runtimeLogCapabilityResolver) *RuntimeLogger {
+	return &RuntimeLogger{db: db, capabilities: capabilities}
 }
 
 func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
@@ -111,9 +116,16 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 	if l.db == nil {
 		return nil
 	}
+	if l.capabilities == nil {
+		return nil
+	}
+	enabled, hasRunID, err := l.capabilities.CanonicalRuntimeLogCapability(withoutSQLTxContext(ctx))
+	if err != nil || !enabled {
+		return nil
+	}
 
 	detail := marshalJSONOrEmpty(e.Detail)
-	if err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, level, component, action, e, detail); err != nil {
+	if err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level, component, action, e, detail); err != nil {
 		return err
 	}
 	return nil
@@ -367,11 +379,10 @@ func isMissingDiagnosticsTable(err error) bool {
 		strings.Contains(msg, "duration_ms")
 }
 
-func logRuntimeEventSpec(ctx context.Context, db *sql.DB, level, component, action string, e RuntimeLogEntry, detail []byte) error {
+func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) error {
 	if db == nil {
 		return nil
 	}
-	hasRunID := runtimeColumnExists(ctx, db, "events", "run_id")
 	detailMap := map[string]any{}
 	_ = json.Unmarshal(detail, &detailMap)
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
@@ -475,23 +486,6 @@ func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detai
 		payload["stack_trace"] = v
 	}
 	return payload
-}
-
-func runtimeColumnExists(ctx context.Context, db *sql.DB, tableName, columnName string) bool {
-	if db == nil {
-		return false
-	}
-	var exists bool
-	if err := db.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM information_schema.columns
-			WHERE table_name = $1 AND column_name = $2
-		)
-	`, strings.TrimSpace(tableName), strings.TrimSpace(columnName)).Scan(&exists); err != nil {
-		return false
-	}
-	return exists
 }
 
 func recordPipelineTransitionSpec(ctx context.Context, db *sql.DB, eventID, handler, pipelineType, pipelineID, action string, before, after []byte, eventsEmitted []string, durationMS int, dropReason, errText string) error {

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -12,8 +12,18 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 )
 
+type runtimeLogCapabilityStub struct {
+	enabled  bool
+	hasRunID bool
+	err      error
+}
+
+func (s runtimeLogCapabilityStub) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
+	return s.enabled, s.hasRunID, s.err
+}
+
 func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
-	logger := NewRuntimeLogger(nil)
+	logger := NewRuntimeLogger(nil, nil)
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 
@@ -73,16 +83,13 @@ func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
 	}
 }
 
-func TestRuntimeLogger_Log_PersistsRuntimeLogPayload(t *testing.T) {
+func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	defer db.Close()
 
-	mock.ExpectQuery(`SELECT EXISTS\(`).
-		WithArgs("events", "run_id").
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec(`INSERT INTO events`).
 		WithArgs("", runtimeLogPayloadArg{
 			level:      "warn",
@@ -104,7 +111,7 @@ func TestRuntimeLogger_Log_PersistsRuntimeLogPayload(t *testing.T) {
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	if err := logger.Log(context.Background(), RuntimeLogEntry{
 		Level:      "warn",
 		Message:    "Tool execution was denied for save_entity_field",
@@ -138,14 +145,11 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 	defer db.Close()
 
 	writeErr := errors.New("insert failed")
-	mock.ExpectQuery(`SELECT EXISTS\(`).
-		WithArgs("events", "run_id").
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec(`INSERT INTO events`).
 		WithArgs("", sqlmock.AnyArg(), "").
 		WillReturnError(writeErr)
 
-	logger := NewRuntimeLogger(db)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	err = logger.Log(context.Background(), RuntimeLogEntry{
 		Level:     "error",
 		Message:   "Persisting the pipeline receipt failed",
@@ -157,6 +161,26 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{})
+	if err := logger.Log(context.Background(), RuntimeLogEntry{
+		Level:   "info",
+		Message: "runtime log",
+	}); err != nil {
+		t.Fatalf("logger.Log() error = %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }
 

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -48,25 +48,27 @@ type PipelineCoordinator struct {
 	entityLockMu sync.Mutex
 	entityLocks  map[string]*sync.Mutex
 
-	module              WorkflowModule
-	workflowStore       *WorkflowInstanceStore
-	expressionEval      *workflowExpressionEvaluator
-	instanceActivator   FlowInstanceActivator
-	instanceDeactivator FlowInstanceDeactivator
-	timerScheduler      *Scheduler
-	timerScheduleStore  SchedulePersistence
+	module                  WorkflowModule
+	workflowStore           *WorkflowInstanceStore
+	expressionEval          *workflowExpressionEvaluator
+	instanceActivator       FlowInstanceActivator
+	instanceDeactivator     FlowInstanceDeactivator
+	timerScheduler          *Scheduler
+	timerScheduleStore      SchedulePersistence
+	eventReceiptsCapability func(context.Context) (bool, error)
 
 	testSubscribeHook   func()
 	testEntityStateHook func(entityID, state string)
 }
 
 type PipelineCoordinatorOptions struct {
-	ShardPlanner        any
-	Module              WorkflowModule
-	InstanceActivator   FlowInstanceActivator
-	InstanceDeactivator FlowInstanceDeactivator
-	TimerScheduler      *Scheduler
-	TimerScheduleStore  SchedulePersistence
+	ShardPlanner            any
+	Module                  WorkflowModule
+	InstanceActivator       FlowInstanceActivator
+	InstanceDeactivator     FlowInstanceDeactivator
+	TimerScheduler          *Scheduler
+	TimerScheduleStore      SchedulePersistence
+	EventReceiptsCapability func(context.Context) (bool, error)
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -78,16 +80,17 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		panic("pipeline: workflow module is required")
 	}
 	return &PipelineCoordinator{
-		bus:                 bus,
-		db:                  db,
-		module:              module,
-		workflowStore:       NewWorkflowInstanceStore(db),
-		expressionEval:      newWorkflowExpressionEvaluator(),
-		instanceActivator:   opts.InstanceActivator,
-		instanceDeactivator: opts.InstanceDeactivator,
-		timerScheduler:      opts.TimerScheduler,
-		timerScheduleStore:  opts.TimerScheduleStore,
-		entityLocks:         make(map[string]*sync.Mutex),
+		bus:                     bus,
+		db:                      db,
+		module:                  module,
+		workflowStore:           NewWorkflowInstanceStore(db),
+		expressionEval:          newWorkflowExpressionEvaluator(),
+		instanceActivator:       opts.InstanceActivator,
+		instanceDeactivator:     opts.InstanceDeactivator,
+		timerScheduler:          opts.TimerScheduler,
+		timerScheduleStore:      opts.TimerScheduleStore,
+		eventReceiptsCapability: opts.EventReceiptsCapability,
+		entityLocks:             make(map[string]*sync.Mutex),
 	}
 }
 

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -17,6 +17,15 @@ import (
 	"swarm/internal/testutil"
 )
 
+type eventReceiptsCapabilityStub struct {
+	enabled bool
+	err     error
+}
+
+func (s eventReceiptsCapabilityStub) resolve(context.Context) (bool, error) {
+	return s.enabled, s.err
+}
+
 func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
@@ -158,6 +167,76 @@ func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *test
 	}
 	if got := asInt(payload["retry_count"]); got != 0 {
 		t.Fatalf("retry_count = %d, want 0", got)
+	}
+}
+
+func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	entityID := uuid.NewString()
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		Type:        "source.evt",
+		SourceAgent: "src",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
+	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+		return nil
+	}, eventReceiptsCapabilityStub{}.resolve)
+	runner.ProcessEventForTest(ctx, evt)
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, evt.ID).Scan(&count); err != nil {
+		t.Fatalf("count event_receipts: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("event_receipts rows = %d, want 0 without canonical capability", count)
+	}
+}
+
+func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	entityID := uuid.NewString()
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		Type:        "source.evt",
+		SourceAgent: "src",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
+	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	attempts := 0
+	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+		attempts++
+		return nil
+	}, eventReceiptsCapabilityStub{enabled: true}.resolve)
+	runner.ProcessEventForTest(ctx, evt)
+	runner.ProcessEventForTest(ctx, evt)
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 after idempotent receipt", attempts)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid AND subscriber_id = 'node-a'`, evt.ID).Scan(&count); err != nil {
+		t.Fatalf("count event_receipts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("event_receipts rows = %d, want 1", count)
 	}
 }
 

--- a/internal/runtime/pipeline/node_background.go
+++ b/internal/runtime/pipeline/node_background.go
@@ -15,10 +15,10 @@ type backgroundWorkflowNode struct {
 }
 
 func newBackgroundWorkflowNode(executor WorkflowNodeExecutor, bus systemNodeBus, db *sql.DB) *backgroundWorkflowNode {
-	return newBackgroundWorkflowNodeWithRetryBase(executor, bus, db, 0)
+	return newBackgroundWorkflowNodeWithRetryBase(executor, bus, db, nil, 0)
 }
 
-func newBackgroundWorkflowNodeWithRetryBase(executor WorkflowNodeExecutor, bus systemNodeBus, db *sql.DB, retryBase time.Duration) *backgroundWorkflowNode {
+func newBackgroundWorkflowNodeWithRetryBase(executor WorkflowNodeExecutor, bus systemNodeBus, db *sql.DB, eventReceiptsCapability func(context.Context) (bool, error), retryBase time.Duration) *backgroundWorkflowNode {
 	if executor == nil || bus == nil {
 		return nil
 	}
@@ -28,7 +28,7 @@ func newBackgroundWorkflowNodeWithRetryBase(executor WorkflowNodeExecutor, bus s
 			return nil
 		}
 		return fmt.Errorf("workflow executor %s did not handle subscribed event %s", executor.NodeID(), evt.Type)
-	}, retryBase)
+	}, retryBase, eventReceiptsCapability)
 	return node
 }
 

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -32,21 +32,22 @@ type systemNodeRunner struct {
 	retryLimit int
 	backoffFn  func(int) time.Duration
 
-	subscriptionsFn func() []events.EventType
-	handleFn        func(context.Context, events.Event) error
-	overrideHandle  func(context.Context, events.Event) error
-	onSubscribe     func()
+	subscriptionsFn         func() []events.EventType
+	handleFn                func(context.Context, events.Event) error
+	overrideHandle          func(context.Context, events.Event) error
+	onSubscribe             func()
+	eventReceiptsCapability func(context.Context) (bool, error)
 
-	ledgerMu      sync.Mutex
-	ledgerChecked bool
-	ledgerEnabled bool
+	receiptsMu      sync.Mutex
+	receiptsChecked bool
+	receiptsEnabled bool
 }
 
-func newSystemNodeRunner(nodeID string, bus systemNodeBus, db *sql.DB, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error) *systemNodeRunner {
-	return newSystemNodeRunnerWithRetryBase(nodeID, bus, db, subscriptionsFn, handleFn, 0)
+func newSystemNodeRunner(nodeID string, bus systemNodeBus, db *sql.DB, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error, eventReceiptsCapability ...func(context.Context) (bool, error)) *systemNodeRunner {
+	return newSystemNodeRunnerWithRetryBase(nodeID, bus, db, subscriptionsFn, handleFn, 0, eventReceiptsCapability...)
 }
 
-func newSystemNodeRunnerWithRetryBase(nodeID string, bus systemNodeBus, db *sql.DB, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error, retryBase time.Duration) *systemNodeRunner {
+func newSystemNodeRunnerWithRetryBase(nodeID string, bus systemNodeBus, db *sql.DB, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error, retryBase time.Duration, eventReceiptsCapability ...func(context.Context) (bool, error)) *systemNodeRunner {
 	nodeID = strings.TrimSpace(nodeID)
 	if nodeID == "" || bus == nil || handleFn == nil {
 		return nil
@@ -54,14 +55,19 @@ func newSystemNodeRunnerWithRetryBase(nodeID string, bus systemNodeBus, db *sql.
 	if retryBase <= 0 {
 		retryBase = time.Second
 	}
+	var receiptsCapability func(context.Context) (bool, error)
+	if len(eventReceiptsCapability) > 0 {
+		receiptsCapability = eventReceiptsCapability[0]
+	}
 	return &systemNodeRunner{
-		nodeID:          nodeID,
-		bus:             bus,
-		db:              db,
-		retryLimit:      DefaultSystemNodeRetryLimit,
-		backoffFn:       func(attempt int) time.Duration { return defaultSystemNodeBackoff(retryBase, attempt) },
-		subscriptionsFn: subscriptionsFn,
-		handleFn:        handleFn,
+		nodeID:                  nodeID,
+		bus:                     bus,
+		db:                      db,
+		retryLimit:              DefaultSystemNodeRetryLimit,
+		backoffFn:               func(attempt int) time.Duration { return defaultSystemNodeBackoff(retryBase, attempt) },
+		subscriptionsFn:         subscriptionsFn,
+		handleFn:                handleFn,
+		eventReceiptsCapability: receiptsCapability,
 	}
 }
 
@@ -274,30 +280,19 @@ func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bo
 	if n == nil || n.db == nil || eventID == "" {
 		return false
 	}
-	if !n.ledgerAvailable(ctx) {
+	if !n.eventReceiptsAvailable(ctx) {
 		return false
 	}
 	var ok bool
-	if eventReceiptsAvailable(ctx, n.db) {
-		err := n.db.QueryRowContext(ctx, `
-			SELECT EXISTS(
-				SELECT 1
-				FROM event_receipts
-				WHERE subscriber_type = 'node'
-				  AND subscriber_id = $1
-				  AND idempotency_key = $2
-			)
-		`, n.nodeID, systemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
-		if err == nil {
-			return ok
-		}
-	}
 	err := n.db.QueryRowContext(ctx, `
 		SELECT EXISTS(
-			SELECT 1 FROM system_node_ledger
-			WHERE event_id = $1::uuid AND node_id = $2
+			SELECT 1
+			FROM event_receipts
+			WHERE subscriber_type = 'node'
+			  AND subscriber_id = $1
+			  AND idempotency_key = $2
 		)
-	`, eventID, n.nodeID).Scan(&ok)
+	`, n.nodeID, systemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
 	return err == nil && ok
 }
 
@@ -306,34 +301,24 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	if n == nil || n.db == nil || eventID == "" {
 		return
 	}
-	if !n.ledgerAvailable(ctx) {
+	if !n.eventReceiptsAvailable(ctx) {
 		return
 	}
-	if eventReceiptsAvailable(ctx, n.db) {
-		sideEffects, _ := json.Marshal(map[string]any{
-			"idempotency_key": systemNodeReceiptIdempotencyKey(n.nodeID, eventID),
-		})
-		_, err := n.db.ExecContext(ctx, `
-			INSERT INTO event_receipts (
-				event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-				outcome, reason_code, side_effects, idempotency_key, processed_at
-			)
-			SELECT
-				e.event_id, 'node', $2, e.entity_id, e.flow_instance,
-				'no_op', 'idempotent_no_op', $3::jsonb, $4, now()
-			FROM events e
-			WHERE e.event_id = $1::uuid
-			ON CONFLICT (event_id, subscriber_id) DO NOTHING
-		`, eventID, n.nodeID, string(sideEffects), systemNodeReceiptIdempotencyKey(n.nodeID, eventID))
-		if err == nil {
-			return
-		}
-	}
+	sideEffects, _ := json.Marshal(map[string]any{
+		"idempotency_key": systemNodeReceiptIdempotencyKey(n.nodeID, eventID),
+	})
 	if _, err := n.db.ExecContext(ctx, `
-		INSERT INTO system_node_ledger (event_id, node_id, processed_at)
-		VALUES ($1::uuid, $2, now())
-		ON CONFLICT (event_id, node_id) DO NOTHING
-	`, eventID, n.nodeID); err != nil {
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, 'node', $2, e.entity_id, e.flow_instance,
+			'no_op', 'idempotent_no_op', $3::jsonb, $4, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_id) DO NOTHING
+	`, eventID, n.nodeID, string(sideEffects), systemNodeReceiptIdempotencyKey(n.nodeID, eventID)); err != nil {
 		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -350,27 +335,24 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	}
 }
 
-func (n *systemNodeRunner) ledgerAvailable(ctx context.Context) bool {
+func (n *systemNodeRunner) eventReceiptsAvailable(ctx context.Context) bool {
 	if n == nil || n.db == nil {
 		return false
 	}
-	n.ledgerMu.Lock()
-	defer n.ledgerMu.Unlock()
-	if n.ledgerChecked {
-		return n.ledgerEnabled
+	n.receiptsMu.Lock()
+	defer n.receiptsMu.Unlock()
+	if n.receiptsChecked {
+		return n.receiptsEnabled
 	}
-	var exists bool
-	if err := n.db.QueryRowContext(ctx, `
-		SELECT (
-			to_regclass('public.event_receipts') IS NOT NULL
-			OR to_regclass('public.system_node_ledger') IS NOT NULL
-		)
-	`).Scan(&exists); err != nil {
-		exists = false
+	enabled := false
+	if n.eventReceiptsCapability != nil {
+		if ok, err := n.eventReceiptsCapability(ctx); err == nil {
+			enabled = ok
+		}
 	}
-	n.ledgerChecked = true
-	n.ledgerEnabled = exists
-	return n.ledgerEnabled
+	n.receiptsChecked = true
+	n.receiptsEnabled = enabled
+	return n.receiptsEnabled
 }
 
 func (n *systemNodeRunner) String() string {
@@ -399,25 +381,6 @@ func defaultSystemNodeBackoff(base time.Duration, attempt int) time.Duration {
 		return 30 * base
 	}
 	return d
-}
-
-func eventReceiptsAvailable(ctx context.Context, db *sql.DB) bool {
-	if db == nil {
-		return false
-	}
-	var exists bool
-	if err := db.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM information_schema.columns
-			WHERE table_schema = 'public'
-			  AND table_name = 'event_receipts'
-			  AND column_name = 'subscriber_id'
-		)
-	`).Scan(&exists); err != nil {
-		return false
-	}
-	return exists
 }
 
 func systemNodeReceiptIdempotencyKey(nodeID, eventID string) string {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -440,7 +440,7 @@ func (pc *PipelineCoordinator) BackgroundNodes(bus systemNodeBus, db *sql.DB) []
 			continue
 		}
 		if executor := pc.backgroundWorkflowExecutor(strings.TrimSpace(node.ID)); executor != nil {
-			if bg := newBackgroundWorkflowNodeWithRetryBase(executor, bus, db, retryBase); bg != nil {
+			if bg := newBackgroundWorkflowNodeWithRetryBase(executor, bus, db, pc.eventReceiptsCapability, retryBase); bg != nil {
 				out = append(out, bg)
 			}
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -45,6 +45,14 @@ type Stores struct {
 	TurnStore         llm.TurnPersistence
 }
 
+type runtimeLogSchemaCapabilityProvider interface {
+	CanonicalRuntimeLogCapability(context.Context) (bool, bool, error)
+}
+
+type eventReceiptSchemaCapabilityProvider interface {
+	CanonicalEventReceiptsCapability(context.Context) (bool, error)
+}
+
 type RuntimeOptions struct {
 	SelfCheck          bool
 	WorkspaceLifecycle workspace.Lifecycle
@@ -236,6 +244,8 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		EmitRegistry:   emitRegistry,
 		PromptResolver: promptResolver,
 	}
+	logCaps := runtimeLogSchemaCapabilities(stores)
+	receiptCaps := canonicalEventReceiptCapabilities(stores)
 	if opts.Credentials != nil {
 		rt.Credentials = opts.Credentials
 	} else {
@@ -243,7 +253,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	}
 
 	if stores.SQLDB != nil {
-		rt.Logger = NewRuntimeLogger(stores.SQLDB)
+		rt.Logger = NewRuntimeLogger(stores.SQLDB, logCaps)
 	}
 	payloadValidator := newRuntimePayloadValidator(runtimeEnvBool("SWARM_STRICT_PAYLOAD_VALIDATION", false), rt.Logger, emitRegistry.EventSchemaSnapshot())
 	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, func() []runtimebus.EventInterceptor {
@@ -307,8 +317,9 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 				}
 				return managerRef.DeactivateFlowInstanceModel(ctx, req)
 			},
-			TimerScheduler:     rt.Scheduler,
-			TimerScheduleStore: stores.ScheduleStore,
+			TimerScheduler:          rt.Scheduler,
+			TimerScheduleStore:      stores.ScheduleStore,
+			EventReceiptsCapability: receiptCaps,
 		})
 		if rt.Pipeline != nil {
 			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)
@@ -443,6 +454,38 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	}
 
 	return rt, nil
+}
+
+func runtimeLogSchemaCapabilities(stores Stores) runtimeLogCapabilityResolver {
+	candidates := []any{
+		stores.EventStore,
+		stores.ManagerStore,
+		stores.ScheduleStore,
+		stores.MailboxStore,
+		stores.InboundStore,
+	}
+	for _, candidate := range candidates {
+		if provider, ok := candidate.(runtimeLogSchemaCapabilityProvider); ok && provider != nil {
+			return provider
+		}
+	}
+	return nil
+}
+
+func canonicalEventReceiptCapabilities(stores Stores) func(context.Context) (bool, error) {
+	candidates := []any{
+		stores.EventStore,
+		stores.ManagerStore,
+		stores.ScheduleStore,
+		stores.MailboxStore,
+		stores.InboundStore,
+	}
+	for _, candidate := range candidates {
+		if provider, ok := candidate.(eventReceiptSchemaCapabilityProvider); ok && provider != nil {
+			return provider.CanonicalEventReceiptsCapability
+		}
+	}
+	return nil
 }
 
 func scheduleEventPayload(sc runtimepipeline.Schedule) []byte {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -147,8 +147,9 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 		),
 		Receipts: detectSchemaFlavor(catalog, "event_receipts",
 			[]string{
-				"event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
-				"outcome", "reason_code", "side_effects", "processed_at",
+				"receipt_id", "event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
+				"outcome", "reason_code", "state_before", "state_after", "side_effects",
+				"duration_ms", "idempotency_key", "processed_at",
 			},
 			[]string{"event_id", "agent_id", "processed_at", "status", "retry_count", "error"},
 		),
@@ -265,6 +266,25 @@ func (s *PostgresStore) SchemaCapabilities() StoreSchemaCapabilities {
 
 func (s *PostgresStore) ResolveSchemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
 	return s.schemaCapabilities(ctx)
+}
+
+func (s *PostgresStore) CanonicalRuntimeLogCapability(ctx context.Context) (bool, bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, false, err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return false, false, nil
+	}
+	return true, caps.Events.LogRunID, nil
+}
+
+func (s *PostgresStore) CanonicalEventReceiptsCapability(ctx context.Context) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+	return caps.Events.Receipts == SchemaFlavorCanonical, nil
 }
 
 func unsupportedSchemaCapability(subject string, flavor SchemaFlavor) error {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -284,7 +284,7 @@ func (s *PostgresStore) CanonicalEventReceiptsCapability(ctx context.Context) (b
 	if err != nil {
 		return false, err
 	}
-	return caps.Events.Receipts == SchemaFlavorCanonical, nil
+	return caps.Events.Log == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical, nil
 }
 
 func unsupportedSchemaCapability(subject string, flavor SchemaFlavor) error {

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -36,8 +36,9 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		"reason_code", "last_error", "active_session_id", "started_at", "delivered_at", "created_at",
 	)
 	addColumns("event_receipts",
-		"event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
-		"outcome", "reason_code", "side_effects", "processed_at",
+		"receipt_id", "event_id", "subscriber_type", "subscriber_id", "entity_id", "flow_instance",
+		"outcome", "reason_code", "state_before", "state_after", "side_effects",
+		"duration_ms", "idempotency_key", "processed_at",
 	)
 	addColumns("agent_sessions",
 		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
@@ -215,6 +216,62 @@ func TestPostgresStore_BindSchemaCapabilities_FailsClosedOnPartialCanonicalShape
 	}
 	if caps.Conversations.TurnBlocks {
 		t.Fatalf("expected partial canonical turns table to report missing turn_blocks: %+v", caps.Conversations)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresStore_CanonicalCapabilityReaders(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"}).
+		AddRow("events", "event_id").
+		AddRow("events", "run_id").
+		AddRow("events", "event_name").
+		AddRow("events", "entity_id").
+		AddRow("events", "flow_instance").
+		AddRow("events", "scope").
+		AddRow("events", "payload").
+		AddRow("events", "chain_depth").
+		AddRow("events", "produced_by").
+		AddRow("events", "produced_by_type").
+		AddRow("events", "source_event_id").
+		AddRow("events", "created_at").
+		AddRow("event_receipts", "receipt_id").
+		AddRow("event_receipts", "event_id").
+		AddRow("event_receipts", "subscriber_type").
+		AddRow("event_receipts", "subscriber_id").
+		AddRow("event_receipts", "entity_id").
+		AddRow("event_receipts", "flow_instance").
+		AddRow("event_receipts", "outcome").
+		AddRow("event_receipts", "reason_code").
+		AddRow("event_receipts", "state_before").
+		AddRow("event_receipts", "state_after").
+		AddRow("event_receipts", "side_effects").
+		AddRow("event_receipts", "duration_ms").
+		AddRow("event_receipts", "idempotency_key").
+		AddRow("event_receipts", "processed_at")
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+
+	pg := &PostgresStore{DB: db}
+	logEnabled, logRunID, err := pg.CanonicalRuntimeLogCapability(context.Background())
+	if err != nil {
+		t.Fatalf("CanonicalRuntimeLogCapability: %v", err)
+	}
+	if !logEnabled || !logRunID {
+		t.Fatalf("runtime log capability = enabled:%v run_id:%v, want true/true", logEnabled, logRunID)
+	}
+	receiptsEnabled, err := pg.CanonicalEventReceiptsCapability(context.Background())
+	if err != nil {
+		t.Fatalf("CanonicalEventReceiptsCapability: %v", err)
+	}
+	if !receiptsEnabled {
+		t.Fatal("CanonicalEventReceiptsCapability = false, want true")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -277,3 +277,47 @@ func TestPostgresStore_CanonicalCapabilityReaders(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestPostgresStore_CanonicalEventReceiptsCapability_FailsClosedWithoutCanonicalEventsLog(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"}).
+		AddRow("events", "id").
+		AddRow("events", "type").
+		AddRow("events", "source_agent").
+		AddRow("events", "task_id").
+		AddRow("events", "entity_id").
+		AddRow("events", "payload").
+		AddRow("events", "created_at").
+		AddRow("event_receipts", "receipt_id").
+		AddRow("event_receipts", "event_id").
+		AddRow("event_receipts", "subscriber_type").
+		AddRow("event_receipts", "subscriber_id").
+		AddRow("event_receipts", "entity_id").
+		AddRow("event_receipts", "flow_instance").
+		AddRow("event_receipts", "outcome").
+		AddRow("event_receipts", "reason_code").
+		AddRow("event_receipts", "state_before").
+		AddRow("event_receipts", "state_after").
+		AddRow("event_receipts", "side_effects").
+		AddRow("event_receipts", "duration_ms").
+		AddRow("event_receipts", "idempotency_key").
+		AddRow("event_receipts", "processed_at")
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+
+	pg := &PostgresStore{DB: db}
+	receiptsEnabled, err := pg.CanonicalEventReceiptsCapability(context.Background())
+	if err != nil {
+		t.Fatalf("CanonicalEventReceiptsCapability: %v", err)
+	}
+	if receiptsEnabled {
+		t.Fatal("CanonicalEventReceiptsCapability = true, want false when events log is not canonical")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
risk: high

## Summary
- make PostgresStore the canonical owner for the touched schema capability decisions
- remove runtime-side schema probing from runtime logging and system-node receipt handling
- fail closed when canonical runtime-log or event-receipt capability is unavailable

## Canonical owner
- new canonical owner: internal/store/schema_capabilities.go
- old invalid paths: runtime-side information_schema and to_regclass probing in runtime diagnostics and system-node runner

## Validation
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-based schema detection for runtime logging and event processing.

* **Improvements**
  * Enhanced event idempotency tracking and runtime event persistence reliability.
  * Strengthened event receipt handling with capability-aware system.

* **Tests**
  * Added comprehensive tests for capability resolver behavior and event idempotency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->