### PR TITLE
[agent-c][issue #117] Unify exact schedule identity across persistence, recovery, and in-memory replay

### DIFF
--- a/internal/runtime/pipeline/scheduler.go
+++ b/internal/runtime/pipeline/scheduler.go
@@ -229,6 +229,7 @@ func scheduleKey(sc Schedule) string {
 		strings.TrimSpace(sc.AgentID),
 		strings.TrimSpace(sc.EventType),
 		strings.TrimSpace(sc.EffectiveEntityID()),
+		strings.TrimSpace(sc.EffectiveFlowInstance()),
 		strings.TrimSpace(sc.TaskID),
 	}, "|")
 }

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -102,6 +102,7 @@ func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
 
 type recordingRuntimeScheduleStore struct {
 	schedules  []runtimepipeline.Schedule
+	active     []runtimepipeline.Schedule
 	firedExact atomic.Int32
 	fired      chan runtimepipeline.Schedule
 }
@@ -115,8 +116,8 @@ func (*recordingRuntimeScheduleStore) CancelScheduleExact(context.Context, runti
 	return nil
 }
 
-func (*recordingRuntimeScheduleStore) LoadActiveSchedules(context.Context) ([]runtimepipeline.Schedule, error) {
-	return nil, nil
+func (s *recordingRuntimeScheduleStore) LoadActiveSchedules(context.Context) ([]runtimepipeline.Schedule, error) {
+	return append([]runtimepipeline.Schedule(nil), s.active...), nil
 }
 
 func (s *recordingRuntimeScheduleStore) MarkScheduleFiredExact(_ context.Context, sc runtimepipeline.Schedule) error {
@@ -250,5 +251,75 @@ func TestNewRuntime_SchedulerMarksSchedulesFiredThroughExactContract(t *testing.
 	}
 	if got := store.firedExact.Load(); got != 1 {
 		t.Fatalf("MarkScheduleFiredExact calls = %d, want 1", got)
+	}
+}
+
+func TestRuntime_StartRestoresExactSchedulesDistinctByFlowInstance(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", "test-boot-success")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	store := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{
+			{
+				AgentID:      "runtime",
+				EventType:    "timer.check",
+				Mode:         "once",
+				At:           time.Now().Add(25 * time.Millisecond),
+				EntityID:     "ent-001",
+				FlowInstance: "review/inst-1",
+				TaskID:       "check_timer",
+				Payload:      []byte(`{"timer_id":"check_timer"}`),
+			},
+			{
+				AgentID:      "runtime",
+				EventType:    "timer.check",
+				Mode:         "once",
+				At:           time.Now().Add(50 * time.Millisecond),
+				EntityID:     "ent-001",
+				FlowInstance: "review/inst-2",
+				TaskID:       "check_timer",
+				Payload:      []byte(`{"timer_id":"check_timer"}`),
+			},
+		},
+		fired: make(chan runtimepipeline.Schedule, 2),
+	}
+	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{ScheduleStore: store}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if rt.Scheduler == nil {
+		t.Fatal("expected scheduler")
+	}
+	t.Cleanup(rt.Scheduler.Stop)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := rt.Start(runCtx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	seenFlows := map[string]bool{}
+	deadline := time.After(2 * time.Second)
+	for len(seenFlows) < 2 {
+		select {
+		case fired := <-store.fired:
+			if fired.TaskID != "check_timer" {
+				t.Fatalf("fired task_id = %q, want check_timer", fired.TaskID)
+			}
+			seenFlows[fired.FlowInstance] = true
+		case <-deadline:
+			t.Fatalf("timed out waiting for restored exact schedules to fire; seen flow instances = %#v", seenFlows)
+		}
+	}
+	if got := store.firedExact.Load(); got != 2 {
+		t.Fatalf("MarkScheduleFiredExact calls = %d, want 2 for distinct restored flow instances", got)
 	}
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1051,7 +1051,7 @@ func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	}
 }
 
