### PR TITLE
[agent-e][issue #42] Tighten constructor and validation hygiene in tool input validator

### DIFF
--- a/internal/runtime/tools/validator.go
+++ b/internal/runtime/tools/validator.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"errors"
 	"strings"
 
 	"swarm/internal/runtime/core/toolcapabilities"
@@ -11,7 +12,14 @@ type ToolInputValidator struct {
 	definitions func() ([]llm.ToolDefinition, error)
 }
 
+var errToolDefinitionsProviderRequired = errors.New("tool definitions provider is required")
+
 func NewToolInputValidator(definitions func() ([]llm.ToolDefinition, error)) *ToolInputValidator {
+	if definitions == nil {
+		definitions = func() ([]llm.ToolDefinition, error) {
+			return nil, errToolDefinitionsProviderRequired
+		}
+	}
 	return &ToolInputValidator{definitions: definitions}
 }
 
@@ -19,6 +27,9 @@ func (v *ToolInputValidator) Validate(name string, input any) error {
 	name = normalizeNativeToolName(name)
 	if name == "" || toolKindPolicy(name) == toolcapabilities.KindEmit {
 		return nil
+	}
+	if v == nil || v.definitions == nil {
+		return errToolDefinitionsProviderRequired
 	}
 	input = validatorNormalizeRuntimeToolInput(name, input)
 	payload := map[string]any{}

--- a/internal/runtime/tools/validator_test.go
+++ b/internal/runtime/tools/validator_test.go
@@ -1,0 +1,47 @@
+package tools
+
+import (
+	"errors"
+	"testing"
+
+	llm "swarm/internal/runtime/llm"
+)
+
+func TestNewToolInputValidator_NilDefinitionsFailClosed(t *testing.T) {
+	validator := NewToolInputValidator(nil)
+
+	err := validator.Validate("save_entity_field", map[string]any{"entity_id": "x"})
+	if !errors.Is(err, errToolDefinitionsProviderRequired) {
+		t.Fatalf("Validate() error = %v, want errToolDefinitionsProviderRequired", err)
+	}
+}
+
+func TestToolInputValidator_ValidateNilReceiverFailsClosed(t *testing.T) {
+	var validator *ToolInputValidator
+
+	err := validator.Validate("save_entity_field", map[string]any{"entity_id": "x"})
+	if !errors.Is(err, errToolDefinitionsProviderRequired) {
+		t.Fatalf("Validate() error = %v, want errToolDefinitionsProviderRequired", err)
+	}
+}
+
+func TestToolInputValidator_EmitToolsStillBypassDefinitionsLookup(t *testing.T) {
+	validator := NewToolInputValidator(nil)
+
+	if err := validator.Validate("emit_customer.updated", map[string]any{"id": "123"}); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestToolInputValidator_UsesDefinitionsProviderWhenConfigured(t *testing.T) {
+	validator := NewToolInputValidator(func() ([]llm.ToolDefinition, error) {
+		return []llm.ToolDefinition{{
+			Name:   "save_entity_field",
+			Schema: map[string]any{"type": "object"},
+		}}, nil
+	})
+
+	if err := validator.Validate("save_entity_field", map[string]any{"entity_id": "x"}); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- tighten `ToolInputValidator` construction so a missing tool-definitions provider fails explicitly instead of leaving an invalid validator state
- add focused tests for nil constructor input, nil receiver use, emit-tool bypass behavior, and the normal configured validation path

## Scope
- issue #42
- narrow support-module slice only: `internal/runtime/tools/validator.go`
- no semantic redesign or spec change

## Validation
- `go test ./internal/runtime/tools`
- `go test ./... -count=1`

## Notes
- no real semantic issue surfaced during the hygiene pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool input validation now requires a properly configured tool definitions provider, preventing invalid configurations from proceeding.
  * Certain special tools can bypass definitions lookup when necessary.
  * Tool validation succeeds when required definitions are available.

* **Tests**
  * Added comprehensive test coverage for tool validation error handling and successful validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->