### PR TITLE
[agent-b][issue #185] Use canonical run_id ownership for run-scoped operator queries

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -580,7 +580,7 @@ func loadRunStatusRuntimeLogs(ctx context.Context, db *sql.DB, runID string, opt
 		SELECT COUNT(*)
 		FROM events
 		WHERE event_name = 'platform.runtime_log'
-		  AND payload->'details'->>'run_id' = $1
+		  AND run_id = $1::uuid
 		  AND payload->>'log_level' = ANY($2::text[])
 		  AND ($3 = '' OR payload->'details'->>'component' = $3)
 	`, runID, pq.Array(logLevels), componentFilter).Scan(&report.WarnErrorLogCount); err != nil {
@@ -594,7 +594,7 @@ func loadRunStatusRuntimeLogs(ctx context.Context, db *sql.DB, runID string, opt
 			COUNT(*)
 		FROM events
 		WHERE event_name = 'platform.runtime_log'
-		  AND payload->'details'->>'run_id' = $1
+		  AND run_id = $1::uuid
 		  AND payload->>'log_level' = ANY($2::text[])
 		  AND ($3 = '' OR payload->'details'->>'component' = $3)
 		GROUP BY payload->>'log_level', payload->'details'->>'component', payload->'details'->>'action'
@@ -624,7 +624,7 @@ func loadRunStatusRuntimeLogs(ctx context.Context, db *sql.DB, runID string, opt
 			created_at
 		FROM events
 		WHERE event_name = 'platform.runtime_log'
-		  AND payload->'details'->>'run_id' = $1
+		  AND run_id = $1::uuid
 		  AND payload->>'log_level' = ANY($2::text[])
 		  AND ($3 = '' OR payload->'details'->>'component' = $3)
 		ORDER BY created_at DESC

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -136,6 +136,74 @@ func TestLoadRunStatusRuntimeLogs_UsesSpecShapedPayload(t *testing.T) {
 	}
 }
 
+func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	targetRunID := uuid.NewString()
+	otherRunID := uuid.NewString()
+	now := time.Unix(1700000000, 0).UTC()
+
+	insertRuntimeLog := func(runID string, payloadRunID string, component string, action string, createdAt time.Time) {
+		t.Helper()
+		payload, err := json.Marshal(map[string]any{
+			"log_level": "warn",
+			"message":   action,
+			"details": map[string]any{
+				"run_id":    payloadRunID,
+				"component": component,
+				"action":    action,
+				"error":     action + "-error",
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal runtime log payload: %v", err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO runs (run_id, status)
+			VALUES ($1::uuid, 'running')
+			ON CONFLICT (run_id) DO NOTHING
+		`, runID); err != nil {
+			t.Fatalf("insert run %s: %v", runID, err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO events (
+				run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+			)
+			VALUES (
+				$1::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb, 'test', 'agent', $3
+			)
+		`, runID, string(payload), createdAt); err != nil {
+			t.Fatalf("insert runtime log for run %s: %v", runID, err)
+		}
+	}
+
+	insertRuntimeLog(targetRunID, otherRunID, "scheduler", "canonical-owner", now)
+	insertRuntimeLog(otherRunID, targetRunID, "scheduler", "payload-only", now.Add(1*time.Minute))
+
+	var report runStatusReport
+	err := loadRunStatusRuntimeLogs(context.Background(), db, targetRunID, runStatusOptions{
+		LogsOnly:  true,
+		Component: "scheduler",
+	}, &report)
+	if err != nil {
+		t.Fatalf("loadRunStatusRuntimeLogs: %v", err)
+	}
+	if report.WarnErrorLogCount != 1 {
+		t.Fatalf("WarnErrorLogCount = %d, want 1", report.WarnErrorLogCount)
+	}
+	if len(report.RuntimeLogSummary) != 1 {
+		t.Fatalf("RuntimeLogSummary len = %d, want 1", len(report.RuntimeLogSummary))
+	}
+	if got := report.RuntimeLogSummary[0]; got.Component != "scheduler" || got.Action != "canonical-owner" || got.Count != 1 {
+		t.Fatalf("RuntimeLogSummary[0] = %#v", got)
+	}
+	if len(report.RuntimeLogs) != 1 {
+		t.Fatalf("RuntimeLogs len = %d, want 1", len(report.RuntimeLogs))
+	}
+	if got := report.RuntimeLogs[0]; got.Component != "scheduler" || got.Action != "canonical-owner" || got.Error != "canonical-owner-error" {
+		t.Fatalf("RuntimeLogs[0] = %#v", got)
+	}
+}
+
 func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}


### PR DESCRIPTION
Closes #185

## Human Summary

This PR makes the run-status runtime-log view use the canonical persisted `events.run_id` owner instead of reconstructing run membership from `payload.details.run_id`. That keeps run-scoped operator output aligned with the persisted run boundary and prevents payload-shaped `run_id` values from leaking logs across runs.

## What Changed

- switched the CLI run-status runtime-log queries in `cmd/swarm/main.go` from `payload->'details'->>'run_id'` filtering to canonical `events.run_id`
- added a Postgres-backed regression in `cmd/swarm/main_test.go` that seeds mismatched canonical and payload `run_id` values and proves the run-status output follows the persisted owner
- audited the likely dashboard and builder seams called out by the issue; no other touched run-scoped operator query was deriving run membership from payload JSON in this seam

## Why This Is Needed

- run status, logs, and operator-facing views should agree on one canonical run owner
- payload-carried `run_id` is duplicated diagnostic context, not the semantic owner for run-scoped membership
- the old query could include a log from another run if its payload happened to carry the requested `run_id`, and could miss a log whose canonical `run_id` was correct but whose payload detail drifted

## Scope Boundaries

- In scope:
  - CLI run-status runtime-log filtering
  - focused regression coverage for canonical `run_id` ownership in that operator query seam
- Not in scope:
  - broader dashboard runtime-log API expansion
  - builder event payload shaping
  - runtime-log write-path redesign

## Tests Run

- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

- other runtime-log readers still rely on diagnostic payload fields for non-run filters like component, action, and error metadata; this PR intentionally only changes run-scoped ownership in the touched operator query seam

## Follow-Up

- if dashboard adds first-class run-scoped runtime-log filtering later, it should use canonical persisted `run_id` from the start instead of adding a payload-derived path
