### PR TITLE
[agent-a][issue #80] Remove remaining executor dependency mutation escape hatches

### DIFF
--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -503,16 +503,24 @@ func decodeToolInput(input any, out any) error {
 	return nil
 }
 
-func (e *Executor) SetMailboxStore(store MailboxPersistence) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.mailboxStore = store
+func (e *Executor) mailboxStoreDependency() (MailboxPersistence, error) {
+	e.mu.RLock()
+	store := e.mailboxStore
+	e.mu.RUnlock()
+	if store == nil {
+		return nil, errors.New("mailbox store is not configured")
+	}
+	return store, nil
 }
 
-func (e *Executor) SetSQLDB(db *sql.DB) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.sqlDB = db
+func (e *Executor) sqlDBDependency() (*sql.DB, error) {
+	e.mu.RLock()
+	db := e.sqlDB
+	e.mu.RUnlock()
+	if db == nil {
+		return nil, errors.New("sql db is not configured")
+	}
+	return db, nil
 }
 
 func (e *Executor) ValidateRuntimeToolInputForTest(name string, input any) error {

--- a/internal/runtime/tools/executor_dependency_test.go
+++ b/internal/runtime/tools/executor_dependency_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	models "swarm/internal/runtime/core/actors"
+)
+
+type allowMailboxAuthority struct{}
+
+func (allowMailboxAuthority) CanonicalRole(role string) string { return strings.TrimSpace(role) }
+func (allowMailboxAuthority) ProducerRoles() []string          { return nil }
+func (allowMailboxAuthority) ProducerEventsForRole(string) []string {
+	return nil
+}
+func (allowMailboxAuthority) HasMessageAuthority(actor, target models.AgentConfig) bool { return false }
+func (allowMailboxAuthority) AuthorizeRouting(actor, target models.AgentConfig, status string) error {
+	return nil
+}
+func (allowMailboxAuthority) AuthorizeManagement(actor, target models.AgentConfig) error { return nil }
+func (allowMailboxAuthority) AuthorizeMailboxSend(actor models.AgentConfig) error        { return nil }
+func (allowMailboxAuthority) CanDecideHumanTasks(role string) bool                       { return true }
+
+type mailboxStoreStub struct {
+	last MailboxItem
+	id   string
+}
+
+func (s *mailboxStoreStub) InsertMailboxItem(_ context.Context, item MailboxItem) (string, error) {
+	s.last = item
+	if strings.TrimSpace(s.id) == "" {
+		return "mailbox-1", nil
+	}
+	return s.id, nil
+}
+func (*mailboxStoreStub) ListMailboxItems(context.Context, string, int) ([]MailboxItem, error) {
+	return nil, nil
+}
+func (*mailboxStoreStub) CountMailboxItems(context.Context, string) (int, error) { return 0, nil }
+func (*mailboxStoreStub) GetMailboxItem(context.Context, string) (MailboxItem, error) {
+	return MailboxItem{}, nil
+}
+func (*mailboxStoreStub) DecideMailboxItem(context.Context, string, string, string, string) error {
+	return nil
+}
+func (*mailboxStoreStub) ExpireMailboxItems(context.Context, int) ([]MailboxItem, error) {
+	return nil, nil
+}
+func (*mailboxStoreStub) ListUnnotifiedCriticalMailboxItems(context.Context, int) ([]MailboxItem, error) {
+	return nil, nil
+}
+func (*mailboxStoreStub) MarkMailboxItemNotified(context.Context, string) error { return nil }
+
+func TestExecutorMailboxSendFailsWithoutMailboxStore(t *testing.T) {
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{AuthorityProvider: allowMailboxAuthority{}})
+
+	_, err := exec.execMailboxSend(context.Background(), models.AgentConfig{ID: "agent-1", EntityID: "entity-1"}, map[string]any{
+		"type": "approval",
+	})
+	if err == nil || !strings.Contains(err.Error(), "mailbox store is not configured") {
+		t.Fatalf("execMailboxSend err = %v, want mailbox store error", err)
+	}
+}
+
+func TestExecutorMailboxSendUsesConstructorOwnedMailboxStore(t *testing.T) {
+	store := &mailboxStoreStub{id: "mailbox-42"}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		MailboxStore:      store,
+		AuthorityProvider: allowMailboxAuthority{},
+	})
+
+	out, err := exec.execMailboxSend(context.Background(), models.AgentConfig{ID: "agent-1", EntityID: "entity-1"}, map[string]any{
+		"type":    "approval",
+		"summary": "Need review",
+	})
+	if err != nil {
+		t.Fatalf("execMailboxSend: %v", err)
+	}
+	result, ok := out.(map[string]any)
+	if !ok || strings.TrimSpace(asString(result["mailbox_id"])) != "mailbox-42" {
+		t.Fatalf("execMailboxSend output = %#v, want mailbox_id mailbox-42", out)
+	}
+	if got := strings.TrimSpace(store.last.Type); got != "approval" {
+		t.Fatalf("stored mailbox type = %q, want approval", got)
+	}
+	if got := strings.TrimSpace(store.last.EntityID); got != "entity-1" {
+		t.Fatalf("stored mailbox entity_id = %q, want entity-1", got)
+	}
+}
+
+func TestExecutorSQLDBDependencyFailsWithoutConstructorOwnedDB(t *testing.T) {
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
+
+	db, err := exec.sqlDBDependency()
+	if db != nil || err == nil || !strings.Contains(err.Error(), "sql db is not configured") {
+		t.Fatalf("sqlDBDependency = (%v, %v), want nil sql db error", db, err)
+	}
+}
+
+func TestExecutorSQLDBDependencyUsesConstructorOwnedDB(t *testing.T) {
+	db := &sql.DB{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{SQLDB: db})
+
+	got, err := exec.sqlDBDependency()
+	if err != nil {
+		t.Fatalf("sqlDBDependency: %v", err)
+	}
+	if got != db {
+		t.Fatalf("sqlDBDependency db = %p, want %p", got, db)
+	}
+}

