### PR TITLE
[agent-d][issue #120] Persist canonical run completion instead of inferring it from quiescence

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +13,14 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	builderpkg "swarm/internal/builder"
+	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
 )
 
 func TestPrintRunStatusReport(t *testing.T) {
@@ -124,6 +133,79 @@ func TestLoadRunStatusRuntimeLogs_UsesSpecShapedPayload(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: eb}
+	handler := builderpkg.NewHandler(builderpkg.Options{
+		CurrentRuntime: func() *runtimepkg.Runtime { return rt },
+	})
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	reqBody, err := json.Marshal(builderpkg.Request{
+		JSONRPC: "2.0",
+		ID:      "run-start-1",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": runID,
+			"inputs": map[string]any{
+				"scan.requested": map[string]any{
+					"entity_id": entityID,
+					"topic":     "sample",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal run.start request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(reqBody))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	ctx := context.Background()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var status string
+		err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, '')
+			FROM runs
+			WHERE run_id = $1::uuid
+		`, runID).Scan(&status)
+		if err == nil && status == "completed" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("run %s did not reach durable completed state: last err=%v", runID, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	if err != nil {
+		t.Fatalf("loadRunStatusReport: %v", err)
+	}
+	if report.RunTableStatus != "completed" {
+		t.Fatalf("RunTableStatus = %q, want completed", report.RunTableStatus)
+	}
+	if report.EndedAt == nil || report.EndedAt.IsZero() {
+		t.Fatal("expected durable ended_at in run status report")
+	}
+	for _, heuristic := range report.Heuristics {
+		if strings.Contains(heuristic, "runs table still says running") {
+			t.Fatalf("unexpected running heuristic after durable completion: %#v", report.Heuristics)
+		}
 	}
 }
 

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
 )
 
 const runCompletionTimeout = 30 * time.Second
@@ -370,6 +371,20 @@ func (h *runHub) awaitCompletion(runID string) {
 		if h.isTerminal(runID) {
 			return
 		}
+		if persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
+			h.markTerminal(runID)
+			h.emit(runID, map[string]any{
+				"id":        uuid.NewString(),
+				"type":      "run.failed",
+				"timestamp": time.Now().UTC().Format(time.RFC3339),
+				"payload": map[string]any{
+					"run_id":            runID,
+					"error":             err.Error(),
+					"persistence_error": persistErr.Error(),
+				},
+			})
+			return
+		}
 		h.markTerminal(runID)
 		h.emit(runID, map[string]any{
 			"id":        uuid.NewString(),
@@ -380,6 +395,20 @@ func (h *runHub) awaitCompletion(runID string) {
 		return
 	}
 	if h.isTerminal(runID) {
+		return
+	}
+	if err := h.persistTerminalState(runID, "completed", "", time.Now().UTC()); err != nil {
+		h.markTerminal(runID)
+		h.emit(runID, map[string]any{
+			"id":        uuid.NewString(),
+			"type":      "run.failed",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"payload": map[string]any{
+				"run_id":            runID,
+				"error":             "persisting canonical run completion failed",
+				"persistence_error": err.Error(),
+			},
+		})
 		return
 	}
 	h.markTerminal(runID)
@@ -406,6 +435,18 @@ func (h *runHub) markTerminal(runID string) {
 	if session := h.sessions[strings.TrimSpace(runID)]; session != nil {
 		session.terminal = true
 	}
+}
+
+func (h *runHub) persistTerminalState(runID, status, errorSummary string, endedAt time.Time) error {
+	session := h.session(runID)
+	if session == nil || session.runtime == nil || session.runtime.Bus == nil {
+		return fmt.Errorf("run terminal persistence is not configured")
+	}
+	writer, ok := session.runtime.Bus.Store().(runtimebus.RunLifecyclePersistence)
+	if !ok || writer == nil {
+		return fmt.Errorf("run terminal persistence is not supported")
+	}
+	return writer.MarkRunTerminal(context.Background(), runID, status, errorSummary, endedAt)
 }
 
 func (h *runHub) isTerminal(runID string) bool {

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -36,3 +36,42 @@ func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
 		t.Fatal("expected run input event to be published")
 	}
 }
+
+func TestRunHubAwaitCompletion_MarksSessionTerminalWhenCompletionPersistenceFails(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: eb}
+	hub := &runHub{
+		sessions: map[string]*runSession{
+			"run-123": {
+				runID:   "run-123",
+				runtime: rt,
+				subs:    map[string]func(RunEventEnvelope){},
+				events:  []RunEventEnvelope{},
+			},
+		},
+	}
+
+	hub.awaitCompletion("run-123")
+
+	if !hub.isTerminal("run-123") {
+		t.Fatal("expected run session to be marked terminal when completion persistence fails")
+	}
+	session := hub.session("run-123")
+	if session == nil {
+		t.Fatal("expected run session to remain addressable")
+	}
+	if len(session.events) == 0 {
+		t.Fatal("expected terminal failure event to be emitted")
+	}
+	last := session.events[len(session.events)-1]
+	if got, _ := last["type"].(string); got != "run.failed" {
+		t.Fatalf("last event type = %q, want run.failed", got)
+	}
+	payload, _ := last["payload"].(map[string]any)
+	if _, ok := payload["persistence_error"]; !ok {
+		t.Fatalf("last payload = %#v, want persistence_error", payload)
+	}
+}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/websocket"
 	builderpkg "swarm/internal/builder"
+	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -80,6 +81,16 @@ type stubObservability struct {
 	eventDetail map[string]eventRecord
 	runtimeLogs []runtimeLogRecord
 	incidents   []incidentRecord
+}
+
+type stubBuilderRunStore struct{}
+
+func (stubBuilderRunStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (stubBuilderRunStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (stubBuilderRunStore) MarkRunTerminal(context.Context, string, string, string, time.Time) error {
+	return nil
 }
 
 type stubConversationCaps struct {
@@ -1301,7 +1312,7 @@ func TestHandler_HealthzAliases(t *testing.T) {
 }
 
 func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1395,7 +1406,7 @@ func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
 }
 
 func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1478,7 +1489,7 @@ func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
 }
 
 func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1578,7 +1589,7 @@ func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
 }
 
 func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1699,7 +1710,7 @@ func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
 }
 
 func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1800,7 +1811,7 @@ func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
 }
 
 func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -1944,7 +1955,7 @@ func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
 }
 
 func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -2062,7 +2073,7 @@ func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
 }
 
 func TestHandler_RunRetryEmitsRetriedAndResumed(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -55,6 +55,12 @@ type PipelineReceiptPersistence interface {
 	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
 }
 
+// RunLifecyclePersistence is an optional capability for persisting canonical
+// terminal run lifecycle state once execution proves the run is done.
+type RunLifecyclePersistence interface {
+	MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error
+}
+
 // AtomicEventPersistence is an optional capability for transactionally
 // persisting an event row and its delivery manifest together.
 type AtomicEventPersistence interface {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -485,6 +485,78 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	return nil
 }
 
+func canonicalRunTerminalStatus(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "completed":
+		return "completed", nil
+	case "failed":
+		return "failed", nil
+	case "cancelled":
+		return "cancelled", nil
+	case "forked":
+		return "forked", nil
+	default:
+		return "", fmt.Errorf("unsupported terminal run status %q", raw)
+	}
+}
+
+func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return fmt.Errorf("run_id is required")
+	}
+	if !caps.Events.HasRuns {
+		return fmt.Errorf("runs table is required")
+	}
+	status, err = canonicalRunTerminalStatus(status)
+	if err != nil {
+		return err
+	}
+	errorSummary = strings.TrimSpace(errorSummary)
+	if status != "failed" {
+		errorSummary = ""
+	}
+	if endedAt.IsZero() {
+		endedAt = time.Now().UTC()
+	}
+	result, err := s.DB.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2,
+		    error_summary = NULLIF($3, ''),
+		    ended_at = COALESCE(ended_at, $4)
+		WHERE run_id = $1::uuid
+		  AND (status IN ('running', 'paused') OR status = $2)
+	`, runID, status, errorSummary, endedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("mark run terminal: %w", err)
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows > 0 {
+		return nil
+	}
+
+	var currentStatus string
+	err = s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&currentStatus)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("run %s not found", runID)
+		}
+		return fmt.Errorf("load run terminal state: %w", err)
+	}
+	currentStatus = strings.TrimSpace(currentStatus)
+	if currentStatus == status {
+		return nil
+	}
+	return fmt.Errorf("run %s already terminal with status %s", runID, currentStatus)
+}
+
 func runIDOrEventID(runID, eventID string) string {
 	if runID = nullUUIDString(runID); runID != "" {
 		return runID

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -318,6 +318,74 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 	}
 }
 
