### PR TITLE
[agent-a][issue #115] Preserve persisted correlation envelope during recovery replay

### DIFF
--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -35,6 +35,11 @@ type Event struct {
 	CreatedAt     time.Time       `json:"created_at"`
 }
 
+type PersistedReplayEvent struct {
+	Event       Event
+	ReplayError string
+}
+
 func (e Event) WithEnvelope(envelope EventEnvelope) Event {
 	e.Envelope = envelope.Normalized()
 	return e

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -72,7 +72,7 @@ type TransactionalEventStore interface {
 }
 
 type PipelineReceiptSweeperStore interface {
-	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.Event, error)
+	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
 }
 
 type EventDeliveryReader interface {

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -90,7 +90,12 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	}
 	dispatcher := engineDispatcher{bus: eb}
 	redelivered := 0
-	for _, evt := range events {
+	for _, record := range events {
+		evt := record.Event
+		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
+			eb.markPipelineReceipt(ctx, evt.ID, "error", replayErr)
+			continue
+		}
 		recipients, err := eb.sweeperRecipients(ctx, evt.ID)
 		if err != nil {
 			eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type sweeperTestStore struct {
-	events      []events.Event
+	events      []events.PersistedReplayEvent
 	deliveries  map[string][]string
 	receipts    map[string]string
 	receiptErrs map[string]string
@@ -31,8 +31,8 @@ func (s *sweeperTestStore) UpsertPipelineReceipt(_ context.Context, eventID, sta
 	s.receiptErrs[eventID] = errText
 	return nil
 }
-func (s *sweeperTestStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.Event, error) {
-	return append([]events.Event(nil), s.events...), nil
+func (s *sweeperTestStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.events...), nil
 }
 func (s *sweeperTestStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
 	return append([]string(nil), s.deliveries[eventID]...), nil
@@ -40,13 +40,13 @@ func (s *sweeperTestStore) ListEventDeliveryRecipients(_ context.Context, eventI
 
 func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	store := &sweeperTestStore{
-		events: []events.Event{
-			(events.Event{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
 				ID:        "evt-1",
 				Type:      events.EventType("custom.emitted"),
 				Payload:   []byte(`{"entity_id":"ent-1"}`),
 				CreatedAt: time.Now().UTC(),
-			}).WithEntityID("ent-1"),
+			}).WithEntityID("ent-1")},
 		},
 		deliveries: map[string][]string{"evt-1": {"agent-a"}},
 	}
@@ -78,13 +78,13 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 
 func TestSweepUndispatchedFallsBackToSubscribedRouting(t *testing.T) {
 	store := &sweeperTestStore{
-		events: []events.Event{
-			(events.Event{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
 				ID:        "evt-2",
 				Type:      events.EventType("custom.routed"),
 				Payload:   []byte(`{"entity_id":"ent-2"}`),
 				CreatedAt: time.Now().UTC(),
-			}).WithEntityID("ent-2"),
+			}).WithEntityID("ent-2")},
 		},
 		deliveries: map[string][]string{},
 	}
@@ -111,5 +111,59 @@ func TestSweepUndispatchedFallsBackToSubscribedRouting(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected subscribed swept delivery")
+	}
+}
+
+func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{
+				Event: events.Event{
+					ID:        "evt-bad",
+					Type:      events.EventType("custom.bad"),
+					CreatedAt: time.Now().UTC(),
+				},
+				ReplayError: "missing canonical run_id",
+			},
+			{
+				Event: (events.Event{
+					ID:        "evt-good",
+					Type:      events.EventType("custom.good"),
+					Payload:   []byte(`{"entity_id":"ent-good"}`),
+					CreatedAt: time.Now().UTC(),
+				}).WithEntityID("ent-good"),
+			},
+		},
+		deliveries: map[string][]string{"evt-good": {"agent-good"}},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("agent-good")
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	if got := store.receipts["evt-bad"]; got != "error" {
+		t.Fatalf("bad receipt status = %q, want error", got)
+	}
+	if got := store.receiptErrs["evt-bad"]; got != "missing canonical run_id" {
+		t.Fatalf("bad receipt error = %q, want missing canonical run_id", got)
+	}
+	if got := store.receipts["evt-good"]; got != "processed" {
+		t.Fatalf("good receipt status = %q, want processed", got)
+	}
+	select {
+	case evt := <-ch:
+		if evt.ID != "evt-good" {
+			t.Fatalf("delivered event id = %q, want evt-good", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected good swept delivery")
 	}
 }

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -33,7 +33,7 @@ func (*recoveryTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEn
 func (b *recoveryTestBus) Store() runtimebus.EventStore                                  { return b }
 func (b *recoveryTestBus) AppendEvent(context.Context, events.Event) error               { return nil }
 func (b *recoveryTestBus) InsertEventDeliveries(context.Context, string, []string) error { return nil }
-func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.Event, error) {
+func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
 	return nil, nil
 }
 func (b *recoveryTestBus) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -10,7 +10,7 @@ import (
 )
 
 type missingPipelineReceiptReader interface {
-	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.Event, error)
+	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
 }
 
 type EventStore interface {
@@ -64,11 +64,18 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 		return err
 	}
 	var firstErr error
