### PR TITLE
[agent-d][issue #74] Collapse agent metadata toward one canonical persisted source of truth

### DIFF
--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,6 +100,66 @@ func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
 	}
 	if len(bus.restored) != 1 || bus.restored[0] != "review/inst-1" {
 		t.Fatalf("restored routes = %#v, want [review/inst-1]", bus.restored)
+	}
+}
+
+func TestRecover_UsesCanonicalLoadedAgentMetadata(t *testing.T) {
+	bus := &recoveryTestBus{}
+	store := &recoveryTestStore{
+		agents: []PersistedAgent{{
+			Config: models.AgentConfig{
+				ID:               "reviewer-inst-1",
+				Type:             "review-worker",
+				Role:             "reviewer",
+				Mode:             "review",
+				ModelTier:        "sonnet",
+				LLMBackend:       "api",
+				ConversationMode: "session_per_entity",
+				Subscriptions:    []string{"review.ready"},
+				EmitEvents:       []string{"review.completed"},
+				WorkspaceClass:   "shared_flow",
+				ManagerFallback:  "control-plane",
+				FlowPath:         "review/inst-1",
+				EntityID:         "ent-1",
+				ParentAgent:      "control-plane",
+				Config: mustRecoveryJSON(t, map[string]any{
+					"system_prompt":      "x",
+					"subscriptions":      []string{"wrong.subscription"},
+					"manager_fallback":   "wrong-manager",
+					"conversation_mode":  "task",
+					"workspace_class":    "wrong-workspace",
+					"max_turns_per_task": 99,
+				}),
+			},
+			StartedAt: time.Now().UTC(),
+		}},
+	}
+	var hydrated models.AgentConfig
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		hydrated = cfg
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, store)
+
+	if err := am.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if hydrated.ID != "reviewer-inst-1" {
+		t.Fatalf("hydrated id = %q, want reviewer-inst-1", hydrated.ID)
+	}
+	if hydrated.ConversationMode != "session_per_entity" {
+		t.Fatalf("conversation_mode = %q, want session_per_entity", hydrated.ConversationMode)
+	}
+	if len(hydrated.Subscriptions) != 1 || hydrated.Subscriptions[0] != "review.ready" {
+		t.Fatalf("subscriptions = %#v, want [review.ready]", hydrated.Subscriptions)
+	}
+	if hydrated.ManagerFallback != "control-plane" {
+		t.Fatalf("manager_fallback = %q, want control-plane", hydrated.ManagerFallback)
+	}
+	if hydrated.WorkspaceClass != "shared_flow" {
+		t.Fatalf("workspace_class = %q, want shared_flow", hydrated.WorkspaceClass)
+	}
+	if strings.TrimSpace(hydrated.FlowPath) != "review/inst-1" {
+		t.Fatalf("flow_path = %q, want review/inst-1", hydrated.FlowPath)
 	}
 }
 

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -28,13 +28,9 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 	if _, err := runtimesessions.ValidateSessionScopeIntent(agentConversationMode(rec.Config), rec.Config.SessionScope); err != nil {
 		return fmt.Errorf("invalid agent session scope: %w", err)
 	}
-	cfgJSON, err := mergeAgentConfigJSON(rec.Config)
+	projection, err := projectPersistedAgentConfig(rec.Config, rec.ParentAgentID)
 	if err != nil {
-		return fmt.Errorf("marshal agent config: %w", err)
-	}
-	runtimeDescriptorJSON, err := marshalPersistedAgentRuntimeDescriptor(rec.Config)
-	if err != nil {
-		return fmt.Errorf("marshal agent runtime descriptor: %w", err)
+		return err
 	}
 
 	var startedAt any
@@ -43,7 +39,7 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 	}
 	switch caps.Agents {
 	case SchemaFlavorCanonical:
-		return s.upsertAgentSpec(ctx, rec, cfgJSON, runtimeDescriptorJSON, startedAt)
+		return s.upsertAgentSpec(ctx, rec, projection, startedAt)
 	default:
 		return unsupportedSchemaCapability("agents", caps.Agents)
 	}
