### PR TITLE
[agent-a][issue #93] Split delivery planning from the event bus into planner and policy layers

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -1,0 +1,113 @@
+package bus
+
+import (
+	"context"
+
+	"swarm/internal/events"
+)
+
+type deliveryRoutingResult struct {
+	Recipients           []string
+	RoutedRecipients     []Subscriber
+	SubscribedRecipients []string
+	ExtraDetail          map[string]any
+}
+
+type deliveryRouteResolver struct {
+	resolveRoutedSubscribers    func(string) []Subscriber
+	resolveSubscribedRecipients func(string) []string
+	describeSubscribersForEvent func(string, []Subscriber) []PublishDiagnosticRecipient
+}
+
+func (r deliveryRouteResolver) Resolve(evt events.Event) deliveryRoutingResult {
+	routedRecipients := r.resolveRoutedSubscribers(string(evt.Type))
+	subscribedRecipients := r.resolveSubscribedRecipients(string(evt.Type))
+	recipients := uniqueStrings(append(subscriberIDs(routedRecipients), subscribedRecipients...))
+	result := deliveryRoutingResult{
+		Recipients:           recipients,
+		RoutedRecipients:     routedRecipients,
+		SubscribedRecipients: subscribedRecipients,
+		ExtraDetail: map[string]any{
+			"routed_recipients_count":       len(routedRecipients),
+			"subscription_recipients_count": len(subscribedRecipients),
+		},
+	}
+	if described := publishDiagnosticRecipientMaps(r.describeSubscribersForEvent(string(evt.Type), routedRecipients)); len(described) > 0 {
+		result.ExtraDetail["routed_recipients"] = described
+	}
+	if direct := uniqueStrings(subscribedRecipients); len(direct) > 0 {
+		result.ExtraDetail["subscription_recipients"] = direct
+	}
+	return result
+}
+
+type deliveryRecipientManifest struct {
+	Recipients          []string
+	PersistedRecipients []string
+}
+
+type deliveryRecipientPolicy struct {
+	loadActiveAgentDescriptors func(context.Context) (map[string]ActiveAgentDescriptor, bool, error)
+}
+
+func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event, recipients []string) (deliveryRecipientManifest, error) {
+	descriptors, ok, err := p.loadActiveAgentDescriptors(ctx)
+	if err != nil {
+		return deliveryRecipientManifest{}, err
+	}
+	if !ok {
+		recipients = uniqueStrings(recipients)
+		return deliveryRecipientManifest{
+			Recipients:          recipients,
+			PersistedRecipients: recipients,
+		}, nil
+	}
+	recipients = filterRecipientsForExplicitAgentScope(evt, recipients, descriptors)
+	return deliveryRecipientManifest{
+		Recipients:          recipients,
+		PersistedRecipients: append([]string(nil), recipients...),
+	}, nil
+}
+
+type deliveryPlanner struct {
+	routeResolver   deliveryRouteResolver
+	recipientPolicy deliveryRecipientPolicy
+}
+
+func newDeliveryPlanner(routeResolver deliveryRouteResolver, recipientPolicy deliveryRecipientPolicy) deliveryPlanner {
+	return deliveryPlanner{
+		routeResolver:   routeResolver,
+		recipientPolicy: recipientPolicy,
+	}
+}
+
+func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
+	plan := eventDeliveryPlan{Event: evt}
+	if evt.Type == events.EventType("platform.runtime_log") {
+		return plan, nil
+	}
+	routing := p.routeResolver.Resolve(evt)
+	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, routing.Recipients)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	plan.Recipients = manifest.Recipients
+	plan.PersistedRecipients = manifest.PersistedRecipients
+	plan.RoutedRecipients = routing.RoutedRecipients
+	plan.SubscribedRecipients = routing.SubscribedRecipients
+	plan.ExtraDetail = routing.ExtraDetail
+	return plan, nil
+}
+
+func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
+	return newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers:    eb.resolveRoutedSubscribers,
+			resolveSubscribedRecipients: eb.resolveSubscribedRecipients,
+			describeSubscribersForEvent: eb.describeSubscribersForEvent,
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: eb.activeAgentDescriptors,
+		},
+	)
+}

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -1,0 +1,146 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"swarm/internal/events"
+)
+
+func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing.T) {
+	resolver := deliveryRouteResolver{
+		resolveRoutedSubscribers: func(string) []Subscriber {
+			return []Subscriber{{
+				ID:           "scan-orchestrator",
+				Type:         "node",
+				Path:         "discovery",
+				MatchPattern: "producer/scan.requested",
+				RouteSource:  "pin_auto_wire",
+			}}
+		},
+		resolveSubscribedRecipients: func(string) []string {
+			return []string{"direct-agent", "scan-orchestrator", "direct-agent"}
+		},
+		describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+			return []PublishDiagnosticRecipient{{
+				ID:             "scan-orchestrator",
+				Type:           "node",
+				Path:           "discovery",
+				MatchedPattern: "producer/scan.requested",
+				RouteSource:    "pin_auto_wire",
+				LocalizedEvent: "scan.requested",
+			}}
+		},
+	}
+
+	result := resolver.Resolve(events.Event{Type: events.EventType("producer/scan.requested")})
+	if got, want := len(result.RoutedRecipients), 1; got != want {
+		t.Fatalf("routed recipients = %d, want %d", got, want)
+	}
+	if got, want := len(result.SubscribedRecipients), 3; got != want {
+		t.Fatalf("subscription recipients = %d, want %d", got, want)
+	}
+	if got, want := len(result.Recipients), 2; got != want {
+		t.Fatalf("candidate recipients = %d, want %d", got, want)
+	}
+	if got := result.Recipients[0]; got != "scan-orchestrator" {
+		t.Fatalf("first candidate recipient = %q, want scan-orchestrator", got)
+	}
+	if got := result.Recipients[1]; got != "direct-agent" {
+		t.Fatalf("second candidate recipient = %q, want direct-agent", got)
+	}
+	if got := result.ExtraDetail["routed_recipients_count"]; got != 1 {
+		t.Fatalf("routed_recipients_count = %#v, want 1", got)
+	}
+	if got := result.ExtraDetail["subscription_recipients_count"]; got != 3 {
+		t.Fatalf("subscription_recipients_count = %#v, want 3", got)
+	}
+	routed, _ := result.ExtraDetail["routed_recipients"].([]map[string]any)
+	if len(routed) != 1 || routed[0]["id"] != "scan-orchestrator" {
+		t.Fatalf("routed_recipients detail = %#v", result.ExtraDetail["routed_recipients"])
+	}
+}
+
+func TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest(t *testing.T) {
+	policy := deliveryRecipientPolicy{
+		loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+			return map[string]ActiveAgentDescriptor{
+				"entity-agent": {AgentID: "entity-agent", EntityID: "ent-1"},
+				"other-agent":  {AgentID: "other-agent", EntityID: "ent-2"},
+				"shared-agent": {AgentID: "shared-agent"},
+			}, true, nil
+		},
+	}
+
+	manifest, err := policy.Evaluate(context.Background(), (events.Event{
+		Type: "task.completed",
+	}).WithEntityID("ent-1"), []string{"entity-agent", "other-agent", "shared-agent"})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got, want := len(manifest.Recipients), 2; got != want {
+		t.Fatalf("recipient count = %d, want %d", got, want)
+	}
+	if manifest.Recipients[0] != "entity-agent" || manifest.Recipients[1] != "shared-agent" {
+		t.Fatalf("recipients = %#v, want [entity-agent shared-agent]", manifest.Recipients)
+	}
+	if len(manifest.PersistedRecipients) != 2 || manifest.PersistedRecipients[0] != "entity-agent" || manifest.PersistedRecipients[1] != "shared-agent" {
+		t.Fatalf("persisted recipients = %#v, want [entity-agent shared-agent]", manifest.PersistedRecipients)
+	}
+}
+
+func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(string) []Subscriber {
+				return []Subscriber{{ID: "worker", Type: "node"}}
+			},
+			resolveSubscribedRecipients: func(string) []string {
+				return []string{"worker", "observer"}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return []PublishDiagnosticRecipient{{ID: "worker", Type: "node"}}
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return nil, false, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), events.Event{Type: "task.completed"})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got, want := len(plan.Recipients), 2; got != want {
+		t.Fatalf("plan recipients = %d, want %d", got, want)
+	}
+	if got, want := len(plan.PersistedRecipients), 2; got != want {
+		t.Fatalf("persisted recipients = %d, want %d", got, want)
+	}
+	if got := plan.ExtraDetail["routed_recipients_count"]; got != 1 {
+		t.Fatalf("routed_recipients_count = %#v, want 1", got)
+	}
+}
+
+func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers:    func(string) []Subscriber { return nil },
+			resolveSubscribedRecipients: func(string) []string { return []string{"worker"} },
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient { return nil },
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return nil, false, errors.New("descriptor store unavailable")
+			},
+		},
+	)
+
+	_, err := planner.Plan(context.Background(), events.Event{Type: "task.completed"})
+	if err == nil || err.Error() != "descriptor store unavailable" {
+		t.Fatalf("Plan err = %v, want descriptor store unavailable", err)
+	}
+}

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -29,6 +29,7 @@ type EventBus struct {
 	agentChans          map[string]chan events.Event
 	subscriptions       map[string][]events.EventType
 	routeTable          *RouteTable
+	deliveryPlanner     deliveryPlanner
 	interceptors        []EventInterceptor
 	interceptorProvider func() []EventInterceptor
 	store               EventStore
@@ -87,7 +88,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		}
 		routeTable = derived
 	}
