### PR TITLE
[agent-a][issue #87] Reduce store capability type-assertion patterns in core runtime paths

### DIFF
--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -17,13 +17,8 @@ import (
 
 type SchedulePersistence interface {
 	UpsertSchedule(ctx context.Context, sc Schedule) error
-	CancelSchedule(ctx context.Context, agentID, eventType string) error
-	LoadActiveSchedules(ctx context.Context) ([]Schedule, error)
-	MarkScheduleFired(ctx context.Context, sc Schedule) error
-}
-
-type ExactSchedulePersistence interface {
 	CancelScheduleExact(ctx context.Context, sc Schedule) error
+	LoadActiveSchedules(ctx context.Context) ([]Schedule, error)
 	MarkScheduleFiredExact(ctx context.Context, sc Schedule) error
 }
 

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -411,16 +411,7 @@ func (pc *PipelineCoordinator) cancelWorkflowTimerSchedule(ctx context.Context, 
 	if pc.timerScheduleStore == nil {
 		return
 	}
-	if exactStore, ok := pc.timerScheduleStore.(ExactSchedulePersistence); ok {
-		if err := exactStore.CancelScheduleExact(ctx, sc); err != nil {
-			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
-				"task_id": strings.TrimSpace(sc.TaskID),
-				"mode":    strings.TrimSpace(sc.Mode),
-			}, err)
-		}
-		return
-	}
-	if err := pc.timerScheduleStore.CancelSchedule(ctx, sc.AgentID, sc.EventType); err != nil {
+	if err := pc.timerScheduleStore.CancelScheduleExact(ctx, sc); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 			"task_id": strings.TrimSpace(sc.TaskID),
 			"mode":    strings.TrimSpace(sc.Mode),
@@ -460,14 +451,7 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 		return
 	}
 	if pc.timerScheduleStore != nil {
-		if exactStore, ok := pc.timerScheduleStore.(ExactSchedulePersistence); ok {
-			if err := exactStore.CancelScheduleExact(ctx, sc); err != nil {
-				pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
-					"task_id": strings.TrimSpace(sc.TaskID),
-					"mode":    strings.TrimSpace(sc.Mode),
-				}, err)
-			}
-		} else if err := pc.timerScheduleStore.CancelSchedule(ctx, sc.AgentID, sc.EventType); err != nil {
+		if err := pc.timerScheduleStore.CancelScheduleExact(ctx, sc); err != nil {
 			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 type recordingSchedulePersistence struct {
-	schedules []Schedule
-	cancels   []Schedule
+	schedules    []Schedule
+	cancels      []Schedule
+	cancelExacts int
 }
 
 func (s *recordingSchedulePersistence) UpsertSchedule(_ context.Context, sc Schedule) error {
@@ -24,19 +25,12 @@ func (s *recordingSchedulePersistence) UpsertSchedule(_ context.Context, sc Sche
 	return nil
 }
 
-func (s *recordingSchedulePersistence) CancelSchedule(context.Context, string, string) error {
-	return nil
-}
-
 func (s *recordingSchedulePersistence) LoadActiveSchedules(context.Context) ([]Schedule, error) {
 	return nil, nil
 }
 
-func (s *recordingSchedulePersistence) MarkScheduleFired(context.Context, Schedule) error {
-	return nil
-}
-
 func (s *recordingSchedulePersistence) CancelScheduleExact(_ context.Context, sc Schedule) error {
+	s.cancelExacts++
 	s.cancels = append(s.cancels, sc)
 	return nil
 }
@@ -378,6 +372,9 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	}
 	if len(store.cancels) != 1 {
 		t.Fatalf("cancelled schedules = %d, want 1", len(store.cancels))
+	}
+	if store.cancelExacts != 1 {
+		t.Fatalf("CancelScheduleExact calls = %d, want 1", store.cancelExacts)
 	}
 	if got := store.cancels[0].TaskID; got != timeridentity.AccumulationTimeoutHandle(timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived")).TaskID() {
 		t.Fatalf("cancelled task_id = %q", got)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -281,17 +281,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			}
 		}
 		if stores.ScheduleStore != nil {
-			if exactStore, ok := stores.ScheduleStore.(runtimepipeline.ExactSchedulePersistence); ok {
-				if err := exactStore.MarkScheduleFiredExact(callbackCtx, sc); err != nil {
-					if rt.Logger != nil {
-						handleRuntimeLogPersistenceError("scheduler", "mark_fired_failed", rt.Logger.Error(callbackCtx, "scheduler", "mark_fired_failed", map[string]any{
-							"agent_id":   sc.AgentID,
-							"event_type": sc.EventType,
-							"entity_id":  sc.EffectiveEntityID(),
-						}, err))
-					}
-				}
-			} else if err := stores.ScheduleStore.MarkScheduleFired(callbackCtx, sc); err != nil {
+			if err := stores.ScheduleStore.MarkScheduleFiredExact(callbackCtx, sc); err != nil {
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("scheduler", "mark_fired_failed", rt.Logger.Error(callbackCtx, "scheduler", "mark_fired_failed", map[string]any{
 						"agent_id":   sc.AgentID,

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	llm "swarm/internal/runtime/llm"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -97,7 +101,9 @@ func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
 }
 
 type recordingRuntimeScheduleStore struct {
-	schedules []runtimepipeline.Schedule
+	schedules  []runtimepipeline.Schedule
+	firedExact atomic.Int32
+	fired      chan runtimepipeline.Schedule
 }
 
 func (s *recordingRuntimeScheduleStore) UpsertSchedule(_ context.Context, sc runtimepipeline.Schedule) error {
@@ -105,7 +111,7 @@ func (s *recordingRuntimeScheduleStore) UpsertSchedule(_ context.Context, sc run
 	return nil
 }
 
-func (*recordingRuntimeScheduleStore) CancelSchedule(context.Context, string, string) error {
+func (*recordingRuntimeScheduleStore) CancelScheduleExact(context.Context, runtimepipeline.Schedule) error {
 	return nil
 }
 
@@ -113,7 +119,14 @@ func (*recordingRuntimeScheduleStore) LoadActiveSchedules(context.Context) ([]ru
 	return nil, nil
 }
 
-func (*recordingRuntimeScheduleStore) MarkScheduleFired(context.Context, runtimepipeline.Schedule) error {
+func (s *recordingRuntimeScheduleStore) MarkScheduleFiredExact(_ context.Context, sc runtimepipeline.Schedule) error {
+	s.firedExact.Add(1)
+	if s.fired != nil {
+		select {
+		case s.fired <- sc:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -134,6 +147,16 @@ func (semanticOnlyWorkflowRuntime) TransitionEvaluator() runtimepipeline.Transit
 }
 func (semanticOnlyWorkflowRuntime) GuardRegistry() runtimepipeline.GuardRegistry   { return nil }
 func (semanticOnlyWorkflowRuntime) ActionRegistry() runtimepipeline.ActionRegistry { return nil }
+
+type noopLLMRuntime struct{}
+
+func (noopLLMRuntime) StartSession(context.Context, string, string, []llm.ToolDefinition) (*llm.Session, error) {
+	return &llm.Session{}, nil
+}
+
+func (noopLLMRuntime) ContinueSession(context.Context, *llm.Session, llm.Message) (*llm.Response, error) {
+	return &llm.Response{}, nil
+}
 
 func TestEnsureRecurringWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
@@ -180,5 +203,52 @@ func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing
 	}
 	if got := store.schedules[0].EventType; got != "timer.daily_report" {
 		t.Fatalf("scheduled event = %q, want timer.daily_report", got)
+	}
+}
+
+func TestNewRuntime_SchedulerMarksSchedulesFiredThroughExactContract(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", "test-boot-success")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	store := &recordingRuntimeScheduleStore{fired: make(chan runtimepipeline.Schedule, 1)}
+	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{ScheduleStore: store}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if rt.Scheduler == nil {
+		t.Fatal("expected scheduler")
+	}
+	t.Cleanup(rt.Scheduler.Stop)
+
+	sc := runtimepipeline.Schedule{
+		AgentID:   "runtime",
+		EventType: "timer.check",
+		Mode:      "once",
+		TaskID:    "check_timer",
+		At:        time.Now().Add(10 * time.Millisecond),
+		EntityID:  "ent-001",
+	}
+	if err := rt.Scheduler.Register(sc); err != nil {
+		t.Fatalf("Register(schedule): %v", err)
+	}
+
+	select {
+	case fired := <-store.fired:
+		if fired.TaskID != sc.TaskID {
+			t.Fatalf("fired task_id = %q, want %q", fired.TaskID, sc.TaskID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for exact schedule fire persistence")
+	}
+	if got := store.firedExact.Load(); got != 1 {
+		t.Fatalf("MarkScheduleFiredExact calls = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary
- remove the runtime schedule persistence exact-vs-generic feature matrix from the core runtime path
- make schedule fire/cancel behavior depend on the explicit schedule persistence contract
- add focused regressions proving runtime fire/cancel paths use the explicit exact contract

## Testing
- go test ./internal/runtime/pipeline ./internal/runtime -count=1
- go test ./... -count=1