-func TestSchedules_LoadActiveSchedulesFallsBackToTimerNameTaskIDForExactRows(t *testing.T) {
+func TestSchedules_LoadActiveSchedulesDoesNotReconstructTaskIDFromTimerName(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1079,31 +1079,11 @@ func TestSchedules_LoadActiveSchedulesFallsBackToTimerNameTaskIDForExactRows(t *
 	if len(active) != 1 {
 		t.Fatalf("active schedules = %d, want 1", len(active))
 	}
-	if got := active[0].TaskID; got != "timer-a" {
-		t.Fatalf("loaded task_id = %q, want timer-a", got)
+	if got := active[0].TaskID; got != "" {
+		t.Fatalf("loaded task_id = %q, want empty without canonical payload task id", got)
 	}
 	if string(active[0].Payload) != `{"timer_id":"timer-a"}` {
 		t.Fatalf("loaded payload = %s, want task metadata without synthetic task id", string(active[0].Payload))
-	}
-
-	if err := pg.MarkScheduleFiredExact(ctx, active[0]); err != nil {
-		t.Fatalf("MarkScheduleFiredExact(loaded fallback task): %v", err)
-	}
-
-	var status string
-	statusQuery := `
-		SELECT status
-		FROM timers
-		WHERE owner_agent = $1
-		  AND fire_event = $2
-		  AND flow_instance = $3
-		  AND ` + exactScheduleTaskIDSQL() + ` = $4
-	`
-	if err := db.QueryRowContext(ctx, statusQuery, active[0].AgentID, active[0].EventType, active[0].FlowInstance, active[0].TaskID).Scan(&status); err != nil {
-		t.Fatalf("query exact timer status: %v", err)
-	}
-	if status != "fired" {
-		t.Fatalf("exact timer status = %q, want fired", status)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -925,6 +925,100 @@ func TestSchedules_ExactIdentityUsesTaskID(t *testing.T) {
 	}
 }
 
+func TestSchedules_ExactIdentityUsesFlowInstance(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	entityID := uuid.NewString()
+
+	first := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-a",
+		Payload:      []byte(`{"timer_id":"timer-a"}`),
+	}
+	second := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(60 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-2",
+		TaskID:       "timer-a",
+		Payload:      []byte(`{"timer_id":"timer-a"}`),
+	}
+	if err := pg.UpsertSchedule(ctx, first); err != nil {
+		t.Fatalf("upsert first exact schedule: %v", err)
+	}
+	if err := pg.UpsertSchedule(ctx, second); err != nil {
+		t.Fatalf("upsert second exact schedule: %v", err)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	var exact []runtimepipeline.Schedule
+	for _, sc := range active {
+		if sc.AgentID == first.AgentID &&
+			sc.EventType == first.EventType &&
+			sc.EntityID == first.EntityID &&
+			sc.TaskID == first.TaskID {
+			exact = append(exact, sc)
+		}
+	}
+	if len(exact) != 2 {
+		t.Fatalf("expected two exact schedules to coexist across flow instances, got %+v", exact)
+	}
+
+	if err := pg.CancelScheduleExact(ctx, first); err != nil {
+		t.Fatalf("CancelScheduleExact(first): %v", err)
+	}
+	if err := pg.MarkScheduleFiredExact(ctx, second); err != nil {
+		t.Fatalf("MarkScheduleFiredExact(second): %v", err)
+	}
+
+	var firstStatus, secondStatus string
+	firstStatusQuery := `
+		SELECT status
+		FROM timers
+		WHERE owner_agent = $1
+		  AND fire_event = $2
+		  AND flow_instance = $3
+		  AND ` + exactScheduleTaskIDSQL() + ` = $4
+	`
+	if err := db.QueryRowContext(ctx, firstStatusQuery, first.AgentID, first.EventType, first.FlowInstance, first.TaskID).Scan(&firstStatus); err != nil {
+		t.Fatalf("query first exact timer status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, firstStatusQuery, second.AgentID, second.EventType, second.FlowInstance, second.TaskID).Scan(&secondStatus); err != nil {
+		t.Fatalf("query second exact timer status: %v", err)
+	}
+	if firstStatus != "cancelled" {
+		t.Fatalf("first exact timer status = %q, want cancelled", firstStatus)
+	}
+	if secondStatus != "fired" {
+		t.Fatalf("second exact timer status = %q, want fired", secondStatus)
+	}
+
+	active, err = pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules(after exact cancel/fire): %v", err)
+	}
+	for _, sc := range active {
+		if sc.AgentID == first.AgentID &&
+			sc.EventType == first.EventType &&
+			sc.EntityID == first.EntityID &&
+			sc.TaskID == first.TaskID &&
+			(sc.FlowInstance == first.FlowInstance || sc.FlowInstance == second.FlowInstance) {
+			t.Fatalf("expected no remaining exact schedules after targeted cancel/fire, found %+v", sc)
+		}
+	}
+}
+
 func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -954,6 +1048,62 @@ func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	}
 	if got := active[0].FlowInstance; got != "review/inst-1" {
 		t.Fatalf("loaded flow_instance = %q, want review/inst-1", got)
+	}
+}
+
+func TestSchedules_LoadActiveSchedulesFallsBackToTimerNameTaskIDForExactRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	entityID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, recurring, recurrence_cron, recurrence_interval,
+			owner_node, owner_agent, task_type, status
+		)
+		VALUES (
+			$1, $2::uuid, $3, $4, $5::jsonb,
+			$6, false, NULL, NULL,
+			NULL, $7, 'timer', 'active'
+		)
+	`, "timer-a", entityID, "review/inst-1", "timer.validation_timeout", `{"timer_id":"timer-a"}`, time.Now().Add(30*time.Minute).UTC(), "validation-orchestrator"); err != nil {
+		t.Fatalf("seed exact timer row: %v", err)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("active schedules = %d, want 1", len(active))
+	}
+	if got := active[0].TaskID; got != "timer-a" {
+		t.Fatalf("loaded task_id = %q, want timer-a", got)
+	}
+	if string(active[0].Payload) != `{"timer_id":"timer-a"}` {
+		t.Fatalf("loaded payload = %s, want task metadata without synthetic task id", string(active[0].Payload))
+	}
+
+	if err := pg.MarkScheduleFiredExact(ctx, active[0]); err != nil {
+		t.Fatalf("MarkScheduleFiredExact(loaded fallback task): %v", err)
+	}
+
+	var status string
+	statusQuery := `
+		SELECT status
+		FROM timers
+		WHERE owner_agent = $1
+		  AND fire_event = $2
+		  AND flow_instance = $3
+		  AND ` + exactScheduleTaskIDSQL() + ` = $4
+	`
+	if err := db.QueryRowContext(ctx, statusQuery, active[0].AgentID, active[0].EventType, active[0].FlowInstance, active[0].TaskID).Scan(&status); err != nil {
+		t.Fatalf("query exact timer status: %v", err)
+	}
+	if status != "fired" {
+		t.Fatalf("exact timer status = %q, want fired", status)
 	}
 }
 

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -140,20 +140,8 @@ func persistedSchedulePayload(sc runtimepipeline.Schedule) []byte {
 	return encoded
 }
 
-func exactScheduleTaskID(taskID, timerName, eventType string) string {
-	taskID = strings.TrimSpace(taskID)
-	if taskID != "" {
-		return taskID
-	}
-	timerName = strings.TrimSpace(timerName)
-	if timerName != "" && timerName != strings.TrimSpace(eventType) {
-		return timerName
-	}
-	return ""
-}
-
 func exactScheduleTaskIDSQL() string {
-	return `COALESCE(NULLIF(fire_payload->>'__schedule_task_id', ''), CASE WHEN NULLIF(timer_name, '') IS NOT NULL AND timer_name IS DISTINCT FROM fire_event THEN timer_name ELSE '' END, '')`
+	return `COALESCE(fire_payload->>'__schedule_task_id', '')`
 }
 
 func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
@@ -255,7 +243,6 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			fire_at,
 			COALESCE(entity_id::text, ''),
 			COALESCE(flow_instance, ''),
-			COALESCE(timer_name, ''),
 			fire_payload
 		FROM timers
 		WHERE status = 'active'
@@ -269,10 +256,9 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 	out := make([]runtimepipeline.Schedule, 0)
 	for rows.Next() {
 		var (
-			sc        runtimepipeline.Schedule
-			fireAt    time.Time
-			timerName string
-			payload   []byte
+			sc      runtimepipeline.Schedule
+			fireAt  time.Time
+			payload []byte
 		)
 		if err := rows.Scan(
 			&sc.AgentID,
@@ -282,13 +268,12 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			&fireAt,
 			&sc.EntityID,
 			&sc.FlowInstance,
-			&timerName,
 			&payload,
 		); err != nil {
 			return nil, fmt.Errorf("scan active timer: %w", err)
 		}
 		sc.At = fireAt
-		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(payload, timerName, sc.EventType)
+		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(payload)
 		out = append(out, sc)
 	}
 	if err := rows.Err(); err != nil {
@@ -338,22 +323,19 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	return nil
 }
 
-func extractPersistedScheduleTaskID(payload []byte, timerName, eventType string) (string, []byte) {
-	taskID := exactScheduleTaskID("", timerName, eventType)
+func extractPersistedScheduleTaskID(payload []byte) (string, []byte) {
 	if len(payload) == 0 {
-		return taskID, payload
+		return "", payload
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil || decoded == nil {
-		return taskID, payload
+		return "", payload
 	}
-	if decodedTaskID, _ := decoded["__schedule_task_id"].(string); strings.TrimSpace(decodedTaskID) != "" {
-		taskID = exactScheduleTaskID(decodedTaskID, timerName, eventType)
-	}
+	taskID, _ := decoded["__schedule_task_id"].(string)
 	delete(decoded, "__schedule_task_id")
 	encoded, err := json.Marshal(decoded)
 	if err != nil {
-		return taskID, payload
+		return strings.TrimSpace(taskID), payload
 	}
-	return taskID, encoded
+	return strings.TrimSpace(taskID), encoded
 }

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -140,6 +140,22 @@ func persistedSchedulePayload(sc runtimepipeline.Schedule) []byte {
 	return encoded
 }
 
+func exactScheduleTaskID(taskID, timerName, eventType string) string {
+	taskID = strings.TrimSpace(taskID)
+	if taskID != "" {
+		return taskID
+	}
+	timerName = strings.TrimSpace(timerName)
+	if timerName != "" && timerName != strings.TrimSpace(eventType) {
+		return timerName
+	}
+	return ""
+}
+
+func exactScheduleTaskIDSQL() string {
+	return `COALESCE(NULLIF(fire_payload->>'__schedule_task_id', ''), CASE WHEN NULLIF(timer_name, '') IS NOT NULL AND timer_name IS DISTINCT FROM fire_event THEN timer_name ELSE '' END, '')`
+}
+
 func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -148,16 +164,16 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 	defer func() { _ = tx.Rollback() }()
 
 	payload := persistedSchedulePayload(sc)
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = 'cancelled'
 		WHERE owner_agent = $1
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
 		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
+		  AND %s = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)); err != nil {
+	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)); err != nil {
 		return fmt.Errorf("deactivate previous timer: %w", err)
 	}
 
@@ -213,16 +229,16 @@ func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, agentID, eventTy
 }
 
 func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
-	_, err := s.DB.ExecContext(ctx, `
+	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = 'cancelled'
 		WHERE owner_agent = $1
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
 		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
+		  AND %s = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
+	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
 	if err != nil {
 		return fmt.Errorf("cancel exact timer: %w", err)
 	}
@@ -239,6 +255,7 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			fire_at,
 			COALESCE(entity_id::text, ''),
 			COALESCE(flow_instance, ''),
+			COALESCE(timer_name, ''),
 			fire_payload
 		FROM timers
 		WHERE status = 'active'
@@ -252,9 +269,10 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 	out := make([]runtimepipeline.Schedule, 0)
 	for rows.Next() {
 		var (
-			sc      runtimepipeline.Schedule
-			fireAt  time.Time
-			payload []byte
+			sc        runtimepipeline.Schedule
+			fireAt    time.Time
+			timerName string
+			payload   []byte
 		)
 		if err := rows.Scan(
 			&sc.AgentID,
@@ -264,12 +282,13 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			&fireAt,
 			&sc.EntityID,
 			&sc.FlowInstance,
+			&timerName,
 			&payload,
 		); err != nil {
 			return nil, fmt.Errorf("scan active timer: %w", err)
 		}
 		sc.At = fireAt
-		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(payload)
+		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(payload, timerName, sc.EventType)
 		out = append(out, sc)
 	}
 	if err := rows.Err(); err != nil {
@@ -302,7 +321,7 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	if !strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
 		status = "active"
 	}
-	_, err := s.DB.ExecContext(ctx, `
+	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = $6,
 		    fired_at = now()
@@ -310,28 +329,31 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 		  AND fire_event = $2
 		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
 		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND COALESCE(fire_payload->>'__schedule_task_id', '') = $5
+		  AND %s = $5
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
+	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
 	if err != nil {
 		return fmt.Errorf("mark exact timer fired: %w", err)
 	}
 	return nil
 }
 
-func extractPersistedScheduleTaskID(payload []byte) (string, []byte) {
+func extractPersistedScheduleTaskID(payload []byte, timerName, eventType string) (string, []byte) {
+	taskID := exactScheduleTaskID("", timerName, eventType)
 	if len(payload) == 0 {
-		return "", payload
+		return taskID, payload
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil || decoded == nil {
-		return "", payload
+		return taskID, payload
 	}
-	taskID, _ := decoded["__schedule_task_id"].(string)
+	if decodedTaskID, _ := decoded["__schedule_task_id"].(string); strings.TrimSpace(decodedTaskID) != "" {
+		taskID = exactScheduleTaskID(decodedTaskID, timerName, eventType)
+	}
 	delete(decoded, "__schedule_task_id")
 	encoded, err := json.Marshal(decoded)
 	if err != nil {
-		return strings.TrimSpace(taskID), payload
+		return taskID, payload
 	}
-	return strings.TrimSpace(taskID), encoded
+	return taskID, encoded
 }


### PR DESCRIPTION
## Summary
- include `flow_instance` in the in-memory exact schedule key so restored schedules match persisted exact row identity
- make exact restore/fire/cancel use one canonical task-id expression, with a narrow fallback to `timer_name` when older exact rows lack `__schedule_task_id`
- add store and runtime regressions for coexistence, restore/replay, and exact targeting

## Root cause
Persisted exact schedules were keyed more precisely than the in-memory scheduler. Storage distinguished exact rows by `(owner_agent, fire_event, entity_id, flow_instance, task_id)`, but the in-memory scheduler dropped `flow_instance`, so restore/replay could collapse distinct exact schedules into one task. Restore also still depended on payload-carried `__schedule_task_id` even though the persisted timer row already had canonical timer identity.

## Validation
- `go test ./internal/store ./internal/runtime -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedules that share task details but belong to different flow instances are no longer de-duplicated; each can coexist and execute independently.
  * Improved database handling to ensure schedule identity and state transitions (cancelled/fired) target the correct schedule instance.

* **Tests**
  * Added tests validating restoration, loading, and exact identity behavior for schedules across distinct flow instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->