-	return &EventBus{
+	eb := &EventBus{
 		channels:            make(map[events.EventType]map[string]chan events.Event),
 		agentChans:          make(map[string]chan events.Event),
 		subscriptions:       make(map[string][]events.EventType),
@@ -98,7 +99,9 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		interceptorProvider: opts.InterceptorProvider,
 		semanticSource:      semanticSource,
 		payloadValidator:    opts.PayloadValidator,
-	}, nil
+	}
+	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
+	return eb, nil
 }
 
 func (eb *EventBus) Store() EventStore {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -133,10 +133,11 @@ func (eb *EventBus) publishTransactional(
 		return fmt.Errorf("persist event: %w", err)
 	}
 
-	inboundPlan, err := eb.buildDeliveryPlan(txctx, evt)
+	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
 	if err != nil {
 		return err
 	}
+	eb.recordPublishDiagnostic(txctx, evt, inboundPlan)
 	if len(inboundPlan.PersistedRecipients) > 0 {
 		if err := txStore.InsertEventDeliveriesTx(txctx, tx, evt.ID, inboundPlan.PersistedRecipients); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
@@ -280,10 +281,11 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		}
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
-	plan, err := eb.buildDeliveryPlan(ctx, evt)
+	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
 	if err != nil {
 		return err
 	}
+	eb.recordPublishDiagnostic(ctx, evt, plan)
 	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
 		return err
 	}
