### PR TITLE
[agent-b][issue #116] Make workflow instance mutation atomic across load, mutate, and upsert

### DIFF
--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -81,7 +81,7 @@ func (s *WorkflowInstanceStore) Load(ctx context.Context, instanceID string) (Wo
 	if len(keys) == 0 {
 		return WorkflowInstance{}, false, nil
 	}
-	return s.loadSpec(ctx, keys)
+	return s.loadSpec(ctx, keys, false)
 }
 
 func (s *WorkflowInstanceStore) List(ctx context.Context) ([]WorkflowInstance, error) {
@@ -136,7 +136,23 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 	if instanceID == "" || s == nil || s.db == nil || fn == nil {
 		return nil
 	}
-	instance, ok, err := s.Load(ctx, instanceID)
+	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	committed := !ownedTx
+	if ownedTx {
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+	}
+	ctx = withSQLTxContext(ctx, tx)
+	if err := lockWorkflowInstanceMutation(ctx, tx, instanceID); err != nil {
+		return err
+	}
+	instance, ok, err := s.loadSpec(ctx, workflowInstanceLookupKeys(instanceID), true)
 	if err != nil {
 		return err
 	}
@@ -144,14 +160,23 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 		instance = WorkflowInstance{InstanceID: instanceID}
 	}
 	fn(&instance)
-	return s.Upsert(ctx, instance)
+	if err := s.Upsert(ctx, instance); err != nil {
+		return err
+	}
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		committed = true
+	}
+	return nil
 }
 
 func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
 	return fmt.Errorf("workflow instance deletion is unsupported: entity_state writes must stay on the mutation-logged upsert path")
 }
 
