### PR TITLE
[agent-c][issue #142] Require authentication for dashboard and runtime-control surfaces

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1326,6 +1326,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		Conversations: conversations,
 		Observability: observability,
 		Runtime:       runtimeCtl,
+		AuthToken:     strings.TrimSpace(os.Getenv("SWARM_OPERATOR_AUTH_TOKEN")),
 		Version:       "swarm-dev",
 		Builder:       builderHandler,
 	}

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -126,6 +126,7 @@ type Options struct {
 	Conversations ConversationReader
 	Observability ObservabilityReader
 	Runtime       RuntimeController
+	AuthToken     string
 	Version       string
 	Builder       http.Handler
 }
@@ -139,6 +140,7 @@ type Handler struct {
 	conversations ConversationReader
 	observability ObservabilityReader
 	runtime       RuntimeController
+	authToken     string
 	version       string
 	builder       http.Handler
 	mux           *http.ServeMux
@@ -154,6 +156,7 @@ func NewHandler(opts Options) http.Handler {
 		conversations: opts.Conversations,
 		observability: opts.Observability,
 		runtime:       opts.Runtime,
+		authToken:     strings.TrimSpace(opts.AuthToken),
 		version:       strings.TrimSpace(opts.Version),
 	}
 	mux := http.NewServeMux()
@@ -196,7 +199,59 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if h.requiresAuthentication(r) {
+		if err := h.authorize(r); err != nil {
+			h.writeAuthError(w, err)
+			return
+		}
+	}
 	h.mux.ServeHTTP(w, r)
+}
+
+var (
+	errDashboardAuthNotConfigured = errors.New("operator authentication is not configured")
+	errDashboardAuthMissingBearer = errors.New("missing authorization bearer token")
+	errDashboardAuthInvalidBearer = errors.New("invalid authorization header")
+	errDashboardAuthInvalidToken  = errors.New("invalid token")
+)
+
+func (h *Handler) requiresAuthentication(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+	path := strings.TrimSpace(r.URL.Path)
+	switch path {
+	case "/api/rpc", "/api/ws":
+		return false
+	}
+	return path == "/api" || strings.HasPrefix(path, "/api/")
+}
+
+func (h *Handler) authorize(r *http.Request) error {
+	if strings.TrimSpace(h.authToken) == "" {
+		return errDashboardAuthNotConfigured
+	}
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authz == "" {
+		return errDashboardAuthMissingBearer
+	}
+	const prefix = "bearer "
+	if !strings.HasPrefix(strings.ToLower(authz), prefix) {
+		return errDashboardAuthInvalidBearer
+	}
+	if strings.TrimSpace(authz[len(prefix):]) != h.authToken {
+		return errDashboardAuthInvalidToken
+	}
+	return nil
+}
+
+func (h *Handler) writeAuthError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errDashboardAuthNotConfigured) {
+		writeJSONError(w, http.StatusServiceUnavailable, err)
+		return
+	}
+	w.Header().Set("WWW-Authenticate", `Bearer realm="swarm-operator"`)
+	writeJSONError(w, http.StatusUnauthorized, err)
 }
 
 type genericAgent struct {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -28,6 +28,11 @@ type builderRPCResponse = builderpkg.RPCResponse
 type builderWSEventFrame = builderpkg.WSEventFrame
 
 const testBuilderAuthToken = "builder-test-token"
+const testOperatorAuthToken = "operator-secret"
+
+func setOperatorAuth(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+testOperatorAuthToken)
+}
 
 type stubAgents struct {
 	rows []runtimemanager.PersistedAgent
@@ -228,6 +233,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 		Health: func(context.Context) (map[string]any, error) {
 			return map[string]any{"database": map[string]any{"ok": true}}, nil
 		},
+		AuthToken: testOperatorAuthToken,
 		Agents: stubAgents{rows: []runtimemanager.PersistedAgent{{
 			Config: runtimeactors.AgentConfig{
 				ID:            "agent-1",
@@ -311,6 +317,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/conversations", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("conversations status=%d body=%s", rec.Code, rec.Body.String())
@@ -318,6 +325,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/conversations/sess-1", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("conversation detail status=%d body=%s", rec.Code, rec.Body.String())
@@ -333,6 +341,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("events status=%d body=%s", rec.Code, rec.Body.String())
@@ -340,6 +349,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/events/evt-1", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("event detail status=%d body=%s", rec.Code, rec.Body.String())
@@ -347,6 +357,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/runtime/logs", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("runtime logs status=%d body=%s", rec.Code, rec.Body.String())
@@ -354,6 +365,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/runtime/incidents", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("runtime incidents status=%d body=%s", rec.Code, rec.Body.String())
@@ -361,6 +373,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/agents/agent-1", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("agent detail status=%d body=%s", rec.Code, rec.Body.String())
@@ -375,6 +388,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/instances/aggregate?group_by=current_state", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("instance aggregate status=%d body=%s", rec.Code, rec.Body.String())
@@ -382,6 +396,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/instances/aggregate?group_by=subject_id&subject_id=subj-1", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("instance aggregate by subject status=%d body=%s", rec.Code, rec.Body.String())
@@ -389,6 +404,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/subjects/subj-1/status", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("subject status=%d body=%s", rec.Code, rec.Body.String())
@@ -403,6 +419,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("health status=%d body=%s", rec.Code, rec.Body.String())
@@ -410,6 +427,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/agents/agent-1/actions/restart", strings.NewReader(`{}`))
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("agent restart status=%d body=%s", rec.Code, rec.Body.String())
@@ -417,6 +435,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/agents/agent-1/actions/directive", strings.NewReader(`{"message":"hello","kill_previous":true}`))
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("agent directive status=%d body=%s", rec.Code, rec.Body.String())
@@ -427,9 +446,101 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/runtime/actions", strings.NewReader(`{"action":"pause"}`))
+	setOperatorAuth(req)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("runtime action status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandler_DashboardRoutesRequireAuthentication(t *testing.T) {
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+		AuthToken: testOperatorAuthToken,
+		Agents: stubAgents{rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{ID: "agent-1"},
+		}}},
+		Runtime: &stubRuntimeControl{},
+	})
+
+	for _, tc := range []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		authHeader string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "dashboard get missing bearer",
+			method:     http.MethodGet,
+			path:       "/api/agents",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  errDashboardAuthMissingBearer.Error(),
+		},
+		{
+			name:       "dashboard get invalid bearer",
+			method:     http.MethodGet,
+			path:       "/api/runtime/logs",
+			authHeader: "Bearer wrong-token",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  errDashboardAuthInvalidToken.Error(),
+		},
+		{
+			name:       "runtime control missing bearer",
+			method:     http.MethodPost,
+			path:       "/api/runtime/actions",
+			body:       `{"action":"pause"}`,
+			wantStatus: http.StatusUnauthorized,
+			wantError:  errDashboardAuthMissingBearer.Error(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			handler.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got != `Bearer realm="swarm-operator"` {
+				t.Fatalf("WWW-Authenticate=%q", got)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal denial payload: %v", err)
+			}
+			if payload["error"] != tc.wantError {
+				t.Fatalf("error=%#v, want %q", payload["error"], tc.wantError)
+			}
+		})
+	}
+}
+
+func TestHandler_DashboardRoutesFailClosedWhenAuthIsNotConfigured(t *testing.T) {
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal denial payload: %v", err)
+	}
+	if payload["error"] != errDashboardAuthNotConfigured.Error() {
+		t.Fatalf("error=%#v, want %q", payload["error"], errDashboardAuthNotConfigured.Error())
 	}
 }
 
