### PR TITLE
[agent-b][issue #86] Route pipeline transition persistence through canonical schema capability ownership

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -15,6 +15,10 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
+type pipelineTransitionSchemaCapabilityProvider interface {
+	CanonicalEventReceiptsCapability(context.Context) (bool, error)
+}
+
 func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
@@ -45,7 +49,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
-	ictx = runtimepipeline.WithPipelineTransitionCollector(ictx, &deferredTransitions)
+	ictx = runtimepipeline.WithPipelineTransitionCollector(ictx, &deferredTransitions, eb.pipelineTransitionCapability())
 	ictx = runtimepipeline.WithPipelinePostCommitActions(ictx, &postCommitActions)
 	ictx = runtimepipeline.WithPipelineReceiptOverride(ictx, receiptOverride)
 	if txStore, ok := eb.store.(TransactionalEventStore); ok {
@@ -98,6 +102,16 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		if err := eb.publishDeferred(ictx, d); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, error) {
+	if eb == nil || eb.store == nil {
+		return nil
+	}
+	if provider, ok := eb.store.(pipelineTransitionSchemaCapabilityProvider); ok && provider != nil {
+		return provider.CanonicalEventReceiptsCapability
 	}
 	return nil
 }

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
@@ -66,13 +64,6 @@ type DigestPersistence interface {
 	CountActiveInstances(ctx context.Context) (int, error)
 	ListInstanceDigestRows(ctx context.Context, limit int) ([]InstanceDigestRow, error)
 }
-
-type deferredPipelineTransition struct {
-	db    *sql.DB
-	input PipelineTransitionInput
-}
-
-type pipelineTransitionCollectorKey struct{}
 
 func NewRuntimeLogger(db *sql.DB, capabilities runtimeLogCapabilityResolver) *RuntimeLogger {
 	return &RuntimeLogger{db: db, capabilities: capabilities}
@@ -195,102 +186,6 @@ func handleRuntimeLogPersistenceError(component, action string, err error) {
 	)
 }
 
-type PipelineTransitionInput struct {
-	EventID      string
-	EventType    string
-	Handler      string
-	PipelineType string
-	PipelineID   string
-	Action       string
-
-	StateBefore   any
-	StateAfter    any
-	EventsEmitted []string
-	DropReason    string
-	Error         string
-	Duration      time.Duration
-}
-
-func RecordPipelineTransition(ctx context.Context, db *sql.DB, in PipelineTransitionInput) error {
-	if db == nil {
-		return nil
-	}
-	ctx = withoutSQLTxContext(ctx)
-	eventID := strings.TrimSpace(in.EventID)
-	pipelineID := strings.TrimSpace(in.PipelineID)
-	if _, err := uuid.Parse(eventID); err != nil {
-		return errors.New("pipeline transition requires valid event_id")
-	}
-	if _, err := uuid.Parse(pipelineID); err != nil {
-		return errors.New("pipeline transition requires valid pipeline_id")
-	}
-	handler := strings.TrimSpace(in.Handler)
-	if handler == "" {
-		handler = "unknown"
-	}
-	pipelineType := strings.TrimSpace(in.PipelineType)
-	if pipelineType == "" {
-		pipelineType = "workflow"
-	}
-	action := strings.TrimSpace(in.Action)
-	if action == "" {
-		action = "consumed"
-	}
-	before := marshalJSONOrNil(in.StateBefore)
-	after := marshalJSONOrNil(in.StateAfter)
-	eventsEmitted := sanitizeStringSlice(in.EventsEmitted)
-
-	durationUS := int(in.Duration / time.Microsecond)
-	if durationUS <= 0 {
-		durationUS = 0
-	}
-
-	var eventExists bool
-	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM events WHERE event_id = $1::uuid)`, eventID).Scan(&eventExists); err != nil {
-		return err
-	}
-	if !eventExists {
-		// Best effort only; skip when events persistence is disabled in tests.
-		return nil
-	}
-
-	return recordPipelineTransitionSpec(ctx, db, eventID, handler, pipelineType, pipelineID, action, before, after, eventsEmitted, durationUS, in.DropReason, in.Error)
-}
-
-func withPipelineTransitionCollector(ctx context.Context, collector *[]deferredPipelineTransition) context.Context {
-	if collector == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, pipelineTransitionCollectorKey{}, collector)
-}
-
-func appendDeferredPipelineTransition(ctx context.Context, item deferredPipelineTransition) bool {
-	if item.db == nil {
-		return false
-	}
-	collector, ok := ctx.Value(pipelineTransitionCollectorKey{}).(*[]deferredPipelineTransition)
-	if !ok || collector == nil {
-		return false
-	}
-	*collector = append(*collector, item)
-	return true
-}
-
-func flushDeferredPipelineTransitions(ctx context.Context, deferred []deferredPipelineTransition) {
-	for _, item := range deferred {
-		if err := RecordPipelineTransition(ctx, item.db, item.input); err != nil {
-			processWarn(
-				"diagnostics",
-				"failed to persist deferred pipeline transition event_id=%s event_type=%s pipeline_id=%s: %v",
-				strings.TrimSpace(item.input.EventID),
-				strings.TrimSpace(item.input.EventType),
-				strings.TrimSpace(item.input.PipelineID),
-				err,
-			)
-		}
-	}
-}
-
 func marshalJSONOrEmpty(v any) []byte {
 	if v == nil {
 		return []byte("{}")
@@ -300,52 +195,6 @@ func marshalJSONOrEmpty(v any) []byte {
 		return []byte("{}")
 	}
 	return b
-}
-
-func marshalJSONOrNil(v any) []byte {
-	if v == nil {
-		return nil
-	}
-	b, err := json.Marshal(v)
-	if err != nil || len(b) == 0 {
-		return nil
-	}
-	return b
-}
-
-func maybeJSONString(v []byte) any {
-	if len(v) == 0 {
-		return nil
-	}
-	return string(v)
-}
-
-func nullableUUID(raw string) any {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil
-	}
-	if _, err := uuid.Parse(raw); err != nil {
-		return nil
-	}
-	return raw
-}
-
-func sanitizeStringSlice(in []string) []string {
-	out := make([]string, 0, len(in))
-	seen := make(map[string]struct{}, len(in))
-	for _, raw := range in {
-		v := strings.TrimSpace(raw)
-		if v == "" {
-			continue
-		}
-		if _, ok := seen[v]; ok {
-			continue
-		}
-		seen[v] = struct{}{}
-		out = append(out, v)
-	}
-	return out
 }
 
 func sanitizeStringMap(in map[string]string) map[string]string {
@@ -365,18 +214,6 @@ func sanitizeStringMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
-}
-
-func isMissingDiagnosticsTable(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "event_name") ||
-		strings.Contains(msg, "subscriber_id") ||
-		strings.Contains(msg, "reason_code") ||
-		strings.Contains(msg, "side_effects") ||
-		strings.Contains(msg, "duration_ms")
 }
 
 func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) error {
@@ -486,77 +323,4 @@ func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detai
 		payload["stack_trace"] = v
 	}
 	return payload
-}
-
-func recordPipelineTransitionSpec(ctx context.Context, db *sql.DB, eventID, handler, pipelineType, pipelineID, action string, before, after []byte, eventsEmitted []string, durationMS int, dropReason, errText string) error {
-	handlerID := strings.TrimSpace(runtimecorrelation.HandlerIDFromContext(ctx))
-	if handlerID == "" {
-		handlerID = strings.TrimSpace(handler)
-	}
-	reasonCode := "pipeline_transition_applied"
-	if strings.TrimSpace(errText) != "" {
-		reasonCode = "pipeline_transition_error"
-	} else if strings.TrimSpace(dropReason) != "" {
-		reasonCode = "pipeline_transition_discarded"
-	}
-	sideEffects, err := json.Marshal(map[string]any{
-		"pipeline_type":  pipelineType,
-		"pipeline_id":    pipelineID,
-		"action":         action,
-		"handler_id":     handlerID,
-		"reason_code":    reasonCode,
-		"events_emitted": eventsEmitted,
-		"drop_reason":    strings.TrimSpace(dropReason),
-		"error":          strings.TrimSpace(errText),
-	})
-	if err != nil {
-		return err
-	}
-	outcome := "success"
-	if strings.TrimSpace(errText) != "" {
-		outcome = "dead_letter"
-	} else if strings.TrimSpace(dropReason) != "" {
-		outcome = "discard"
-	}
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, reason_code, state_before, state_after, side_effects, duration_ms, processed_at
-		)
-		SELECT
-			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
-			$3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), $7::jsonb, NULLIF($8,0), now()
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			outcome = EXCLUDED.outcome,
-			reason_code = EXCLUDED.reason_code,
-			state_before = EXCLUDED.state_before,
-			state_after = EXCLUDED.state_after,
-			side_effects = EXCLUDED.side_effects,
-			duration_ms = EXCLUDED.duration_ms,
-			processed_at = now()
-	`, eventID, "pipeline:"+pipelineID, outcome, reasonCode, string(before), string(after), string(sideEffects), durationMS)
-	if err == nil || !isMissingDiagnosticsTable(err) {
-		return err
-	}
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, state_before, state_after, side_effects, duration_ms, processed_at
-		)
-		SELECT
-			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
-			$3, NULLIF($4,''), NULLIF($5,''), $6::jsonb, NULLIF($7,0), now()
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			outcome = EXCLUDED.outcome,
-			state_before = EXCLUDED.state_before,
-			state_after = EXCLUDED.state_after,
-			side_effects = EXCLUDED.side_effects,
-			duration_ms = EXCLUDED.duration_ms,
-			processed_at = now()
-	`, eventID, "pipeline:"+pipelineID, outcome, string(before), string(after), string(sideEffects), durationMS)
-	return err
 }

--- a/internal/runtime/pipeline/workflow_transitions.go
+++ b/internal/runtime/pipeline/workflow_transitions.go
@@ -13,11 +13,13 @@ import (
 )
 
 type DeferredPipelineTransition struct {
-	db    *sql.DB
-	input PipelineTransitionInput
+	db         *sql.DB
+	input      PipelineTransitionInput
+	capability func(context.Context) (bool, error)
 }
 
 type pipelineTransitionCollectorKey struct{}
+type pipelineTransitionCapabilityKey struct{}
 
 type PipelineTransitionInput struct {
 	EventID       string
@@ -34,11 +36,21 @@ type PipelineTransitionInput struct {
 	Duration      time.Duration
 }
 
-func RecordPipelineTransition(ctx context.Context, db *sql.DB, in PipelineTransitionInput) error {
+func RecordPipelineTransition(ctx context.Context, db *sql.DB, capability func(context.Context) (bool, error), in PipelineTransitionInput) error {
 	if db == nil {
 		return nil
 	}
 	ctx = withoutSQLTxContext(ctx)
+	if capability == nil {
+		return nil
+	}
+	enabled, err := capability(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return nil
+	}
 	eventID := strings.TrimSpace(in.EventID)
 	pipelineID := strings.TrimSpace(in.PipelineID)
 	if _, err := uuid.Parse(eventID); err != nil {
@@ -76,16 +88,25 @@ func RecordPipelineTransition(ctx context.Context, db *sql.DB, in PipelineTransi
 	return recordPipelineTransitionReceipt(ctx, db, eventID, handler, pipelineType, pipelineID, action, before, after, eventsEmitted, durationUS, in.DropReason, in.Error)
 }
 
-func WithPipelineTransitionCollector(ctx context.Context, collector *[]DeferredPipelineTransition) context.Context {
+func WithPipelineTransitionCollector(ctx context.Context, collector *[]DeferredPipelineTransition, capability func(context.Context) (bool, error)) context.Context {
 	if collector == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, pipelineTransitionCollectorKey{}, collector)
+	ctx = context.WithValue(ctx, pipelineTransitionCollectorKey{}, collector)
+	if capability != nil {
+		ctx = context.WithValue(ctx, pipelineTransitionCapabilityKey{}, capability)
+	}
+	return ctx
 }
 
 func AppendDeferredPipelineTransition(ctx context.Context, item DeferredPipelineTransition) bool {
 	if item.db == nil {
 		return false
+	}
+	if item.capability == nil {
+		if capability, ok := ctx.Value(pipelineTransitionCapabilityKey{}).(func(context.Context) (bool, error)); ok {
+			item.capability = capability
+		}
 	}
 	collector, ok := ctx.Value(pipelineTransitionCollectorKey{}).(*[]DeferredPipelineTransition)
 	if !ok || collector == nil {
@@ -97,7 +118,7 @@ func AppendDeferredPipelineTransition(ctx context.Context, item DeferredPipeline
 
 func FlushDeferredPipelineTransitions(ctx context.Context, deferred []DeferredPipelineTransition) {
 	for _, item := range deferred {
-		if err := RecordPipelineTransition(ctx, item.db, item.input); err != nil {
+		if err := RecordPipelineTransition(ctx, item.db, item.capability, item.input); err != nil {
 			processWarn("diagnostics", "failed to persist deferred pipeline transition event_id=%s event_type=%s pipeline_id=%s: %v", strings.TrimSpace(item.input.EventID), strings.TrimSpace(item.input.EventType), strings.TrimSpace(item.input.PipelineID), err)
 		}
 	}
@@ -136,17 +157,6 @@ func sanitizeStringSlice(in []string) []string {
 		out = append(out, v)
 	}
 	return out
-}
-
-func isMissingDiagnosticsTable(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "subscriber_id") ||
-		strings.Contains(msg, "reason_code") ||
-		strings.Contains(msg, "side_effects") ||
-		strings.Contains(msg, "duration_ms")
 }
 
 func recordPipelineTransitionReceipt(ctx context.Context, db *sql.DB, eventID, handler, pipelineType, pipelineID, action string, before, after []byte, eventsEmitted []string, durationMS int, dropReason, errText string) error {
@@ -198,26 +208,5 @@ func recordPipelineTransitionReceipt(ctx context.Context, db *sql.DB, eventID, h
 			duration_ms = EXCLUDED.duration_ms,
 			processed_at = now()
 	`, eventID, "pipeline:"+pipelineID, outcome, reasonCode, string(before), string(after), string(sideEffects), durationMS)
