### PR TITLE
[agent-d][issue #85] Replace string-heavy core runtime semantics with stronger domain types in stable seams

### DIFF
--- a/internal/builder/runs_runtime.go
+++ b/internal/builder/runs_runtime.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
+	"swarm/internal/runtime/diaglog"
 )
 
 func (h *runHub) handleRuntimeLog(entry runtimepkg.RuntimeLogEntry) {
@@ -66,7 +67,7 @@ func (h *runHub) toRunEvent(entry runtimepkg.RuntimeLogEntry) RunEventEnvelope {
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
 		"instance_id": strings.TrimSpace(entry.EntityID),
 		"payload": map[string]any{
-			"level":      strings.TrimSpace(entry.Level),
+			"level":      entry.Level.String(),
 			"component":  strings.TrimSpace(entry.Component),
 			"action":     strings.TrimSpace(entry.Action),
 			"event_type": strings.TrimSpace(entry.EventType),
@@ -267,7 +268,7 @@ type runtimeLoggerHook struct {
 	hub  *runHub
 }
 
-func (h runtimeLoggerHook) Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
+func (h runtimeLoggerHook) Log(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
 	entry := runtimepkg.RuntimeLogEntry{
 		Level: level, Message: message, Component: component, Action: action, EventID: eventID, EventType: eventType,
 		AgentID: agentID, EntityID: entityID, SessionID: sessionID, Correlation: correlation,

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -15,6 +15,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/flowmodel"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -164,7 +165,7 @@ type recordedLogEntry struct {
 	Detail any
 }
 
-func (h *recordingLoggerHook) Log(_ context.Context, _, _, _, action, _, _, _, _, _ string, _ map[string]string, detail any, _ string, _ int) error {
+func (h *recordingLoggerHook) Log(_ context.Context, _ diaglog.Level, _, _, action, _, _, _, _, _ string, _ map[string]string, detail any, _ string, _ int) error {
 	h.entries = append(h.entries, recordedLogEntry{Action: action, Detail: detail})
 	return nil
 }

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -239,7 +239,7 @@ func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, er
 	}
 }
 
-func (eb *EventBus) logRuntime(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
+func (eb *EventBus) logRuntime(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
 	if eb == nil {
 		return nil
 	}

--- a/internal/runtime/bus/hooks.go
+++ b/internal/runtime/bus/hooks.go
@@ -1,7 +1,11 @@
 package bus
 
-import "context"
+import (
+	"context"
+
+	"swarm/internal/runtime/diaglog"
+)
 
 type LoggerHook interface {
-	Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error
+	Log(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error
 }

--- a/internal/runtime/bus/turn_context.go
+++ b/internal/runtime/bus/turn_context.go
@@ -135,7 +135,7 @@ func (r *EmittedEventsRecorder) AppendRuntimeLog(entry diaglog.RunEntry) {
 	r.mu.Lock()
 	r.flightRecorder = append(r.flightRecorder, FlightRecorderEntry{
 		Kind:       "runtime_log",
-		LogLevel:   strings.TrimSpace(entry.Level),
+		LogLevel:   entry.Level.String(),
 		Message:    strings.TrimSpace(entry.Message),
 		Details:    cloneJSONValue(runtimeLogDetails(entry)),
 		StackTrace: strings.TrimSpace(entry.StackTrace),

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -49,13 +49,13 @@ func TestSessionScopeConformance(t *testing.T) {
 	cases := []sessionScopeConformanceCase{
 		{
 			name:               "task_stateless",
-			actor:              runtimeactors.AgentConfig{ID: "task-agent", Role: "task_agent", ConversationMode: runtimesessions.RuntimeModeTask},
+			actor:              runtimeactors.AgentConfig{ID: "task-agent", Role: "task_agent", ConversationMode: runtimesessions.RuntimeModeTask.String()},
 			expectLoadFound:    false,
 			acquireErrContains: "task-scoped sessions are stateless",
 		},
 		{
 			name:               "task_rejects_session_scope",
-			actor:              runtimeactors.AgentConfig{ID: "task-invalid", Role: "task_invalid", ConversationMode: runtimesessions.RuntimeModeTask, SessionScope: runtimesessions.SessionScopeGlobal},
+			actor:              runtimeactors.AgentConfig{ID: "task-invalid", Role: "task_invalid", ConversationMode: runtimesessions.RuntimeModeTask.String(), SessionScope: runtimesessions.SessionScopeGlobal.String()},
 			bootErrContains:    "task mode does not use sessions; session_scope must be absent",
 			buildErrContains:   "task mode does not use sessions; session_scope must be absent",
 			acquireErrContains: "task mode does not use sessions; session_scope must be absent",
@@ -64,14 +64,14 @@ func TestSessionScopeConformance(t *testing.T) {
 		},
 		{
 			name:            "session_global_root",
-			actor:           runtimeactors.AgentConfig{ID: "global-agent", Role: "global_agent", ConversationMode: runtimesessions.RuntimeModeSession, SessionScope: runtimesessions.SessionScopeGlobal},
+			actor:           runtimeactors.AgentConfig{ID: "global-agent", Role: "global_agent", ConversationMode: runtimesessions.RuntimeModeSession.String(), SessionScope: runtimesessions.SessionScopeGlobal.String()},
 			expectLoadFound: true,
-			expectScope:     runtimesessions.SessionScopeGlobal,
-			expectScopeKey:  runtimesessions.SessionScopeGlobal,
+			expectScope:     runtimesessions.SessionScopeGlobal.String(),
+			expectScopeKey:  runtimesessions.SessionScopeGlobal.String(),
 		},
 		{
 			name:               "session_requires_explicit_scope",
-			actor:              runtimeactors.AgentConfig{ID: "session-invalid", Role: "session_invalid", ConversationMode: runtimesessions.RuntimeModeSession},
+			actor:              runtimeactors.AgentConfig{ID: "session-invalid", Role: "session_invalid", ConversationMode: runtimesessions.RuntimeModeSession.String()},
 			bootErrContains:    "session mode requires explicit session_scope (global or flow)",
 			buildErrContains:   "session mode requires explicit session_scope (global or flow)",
 			acquireErrContains: "session mode requires explicit session_scope (global or flow)",
@@ -80,15 +80,15 @@ func TestSessionScopeConformance(t *testing.T) {
 		},
 		{
 			name:            "session_flow_in_flow",
-			actor:           runtimeactors.AgentConfig{ID: "flow-agent", Role: "flow_agent", ConversationMode: runtimesessions.RuntimeModeSession, SessionScope: runtimesessions.SessionScopeFlow, FlowPath: "support/inst-1"},
+			actor:           runtimeactors.AgentConfig{ID: "flow-agent", Role: "flow_agent", ConversationMode: runtimesessions.RuntimeModeSession.String(), SessionScope: runtimesessions.SessionScopeFlow.String(), FlowPath: "support/inst-1"},
 			bootInFlow:      true,
 			expectLoadFound: true,
-			expectScope:     runtimesessions.SessionScopeFlow,
+			expectScope:     runtimesessions.SessionScopeFlow.String(),
 			expectScopeKey:  "support/inst-1",
 		},
 		{
 			name:               "session_flow_requires_flow_metadata",
-			actor:              runtimeactors.AgentConfig{ID: "flow-root-invalid", Role: "flow_root_invalid", ConversationMode: runtimesessions.RuntimeModeSession, SessionScope: runtimesessions.SessionScopeFlow},
+			actor:              runtimeactors.AgentConfig{ID: "flow-root-invalid", Role: "flow_root_invalid", ConversationMode: runtimesessions.RuntimeModeSession.String(), SessionScope: runtimesessions.SessionScopeFlow.String()},
 			bootErrContains:    "session_scope flow requires flow-scoped declaration",
 			buildErrContains:   "session_scope flow requires flow path metadata",
 			acquireErrContains: "session_scope flow requires actor flow path",
@@ -97,16 +97,16 @@ func TestSessionScopeConformance(t *testing.T) {
 		},
 		{
 			name:            "session_per_entity_in_flow",
-			actor:           runtimeactors.AgentConfig{ID: "entity-agent", Role: "entity_agent", ConversationMode: runtimesessions.RuntimeModeSessionPerEntity, SessionScope: runtimesessions.SessionScopeEntity, FlowPath: "support/inst-1"},
+			actor:           runtimeactors.AgentConfig{ID: "entity-agent", Role: "entity_agent", ConversationMode: runtimesessions.RuntimeModeSessionPerEntity.String(), SessionScope: runtimesessions.SessionScopeEntity.String(), FlowPath: "support/inst-1"},
 			bootInFlow:      true,
 			runtimeScopeKey: "11111111-1111-1111-1111-111111111111",
 			expectLoadFound: true,
-			expectScope:     runtimesessions.SessionScopeEntity,
+			expectScope:     runtimesessions.SessionScopeEntity.String(),
 			expectScopeKey:  "11111111-1111-1111-1111-111111111111",
 		},
 		{
 			name:               "session_per_entity_rejects_global_scope",
-			actor:              runtimeactors.AgentConfig{ID: "entity-global-invalid", Role: "entity_global_invalid", ConversationMode: runtimesessions.RuntimeModeSessionPerEntity, SessionScope: runtimesessions.SessionScopeGlobal, FlowPath: "support/inst-1"},
+			actor:              runtimeactors.AgentConfig{ID: "entity-global-invalid", Role: "entity_global_invalid", ConversationMode: runtimesessions.RuntimeModeSessionPerEntity.String(), SessionScope: runtimesessions.SessionScopeGlobal.String(), FlowPath: "support/inst-1"},
 			bootInFlow:         true,
 			bootErrContains:    "session_per_entity does not support global scope; use session with session_scope: global",
 			buildErrContains:   "session_per_entity does not support global scope; use session with session_scope: global",
@@ -153,7 +153,7 @@ func assertSessionAcquisitionBoundary(t *testing.T, tc sessionScopeConformanceCa
 	t.Helper()
 	registry := runtimesessions.NewInMemoryRegistry(0)
 	ctx := runtimeactors.WithActor(context.Background(), tc.actor)
-	lease, err := registry.Acquire(ctx, tc.actor.ID, conversationModeOrTask(tc.actor), tc.actor.SessionScope, "conformance", tc.scopeKey())
+	lease, err := registry.Acquire(ctx, tc.actor.ID, conversationModeOrTask(tc.actor), runtimesessions.NormalizeSessionScope(tc.actor.SessionScope), "conformance", tc.scopeKey())
 	if strings.TrimSpace(tc.acquireErrContains) != "" {
 		assertErrorContains(t, "session acquisition", err, tc.acquireErrContains)
 		return
@@ -164,7 +164,7 @@ func assertSessionAcquisitionBoundary(t *testing.T, tc sessionScopeConformanceCa
 	if lease == nil {
 		t.Fatal("session acquisition returned nil lease")
 	}
-	if lease.SessionScope != tc.expectScope {
+	if lease.SessionScope.String() != tc.expectScope {
 		t.Fatalf("lease.SessionScope = %q, want %q", lease.SessionScope, tc.expectScope)
 	}
 	if lease.ScopeKey != tc.expectScopeKey {
@@ -189,7 +189,7 @@ func assertConversationPersistenceBoundary(t *testing.T, ctx context.Context, pg
 		AgentID:      tc.actor.ID,
 		SessionScope: tc.actor.SessionScope,
 		ScopeKey:     tc.scopeKey(),
-		Mode:         conversationModeOrTask(tc.actor),
+		Mode:         conversationModeOrTask(tc.actor).String(),
 		Messages:     []runtimellm.Message{{Role: "assistant", Content: "ok"}},
 		Summary:      "ok",
 		TurnCount:    1,
@@ -204,7 +204,7 @@ func assertConversationPersistenceBoundary(t *testing.T, ctx context.Context, pg
 		t.Fatalf("conversation persistence: %v", err)
 	}
 
-	loaded, ok, err := pg.LoadActiveConversation(ctx, tc.actor.ID, conversationModeOrTask(tc.actor), tc.actor.SessionScope, tc.scopeKey())
+	loaded, ok, err := pg.LoadActiveConversation(ctx, tc.actor.ID, conversationModeOrTask(tc.actor).String(), tc.actor.SessionScope, tc.scopeKey())
 	if err != nil {
 		t.Fatalf("conversation load: %v", err)
 	}
@@ -247,8 +247,8 @@ func assertRecoveryBoundary(t *testing.T, tc sessionScopeConformanceCase) {
 	if !ok {
 		t.Fatalf("recover did not restore agent %s", tc.actor.ID)
 	}
-	if cfg.ConversationMode != conversationModeOrTask(tc.actor) {
-		t.Fatalf("recovered ConversationMode = %q, want %q", cfg.ConversationMode, conversationModeOrTask(tc.actor))
+	if cfg.ConversationMode != conversationModeOrTask(tc.actor).String() {
+		t.Fatalf("recovered ConversationMode = %q, want %q", cfg.ConversationMode, conversationModeOrTask(tc.actor).String())
 	}
 	if cfg.SessionScope != tc.actor.SessionScope {
 		t.Fatalf("recovered SessionScope = %q, want %q", cfg.SessionScope, tc.actor.SessionScope)
@@ -260,18 +260,18 @@ func (tc sessionScopeConformanceCase) scopeKey() string {
 		return scopeKey
 	}
 	switch strings.TrimSpace(tc.actor.SessionScope) {
-	case runtimesessions.SessionScopeGlobal:
-		return runtimesessions.SessionScopeGlobal
-	case runtimesessions.SessionScopeFlow:
+	case runtimesessions.SessionScopeGlobal.String():
+		return runtimesessions.SessionScopeGlobal.String()
+	case runtimesessions.SessionScopeFlow.String():
 		return tc.actor.CanonicalFlowPath()
 	default:
 		return ""
 	}
 }
 
-func conversationModeOrTask(actor runtimeactors.AgentConfig) string {
+func conversationModeOrTask(actor runtimeactors.AgentConfig) runtimesessions.RuntimeMode {
 	if mode := strings.TrimSpace(actor.ConversationMode); mode != "" {
-		return mode
+		return runtimesessions.NormalizeConversationRuntimeMode(mode)
 	}
 	return runtimesessions.RuntimeModeTask
 }

--- a/internal/runtime/diaglog/diaglog.go
+++ b/internal/runtime/diaglog/diaglog.go
@@ -8,8 +8,29 @@ import (
 	"strings"
 )
 
+type Level string
+
+const (
+	LevelInfo  Level = "info"
+	LevelWarn  Level = "warn"
+	LevelError Level = "error"
+)
+
+func (l Level) String() string { return string(l) }
+
+func NormalizeLevel(raw string) Level {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "warn", "warning":
+		return LevelWarn
+	case "error":
+		return LevelError
+	default:
+		return LevelInfo
+	}
+}
+
 type RunEntry struct {
-	Level       string
+	Level       Level
 	Message     string
 	Component   string
 	Action      string
@@ -47,11 +68,8 @@ func RunLog(ctx context.Context, logger RunLogger, entry RunEntry) error {
 	return logger.LogRuntime(ctx, entry)
 }
 
-func ProcessLog(level, component, message string, fields ...any) {
-	level = strings.TrimSpace(strings.ToLower(level))
-	if level == "" {
-		level = "info"
-	}
+func ProcessLog(level Level, component, message string, fields ...any) {
+	level = NormalizeLevel(level.String())
 	component = strings.TrimSpace(component)
 	if component == "" {
 		component = "runtime"
@@ -82,11 +100,11 @@ func ProcessLog(level, component, message string, fields ...any) {
 	log.Printf("%s component=%s detail=%s", levelTag(level), component, string(raw))
 }
 
-func levelTag(level string) string {
-	switch strings.TrimSpace(strings.ToLower(level)) {
-	case "warn", "warning":
+func levelTag(level Level) string {
+	switch NormalizeLevel(level.String()) {
+	case LevelWarn:
 		return "runtime.warn"
-	case "error":
+	case LevelError:
 		return "runtime.error"
 	default:
 		return "runtime.info"

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -14,7 +14,7 @@ import (
 
 // RuntimeLogEntry is a structured runtime operation record (spec v2.0.14).
 type RuntimeLogEntry struct {
-	Level     string
+	Level     diaglog.Level
 	Message   string
 	Component string
 	Action    string
@@ -73,10 +73,7 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 	if l == nil {
 		return nil
 	}
-	level := strings.ToLower(strings.TrimSpace(e.Level))
-	if level == "" {
-		level = "info"
-	}
+	level := diaglog.NormalizeLevel(e.Level.String())
 	component := strings.TrimSpace(e.Component)
 	if component == "" {
 		component = "runtime"
@@ -116,7 +113,7 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 	}
 
 	detail := marshalJSONOrEmpty(e.Detail)
-	if err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level, component, action, e, detail); err != nil {
+	if err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level.String(), component, action, e, detail); err != nil {
 		return err
 	}
 	return nil
@@ -131,8 +128,8 @@ func (l *RuntimeLogger) Warn(ctx context.Context, component, action string, deta
 		errText = strings.TrimSpace(err.Error())
 	}
 	return l.Log(ctx, RuntimeLogEntry{
-		Level:     "warn",
-		Message:   runtimeLogHelperMessage("warn", component, action),
+		Level:     diaglog.LevelWarn,
+		Message:   runtimeLogHelperMessage(diaglog.LevelWarn, component, action),
 		Component: strings.TrimSpace(component),
 		Action:    strings.TrimSpace(action),
 		Detail:    detail,
@@ -149,8 +146,8 @@ func (l *RuntimeLogger) Error(ctx context.Context, component, action string, det
 		errText = strings.TrimSpace(err.Error())
 	}
 	return l.Log(ctx, RuntimeLogEntry{
-		Level:     "error",
-		Message:   runtimeLogHelperMessage("error", component, action),
+		Level:     diaglog.LevelError,
+		Message:   runtimeLogHelperMessage(diaglog.LevelError, component, action),
 		Component: strings.TrimSpace(component),
 		Action:    strings.TrimSpace(action),
 		Detail:    detail,
@@ -158,11 +155,11 @@ func (l *RuntimeLogger) Error(ctx context.Context, component, action string, det
 	})
 }
 
-func runtimeLogHelperMessage(level, component, action string) string {
+func runtimeLogHelperMessage(level diaglog.Level, component, action string) string {
 	component = strings.TrimSpace(component)
 	action = strings.TrimSpace(action)
-	switch strings.ToLower(strings.TrimSpace(level)) {
-	case "error":
+	switch diaglog.NormalizeLevel(level.String()) {
+	case diaglog.LevelError:
 		if component != "" {
 			return "Runtime error recorded by " + component
 		}

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -8,6 +8,7 @@ import (
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 )
@@ -76,7 +77,7 @@ type runtimeLoggerHook struct {
 	logger *RuntimeLogger
 }
 
-func (h runtimeLoggerHook) Log(ctx context.Context, level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
+func (h runtimeLoggerHook) Log(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
 	if h.logger == nil {
 		return nil
 	}

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -71,7 +71,7 @@ func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
-		Mode:         mode,
+		Mode:         mode.String(),
 		Messages:     s.Messages,
 		Summary:      BuildSessionSummary(s),
 		TurnCount:    s.TurnCount,
@@ -81,7 +81,7 @@ func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s
 
 func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
 	scope := sessions.ScopeFromContext(ctx)
-	resolved, err := resolvedSessionScope(ctx, scope.ConversationMode, scope.SessionScope, scope.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(scope.ConversationMode), sessions.NormalizeSessionScope(scope.SessionScope), scope.ScopeKey)
 	if err != nil {
 		return nil, err
 	}
@@ -105,9 +105,9 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 			return ""
 		}()),
 		AgentID:          agentID,
-		RuntimeMode:      resolved.RuntimeMode,
-		ConversationMode: resolved.RuntimeMode,
-		SessionScope:     resolved.Scope,
+		RuntimeMode:      resolved.RuntimeMode.String(),
+		ConversationMode: resolved.RuntimeMode.String(),
+		SessionScope:     resolved.Scope.String(),
 		ScopeKey:         resolved.ScopeKey,
 		ProviderSessionID: func() string {
 			if lease != nil {
@@ -120,7 +120,7 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 		Messages:     nil,
 	}
 	if r.conversations != nil && !resolved.Stateless {
-		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode, resolved.Scope, resolved.ScopeKey); err == nil && ok {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
 		}
@@ -148,7 +148,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		}
 	}
 
-	resolved, err := resolvedSessionScope(ctx, coalesce(s.ConversationMode, s.RuntimeMode), coalesce(s.SessionScope, ""), s.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode)), sessions.NormalizeSessionScope(coalesce(s.SessionScope, "")), s.ScopeKey)
 	if err != nil {
 		return nil, err
 	}
@@ -161,14 +161,14 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		defer func() { _ = r.sessions.Release(ctx, lease) }()
 		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
 			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the API session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
-				"runtime_mode": resolved.RuntimeMode,
+				"runtime_mode": resolved.RuntimeMode.String(),
 				"scope_key":    resolved.ScopeKey,
 			}, heartbeatErr)
 		})
 		defer stopLeaseHeartbeat()
 
 		if lease.SessionID != s.ID {
-			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode, s.ID, lease.SessionID, resolved.ScopeKey)
+			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), s.ID, lease.SessionID, resolved.ScopeKey)
 			s.ID = lease.SessionID
 		}
 	}
@@ -226,7 +226,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 		s.ParseFailures++
 		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
 			AgentID:        s.AgentID,
-			RuntimeMode:    resolved.RuntimeMode,
+			RuntimeMode:    resolved.RuntimeMode.String(),
 			SessionID:      s.ID,
 			RequestPayload: reqJSON,
 			ResponseRaw:    rawResp,
@@ -257,7 +257,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 
 	r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
 		AgentID:        s.AgentID,
-		RuntimeMode:    resolved.RuntimeMode,
+		RuntimeMode:    resolved.RuntimeMode.String(),
 		SessionID:      s.ID,
 		RequestPayload: reqJSON,
 		ResponseRaw:    rawResp,
@@ -308,14 +308,14 @@ func (r *AnthropicAPIRuntime) persistConversation(ctx context.Context, s *Sessio
 		AgentID:      s.AgentID,
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
-		Mode:         mode,
+		Mode:         mode.String(),
 		Messages:     s.Messages,
 		Summary:      BuildSessionSummary(s),
 		TurnCount:    s.TurnCount,
 		Status:       "active",
 	}); err != nil {
 		logPublisherRuntime(ctx, r.events, "error", "persist_api_conversation_failed", "Persisting the API conversation failed", s.AgentID, s.ID, "", map[string]any{
-			"conversation_mode": mode,
+			"conversation_mode": mode.String(),
 			"scope_key":         strings.TrimSpace(s.ScopeKey),
 		}, err)
 	}

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -108,7 +108,7 @@ func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *S
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
-		Mode:         mode,
+		Mode:         mode.String(),
 		Messages:     s.Messages,
 		Summary:      BuildSessionSummary(s),
 		TurnCount:    s.TurnCount,
@@ -118,7 +118,7 @@ func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *S
 
 func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
 	scope := sessions.ScopeFromContext(ctx)
-	resolved, err := resolvedSessionScope(ctx, scope.ConversationMode, scope.SessionScope, scope.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(scope.ConversationMode), sessions.NormalizeSessionScope(scope.SessionScope), scope.ScopeKey)
 	if err != nil {
 		return nil, err
 	}
@@ -148,16 +148,16 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 			return ""
 		}(),
 		AgentID:          agentID,
-		RuntimeMode:      resolved.RuntimeMode,
-		ConversationMode: resolved.RuntimeMode,
-		SessionScope:     resolved.Scope,
+		RuntimeMode:      resolved.RuntimeMode.String(),
+		ConversationMode: resolved.RuntimeMode.String(),
+		SessionScope:     resolved.Scope.String(),
 		ScopeKey:         resolved.ScopeKey,
 		SystemPrompt:     augmentCLISystemPrompt(systemPrompt, tools),
 		Tools:            tools,
 		Messages:         nil,
 	}
 	if r.conversations != nil && !resolved.Stateless {
-		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode, resolved.Scope, resolved.ScopeKey); err == nil && ok {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
 		}
@@ -187,7 +187,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 	}
 
-	resolved, err := resolvedSessionScope(ctx, coalesce(s.ConversationMode, s.RuntimeMode), coalesce(s.SessionScope, ""), s.ScopeKey)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode)), sessions.NormalizeSessionScope(coalesce(s.SessionScope, "")), s.ScopeKey)
 	if err != nil {
 		return nil, err
 	}
@@ -200,14 +200,14 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		defer func() { _ = r.sessions.Release(ctx, lease) }()
 		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
 			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the CLI session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
-				"runtime_mode": resolved.RuntimeMode,
+				"runtime_mode": resolved.RuntimeMode.String(),
 				"scope_key":    resolved.ScopeKey,
 			}, heartbeatErr)
 		})
 		defer stopLeaseHeartbeat()
 
 		if lease.SessionID != s.ID {
-			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode, s.ID, lease.SessionID, resolved.ScopeKey)
+			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), s.ID, lease.SessionID, resolved.ScopeKey)
 			s.ID = lease.SessionID
 		}
 		if sid := strings.TrimSpace(lease.ProviderSessionID); sid != "" {
@@ -225,7 +225,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		s.ParseFailures++
 		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
 			AgentID:        s.AgentID,
-			RuntimeMode:    resolved.RuntimeMode,
+			RuntimeMode:    resolved.RuntimeMode.String(),
 			SessionID:      s.ID,
 			RequestPayload: jsonBytes(map[string]any{"message": message}),
 			ParseOK:        false,
@@ -334,7 +334,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 				if len(s.Messages) > 0 {
 					s.Messages = []Message{{Role: "system", Content: "Session rotated due to CLI runtime recovery."}}
 				}
-				LogSessionRotatedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode, oldSessionID, rotated.SessionID, resolved.ScopeKey, rotateReason, oldTurnCount, oldParseFailures)
+				LogSessionRotatedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), oldSessionID, rotated.SessionID, resolved.ScopeKey, rotateReason, oldTurnCount, oldParseFailures)
 				args = []string{
 					"-p",
 					"--session-id", sessionToken(s),
@@ -387,7 +387,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		s.ParseFailures++
 		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
 			AgentID:     s.AgentID,
-			RuntimeMode: resolved.RuntimeMode,
+			RuntimeMode: resolved.RuntimeMode.String(),
 			SessionID:   s.ID,
 			RequestPayload: jsonBytes(map[string]any{
 				"args":                          args,
@@ -419,7 +419,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 				}, err)
 			} else {
 				s.ProviderSessionID = sid
-				LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode, oldSessionID, sid, resolved.ScopeKey)
+				LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), oldSessionID, sid, resolved.ScopeKey)
 			}
 		} else {
 			s.ProviderSessionID = sid
@@ -436,7 +436,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 
 	r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
 		AgentID:     s.AgentID,
-		RuntimeMode: resolved.RuntimeMode,
+		RuntimeMode: resolved.RuntimeMode.String(),
 		SessionID:   s.ID,
 		RequestPayload: jsonBytes(map[string]any{
 			"args":                          args,

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -47,14 +47,14 @@ func (r *ClaudeCLIRuntime) persistConversation(ctx context.Context, s *Session) 
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
-		Mode:         mode,
+		Mode:         mode.String(),
 		Messages:     s.Messages,
 		Summary:      BuildSessionSummary(s),
 		TurnCount:    s.TurnCount,
 		Status:       "active",
 	}); err != nil {
 		logPublisherRuntime(ctx, r.events, "error", "persist_cli_conversation_failed", "Persisting the CLI conversation failed", s.AgentID, s.ID, "", map[string]any{
-			"conversation_mode": mode,
+			"conversation_mode": mode.String(),
 			"scope_key":         strings.TrimSpace(s.ScopeKey),
 		}, err)
 	}
@@ -174,10 +174,10 @@ func dedupeToolCalls(calls []ToolCall) []ToolCall {
 }
 
 type sessionIDAdopter interface {
-	AdoptSessionID(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, newSessionID, scopeKey string) error
+	AdoptSessionID(ctx context.Context, agentID string, runtimeMode sessions.RuntimeMode, sessionScope sessions.SessionScope, lockOwner, newSessionID, scopeKey string) error
 }
 
-func adoptRegistrySessionID(ctx context.Context, reg sessions.Registry, agentID, runtimeMode, sessionScope, lockOwner, newSessionID, scopeKey string) error {
+func adoptRegistrySessionID(ctx context.Context, reg sessions.Registry, agentID string, runtimeMode sessions.RuntimeMode, sessionScope sessions.SessionScope, lockOwner, newSessionID, scopeKey string) error {
 	if reg == nil {
 		return nil
 	}

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -68,11 +68,11 @@ type Conversation struct {
 func ConversationModeString(mode ConversationMode) string {
 	switch mode {
 	case TaskScoped:
-		return sessions.RuntimeModeTask
+		return sessions.RuntimeModeTask.String()
 	case SessionScoped:
-		return sessions.RuntimeModeSession
+		return sessions.RuntimeModeSession.String()
 	case SessionPerEntityScoped:
-		return sessions.RuntimeModeSessionPerEntity
+		return sessions.RuntimeModeSessionPerEntity.String()
 	default:
 		return ""
 	}

--- a/internal/runtime/llm/runtime_logging.go
+++ b/internal/runtime/llm/runtime_logging.go
@@ -13,7 +13,7 @@ type RuntimeLogSink interface {
 	LogRuntime(ctx context.Context, entry runtimepipeline.RuntimeLogEntry) error
 }
 
-func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, message, agentID, sessionID, entityID string, detail any, err error) {
+func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level diaglog.Level, action, message, agentID, sessionID, entityID string, detail any, err error) {
 	if logger == nil {
 		return
 	}
@@ -23,7 +23,7 @@ func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, me
 		errText = strings.TrimSpace(err.Error())
 	}
 	if err := diaglog.RunLog(ctx, logger, runtimepipeline.RuntimeLogEntry{
-		Level:     strings.TrimSpace(level),
+		Level:     diaglog.NormalizeLevel(level.String()),
 		Message:   strings.TrimSpace(message),
 		Component: "llm-runtime",
 		Action:    strings.TrimSpace(action),
@@ -43,7 +43,7 @@ func logRunRuntime(ctx context.Context, logger RuntimeLogSink, level, action, me
 	}
 }
 
-func logPublisherRuntime(ctx context.Context, publisher EventPublisher, level, action, message, agentID, sessionID, entityID string, detail any, err error) {
+func logPublisherRuntime(ctx context.Context, publisher EventPublisher, level diaglog.Level, action, message, agentID, sessionID, entityID string, detail any, err error) {
 	if publisher == nil {
 		return
 	}

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -28,10 +28,10 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 		"model_tier":        sessionModelTier(actor),
 		"timestamp":         time.Now().UTC().Format(time.RFC3339Nano),
 	}
-	if flowInstance := strings.TrimSpace(actor.CanonicalFlowPath()); flowInstance != "" && strings.TrimSpace(session.SessionScope) == sessions.SessionScopeEntity {
+	if flowInstance := strings.TrimSpace(actor.CanonicalFlowPath()); flowInstance != "" && strings.TrimSpace(session.SessionScope) == sessions.SessionScopeEntity.String() {
 		payload["flow_instance"] = flowInstance
 	}
-	if flowInstance := strings.TrimSpace(session.ScopeKey); flowInstance != "" && strings.TrimSpace(session.SessionScope) == sessions.SessionScopeFlow {
+	if flowInstance := strings.TrimSpace(session.ScopeKey); flowInstance != "" && strings.TrimSpace(session.SessionScope) == sessions.SessionScopeFlow.String() {
 		payload["flow_instance"] = flowInstance
 	}
 	raw, err := json.Marshal(payload)

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -82,7 +82,7 @@ func (s *failingTurnStore) AppendAgentTurn(context.Context, AgentTurnRecord) err
 func TestAnthropicAPIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	publisher := &eventPublisherStub{}
 	runtime := NewAnthropicAPIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, publisher)
-	ctx := runtimeactors.WithActor(sessions.WithScope(context.Background(), sessions.RuntimeModeTask, "", "task-1"), runtimeactors.AgentConfig{
+	ctx := runtimeactors.WithActor(sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1"), runtimeactors.AgentConfig{
 		ID:       "agent-1",
 		Type:     "sonnet",
 		EntityID: "entity-1",
@@ -112,7 +112,7 @@ func TestAnthropicAPIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	if got := payload["agent_id"]; got != "agent-1" {
 		t.Fatalf("agent_id = %#v, want agent-1", got)
 	}
-	if got := payload["conversation_mode"]; got != sessions.RuntimeModeTask {
+	if got := payload["conversation_mode"]; got != sessions.RuntimeModeTask.String() {
 		t.Fatalf("conversation_mode = %#v, want task", got)
 	}
 	if got := payload["model_tier"]; got != "sonnet" {
@@ -126,7 +126,7 @@ func TestAnthropicAPIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 func TestClaudeCLIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	publisher := &eventPublisherStub{}
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, publisher)
-	ctx := runtimeactors.WithActor(sessions.WithScope(context.Background(), sessions.RuntimeModeTask, "", "task-1"), runtimeactors.AgentConfig{
+	ctx := runtimeactors.WithActor(sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1"), runtimeactors.AgentConfig{
 		ID:   "agent-2",
 		Type: "haiku",
 	})
@@ -162,7 +162,7 @@ func TestClaudeCLIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 
 func TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools(t *testing.T) {
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
-	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask, "", "task-1")
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1")
 
 	s, err := runtime.StartSession(ctx, "agent-2", "base prompt", []ToolDefinition{
 		{Name: "emit_market_research_scan_complete"},
@@ -194,14 +194,14 @@ func TestAnthropicAPIRuntime_PersistTurnIncludesTaskMode(t *testing.T) {
 
 	runtime.persistTurn(context.Background(), AgentTurnRecord{
 		AgentID:     "agent-1",
-		RuntimeMode: sessions.RuntimeModeTask,
+		RuntimeMode: sessions.RuntimeModeTask.String(),
 		SessionID:   "session-1",
 	})
 
 	if len(turns.records) != 1 {
 		t.Fatalf("expected task-mode turn to persist, got %d records", len(turns.records))
 	}
-	if turns.records[0].RuntimeMode != sessions.RuntimeModeTask {
+	if turns.records[0].RuntimeMode != sessions.RuntimeModeTask.String() {
 		t.Fatalf("runtime_mode = %q, want task", turns.records[0].RuntimeMode)
 	}
 }
@@ -212,14 +212,14 @@ func TestClaudeCLIRuntime_PersistTurnIncludesTaskMode(t *testing.T) {
 
 	runtime.persistTurn(context.Background(), AgentTurnRecord{
 		AgentID:     "agent-2",
-		RuntimeMode: sessions.RuntimeModeTask,
+		RuntimeMode: sessions.RuntimeModeTask.String(),
 		SessionID:   "session-2",
 	})
 
 	if len(turns.records) != 1 {
 		t.Fatalf("expected task-mode turn to persist, got %d records", len(turns.records))
 	}
-	if turns.records[0].RuntimeMode != sessions.RuntimeModeTask {
+	if turns.records[0].RuntimeMode != sessions.RuntimeModeTask.String() {
 		t.Fatalf("runtime_mode = %q, want task", turns.records[0].RuntimeMode)
 	}
 }
@@ -237,8 +237,8 @@ func TestPublishAgentStarted_LogsRuntimeFailures(t *testing.T) {
 	publishAgentStarted(ctx, publisher, &Session{
 		ID:                "session-1",
 		AgentID:           "agent-1",
-		ConversationMode:  sessions.RuntimeModeTask,
-		RuntimeMode:       sessions.RuntimeModeTask,
+		ConversationMode:  sessions.RuntimeModeTask.String(),
+		RuntimeMode:       sessions.RuntimeModeTask.String(),
 		ProviderSessionID: "provider-1",
 	}, events.EventType("platform.agent_started"))
 
@@ -278,7 +278,7 @@ func TestAnthropicAPIRuntime_PersistConversationFailureLogsRuntime(t *testing.T)
 	runtime.persistConversation(context.Background(), &Session{
 		ID:               "session-3",
 		AgentID:          "agent-3",
-		ConversationMode: sessions.RuntimeModeTask,
+		ConversationMode: sessions.RuntimeModeTask.String(),
 		ScopeKey:         "task-3",
 	})
 
@@ -297,12 +297,12 @@ func TestAnthropicAPIRuntime_PersistConversationIncludesSessionScope(t *testing.
 	runtime.persistConversation(context.Background(), &Session{
 		ID:               "session-3",
 		AgentID:          "agent-3",
-		ConversationMode: sessions.RuntimeModeSession,
-		SessionScope:     sessions.SessionScopeFlow,
+		ConversationMode: sessions.RuntimeModeSession.String(),
+		SessionScope:     sessions.SessionScopeFlow.String(),
 		ScopeKey:         "review/inst-1",
 	})
 
-	if store.record.SessionScope != sessions.SessionScopeFlow {
+	if store.record.SessionScope != sessions.SessionScopeFlow.String() {
 		t.Fatalf("SessionScope = %q, want %q", store.record.SessionScope, sessions.SessionScopeFlow)
 	}
 }
@@ -314,12 +314,12 @@ func TestClaudeCLIRuntime_PersistConversationIncludesSessionScope(t *testing.T) 
 	runtime.persistConversation(context.Background(), &Session{
 		ID:               "session-4",
 		AgentID:          "agent-4",
-		ConversationMode: sessions.RuntimeModeSessionPerEntity,
-		SessionScope:     sessions.SessionScopeEntity,
+		ConversationMode: sessions.RuntimeModeSessionPerEntity.String(),
+		SessionScope:     sessions.SessionScopeEntity.String(),
 		ScopeKey:         "entity-1",
 	})
 
-	if store.record.SessionScope != sessions.SessionScopeEntity {
+	if store.record.SessionScope != sessions.SessionScopeEntity.String() {
 		t.Fatalf("SessionScope = %q, want %q", store.record.SessionScope, sessions.SessionScopeEntity)
 	}
 }
@@ -387,7 +387,7 @@ func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 
 	rec := enrichTurnRecord(ctx, session, AgentTurnRecord{
 		AgentID:     "market-research-agent",
-		RuntimeMode: sessions.RuntimeModeSession,
+		RuntimeMode: sessions.RuntimeModeSession.String(),
 		SessionID:   session.ID,
 	}, resp)
 

--- a/internal/runtime/llm/session_helpers.go
+++ b/internal/runtime/llm/session_helpers.go
@@ -8,7 +8,7 @@ import (
 	"swarm/internal/runtime/sessions"
 )
 
-func resolvedSessionScope(ctx context.Context, mode, sessionScope, scopeKey string) (sessions.ResolvedScope, error) {
+func resolvedSessionScope(ctx context.Context, mode sessions.RuntimeMode, sessionScope sessions.SessionScope, scopeKey string) (sessions.ResolvedScope, error) {
 	return sessions.ResolveScope(ctx, mode, sessionScope, scopeKey)
 }
 
@@ -30,6 +30,6 @@ func sessionToken(s *Session) string {
 	return strings.TrimSpace(s.ID)
 }
 
-func shouldPersistConversationMode(mode string) bool {
+func shouldPersistConversationMode(mode sessions.RuntimeMode) bool {
 	return true
 }

--- a/internal/runtime/llm/session_rotation.go
+++ b/internal/runtime/llm/session_rotation.go
@@ -9,7 +9,7 @@ import (
 	"swarm/internal/runtime/sessions"
 )
 
-func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode string, registry sessions.Registry, lockOwner string, rotateAfter int, sink any) (*sessions.Lease, error) {
+func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode sessions.RuntimeMode, registry sessions.Registry, lockOwner string, rotateAfter int, sink any) (*sessions.Lease, error) {
 	if s == nil || registry == nil || rotateAfter <= 0 {
 		return nil, nil
 	}
@@ -20,7 +20,7 @@ func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode string, r
 	oldTurnCount := s.TurnCount
 	oldParseFailures := s.ParseFailures
 	summary := BuildRotationCheckpoint(fmt.Sprintf("turn_limit_reached:%d", rotateAfter), s)
-	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, strings.TrimSpace(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
+	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
 	if err != nil {
 		return nil, err
 	}
@@ -31,11 +31,11 @@ func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode string, r
 		{Role: "system", Content: "Previous session summary:\n" + summary},
 	}
 	if sink != nil {
-		LogSessionRotatedForRun(ctx, sink, s.AgentID, runtimeMode, oldSessionID, lease.SessionID, strings.TrimSpace(s.ScopeKey), fmt.Sprintf("turn_limit_reached:%d", rotateAfter), oldTurnCount, oldParseFailures)
+		LogSessionRotatedForRun(ctx, sink, s.AgentID, runtimeMode.String(), oldSessionID, lease.SessionID, strings.TrimSpace(s.ScopeKey), fmt.Sprintf("turn_limit_reached:%d", rotateAfter), oldTurnCount, oldParseFailures)
 	} else {
 		LogSessionRotated(
 			s.AgentID,
-			runtimeMode,
+			runtimeMode.String(),
 			oldSessionID,
 			lease.SessionID,
 			strings.TrimSpace(s.ScopeKey),
@@ -47,7 +47,7 @@ func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode string, r
 	return lease, nil
 }
 
-func MaybeRotateAfterParseFailures(ctx context.Context, s *Session, runtimeMode string, registry sessions.Registry, lockOwner string, threshold int, sink any) (*sessions.Lease, error) {
+func MaybeRotateAfterParseFailures(ctx context.Context, s *Session, runtimeMode sessions.RuntimeMode, registry sessions.Registry, lockOwner string, threshold int, sink any) (*sessions.Lease, error) {
 	if s == nil || registry == nil || threshold <= 0 {
 		return nil, nil
 	}
@@ -58,7 +58,7 @@ func MaybeRotateAfterParseFailures(ctx context.Context, s *Session, runtimeMode 
 	oldTurnCount := s.TurnCount
 	oldParseFailures := s.ParseFailures
 	summary := BuildRotationCheckpoint(fmt.Sprintf("parse_failures_threshold:%d", threshold), s)
-	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, strings.TrimSpace(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
+	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
 	if err != nil {
 		return nil, err
 	}
@@ -69,11 +69,11 @@ func MaybeRotateAfterParseFailures(ctx context.Context, s *Session, runtimeMode 
 		{Role: "system", Content: "Previous session summary:\n" + summary},
 	}
 	if sink != nil {
-		LogSessionRotatedForRun(ctx, sink, s.AgentID, runtimeMode, oldSessionID, lease.SessionID, strings.TrimSpace(s.ScopeKey), fmt.Sprintf("parse_failures_threshold:%d", threshold), oldTurnCount, oldParseFailures)
+		LogSessionRotatedForRun(ctx, sink, s.AgentID, runtimeMode.String(), oldSessionID, lease.SessionID, strings.TrimSpace(s.ScopeKey), fmt.Sprintf("parse_failures_threshold:%d", threshold), oldTurnCount, oldParseFailures)
 	} else {
 		LogSessionRotated(
 			s.AgentID,
-			runtimeMode,
+			runtimeMode.String(),
 			oldSessionID,
 			lease.SessionID,
 			strings.TrimSpace(s.ScopeKey),

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -336,12 +336,13 @@ func (am *AgentManager) ReconfigureAgent(agentID string, cfg models.AgentConfig)
 	am.mu.RUnlock()
 	conversationMode := strings.TrimSpace(updated.ConversationMode)
 	if sessionRegistry != nil && conversationMode != "" && sessions.IsLiveSessionRuntimeMode(conversationMode) {
+		runtimeMode := sessions.NormalizeConversationRuntimeMode(conversationMode)
 		scopeKey, err := sessions.DeclaredScopeKey(updated)
 		if err != nil {
 			return fmt.Errorf("agent reconfigure session rotation failed: agent=%s runtime=%s: %w", agentID, conversationMode, err)
 		}
 		rotationCtx := models.WithActor(am.runtimeContext(), updated)
-		rotated, err := sessionRegistry.Rotate(rotationCtx, agentID, conversationMode, strings.TrimSpace(updated.SessionScope), "reconfigure", "agent reconfigured", scopeKey)
+		rotated, err := sessionRegistry.Rotate(rotationCtx, agentID, runtimeMode, sessions.NormalizeSessionScope(updated.SessionScope), "reconfigure", "agent reconfigured", scopeKey)
 		if err != nil {
 			return fmt.Errorf("agent reconfigure session rotation failed: agent=%s runtime=%s: %w", agentID, conversationMode, err)
 		} else if rotated != nil {

--- a/internal/runtime/manager/reconfigure_test.go
+++ b/internal/runtime/manager/reconfigure_test.go
@@ -28,8 +28,8 @@ func TestReconfigureAgent_RotatesFlowScopedSession(t *testing.T) {
 
 	cfg := models.AgentConfig{
 		ID:               "flow-agent",
-		ConversationMode: sessions.RuntimeModeSession,
-		SessionScope:     sessions.SessionScopeFlow,
+		ConversationMode: sessions.RuntimeModeSession.String(),
+		SessionScope:     sessions.SessionScopeFlow.String(),
 		FlowPath:         "review/inst-1",
 	}
 	if err := am.SpawnAgent(cfg); err != nil {
@@ -37,7 +37,7 @@ func TestReconfigureAgent_RotatesFlowScopedSession(t *testing.T) {
 	}
 
 	seedCtx := models.WithActor(context.Background(), cfg)
-	lease, err := registry.Acquire(seedCtx, cfg.ID, cfg.ConversationMode, cfg.SessionScope, "reconfigure", cfg.CanonicalFlowPath())
+	lease, err := registry.Acquire(seedCtx, cfg.ID, sessions.NormalizeConversationRuntimeMode(cfg.ConversationMode), sessions.NormalizeSessionScope(cfg.SessionScope), "reconfigure", cfg.CanonicalFlowPath())
 	if err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
@@ -66,8 +66,8 @@ func TestReconfigureAgent_RotatesEntityScopedSession(t *testing.T) {
 
 	cfg := models.AgentConfig{
 		ID:               "entity-agent",
-		ConversationMode: sessions.RuntimeModeSessionPerEntity,
-		SessionScope:     sessions.SessionScopeEntity,
+		ConversationMode: sessions.RuntimeModeSessionPerEntity.String(),
+		SessionScope:     sessions.SessionScopeEntity.String(),
 		FlowPath:         "review/inst-1",
 		EntityID:         "entity-1",
 	}
@@ -76,7 +76,7 @@ func TestReconfigureAgent_RotatesEntityScopedSession(t *testing.T) {
 	}
 
 	seedCtx := models.WithActor(context.Background(), cfg)
-	lease, err := registry.Acquire(seedCtx, cfg.ID, cfg.ConversationMode, cfg.SessionScope, "reconfigure", cfg.EffectiveEntityID())
+	lease, err := registry.Acquire(seedCtx, cfg.ID, sessions.NormalizeConversationRuntimeMode(cfg.ConversationMode), sessions.NormalizeSessionScope(cfg.SessionScope), "reconfigure", cfg.EffectiveEntityID())
 	if err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestReconfigureAgent_RotatesEntityScopedSession(t *testing.T) {
 
 func TestReconfigureAgent_ClearsSessionScopeWhenSwitchingToTask(t *testing.T) {
 	am := NewAgentManager(nil, func(cfg models.AgentConfig) (Agent, error) {
-		if _, err := sessions.ValidateSessionScopeIntent(cfg.ConversationMode, cfg.SessionScope); err != nil {
+		if _, err := sessions.ValidateSessionScopeIntent(sessions.NormalizeConversationRuntimeMode(cfg.ConversationMode), cfg.SessionScope); err != nil {
 			return nil, err
 		}
 		return reconfigureTestAgent{id: cfg.ID}, nil
@@ -107,20 +107,20 @@ func TestReconfigureAgent_ClearsSessionScopeWhenSwitchingToTask(t *testing.T) {
 
 	cfg := models.AgentConfig{
 		ID:               "task-switch-agent",
-		ConversationMode: sessions.RuntimeModeSession,
-		SessionScope:     sessions.SessionScopeGlobal,
+		ConversationMode: sessions.RuntimeModeSession.String(),
+		SessionScope:     sessions.SessionScopeGlobal.String(),
 	}
 	if err := am.SpawnAgent(cfg); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 
-	if err := am.ReconfigureAgent(cfg.ID, models.AgentConfig{ConversationMode: sessions.RuntimeModeTask}); err != nil {
+	if err := am.ReconfigureAgent(cfg.ID, models.AgentConfig{ConversationMode: sessions.RuntimeModeTask.String()}); err != nil {
 		t.Fatalf("ReconfigureAgent(task): %v", err)
 	}
 
 	got := am.agentCfg[cfg.ID]
-	if got.ConversationMode != sessions.RuntimeModeTask {
-		t.Fatalf("ConversationMode = %q, want %q", got.ConversationMode, sessions.RuntimeModeTask)
+	if got.ConversationMode != sessions.RuntimeModeTask.String() {
+		t.Fatalf("ConversationMode = %q, want %q", got.ConversationMode, sessions.RuntimeModeTask.String())
 	}
 	if got.SessionScope != "" {
 		t.Fatalf("SessionScope = %q, want empty", got.SessionScope)

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -597,7 +597,7 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 		am.resetRuntimeOwnedState()
 	}
 	if resetter, ok := am.sessions.(sessions.Resetter); ok && resetter != nil {
-		if err := resetter.ResetAll(am.runtimeMode); err != nil {
+		if err := resetter.ResetAll(sessions.NormalizeConversationRuntimeMode(am.runtimeMode)); err != nil {
 			if am.bus != nil {
 				am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
 					Level:     "error",

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -7,6 +7,7 @@ import (
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/diaglog"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimetools "swarm/internal/runtime/tools"
@@ -112,7 +113,7 @@ func runtimeMCPLog(logger *RuntimeLogger, ctx context.Context, level, action, ag
 		return
 	}
 	handleRuntimeLogPersistenceError("mcp-gateway", action, logger.Log(ctx, RuntimeLogEntry{
-		Level:     strings.ToLower(strings.TrimSpace(level)),
+		Level:     diaglog.NormalizeLevel(level),
 		Message:   runtimeMCPMessage(action, detail, errText),
 		Component: "mcp-gateway",
 		Action:    strings.TrimSpace(action),

--- a/internal/runtime/sessions/heartbeat.go
+++ b/internal/runtime/sessions/heartbeat.go
@@ -13,19 +13,18 @@ const (
 	maxLeaseHeartbeatInterval = 45 * time.Second
 )
 
-func StartLeaseHeartbeat(ctx context.Context, sessions Registry, lease *Lease, runtimeMode string) func() {
+func StartLeaseHeartbeat(ctx context.Context, sessions Registry, lease *Lease, runtimeMode RuntimeMode) func() {
 	return StartLeaseHeartbeatWithErrorHandler(ctx, sessions, lease, runtimeMode, nil)
 }
 
-func StartLeaseHeartbeatWithErrorHandler(ctx context.Context, sessions Registry, lease *Lease, runtimeMode string, onError func(error)) func() {
+func StartLeaseHeartbeatWithErrorHandler(ctx context.Context, sessions Registry, lease *Lease, runtimeMode RuntimeMode, onError func(error)) func() {
 	if sessions == nil || lease == nil {
 		return func() {}
 	}
 	agentID := strings.TrimSpace(lease.AgentID)
 	lockOwner := strings.TrimSpace(lease.LockOwner)
 	scopeKey := strings.TrimSpace(lease.ScopeKey)
-	sessionScope := strings.TrimSpace(lease.SessionScope)
-	runtimeMode = strings.TrimSpace(runtimeMode)
+	sessionScope := lease.SessionScope
 	if agentID == "" || lockOwner == "" || runtimeMode == "" {
 		return func() {}
 	}
@@ -51,7 +50,7 @@ func StartLeaseHeartbeatWithErrorHandler(ctx context.Context, sessions Registry,
 					if onError != nil {
 						onError(err)
 					} else {
-						log.Printf("session lease heartbeat failed: agent=%s runtime=%s err=%v", agentID, runtimeMode, err)
+						log.Printf("session lease heartbeat failed: agent=%s runtime=%s err=%v", agentID, runtimeMode.String(), err)
 					}
 					continue
 				}

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -30,7 +30,7 @@ func NewPostgresRegistry(db *sql.DB, lockTTL time.Duration) *PostgresRegistry {
 	}
 }
 
-func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, scopeKey string) (*Lease, error) {
+func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, scopeKey string) (*Lease, error) {
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
@@ -198,10 +198,6 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	mode, err := ParseConversationRuntimeMode(lease.RuntimeMode)
-	if err != nil {
-		return err
-	}
 	res, err := sr.db.ExecContext(ctx, `
 		UPDATE agent_sessions
 		SET lease_holder = NULL,
@@ -213,7 +209,7 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 		  AND scope_key = $4
 		  AND lease_holder = $5
 		  AND status = 'active'
-	`, lease.AgentID, mode, lease.SessionID, strings.TrimSpace(lease.ScopeKey), lease.LockOwner)
+	`, lease.AgentID, lease.RuntimeMode, lease.SessionID, strings.TrimSpace(lease.ScopeKey), lease.LockOwner)
 	if err != nil {
 		return fmt.Errorf("release lease: %w", err)
 	}
@@ -224,7 +220,7 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 	return nil
 }
 
-func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
+func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
@@ -309,7 +305,7 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID, runtimeMode, se
 	}, nil
 }
 
-func (sr *PostgresRegistry) IncrementTurn(ctx context.Context, agentID, runtimeMode, sessionScope, sessionID, scopeKey string) error {
+func (sr *PostgresRegistry) IncrementTurn(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, sessionID, scopeKey string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -337,7 +333,7 @@ func (sr *PostgresRegistry) IncrementTurn(ctx context.Context, agentID, runtimeM
 	return nil
 }
 
-func (sr *PostgresRegistry) AdoptSessionID(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, newSessionID, scopeKey string) error {
+func (sr *PostgresRegistry) AdoptSessionID(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, newSessionID, scopeKey string) error {
 	agentID = strings.TrimSpace(agentID)
 	lockOwner = strings.TrimSpace(lockOwner)
 	newSessionID = strings.TrimSpace(newSessionID)
@@ -419,8 +415,7 @@ func (sr *PostgresRegistry) ScopeKeyEnabledForTest() bool {
 	return true
 }
 
-func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
-	runtimeMode = strings.TrimSpace(runtimeMode)
+func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode) error {
 	if runtimeMode == "" {
 		_, err := sr.db.Exec(`
 			UPDATE agent_sessions
@@ -436,23 +431,19 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode string) error {
 		}
 		return nil
 	}
-	mode, err := ParseConversationRuntimeMode(runtimeMode)
-	if err != nil {
-		return err
-	}
-	if mode == RuntimeModeTask {
+	if runtimeMode == RuntimeModeTask {
 		return nil
 	}
-	_, err = sr.db.Exec(`
+	_, err := sr.db.Exec(`
 		UPDATE agent_sessions
 		SET status = 'terminated',
 		    lease_holder = NULL,
 		    lease_expires_at = NULL,
 		    updated_at = now()
 		WHERE status = 'active' AND runtime_mode = $1
-	`, mode)
+	`, runtimeMode)
 	if err != nil {
-		return fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode, err)
+		return fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode.String(), err)
 	}
 	return nil
 }

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -12,22 +12,22 @@ import (
 )
 
 type Registry interface {
-	Acquire(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, scopeKey string) (*Lease, error)
+	Acquire(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, scopeKey string) (*Lease, error)
 	Release(ctx context.Context, lease *Lease) error
-	Rotate(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, summary, scopeKey string) (*Lease, error)
-	IncrementTurn(ctx context.Context, agentID, runtimeMode, sessionScope, sessionID, scopeKey string) error
+	Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error)
+	IncrementTurn(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, sessionID, scopeKey string) error
 }
 
 type Resetter interface {
-	ResetAll(runtimeMode string) error
+	ResetAll(runtimeMode RuntimeMode) error
 }
 
 type Lease struct {
 	SessionID         string
 	ProviderSessionID string
 	AgentID           string
-	RuntimeMode       string
-	SessionScope      string
+	RuntimeMode       RuntimeMode
+	SessionScope      SessionScope
 	LockOwner         string
 	ScopeKey          string
 	ExpiresAt         time.Time
@@ -37,7 +37,7 @@ type Record struct {
 	SessionID         string
 	ProviderSessionID string
 	AgentID           string
-	RuntimeMode       string
+	RuntimeMode       RuntimeMode
 	ScopeKey          string
 	Status            string
 	TurnCount         int
@@ -69,11 +69,11 @@ func NewRegistry(lockTTL time.Duration) Registry {
 	return NewInMemoryRegistry(lockTTL)
 }
 
-func registryKey(agentID, runtimeMode, scopeKey string) string {
-	return strings.TrimSpace(agentID) + "|" + strings.TrimSpace(runtimeMode) + "|" + strings.TrimSpace(scopeKey)
+func registryKey(agentID string, runtimeMode RuntimeMode, scopeKey string) string {
+	return strings.TrimSpace(agentID) + "|" + runtimeMode.String() + "|" + strings.TrimSpace(scopeKey)
 }
 
-func (sr *InMemoryRegistry) Acquire(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, scopeKey string) (*Lease, error) {
+func (sr *InMemoryRegistry) Acquire(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, scopeKey string) (*Lease, error) {
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
@@ -145,7 +145,7 @@ func (sr *InMemoryRegistry) Release(_ context.Context, lease *Lease) error {
 	return nil
 }
 
-func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
+func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
 	resolved, err := ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID, runtimeMode, se
 	}, nil
 }
 
-func (sr *InMemoryRegistry) IncrementTurn(ctx context.Context, agentID, runtimeMode, sessionScope, sessionID, scopeKey string) error {
+func (sr *InMemoryRegistry) IncrementTurn(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, sessionID, scopeKey string) error {
 	resolved, err := ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
 	if err != nil {
 		return err
@@ -213,9 +213,8 @@ func (sr *InMemoryRegistry) IncrementTurn(ctx context.Context, agentID, runtimeM
 	return fmt.Errorf("session for agent %s not found", agentID)
 }
 
-func (sr *InMemoryRegistry) AdoptSessionID(ctx context.Context, agentID, runtimeMode, sessionScope, lockOwner, newSessionID, scopeKey string) error {
+func (sr *InMemoryRegistry) AdoptSessionID(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, newSessionID, scopeKey string) error {
 	agentID = strings.TrimSpace(agentID)
-	runtimeMode = strings.TrimSpace(runtimeMode)
 	lockOwner = strings.TrimSpace(lockOwner)
 	newSessionID = strings.TrimSpace(newSessionID)
 	if agentID == "" || runtimeMode == "" || lockOwner == "" || newSessionID == "" {
@@ -283,19 +282,14 @@ func (sr *InMemoryRegistry) Snapshot(agentID string) (*Record, bool) {
 	return nil, false
 }
 
-func (sr *InMemoryRegistry) ResetAll(runtimeMode string) error {
-	runtimeMode = strings.TrimSpace(runtimeMode)
+func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode) error {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	if runtimeMode == "" {
 		sr.byKey = make(map[string]*Record)
 		return nil
 	}
-	mode, err := ParseConversationRuntimeMode(runtimeMode)
-	if err != nil {
-		return err
-	}
-	if mode == RuntimeModeTask {
+	if runtimeMode == RuntimeModeTask {
 		return nil
 	}
 	for key, rec := range sr.byKey {
@@ -303,7 +297,7 @@ func (sr *InMemoryRegistry) ResetAll(runtimeMode string) error {
 			delete(sr.byKey, key)
 			continue
 		}
-		if strings.TrimSpace(rec.RuntimeMode) == mode {
+		if rec.RuntimeMode == runtimeMode {
 			delete(sr.byKey, key)
 		}
 	}

--- a/internal/runtime/sessions/scope.go
+++ b/internal/runtime/sessions/scope.go
@@ -187,9 +187,13 @@ func ValidateSessionScopeIntent(runtimeMode RuntimeMode, sessionScope string) (S
 }
 
 func ValidateAgentSessionScopeConfig(actor runtimeactors.AgentConfig) (SessionScope, error) {
-	runtimeMode := NormalizeConversationRuntimeMode(actor.ConversationMode)
-	if runtimeMode == "" {
-		runtimeMode = RuntimeModeTask
+	runtimeMode := RuntimeModeTask
+	if rawMode := strings.TrimSpace(actor.ConversationMode); rawMode != "" {
+		parsedMode, err := ParseConversationRuntimeMode(rawMode)
+		if err != nil {
+			return "", err
+		}
+		runtimeMode = parsedMode
 	}
 	sessionScope, err := ValidateSessionScopeIntent(runtimeMode, actor.SessionScope)
 	if err != nil {

--- a/internal/runtime/sessions/scope.go
+++ b/internal/runtime/sessions/scope.go
@@ -8,14 +8,31 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
+type RuntimeMode string
+
 const (
-	RuntimeModeTask             = "task"
-	RuntimeModeSession          = "session"
-	RuntimeModeSessionPerEntity = "session_per_entity"
-	SessionScopeGlobal          = "global"
-	SessionScopeFlow            = "flow"
-	SessionScopeEntity          = "entity"
+	RuntimeModeTask             RuntimeMode = "task"
+	RuntimeModeSession          RuntimeMode = "session"
+	RuntimeModeSessionPerEntity RuntimeMode = "session_per_entity"
 )
+
+func (m RuntimeMode) String() string { return string(m) }
+func (m RuntimeMode) IsStateless() bool {
+	return m == RuntimeModeTask
+}
+func (m RuntimeMode) IsLiveSession() bool {
+	return m != "" && m != RuntimeModeTask
+}
+
+type SessionScope string
+
+const (
+	SessionScopeGlobal SessionScope = "global"
+	SessionScopeFlow   SessionScope = "flow"
+	SessionScopeEntity SessionScope = "entity"
+)
+
+func (s SessionScope) String() string { return string(s) }
 
 type ScopeContext struct {
 	ConversationMode string
@@ -24,9 +41,9 @@ type ScopeContext struct {
 }
 
 type ResolvedScope struct {
-	RuntimeMode  string
+	RuntimeMode  RuntimeMode
 	ScopeKey     string
-	Scope        string
+	Scope        SessionScope
 	EntityID     string
 	FlowInstance string
 	Stateless    bool
@@ -58,25 +75,25 @@ func ScopeFromContext(ctx context.Context) ScopeContext {
 	return payload
 }
 
-func canonicalConversationRuntimeMode(raw string) (string, bool) {
+func canonicalConversationRuntimeMode(raw string) (RuntimeMode, bool) {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
-	case RuntimeModeTask, "stateless":
+	case RuntimeModeTask.String(), "stateless":
 		return RuntimeModeTask, true
-	case RuntimeModeSession:
+	case RuntimeModeSession.String():
 		return RuntimeModeSession, true
-	case RuntimeModeSessionPerEntity:
+	case RuntimeModeSessionPerEntity.String():
 		return RuntimeModeSessionPerEntity, true
 	default:
 		return "", false
 	}
 }
 
-func NormalizeConversationRuntimeMode(raw string) string {
+func NormalizeConversationRuntimeMode(raw string) RuntimeMode {
 	mode, _ := canonicalConversationRuntimeMode(raw)
 	return mode
 }
 
-func ParseConversationRuntimeMode(raw string) (string, error) {
+func ParseConversationRuntimeMode(raw string) (RuntimeMode, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", fmt.Errorf("conversation mode is required")
@@ -90,33 +107,33 @@ func ParseConversationRuntimeMode(raw string) (string, error) {
 
 func IsStatelessRuntimeMode(raw string) bool {
 	mode, ok := canonicalConversationRuntimeMode(raw)
-	return ok && mode == RuntimeModeTask
+	return ok && mode.IsStateless()
 }
 
 func IsLiveSessionRuntimeMode(raw string) bool {
 	mode, ok := canonicalConversationRuntimeMode(raw)
-	return ok && mode != RuntimeModeTask
+	return ok && mode.IsLiveSession()
 }
 
-func canonicalSessionScope(raw string) (string, bool) {
+func canonicalSessionScope(raw string) (SessionScope, bool) {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
-	case SessionScopeGlobal:
+	case SessionScopeGlobal.String():
 		return SessionScopeGlobal, true
-	case SessionScopeFlow:
+	case SessionScopeFlow.String():
 		return SessionScopeFlow, true
-	case SessionScopeEntity:
+	case SessionScopeEntity.String():
 		return SessionScopeEntity, true
 	default:
 		return "", false
 	}
 }
 
-func NormalizeSessionScope(raw string) string {
+func NormalizeSessionScope(raw string) SessionScope {
 	scope, _ := canonicalSessionScope(raw)
 	return scope
 }
 
-func ParseSessionScope(raw string) (string, error) {
+func ParseSessionScope(raw string) (SessionScope, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", fmt.Errorf("session scope is required")
@@ -128,11 +145,8 @@ func ParseSessionScope(raw string) (string, error) {
 	return scope, nil
 }
 
-func ValidateSessionScopeIntent(runtimeMode, sessionScope string) (string, error) {
-	mode, err := ParseConversationRuntimeMode(runtimeMode)
-	if err != nil {
-		return "", err
-	}
+func ValidateSessionScopeIntent(runtimeMode RuntimeMode, sessionScope string) (SessionScope, error) {
+	mode := runtimeMode
 	sessionScope = strings.TrimSpace(sessionScope)
 	switch mode {
 	case RuntimeModeTask:
@@ -172,8 +186,8 @@ func ValidateSessionScopeIntent(runtimeMode, sessionScope string) (string, error
 	}
 }
 
-func ValidateAgentSessionScopeConfig(actor runtimeactors.AgentConfig) (string, error) {
-	runtimeMode := strings.TrimSpace(actor.ConversationMode)
+func ValidateAgentSessionScopeConfig(actor runtimeactors.AgentConfig) (SessionScope, error) {
+	runtimeMode := NormalizeConversationRuntimeMode(actor.ConversationMode)
 	if runtimeMode == "" {
 		runtimeMode = RuntimeModeTask
 	}
@@ -203,7 +217,7 @@ func DeclaredScopeKey(actor runtimeactors.AgentConfig) (string, error) {
 	case "":
 		return "", nil
 	case SessionScopeGlobal:
-		return SessionScopeGlobal, nil
+		return SessionScopeGlobal.String(), nil
 	case SessionScopeFlow:
 		flowPath := actor.CanonicalFlowPath()
 		if flowPath == "" {
@@ -221,12 +235,9 @@ func DeclaredScopeKey(actor runtimeactors.AgentConfig) (string, error) {
 	}
 }
 
-func ResolveScope(ctx context.Context, runtimeMode, sessionScope, scopeKey string) (ResolvedScope, error) {
-	mode, err := ParseConversationRuntimeMode(runtimeMode)
-	if err != nil {
-		return ResolvedScope{}, err
-	}
-	sessionScope, err = ValidateSessionScopeIntent(mode, sessionScope)
+func ResolveScope(ctx context.Context, runtimeMode RuntimeMode, sessionScope SessionScope, scopeKey string) (ResolvedScope, error) {
+	mode := runtimeMode
+	resolvedScope, err := ValidateSessionScopeIntent(mode, sessionScope.String())
 	if err != nil {
 		return ResolvedScope{}, err
 	}
@@ -244,7 +255,7 @@ func ResolveScope(ctx context.Context, runtimeMode, sessionScope, scopeKey strin
 		out.Stateless = true
 		return out, nil
 	case RuntimeModeSessionPerEntity:
-		if sessionScope != SessionScopeEntity {
+		if resolvedScope != SessionScopeEntity {
 			return ResolvedScope{}, fmt.Errorf("session_per_entity requires explicit session_scope: entity")
 		}
 		if scopeKey == "" {
@@ -253,24 +264,24 @@ func ResolveScope(ctx context.Context, runtimeMode, sessionScope, scopeKey strin
 		if flowPath == "" {
 			return ResolvedScope{}, fmt.Errorf("session_per_entity requires actor flow path")
 		}
-		out.Scope = "entity"
+		out.Scope = SessionScopeEntity
 		out.EntityID = scopeKey
 		out.FlowInstance = flowPath
 		return out, nil
 	case RuntimeModeSession:
-		switch sessionScope {
+		switch resolvedScope {
 		case SessionScopeGlobal:
 			switch scopeKey {
-			case "", SessionScopeGlobal:
+			case "", SessionScopeGlobal.String():
 				out.Scope = SessionScopeGlobal
-				out.ScopeKey = SessionScopeGlobal
+				out.ScopeKey = SessionScopeGlobal.String()
 				return out, nil
 			default:
 				return ResolvedScope{}, fmt.Errorf("session_scope global requires scope_key global or empty")
 			}
 		case SessionScopeFlow:
 			switch {
-			case scopeKey == SessionScopeGlobal:
+			case scopeKey == SessionScopeGlobal.String():
 				return ResolvedScope{}, fmt.Errorf("session_scope flow does not allow global scope key")
 			case scopeKey != "" && flowPath != "" && scopeKey != flowPath:
 				return ResolvedScope{}, fmt.Errorf("session_scope flow scope key %q does not match actor flow path %q", scopeKey, flowPath)
@@ -292,5 +303,5 @@ func ResolveScope(ctx context.Context, runtimeMode, sessionScope, scopeKey strin
 		}
 	}
 
-	return ResolvedScope{}, fmt.Errorf("unsupported conversation mode %q", runtimeMode)
+	return ResolvedScope{}, fmt.Errorf("unsupported conversation mode %q", runtimeMode.String())
 }

--- a/internal/runtime/sessions/scope_heartbeat_test.go
+++ b/internal/runtime/sessions/scope_heartbeat_test.go
@@ -25,7 +25,7 @@ func TestNormalizeConversationRuntimeMode_AcceptsStatelessAlias(t *testing.T) {
 	if got := NormalizeConversationRuntimeMode("stateless"); got != RuntimeModeTask {
 		t.Fatalf("NormalizeConversationRuntimeMode(stateless) = %q, want %q", got, RuntimeModeTask)
 	}
-	scope, err := ResolveScope(context.Background(), "stateless", "", "ignored")
+	scope, err := ResolveScope(context.Background(), NormalizeConversationRuntimeMode("stateless"), "", "ignored")
 	if err != nil {
 		t.Fatalf("ResolveScope(stateless): %v", err)
 	}

--- a/internal/runtime/sessions/scope_heartbeat_test.go
+++ b/internal/runtime/sessions/scope_heartbeat_test.go
@@ -74,6 +74,19 @@ func TestResolveScope_InvalidSessionConfigurationsFailClosed(t *testing.T) {
 	}
 }
 
+func TestValidateAgentSessionScopeConfig_RejectsInvalidConversationMode(t *testing.T) {
+	_, err := ValidateAgentSessionScopeConfig(runtimeactors.AgentConfig{
+		ID:               "agent-invalid-mode",
+		ConversationMode: "nonsense",
+	})
+	if err == nil {
+		t.Fatal("expected invalid conversation mode to fail")
+	}
+	if got := err.Error(); got != `invalid conversation mode "nonsense"` {
+		t.Fatalf("ValidateAgentSessionScopeConfig error = %q", got)
+	}
+}
+
 func TestLeaseHeartbeatInterval_ClampsRange(t *testing.T) {
 	if got := LeaseHeartbeatInterval(time.Time{}); got != 30*time.Second {
 		t.Fatalf("zero expiry: got %s", got)

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -17,6 +17,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
 	runtimecredentials "swarm/internal/runtime/credentials"
+	"swarm/internal/runtime/diaglog"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -336,7 +337,7 @@ func (e *Executor) emitToolExecutionEvent(
 		detail["actor_role"] = strings.TrimSpace(actor.Role)
 	}
 	logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
-		Level:      level,
+		Level:      diaglog.NormalizeLevel(level),
 		Message:    toolExecutionMessage(toolName, execErr),
 		Component:  "tool-executor",
 		Action:     action,

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -265,11 +265,11 @@ func agentPersistedType(cfg runtimeactors.AgentConfig, modelTier string) string 
 	return "generic"
 }
 
-func agentConversationMode(cfg runtimeactors.AgentConfig) runtimesessions.RuntimeMode {
+func agentConversationMode(cfg runtimeactors.AgentConfig) (runtimesessions.RuntimeMode, error) {
 	if v := strings.TrimSpace(cfg.ConversationMode); v != "" {
-		return runtimesessions.NormalizeConversationRuntimeMode(v)
+		return runtimesessions.ParseConversationRuntimeMode(v)
 	}
-	return runtimesessions.RuntimeModeTask
+	return runtimesessions.RuntimeModeTask, nil
 }
 
 func agentFlowInstance(cfg runtimeactors.AgentConfig) string {

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -265,7 +265,7 @@ func agentPersistedType(cfg runtimeactors.AgentConfig, modelTier string) string 
 	return "generic"
 }
 
-func agentConversationMode(cfg runtimeactors.AgentConfig) string {
+func agentConversationMode(cfg runtimeactors.AgentConfig) runtimesessions.RuntimeMode {
 	if v := strings.TrimSpace(cfg.ConversationMode); v != "" {
 		return runtimesessions.NormalizeConversationRuntimeMode(v)
 	}

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -28,7 +28,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	runtimeMode := runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode)
 	targetTable := "agent_sessions"
 	hasConversationRunID := caps.Conversations.SessionRunID
-	if runtimesessions.IsStatelessRuntimeMode(runtimeMode) {
+	if runtimeMode.IsStateless() {
 		if err := s.ensureConversationAuditTable(ctx); err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	insertArgs := []any{
 		rec.AgentID,
 		rec.SessionID,
-		runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode),
+		runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
 		rec.ScopeKey,
 		rec.EntityID,
 		rec.TriggerEventID,
@@ -260,7 +260,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		insertArgs = []any{
 			rec.AgentID,
 			rec.SessionID,
-			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode),
+			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
 			rec.ScopeKey,
 			rec.EntityID,
 			rec.TriggerEventID,
@@ -319,7 +319,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			nullUUIDString(runID),
 			rec.AgentID,
 			rec.SessionID,
-			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode),
+			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
 			rec.ScopeKey,
 			rec.EntityID,
 			rec.TriggerEventID,
@@ -374,7 +374,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 				nullUUIDString(runID),
 				rec.AgentID,
 				rec.SessionID,
-				runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode),
+				runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
 				rec.ScopeKey,
 				rec.EntityID,
 				rec.TriggerEventID,
@@ -470,7 +470,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 		rec.EntityID,
 		scopeKey,
 		"global",
-		runtimesessions.RuntimeModeTask,
+		runtimesessions.RuntimeModeTask.String(),
 	}
 	if caps.Conversations.AuditRunID {
 		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID); err != nil {
@@ -515,7 +515,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			rec.EntityID,
 			scopeKey,
 			"global",
-			runtimesessions.RuntimeModeTask,
+			runtimesessions.RuntimeModeTask.String(),
 		}
 	}
 	execFn := s.DB.ExecContext
@@ -569,7 +569,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if err != nil {
 		return err
 	}
-	resolved, err := runtimesessions.ResolveScope(ctx, mode, rec.SessionScope, rec.ScopeKey)
+	resolved, err := runtimesessions.ResolveScope(ctx, mode, runtimesessions.NormalizeSessionScope(rec.SessionScope), rec.ScopeKey)
 	if err != nil {
 		return err
 	}
@@ -609,9 +609,9 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 		}
 		scopeKey := strings.TrimSpace(rec.ScopeKey)
-		scope := strings.TrimSpace(resolved.Scope)
+		scope := resolved.Scope.String()
 		if scope == "" {
-			scope = "global"
+			scope = runtimesessions.SessionScopeGlobal.String()
 		}
 		q := `
 			INSERT INTO agent_conversation_audits (
@@ -655,7 +655,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			scope,
 			string(msgJSON),
 			rec.TurnCount,
-			mode,
+			mode.String(),
 			summary,
 			status,
 		}
@@ -708,7 +708,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				scope,
 				string(msgJSON),
 				rec.TurnCount,
-				mode,
+				mode.String(),
 				summary,
 				status,
 			}
@@ -738,7 +738,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			$7,
 			$8,
 			jsonb_build_object('summary', NULLIF($9,'')),
-			$10,
+					$10,
 			now(),
 			now()
 		)
@@ -758,10 +758,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		resolved.EntityID,
 		resolved.FlowInstance,
 		resolved.ScopeKey,
-		resolved.Scope,
+		resolved.Scope.String(),
 		string(msgJSON),
 		rec.TurnCount,
-		mode,
+		mode.String(),
 		summary,
 		status,
 		sessionID,
@@ -808,10 +808,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			resolved.EntityID,
 			resolved.FlowInstance,
 			resolved.ScopeKey,
-			resolved.Scope,
+			resolved.Scope.String(),
 			string(msgJSON),
 			rec.TurnCount,
-			mode,
+			mode.String(),
 			summary,
 			status,
 			runID,
@@ -841,11 +841,11 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 		return runtimellm.ConversationRecord{}, false, fmt.Errorf("agent_id is required")
 	}
 
-	mode, err := runtimesessions.ParseConversationRuntimeMode(mode)
+	resolvedMode, err := runtimesessions.ParseConversationRuntimeMode(mode)
 	if err != nil {
 		return runtimellm.ConversationRecord{}, false, err
 	}
-	resolved, err := runtimesessions.ResolveScope(ctx, mode, sessionScope, scopeKey)
+	resolved, err := runtimesessions.ResolveScope(ctx, resolvedMode, runtimesessions.NormalizeSessionScope(sessionScope), scopeKey)
 	if err != nil {
 		return runtimellm.ConversationRecord{}, false, err
 	}
@@ -878,11 +878,11 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 
 	var rec runtimellm.ConversationRecord
 	rec.AgentID = agentID
-	rec.Mode = mode
-	rec.SessionScope = resolved.Scope
+	rec.Mode = resolvedMode.String()
+	rec.SessionScope = resolved.Scope.String()
 
 	var rawMessages []byte
-	err = s.DB.QueryRowContext(ctx, q, agentID, mode, resolved.ScopeKey).Scan(
+	err = s.DB.QueryRowContext(ctx, q, agentID, resolvedMode.String(), resolved.ScopeKey).Scan(
 		&rec.ScopeKey,
 		&rawMessages,
 		&rec.Summary,

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -114,7 +114,7 @@ func projectPersistedAgentConfig(cfg runtimeactors.AgentConfig, parentAgentID st
 		Role:              strings.TrimSpace(cfg.Role),
 		ModelTier:         modelTier,
 		LLMBackend:        llmBackend,
-		ConversationMode:  conversationMode,
+		ConversationMode:  conversationMode.String(),
 		ParentAgentID:     nullable(strings.TrimSpace(parentAgentID), strings.TrimSpace(cfg.ParentAgent)),
 		EntityID:          cfg.EffectiveEntityID(),
 		ConfigJSON:        configJSON,
@@ -141,8 +141,8 @@ func hydratePersistedAgentConfig(row persistedAgentProjection) (runtimeactors.Ag
 	if llmBackend == "" {
 		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s missing llm_backend", strings.TrimSpace(row.AgentID))
 	}
-	conversationMode := strings.TrimSpace(row.ConversationMode)
-	if _, err := runtimesessions.ParseConversationRuntimeMode(conversationMode); err != nil {
+	conversationMode, err := runtimesessions.ParseConversationRuntimeMode(row.ConversationMode)
+	if err != nil {
 		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid conversation_mode %q: %w", strings.TrimSpace(row.AgentID), conversationMode, err)
 	}
 	if err := validateOpaqueAgentConfig(row.ConfigJSON); err != nil {
@@ -164,8 +164,8 @@ func hydratePersistedAgentConfig(row persistedAgentProjection) (runtimeactors.Ag
 		Mode:             desc.Mode,
 		ModelTier:        modelTier,
 		LLMBackend:       llmBackend,
-		ConversationMode: conversationMode,
-		SessionScope:     sessionScope,
+		ConversationMode: conversationMode.String(),
+		SessionScope:     sessionScope.String(),
 		MaxTurnsPerTask:  desc.MaxTurnsPerTask,
 		Subscriptions:    decodeJSONStringList(row.SubscriptionsJSON),
 		EmitEvents:       decodeJSONStringList(row.EmitEventsJSON),

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -98,7 +98,10 @@ func projectPersistedAgentConfig(cfg runtimeactors.AgentConfig, parentAgentID st
 	cfg.NormalizeEntityID()
 	cfg.NormalizeRuntimeDescriptor()
 	modelTier := agentModelTier(cfg)
-	conversationMode := agentConversationMode(cfg)
+	conversationMode, err := agentConversationMode(cfg)
+	if err != nil {
+		return persistedAgentProjection{}, fmt.Errorf("invalid conversation mode: %w", err)
+	}
 	llmBackend := agentLLMBackend(cfg)
 	configJSON, err := mergeAgentConfigJSON(cfg)
 	if err != nil {
@@ -143,7 +146,7 @@ func hydratePersistedAgentConfig(row persistedAgentProjection) (runtimeactors.Ag
 	}
 	conversationMode, err := runtimesessions.ParseConversationRuntimeMode(row.ConversationMode)
 	if err != nil {
-		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid conversation_mode %q: %w", strings.TrimSpace(row.AgentID), conversationMode, err)
+		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid conversation_mode %q: %w", strings.TrimSpace(row.AgentID), strings.TrimSpace(row.ConversationMode), err)
 	}
 	if err := validateOpaqueAgentConfig(row.ConfigJSON); err != nil {
 		return runtimeactors.AgentConfig{}, fmt.Errorf("agent %s invalid opaque config: %w", strings.TrimSpace(row.AgentID), err)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2240,6 +2240,36 @@ func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *test
 	}
 }
 
+func TestManagerStore_UpsertAgent_RejectsInvalidConversationModeAtAdmission(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-invalid-mode",
+			Role:             "reviewer",
+			Type:             "review-worker",
+			ConversationMode: "nonsense",
+		},
+		Status: "active",
+	})
+	if err == nil {
+		t.Fatal("expected invalid conversation mode to fail")
+	}
+	if !strings.Contains(err.Error(), `invalid agent session scope: invalid conversation mode "nonsense"`) {
+		t.Fatalf("UpsertAgent error = %q", err.Error())
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agents WHERE agent_id = 'agent-invalid-mode'`).Scan(&count); err != nil {
+		t.Fatalf("count invalid-mode agent rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("persisted invalid-mode agent rows = %d, want 0", count)
+	}
+}
+
 func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeKeys(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary
- introduce typed canonical owners for stable session semantics (`RuntimeMode`, `SessionScope`) and runtime-log severity (`diaglog.Level`)
- propagate those types through touched runtime, LLM, store, and bus seams while preserving string boundaries only at persisted/public edges
- align conformance coverage after the rebase so the typed seam remains the semantic owner

## Tests
- go test ./internal/runtime/sessions -count=1
- go test ./internal/runtime/llm ./internal/store ./internal/runtime/bus ./internal/runtime -count=1
- go test ./internal/runtime/conformance -count=1
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Runtime logging, conversation modes, and session scopes now use stronger typed enums for more consistent level/mode handling across the system.
* **Bug Fixes / Validation**
  * Configuration and persistence now enforce and normalize conversation mode/session scope values; invalid conversation modes are rejected at admission/persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->