### PR TITLE
[agent-d][issue #141] Cap delegable privileges on agent hire and reconfigure

### DIFF
--- a/internal/runtime/tools/delegation.go
+++ b/internal/runtime/tools/delegation.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	runtimeauthority "swarm/internal/runtime/authority"
+	models "swarm/internal/runtime/core/actors"
+)
+
+func authorizeDelegableAgentConfig(actor, current, proposed models.AgentConfig, provider runtimeauthority.Provider, emitRegistry *EmitRegistry) error {
+	actor.NormalizeRuntimeDescriptor()
+	current.NormalizeRuntimeDescriptor()
+	proposed.NormalizeRuntimeDescriptor()
+
+	for _, perm := range addedCanonicalValues(current.Permissions, proposed.Permissions, identityValue) {
+		if agentHasPermission(actor, perm) {
+			continue
+		}
+		return fmt.Errorf("delegated permission %q exceeds caller authority", perm)
+	}
+
+	for _, capability := range addedNativeToolCapabilities(current.NativeTools, proposed.NativeTools) {
+		if actor.NativeTools.Enabled(capability) {
+			continue
+		}
+		return fmt.Errorf("delegated native_tools.%s exceeds caller authority", capability)
+	}
+
+	for _, toolName := range addedCanonicalValues(current.Tools, proposed.Tools, normalizeNativeToolName) {
+		if classifyToolAuthorization(actor, toolName, provider, emitRegistry).allowed {
+			continue
+		}
+		return fmt.Errorf("delegated tool %q exceeds caller authority", toolName)
+	}
+
+	actorEmitEvents := effectiveDelegableEmitEvents(actor, provider)
+	currentEmitEvents := effectiveDelegableEmitEvents(current, provider)
+	proposedEmitEvents := effectiveDelegableEmitEvents(proposed, provider)
+	for _, eventType := range addedCanonicalValues(currentEmitEvents, proposedEmitEvents, localEmitEventType) {
+		if containsEquivalentEmitEvent(actorEmitEvents, eventType) {
+			continue
+		}
+		return fmt.Errorf("delegated emit authority %q exceeds caller authority", eventType)
+	}
+
+	return nil
+}
+
+func mergeDelegablePrivilegeConfig(base, patch models.AgentConfig) models.AgentConfig {
+	out := base
+	if strings.TrimSpace(patch.Role) != "" {
+		out.Role = strings.TrimSpace(patch.Role)
+	}
+	if len(patch.EmitEvents) > 0 {
+		out.EmitEvents = append([]string(nil), patch.EmitEvents...)
+	}
+	if len(patch.Tools) > 0 {
+		out.Tools = append([]string(nil), patch.Tools...)
+	}
+	if len(patch.Permissions) > 0 {
+		out.Permissions = append([]string(nil), patch.Permissions...)
+	}
+	if patch.NativeTools.Any() {
+		out.NativeTools = patch.NativeTools
+	}
+	out.NormalizeRuntimeDescriptor()
+	return out
+}
+
+func effectiveDelegableEmitEvents(cfg models.AgentConfig, provider runtimeauthority.Provider) []string {
+	if configured := UniqueNonEmpty(cfg.EmitEvents); len(configured) > 0 {
+		return configured
+	}
+	return UniqueNonEmpty(runtimeauthority.ProviderOrNoop(provider).ProducerEventsForRole(cfg.Role))
+}
+
+func containsEquivalentEmitEvent(events []string, candidate string) bool {
+	candidate = localEmitEventType(candidate)
+	if candidate == "" {
+		return false
+	}
+	for _, eventType := range events {
+		if localEmitEventType(eventType) == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func addedNativeToolCapabilities(current, proposed models.NativeToolConfig) []string {
+	out := make([]string, 0, 3)
+	for _, capability := range []string{"bash", "web_search", "file_io"} {
+		if !current.Enabled(capability) && proposed.Enabled(capability) {
+			out = append(out, capability)
+		}
+	}
+	return out
+}
+
+func addedCanonicalValues(current, proposed []string, canonicalize func(string) string) []string {
+	currentSet := make(map[string]struct{}, len(current))
+	for _, value := range current {
+		value = canonicalize(value)
+		if value != "" {
+			currentSet[value] = struct{}{}
+		}
+	}
+	added := make([]string, 0, len(proposed))
+	for _, value := range proposed {
+		value = canonicalize(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := currentSet[value]; ok {
+			continue
+		}
+		if slices.Contains(added, value) {
+			continue
+		}
+		added = append(added, value)
+	}
+	return added
+}
+
+func identityValue(value string) string {
+	return strings.TrimSpace(value)
+}

--- a/internal/runtime/tools/executor_agents.go
+++ b/internal/runtime/tools/executor_agents.go
@@ -247,6 +247,9 @@ func (e *Executor) execAgentHire(actor models.AgentConfig, input any) (any, erro
 	if err := authorizeManage(e.authority, actor, in.Config, manager); err != nil {
 		return nil, err
 	}
+	if err := authorizeDelegableAgentConfig(actor, models.AgentConfig{}, in.Config, e.authority, e.emitRegistry); err != nil {
+		return nil, err
+	}
 	if err := manager.SpawnAgentForEntity(in.Config.EffectiveEntityID(), in.Config); err != nil {
 		return nil, err
 	}
@@ -306,6 +309,9 @@ func (e *Executor) execAgentReconfigure(actor models.AgentConfig, input any) (an
 		return nil, fmt.Errorf("target agent not found: %s", in.AgentID)
 	}
 	if err := authorizeManage(e.authority, actor, targetCfg, manager); err != nil {
+		return nil, err
+	}
+	if err := authorizeDelegableAgentConfig(actor, targetCfg, mergeDelegablePrivilegeConfig(targetCfg, in.Config), e.authority, e.emitRegistry); err != nil {
 		return nil, err
 	}
 	if err := manager.ReconfigureAgent(in.AgentID, in.Config); err != nil {

--- a/internal/runtime/tools/executor_agents_test.go
+++ b/internal/runtime/tools/executor_agents_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"swarm/internal/events"
@@ -32,6 +33,48 @@ func (b *publishDirectBusStub) Publish(context.Context, events.Event) error { re
 
 func (b *publishDirectBusStub) PublishDirect(_ context.Context, _ events.Event, recipients []string) error {
 	b.recipients = append([]string{}, recipients...)
+	return nil
+}
+
+type captureManagerStub struct {
+	agents            map[string]models.AgentConfig
+	spawnedEntityID   string
+	spawnedConfig     models.AgentConfig
+	spawnCalled       bool
+	reconfiguredID    string
+	reconfiguredPatch models.AgentConfig
+	reconfigureCalled bool
+}
+
+func (m *captureManagerStub) GetAgentConfig(agentID string) (models.AgentConfig, bool) {
+	cfg, ok := m.agents[agentID]
+	return cfg, ok
+}
+
+func (m *captureManagerStub) SpawnAgentForEntity(entityID string, cfg models.AgentConfig) error {
+	m.spawnedEntityID = entityID
+	m.spawnedConfig = cfg
+	m.spawnCalled = true
+	if m.agents == nil {
+		m.agents = map[string]models.AgentConfig{}
+	}
+	m.agents[cfg.ID] = cfg
+	return nil
+}
+
+func (m *captureManagerStub) TeardownAgent(string) error { return nil }
+
+func (m *captureManagerStub) ReconfigureAgent(agentID string, cfg models.AgentConfig) error {
+	m.reconfiguredID = agentID
+	m.reconfiguredPatch = cfg
+	m.reconfigureCalled = true
+	if m.agents == nil {
+		m.agents = map[string]models.AgentConfig{}
+	}
+	current := m.agents[agentID]
+	current = mergeDelegablePrivilegeConfig(current, cfg)
+	current.ID = agentID
+	m.agents[agentID] = current
 	return nil
 }
 
@@ -136,5 +179,239 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	}
 	if len(bus.recipients) != 1 || bus.recipients[0] != "target-1" {
 		t.Fatalf("recipients = %#v, want [target-1]", bus.recipients)
+	}
+}
+
+func TestExecAgentHire_DeniesDelegatedPermissionEscalation(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager"},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_hire"},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"config": map[string]any{
+			"id":               "worker-1",
+			"role":             "worker",
+			"manager_fallback": "manager",
+			"flow_path":        "review/inst-1",
+			"permissions":      []any{"agent_fire"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected delegated permission escalation to be denied")
+	}
+	if !strings.Contains(err.Error(), `delegated permission "agent_fire"`) {
+		t.Fatalf("error = %q, want delegated permission denial", err.Error())
+	}
+	if manager.spawnCalled {
+		t.Fatal("expected denied hire to fail closed before spawning")
+	}
+}
+
+func TestExecAgentHire_DeniesDelegatedToolEscalation(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager"},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_hire"},
+		Tools:       []string{"lookup_data"},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"config": map[string]any{
+			"id":               "worker-1",
+			"role":             "worker",
+			"manager_fallback": "manager",
+			"flow_path":        "review/inst-1",
+			"tools":            []any{"deploy_prod"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected delegated tool escalation to be denied")
+	}
+	if !strings.Contains(err.Error(), `delegated tool "deploy_prod"`) {
+		t.Fatalf("error = %q, want delegated tool denial", err.Error())
+	}
+	if manager.spawnCalled {
+		t.Fatal("expected denied hire to fail closed before spawning")
+	}
+}
+
+func TestExecAgentHire_DeniesRoleBasedEmitEscalation(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager":   {ID: "manager", Role: "manager", EmitEvents: []string{"review.started"}},
+			"worker":    {ID: "worker", Role: "worker", ManagerFallback: "manager", EmitEvents: []string{"review.started"}},
+			"escalated": {ID: "escalated", Role: "escalated", ManagerFallback: "manager", EmitEvents: []string{"security.root"}},
+		},
+	})
+	manager := &captureManagerStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_hire"},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"config": map[string]any{
+			"id":               "worker-1",
+			"role":             "escalated",
+			"manager_fallback": "manager",
+			"flow_path":        "review/inst-1",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected role-based emit authority escalation to be denied")
+	}
+	if !strings.Contains(err.Error(), `delegated emit authority "security.root"`) {
+		t.Fatalf("error = %q, want delegated emit authority denial", err.Error())
+	}
+	if manager.spawnCalled {
+		t.Fatal("expected denied hire to fail closed before spawning")
+	}
+}
+
+func TestExecAgentHire_AllowsDelegablePrivileges(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager", EmitEvents: []string{"review.started"}},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_hire", "schedule"},
+		Tools:       []string{"lookup_data"},
+		NativeTools: models.NativeToolConfig{FileIO: true},
+		EmitEvents:  []string{"review.started"},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"config": map[string]any{
+			"id":               "worker-1",
+			"role":             "worker",
+			"manager_fallback": "manager",
+			"flow_path":        "review/inst-1",
+			"permissions":      []any{"schedule"},
+			"tools":            []any{"lookup_data"},
+			"native_tools": map[string]any{
+				"file_io": true,
+			},
+			"emit_events": []any{"review.started"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected delegable privilege set to be allowed, got %v", err)
+	}
+	if !manager.spawnCalled {
+		t.Fatal("expected allowed hire to spawn agent")
+	}
+	if manager.spawnedEntityID != "" {
+		t.Fatalf("spawned entity id = %q, want empty", manager.spawnedEntityID)
+	}
+	if len(manager.spawnedConfig.Permissions) != 1 || manager.spawnedConfig.Permissions[0] != "schedule" {
+		t.Fatalf("spawned permissions = %#v, want [schedule]", manager.spawnedConfig.Permissions)
+	}
+	if len(manager.spawnedConfig.Tools) != 1 || manager.spawnedConfig.Tools[0] != "lookup_data" {
+		t.Fatalf("spawned tools = %#v, want [lookup_data]", manager.spawnedConfig.Tools)
+	}
+	if !manager.spawnedConfig.NativeTools.FileIO {
+		t.Fatalf("spawned native tools = %#v, want file_io enabled", manager.spawnedConfig.NativeTools)
+	}
+	if len(manager.spawnedConfig.EmitEvents) != 1 || manager.spawnedConfig.EmitEvents[0] != "review.started" {
+		t.Fatalf("spawned emit events = %#v, want [review.started]", manager.spawnedConfig.EmitEvents)
+	}
+}
+
+func TestExecAgentReconfigure_DeniesNativeToolEscalation(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager"},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{
+		agents: map[string]models.AgentConfig{
+			"worker-1": {
+				ID:              "worker-1",
+				Role:            "worker",
+				ManagerFallback: "manager",
+				FlowPath:        "review/inst-1",
+			},
+		},
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentReconfigureDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_reconfigure"},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"agent_id": "worker-1",
+		"config": map[string]any{
+			"native_tools": map[string]any{
+				"bash": true,
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected delegated native tool escalation to be denied")
+	}
+	if !strings.Contains(err.Error(), "delegated native_tools.bash") {
+		t.Fatalf("error = %q, want delegated native tool denial", err.Error())
+	}
+	if manager.reconfigureCalled {
+		t.Fatal("expected denied reconfigure to fail closed before persistence")
 	}
 }


### PR DESCRIPTION
Closes #141

## Human Summary
Agent hire and reconfigure now fail closed when a caller tries to grant permissions, native tools, explicit tools, or emit authority beyond the caller's own delegable runtime authority.

## What Changed
- added one shared runtime delegation-cap helper in `internal/runtime/tools/delegation.go`
- enforced that cap in both `agent_hire` and `agent_reconfigure` before manager persistence/execution
- capped newly granted permissions, native tools, explicit tools, and effective emit authority
- treated role-based emit authority as privilege-bearing, so role changes cannot mint stronger emit power than the caller can delegate
- added focused executor tests for denied escalation and allowed same-boundary delegation

## Why This Is Needed
Management authorization previously checked relationship and management capability, but it did not cap what authority the caller could mint into the target agent config. That left an intra-runtime privilege-escalation path in the canonical hire/reconfigure seam.

## Scope Boundaries
- scoped only to runtime agent hire/reconfigure privilege capping
- no gateway auth redesign
- no builder auth work
- no broad permission-system redesign
- no compatibility shim for older permissive behavior

## Tests Run
- `go test ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
This change caps the runtime-managed hire/reconfigure seam. Direct store writes or any future management path that bypasses the runtime tool executor would still need to enforce the same invariant intentionally.

## Follow-Up
If the project wants broader delegation semantics beyond the touched seam, the next separate step would be lifting this invariant into any other management entrypoint that can materialize agent configs without going through `agent_hire` / `agent_reconfigure`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegation authorization framework to enforce privilege controls for agents; validates that delegated permissions, tools, native tool capabilities, and event authorities remain within caller authorization limits during agent hiring and reconfiguration.

* **Tests**
  * Added comprehensive tests for authorization scenarios including privilege escalation prevention in agent hiring and reconfiguration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->