-	if err == nil || !isMissingDiagnosticsTable(err) {
-		return err
-	}
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, state_before, state_after, side_effects, duration_ms, processed_at
-		)
-		SELECT
-			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
-			$3, NULLIF($4,''), NULLIF($5,''), $6::jsonb, NULLIF($7,0), now()
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			outcome = EXCLUDED.outcome,
-			state_before = EXCLUDED.state_before,
-			state_after = EXCLUDED.state_after,
-			side_effects = EXCLUDED.side_effects,
-			duration_ms = EXCLUDED.duration_ms,
-			processed_at = now()
-	`, eventID, "pipeline:"+pipelineID, outcome, string(before), string(after), string(sideEffects), durationMS)
 	return err
 }

--- a/internal/runtime/pipeline/workflow_transitions_test.go
+++ b/internal/runtime/pipeline/workflow_transitions_test.go
@@ -1,0 +1,120 @@
+package pipeline_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/store"
+)
+
+func TestRecordPipelineTransition_PersistsViaCanonicalCapabilityOwner(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(canonicalTransitionSchemaRows())
+	eventID := uuid.NewString()
+	pipelineID := uuid.NewString()
+	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM events WHERE event_id = \$1::uuid\)`).
+		WithArgs(eventID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("INSERT INTO event_receipts").
+		WithArgs(eventID, "pipeline:"+pipelineID, "success", "pipeline_transition_applied", "", "", sqlmock.AnyArg(), 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	pg := &store.PostgresStore{DB: db}
+	err = runtimepipeline.RecordPipelineTransition(context.Background(), db, pg.CanonicalEventReceiptsCapability, runtimepipeline.PipelineTransitionInput{
+		EventID:    eventID,
+		EventType:  "review.requested",
+		Handler:    "node-a",
+		PipelineID: pipelineID,
+	})
+	if err != nil {
+		t.Fatalf("RecordPipelineTransition: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestRecordPipelineTransition_FailsClosedOnMixedSchemaCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(mixedTransitionSchemaRows())
+	pg := &store.PostgresStore{DB: db}
+	err = runtimepipeline.RecordPipelineTransition(context.Background(), db, pg.CanonicalEventReceiptsCapability, runtimepipeline.PipelineTransitionInput{
+		EventID:    uuid.NewString(),
+		EventType:  "review.requested",
+		Handler:    "node-a",
+		PipelineID: uuid.NewString(),
+	})
+	if err != nil {
+		t.Fatalf("RecordPipelineTransition: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func canonicalTransitionSchemaRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"table_name", "column_name"}).
+		AddRow("events", "event_id").
+		AddRow("events", "event_name").
+		AddRow("events", "entity_id").
+		AddRow("events", "flow_instance").
+		AddRow("events", "scope").
+		AddRow("events", "payload").
+		AddRow("events", "chain_depth").
+		AddRow("events", "produced_by").
+		AddRow("events", "produced_by_type").
+		AddRow("events", "source_event_id").
+		AddRow("events", "created_at").
+		AddRow("event_receipts", "receipt_id").
+		AddRow("event_receipts", "event_id").
+		AddRow("event_receipts", "subscriber_type").
+		AddRow("event_receipts", "subscriber_id").
+		AddRow("event_receipts", "entity_id").
+		AddRow("event_receipts", "flow_instance").
+		AddRow("event_receipts", "outcome").
+		AddRow("event_receipts", "reason_code").
+		AddRow("event_receipts", "state_before").
+		AddRow("event_receipts", "state_after").
+		AddRow("event_receipts", "side_effects").
+		AddRow("event_receipts", "duration_ms").
+		AddRow("event_receipts", "idempotency_key").
+		AddRow("event_receipts", "processed_at")
+}
+
+func mixedTransitionSchemaRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"table_name", "column_name"}).
+		AddRow("events", "id").
+		AddRow("events", "type").
+		AddRow("events", "source_agent").
+		AddRow("events", "task_id").
+		AddRow("events", "entity_id").
+		AddRow("events", "payload").
+		AddRow("events", "created_at").
+		AddRow("event_receipts", "receipt_id").
+		AddRow("event_receipts", "event_id").
+		AddRow("event_receipts", "subscriber_type").
+		AddRow("event_receipts", "subscriber_id").
+		AddRow("event_receipts", "entity_id").
+		AddRow("event_receipts", "flow_instance").
+		AddRow("event_receipts", "outcome").
+		AddRow("event_receipts", "reason_code").
+		AddRow("event_receipts", "state_before").
+		AddRow("event_receipts", "state_after").
+		AddRow("event_receipts", "side_effects").
+		AddRow("event_receipts", "duration_ms").
+		AddRow("event_receipts", "idempotency_key").
+		AddRow("event_receipts", "processed_at")
+}


### PR DESCRIPTION
risk: high

## Summary
- route pipeline transition persistence through the store-owned canonical schema capability boundary
- remove the duplicate runtime diagnostics implementation of pipeline transition persistence
- fail closed for mixed-schema and capability-missing cases instead of making local fallback decisions

## Canonical owner
- canonical schema decision owner: internal/store/schema_capabilities.go
- touched runtime consumer: internal/runtime/pipeline/workflow_transitions.go
- bus wiring: internal/runtime/bus/eventbus_publish.go

## Validation
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated pipeline transition persistence to check store capabilities before recording event receipts.
  * Removed legacy pipeline transition diagnostics API.
  * Simplified transition recording by eliminating fallback error-handling logic.

* **Tests**
  * Added test coverage for pipeline transition recording with canonical event receipts capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->