-	for _, evt := range eventsToReplay {
+	for _, record := range eventsToReplay {
+		evt := record.Event
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if strings.TrimSpace(evt.ID) == "" {
+			continue
+		}
+		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("replay event %s: %s", evt.ID, replayErr)
+			}
 			continue
 		}
 		if err := r.bus.Publish(ctx, evt); err != nil {

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -13,6 +13,10 @@ type missingPipelineReceiptReader interface {
 	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
 }
 
+type pipelineReceiptRecorder interface {
+	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
+}
+
 type EventStore interface {
 	AppendEvent(ctx context.Context, evt events.Event) error
 	InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error
@@ -63,6 +67,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	recorder, _ := r.store.(pipelineReceiptRecorder)
 	var firstErr error
 	for _, record := range eventsToReplay {
 		evt := record.Event
@@ -73,8 +78,16 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			continue
 		}
 		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("replay event %s: %s", evt.ID, replayErr)
+			if recorder == nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("mark replay event %s error receipt: missing pipeline receipt recorder", evt.ID)
+				}
+				continue
+			}
+			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "error", replayErr); err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("mark replay event %s error receipt: %w", evt.ID, err)
+				}
 			}
 			continue
 		}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -126,15 +126,42 @@ func TestRecoveryManager_FailsClosedOnMissingPersistedRunID(t *testing.T) {
 	}
 	capture := &recoveryCapturePublisher{inner: bus}
 
-	eventID := uuid.NewString()
+	badEventID := uuid.NewString()
+	goodRunID := uuid.NewString()
+	goodParentID := uuid.NewString()
+	goodEventID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
 		) VALUES (
 			$1::uuid, 'system.recover', 'global', '{}'::jsonb, 'runtime', 'platform', now()
 		)