@@ -132,16 +128,7 @@ func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string)
 	return nil
 }
 
-func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.PersistedAgent, cfgJSON, runtimeDescriptorJSON []byte, startedAt any) error {
-	modelTier := agentModelTier(rec.Config)
-	conversationMode := agentConversationMode(rec.Config)
-	emitEvents := rec.Config.EmitEvents
-	tools := rec.Config.Tools
-	permissions := rec.Config.Permissions
-	subscriptions := rec.Config.Subscriptions
-	flowInstance := agentFlowInstance(rec.Config)
-	llmBackend := agentLLMBackend(rec.Config)
-
+func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.PersistedAgent, projection persistedAgentProjection, startedAt any) error {
 	const q = `
 		INSERT INTO agents (
 			agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
@@ -171,20 +158,20 @@ func (s *PostgresStore) upsertAgentSpec(ctx context.Context, rec runtimemanager.
 			last_active_at = now()
 	`
 	_, err := s.DB.ExecContext(ctx, q,
-		rec.Config.ID,
-		flowInstance,
-		rec.Config.Role,
-		modelTier,
-		llmBackend,
-		conversationMode,
-		nullable(rec.ParentAgentID, rec.Config.ParentAgent),
-		rec.Config.EffectiveEntityID(),
-		string(cfgJSON),
-		mustJSONString(subscriptions),
-		mustJSONString(emitEvents),
-		mustJSONString(tools),
-		mustJSONString(permissions),
-		string(runtimeDescriptorJSON),
+		projection.AgentID,
+		projection.FlowInstance,
+		projection.Role,
+		projection.ModelTier,
+		projection.LLMBackend,
+		projection.ConversationMode,
+		projection.ParentAgentID,
+		projection.EntityID,
+		string(projection.ConfigJSON),
+		string(projection.SubscriptionsJSON),
+		string(projection.EmitEventsJSON),
+		string(projection.ToolsJSON),
+		string(projection.PermissionsJSON),
+		string(projection.RuntimeDescriptor),
 		agentPersistedStatus(rec.Status),
 		startedAt,
 	)
@@ -223,58 +210,33 @@ func (s *PostgresStore) loadAgentsSpec(ctx context.Context) ([]runtimemanager.Pe
 	var out []runtimemanager.PersistedAgent
 	for rows.Next() {
 		var rec runtimemanager.PersistedAgent
-		var (
-			flowInstance      string
-			modelTier         string
-			llmBackend        string
-			conversationMode  string
-			cfgRaw            []byte
-			runtimeDescriptor []byte
-			subscriptionsJSON []byte
-			emitEventsJSON    []byte
-			toolsJSON         []byte
-			permissionsJSON   []byte
-		)
+		var row persistedAgentProjection
 		if err := rows.Scan(
-			&rec.Config.ID,
-			&flowInstance,
-			&rec.Config.Role,
-			&modelTier,
-			&llmBackend,
-			&conversationMode,
-			&rec.ParentAgentID,
-			&rec.Config.EntityID,
-			&cfgRaw,
-			&runtimeDescriptor,
-			&subscriptionsJSON,
-			&emitEventsJSON,
-			&toolsJSON,
-			&permissionsJSON,
+			&row.AgentID,
+			&row.FlowInstance,
+			&row.Role,
+			&row.ModelTier,
+			&row.LLMBackend,
+			&row.ConversationMode,
+			&row.ParentAgentID,
+			&row.EntityID,
+			&row.ConfigJSON,
+			&row.RuntimeDescriptor,
+			&row.SubscriptionsJSON,
+			&row.EmitEventsJSON,
+			&row.ToolsJSON,
+			&row.PermissionsJSON,
 			&rec.Status,
 			&rec.StartedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent row: %w", err)
 		}
-		desc := decodePersistedAgentRuntimeDescriptor(runtimeDescriptor)
-		rec.Config.ParentAgent = rec.ParentAgentID
-		rec.Config.NormalizeEntityID()
-		rec.Config.Config = cfgRaw
-		rec.Config.Type = coalesce(desc.Type, modelTier)
-		rec.Config.Mode = desc.Mode
-		rec.Config.ModelTier = strings.TrimSpace(modelTier)
-		rec.Config.LLMBackend = llmBackend
-		rec.Config.ConversationMode = strings.TrimSpace(conversationMode)
-		rec.Config.SessionScope = desc.SessionScope
-		rec.Config.MaxTurnsPerTask = desc.MaxTurnsPerTask
-		rec.Config.Subscriptions = decodeJSONStringList(subscriptionsJSON)
-		rec.Config.EmitEvents = decodeJSONStringList(emitEventsJSON)
-		rec.Config.Tools = decodeJSONStringList(toolsJSON)
-		rec.Config.Permissions = decodeJSONStringList(permissionsJSON)
-		rec.Config.NativeTools = desc.NativeTools
-		rec.Config.WorkspaceClass = desc.WorkspaceClass
-		rec.Config.ManagerFallback = desc.ManagerFallback
-		rec.Config.FlowPath = strings.Trim(strings.TrimSpace(flowInstance), "/")
-		rec.Config.NormalizeRuntimeDescriptor()
+		cfg, err := hydratePersistedAgentConfig(row)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate agent row %s: %w", strings.TrimSpace(row.AgentID), err)
+		}
+		rec.ParentAgentID = row.ParentAgentID
+		rec.Config = cfg
 		out = append(out, rec)
 	}
 	if err := rows.Err(); err != nil {
@@ -288,6 +250,16 @@ func agentModelTier(cfg runtimeactors.AgentConfig) string {
 		return v
 	}
 	if v := strings.TrimSpace(cfg.Type); v != "" {
+		return v
+	}
+	return "generic"
+}
+
+func agentPersistedType(cfg runtimeactors.AgentConfig, modelTier string) string {
+	if v := strings.TrimSpace(cfg.Type); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(modelTier); v != "" {
 		return v
 	}
 	return "generic"
@@ -323,14 +295,6 @@ func agentPersistedStatus(raw string) string {
 	default:
 		return "active"
 	}
-}
-
-func mustJSONString(v any) string {
-	b, err := json.Marshal(v)
-	if err != nil || len(b) == 0 {
-		return "[]"
-	}
-	return string(b)
 }
 
 func decodeJSONStringList(raw []byte) []string {

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -2,10 +2,13 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimesessions "swarm/internal/runtime/sessions"
 )
 
 type persistedAgentRuntimeDescriptor struct {
@@ -16,6 +19,23 @@ type persistedAgentRuntimeDescriptor struct {
 	NativeTools     runtimeactors.NativeToolConfig `json:"native_tools,omitempty"`
 	WorkspaceClass  string                         `json:"workspace_class,omitempty"`
 	ManagerFallback string                         `json:"manager_fallback,omitempty"`
+}
+
+type persistedAgentProjection struct {
+	AgentID           string
+	FlowInstance      string
+	Role              string
+	ModelTier         string
+	LLMBackend        string
+	ConversationMode  string
+	ParentAgentID     string
+	EntityID          string
+	ConfigJSON        []byte
+	RuntimeDescriptor []byte
+	SubscriptionsJSON []byte
+	EmitEventsJSON    []byte
+	ToolsJSON         []byte
+	PermissionsJSON   []byte
 }
 
 var runtimeConfigKeys = map[string]struct{}{
@@ -35,6 +55,16 @@ var runtimeConfigKeys = map[string]struct{}{
 	"manager_fallback":   {},
 	"flow_path":          {},
 	"flow_instance":      {},
+}
+
+var persistedAgentRuntimeDescriptorKeys = map[string]struct{}{
+	"type":               {},
+	"mode":               {},
+	"session_scope":      {},
+	"max_turns_per_task": {},
+	"native_tools":       {},
+	"workspace_class":    {},
+	"manager_fallback":   {},
 }
 
 func mergeAgentConfigJSON(cfg runtimeactors.AgentConfig) ([]byte, error) {
@@ -64,9 +94,99 @@ func sanitizeOpaqueAgentConfig(raw json.RawMessage) ([]byte, error) {
 	return json.Marshal(obj)
 }
 
-func marshalPersistedAgentRuntimeDescriptor(cfg runtimeactors.AgentConfig) ([]byte, error) {
+func projectPersistedAgentConfig(cfg runtimeactors.AgentConfig, parentAgentID string) (persistedAgentProjection, error) {
+	cfg.NormalizeEntityID()
+	cfg.NormalizeRuntimeDescriptor()
+	modelTier := agentModelTier(cfg)
+	conversationMode := agentConversationMode(cfg)
+	llmBackend := agentLLMBackend(cfg)
+	configJSON, err := mergeAgentConfigJSON(cfg)
+	if err != nil {
+		return persistedAgentProjection{}, fmt.Errorf("marshal agent config: %w", err)
+	}
+	runtimeDescriptorJSON, err := marshalPersistedAgentRuntimeDescriptor(cfg, modelTier)
+	if err != nil {
+		return persistedAgentProjection{}, fmt.Errorf("marshal agent runtime descriptor: %w", err)
+	}
+	return persistedAgentProjection{
+		AgentID:           strings.TrimSpace(cfg.ID),
+		FlowInstance:      agentFlowInstance(cfg),
+		Role:              strings.TrimSpace(cfg.Role),
+		ModelTier:         modelTier,
+		LLMBackend:        llmBackend,
+		ConversationMode:  conversationMode,
+		ParentAgentID:     nullable(strings.TrimSpace(parentAgentID), strings.TrimSpace(cfg.ParentAgent)),
+		EntityID:          cfg.EffectiveEntityID(),
+		ConfigJSON:        configJSON,
+		RuntimeDescriptor: runtimeDescriptorJSON,
+		SubscriptionsJSON: mustJSONBytes(cfg.Subscriptions, "[]"),
+		EmitEventsJSON:    mustJSONBytes(cfg.EmitEvents, "[]"),
+		ToolsJSON:         mustJSONBytes(cfg.Tools, "[]"),
+		PermissionsJSON:   mustJSONBytes(cfg.Permissions, "[]"),
+	}, nil
+}
+
+func hydratePersistedAgentConfig(row persistedAgentProjection) (runtimeactors.AgentConfig, error) {
+	if strings.TrimSpace(row.AgentID) == "" {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent row missing agent_id")
+	}
+	if strings.TrimSpace(row.Role) == "" {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s missing role", strings.TrimSpace(row.AgentID))
+	}
+	modelTier := strings.TrimSpace(row.ModelTier)
+	if modelTier == "" {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s missing model_tier", strings.TrimSpace(row.AgentID))
+	}
+	llmBackend := strings.TrimSpace(row.LLMBackend)
+	if llmBackend == "" {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s missing llm_backend", strings.TrimSpace(row.AgentID))
+	}
+	conversationMode := strings.TrimSpace(row.ConversationMode)
+	if _, err := runtimesessions.ParseConversationRuntimeMode(conversationMode); err != nil {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid conversation_mode %q: %w", strings.TrimSpace(row.AgentID), conversationMode, err)
+	}
+	if err := validateOpaqueAgentConfig(row.ConfigJSON); err != nil {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid opaque config: %w", strings.TrimSpace(row.AgentID), err)
+	}
+	desc, err := decodePersistedAgentRuntimeDescriptor(row.RuntimeDescriptor)
+	if err != nil {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid runtime_descriptor: %w", strings.TrimSpace(row.AgentID), err)
+	}
+	sessionScope, err := runtimesessions.ValidateSessionScopeIntent(conversationMode, desc.SessionScope)
+	if err != nil {
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid session scope: %w", strings.TrimSpace(row.AgentID), err)
+	}
+
+	cfg := runtimeactors.AgentConfig{
+		ID:               strings.TrimSpace(row.AgentID),
+		Type:             desc.Type,
+		Role:             strings.TrimSpace(row.Role),
+		Mode:             desc.Mode,
+		ModelTier:        modelTier,
+		LLMBackend:       llmBackend,
+		ConversationMode: conversationMode,
+		SessionScope:     sessionScope,
+		MaxTurnsPerTask:  desc.MaxTurnsPerTask,
+		Subscriptions:    decodeJSONStringList(row.SubscriptionsJSON),
+		EmitEvents:       decodeJSONStringList(row.EmitEventsJSON),
+		Tools:            decodeJSONStringList(row.ToolsJSON),
+		Permissions:      decodeJSONStringList(row.PermissionsJSON),
+		NativeTools:      desc.NativeTools,
+		WorkspaceClass:   desc.WorkspaceClass,
+		ManagerFallback:  desc.ManagerFallback,
+		FlowPath:         strings.Trim(strings.TrimSpace(row.FlowInstance), "/"),
+		EntityID:         strings.TrimSpace(row.EntityID),
+		ParentAgent:      strings.TrimSpace(row.ParentAgentID),
+		Config:           append(json.RawMessage(nil), row.ConfigJSON...),
+	}
+	cfg.NormalizeEntityID()
+	cfg.NormalizeRuntimeDescriptor()
+	return cfg, nil
+}
+
+func marshalPersistedAgentRuntimeDescriptor(cfg runtimeactors.AgentConfig, modelTier string) ([]byte, error) {
 	desc := persistedAgentRuntimeDescriptor{
-		Type:            strings.TrimSpace(cfg.Type),
+		Type:            agentPersistedType(cfg, modelTier),
 		Mode:            strings.TrimSpace(cfg.Mode),
 		SessionScope:    strings.TrimSpace(cfg.SessionScope),
 		MaxTurnsPerTask: cfg.MaxTurnsPerTask,
@@ -80,7 +200,36 @@ func marshalPersistedAgentRuntimeDescriptor(cfg runtimeactors.AgentConfig) ([]by
 	return json.Marshal(desc)
 }
 
-func decodePersistedAgentRuntimeDescriptor(raw []byte) persistedAgentRuntimeDescriptor {
+func decodePersistedAgentRuntimeDescriptor(raw []byte) (persistedAgentRuntimeDescriptor, error) {
+	obj := map[string]json.RawMessage{}
+	if len(raw) == 0 {
+		raw = []byte(`{}`)
+	}
+	if !json.Valid(raw) {
+		return persistedAgentRuntimeDescriptor{}, fmt.Errorf("runtime_descriptor must be valid json")
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return persistedAgentRuntimeDescriptor{}, fmt.Errorf("decode runtime_descriptor: %w", err)
+	}
+	if unknown := invalidPersistedAgentRuntimeDescriptorKeys(obj); len(unknown) > 0 {
+		return persistedAgentRuntimeDescriptor{}, fmt.Errorf("runtime_descriptor contains unsupported keys: %s", strings.Join(unknown, ", "))
+	}
+	var desc persistedAgentRuntimeDescriptor
+	if err := json.Unmarshal(raw, &desc); err != nil {
+		return persistedAgentRuntimeDescriptor{}, fmt.Errorf("decode runtime_descriptor: %w", err)
+	}
+	desc.Type = strings.TrimSpace(desc.Type)
+	desc.Mode = strings.TrimSpace(desc.Mode)
+	desc.SessionScope = strings.TrimSpace(desc.SessionScope)
+	desc.WorkspaceClass = strings.TrimSpace(desc.WorkspaceClass)
+	desc.ManagerFallback = strings.TrimSpace(desc.ManagerFallback)
+	if desc.Type == "" {
+		return persistedAgentRuntimeDescriptor{}, fmt.Errorf("missing type")
+	}
+	return desc, nil
+}
+
+func decodePersistedAgentRuntimeDescriptorLoose(raw []byte) persistedAgentRuntimeDescriptor {
 	if len(raw) == 0 || !json.Valid(raw) {
 		return persistedAgentRuntimeDescriptor{}
 	}
@@ -156,6 +305,63 @@ func extractStringListField(raw []byte, key string) []string {
 		}
 	}
 	return out
+}
+
+func validateOpaqueAgentConfig(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	if !json.Valid(raw) {
+		return fmt.Errorf("config must be valid json")
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return fmt.Errorf("decode config: %w", err)
+	}
+	conflicts := make([]string, 0)
+	for key := range runtimeConfigKeys {
+		if _, ok := obj[key]; ok {
+			conflicts = append(conflicts, key)
+		}
+	}
+	if constraints, ok := obj["constraints"].(map[string]any); ok {
+		for _, key := range []string{"conversation_mode", "max_turns_per_task"} {
+			if _, exists := constraints[key]; exists {
+				conflicts = append(conflicts, "constraints."+key)
+			}
+		}
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	sort.Strings(conflicts)
+	return fmt.Errorf("config contains runtime-owned keys: %s", strings.Join(conflicts, ", "))
+}
+
+func invalidPersistedAgentRuntimeDescriptorKeys(obj map[string]json.RawMessage) []string {
+	if len(obj) == 0 {
+		return nil
+	}
+	unknown := make([]string, 0)
+	for key := range obj {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := persistedAgentRuntimeDescriptorKeys[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+func mustJSONBytes(v any, fallback string) []byte {
+	b, err := json.Marshal(v)
+	if err != nil || len(b) == 0 {
+		return []byte(fallback)
+	}
+	return b
 }
 
 func normalizeJSONPayload(raw []byte) string {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -166,7 +166,7 @@ func (s *PostgresStore) migrateLegacyAgentRuntimeDescriptors(ctx context.Context
 		return nil
 	}
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT agent_id, COALESCE(config, '{}'::jsonb), COALESCE(runtime_descriptor, '{}'::jsonb)
+		SELECT agent_id, COALESCE(model_tier, ''), COALESCE(config, '{}'::jsonb), COALESCE(runtime_descriptor, '{}'::jsonb)
 		FROM agents
 	`)
 	if err != nil {
@@ -183,16 +183,17 @@ func (s *PostgresStore) migrateLegacyAgentRuntimeDescriptors(ctx context.Context
 	for rows.Next() {
 		var (
 			agentID           string
+			modelTier         string
 			configRaw         []byte
 			runtimeDescriptor []byte
 		)
-		if err := rows.Scan(&agentID, &configRaw, &runtimeDescriptor); err != nil {
+		if err := rows.Scan(&agentID, &modelTier, &configRaw, &runtimeDescriptor); err != nil {
 			return fmt.Errorf("scan agent runtime descriptor migration row: %w", err)
 		}
-		desc := decodePersistedAgentRuntimeDescriptor(runtimeDescriptor)
+		desc := decodePersistedAgentRuntimeDescriptorLoose(runtimeDescriptor)
 		legacy := decodeLegacyAgentRuntimeConfig(configRaw)
 		if desc.Type == "" {
-			desc.Type = legacy.Type
+			desc.Type = coalesce(legacy.Type, strings.TrimSpace(modelTier))
 		}
 		if desc.Mode == "" {
 			desc.Mode = legacy.Mode

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2086,6 +2086,178 @@ func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
 	}
 }
 
+func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	entityID := uuid.NewString()
+	rec := runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-canonical-1",
+			Type:             "review-worker",
+			Role:             "reviewer",
+			Mode:             "review",
+			ModelTier:        "sonnet",
+			LLMBackend:       "cli_test",
+			ConversationMode: "session_per_entity",
+			MaxTurnsPerTask:  7,
+			Subscriptions:    []string{"review.ready"},
+			EmitEvents:       []string{"review.completed"},
+			Tools:            []string{"agent_message"},
+			Permissions:      []string{"agent_message"},
+			NativeTools:      runtimeactors.NativeToolConfig{FileIO: true},
+			WorkspaceClass:   "shared_flow",
+			ManagerFallback:  "control-plane",
+			FlowPath:         "review/inst-1",
+			EntityID:         entityID,
+			ParentAgent:      "manager-1",
+			Config: json.RawMessage(`{
+				"system_prompt":"x",
+				"type":"wrong-type",
+				"conversation_mode":"task",
+				"subscriptions":["wrong.subscription"],
+				"manager_fallback":"wrong-manager",
+				"workspace_class":"wrong-workspace"
+			}`),
+		},
+		Status: "active",
+	}
+	if err := pg.UpsertAgent(ctx, rec); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	agents, err := pg.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("agent count = %d, want 1", len(agents))
+	}
+	got := agents[0].Config
+	if got.Type != "review-worker" {
+		t.Fatalf("type = %q, want review-worker", got.Type)
+	}
+	if got.ModelTier != "sonnet" {
+		t.Fatalf("model_tier = %q, want sonnet", got.ModelTier)
+	}
+	if got.LLMBackend != "cli_test" {
+		t.Fatalf("llm_backend = %q, want cli_test", got.LLMBackend)
+	}
+	if got.ConversationMode != "session_per_entity" {
+		t.Fatalf("conversation_mode = %q, want session_per_entity", got.ConversationMode)
+	}
+	if got.MaxTurnsPerTask != 7 {
+		t.Fatalf("max_turns_per_task = %d, want 7", got.MaxTurnsPerTask)
+	}
+	if len(got.Subscriptions) != 1 || got.Subscriptions[0] != "review.ready" {
+		t.Fatalf("subscriptions = %#v, want [review.ready]", got.Subscriptions)
+	}
+	if len(got.EmitEvents) != 1 || got.EmitEvents[0] != "review.completed" {
+		t.Fatalf("emit_events = %#v, want [review.completed]", got.EmitEvents)
+	}
+	if got.ManagerFallback != "control-plane" {
+		t.Fatalf("manager_fallback = %q, want control-plane", got.ManagerFallback)
+	}
+	if got.WorkspaceClass != "shared_flow" {
+		t.Fatalf("workspace_class = %q, want shared_flow", got.WorkspaceClass)
+	}
+	if got.CanonicalFlowPath() != "review/inst-1" {
+		t.Fatalf("flow_path = %q, want review/inst-1", got.FlowPath)
+	}
+	if got.ParentAgent != "manager-1" {
+		t.Fatalf("parent_agent = %q, want manager-1", got.ParentAgent)
+	}
+	var opaque map[string]any
+	if err := json.Unmarshal(got.Config, &opaque); err != nil {
+		t.Fatalf("unmarshal opaque config: %v", err)
+	}
+	if len(opaque) != 1 || opaque["system_prompt"] != "x" {
+		t.Fatalf("opaque config = %#v, want only system_prompt", opaque)
+	}
+
+	var (
+		configRaw            []byte
+		runtimeDescriptorRaw []byte
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT config, runtime_descriptor
+		FROM agents
+		WHERE agent_id = $1
+	`, rec.Config.ID).Scan(&configRaw, &runtimeDescriptorRaw); err != nil {
+		t.Fatalf("query persisted agent row: %v", err)
+	}
+	if err := validateOpaqueAgentConfig(configRaw); err != nil {
+		t.Fatalf("validateOpaqueAgentConfig: %v", err)
+	}
+	desc, err := decodePersistedAgentRuntimeDescriptor(runtimeDescriptorRaw)
+	if err != nil {
+		t.Fatalf("decodePersistedAgentRuntimeDescriptor: %v", err)
+	}
+	if desc.Type != "review-worker" {
+		t.Fatalf("runtime_descriptor.type = %q, want review-worker", desc.Type)
+	}
+	if desc.ManagerFallback != "control-plane" {
+		t.Fatalf("runtime_descriptor.manager_fallback = %q, want control-plane", desc.ManagerFallback)
+	}
+}
+
+func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeKeys(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if err := pg.ensureSchemaCompatibilityColumns(ctx); err != nil {
+		t.Fatalf("ensureSchemaCompatibilityColumns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
+			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
+			runtime_descriptor, status
+		) VALUES (
+			$1, '', 'reviewer', 'sonnet', 'api', 'task',
+			NULL, NULL, $2::jsonb, '["review.ready"]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			$3::jsonb, 'active'
+		)
+	`, "agent-invalid-config", `{"system_prompt":"x","subscriptions":["wrong"]}`, `{"type":"review-worker","mode":"review"}`); err != nil {
+		t.Fatalf("seed agent row: %v", err)
+	}
+
+	_, err := pg.loadAgentsSpec(ctx)
+	if err == nil || !strings.Contains(err.Error(), "config contains runtime-owned keys: subscriptions") {
+		t.Fatalf("loadAgentsSpec error = %v, want runtime-owned config key failure", err)
+	}
+}
+
+func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelTierMissing(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if err := pg.ensureSchemaCompatibilityColumns(ctx); err != nil {
+		t.Fatalf("ensureSchemaCompatibilityColumns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
+			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
+			runtime_descriptor, status
+		) VALUES (
+			$1, '', 'reviewer', '', 'api', 'task',
+			NULL, NULL, '{}'::jsonb, '["review.ready"]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			$2::jsonb, 'active'
+		)
+	`, "agent-missing-type", `{"mode":"review"}`); err != nil {
+		t.Fatalf("seed agent row: %v", err)
+	}
+
+	_, err := pg.LoadAgents(ctx)
+	if err == nil || !strings.Contains(err.Error(), "missing model_tier") {
+		t.Fatalf("LoadAgents error = %v, want missing model_tier failure", err)
+	}
+}
+
 func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2101,6 +2101,7 @@ func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *test
 			ModelTier:        "sonnet",
 			LLMBackend:       "cli_test",
 			ConversationMode: "session_per_entity",
+			SessionScope:     "entity",
 			MaxTurnsPerTask:  7,
 			Subscriptions:    []string{"review.ready"},
 			EmitEvents:       []string{"review.completed"},


### PR DESCRIPTION
## Summary
- collapse touched agent control-plane metadata onto one canonical persisted row projection
- stop load/upsert paths from deciding ad hoc among typed columns, runtime_descriptor, and opaque config
- fail closed on invalid or overlapping runtime-owned metadata and cover the canonical ownership path with focused tests

## Canonical ownership
- typed columns own `role`, `model_tier`, `llm_backend`, `conversation_mode`, `parent_agent_id`, `flow_instance`, and `entity_id`
- JSON arrays own `subscriptions`, `emit_events`, `tools`, and `permissions`
- `runtime_descriptor` owns the remaining touched control-plane fields such as `type`, `mode`, `session_scope`, `workspace_class`, `manager_fallback`, `max_turns_per_task`, and `native_tools`
- `config` is treated as opaque payload only and rejected when it still carries runtime-owned keys

## Tests
- `go test ./internal/store ./internal/runtime/manager -count=1`
- `go test ./internal/store ./internal/runtime/... -count=1`
- `go test ./... -count=1`