+func TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	completedRunID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, completedRunID); err != nil {
+		t.Fatalf("seed completed run: %v", err)
+	}
+	completedAt := time.Now().UTC().Round(time.Second)
+	if err := pg.MarkRunTerminal(ctx, completedRunID, "completed", "", completedAt); err != nil {
+		t.Fatalf("MarkRunTerminal(completed): %v", err)
+	}
+
+	var (
+		completedStatus string
+		completedErr    string
+		completedEnded  time.Time
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(error_summary, ''), ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, completedRunID).Scan(&completedStatus, &completedErr, &completedEnded); err != nil {
+		t.Fatalf("load completed run: %v", err)
+	}
+	if completedStatus != "completed" {
+		t.Fatalf("completed run status = %q, want completed", completedStatus)
+	}
+	if completedErr != "" {
+		t.Fatalf("completed run error_summary = %q, want empty", completedErr)
+	}
+	if completedEnded.IsZero() {
+		t.Fatal("completed run ended_at not persisted")
+	}
+
+	failedRunID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, failedRunID); err != nil {
+		t.Fatalf("seed failed run: %v", err)
+	}
+	failedAt := time.Now().UTC().Round(time.Second)
+	if err := pg.MarkRunTerminal(ctx, failedRunID, "failed", "quiescence timeout", failedAt); err != nil {
+		t.Fatalf("MarkRunTerminal(failed): %v", err)
+	}
+
+	var (
+		failedStatus string
+		failedErr    string
+		failedEnded  time.Time
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(error_summary, ''), ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, failedRunID).Scan(&failedStatus, &failedErr, &failedEnded); err != nil {
+		t.Fatalf("load failed run: %v", err)
+	}
+	if failedStatus != "failed" {
+		t.Fatalf("failed run status = %q, want failed", failedStatus)
+	}
+	if failedErr != "quiescence timeout" {
+		t.Fatalf("failed run error_summary = %q, want quiescence timeout", failedErr)
+	}
+	if failedEnded.IsZero() {
+		t.Fatal("failed run ended_at not persisted")
+	}
+}
+
 func TestPostgresStore_ListPendingEventsForAgentSpec_PreservesRunID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #120