@@ -1304,12 +1415,28 @@ func TestHandler_HealthzAliases(t *testing.T) {
 		Health: func(context.Context) (map[string]any, error) {
 			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
 		},
-		Version: "swarm-test",
+		AuthToken: testOperatorAuthToken,
+		Version:   "swarm-test",
 	})
 
-	for _, path := range []string{"/healthz", "/api/healthz"} {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/healthz status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal /healthz: %v", err)
+	}
+	if payload["ok"] != true {
+		t.Fatalf("unexpected /healthz payload: %#v", payload)
+	}
+
+	for _, path := range []string{"/api/healthz", "/api/health"} {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, path, nil)
+		setOperatorAuth(req)
 		handler.ServeHTTP(rec, req)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("%s status=%d body=%s", path, rec.Code, rec.Body.String())


### PR DESCRIPTION
Closes #142

## Human Summary

This PR makes the default listener fail closed for dashboard and dashboard-owned runtime-control routes unless the caller presents the configured operator bearer token. The old behavior left those `/api/*` surfaces reachable without authentication. This change keeps the public health endpoints and the separately-tracked builder RPC/WebSocket aliases unchanged, while making the dashboard/operator surface explicit and denied by default.

## What Changed

- added an explicit operator auth token to [`dashboardserver.Options`](/Users/youmew/dev/swarm/worktrees/agent-c/internal/dashboard/server/server.go)
- require bearer-token authentication for dashboard `/api/*` routes in [`internal/dashboard/server/server.go`](/Users/youmew/dev/swarm/worktrees/agent-c/internal/dashboard/server/server.go)
- fail closed with explicit denial when:
  - operator auth is not configured on the server
  - the caller omits the bearer token
  - the caller sends an invalid bearer token