-	`, eventID); err != nil {
+	`, badEventID); err != nil {
 		t.Fatalf("seed malformed event: %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          goodParentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       goodRunID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(good parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            goodEventID,
+		Type:          events.EventType("system.recover.good"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         goodRunID,
+		ParentEventID: goodParentID,
+		CreatedAt:     time.Now().Add(-1 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(good child): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, goodParentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(good parent): %v", err)
 	}
 
 	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
@@ -142,7 +169,10 @@ func TestRecoveryManager_FailsClosedOnMissingPersistedRunID(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "missing canonical run_id") {
 		t.Fatalf("Recover error = %v, want missing canonical run_id", err)
 	}
-	if len(capture.published) != 0 {
-		t.Fatalf("published events = %#v, want none", capture.published)
+	if len(capture.published) != 1 {
+		t.Fatalf("published events = %#v, want one valid replay", capture.published)
+	}
+	if capture.published[0].ID != goodEventID {
+		t.Fatalf("published event id = %q, want %q", capture.published[0].ID, goodEventID)
 	}
 }

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -191,3 +191,58 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 		t.Fatalf("bad receipt reason = %q, want pipeline_error", badReason)
 	}
 }
+
+func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	if _, err := db.ExecContext(ctx, `ALTER TABLE events DROP COLUMN run_id`); err != nil {
+		t.Fatalf("drop events.run_id: %v", err)
+	}
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	eventID := uuid.NewString()
+	parentID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            eventID,
+		Type:          events.EventType("system.recover.no-run-id"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.published) != 0 {
+		t.Fatalf("published events = %#v, want none", capture.published)
+	}
+
+	var outcome, reason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load receipt: %v", err)
+	}
+	if outcome != "dead_letter" {
+		t.Fatalf("receipt outcome = %q, want dead_letter", outcome)
+	}
+	if reason != "pipeline_error" {
+		t.Fatalf("receipt reason = %q, want pipeline_error", reason)
+	}
+}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -1,0 +1,148 @@
+package pipeline_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+type recoveryCapturePublisher struct {
+	inner     runtimepipeline.Publisher
+	published []events.Event
+}
+
+func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event) error {
+	p.published = append(p.published, evt)
+	return p.inner.Publish(ctx, evt)
+}
+
+func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	childID := uuid.NewString()
+
+	parent := events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}
+	child := events.Event{
+		ID:            childID,
+		Type:          events.EventType("system.recover"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-1 * time.Minute).UTC(),
+	}
+
+	if err := pg.AppendEvent(ctx, parent); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, child); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+
+	var runsBefore int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs`).Scan(&runsBefore); err != nil {
+		t.Fatalf("count runs before recovery: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.published) != 1 {
+		t.Fatalf("published events = %#v, want one replayed event", capture.published)
+	}
+	replayed := capture.published[0]
+	if replayed.ID != childID {
+		t.Fatalf("replayed event id = %q, want %q", replayed.ID, childID)
+	}
+	if replayed.RunID != runID {
+		t.Fatalf("replayed run_id = %q, want %q", replayed.RunID, runID)
+	}
+	if replayed.ParentEventID != parentID {
+		t.Fatalf("replayed parent_event_id = %q, want %q", replayed.ParentEventID, parentID)
+	}
+
+	var runsAfter int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs`).Scan(&runsAfter); err != nil {
+		t.Fatalf("count runs after recovery: %v", err)
+	}
+	if runsAfter != runsBefore {
+		t.Fatalf("run rows after recovery = %d, want %d", runsAfter, runsBefore)
+	}
+
+	var receiptStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, childID).Scan(&receiptStatus); err != nil {
+		t.Fatalf("load child receipt: %v", err)
+	}
+	if receiptStatus != "success" {
+		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
+	}
+}
+
+func TestRecoveryManager_FailsClosedOnMissingPersistedRunID(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, 'system.recover', 'global', '{}'::jsonb, 'runtime', 'platform', now()
+		)
+	`, eventID); err != nil {
+		t.Fatalf("seed malformed event: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	err = rm.Recover(ctx)
+	if err == nil || !strings.Contains(err.Error(), "missing canonical run_id") {
+		t.Fatalf("Recover error = %v, want missing canonical run_id", err)
+	}
+	if len(capture.published) != 0 {
+		t.Fatalf("published events = %#v, want none", capture.published)
+	}
+}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -2,7 +2,6 @@ package pipeline_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -114,7 +113,7 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	}
 }
 
-func TestRecoveryManager_FailsClosedOnMissingPersistedRunID(t *testing.T) {
+func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -165,14 +164,30 @@ func TestRecoveryManager_FailsClosedOnMissingPersistedRunID(t *testing.T) {
 	}
 
 	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
-	err = rm.Recover(ctx)
-	if err == nil || !strings.Contains(err.Error(), "missing canonical run_id") {
-		t.Fatalf("Recover error = %v, want missing canonical run_id", err)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
 	}
 	if len(capture.published) != 1 {
 		t.Fatalf("published events = %#v, want one valid replay", capture.published)
 	}
 	if capture.published[0].ID != goodEventID {
 		t.Fatalf("published event id = %q, want %q", capture.published[0].ID, goodEventID)
+	}
+
+	var badOutcome, badReason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, badEventID).Scan(&badOutcome, &badReason); err != nil {
+		t.Fatalf("load bad receipt: %v", err)
+	}
+	if badOutcome != "dead_letter" {
+		t.Fatalf("bad receipt outcome = %q, want dead_letter", badOutcome)
+	}
+	if badReason != "pipeline_error" {
+		t.Fatalf("bad receipt reason = %q, want pipeline_error", badReason)
 	}
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -141,7 +141,7 @@ func (s *PostgresStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx,
 	return s.upsertPipelineReceiptSpec(ctx, tx, eventID, status, errText)
 }
 
-func (s *PostgresStore) ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.Event, error) {
+func (s *PostgresStore) ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return nil, err
@@ -392,7 +392,7 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 	return nil
 }
 
-func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context, since time.Time, limit int) ([]events.Event, error) {
+func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -413,7 +413,7 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 	}
 	defer rows.Close()
 
-	out := make([]events.Event, 0, limit)
+	out := make([]events.PersistedReplayEvent, 0, limit)
 	for rows.Next() {
 		var evt events.Event
 		var entityID, flowInstance, scope string
@@ -431,15 +431,16 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 		); err != nil {
 			return nil, fmt.Errorf("scan missing pipeline receipt event: %w", err)
 		}
-		if strings.TrimSpace(evt.RunID) == "" {
-			return nil, fmt.Errorf("scan missing pipeline receipt event %s: missing canonical run_id", strings.TrimSpace(evt.ID))
-		}
 		evt = evt.WithEnvelope(events.EventEnvelope{
 			EntityID:     entityID,
 			FlowInstance: flowInstance,
 			Scope:        events.EventScope(scope),
 		})
-		out = append(out, evt)
+		record := events.PersistedReplayEvent{Event: evt}
+		if strings.TrimSpace(evt.RunID) == "" {
+			record.ReplayError = "missing canonical run_id"
+		}
+		out = append(out, record)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read missing pipeline receipt events: %w", err)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -395,9 +395,9 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context, since time.Time, limit int) ([]events.Event, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
-			e.event_id::text, e.event_name, COALESCE(e.produced_by, ''),
+			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
 			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
-			e.payload, e.created_at
+			e.payload, e.created_at, COALESCE(e.source_event_id::text, '')
 		FROM events e
 		LEFT JOIN event_receipts r
 			ON r.event_id = e.event_id
@@ -419,6 +419,7 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 		var entityID, flowInstance, scope string
 		if err := rows.Scan(
 			&evt.ID,
+			&evt.RunID,
 			&evt.Type,
 			&evt.SourceAgent,
 			&entityID,
@@ -426,8 +427,12 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 			&scope,
 			&evt.Payload,
 			&evt.CreatedAt,
+			&evt.ParentEventID,
 		); err != nil {
 			return nil, fmt.Errorf("scan missing pipeline receipt event: %w", err)
+		}
+		if strings.TrimSpace(evt.RunID) == "" {
+			return nil, fmt.Errorf("scan missing pipeline receipt event %s: missing canonical run_id", strings.TrimSpace(evt.ID))
 		}
 		evt = evt.WithEnvelope(events.EventEnvelope{
 			EntityID:     entityID,

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -158,7 +158,7 @@ func (s *PostgresStore) ListEventsMissingPipelineReceipt(ctx context.Context, si
 		}
 		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
 	}
-	return s.listEventsMissingPipelineReceiptSpec(ctx, since, limit)
+	return s.listEventsMissingPipelineReceiptSpec(ctx, caps, since, limit)
 }
 
 func (s *PostgresStore) EventExists(ctx context.Context, eventID string) (bool, error) {
@@ -392,10 +392,14 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 	return nil
 }
 
-func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
-	rows, err := s.DB.QueryContext(ctx, `
+func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context, caps StoreSchemaCapabilities, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
+	runIDExpr := `COALESCE(e.run_id::text, '')`
+	if !caps.Events.LogRunID {
+		runIDExpr = `''`
+	}
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
-			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
+			e.event_id::text, %s, e.event_name, COALESCE(e.produced_by, ''),
 			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
 			e.payload, e.created_at, COALESCE(e.source_event_id::text, '')
 		FROM events e