--- a/internal/runtime/tools/executor_entity.go
+++ b/internal/runtime/tools/executor_entity.go
@@ -30,13 +30,13 @@ var entityStateTopLevelFields = map[string]struct{}{
 }
 
 func (e *Executor) entityToolDependencies(input any) (*sql.DB, entityToolSchema, map[string]any, error) {
-	e.mu.RLock()
-	db := e.sqlDB
-	source := e.workflowSource
-	e.mu.RUnlock()
-	if db == nil {
+	db, err := e.sqlDBDependency()
+	if err != nil {
 		return nil, entityToolSchema{}, nil, NewRuntimeError("dependency_unavailable", "tool-executor", "entity_tool.db", true, "sql database is not configured")
 	}
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
 	payload := map[string]any{}
 	if err := decodeToolInput(input, &payload); err != nil {
 		return nil, entityToolSchema{}, nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "entity_tool.decode", false, err, "decode entity tool input")

--- a/internal/runtime/tools/executor_human_tasks.go
+++ b/internal/runtime/tools/executor_human_tasks.go
@@ -14,13 +14,13 @@ import (
 )
 
 func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
+	db, err := e.sqlDBDependency()
+	if err != nil {
+		return nil, err
+	}
 	e.mu.RLock()
-	db := e.sqlDB
 	cfg := e.cfg
 	e.mu.RUnlock()
-	if db == nil {
-		return nil, errors.New("sql db is not configured")
-	}
 	var in struct {
 		EntityID        string `json:"entity_id"`
 		Category        string `json:"category"`
@@ -97,13 +97,13 @@ func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentC
 }
 
 func (e *Executor) execHumanTaskDecide(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
+	db, err := e.sqlDBDependency()
+	if err != nil {
+		return nil, err
+	}
 	e.mu.RLock()
-	db := e.sqlDB
 	cfg := e.cfg
 	e.mu.RUnlock()
-	if db == nil {
-		return nil, errors.New("sql db is not configured")
-	}
 	if !runtimeauthority.ProviderOrNoop(e.authority).CanDecideHumanTasks(actor.Role) {
 		return nil, fmt.Errorf("role %s is not authorized to decide human tasks", actor.Role)
 	}

--- a/internal/runtime/tools/executor_mailbox.go
+++ b/internal/runtime/tools/executor_mailbox.go
@@ -12,8 +12,9 @@ import (
 )
 
 func (e *Executor) execMailboxSend(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	if e.mailboxStore == nil {
-		return nil, errors.New("mailbox store is not configured")
+	store, err := e.mailboxStoreDependency()
+	if err != nil {
+		return nil, err
 	}
 	if err := authorizeMailboxSend(e.authority, actor); err != nil {
 		return nil, err
@@ -67,7 +68,7 @@ func (e *Executor) execMailboxSend(ctx context.Context, actor models.AgentConfig
 		timeout = parsed
 	}
 
-	id, err := e.mailboxStore.InsertMailboxItem(ctx, MailboxItem{
+	id, err := store.InsertMailboxItem(ctx, MailboxItem{
 		EventID:   in.EventID,
 		EntityID:  in.EntityID,
 		FromAgent: actor.ID,


### PR DESCRIPTION
## What changed
- removed the remaining executor mailbox/SQL dependency mutation escape hatches
- centralized executor-owned mailbox and SQL dependency checks behind explicit dependency accessors
- updated entity, mailbox, and human-task execution paths to use constructor-owned dependencies
- added focused tests for constructor-owned success and missing-dependency failure behavior

## Why
Issue #80 is about eliminating the remaining executor dependency mutation escape hatches. Canonical executor behavior should come from constructor or validated-option ownership, not post-construction adjustment.

## Impact
- executor mailbox and SQL dependencies are no longer adjustable after construction
- touched executor paths fail closed when those required dependencies are missing
- canonical runtime wiring remains unchanged except that it now relies solely on `ExecutorOptions`

## Validation
- `go test ./internal/runtime/tools ./internal/runtime ./internal/runtime/agents -count=1`
- `go test ./internal/runtime/tools -run 'TestExecutor(MailboxSendFailsWithoutMailboxStore|MailboxSendUsesConstructorOwnedMailboxStore|SQLDBDependencyFailsWithoutConstructorOwnedDB|SQLDBDependencyUsesConstructorOwnedDB)$' -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release includes internal improvements with no user-facing changes.

* **Refactor**
  * Enhanced internal dependency management patterns to improve system reliability and error reporting.

* **Tests**
  * Added comprehensive validation tests for critical system dependencies and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->