- left `/healthz` public on the outer listener path and left `/api/rpc` and `/api/ws` untouched because builder RPC/WS auth is a separate issue
- wired the default listener to the new token through `SWARM_OPERATOR_AUTH_TOKEN` in [`cmd/swarm/main.go`](/Users/youmew/dev/swarm/worktrees/agent-c/cmd/swarm/main.go)
- added focused dashboard handler coverage for authenticated access, unauthenticated denial, invalid-token denial, and fail-closed behavior when auth is not configured in [`internal/dashboard/server/server_test.go`](/Users/youmew/dev/swarm/worktrees/agent-c/internal/dashboard/server/server_test.go)

## Why This Is Needed

The default listener currently exposes operator-facing dashboard reads and dashboard-owned runtime-control actions on `/api/*` without any authentication boundary. That leaves an unauthenticated control and observability surface on the default HTTP listener. The correct behavior is to require explicit operator authentication and fail closed instead of preserving local convenience access.

## Scope Boundaries

In scope:
- dashboard `/api/*` routes on the default listener
- dashboard-owned runtime-control actions exposed through those routes
- explicit bearer-token denial behavior for missing, invalid, or unconfigured auth

Not in scope:
- builder RPC / WebSocket auth on `/api/rpc` and `/api/ws`
- gateway / tool auth
- unrelated listener or transport redesign

## Tests Run

- `go test ./internal/dashboard/server -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

- when `SWARM_OPERATOR_AUTH_TOKEN` is unset, dashboard `/api/*` routes now return explicit denial instead of remaining reachable. That is intentional fail-closed behavior, but operators need the token configured before relying on those surfaces.
- builder RPC / WebSocket aliases on the default listener remain out of scope here and still need their own auth boundary under the separate builder control-plane issue.

## Follow-Up

- authenticate builder RPC and WebSocket control-plane access on `/api/rpc` and `/api/ws` in the separate builder auth workstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard endpoints now require bearer-token authentication for protected API routes.
  * Configure the operator token via the SWARM_OPERATOR_AUTH_TOKEN environment variable.
  * Unauthenticated requests to protected endpoints return 401 with a WWW-Authenticate header.
  * If the token is not configured, protected endpoints return 503.
  * WebSocket and RPC endpoints remain accessible without authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->