@@ -372,10 +374,11 @@ func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, duration
 }
 
 func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error {
-	plan, err := eb.buildDeliveryPlan(ctx, evt)
+	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
 	if err != nil {
 		return err
 	}
+	eb.recordPublishDiagnostic(ctx, evt, plan)
 	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
 		return err
 	}
@@ -392,41 +395,6 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 		_ = eb.emitContradiction(ctx, evt, plan.ContradictionReason)
 	}
 	return nil
-}
-
-func (eb *EventBus) buildDeliveryPlan(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
-	plan := eventDeliveryPlan{Event: evt}
-	if evt.Type == events.EventType("platform.runtime_log") {
-		return plan, nil
-	}
-	plan.RoutedRecipients = eb.resolveRoutedSubscribers(string(evt.Type))
-	plan.SubscribedRecipients = eb.resolveSubscribedRecipients(string(evt.Type))
-	plan.Recipients = uniqueStrings(append(
-		subscriberIDs(plan.RoutedRecipients),
-		plan.SubscribedRecipients...,
-	))
-	plan.ExtraDetail = map[string]any{
-		"routed_recipients_count":       len(plan.RoutedRecipients),
-		"subscription_recipients_count": len(plan.SubscribedRecipients),
-	}
-	if described := publishDiagnosticRecipientMaps(eb.describeSubscribersForEvent(string(evt.Type), plan.RoutedRecipients)); len(described) > 0 {
-		plan.ExtraDetail["routed_recipients"] = described
-	}
-	if direct := uniqueStrings(plan.SubscribedRecipients); len(direct) > 0 {
-		plan.ExtraDetail["subscription_recipients"] = direct
-	}
-	descriptors, ok, err := eb.activeAgentDescriptors(ctx)
-	if err != nil {
-		return eventDeliveryPlan{}, err
-	}
-	if ok {
-		plan.Recipients = filterRecipientsForExplicitAgentScope(evt, plan.Recipients, descriptors)
-		plan.PersistedRecipients = append([]string(nil), plan.Recipients...)
-	} else {
-		plan.PersistedRecipients = uniqueStrings(plan.Recipients)
-	}
-	eb.recordPublishDiagnostic(ctx, evt, plan)
-	return plan, nil
 }
 
 func (eb *EventBus) persistEventRecord(ctx context.Context, evt events.Event, recipients []string) error {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -70,10 +70,11 @@ func (o engineOutbox) persistedRecipientsForIntent(ctx context.Context, intent r
 	if len(intent.Recipients) > 0 {
 		return uniqueStrings(intent.Recipients), nil
 	}
-	plan, err := o.bus.buildDeliveryPlan(ctx, intent.Event)
+	plan, err := o.bus.deliveryPlanner.Plan(ctx, intent.Event)
 	if err != nil {
 		return nil, err
 	}
+	o.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
 	return plan.PersistedRecipients, nil
 }
 
@@ -121,10 +122,11 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 	if !passthrough {
 		return nil
 	}
-	plan, err := d.bus.buildDeliveryPlan(ctx, intent.Event)
+	plan, err := d.bus.deliveryPlanner.Plan(ctx, intent.Event)
 	if err != nil {
 		return err
 	}
+	d.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
 	if len(plan.Recipients) > 0 {
 		d.bus.deliverToAgents(ctx, intent.Event, plan.Recipients)
 		d.bus.logDelivery(ctx, intent.Event, plan.Recipients, plan.ExtraDetail)


### PR DESCRIPTION
## Summary
- extract routed delivery planning into an explicit delivery planner with separate route-resolution and recipient-policy layers
- make publish, deferred publish, and outbox paths consume the shared planner instead of rebuilding planning logic inline
- add focused planner and policy tests while preserving existing delivery behavior in bus integration tests

## Testing
- go test ./internal/runtime/bus -count=1
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted event delivery planning into a dedicated, reusable component within the bus package.
  * Simplified event publishing logic by delegating plan construction to the new delivery planner.

* **Tests**
  * Added comprehensive unit tests for delivery planning, route resolution, and recipient policy evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->