### PR TITLE
[agent-a][issue #139] Make gateway auth fail closed and remove caller-owned privilege data from tool authorization

### DIFF
--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -387,8 +387,12 @@ func estimateTokensFromBytes(b []byte) int {
 }
 
 func toolNamesCSV(tools []ToolDefinition) string {
+	return strings.Join(toolNames(tools), ",")
+}
+
+func toolNames(tools []ToolDefinition) []string {
 	if len(tools) == 0 {
-		return ""
+		return nil
 	}
 	names := make([]string, 0, len(tools))
 	seen := make(map[string]struct{}, len(tools))
@@ -403,7 +407,7 @@ func toolNamesCSV(tools []ToolDefinition) string {
 		seen[name] = struct{}{}
 		names = append(names, name)
 	}
-	return strings.Join(names, ",")
+	return names
 }
 
 func buildInitialPrompt(s *Session, firstMessage string) string {

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -46,9 +46,6 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 	if strings.TrimSpace(actor.ID) == "" {
 		actor.ID = strings.TrimSpace(s.AgentID)
 	}
-	if strings.TrimSpace(actor.Role) == "" {
-		actor.Role = actor.ID
-	}
 	if strings.TrimSpace(actor.ID) == "" {
 		return "", "", false, nil
 	}
@@ -64,24 +61,16 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 	if serverURL == "" {
 		return "", "", false, nil
 	}
-	allowedTools := toolNamesCSV(s.Tools)
-	headers := map[string]string{
-		mcpActorIDHeader:      strings.TrimSpace(actor.ID),
-		mcpActorRoleHeader:    strings.TrimSpace(actor.Role),
-		mcpEntityIDHeader:     strings.TrimSpace(actor.EffectiveEntityID()),
-		mcpAllowedToolsHeader: allowedTools,
-	}
-	if mode := strings.TrimSpace(actor.Mode); mode != "" {
-		headers[mcpActorModeHeader] = mode
-	}
+	allowedTools := toolNames(s.Tools)
+	headers := map[string]string{}
 	if token := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); token != "" {
 		headers["Authorization"] = "Bearer " + token
 	}
-	contextToken = r.mcpTurns.RegisterTurnContextWithTTL(ctx, r.mcpContextTokenTTL(ctx))
+	contextToken = r.mcpTurns.RegisterTurnContextWithAllowedTools(ctx, r.mcpContextTokenTTL(ctx), allowedTools)
 	if contextToken != "" {
 		headers[mcpContextTokenHeader] = contextToken
 	}
-	serverURL = withMCPContextQuery(serverURL, actor, contextToken, allowedTools)
+	serverURL = withMCPContextQuery(serverURL, contextToken)
 	cfg := map[string]any{
 		"mcpServers": map[string]any{
 			"runtime-tools": map[string]any{
@@ -152,7 +141,7 @@ func normalizeMCPServerURL(raw string) string {
 	return strings.TrimSpace(u.String())
 }
 
-func withMCPContextQuery(rawURL string, actor models.AgentConfig, contextToken, allowedTools string) string {
+func withMCPContextQuery(rawURL string, contextToken string) string {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
 		return rawURL
@@ -164,21 +153,6 @@ func withMCPContextQuery(rawURL string, actor models.AgentConfig, contextToken, 
 	q := u.Query()
 	if v := strings.TrimSpace(contextToken); v != "" {
 		q.Set(mcpContextTokenQuery, v)
-	}
-	if v := strings.TrimSpace(actor.ID); v != "" {
-		q.Set(mcpActorIDQuery, v)
-	}
-	if v := strings.TrimSpace(actor.Role); v != "" {
-		q.Set(mcpActorRoleQuery, v)
-	}
-	if v := strings.TrimSpace(actor.Mode); v != "" {
-		q.Set(mcpActorModeQuery, v)
-	}
-	if v := strings.TrimSpace(actor.EffectiveEntityID()); v != "" {
-		q.Set(mcpEntityIDQuery, v)
-	}
-	if v := strings.TrimSpace(allowedTools); v != "" {
-		q.Set(mcpAllowedToolsQuery, v)
 	}
 	u.RawQuery = q.Encode()
 	return strings.TrimSpace(u.String())

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -13,15 +13,19 @@ import (
 )
 
 type mcpTurnContextStoreStub struct {
-	register   func(context.Context, time.Duration) string
+	register   func(context.Context, time.Duration, []string) string
 	unregister func(string)
 }
 
 func (s mcpTurnContextStoreStub) RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
+	return s.RegisterTurnContextWithAllowedTools(ctx, ttl, nil)
+}
+
+func (s mcpTurnContextStoreStub) RegisterTurnContextWithAllowedTools(ctx context.Context, ttl time.Duration, allowedTools []string) string {
 	if s.register == nil {
 		return ""
 	}
-	return s.register(ctx, ttl)
+	return s.register(ctx, ttl, allowedTools)
 }
 
 func (s mcpTurnContextStoreStub) UnregisterTurnContext(token string) {
@@ -117,7 +121,12 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	r := &ClaudeCLIRuntime{
 		cfg: &config.Config{},
 		mcpTurns: mcpTurnContextStoreStub{
-			register:   func(context.Context, time.Duration) string { return "ctx-token-123" },
+			register: func(_ context.Context, _ time.Duration, allowedTools []string) string {
+				if !slices.Equal(allowedTools, []string{"emit_category_assessed", "query_entities"}) {
+					t.Fatalf("allowedTools = %#v", allowedTools)
+				}
+				return "ctx-token-123"
+			},
 			unregister: func(string) {},
 		},
 	}
@@ -158,10 +167,32 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	if got := headers[mcpContextTokenHeader]; got != contextToken {
 		t.Fatalf("context header = %#v, want %q", got, contextToken)
 	}
+	for _, key := range []string{
+		mcpActorIDHeader,
+		mcpActorRoleHeader,
+		mcpActorModeHeader,
+		mcpEntityIDHeader,
+		mcpAllowedToolsHeader,
+	} {
+		if got := headers[key]; got != nil {
+			t.Fatalf("unexpected gateway identity header %q = %#v", key, got)
+		}
+	}
 	urlRaw := runtimeTools["url"].(string)
 	legacyTraceQuery := "trace" + "_id="
 	if strings.Contains(urlRaw, legacyTraceQuery) {
 		t.Fatalf("url %q should not propagate legacy trace query params", urlRaw)
+	}
+	for _, key := range []string{
+		mcpActorIDQuery,
+		mcpActorRoleQuery,
+		mcpActorModeQuery,
+		mcpEntityIDQuery,
+		mcpAllowedToolsQuery,
+	} {
+		if strings.Contains(urlRaw, key+"=") {
+			t.Fatalf("url %q should not propagate %s", urlRaw, key)
+		}
 	}
 }
 

--- a/internal/runtime/llm/helpers_runtime.go
+++ b/internal/runtime/llm/helpers_runtime.go
@@ -39,5 +39,6 @@ func asString(v any) string {
 
 type MCPTurnContextStore interface {
 	RegisterTurnContextWithTTL(context.Context, time.Duration) string
+	RegisterTurnContextWithAllowedTools(context.Context, time.Duration, []string) string
 	UnregisterTurnContext(string)
 }

--- a/internal/runtime/mcp/context.go
+++ b/internal/runtime/mcp/context.go
@@ -10,6 +10,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolidentity"
 )
 
 type actorResolverFn func(context.Context) (models.AgentConfig, bool)
@@ -18,6 +19,7 @@ type TurnContext struct {
 	Actor      models.AgentConfig
 	Inbound    events.Event
 	HasInbound bool
+	Allowed    map[string]struct{}
 	Recorder   *runtimebus.EmittedEventsRecorder
 	Emitted    map[string]struct{}
 	CreatedAt  time.Time
@@ -48,6 +50,10 @@ func (r *TurnContextRegistry) RegisterTurnContext(ctx context.Context) string {
 }
 
 func (r *TurnContextRegistry) RegisterTurnContextWithTTL(ctx context.Context, ttl time.Duration) string {
+	return r.RegisterTurnContextWithAllowedTools(ctx, ttl, nil)
+}
+
+func (r *TurnContextRegistry) RegisterTurnContextWithAllowedTools(ctx context.Context, ttl time.Duration, allowedTools []string) string {
 	if r == nil || r.actorResolver == nil {
 		return ""
 	}
@@ -66,6 +72,7 @@ func (r *TurnContextRegistry) RegisterTurnContextWithTTL(ctx context.Context, tt
 		Actor:      actor,
 		Inbound:    inbound,
 		HasInbound: hasInbound,
+		Allowed:    normalizeAllowedTools(allowedTools),
 		Recorder:   recorder,
 		CreatedAt:  now,
 		ExpiresAt:  now.Add(ttl),
@@ -135,6 +142,14 @@ func (r *TurnContextRegistry) put(token string, data TurnContext) {
 	if data.ExpiresAt.IsZero() {
 		data.ExpiresAt = data.CreatedAt.Add(r.defaultTTL)
 	}
+	data.Allowed = copyAllowedTools(data.Allowed)
+	if data.Emitted != nil {
+		cloned := make(map[string]struct{}, len(data.Emitted))
+		for key := range data.Emitted {
+			cloned[key] = struct{}{}
+		}
+		data.Emitted = cloned
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pruneLocked(now)
@@ -150,6 +165,14 @@ func (r *TurnContextRegistry) get(token string) (TurnContext, bool) {
 	defer r.mu.Unlock()
 	r.pruneLocked(now)
 	v, ok := r.data[token]
+	v.Allowed = copyAllowedTools(v.Allowed)
+	if v.Emitted != nil {
+		cloned := make(map[string]struct{}, len(v.Emitted))
+		for key := range v.Emitted {
+			cloned[key] = struct{}{}
+		}
+		v.Emitted = cloned
+	}
 	return v, ok
 }
 
@@ -206,4 +229,33 @@ func (r *TurnContextRegistry) pruneLocked(now time.Time) {
 			delete(r.data, k)
 		}
 	}
+}
+
+func normalizeAllowedTools(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		name := toolidentity.CanonicalName(raw)
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func copyAllowedTools(values map[string]struct{}) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for key := range values {
+		out[key] = struct{}{}
+	}
+	return out
 }

--- a/internal/runtime/mcp/errors.go
+++ b/internal/runtime/mcp/errors.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	ErrCodeAuthUnconfigured  = "mcp_auth_unconfigured"
 	ErrCodeAuthMissingBearer = "mcp_auth_missing_bearer"
 	ErrCodeAuthInvalidBearer = "mcp_auth_invalid_bearer"
 	ErrCodeContextMissing    = "mcp_context_token_missing"

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -59,28 +59,17 @@ func NewGateway(executor runtimeGatewayExecutor, authToken string, hooks Gateway
 }
 
 func (g *Gateway) hydrateActor(actor models.AgentConfig) models.AgentConfig {
+	actor.NormalizeRuntimeDescriptor()
+	actor.NormalizeEntityID()
 	actor.ID = strings.TrimSpace(actor.ID)
 	if actor.ID == "" || g.hooks.ResolveActorConfig == nil {
-		actor.NormalizeEntityID()
 		return actor
 	}
 	if resolved, ok := g.hooks.ResolveActorConfig(actor.ID); ok {
-		if strings.TrimSpace(actor.Role) != "" {
-			resolved.Role = strings.TrimSpace(actor.Role)
-		}
-		if strings.TrimSpace(actor.Mode) != "" {
-			resolved.Mode = strings.TrimSpace(actor.Mode)
-		}
-		if strings.TrimSpace(actor.ParentAgent) != "" {
-			resolved.ParentAgent = strings.TrimSpace(actor.ParentAgent)
-		}
-		if strings.TrimSpace(actor.EntityID) != "" {
-			resolved.EntityID = strings.TrimSpace(actor.EntityID)
-		}
+		resolved.NormalizeRuntimeDescriptor()
 		resolved.NormalizeEntityID()
 		return resolved
 	}
-	actor.NormalizeEntityID()
 	return actor
 }
 
@@ -131,21 +120,7 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.NormalizeEntityID()
-	actor := req.Actor
-	if strings.TrimSpace(actor.ID) == "" {
-		actor.ID = strings.TrimSpace(req.AgentID)
-		actor.Role = strings.TrimSpace(req.AgentRole)
-		actor.EntityID = strings.TrimSpace(req.EffectiveEntityID())
-		actor.Mode = strings.TrimSpace(req.Mode)
-	}
-	actor.NormalizeEntityID()
-	if strings.TrimSpace(actor.ID) == "" {
-		WriteJSON(w, http.StatusBadRequest, ToolGatewayResponse{OK: false, Error: "actor id is required"})
-		return
-	}
-	actor = g.hydrateActor(actor)
-
-	ctx, err := g.toolExecutionContext(r, actor, toolName)
+	ctx, err := g.toolExecutionContext(r, toolName)
 	if err != nil {
 		g.logMCP(r, "warn", "tool.context_error", err, map[string]any{
 			"tool_name": toolName,
@@ -323,131 +298,57 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 func (g *Gateway) mcpExecutionContext(r *http.Request, toolName string) (context.Context, error) {
 	toolName = normalizeGatewayToolName(toolName)
-	allowed := ParseAllowedToolsFromRequest(r)
-	if token := ContextTokenFromRequest(r); token != "" {
-		if g.hooks.ResolveTurnContext != nil {
-			if turn, ok := g.hooks.ResolveTurnContext(token); ok {
-				ctx := context.Background()
-				if g.hooks.WithActor != nil {
-					ctx = g.hooks.WithActor(ctx, g.hydrateActor(turn.Actor))
-				}
-				if g.hooks.WithCurrentRuntimeEpoch != nil {
-					ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-				}
-				ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
-				if turn.HasInbound && g.hooks.WithInboundEvent != nil {
-					ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
-				}
-				if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
-					ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
-				}
-				actor := g.hydrateActor(turn.Actor)
-				ctx = g.withToolCapabilities(ctx, actor, g.catalogNames(g.toolCatalog(actor, true, strings.TrimSpace(actor.Role))), allowed)
-				return ctx, nil
-			}
-		}
-		if actor, ok := ActorFromRequest(r); ok {
-			actor = g.hydrateActor(actor)
-			fallbackAllowed := g.contextFallbackAllowed(actor, true, strings.TrimSpace(actor.Role), toolName, allowed)
-			if AllowContextFallbackOnMiss() && fallbackAllowed {
-				g.logContextFallback(r, "mcp.context.fallback_used", toolName, "token_not_found", token, true, fallbackAllowed)
-				ctx := context.Background()
-				if g.hooks.WithActor != nil {
-					ctx = g.hooks.WithActor(ctx, actor)
-				}
-				if g.hooks.WithCurrentRuntimeEpoch != nil {
-					ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-				}
-				ctx = g.withToolCapabilities(ctx, actor, g.catalogNames(g.toolCatalog(actor, true, strings.TrimSpace(actor.Role))), allowed)
-				return ctx, nil
-			}
-			g.logContextFallback(r, "mcp.context.fallback_blocked", toolName, "token_not_found", token, false, fallbackAllowed)
-			return nil, g.newRuntimeError(ErrCodeContextNotFound, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
-		}
-		g.logContextFallback(r, "mcp.context.fallback_blocked", toolName, "token_not_found", token, false, false)
+	token := ContextTokenFromRequest(r)
+	if token == "" {
+		return nil, g.newRuntimeError(ErrCodeContextMissing, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
+	}
+	turn, ok := g.resolveRuntimeTurnContext(token)
+	if !ok {
 		return nil, g.newRuntimeError(ErrCodeContextNotFound, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
 	}
-	actor, ok := ActorFromRequest(r)
-	if !ok {
-		return nil, g.newRuntimeError(ErrCodeActorMissing, "mcp.context.resolve", false, nil, "missing actor id for mcp tool execution")
-	}
-	actor = g.hydrateActor(actor)
-	fallbackAllowed := g.contextFallbackAllowed(actor, true, strings.TrimSpace(actor.Role), toolName, allowed)
-	if !fallbackAllowed {
-		g.logContextFallback(r, "mcp.context.fallback_blocked", toolName, "token_missing", "", false, fallbackAllowed)
-		return nil, g.newRuntimeError(ErrCodeContextMissing, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
-	}
-	if RequireContextToken() {
-		g.logContextFallback(r, "mcp.context.fallback_blocked", toolName, "token_missing", "", false, fallbackAllowed)
-		return nil, g.newRuntimeError(ErrCodeContextMissing, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
-	}
-	g.logContextFallback(r, "mcp.context.fallback_used", toolName, "token_missing", "", true, fallbackAllowed)
 	ctx := context.Background()
 	if g.hooks.WithActor != nil {
-		ctx = g.hooks.WithActor(ctx, actor)
+		ctx = g.hooks.WithActor(ctx, turn.Actor)
 	}
 	if g.hooks.WithCurrentRuntimeEpoch != nil {
 		ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
 	}
-	ctx = g.withToolCapabilities(ctx, actor, g.catalogNames(g.toolCatalog(actor, true, strings.TrimSpace(actor.Role))), allowed)
+	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
+	if turn.HasInbound && g.hooks.WithInboundEvent != nil {
+		ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
+	}
+	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
+		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
+	}
+	ctx = g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
 	return ctx, nil
 }
 
-func (g *Gateway) toolExecutionContext(r *http.Request, actor models.AgentConfig, toolName string) (context.Context, error) {
+func (g *Gateway) toolExecutionContext(r *http.Request, toolName string) (context.Context, error) {
 	toolName = normalizeGatewayToolName(toolName)
-	allowed := ParseAllowedToolsFromRequest(r)
-	if token := ContextTokenFromRequest(r); token != "" {
-		if g.hooks.ResolveTurnContext != nil {
-			if turn, ok := g.hooks.ResolveTurnContext(token); ok {
-				ctx := r.Context()
-				if g.hooks.WithActor != nil {
-					ctx = g.hooks.WithActor(ctx, g.hydrateActor(turn.Actor))
-				}
-				if g.hooks.WithCurrentRuntimeEpoch != nil {
-					ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-				}
-				ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
-				if turn.HasInbound && g.hooks.WithInboundEvent != nil {
-					ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
-				}
-				if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
-					ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
-				}
-				resolvedActor := g.hydrateActor(turn.Actor)
-				ctx = g.withToolCapabilities(ctx, resolvedActor, g.catalogNames(g.toolCatalog(resolvedActor, true, strings.TrimSpace(resolvedActor.Role))), allowed)
-				return ctx, nil
-			}
-		}
-		fallbackAllowed := g.contextFallbackAllowed(actor, true, strings.TrimSpace(actor.Role), toolName, allowed)
-		if AllowContextFallbackOnMiss() && fallbackAllowed {
-			g.logContextFallback(r, "tool.context.fallback_used", toolName, "token_not_found", token, true, fallbackAllowed)
-			ctx := r.Context()
-			if g.hooks.WithActor != nil {
-				ctx = g.hooks.WithActor(ctx, actor)
-			}
-			if g.hooks.WithCurrentRuntimeEpoch != nil {
-				ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-			}
-			ctx = g.withToolCapabilities(ctx, actor, g.catalogNames(g.toolCatalog(actor, true, strings.TrimSpace(actor.Role))), allowed)
-			return ctx, nil
-		}
-		g.logContextFallback(r, "tool.context.fallback_blocked", toolName, "token_not_found", token, false, fallbackAllowed)
-		return nil, g.newRuntimeError(ErrCodeContextNotFound, "tool.context.resolve", false, nil, "missing or invalid mcp context token")
-	}
-	fallbackAllowed := g.contextFallbackAllowed(actor, true, strings.TrimSpace(actor.Role), toolName, allowed)
-	if !fallbackAllowed {
-		g.logContextFallback(r, "tool.context.fallback_blocked", toolName, "token_missing", "", false, fallbackAllowed)
+	token := ContextTokenFromRequest(r)
+	if token == "" {
 		return nil, g.newRuntimeError(ErrCodeContextMissing, "tool.context.resolve", false, nil, "missing or invalid mcp context token")
 	}
-	g.logContextFallback(r, "tool.context.fallback_used", toolName, "token_missing", "", true, fallbackAllowed)
+	turn, ok := g.resolveRuntimeTurnContext(token)
+	if !ok {
+		return nil, g.newRuntimeError(ErrCodeContextNotFound, "tool.context.resolve", false, nil, "missing or invalid mcp context token")
+	}
 	ctx := r.Context()
 	if g.hooks.WithActor != nil {
-		ctx = g.hooks.WithActor(ctx, actor)
+		ctx = g.hooks.WithActor(ctx, turn.Actor)
 	}
 	if g.hooks.WithCurrentRuntimeEpoch != nil {
 		ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
 	}
-	ctx = g.withToolCapabilities(ctx, actor, g.catalogNames(g.toolCatalog(actor, true, strings.TrimSpace(actor.Role))), allowed)
+	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
+	if turn.HasInbound && g.hooks.WithInboundEvent != nil {
+		ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
+	}
+	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
+		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
+	}
+	ctx = g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
 	return ctx, nil
 }
 
@@ -521,18 +422,9 @@ func emitTurnDedupeKey(toolName string, arguments any) string {
 }
 
 func (g *Gateway) mcpToolsForRequest(r *http.Request) []ToolDef {
-	allowed := ParseAllowedToolsFromRequest(r)
-	role := ""
-	actor, actorOK := ActorFromRequest(r)
-	if actorOK {
-		actor = g.hydrateActor(actor)
-		role = strings.TrimSpace(actor.Role)
-	}
-	if role == "" {
-		role = headerValue(r, actorRoleHeader)
-	}
-	catalog := g.toolCatalog(actor, actorOK, role)
-	set, hasSet := g.requestToolCapabilities(actor, actorOK, role, catalog, allowed)
+	actor, allowed, actorOK := g.actorForCatalogRequest(r)
+	catalog := g.toolCatalog(actor, actorOK)
+	set, hasSet := g.requestToolCapabilities(actor, actorOK, catalog, allowed)
 
 	names := make([]string, 0, len(catalog))
 	if hasSet {
@@ -589,9 +481,12 @@ func (g *Gateway) mcpToolsForRequest(r *http.Request) []ToolDef {
 	return out
 }
 
-func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool, role string) map[string]llm.ToolDefinition {
+func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string]llm.ToolDefinition {
 	catalog := map[string]llm.ToolDefinition{}
-	if g.executor != nil && actorOK {
+	if !actorOK {
+		return catalog
+	}
+	if g.executor != nil {
 		for _, def := range g.executor.ToolDefinitionsForActor(actor) {
 			name := normalizeGatewayToolName(def.Name)
 			if name != "" {
@@ -609,7 +504,7 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool, role strin
 			}
 		}
 	}
-	if actorOK && g.hooks.EmitToolsForActor != nil {
+	if g.hooks.EmitToolsForActor != nil {
 		for _, def := range g.hooks.EmitToolsForActor(actor) {
 			name := normalizeGatewayToolName(def.Name)
 			if name != "" {
@@ -617,40 +512,27 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool, role strin
 				catalog[name] = def
 			}
 		}
-	} else if role != "" && g.hooks.EmitTools != nil {
-		for _, def := range g.hooks.EmitTools(role) {
-			name := normalizeGatewayToolName(def.Name)
-			if name != "" {
-				def.Name = name
-				catalog[name] = def
+	}
+	if g.hooks.EmitTools != nil {
+		role := strings.TrimSpace(actor.Role)
+		if role != "" {
+			for _, def := range g.hooks.EmitTools(role) {
+				name := normalizeGatewayToolName(def.Name)
+				if name != "" {
+					def.Name = name
+					catalog[name] = def
+				}
 			}
 		}
 	}
 	return catalog
 }
 
-func (g *Gateway) requestToolCapabilities(actor models.AgentConfig, actorOK bool, _ string, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {
+func (g *Gateway) requestToolCapabilities(actor models.AgentConfig, actorOK bool, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {
 	if g.executor == nil || !actorOK {
 		return toolcapabilities.Set{}, false
 	}
 	return g.executor.ToolCapabilitiesForActor(actor, g.catalogNames(catalog), requestAllowed), true
-}
-
-func (g *Gateway) requestToolCapability(actor models.AgentConfig, actorOK bool, role string, toolName string, requestAllowed map[string]struct{}) (toolcapabilities.Capability, bool) {
-	catalog := g.toolCatalog(actor, actorOK, role)
-	set, ok := g.requestToolCapabilities(actor, actorOK, role, catalog, requestAllowed)
-	if !ok {
-		return toolcapabilities.Capability{}, false
-	}
-	return set.Capability(toolName)
-}
-
-func (g *Gateway) contextFallbackAllowed(actor models.AgentConfig, actorOK bool, role string, toolName string, requestAllowed map[string]struct{}) bool {
-	cap, ok := g.requestToolCapability(actor, actorOK, role, toolName, requestAllowed)
-	if !ok {
-		return false
-	}
-	return cap.ContextRequirement == toolcapabilities.ContextRequirementActorContext
 }
 
 func (g *Gateway) catalogNames(catalog map[string]llm.ToolDefinition) []string {
@@ -664,7 +546,7 @@ func (g *Gateway) catalogNames(catalog map[string]llm.ToolDefinition) []string {
 
 func (g *Gateway) authorize(r *http.Request) error {
 	if strings.TrimSpace(g.authToken) == "" {
-		return nil
+		return g.newRuntimeError(ErrCodeAuthUnconfigured, "mcp.authorize", false, nil, "gateway authorization token is not configured")
 	}
 	authz := strings.TrimSpace(r.Header.Get("Authorization"))
 	if authz == "" {
@@ -679,6 +561,47 @@ func (g *Gateway) authorize(r *http.Request) error {
 		return g.newRuntimeError(ErrCodeAuthInvalidBearer, "mcp.authorize", false, nil, "invalid token")
 	}
 	return nil
+}
+
+func (g *Gateway) resolveRuntimeTurnContext(token string) (TurnContext, bool) {
+	if g == nil || g.hooks.ResolveTurnContext == nil {
+		return TurnContext{}, false
+	}
+	turn, ok := g.hooks.ResolveTurnContext(strings.TrimSpace(token))
+	if !ok {
+		return TurnContext{}, false
+	}
+	turn.Actor = g.hydrateActor(turn.Actor)
+	turn.Allowed = copyAllowedTools(turn.Allowed)
+	return turn, strings.TrimSpace(turn.Actor.ID) != ""
+}
+
+func (g *Gateway) actorForCatalogRequest(r *http.Request) (models.AgentConfig, map[string]struct{}, bool) {
+	if token := ContextTokenFromRequest(r); token != "" {
+		if turn, ok := g.resolveRuntimeTurnContext(token); ok {
+			return turn.Actor, turn.Allowed, true
+		}
+	}
+	agentID := strings.TrimSpace(requestAgentID(r))
+	if agentID == "" || g == nil || g.hooks.ResolveActorConfig == nil {
+		return models.AgentConfig{}, nil, false
+	}
+	actor, ok := g.hooks.ResolveActorConfig(agentID)
+	if !ok {
+		return models.AgentConfig{}, nil, false
+	}
+	actor = g.hydrateActor(actor)
+	if strings.TrimSpace(actor.ID) == "" {
+		return models.AgentConfig{}, nil, false
+	}
+	return actor, nil, true
+}
+
+func requestAgentID(r *http.Request) string {
+	return FirstNonEmpty(
+		headerValue(r, actorIDHeader),
+		strings.TrimSpace(r.URL.Query().Get(actorIDQuery)),
+	)
 }
 
 func (g *Gateway) AuthorizeForTest(r *http.Request) error {

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -423,6 +423,18 @@ func emitTurnDedupeKey(toolName string, arguments any) string {
 
 func (g *Gateway) mcpToolsForRequest(r *http.Request) []ToolDef {
 	actor, allowed, actorOK := g.actorForCatalogRequest(r)
+	return g.mcpToolsForActor(actor, allowed, actorOK)
+}
+
+func (g *Gateway) MCPToolsForActor(actor models.AgentConfig) []ToolDef {
+	actor = g.hydrateActor(actor)
+	if strings.TrimSpace(actor.ID) == "" {
+		return nil
+	}
+	return g.mcpToolsForActor(actor, nil, true)
+}
+
+func (g *Gateway) mcpToolsForActor(actor models.AgentConfig, allowed map[string]struct{}, actorOK bool) []ToolDef {
 	catalog := g.toolCatalog(actor, actorOK)
 	set, hasSet := g.requestToolCapabilities(actor, actorOK, catalog, allowed)
 
@@ -582,26 +594,7 @@ func (g *Gateway) actorForCatalogRequest(r *http.Request) (models.AgentConfig, m
 			return turn.Actor, turn.Allowed, true
 		}
 	}
-	agentID := strings.TrimSpace(requestAgentID(r))
-	if agentID == "" || g == nil || g.hooks.ResolveActorConfig == nil {
-		return models.AgentConfig{}, nil, false
-	}
-	actor, ok := g.hooks.ResolveActorConfig(agentID)
-	if !ok {
-		return models.AgentConfig{}, nil, false
-	}
-	actor = g.hydrateActor(actor)
-	if strings.TrimSpace(actor.ID) == "" {
-		return models.AgentConfig{}, nil, false
-	}
-	return actor, nil, true
-}
-
-func requestAgentID(r *http.Request) string {
-	return FirstNonEmpty(
-		headerValue(r, actorIDHeader),
-		strings.TrimSpace(r.URL.Query().Get(actorIDQuery)),
-	)
+	return models.AgentConfig{}, nil, false
 }
 
 func (g *Gateway) AuthorizeForTest(r *http.Request) error {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -18,6 +18,14 @@ import (
 	llm "swarm/internal/runtime/llm"
 )
 
+const testGatewayToken = "gateway-token"
+
+func authorizeGatewayRequest(req *http.Request) {
+	if req != nil {
+		req.Header.Set("Authorization", "Bearer "+testGatewayToken)
+	}
+}
+
 type testToolExecutor func(context.Context, string, any) (any, error)
 
 func (f testToolExecutor) Execute(ctx context.Context, name string, input any) (any, error) {
@@ -150,6 +158,54 @@ func (s *capabilityAwareExecutorStub) ToolCapabilitiesForActor(_ models.AgentCon
 	return toolcapabilities.NewSet(caps)
 }
 
+type actorAwareToolExecutorStub struct {
+	callCount int
+}
+
+func (s *actorAwareToolExecutorStub) Execute(context.Context, string, any) (any, error) {
+	s.callCount++
+	return map[string]any{"ok": true}, nil
+}
+
+func (s *actorAwareToolExecutorStub) ToolDefinitions() []llm.ToolDefinition {
+	return []llm.ToolDefinition{
+		{Name: "query_entities"},
+		{Name: "emit_score_dimension_complete"},
+	}
+}
+
+func (s *actorAwareToolExecutorStub) ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition {
+	return s.ToolDefinitions()
+}
+
+func (s *actorAwareToolExecutorStub) ToolCapabilitiesForActor(actor models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, raw := range names {
+		name := toolidentity.CanonicalName(raw)
+		if name == "" {
+			continue
+		}
+		visible := true
+		callable := true
+		if name == "emit_score_dimension_complete" && strings.TrimSpace(actor.Role) != "campaign_coordinator" {
+			visible = false
+			callable = false
+		}
+		kind := toolcapabilities.KindStandard
+		if toolidentity.IsEmitToolName(name) {
+			kind = toolcapabilities.KindEmit
+		}
+		caps = append(caps, toolcapabilities.Capability{
+			Name:               name,
+			Kind:               kind,
+			Visible:            visible,
+			Callable:           callable,
+			ContextRequirement: toolcapabilities.ContextRequirementTurnContext,
+		})
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
 func newTestTurnContextRegistry() *TurnContextRegistry {
 	return NewTurnContextRegistry(nil)
 }
@@ -162,7 +218,7 @@ func putTestTurnContext(t testing.TB, registry *TurnContextRegistry, token strin
 	})
 }
 
-func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
+func TestGatewayHydrateActor_PrefersResolvedRuntimeConfig(t *testing.T) {
 	g := NewGateway(nil, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			if agentID != "market-research-agent" {
@@ -181,7 +237,8 @@ func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
 
 	hydrated := g.hydrateActor(models.AgentConfig{
 		ID:   "market-research-agent",
-		Role: "market_research",
+		Role: "spoofed_role",
+		Mode: "spoofed_mode",
 	})
 
 	if len(hydrated.EmitEvents) != 2 {
@@ -189,6 +246,9 @@ func TestGatewayHydrateActorMergesResolvedConfig(t *testing.T) {
 	}
 	if hydrated.Mode != "discovery" {
 		t.Fatalf("mode = %q, want discovery", hydrated.Mode)
+	}
+	if hydrated.Role != "market_research" {
+		t.Fatalf("role = %q, want market_research", hydrated.Role)
 	}
 	if len(hydrated.Permissions) != 1 || hydrated.Permissions[0] != "schedule" {
 		t.Fatalf("permissions = %#v", hydrated.Permissions)
@@ -331,7 +391,7 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 	}
 }
 
-func TestGatewayMCPToolsForRequest_FiltersListedToolsThroughCanonicalCapabilitySet(t *testing.T) {
+func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 	g := NewGateway(actorScopedToolExecutorStub{
 		actorDefs: []llm.ToolDefinition{
 			{Name: "query_entities", Description: "actor scoped"},
@@ -345,15 +405,17 @@ func TestGatewayMCPToolsForRequest_FiltersListedToolsThroughCanonicalCapabilityS
 
 	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent&allowed_tools=Read", nil)
 	tools := g.mcpToolsForRequest(req)
-	if len(tools) != 1 {
-		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
+	if len(tools) != 2 {
+		t.Fatalf("tool count = %d, want 2 (%#v)", len(tools), tools)
 	}
-	if tools[0].Name != "read_file" {
-		t.Fatalf("tool name = %q, want read_file", tools[0].Name)
+	names := []string{tools[0].Name, tools[1].Name}
+	slices.Sort(names)
+	if !slices.Equal(names, []string{"query_entities", "read_file"}) {
+		t.Fatalf("tool names = %#v", names)
 	}
 }
 
-func TestGatewayMCPToolsForRequest_DoesNotInventUnknownAllowedToolEntries(t *testing.T) {
+func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing.T) {
 	g := NewGateway(actorScopedToolExecutorStub{
 		actorDefs: []llm.ToolDefinition{
 			{Name: "query_entities", Description: "actor scoped"},
@@ -366,8 +428,11 @@ func TestGatewayMCPToolsForRequest_DoesNotInventUnknownAllowedToolEntries(t *tes
 
 	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent&allowed_tools=does_not_exist", nil)
 	tools := g.mcpToolsForRequest(req)
-	if len(tools) != 0 {
-		t.Fatalf("tool count = %d, want 0 (%#v)", len(tools), tools)
+	if len(tools) != 1 {
+		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
+	}
+	if tools[0].Name != "query_entities" {
+		t.Fatalf("tool name = %q, want query_entities", tools[0].Name)
 	}
 }
 
@@ -412,7 +477,7 @@ func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{
+	}), testGatewayToken, GatewayHooks{
 		ResolveTurnContext: registry.ResolveTurnContext,
 		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
 	})
@@ -437,6 +502,7 @@ func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
 			t.Fatalf("marshal request: %v", err)
 		}
 		req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-emit-gateway", strings.NewReader(string(body)))
+		authorizeGatewayRequest(req)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 		return rec
@@ -462,16 +528,17 @@ func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
 	}
 }
 
-func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *testing.T) {
+func TestGatewayHandleMCP_AllowsPrefixedToolNameFromRuntimeOwnedTurnContext(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	exec := &capabilityAwareExecutorStub{}
-	g := NewGateway(exec, "", GatewayHooks{
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
 		ResolveTurnContext: registry.ResolveTurnContext,
 		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
 	})
 
 	putTestTurnContext(t, registry, "ctx-prefixed-emit", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		Allowed:   map[string]struct{}{"emit_score_dimension_complete": {}},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
@@ -487,7 +554,8 @@ func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-prefixed-emit&allowed_tools=emit_score_dimension_complete", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-prefixed-emit&allowed_tools=query_entities", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -502,12 +570,12 @@ func TestGatewayHandleMCP_AllowsPrefixedToolNameWhenAllowedListUsesLocalName(t *
 	}
 }
 
-func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *testing.T) {
+func TestGatewayHandleMCP_DoesNotLetCallerAllowlistGrantToolAccess(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	exec := &capabilityAwareExecutorStub{}
 	var loggedAction string
 	var denialLayer string
-	g := NewGateway(exec, "", GatewayHooks{
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
 		ResolveTurnContext: registry.ResolveTurnContext,
 		MarkEmitKeyUsed:    registry.MarkEmitKeyUsed,
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
@@ -518,6 +586,7 @@ func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *tes
 
 	putTestTurnContext(t, registry, "ctx-denied-allowlist", TurnContext{
 		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		Allowed:   map[string]struct{}{"query_entities": {}},
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
@@ -533,7 +602,8 @@ func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *tes
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-denied-allowlist&allowed_tools=query_entities", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-denied-allowlist&allowed_tools=emit_score_dimension_complete", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -554,12 +624,12 @@ func TestGatewayHandleMCP_RejectsToolWhenRequestAllowlistDoesNotIncludeIt(t *tes
 	}
 }
 
-func TestGatewayHandleMCP_RejectsMutatingToolWhenContextTokenMisses(t *testing.T) {
+func TestGatewayHandleMCP_RejectsToolWhenContextTokenMisses(t *testing.T) {
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{})
+	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -573,6 +643,7 @@ func TestGatewayHandleMCP_RejectsMutatingToolWhenContextTokenMisses(t *testing.T
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -655,12 +726,40 @@ func TestGatewayMCPExecutionContext_KeepsOtherRegistryTokensValidAfterGlobalEpoc
 	}
 }
 
-func TestGatewayHandleMCP_AllowsReadOnlyToolWhenContextTokenMisses(t *testing.T) {
+func TestGatewayAuthorize_FailsClosedWithoutConfiguredToken(t *testing.T) {
+	g := NewGateway(nil, "", GatewayHooks{})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	err := g.AuthorizeForTest(req)
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("AuthorizeForTest err = %v, want unconfigured auth error", err)
+	}
+}
+
+func TestGatewayAuthorize_DeniesMissingBearer(t *testing.T) {
+	g := NewGateway(nil, testGatewayToken, GatewayHooks{})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	err := g.AuthorizeForTest(req)
+	if err == nil || !strings.Contains(err.Error(), "missing authorization bearer token") {
+		t.Fatalf("AuthorizeForTest err = %v, want missing bearer error", err)
+	}
+}
+
+func TestGatewayAuthorize_DeniesInvalidBearer(t *testing.T) {
+	g := NewGateway(nil, testGatewayToken, GatewayHooks{})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	err := g.AuthorizeForTest(req)
+	if err == nil || !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("AuthorizeForTest err = %v, want invalid token error", err)
+	}
+}
+
+func TestGatewayHandleMCP_RejectsReadOnlyToolWhenContextTokenMisses(t *testing.T) {
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{})
+	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(map[string]any{
 		"id":     "req-1",
@@ -674,16 +773,17 @@ func TestGatewayHandleMCP_AllowsReadOnlyToolWhenContextTokenMisses(t *testing.T)
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if callCount != 1 {
-		t.Fatalf("executor call count = %d, want 1", callCount)
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
 	}
-	if strings.Contains(rec.Body.String(), "missing or invalid mcp context token") {
+	if !strings.Contains(rec.Body.String(), "missing or invalid mcp context token") {
 		t.Fatalf("body = %s", rec.Body.String())
 	}
 }
@@ -693,7 +793,7 @@ func TestGatewayHandleTool_RejectsMutatingToolWithoutContextToken(t *testing.T) 
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{})
+	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
 		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
@@ -703,6 +803,7 @@ func TestGatewayHandleTool_RejectsMutatingToolWithoutContextToken(t *testing.T) 
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -717,12 +818,12 @@ func TestGatewayHandleTool_RejectsMutatingToolWithoutContextToken(t *testing.T) 
 	}
 }
 
-func TestGatewayHandleTool_AllowsReadOnlyToolWithoutContextToken(t *testing.T) {
+func TestGatewayHandleTool_RejectsReadOnlyToolWithoutContextToken(t *testing.T) {
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		callCount++
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{})
+	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
 		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
@@ -732,28 +833,102 @@ func TestGatewayHandleTool_AllowsReadOnlyToolWithoutContextToken(t *testing.T) {
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+	if !strings.Contains(rec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("body = %s", rec.Body.String())
+	}
+}
+
+func TestGatewayHandleTool_IgnoresCallerSuppliedPrivilegeFields(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	exec := &actorAwareToolExecutorStub{}
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-analysis", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(ToolGatewayRequest{
+		Actor: models.AgentConfig{
+			ID:          "analysis-agent",
+			Role:        "campaign_coordinator",
+			Tools:       []string{"emit_score_dimension_complete"},
+			Permissions: []string{"schedule"},
+			EmitEvents:  []string{"score_dimension.complete"},
+		},
+		Input: map[string]any{"dimension": "build_complexity", "score": 72},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete?ctx_token=ctx-analysis", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if exec.callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", exec.callCount)
+	}
+	if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
+		t.Fatalf("body = %s", rec.Body.String())
+	}
+}
+
+func TestGatewayHandleTool_AllowsLegitimateRuntimeOwnedActorContext(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	exec := &actorAwareToolExecutorStub{}
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-coordinator", TurnContext{
+		Actor:     models.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(ToolGatewayRequest{
+		Input: map[string]any{"dimension": "build_complexity", "score": 72},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete?ctx_token=ctx-coordinator", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if callCount != 1 {
-		t.Fatalf("executor call count = %d, want 1", callCount)
+	if exec.callCount != 1 {
+		t.Fatalf("executor call count = %d, want 1", exec.callCount)
 	}
 }
 
-func TestGatewayHandleMCP_LogsFallbackUsedReason(t *testing.T) {
+func TestGatewayHandleMCP_DoesNotLogFallbackUsedReason(t *testing.T) {
 	var actions []string
-	var reasons []string
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{
+	}), testGatewayToken, GatewayHooks{
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
 			actions = append(actions, action)
-			if reason, _ := detail["reason"].(string); strings.TrimSpace(reason) != "" {
-				reasons = append(reasons, strings.TrimSpace(reason))
-			}
 		},
 	})
 
@@ -769,31 +944,25 @@ func TestGatewayHandleMCP_LogsFallbackUsedReason(t *testing.T) {
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if !slices.Contains(actions, "mcp.context.fallback_used") {
-		t.Fatalf("actions = %#v, want mcp.context.fallback_used", actions)
-	}
-	if !slices.Contains(reasons, "token_not_found") {
-		t.Fatalf("reasons = %#v, want token_not_found", reasons)
+	if slices.Contains(actions, "mcp.context.fallback_used") {
+		t.Fatalf("actions = %#v, did not expect mcp.context.fallback_used", actions)
 	}
 }
 
-func TestGatewayHandleTool_LogsFallbackBlockedReason(t *testing.T) {
+func TestGatewayHandleTool_DoesNotLogFallbackBlockedReason(t *testing.T) {
 	var actions []string
-	var reasons []string
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
 		return map[string]any{"ok": true, "name": name, "input": input}, nil
-	}), "", GatewayHooks{
+	}), testGatewayToken, GatewayHooks{
 		Log: func(_ context.Context, level, action, agentID, entityID string, detail map[string]any, errText string) {
 			actions = append(actions, action)
-			if reason, _ := detail["reason"].(string); strings.TrimSpace(reason) != "" {
-				reasons = append(reasons, strings.TrimSpace(reason))
-			}
 		},
 	})
 
@@ -805,16 +974,14 @@ func TestGatewayHandleTool_LogsFallbackBlockedReason(t *testing.T) {
 		t.Fatalf("marshal request: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
-	if !slices.Contains(actions, "tool.context.fallback_blocked") {
-		t.Fatalf("actions = %#v, want tool.context.fallback_blocked", actions)
-	}
-	if !slices.Contains(reasons, "token_missing") {
-		t.Fatalf("reasons = %#v, want token_missing", reasons)
+	if slices.Contains(actions, "tool.context.fallback_blocked") {
+		t.Fatalf("actions = %#v, did not expect tool.context.fallback_blocked", actions)
 	}
 }

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -291,6 +291,7 @@ func TestParseToolListHeaderCanonicalizesAliases(t *testing.T) {
 }
 
 func TestGatewayMCPToolsForRequest_UsesHydratedActorRoleForEmitTools(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(nil, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			if agentID != "campaign-coordinator" {
@@ -311,9 +312,16 @@ func TestGatewayMCPToolsForRequest_UsesHydratedActorRoleForEmitTools(t *testing.
 				Schema:      map[string]any{"type": "object"},
 			}}
 		},
+		ResolveTurnContext: registry.ResolveTurnContext,
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=campaign-coordinator", nil)
+	putTestTurnContext(t, registry, "ctx-hydrated-role", TurnContext{
+		Actor:     models.AgentConfig{ID: "campaign-coordinator"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-hydrated-role", nil)
 	tools := g.mcpToolsForRequest(req)
 	for _, tool := range tools {
 		if tool.Name == "emit_scan_requested" {
@@ -365,6 +373,7 @@ func TestGatewayMCPToolsForRequest_KeepsEmitToolsForDirectMCPContext(t *testing.
 }
 
 func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(actorScopedToolExecutorStub{
 		defs: []llm.ToolDefinition{
 			{Name: "workflow_custom_tool", Description: "global"},
@@ -379,9 +388,16 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 				Role: "analysis",
 			}, true
 		},
+		ResolveTurnContext: registry.ResolveTurnContext,
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent", nil)
+	putTestTurnContext(t, registry, "ctx-actor-scoped", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-actor-scoped", nil)
 	tools := g.mcpToolsForRequest(req)
 	if len(tools) != 1 {
 		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
@@ -392,6 +408,7 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 }
 
 func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(actorScopedToolExecutorStub{
 		actorDefs: []llm.ToolDefinition{
 			{Name: "query_entities", Description: "actor scoped"},
@@ -401,9 +418,16 @@ func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			return models.AgentConfig{ID: agentID, Role: "analysis"}, true
 		},
+		ResolveTurnContext: registry.ResolveTurnContext,
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent&allowed_tools=Read", nil)
+	putTestTurnContext(t, registry, "ctx-ignore-allowlist", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-ignore-allowlist&allowed_tools=Read", nil)
 	tools := g.mcpToolsForRequest(req)
 	if len(tools) != 2 {
 		t.Fatalf("tool count = %d, want 2 (%#v)", len(tools), tools)
@@ -416,6 +440,35 @@ func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 }
 
 func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	g := NewGateway(actorScopedToolExecutorStub{
+		actorDefs: []llm.ToolDefinition{
+			{Name: "query_entities", Description: "actor scoped"},
+		},
+	}, "", GatewayHooks{
+		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
+			return models.AgentConfig{ID: agentID, Role: "analysis"}, true
+		},
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-unknown-allowlist", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-unknown-allowlist&allowed_tools=does_not_exist", nil)
+	tools := g.mcpToolsForRequest(req)
+	if len(tools) != 1 {
+		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
+	}
+	if tools[0].Name != "query_entities" {
+		t.Fatalf("tool name = %q, want query_entities", tools[0].Name)
+	}
+}
+
+func TestGatewayMCPToolsForRequest_DoesNotTrustCallerAgentIDWithoutTurnContext(t *testing.T) {
 	g := NewGateway(actorScopedToolExecutorStub{
 		actorDefs: []llm.ToolDefinition{
 			{Name: "query_entities", Description: "actor scoped"},
@@ -426,13 +479,10 @@ func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing
 		},
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent&allowed_tools=does_not_exist", nil)
+	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent", nil)
 	tools := g.mcpToolsForRequest(req)
-	if len(tools) != 1 {
-		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
-	}
-	if tools[0].Name != "query_entities" {
-		t.Fatalf("tool name = %q, want query_entities", tools[0].Name)
+	if len(tools) != 0 {
+		t.Fatalf("tool count = %d, want 0 (%#v)", len(tools), tools)
 	}
 }
 

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	ErrCodeMCPAuthUnconfigured  = runtimemcp.ErrCodeAuthUnconfigured
 	ErrCodeMCPAuthMissingBearer = runtimemcp.ErrCodeAuthMissingBearer
 	ErrCodeMCPAuthInvalidBearer = runtimemcp.ErrCodeAuthInvalidBearer
 	ErrCodeMCPContextMissing    = runtimemcp.ErrCodeContextMissing

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -2,10 +2,7 @@ package runtime
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"sort"
 	"strings"
 
@@ -68,58 +65,21 @@ func validateClaudeMCPToolsForManagedAgents(cfg *config.Config, gateway *runtime
 	if manager == nil {
 		return fmt.Errorf("agent manager is required for claude cli runtime")
 	}
-	token := strings.TrimSpace(toolGatewayToken)
-	if token == "" {
+	if strings.TrimSpace(toolGatewayToken) == "" {
 		return fmt.Errorf("tool gateway token must be configured for claude cli runtime")
 	}
-	handler := gateway.Handler()
 	for _, agentCfg := range manager.ListAgentConfigs() {
 		agentID := strings.TrimSpace(agentCfg.ID)
 		if agentID == "" {
 			continue
 		}
-		reqBody, err := json.Marshal(map[string]any{
-			"jsonrpc": "2.0",
-			"id":      agentID,
-			"method":  "tools/list",
-		})
-		if err != nil {
-			return fmt.Errorf("encode mcp tools/list for agent %s: %w", agentID, err)
-		}
-		req := httptest.NewRequest(http.MethodPost, "/mcp?agent_id="+agentID, strings.NewReader(string(reqBody)))
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("Content-Type", "application/json")
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-		if rec.Code != http.StatusOK {
-			return fmt.Errorf("mcp tools/list failed for agent %s: http %d", agentID, rec.Code)
-		}
-		var rpcResp struct {
-			Result map[string]json.RawMessage `json:"result"`
-			Error  *struct {
-				Message string `json:"message"`
-			} `json:"error"`
-		}
-		if err := json.Unmarshal(rec.Body.Bytes(), &rpcResp); err != nil {
-			return fmt.Errorf("decode mcp tools/list for agent %s: %w", agentID, err)
-		}
-		if rpcResp.Error != nil {
-			return fmt.Errorf("mcp tools/list failed for agent %s: %s", agentID, strings.TrimSpace(rpcResp.Error.Message))
-		}
-		rawTools, ok := rpcResp.Result["tools"]
-		if !ok {
-			return fmt.Errorf("mcp tools/list returned no tools payload for agent %s", agentID)
-		}
-		var tools []map[string]any
-		if err := json.Unmarshal(rawTools, &tools); err != nil {
-			return fmt.Errorf("decode mcp tools array for agent %s: %w", agentID, err)
-		}
+		tools := gateway.MCPToolsForActor(agentCfg)
 		if len(tools) == 0 {
 			return fmt.Errorf("mcp tools/list returned no tools for agent %s", agentID)
 		}
 		toolNames := make(map[string]struct{}, len(tools))
 		for _, tool := range tools {
-			name := strings.TrimSpace(asString(tool["name"]))
+			name := strings.TrimSpace(tool.Name)
 			if name == "" {
 				continue
 			}


### PR DESCRIPTION
Closes #139

## Human Summary
Gateway tool authorization no longer trusts caller-supplied actor, privilege, or allowlist data. Execution now requires valid runtime-owned auth and turn context, and missing or invalid auth is denied explicitly.

## What Changed
- made gateway auth fail closed when the gateway auth token is unconfigured, missing, or invalid
- removed execution-time fallback from runtime-owned turn context to caller-supplied actor and allowlist fields
- changed MCP turn-context registration to carry the runtime-owned allowed tool subset for that turn
- stopped the CLI MCP transport from sending actor role, mode, entity, and allowed-tools privilege hints to the gateway
- updated gateway actor hydration so resolved runtime actor config is authoritative instead of being merged with caller overrides
- added focused denial/allow regressions for missing auth, missing context token, spoofed privilege inputs, and valid runtime-owned context

## Why This Is Needed
The previous seam allowed caller-shaped request data to influence authorization decisions, which meant missing auth context could degrade into permissive behavior and spoofed privilege fields could shape tool access. The gateway needs one runtime-owned authorization source and explicit denial when that source is absent or invalid.

## Scope Boundaries
This PR is intentionally limited to gateway and tool-authorization behavior in the MCP/runtime seam. It does not broaden into dashboard auth, builder auth, or a general security refactor.

## Tests Run
- `go test ./internal/runtime/mcp ./internal/runtime/llm ./internal/runtime -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
Tool listing without a turn context now depends on runtime-owned actor resolution by `agent_id`. Callers without a resolvable runtime actor will receive an empty catalog instead of any permissive fallback. That is intentional for this seam.

## Follow-Up
If there are any remaining non-gateway callers that still expect caller-shaped privilege hints to influence tool availability, they should be updated separately to use explicit runtime-owned auth context rather than reintroducing request-side privilege shaping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway now fails closed when gateway auth is unconfigured/invalid and no longer exposes actor identity via headers or URL query parameters.

* **New Features**
  * Turn-level context can include a restricted set of allowed tools; tool names are normalized and deduplicated.

* **Chores**
  * Hardened context storage/copying and clearer auth error signaling; updated tests and gateway validation to enforce new auth/authorization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->