## Human Summary
This change makes run completion durable. When builder quiescence determines a run has finished or failed, the runtime now writes the terminal lifecycle back to `runs` before emitting transient completion events, so operator surfaces can prove completion from persisted state.

## What Changed
- added a store-owned `MarkRunTerminal` path for canonical `runs` terminal lifecycle persistence
- updated builder run completion/failure handling to persist terminal run state before emitting `run.completed` or `run.failed`
- added focused regression coverage for durable run lifecycle persistence and status readback
- kept builder/dashboard test-only in-memory seams working through a narrow test stub run store

## Why This Is Needed
`runs` rows were created with `status = running`, but completion was still inferred from in-memory quiescence and transient notifications. That left operator/status surfaces without durable proof that a run had actually completed.

## Scope Boundaries
- in scope: canonical durable run completion/failure persistence in the touched builder/store seam and immediate status readback
- not in scope: broader operator observability redesign, explicit stop/cancel lifecycle redesign, or flow-instance terminal semantics

## Tests Run
- `go test ./internal/store ./internal/builder ./internal/dashboard/server ./cmd/swarm -count=1`
- `go test ./internal/builder -count=1`
- `go test ./... -count=1`

## Residual Risk
- explicit stop/cancel lifecycle persistence is still a separate seam; this PR is intentionally narrow to quiescence-derived completion/failure
- builder runtimes without a store implementing the run terminal capability cannot durably claim completion, so test-only in-memory builder seams use a stub store where they need completion events

## Follow-Up
- explicit stop/cancel terminal lifecycle persistence can be addressed separately if that seam is prioritized, because it is broader than this quiescence-derived completion fix
