### PR TITLE
[agent-e][issue #91] Add malformed runtime_descriptor store regression slice

### DIFF
--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -229,20 +229,30 @@ func decodePersistedAgentRuntimeDescriptor(raw []byte) (persistedAgentRuntimeDes
 	return desc, nil
 }
 
-func decodePersistedAgentRuntimeDescriptorLoose(raw []byte) persistedAgentRuntimeDescriptor {
-	if len(raw) == 0 || !json.Valid(raw) {
-		return persistedAgentRuntimeDescriptor{}
+func decodePersistedAgentRuntimeDescriptorLoose(raw []byte) (persistedAgentRuntimeDescriptor, bool) {
+	if len(raw) == 0 {
+		return persistedAgentRuntimeDescriptor{}, true
+	}
+	if !json.Valid(raw) {
+		return persistedAgentRuntimeDescriptor{}, false
+	}
+	obj := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return persistedAgentRuntimeDescriptor{}, false
+	}
+	if unknown := invalidPersistedAgentRuntimeDescriptorKeys(obj); len(unknown) > 0 {
+		return persistedAgentRuntimeDescriptor{}, false
 	}
 	var desc persistedAgentRuntimeDescriptor
 	if err := json.Unmarshal(raw, &desc); err != nil {
-		return persistedAgentRuntimeDescriptor{}
+		return persistedAgentRuntimeDescriptor{}, false
 	}
 	desc.Type = strings.TrimSpace(desc.Type)
 	desc.Mode = strings.TrimSpace(desc.Mode)
 	desc.SessionScope = strings.TrimSpace(desc.SessionScope)
 	desc.WorkspaceClass = strings.TrimSpace(desc.WorkspaceClass)
 	desc.ManagerFallback = strings.TrimSpace(desc.ManagerFallback)
-	return desc
+	return desc, true
 }
 
 func extractSubscriptions(raw []byte) []string {

--- a/internal/store/manager_runtime_descriptor_regression_test.go
+++ b/internal/store/manager_runtime_descriptor_regression_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"swarm/internal/testutil"
+)
+
+func TestManagerStore_LoadAgents_FailsClosedOnMalformedRuntimeDescriptor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		runtimeDescriptor  string
+		wantErrorSubstring string
+	}{
+		{
+			name:               "non object runtime descriptor",
+			runtimeDescriptor:  `[]`,
+			wantErrorSubstring: `invalid runtime_descriptor: decode runtime_descriptor: json: cannot unmarshal array into Go value of type map[string]json.RawMessage`,
+		},
+		{
+			name:               "unsupported runtime descriptor keys",
+			runtimeDescriptor:  `{"type":"review-worker","mode":"review","legacy_scope":"global"}`,
+			wantErrorSubstring: `invalid runtime_descriptor: runtime_descriptor contains unsupported keys: legacy_scope`,
+		},
+		{
+			name:               "wrong runtime descriptor field types",
+			runtimeDescriptor:  `{"type":1,"mode":"review"}`,
+			wantErrorSubstring: `invalid runtime_descriptor: decode runtime_descriptor: json: cannot unmarshal number into Go struct field persistedAgentRuntimeDescriptor.type of type string`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+
+			if err := pg.ensureSchemaCompatibilityColumns(ctx); err != nil {
+				t.Fatalf("ensureSchemaCompatibilityColumns: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO agents (
+					agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
+					parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
+					runtime_descriptor, status
+				) VALUES (
+					$1, '', 'reviewer', 'sonnet', 'api', 'task',
+					NULL, NULL, '{}'::jsonb, '["review.ready"]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb,
+					$2::jsonb, 'active'
+				)
+			`, "agent-malformed-runtime-descriptor", tt.runtimeDescriptor); err != nil {
+				t.Fatalf("seed agent row: %v", err)
+			}
+
+			_, err := pg.LoadAgents(ctx)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrorSubstring) {
+				t.Fatalf("LoadAgents error = %v, want substring %q", err, tt.wantErrorSubstring)
+			}
+		})
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -190,7 +190,12 @@ func (s *PostgresStore) migrateLegacyAgentRuntimeDescriptors(ctx context.Context
 		if err := rows.Scan(&agentID, &modelTier, &configRaw, &runtimeDescriptor); err != nil {
 			return fmt.Errorf("scan agent runtime descriptor migration row: %w", err)
 		}
-		desc := decodePersistedAgentRuntimeDescriptorLoose(runtimeDescriptor)
+		desc, ok := decodePersistedAgentRuntimeDescriptorLoose(runtimeDescriptor)
+		if !ok {
+			// Malformed canonical descriptors must fail closed during hydration rather than
+			// being silently rewritten into a new shape by the legacy migration pass.
+			continue
+		}
 		legacy := decodeLegacyAgentRuntimeConfig(configRaw)
 		if desc.Type == "" {
 			desc.Type = coalesce(legacy.Type, strings.TrimSpace(modelTier))


### PR DESCRIPTION
## Summary
- add focused store regression coverage for malformed `agents.runtime_descriptor` load paths
- tighten the legacy runtime-descriptor migration so malformed canonical descriptors are not silently rewritten before hydration
- keep legacy backfill for empty or structurally valid partial descriptor objects

## Why
This issue targets the store hydration seam directly. The new regression slice proves `LoadAgents` fails closed for malformed canonical `runtime_descriptor` rows instead of relying on helper inspection alone.

## Risk
- `risk: medium`
- narrow store-only seam, but it changes startup/load behavior for malformed persisted agent rows

## Validation
- `go test ./internal/store`
- `go test ./internal/store ./... -count=1`

## Notes
- real issue found: the legacy migration path was healing malformed canonical `runtime_descriptor` shapes before `LoadAgents` could reject them
- intentionally not frozen as a regression: object-shaped descriptors missing `type` still follow the existing partial-descriptor backfill path
