### PR TITLE
[agent-c][issue #89] Replace semantically important map[string]any control surfaces with typed contract structs

### DIFF
--- a/internal/store/event_receipt_side_effects.go
+++ b/internal/store/event_receipt_side_effects.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	runtimemanager "swarm/internal/runtime/manager"
+)
+
+type agentReceiptSideEffects struct {
+	ManagerStatus runtimemanager.ReceiptStatus `json:"manager_status"`
+	ReasonCode    string                       `json:"reason_code,omitempty"`
+	RetryCount    int                          `json:"retry_count"`
+	Error         string                       `json:"error,omitempty"`
+}
+
+type pipelineReceiptSideEffects struct {
+	ManagerStatus string `json:"manager_status"`
+	ReasonCode    string `json:"reason_code,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+func newAgentReceiptSideEffects(status runtimemanager.ReceiptStatus, reasonCode string, retryCount int, errText string) agentReceiptSideEffects {
+	return agentReceiptSideEffects{
+		ManagerStatus: runtimemanager.ReceiptStatus(strings.TrimSpace(string(status))),
+		ReasonCode:    strings.TrimSpace(reasonCode),
+		RetryCount:    retryCount,
+		Error:         strings.TrimSpace(errText),
+	}
+}
+
+func (p agentReceiptSideEffects) validate() error {
+	switch p.ManagerStatus {
+	case runtimemanager.ReceiptStatusProcessed, runtimemanager.ReceiptStatusError, runtimemanager.ReceiptStatusDeadLetter:
+	default:
+		if strings.TrimSpace(string(p.ManagerStatus)) == "" {
+			return fmt.Errorf("manager_status is required")
+		}
+		return fmt.Errorf("invalid manager_status %q", p.ManagerStatus)
+	}
+	if p.RetryCount < 0 {
+		return fmt.Errorf("retry_count must be >= 0")
+	}
+	return nil
+}
+
+func marshalAgentReceiptSideEffects(payload agentReceiptSideEffects) ([]byte, error) {
+	if err := payload.validate(); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func decodeAgentReceiptSideEffects(raw []byte) (agentReceiptSideEffects, error) {
+	var payload agentReceiptSideEffects
+	if len(raw) == 0 {
+		return payload, fmt.Errorf("agent receipt side effects are required")
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return payload, err
+	}
+	payload.ReasonCode = strings.TrimSpace(payload.ReasonCode)
+	payload.Error = strings.TrimSpace(payload.Error)
+	if err := payload.validate(); err != nil {
+		return payload, err
+	}
+	return payload, nil
+}
+
+func newPipelineReceiptSideEffects(status, reasonCode, errText string) pipelineReceiptSideEffects {
+	return pipelineReceiptSideEffects{
+		ManagerStatus: strings.TrimSpace(status),
+		ReasonCode:    strings.TrimSpace(reasonCode),
+		Error:         strings.TrimSpace(errText),
+	}
+}
+
+func (p pipelineReceiptSideEffects) validate() error {
+	if strings.TrimSpace(p.ManagerStatus) == "" {
+		return fmt.Errorf("manager_status is required")
+	}
+	return nil
+}
+
+func marshalPipelineReceiptSideEffects(payload pipelineReceiptSideEffects) ([]byte, error) {
+	if err := payload.validate(); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/internal/store/event_receipt_side_effects_test.go
+++ b/internal/store/event_receipt_side_effects_test.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	runtimemanager "swarm/internal/runtime/manager"
+)
+
+func TestAgentReceiptSideEffects_RoundTrip(t *testing.T) {
+	raw, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(
+		runtimemanager.ReceiptStatusDeadLetter,
+		"cancelled_by_kill_previous",
+		2,
+		"boom",
+	))
+	if err != nil {
+		t.Fatalf("marshalAgentReceiptSideEffects: %v", err)
+	}
+	got, err := decodeAgentReceiptSideEffects(raw)
+	if err != nil {
+		t.Fatalf("decodeAgentReceiptSideEffects: %v", err)
+	}
+	if got.ManagerStatus != runtimemanager.ReceiptStatusDeadLetter {
+		t.Fatalf("ManagerStatus = %q, want dead_letter", got.ManagerStatus)
+	}
+	if got.ReasonCode != "cancelled_by_kill_previous" {
+		t.Fatalf("ReasonCode = %q", got.ReasonCode)
+	}
+	if got.RetryCount != 2 {
+		t.Fatalf("RetryCount = %d, want 2", got.RetryCount)
+	}
+	if got.Error != "boom" {
+		t.Fatalf("Error = %q, want boom", got.Error)
+	}
+}
+
+func TestAgentReceiptSideEffects_FailsClosedOnMalformedPayload(t *testing.T) {
+	_, err := decodeAgentReceiptSideEffects([]byte(`{"retry_count":"bad"}`))
+	if err == nil {
+		t.Fatal("expected malformed agent receipt side effects to fail")
+	}
+	if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -134,14 +133,26 @@ func (s *PostgresStore) GetEventReceipt(ctx context.Context, eventID, agentID st
 }
 
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
-	var retryCount int
-	_ = s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE((side_effects->>'retry_count')::int, 0)
+	var sideEffectsRaw []byte
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(side_effects, '{}'::jsonb)
 		FROM event_receipts
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
 		  AND subscriber_id = $2
-	`, eventID, agentID).Scan(&retryCount)
+	`, eventID, agentID).Scan(&sideEffectsRaw)
+	var retryCount int
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+	case err != nil:
+		return fmt.Errorf("load event receipt side effects: %w", err)
+	default:
+		payload, err := decodeAgentReceiptSideEffects(sideEffectsRaw)
+		if err != nil {
+			return fmt.Errorf("decode event receipt side effects: %w", err)
+		}
+		retryCount = payload.RetryCount
+	}
 	if status == runtimemanager.ReceiptStatusError {
 		retryCount++
 	}
@@ -150,12 +161,7 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 		finalStatus = runtimemanager.ReceiptStatusDeadLetter
 	}
 	reasonCode := managerReceiptReasonCode(finalStatus, errText)
-	sideEffects, err := json.Marshal(map[string]any{
-		"manager_status": finalStatus,
-		"reason_code":    reasonCode,
-		"retry_count":    retryCount,
-		"error":          strings.TrimSpace(errText),
-	})
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(finalStatus, reasonCode, retryCount, errText))
 	if err != nil {
 		return fmt.Errorf("marshal event receipt side effects: %w", err)
 	}
@@ -362,19 +368,13 @@ func (s *PostgresStore) getEventReceiptSpec(ctx context.Context, eventID, agentI
 		Status:  mapOutcomeToManagerReceiptStatus(outcome),
 	}
 	if len(sideEffects) > 0 {
-		var payload map[string]any
-		if json.Unmarshal(sideEffects, &payload) == nil {
-			if raw, ok := payload["manager_status"].(string); ok && strings.TrimSpace(raw) != "" {
-				receipt.Status = runtimemanager.ReceiptStatus(strings.TrimSpace(raw))
-			}
-			switch raw := payload["retry_count"].(type) {
-			case float64:
-				receipt.RetryCount = int(raw)
-			}
-			if raw, ok := payload["error"].(string); ok {
-				receipt.Error = strings.TrimSpace(raw)
-			}
+		payload, err := decodeAgentReceiptSideEffects(sideEffects)
+		if err != nil {
+			return runtimemanager.EventReceipt{}, false, fmt.Errorf("decode event receipt side effects: %w", err)
 		}
+		receipt.Status = payload.ManagerStatus
+		receipt.RetryCount = payload.RetryCount
+		receipt.Error = payload.Error
 	}
 	return receipt, true, nil
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -361,11 +361,7 @@ func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, caps Stor
 
 func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {
 	reasonCode := pipelineReceiptReasonCode(status, errText)
-	sideEffects, err := json.Marshal(map[string]any{
-		"manager_status": strings.TrimSpace(status),
-		"reason_code":    reasonCode,
-		"error":          strings.TrimSpace(errText),
-	})
+	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects(status, reasonCode, errText))
 	if err != nil {
 		return fmt.Errorf("marshal pipeline receipt side effects: %w", err)
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1267,6 +1267,43 @@ func TestManagerStore_EventReceiptBranches(t *testing.T) {
 	}
 }
 
+func TestManagerStore_GetEventReceipt_FailsClosedOnMalformedSideEffects(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	entityID := uuid.NewString()
+	seedSpecAgent(t, ctx, pg, "a1", "", "*")
+	eventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, (events.Event{
+		ID:          eventID,
+		Type:        "system.started",
+		SourceAgent: "runtime",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now(),
+	}).WithEntityID(entityID)); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'agent', 'a1', e.entity_id, e.flow_instance,
+			'dead_letter', '{"retry_count":"bad"}'::jsonb, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+	`, eventID); err != nil {
+		t.Fatalf("insert malformed receipt: %v", err)
+	}
+
+	if _, ok, err := pg.GetEventReceipt(ctx, eventID, "a1"); err == nil || ok {
+		t.Fatalf("expected malformed side effects error, got ok=%v err=%v", ok, err)
+	}
+}
+
 func TestManagerStore_MarkEventDeliveryInProgress_RequiresIDs(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/trace_cancel.go
+++ b/internal/store/trace_cancel.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -97,12 +96,7 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 		return nil, fmt.Errorf("read affected agents: %w", err)
 	}
 