-func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string) (WorkflowInstance, bool, error) {
+func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, forUpdate bool) (WorkflowInstance, bool, error) {
 	var (
 		item         WorkflowInstance
 		gatesRaw     []byte
@@ -164,7 +189,7 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string) (Wo
 		slug         sql.NullString
 		name         sql.NullString
 	)
-	err := dbQueryRowContext(ctx, s.db, `
+	query := `
 		SELECT
 			es.entity_id::text,
 			es.subject_id::text,
@@ -187,7 +212,11 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string) (Wo
 		WHERE es.entity_id = ANY($1::uuid[])
 		ORDER BY es.created_at DESC, es.entity_id DESC
 		LIMIT 1
-	`, pqStringArray(keys)).Scan(
+	`
+	if forUpdate {
+		query += ` FOR UPDATE OF es`
+	}
+	err := dbQueryRowContext(ctx, s.db, query, pqStringArray(keys)).Scan(
 		&item.InstanceID,
 		&subjectID,
 		&item.WorkflowName,
@@ -469,6 +498,20 @@ func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, er
 	return tx, true, nil
 }
 
+func lockWorkflowInstanceMutation(ctx context.Context, tx *sql.Tx, instanceID string) error {
+	if tx == nil {
+		return nil
+	}
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, "workflow-instance:"+instanceID); err != nil {
+		return fmt.Errorf("lock workflow instance mutation: %w", err)
+	}
+	return nil
+}
+
 func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, entityID string) (runtimemutationlog.EntityStateProjection, error) {
 	if tx == nil || strings.TrimSpace(entityID) == "" {
 		return runtimemutationlog.EntityStateProjection{}, nil
@@ -518,7 +561,7 @@ func jsonObjectMap(raw []byte) map[string]any {
 }
 
 func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, entityID string) ([]WorkflowTimerState, error) {
-	rows, err := dbQueryContext(withoutSQLTxContext(ctx), s.db, `
+	rows, err := dbQueryContext(ctx, s.db, `
 		SELECT
 			timer_name,
 			fire_event,

--- a/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
@@ -1,0 +1,222 @@
+package pipeline
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestWorkflowInstanceStoreMutate_SerializesOverlappingMutations(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	entityID := uuid.NewString()
+	seedWorkflowInstanceForMutationTest(t, store, entityID)
+
+	ctx := context.Background()
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- store.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
+			setWorkflowGate(instance, "g_first")
+			appendWorkflowEvidence(instance, "audit", map[string]any{"writer": "first"})
+			close(firstEntered)
+			<-releaseFirst
+		})
+	}()
+
+	<-firstEntered
+	go func() {
+		errCh <- store.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
+			close(secondEntered)
+			setWorkflowGate(instance, "g_second")
+			appendWorkflowEvidence(instance, "audit", map[string]any{"writer": "second"})
+			instance.CurrentState = "done"
+		})
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("second mutation entered callback before first mutation committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("mutate[%d]: %v", i, err)
+		}
+	}
+
+	instance, ok, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := instance.CurrentState; got != "done" {
+		t.Fatalf("current_state = %q, want done", got)
+	}
+	gates := workflowStateGatesAsBools(instance.Metadata)
+	if !gates["g_first"] || !gates["g_second"] {
+		t.Fatalf("gates = %#v, want both concurrent mutations preserved", gates)
+	}
+	evidence := workflowEvidenceEntries(t, instance, "audit")
+	if len(evidence) != 2 {
+		t.Fatalf("evidence entries = %d, want 2 (%#v)", len(evidence), evidence)
+	}
+}
+
+func TestUpdateEntityState_PreservesMutationCommittedWhileTransitionWaits(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	entityID := uuid.NewString()
+	seedWorkflowInstanceForMutationTest(t, store, entityID)
+
+	pc := &PipelineCoordinator{
+		workflowStore: store,
+		module:        NewGenericTestWorkflowModule(),
+		entityLocks:   map[string]*sync.Mutex{},
+	}
+
+	ctx := context.Background()
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- store.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
+			setWorkflowGate(instance, "g_ready")
+			close(firstEntered)
+			<-releaseFirst
+		})
+	}()
+
+	<-firstEntered
+	go func() {
+		errCh <- pc.updateEntityState(ctx, entityID, "done", "workflow.completed")
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(releaseFirst)
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("update[%d]: %v", i, err)
+		}
+	}
+
+	instance, ok, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := instance.CurrentState; got != "done" {
+		t.Fatalf("current_state = %q, want done", got)
+	}
+	gates := workflowStateGatesAsBools(instance.Metadata)
+	if !gates["g_ready"] {
+		t.Fatalf("gates = %#v, want concurrent gate mutation preserved", gates)
+	}
+	if len(instance.TransitionHistory) == 0 {
+		t.Fatal("expected transition history to be recorded")
+	}
+}
+
+func TestWorkflowInstanceStoreMutate_PersistsSingleWriterUpdates(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	entityID := uuid.NewString()
+	seedWorkflowInstanceForMutationTest(t, store, entityID)
+
+	if err := store.Mutate(context.Background(), entityID, func(instance *WorkflowInstance) {
+		setWorkflowGate(instance, "g_single")
+		appendWorkflowEvidence(instance, "audit", map[string]any{"writer": "single"})
+		instance.CurrentState = "processing"
+	}); err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+
+	instance, ok, err := store.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := instance.CurrentState; got != "processing" {
+		t.Fatalf("current_state = %q, want processing", got)
+	}
+	gates := workflowStateGatesAsBools(instance.Metadata)
+	if !gates["g_single"] {
+		t.Fatalf("gates = %#v, want g_single=true", gates)
+	}
+	evidence := workflowEvidenceEntries(t, instance, "audit")
+	if len(evidence) != 1 {
+		t.Fatalf("evidence entries = %d, want 1 (%#v)", len(evidence), evidence)
+	}
+}
+
+func seedWorkflowInstanceForMutationTest(t *testing.T, store *WorkflowInstanceStore, entityID string) {
+	t.Helper()
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "mutation-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata:        map[string]any{},
+		StateBuckets:    map[string]any{},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+}
+
+func setWorkflowGate(instance *WorkflowInstance, gate string) {
+	metadata := cloneStringAnyMap(instance.Metadata)
+	gates := workflowStateGatesAsBools(metadata)
+	gates[gate] = true
+	metadata["gates"] = workflowBoolGatesAsMap(gates)
+	instance.Metadata = metadata
+}
+
+func appendWorkflowEvidence(instance *WorkflowInstance, bucketID string, payload map[string]any) {
+	bucket := workflowMutableStateBucket(instance, "evidence")
+	workflowAppendEvidence(bucket, bucketID, payload)
+	workflowSetStateBucket(instance, "evidence", bucket)
+}
+
+func workflowEvidenceEntries(t *testing.T, instance WorkflowInstance, bucketID string) []map[string]any {
+	t.Helper()
+	evidence, ok := workflowStateBucketObject(instance, "evidence")
+	if !ok {
+		return nil
+	}
+	raw, ok := evidence[bucketID].([]any)
+	if !ok {
+		t.Fatalf("evidence[%s] = %#v, want []any", bucketID, evidence[bucketID])
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("evidence entry = %#v, want map[string]any", item)
+		}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/internal/runtime/pipeline/workflow_state_persistence.go
+++ b/internal/runtime/pipeline/workflow_state_persistence.go
@@ -39,12 +39,12 @@ func (pc *PipelineCoordinator) updateEntityState(ctx context.Context, entityID, 
 	if entityID == "" || nextState == "" {
 		return nil
 	}
-	current := pc.currentWorkflowState(ctx, entityID)
-	currentState := strings.TrimSpace(string(current.Stage))
 	source := pc.SemanticSource()
+	currentState := ""
 	if err := pc.workflowStore.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
+		currentState = strings.TrimSpace(instance.CurrentState)
 		enteredStateAt := time.Now().UTC()
-		if strings.TrimSpace(instance.CurrentState) == nextState && !instance.EnteredStageAt.IsZero() {
+		if currentState == nextState && !instance.EnteredStageAt.IsZero() {
 			enteredStateAt = instance.EnteredStageAt
 		}
 		if strings.TrimSpace(instance.WorkflowName) == "" {
@@ -53,10 +53,7 @@ func (pc *PipelineCoordinator) updateEntityState(ctx context.Context, entityID, 
 		if strings.TrimSpace(instance.WorkflowVersion) == "" {
 			instance.WorkflowVersion = source.WorkflowVersion()
 		}
-		metadata := cloneStringAnyMap(current.Metadata)
-		if strings.TrimSpace(current.Status) != "" {
-			metadata["status"] = strings.TrimSpace(current.Status)
-		}
+		metadata := cloneStringAnyMap(instance.Metadata)
 		if sourceEvent != "" {
 			metadata["last_source_event"] = sourceEvent
 		}


### PR DESCRIPTION
## Summary
- serialize WorkflowInstanceStore.Mutate() through a transaction-scoped database lock and lock the loaded row before invoking the mutation callback
- keep timer and state reads on the same transaction path and remove the stale pre-read from updateEntityState
- add focused regression tests for overlapping mutations, concurrent gate/state pressure, and normal single-writer callers

## Tests
- go test ./internal/runtime/pipeline -count=1
- go test ./... -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent workflow mutations with enhanced transaction isolation and locking to prevent race conditions.
  * Ensured workflow state is correctly captured and persisted when multiple mutations overlap.

* **Tests**
  * Added comprehensive integration tests validating concurrent mutation serialization and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->