### PR TITLE
[agent-b][issue #140] Authenticate builder RPC and WebSocket as a privileged control plane

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1311,6 +1311,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		Instances:      runtimepipeline.NewWorkflowInstanceStore(stores.SQLDB),
 		Runtime:        runtimeCtl,
 		Credentials:    credentialStore,
+		AuthToken:      strings.TrimSpace(os.Getenv("SWARM_BUILDER_AUTH_TOKEN")),
 		Version:        "swarm-dev",
 		CurrentSource:  sourceProvider,
 		CurrentRuntime: runtimeProvider,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -146,6 +146,7 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	rt := &runtimepkg.Runtime{Bus: eb}
 	handler := builderpkg.NewHandler(builderpkg.Options{
 		CurrentRuntime: func() *runtimepkg.Runtime { return rt },
+		AuthToken:      "builder-test-token",
 	})
 
 	runID := uuid.NewString()
@@ -169,6 +170,7 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer builder-test-token")
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -48,6 +48,7 @@ type Options struct {
 	Instances      InstanceReader
 	Runtime        RuntimeController
 	Credentials    runtimecredentials.Store
+	AuthToken      string
 	Version        string
 	SemanticSource semanticview.Source
 	RuntimeRef     *runtimepkg.Runtime
@@ -147,6 +148,7 @@ func NewHandler(opts Options) http.Handler {
 		instances:      opts.Instances,
 		runtime:        opts.Runtime,
 		credentials:    opts.Credentials,
+		authToken:      strings.TrimSpace(opts.AuthToken),
 		version:        strings.TrimSpace(opts.Version),
 		semanticSource: opts.SemanticSource,
 		currentSource:  opts.CurrentSource,

--- a/internal/builder/handler.go
+++ b/internal/builder/handler.go
@@ -14,6 +14,7 @@ type handler struct {
 	instances      InstanceReader
 	runtime        RuntimeController
 	credentials    runtimecredentials.Store
+	authToken      string
 	version        string
 	semanticSource semanticview.Source
 	currentSource  SourceProvider

--- a/internal/builder/handler_auth.go
+++ b/internal/builder/handler_auth.go
@@ -1,0 +1,55 @@
+package builder
+
+import (
+	"net/http"
+	"strings"
+)
+
+const builderRPCAuthErrorCode = -32001
+
+type builderAuthFailure struct {
+	status  int
+	message string
+}
+
+func (h *handler) authorizeControlPlane(r *http.Request) *builderAuthFailure {
+	if h == nil {
+		return &builderAuthFailure{status: http.StatusNotFound, message: "builder handler is unavailable"}
+	}
+	if strings.TrimSpace(h.authToken) == "" {
+		return &builderAuthFailure{status: http.StatusServiceUnavailable, message: "builder control-plane auth is not configured"}
+	}
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authz == "" {
+		return &builderAuthFailure{status: http.StatusUnauthorized, message: "missing authorization bearer token"}
+	}
+	const prefix = "bearer "
+	if !strings.HasPrefix(strings.ToLower(authz), prefix) {
+		return &builderAuthFailure{status: http.StatusUnauthorized, message: "invalid authorization header"}
+	}
+	token := strings.TrimSpace(authz[len(prefix):])
+	if token != h.authToken {
+		return &builderAuthFailure{status: http.StatusUnauthorized, message: "invalid bearer token"}
+	}
+	return nil
+}
+
+func (h *handler) writeAuthFailure(w http.ResponseWriter, r *http.Request, failure *builderAuthFailure) {
+	if failure == nil {
+		return
+	}
+	if failure.status == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="swarm-builder"`)
+	}
+	if r != nil && r.Method == http.MethodPost {
+		writeJSON(w, failure.status, RPCResponse{
+			JSONRPC: "2.0",
+			Error: &RPCError{
+				Code:    builderRPCAuthErrorCode,
+				Message: failure.message,
+			},
+		})
+		return
+	}
+	http.Error(w, failure.message, failure.status)
+}

--- a/internal/builder/handler_auth_test.go
+++ b/internal/builder/handler_auth_test.go
@@ -1,0 +1,118 @@
+package builder
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestHandler_RPCRejectsUnauthenticatedAccess(t *testing.T) {
+	handler := NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"engine.ping"}`))
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+		t.Fatalf("WWW-Authenticate = %q, want bearer challenge", got)
+	}
+	var resp RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode rpc denial: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != builderRPCAuthErrorCode {
+		t.Fatalf("rpc error = %#v, want auth denial code", resp.Error)
+	}
+	if !strings.Contains(resp.Error.Message, "authorization bearer token") {
+		t.Fatalf("rpc denial message = %q", resp.Error.Message)
+	}
+}
+
+func TestHandler_RPCRejectsWhenControlPlaneAuthIsNotConfigured(t *testing.T) {
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"engine.ping"}`))
+	req.Header.Set("Authorization", "Bearer "+testBuilderAuthToken)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	var resp RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode rpc denial: %v", err)
+	}
+	if resp.Error == nil || !strings.Contains(resp.Error.Message, "not configured") {
+		t.Fatalf("rpc error = %#v, want explicit unconfigured denial", resp.Error)
+	}
+}
+
+func TestHandler_WSRejectsUnauthenticatedUpgrade(t *testing.T) {
+	ts := httptest.NewServer(NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+	}))
+	defer ts.Close()
+
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		t.Fatal("expected websocket upgrade denial")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("upgrade response = %#v, want 401", resp)
+	}
+}
+
+func TestHandler_WSAllowsAuthenticatedUpgrade(t *testing.T) {
+	restore := SetHealthHeartbeatIntervalForTest(20 * time.Millisecond)
+	defer restore()
+	ts := httptest.NewServer(NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+		Version: "builder-auth-test",
+	}))
+	defer ts.Close()
+
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
+	headers := http.Header{"Authorization": []string{"Bearer " + testBuilderAuthToken}}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{"type": "subscribe", "channel": "engine:health"}); err != nil {
+		t.Fatalf("subscribe write: %v", err)
+	}
+	var frame WSEventFrame
+	if err := conn.ReadJSON(&frame); err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	if frame.Channel != "engine:health" {
+		t.Fatalf("channel = %q, want engine:health", frame.Channel)
+	}
+}

--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -14,6 +14,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if failure := h.authorizeControlPlane(r); failure != nil {
+		h.writeAuthFailure(w, r, failure)
+		return
+	}
 	if h.mux == nil {
 		mux := http.NewServeMux()
 		mux.HandleFunc("POST /rpc", h.handleRPC)

--- a/internal/builder/handler_test.go
+++ b/internal/builder/handler_test.go
@@ -14,6 +14,8 @@ import (
 	"swarm/internal/runtime/semanticview"
 )
 
+const testBuilderAuthToken = "builder-test-token"
+
 func TestHandler_CredentialsListSetDelete(t *testing.T) {
 	ctx := context.Background()
 	fileStore, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
@@ -41,6 +43,7 @@ func TestHandler_CredentialsListSetDelete(t *testing.T) {
 			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
 		},
 		Credentials:    store,
+		AuthToken:      testBuilderAuthToken,
 		SemanticSource: source,
 		Version:        "test",
 	})
@@ -106,6 +109,7 @@ func callBuilderRPC(t *testing.T, handler http.Handler, req Request) RPCResponse
 	}
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(raw))
+	httpReq.Header.Set("Authorization", "Bearer "+testBuilderAuthToken)
 	handler.ServeHTTP(rec, httpReq)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("unexpected status %d body=%s", rec.Code, rec.Body.String())

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -27,6 +27,8 @@ import (
 type builderRPCResponse = builderpkg.RPCResponse
 type builderWSEventFrame = builderpkg.WSEventFrame
 
+const testBuilderAuthToken = "builder-test-token"
+
 type stubAgents struct {
 	rows []runtimemanager.PersistedAgent
 }
@@ -202,10 +204,21 @@ func newBuilderHandlerForTest(
 		Health:         builderpkg.HealthChecker(health),
 		Instances:      instances,
 		Runtime:        runtimeCtl,
+		AuthToken:      testBuilderAuthToken,
 		Version:        version,
 		CurrentRuntime: runtimeProvider,
 		ProjectControl: projectCtl,
 	})
+}
+
+func builderAuthRequest(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testBuilderAuthToken)
+	return req
+}
+
+func builderAuthHeader() http.Header {
+	return http.Header{"Authorization": []string{"Bearer " + testBuilderAuthToken}}
 }
 
 func TestHandler_ConversationsAndAggregates(t *testing.T) {
@@ -1095,7 +1108,7 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"engine.ping"}`))
+	req := builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"1","method":"engine.ping"}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("engine.ping status=%d body=%s", rec.Code, rec.Body.String())
@@ -1113,7 +1126,7 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"2","method":"state.list_instances"}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"2","method":"state.list_instances"}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("state.list_instances status=%d body=%s", rec.Code, rec.Body.String())
@@ -1132,14 +1145,14 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"3","method":"state.get_instances"}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"3","method":"state.get_instances"}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("state.get_instances status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"4","method":"state.get_entity","params":{"instance_id":"wf-1"}}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"4","method":"state.get_entity","params":{"instance_id":"wf-1"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("state.get_entity status=%d body=%s", rec.Code, rec.Body.String())
@@ -1173,7 +1186,7 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"5","method":"project.open","params":{"project_dir":"/tmp/builder-project"}}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"5","method":"project.open","params":{"project_dir":"/tmp/builder-project"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("project.open status=%d body=%s", rec.Code, rec.Body.String())
@@ -1188,7 +1201,7 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/api/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"6","method":"engine.ping"}`))
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"6","method":"engine.ping"}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/api/rpc engine.ping status=%d body=%s", rec.Code, rec.Body.String())
@@ -1217,7 +1230,7 @@ func TestHandler_BuilderWSHealthHeartbeat(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -1257,7 +1270,7 @@ func TestHandler_BuilderWSHealthHeartbeat_APIAlias(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial builder ws alias: %v", err)
 	}
@@ -1339,7 +1352,7 @@ func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -1351,7 +1364,7 @@ func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_001","inputs":{"intake.requested":{"topic":"sample"}}}}`))
+	req := builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
@@ -1433,7 +1446,7 @@ func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -1445,14 +1458,14 @@ func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_stop_001","inputs":{"intake.requested":{"topic":"sample"}}}}`))
+	req := builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_stop_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.stop","params":{"run_id":"run_test_stop_001"}}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.stop","params":{"run_id":"run_test_stop_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.stop status=%d body=%s", rec.Code, rec.Body.String())
@@ -1516,7 +1529,7 @@ func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -1528,21 +1541,21 @@ func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_pause_001","inputs":{"intake.requested":{"topic":"sample"}}}}`))
+	req := builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_pause_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.pause","params":{"run_id":"run_test_pause_001"}}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.pause","params":{"run_id":"run_test_pause_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.pause status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"12","method":"run.continue","params":{"run_id":"run_test_pause_001"}}`))
+	req = builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"12","method":"run.continue","params":{"run_id":"run_test_pause_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.continue status=%d body=%s", rec.Code, rec.Body.String())
@@ -1616,7 +1629,7 @@ func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -1631,33 +1644,21 @@ func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_api_alias_001","inputs":{"intake.requested":{"topic":"sample"}}}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_api_alias_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.pause","params":{"run_id":"run_test_api_alias_001"}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.pause","params":{"run_id":"run_test_api_alias_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.pause alias status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"12","method":"run.continue","params":{"run_id":"run_test_api_alias_001"}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"12","method":"run.continue","params":{"run_id":"run_test_api_alias_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.continue alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -1737,7 +1738,7 @@ func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -1752,11 +1753,7 @@ func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_breakpoint_001","inputs":{"intake.requested":{"topic":"sample"}},"breakpoints":["agent-source"]}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_breakpoint_001","inputs":{"intake.requested":{"topic":"sample"}},"breakpoints":["agent-source"]}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -1838,7 +1835,7 @@ func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -1853,11 +1850,7 @@ func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_human_001","inputs":{"intake.requested":{"topic":"sample"}}}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_human_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -1907,11 +1900,7 @@ func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.continue","params":{"run_id":"run_test_human_001","decision":"approved","instance_ids":["run_test_human_001"]}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.continue","params":{"run_id":"run_test_human_001","decision":"approved","instance_ids":["run_test_human_001"]}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.continue alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -1982,7 +1971,7 @@ func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -1997,22 +1986,14 @@ func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_step_001","inputs":{"intake.requested":{"topic":"sample"}}}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_step_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.step","params":{"run_id":"run_test_step_001","node_id":"agent-source","instance_id":"run_test_step_001"}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.step","params":{"run_id":"run_test_step_001","node_id":"agent-source","instance_id":"run_test_step_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.step alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -2100,7 +2081,7 @@ func TestHandler_RunRetryEmitsRetriedAndResumed(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -2115,22 +2096,14 @@ func TestHandler_RunRetryEmitsRetriedAndResumed(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_retry_001","inputs":{"intake.requested":{"topic":"sample"}}}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_retry_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.retry","params":{"run_id":"run_test_retry_001","node_id":"agent-source","instance_id":"run_test_retry_001"}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.retry","params":{"run_id":"run_test_retry_001","node_id":"agent-source","instance_id":"run_test_retry_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.retry alias status=%d body=%s", rec.Code, rec.Body.String())
@@ -2201,7 +2174,7 @@ func TestHandler_RunSkipEmitsSkippedAndResumed(t *testing.T) {
 	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
 	if err != nil {
 		t.Fatalf("dial websocket alias: %v", err)
 	}
@@ -2216,22 +2189,14 @@ func TestHandler_RunSkipEmitsSkippedAndResumed(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_skip_001","inputs":{"intake.requested":{"topic":"sample"}}}}`),
-	)
+	req := builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_test_skip_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.start alias status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(
-		http.MethodPost,
-		"/api/rpc",
-		strings.NewReader(`{"jsonrpc":"2.0","id":"11","method":"run.skip","params":{"run_id":"run_test_skip_001","node_id":"agent-source","instance_id":"run_test_skip_001"}}`),
-	)
+	req = builderAuthRequest(http.MethodPost, "/api/rpc", `{"jsonrpc":"2.0","id":"11","method":"run.skip","params":{"run_id":"run_test_skip_001","node_id":"agent-source","instance_id":"run_test_skip_001"}}`)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("run.skip alias status=%d body=%s", rec.Code, rec.Body.String())


### PR DESCRIPTION
Closes #140

## Human Summary

This PR locks down the builder RPC and WebSocket surfaces so they behave as authenticated control-plane endpoints instead of unauthenticated management entry points. Builder requests now require an explicit bearer token, and missing or invalid auth is denied before any privileged builder operation or subscription can run.

## What Changed

- added one builder-owned bearer-token authorization check that runs before the builder RPC and WebSocket routes dispatch
- made RPC denial return explicit JSON-RPC auth errors with HTTP denial status instead of falling through to privileged handlers
- made WebSocket upgrades fail closed before the upgrade when auth is missing or invalid
- wired the runtime entrypoint to pass `SWARM_BUILDER_AUTH_TOKEN` into the builder handler
- updated builder, dashboard server, and swarm command tests to use authenticated builder requests
- added focused builder auth regressions for unauthenticated RPC denial, unauthenticated WebSocket denial, fail-closed behavior when the handler is unconfigured, and authenticated WebSocket success

## Why This Is Needed

- builder RPC and builder WebSocket expose privileged control-plane actions such as project open/reload/close, run control, state inspection, and credential management
- before this change those surfaces were reachable without authentication
- this issue is specifically about making those control-plane seams fail closed instead of leaving local-convenience access open by default

## Scope Boundaries

- In scope:
  - builder RPC auth
  - builder WebSocket upgrade auth
  - minimal handler/runtime wiring needed to make builder auth enforceable
  - targeted tests for deny vs allow behavior on builder control-plane paths
- Not in scope:
  - broader dashboard API authentication
  - gateway or default listener auth cleanup
  - broad auth abstraction refactors outside the builder seam

## Tests Run

- `go test ./internal/builder ./internal/dashboard/server ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

- builder access now depends on `SWARM_BUILDER_AUTH_TOKEN` being configured in environments that need these surfaces; if it is unset, the builder control plane denies requests with an explicit unconfigured-auth error
- this PR intentionally does not secure unrelated dashboard REST endpoints; those remain a separate boundary decision

## Follow-Up

- none in this seam; broader dashboard/default-listener auth should remain separate because it is a wider boundary decision than builder RPC/WebSocket control-plane auth