-	sideEffects, err := json.Marshal(map[string]any{
-		"manager_status": "dead_letter",
-		"reason_code":    "cancelled_by_kill_previous",
-		"retry_count":    0,
-		"error":          "cancelled by --kill-previous",
-	})
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects("dead_letter", "cancelled_by_kill_previous", 0, "cancelled by --kill-previous"))
 	if err != nil {
 		return nil, fmt.Errorf("marshal kill_previous receipt side effects: %w", err)
 	}


### PR DESCRIPTION
## What changed
- replaced the canonical `event_receipts.side_effects` control payload with typed store-owned structs instead of ad hoc `map[string]any`
- added typed encode/decode helpers for agent and pipeline receipt side effects
- made `GetEventReceipt` fail closed when persisted receipt side effects are malformed instead of silently ignoring bad control data

## Why
`event_receipts.side_effects` already had a stable semantic contract: `manager_status`, `reason_code`, `retry_count`, and `error`. The code was still writing and reading that control surface through raw maps, which made drift cheap and malformed payloads too easy to tolerate. This narrows the surface to one explicit canonical shape.

## Impact
- agent receipt side effects are now written and read through typed structs
- pipeline receipt side effects use the same typed pattern on write
- malformed persisted agent receipt side effects now surface an error at the canonical reader boundary

## Validation
- `go test ./internal/store -count=1`
- `go test ./... -count=1`