@@ -407,7 +411,7 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 		  AND e.created_at >= $1
 		ORDER BY e.created_at ASC
 		LIMIT $2
-	`, since, limit)
+	`, runIDExpr), since, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list events missing pipeline receipt: %w", err)
 	}
@@ -437,7 +441,9 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 			Scope:        events.EventScope(scope),
 		})
 		record := events.PersistedReplayEvent{Event: evt}
-		if strings.TrimSpace(evt.RunID) == "" {
+		if !caps.Events.LogRunID {
+			record.ReplayError = "missing run_id schema capability"
+		} else if strings.TrimSpace(evt.RunID) == "" {
 			record.ReplayError = "missing canonical run_id"
 		}
 		out = append(out, record)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -508,14 +508,17 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	if len(missing) != 1 {
 		t.Fatalf("expected 1 missing event, got %d", len(missing))
 	}
-	if missing[0].ID != eventMissing.ID {
-		t.Fatalf("expected missing event id=%s got=%s", eventMissing.ID, missing[0].ID)
+	if missing[0].Event.ID != eventMissing.ID {
+		t.Fatalf("expected missing event id=%s got=%s", eventMissing.ID, missing[0].Event.ID)
 	}
-	if missing[0].RunID != runID {
-		t.Fatalf("missing event run_id = %q, want %q", missing[0].RunID, runID)
+	if missing[0].Event.RunID != runID {
+		t.Fatalf("missing event run_id = %q, want %q", missing[0].Event.RunID, runID)
 	}
-	if missing[0].ParentEventID != parentID {
-		t.Fatalf("missing event parent_event_id = %q, want %q", missing[0].ParentEventID, parentID)
+	if missing[0].Event.ParentEventID != parentID {
+		t.Fatalf("missing event parent_event_id = %q, want %q", missing[0].Event.ParentEventID, parentID)
+	}
+	if missing[0].ReplayError != "" {
+		t.Fatalf("missing event replay_error = %q, want empty", missing[0].ReplayError)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -522,6 +522,50 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	}
 }
 
+func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCapability(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `ALTER TABLE events DROP COLUMN run_id`); err != nil {
+		t.Fatalf("drop events.run_id: %v", err)
+	}
+
+	pg := &PostgresStore{DB: db}
+	eventID := uuid.NewString()
+	parentID := uuid.NewString()
+	evt := events.Event{
+		ID:            eventID,
+		Type:          events.EventType("system.directive"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"directive":"x"}`),
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	missing, err := pg.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
+	}
+	if len(missing) != 1 {
+		t.Fatalf("missing events = %d, want 1", len(missing))
+	}
+	if missing[0].Event.ID != eventID {
+		t.Fatalf("missing event id = %q, want %q", missing[0].Event.ID, eventID)
+	}
+	if missing[0].Event.ParentEventID != parentID {
+		t.Fatalf("missing event parent_event_id = %q, want %q", missing[0].Event.ParentEventID, parentID)
+	}
+	if missing[0].Event.RunID != "" {
+		t.Fatalf("missing event run_id = %q, want empty", missing[0].Event.RunID)
+	}
+	if missing[0].ReplayError != "missing run_id schema capability" {
+		t.Fatalf("missing event replay_error = %q, want missing run_id schema capability", missing[0].ReplayError)
+	}
+}
+
 func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -457,6 +457,8 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
 	eventProcessed := events.Event{
 		ID:          uuid.NewString(),
 		Type:        events.EventType("system.started"),
@@ -465,17 +467,35 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 		CreatedAt:   time.Now().Add(-2 * time.Minute),
 	}
 	eventMissing := events.Event{
-		ID:          uuid.NewString(),
-		Type:        events.EventType("system.directive"),
-		SourceAgent: "human",
-		Payload:     []byte(`{"directive":"x"}`),
-		CreatedAt:   time.Now().Add(-1 * time.Minute),
+		ID:            uuid.NewString(),
+		Type:          events.EventType("system.directive"),
+		SourceAgent:   "human",
+		Payload:       []byte(`{"directive":"x"}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-1 * time.Minute),
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running') ON CONFLICT (run_id) DO NOTHING`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-3 * time.Minute),
+	}); err != nil {
+		t.Fatalf("append parent event: %v", err)
 	}
 	if err := pg.AppendEvent(ctx, eventProcessed); err != nil {
 		t.Fatalf("append processed event: %v", err)
 	}
 	if err := pg.AppendEvent(ctx, eventMissing); err != nil {
 		t.Fatalf("append missing event: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("upsert parent receipt: %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, eventProcessed.ID, "processed", ""); err != nil {
 		t.Fatalf("upsert processed receipt: %v", err)
@@ -490,6 +510,12 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	}
 	if missing[0].ID != eventMissing.ID {
 		t.Fatalf("expected missing event id=%s got=%s", eventMissing.ID, missing[0].ID)
+	}
+	if missing[0].RunID != runID {
+		t.Fatalf("missing event run_id = %q, want %q", missing[0].RunID, runID)
+	}
+	if missing[0].ParentEventID != parentID {
+		t.Fatalf("missing event parent_event_id = %q, want %q", missing[0].ParentEventID, parentID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- load the full persisted recovery correlation envelope from the missing-pipeline-receipt query, including run_id and source_event_id
- fail closed when a persisted recovery row is missing canonical run_id instead of letting replay mint a fresh run chain
- add real store/runtime seam regressions covering recovery replay lineage preservation and malformed-row failure

## Testing
- go test ./internal/store ./internal/runtime/pipeline -count=1
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering recovery and sweeper behavior for persisted replay records, including replay, quarantining of malformed rows, and schema-change scenarios.

* **Bug Fixes**
  * Malformed or schema-incompatible persisted replay rows are now marked as errors/dead-letter and skipped while valid events are replayed without creating extra run records; pipeline receipt outcomes are recorded accordingly.

* **Refactor**
  * Replay handling now uses a wrapped persisted-replay record type that preserves per-record replay errors for conditional processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->