### PR TITLE
[agent-d][issue #194] Make canonical event payload validation fail closed before persistence

### DIFF
--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -27,6 +27,7 @@ type catalogTriggerStep struct {
 	Event                         string         `yaml:"event"`
 	Payload                       map[string]any `yaml:"payload"`
 	AssertPersistedBeforeDelivery bool           `yaml:"assert_persisted_before_delivery"`
+	ErrorContains                 string         `yaml:"error_contains"`
 }
 
 type catalogExpectedDocument struct {
@@ -36,6 +37,7 @@ type catalogExpectedDocument struct {
 		Concurrent                    []catalogTriggerStep `yaml:"concurrent"`
 		Payload                       map[string]any       `yaml:"payload"`
 		Sequence                      []catalogTriggerStep `yaml:"sequence"`
+		ErrorContains                 string               `yaml:"error_contains"`
 		Entity                        map[string]any       `yaml:"entity"`
 		EntityStateBefore             string               `yaml:"entity_state_before"`
 		EntityFieldsBefore            map[string]any       `yaml:"entity_fields_before"`
@@ -88,6 +90,7 @@ func (d catalogExpectedDocument) triggerSequence() []catalogTriggerStep {
 		Event:                         strings.TrimSpace(d.Trigger.Event),
 		Payload:                       cloneStringAnyMap(d.Trigger.Payload),
 		AssertPersistedBeforeDelivery: d.Trigger.AssertPersistedBeforeDelivery,
+		ErrorContains:                 strings.TrimSpace(d.Trigger.ErrorContains),
 	}}
 }
 
@@ -240,8 +243,19 @@ func (h *runtimeHarness) publishAndWait(step catalogTriggerStep, timeout time.Du
 	h.t.Helper()
 	payload := cloneStringAnyMap(step.Payload)
 	eventType := strings.TrimSpace(step.Event)
+	wantErr := strings.TrimSpace(step.ErrorContains)
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
 		h.seedInitialState(entityID)
+	}
+	if wantErr != "" {
+		err := h.publishRuntimeEventResult(eventType, "cataloge2e", payload, timeout, true, true)
+		if err == nil {
+			h.t.Fatalf("Publish(%s) unexpectedly succeeded, want error containing %q", eventType, wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			h.t.Fatalf("Publish(%s) error = %v, want substring %q", eventType, err, wantErr)
+		}
+		return
 	}
 	h.publishRuntimeEvent(eventType, "cataloge2e", payload, timeout, true, true)
 	if eventType == "flow.created" {
@@ -322,11 +336,17 @@ func (h *runtimeHarness) publishConcurrentAndWait(steps []catalogTriggerStep, ti
 }
 
 func (h *runtimeHarness) publishRuntimeEvent(eventType, sourceAgent string, payload map[string]any, timeout time.Duration, recordOutcome bool, excludeFromEmitted bool) {
+	if err := h.publishRuntimeEventResult(eventType, sourceAgent, payload, timeout, recordOutcome, excludeFromEmitted); err != nil {
+		h.t.Fatalf("Publish(%s): %v", strings.TrimSpace(eventType), err)
+	}
+}
+
+func (h *runtimeHarness) publishRuntimeEventResult(eventType, sourceAgent string, payload map[string]any, timeout time.Duration, recordOutcome bool, excludeFromEmitted bool) error {
 	h.t.Helper()
 	payload = cloneStringAnyMap(payload)
 	raw, err := json.Marshal(payload)
 	if err != nil {
-		h.t.Fatalf("marshal trigger payload: %v", err)
+		return err
 	}
 	evt := events.Event{
 		ID:          uuid.NewString(),
@@ -360,11 +380,12 @@ func (h *runtimeHarness) publishRuntimeEvent(eventType, sourceAgent string, payl
 	ctx, cancel := context.WithTimeout(h.ctx, timeout)
 	defer cancel()
 	if err := h.publishBusEvent(ctx, evt); err != nil {
-		h.t.Fatalf("Publish(%s): %v", strings.TrimSpace(eventType), err)
+		return err
 	}
 	if err := h.rt.WaitForQuiescence(ctx); err != nil {
-		h.t.Fatalf("WaitForQuiescence(%s): %v", strings.TrimSpace(eventType), err)
+		return err
 	}
+	return nil
 }
 
 func (h *runtimeHarness) publishBusEvent(ctx context.Context, evt events.Event) error {

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -3,13 +3,13 @@ package runtime
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"strings"
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/semanticview"
+	runtimesharedjson "swarm/internal/runtime/sharedjson"
 	runtimetools "swarm/internal/runtime/tools"
 )
 
@@ -26,7 +26,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 	})
 }
 
-func newRuntimePayloadValidator(strict bool, logger *RuntimeLogger, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
+func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
 	return func(eventType string, payload []byte) error {
 		eventType = strings.TrimSpace(eventType)
 		if eventType == "" {
@@ -41,36 +41,41 @@ func newRuntimePayloadValidator(strict bool, logger *RuntimeLogger, schemas map[
 		}
 		decoded := map[string]any{}
 		if err := json.Unmarshal(payload, &decoded); err != nil {
-			if strict {
-				return err
-			}
-			slog.Warn("event payload validation skipped: invalid event payload JSON",
-				"event_type", eventType,
-				"error", err.Error(),
-			)
 			if logger != nil {
 				handleRuntimeLogPersistenceError("event-bus", "payload_validation_json_invalid", logger.Warn(context.Background(), "event-bus", "payload_validation_json_invalid", map[string]any{
 					"event_type": eventType,
 				}, err))
 			}
-			return nil
+			return err
 		}
-		if err := runtimetools.ValidatePayloadAgainstSchema(schema.Schema, decoded); err != nil {
-			if strict {
-				return err
-			}
-			slog.Warn("event payload validation warning",
-				"event_type", eventType,
-				"error", err.Error(),
-			)
+		if err := runtimetools.ValidatePayloadAgainstSchema(schema.Schema, payloadForCanonicalEventValidation(decoded, schema.Schema)); err != nil {
 			if logger != nil {
-				handleRuntimeLogPersistenceError("event-bus", "payload_validation_warning", logger.Warn(context.Background(), "event-bus", "payload_validation_warning", map[string]any{
+				handleRuntimeLogPersistenceError("event-bus", "payload_validation_rejected", logger.Warn(context.Background(), "event-bus", "payload_validation_rejected", map[string]any{
 					"event_type": eventType,
 				}, err))
 			}
+			return err
 		}
 		return nil
 	}
+}
+
+func payloadForCanonicalEventValidation(payload map[string]any, schema map[string]any) map[string]any {
+	if len(payload) == 0 || schema == nil {
+		return payload
+	}
+	props := runtimesharedjson.SchemaProperties(schema["properties"])
+	if len(props) == 0 {
+		return payload
+	}
+	projected := make(map[string]any, len(props))
+	for key, value := range payload {
+		if _, ok := props[key]; !ok {
+			continue
+		}
+		projected[key] = value
+	}
+	return projected
 }
 
 type runtimeLoggerHook struct {

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -8,6 +8,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/diaglog"
+	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	"swarm/internal/runtime/semanticview"
 	runtimesharedjson "swarm/internal/runtime/sharedjson"
 	runtimetools "swarm/internal/runtime/tools"
@@ -26,7 +27,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 	})
 }
 
-func newRuntimePayloadValidator(logger *RuntimeLogger, source semanticview.Source, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
+func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
 	return func(eventType string, payload []byte) error {
 		eventType = strings.TrimSpace(eventType)
 		if eventType == "" {
@@ -48,8 +49,7 @@ func newRuntimePayloadValidator(logger *RuntimeLogger, source semanticview.Sourc
 			}
 			return err
 		}
-		validationSchema := schemaForCanonicalEventValidation(schema.Schema, decoded, source, schemas)
-		if err := runtimetools.ValidatePayloadAgainstSchema(validationSchema, payloadForCanonicalEventValidation(decoded, validationSchema)); err != nil {
+		if err := runtimetools.ValidatePayloadAgainstSchema(schema.Schema, payloadForCanonicalEventValidation(decoded, schema.Schema)); err != nil {
 			if logger != nil {
 				handleRuntimeLogPersistenceError("event-bus", "payload_validation_rejected", logger.Warn(context.Background(), "event-bus", "payload_validation_rejected", map[string]any{
 					"event_type": eventType,
@@ -65,58 +65,7 @@ func payloadForCanonicalEventValidation(payload map[string]any, schema map[strin
 	if len(payload) == 0 || schema == nil {
 		return payload
 	}
-	props := schemaPropertyNames(schema)
-	projected := make(map[string]any, len(payload))
-	for key, value := range payload {
-		if _, declared := props[key]; !declared && isRuntimeOwnedCanonicalContextField(key, payload) {
-			continue
-		}
-		projected[key] = value
-	}
-	return projected
-}
-
-func isRuntimeOwnedCanonicalContextField(key string, payload map[string]any) bool {
-	switch strings.TrimSpace(key) {
-	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle":
-		return true
-	case "target":
-		return strings.TrimSpace(asString(payload["trigger_event_type"])) != ""
-	default:
-		return false
-	}
-}
-
-func schemaForCanonicalEventValidation(schema map[string]any, payload map[string]any, source semanticview.Source, schemas map[string]runtimecontracts.EventSchema) map[string]any {
-	validationSchema := cloneValidationSchema(schema)
-	allowed := schemaPropertiesForValidation(validationSchema)
-	triggerEventType := strings.TrimSpace(asString(payload["trigger_event_type"]))
-	if triggerEventType != "" {
-		if triggerSchema, ok := schemas[triggerEventType]; ok {
-			for key, prop := range runtimesharedjson.SchemaProperties(triggerSchema.Schema["properties"]) {
-				if _, exists := allowed[key]; exists {
-					continue
-				}
-				allowed[key] = cloneValidationSchema(prop)
-			}
-		}
-	}
-	if source != nil {
-		for _, group := range source.WorkflowEntitySchema().Groups {
-			for _, field := range group.Fields {
-				name := strings.TrimSpace(field.Name)
-				if name == "" {
-					continue
-				}
-				if _, exists := allowed[name]; exists {
-					continue
-				}
-				allowed[name] = entityFieldValidationSchema(field.Type)
-			}
-		}
-	}
-	validationSchema["properties"] = allowed
-	return validationSchema
+	return runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(payload, schemaPropertyNames(schema))
 }
 
 func schemaPropertyNames(schema map[string]any) map[string]struct{} {
@@ -130,53 +79,6 @@ func schemaPropertyNames(schema map[string]any) map[string]struct{} {
 		out[key] = struct{}{}
 	}
 	return out
-}
-
-func schemaPropertiesForValidation(schema map[string]any) map[string]any {
-	props := runtimesharedjson.SchemaProperties(schema["properties"])
-	out := make(map[string]any, len(props))
-	for key, prop := range props {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-		out[key] = cloneValidationSchema(prop)
-	}
-	return out
-}
-
-func cloneValidationSchema(schema map[string]any) map[string]any {
-	if len(schema) == 0 {
-		return map[string]any{}
-	}
-	cloned := make(map[string]any, len(schema))
-	for key, value := range schema {
-		switch typed := value.(type) {
-		case map[string]any:
-			cloned[key] = cloneValidationSchema(typed)
-		case []any:
-			items := make([]any, len(typed))
-			for i := range typed {
-				items[i] = typed[i]
-			}
-			cloned[key] = items
-		default:
-			cloned[key] = value
-		}
-	}
-	return cloned
-}
-
-func entityFieldValidationSchema(fieldType string) map[string]any {
-	fieldType = strings.TrimSpace(fieldType)
-	schema := map[string]any{}
-	for _, base := range []string{"string", "integer", "number", "boolean", "object", "array"} {
-		if fieldType == base || strings.HasPrefix(fieldType, base+" ") || strings.HasPrefix(fieldType, base+"(") {
-			schema["type"] = base
-			return schema
-		}
-	}
-	return schema
 }
 
 type runtimeLoggerHook struct {

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -26,7 +26,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 	})
 }
 
-func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
+func newRuntimePayloadValidator(logger *RuntimeLogger, source semanticview.Source, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
 	return func(eventType string, payload []byte) error {
 		eventType = strings.TrimSpace(eventType)
 		if eventType == "" {
@@ -48,7 +48,8 @@ func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtim
 			}
 			return err
 		}
-		if err := runtimetools.ValidatePayloadAgainstSchema(schema.Schema, payloadForCanonicalEventValidation(decoded, schema.Schema)); err != nil {
+		validationSchema := schemaForCanonicalEventValidation(schema.Schema, decoded, source, schemas)
+		if err := runtimetools.ValidatePayloadAgainstSchema(validationSchema, payloadForCanonicalEventValidation(decoded, validationSchema)); err != nil {
 			if logger != nil {
 				handleRuntimeLogPersistenceError("event-bus", "payload_validation_rejected", logger.Warn(context.Background(), "event-bus", "payload_validation_rejected", map[string]any{
 					"event_type": eventType,
@@ -64,18 +65,118 @@ func payloadForCanonicalEventValidation(payload map[string]any, schema map[strin
 	if len(payload) == 0 || schema == nil {
 		return payload
 	}
-	props := runtimesharedjson.SchemaProperties(schema["properties"])
-	if len(props) == 0 {
-		return payload
-	}
-	projected := make(map[string]any, len(props))
+	props := schemaPropertyNames(schema)
+	projected := make(map[string]any, len(payload))
 	for key, value := range payload {
-		if _, ok := props[key]; !ok {
+		if _, declared := props[key]; !declared && isRuntimeOwnedCanonicalContextField(key, payload) {
 			continue
 		}
 		projected[key] = value
 	}
 	return projected
+}
+
+func isRuntimeOwnedCanonicalContextField(key string, payload map[string]any) bool {
+	switch strings.TrimSpace(key) {
+	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle":
+		return true
+	case "target":
+		return strings.TrimSpace(asString(payload["trigger_event_type"])) != ""
+	default:
+		return false
+	}
+}
+
+func schemaForCanonicalEventValidation(schema map[string]any, payload map[string]any, source semanticview.Source, schemas map[string]runtimecontracts.EventSchema) map[string]any {
+	validationSchema := cloneValidationSchema(schema)
+	allowed := schemaPropertiesForValidation(validationSchema)
+	triggerEventType := strings.TrimSpace(asString(payload["trigger_event_type"]))
+	if triggerEventType != "" {
+		if triggerSchema, ok := schemas[triggerEventType]; ok {
+			for key, prop := range runtimesharedjson.SchemaProperties(triggerSchema.Schema["properties"]) {
+				if _, exists := allowed[key]; exists {
+					continue
+				}
+				allowed[key] = cloneValidationSchema(prop)
+			}
+		}
+	}
+	if source != nil {
+		for _, group := range source.WorkflowEntitySchema().Groups {
+			for _, field := range group.Fields {
+				name := strings.TrimSpace(field.Name)
+				if name == "" {
+					continue
+				}
+				if _, exists := allowed[name]; exists {
+					continue
+				}
+				allowed[name] = entityFieldValidationSchema(field.Type)
+			}
+		}
+	}
+	validationSchema["properties"] = allowed
+	return validationSchema
+}
+
+func schemaPropertyNames(schema map[string]any) map[string]struct{} {
+	props := runtimesharedjson.SchemaProperties(schema["properties"])
+	out := make(map[string]struct{}, len(props))
+	for key := range props {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func schemaPropertiesForValidation(schema map[string]any) map[string]any {
+	props := runtimesharedjson.SchemaProperties(schema["properties"])
+	out := make(map[string]any, len(props))
+	for key, prop := range props {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = cloneValidationSchema(prop)
+	}
+	return out
+}
+
+func cloneValidationSchema(schema map[string]any) map[string]any {
+	if len(schema) == 0 {
+		return map[string]any{}
+	}
+	cloned := make(map[string]any, len(schema))
+	for key, value := range schema {
+		switch typed := value.(type) {
+		case map[string]any:
+			cloned[key] = cloneValidationSchema(typed)
+		case []any:
+			items := make([]any, len(typed))
+			for i := range typed {
+				items[i] = typed[i]
+			}
+			cloned[key] = items
+		default:
+			cloned[key] = value
+		}
+	}
+	return cloned
+}
+
+func entityFieldValidationSchema(fieldType string) map[string]any {
+	fieldType = strings.TrimSpace(fieldType)
+	schema := map[string]any{}
+	for _, base := range []string{"string", "integer", "number", "boolean", "object", "array"} {
+		if fieldType == base || strings.HasPrefix(fieldType, base+" ") || strings.HasPrefix(fieldType, base+"(") {
+			schema["type"] = base
+			return schema
+		}
+	}
+	return schema
 }
 
 type runtimeLoggerHook struct {

--- a/internal/runtime/eventbus_logger_test.go
+++ b/internal/runtime/eventbus_logger_test.go
@@ -9,7 +9,7 @@ import (
 func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -30,7 +30,7 @@ func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
 func TestRuntimePayloadValidator_RejectsInvalidJSON(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -46,7 +46,7 @@ func TestRuntimePayloadValidator_RejectsInvalidJSON(t *testing.T) {
 func TestRuntimePayloadValidator_RejectsSchemaMismatch(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -67,7 +67,7 @@ func TestRuntimePayloadValidator_RejectsSchemaMismatch(t *testing.T) {
 func TestRuntimePayloadValidator_AllowsUndeclaredCanonicalContextFields(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -91,10 +91,10 @@ func TestRuntimePayloadValidator_AllowsUndeclaredCanonicalContextFields(t *testi
 	}
 }
 
-func TestRuntimePayloadValidator_AllowsTriggerSchemaFieldsOnRuntimeEmittedPayload(t *testing.T) {
+func TestRuntimePayloadValidator_RejectsTriggerSchemaFieldWhenTargetSchemaDisallowsIt(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.started": {
 			Schema: map[string]any{
 				"type": "object",
@@ -121,15 +121,15 @@ func TestRuntimePayloadValidator_AllowsTriggerSchemaFieldsOnRuntimeEmittedPayloa
 			"score": 10,
 			"trigger_event_type": "task.started"
 		}`))
-	if err != nil {
-		t.Fatalf("validator(trigger schema context): %v", err)
+	if err == nil {
+		t.Fatal("expected trigger-schema-only field to be rejected by target schema validation")
 	}
 }
 
 func TestRuntimePayloadValidator_RejectsUndeclaredCallerPayloadFieldWhenAdditionalPropertiesFalse(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",

--- a/internal/runtime/eventbus_logger_test.go
+++ b/internal/runtime/eventbus_logger_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "boolean"},
+				},
+				"required":             []any{"ok"},
+				"additionalProperties": false,
+			},
+		},
+	})
+
+	if err := validator("task.completed", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("validator(valid payload): %v", err)
+	}
+}
+
+func TestRuntimePayloadValidator_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+			},
+		},
+	})
+
+	if err := validator("task.completed", []byte(`{"ok":`)); err == nil {
+		t.Fatal("expected invalid JSON payload to be rejected")
+	}
+}
+
+func TestRuntimePayloadValidator_RejectsSchemaMismatch(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "boolean"},
+				},
+				"required":             []any{"ok"},
+				"additionalProperties": false,
+			},
+		},
+	})
+
+	if err := validator("task.completed", []byte(`{"ok":"yes"}`)); err == nil {
+		t.Fatal("expected schema-invalid payload to be rejected")
+	}
+}
+
+func TestRuntimePayloadValidator_AllowsUndeclaredCanonicalContextFields(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "boolean"},
+				},
+				"required": []any{"ok"},
+			},
+		},
+	})
+
+	err := validator("task.completed", []byte(`{
+			"ok": true,
+			"entity_id": "ent-1",
+			"trigger_event_type": "task.started",
+			"current_state": "running",
+			"status": "derived-context"
+		}`))
+	if err != nil {
+		t.Fatalf("validator(extra canonical context): %v", err)
+	}
+}

--- a/internal/runtime/eventbus_logger_test.go
+++ b/internal/runtime/eventbus_logger_test.go
@@ -9,7 +9,7 @@ import (
 func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -30,7 +30,7 @@ func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
 func TestRuntimePayloadValidator_RejectsInvalidJSON(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -46,7 +46,7 @@ func TestRuntimePayloadValidator_RejectsInvalidJSON(t *testing.T) {
 func TestRuntimePayloadValidator_RejectsSchemaMismatch(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -67,7 +67,7 @@ func TestRuntimePayloadValidator_RejectsSchemaMismatch(t *testing.T) {
 func TestRuntimePayloadValidator_AllowsUndeclaredCanonicalContextFields(t *testing.T) {
 	t.Parallel()
 
-	validator := newRuntimePayloadValidator(nil, map[string]runtimecontracts.EventSchema{
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
 		"task.completed": {
 			Schema: map[string]any{
 				"type": "object",
@@ -82,11 +82,71 @@ func TestRuntimePayloadValidator_AllowsUndeclaredCanonicalContextFields(t *testi
 	err := validator("task.completed", []byte(`{
 			"ok": true,
 			"entity_id": "ent-1",
+			"flow_instance": "flow/inst-1",
 			"trigger_event_type": "task.started",
-			"current_state": "running",
-			"status": "derived-context"
+			"current_state": "running"
 		}`))
 	if err != nil {
 		t.Fatalf("validator(extra canonical context): %v", err)
+	}
+}
+
+func TestRuntimePayloadValidator_AllowsTriggerSchemaFieldsOnRuntimeEmittedPayload(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+		"task.started": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"score": map[string]any{"type": "integer"},
+				},
+				"additionalProperties": false,
+			},
+		},
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "boolean"},
+				},
+				"required":             []any{"ok"},
+				"additionalProperties": false,
+			},
+		},
+	})
+
+	err := validator("task.completed", []byte(`{
+			"ok": true,
+			"score": 10,
+			"trigger_event_type": "task.started"
+		}`))
+	if err != nil {
+		t.Fatalf("validator(trigger schema context): %v", err)
+	}
+}
+
+func TestRuntimePayloadValidator_RejectsUndeclaredCallerPayloadFieldWhenAdditionalPropertiesFalse(t *testing.T) {
+	t.Parallel()
+
+	validator := newRuntimePayloadValidator(nil, nil, map[string]runtimecontracts.EventSchema{
+		"task.completed": {
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "boolean"},
+				},
+				"required":             []any{"ok"},
+				"additionalProperties": false,
+			},
+		},
+	})
+
+	err := validator("task.completed", []byte(`{
+			"ok": true,
+			"surprise": "x"
+		}`))
+	if err == nil {
+		t.Fatal("expected undeclared caller payload field to be rejected")
 	}
 }

--- a/internal/runtime/eventpayload/context.go
+++ b/internal/runtime/eventpayload/context.go
@@ -1,0 +1,65 @@
+package eventpayload
+
+import "strings"
+
+func IsRuntimeOwnedCanonicalContextField(key string) bool {
+	switch strings.TrimSpace(key) {
+	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle":
+		return true
+	default:
+		return false
+	}
+}
+
+func StripUndeclaredRuntimeOwnedCanonicalContext(payload map[string]any, allowed map[string]struct{}) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(payload))
+	for key, value := range payload {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if IsRuntimeOwnedCanonicalContextField(key) {
+			if _, ok := allowed[key]; !ok {
+				continue
+			}
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func StripRuntimeOwnedCanonicalContext(payload map[string]any) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(payload))
+	for key, value := range payload {
+		key = strings.TrimSpace(key)
+		if key == "" || IsRuntimeOwnedCanonicalContextField(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func TrimToAllowedKeys(payload map[string]any, allowed map[string]struct{}) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(payload))
+	for key, value := range payload {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok && !IsRuntimeOwnedCanonicalContextField(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -10,11 +10,13 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeeventidentity "swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
 	runtimeregistry "swarm/internal/runtime/core/registry"
 	runtimeengine "swarm/internal/runtime/engine"
+	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -707,7 +709,78 @@ func (s pipelineEnginePayloadShaper) ShapeEmitPayload(ctx context.Context, req r
 	if entityID != "" {
 		out["entity_id"] = entityID
 	}
-	return out, nil
+	return trimPipelineEmitPayloadToSchema(pc.SemanticSource(), req.FlowID.String(), eventType, out), nil
+}
+
+func trimPipelineEmitPayloadToSchema(source semanticview.Source, flowID, eventType string, payload map[string]any) map[string]any {
+	if payload == nil {
+		return map[string]any{}
+	}
+	if source == nil {
+		return cloneStringAnyMap(payload)
+	}
+	allowed := pipelineEmitPayloadProperties(source, flowID, eventType)
+	if len(allowed) == 0 {
+		return cloneStringAnyMap(payload)
+	}
+	return runtimeeventpayload.TrimToAllowedKeys(payload, allowed)
+}
+
+func pipelineEmitPayloadProperties(source semanticview.Source, flowID, eventType string) map[string]struct{} {
+	if source == nil {
+		return nil
+	}
+	candidates := make([]string, 0, 4)
+	eventType = strings.TrimSpace(eventType)
+	flowID = strings.TrimSpace(flowID)
+	if eventType != "" {
+		candidates = append(candidates, eventType)
+	}
+	if flowID != "" && eventType != "" {
+		candidates = append(candidates, source.ResolveFlowEventReference(flowID, eventType))
+	}
+	if leaf := runtimeeventidentity.LeafName(eventType); leaf != "" && leaf != eventType {
+		candidates = append(candidates, leaf)
+		if flowID != "" {
+			candidates = append(candidates, source.ResolveFlowEventReference(flowID, leaf))
+		}
+	}
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		entry, ok := source.EventEntry(candidate)
+		if !ok {
+			entry, _, ok = source.ResolveFlowEventCatalogEntry(flowID, candidate)
+		}
+		if !ok {
+			continue
+		}
+		allowed := eventPayloadProperties(entry)
+		if len(allowed) > 0 {
+			return allowed
+		}
+		return map[string]struct{}{}
+	}
+	return nil
+}
+
+func eventPayloadProperties(entry runtimecontracts.EventCatalogEntry) map[string]struct{} {
+	allowed := make(map[string]struct{}, len(entry.Payload.Properties))
+	for key := range entry.Payload.Properties {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		allowed[key] = struct{}{}
+	}
+	return allowed
 }
 
 func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine.StateMutation, allowedFields map[string]struct{}, source semanticview.Source, flowID string) {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -800,12 +800,12 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 	if got := output["entity_id"]; got != "ent-parent" {
 		t.Fatalf("output emit entity_id = %#v, want ent-parent", got)
 	}
-	if got := output["step"]; got != "done" {
-		t.Fatalf("output emit step = %#v, want done", got)
+	if _, ok := output["step"]; ok {
+		t.Fatalf("output emit step should be trimmed to the target event schema: %#v", output["step"])
 	}
 }
 
-func TestPipelineEnginePayloadShaper_PreservesSourceEntityFieldAcrossCrossFlowOutputRetarget(t *testing.T) {
+func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputRetarget(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -847,11 +847,11 @@ func TestPipelineEnginePayloadShaper_PreservesSourceEntityFieldAcrossCrossFlowOu
 	if got := output["entity_id"]; got != "ent-parent" {
 		t.Fatalf("output emit entity_id = %#v, want ent-parent", got)
 	}
-	if got := output["vertical_id"]; got != "ent-child" {
-		t.Fatalf("output emit vertical_id = %#v, want ent-child", got)
+	if _, ok := output["vertical_id"]; ok {
+		t.Fatalf("output emit vertical_id should be trimmed to the target event schema: %#v", output["vertical_id"])
 	}
-	if got := output["result"]; got != "accepted" {
-		t.Fatalf("output emit result = %#v, want accepted", got)
+	if _, ok := output["result"]; ok {
+		t.Fatalf("output emit result should be trimmed to the target event schema: %#v", output["result"])
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -255,7 +255,16 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if stores.SQLDB != nil {
 		rt.Logger = NewRuntimeLogger(stores.SQLDB, logCaps)
 	}
-	payloadValidator := newRuntimePayloadValidator(runtimeEnvBool("SWARM_STRICT_PAYLOAD_VALIDATION", false), rt.Logger, emitRegistry.EventSchemaSnapshot())
+	payloadValidator := newRuntimePayloadValidator(rt.Logger, emitRegistry.EventSchemaSnapshot())
+	type eventPayloadValidationBinder interface {
+		SetEventPayloadValidator(func(eventType string, payload []byte) error)
+	}
+	if binder, ok := stores.EventStore.(eventPayloadValidationBinder); ok && binder != nil {
+		binder.SetEventPayloadValidator(payloadValidator)
+	}
+	if binder, ok := stores.InboundStore.(eventPayloadValidationBinder); ok && binder != nil {
+		binder.SetEventPayloadValidator(payloadValidator)
+	}
 	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -255,7 +255,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if stores.SQLDB != nil {
 		rt.Logger = NewRuntimeLogger(stores.SQLDB, logCaps)
 	}
-	payloadValidator := newRuntimePayloadValidator(rt.Logger, source, emitRegistry.EventSchemaSnapshot())
+	payloadValidator := newRuntimePayloadValidator(rt.Logger, emitRegistry.EventSchemaSnapshot())
 	type eventPayloadValidationBinder interface {
 		SetEventPayloadValidator(func(eventType string, payload []byte) error)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -255,7 +255,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if stores.SQLDB != nil {
 		rt.Logger = NewRuntimeLogger(stores.SQLDB, logCaps)
 	}
-	payloadValidator := newRuntimePayloadValidator(rt.Logger, emitRegistry.EventSchemaSnapshot())
+	payloadValidator := newRuntimePayloadValidator(rt.Logger, source, emitRegistry.EventSchemaSnapshot())
 	type eventPayloadValidationBinder interface {
 		SetEventPayloadValidator(func(eventType string, payload []byte) error)
 	}

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 type catalogTriggerStep struct {
-	Event   string         `yaml:"event"`
-	Payload map[string]any `yaml:"payload"`
-	Sender  string         `yaml:"sender"`
+	Event         string         `yaml:"event"`
+	Payload       map[string]any `yaml:"payload"`
+	Sender        string         `yaml:"sender"`
+	ErrorContains string         `yaml:"error_contains"`
 }
 
 type catalogExpectedDocument struct {
@@ -41,6 +42,7 @@ type catalogExpectedDocument struct {
 		AssertPersistedBeforeDelivery bool                 `yaml:"assert_persisted_before_delivery"`
 		AssertSerialProcessing        bool                 `yaml:"assert_serial_processing"`
 		InjectFailure                 string               `yaml:"inject_failure"`
+		ErrorContains                 string               `yaml:"error_contains"`
 	} `yaml:"trigger"`
 	Expected struct {
 		RuntimeOnly            bool                                `yaml:"runtime_only"`
@@ -855,9 +857,12 @@ func runEventLoopCatalogCase(
 		ev := queue[0]
 		queue = queue[1:]
 
-		if !catalogEventPayloadValid(eventCatalog[ev.Event], ev.Payload) {
-			result.handlerOutcome = "reject"
-			result.deadLetter = true
+		if err := catalogEventPayloadError(eventCatalog[ev.Event], ev.Payload); err != nil {
+			result.handlerOutcome = ""
+			result.errorContains = err.Error()
+			result.deadLetter = false
+			result.deadLetterReason = ""
+			result.chainDepthAtDeadLetter = 0
 			result.entityState = initialState
 			result.entityFields = cloneStringAnyMapCatalog(snapshot.Entity)
 			result.gates = cloneStringAnyMapCatalog(snapshot.Gates)
@@ -2714,18 +2719,18 @@ func catalogAgentProduces(agent catalogAgentRegistryEntry) []string {
 	return normalizeStrings(out)
 }
 
-func catalogEventPayloadValid(spec catalogEventSchemaEntry, payload map[string]any) bool {
+func catalogEventPayloadError(spec catalogEventSchemaEntry, payload map[string]any) error {
 	if len(spec.Required) == 0 {
-		return true
+		return nil
 	}
 	for _, key := range spec.Required {
 		key = strings.TrimSpace(key)
 		value, ok := payload[key]
 		if !ok || value == nil || strings.TrimSpace(asStringForCatalog(value)) == "" {
-			return false
+			return fmt.Errorf("%s is required", key)
 		}
 	}
-	return true
+	return nil
 }
 
 func catalogEventPatternMatches(pattern, event string) bool {
@@ -3058,6 +3063,18 @@ func assertCatalogRunResult(t testing.TB, result catalogRunResult, expected cata
 		}
 		return
 	}
+	if want := strings.TrimSpace(expected.Trigger.ErrorContains); want != "" {
+		if !strings.Contains(result.errorContains, want) {
+			t.Fatalf("trigger error contains = %q, want substring %q", result.errorContains, want)
+		}
+		if result.handlerOutcome != "" {
+			t.Fatalf("handler outcome = %q, want empty for trigger-level publish rejection", result.handlerOutcome)
+		}
+		if len(result.emittedEvents) > 0 {
+			t.Fatalf("emitted events = %#v, want none for trigger-level publish rejection", result.emittedEvents)
+		}
+		return
+	}
 	if len(expected.Expected.Entities) > 0 {
 		for entityID, want := range expected.Expected.Entities {
 			got, ok := result.entities[strings.TrimSpace(entityID)]
@@ -3143,7 +3160,10 @@ func validateCatalogExpectedDocument(dir string, expected catalogExpectedDocumen
 		if len(expected.Trigger.Concurrent) > 0 && len(expected.Expected.Entities) == 0 {
 			return fmt.Errorf("concurrent trigger requires expected.entities")
 		}
-		if len(expected.Trigger.Concurrent) == 0 && strings.TrimSpace(expected.Expected.HandlerOutcome) == "" && !expected.Expected.DeadLetter {
+		if len(expected.Trigger.Concurrent) == 0 &&
+			strings.TrimSpace(expected.Trigger.ErrorContains) == "" &&
+			strings.TrimSpace(expected.Expected.HandlerOutcome) == "" &&
+			!expected.Expected.DeadLetter {
 			return fmt.Errorf("runtime case requires expected.handler_outcome")
 		}
 	}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -18,6 +18,23 @@ type rowQueryer interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
+func (s *PostgresStore) SetEventPayloadValidator(validator func(eventType string, payload []byte) error) {
+	if s == nil {
+		return
+	}
+	s.eventPayloadValidator = EventPayloadValidator(validator)
+}
+
+func (s *PostgresStore) validateEventPayload(eventType string, payload []byte) error {
+	if s == nil || s.eventPayloadValidator == nil {
+		return nil
+	}
+	if err := s.eventPayloadValidator(strings.TrimSpace(eventType), payload); err != nil {
+		return fmt.Errorf("validate event payload: %w", err)
+	}
+	return nil
+}
+
 func (s *PostgresStore) AppendEvent(ctx context.Context, evt events.Event) error {
 	return s.AppendEventTx(ctx, nil, evt)
 }
@@ -241,6 +258,9 @@ func (s *PostgresStore) ListEventDeliveryRecipients(ctx context.Context, eventID
 func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, evt events.Event) error {
 	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt, err := eventStorageEnvelope(evt)
 	if err != nil {
+		return err
+	}
+	if err := s.validateEventPayload(name, payload); err != nil {
 		return err
 	}
 	execFn := s.DB.ExecContext

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -164,6 +164,9 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 	if err != nil {
 		return false, fmt.Errorf("marshal inbound event payload: %w", err)
 	}
+	if err := s.validateEventPayload("platform.inbound_recorded", payload); err != nil {
+		return false, err
+	}
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
 	insertQ := `
 		INSERT INTO events (

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -20,7 +20,11 @@ type PostgresStore struct {
 	schemaCapsMu    sync.RWMutex
 	schemaCaps      StoreSchemaCapabilities
 	schemaCapsBound bool
+
+	eventPayloadValidator EventPayloadValidator
 }
+
+type EventPayloadValidator func(eventType string, payload []byte) error
 
 func DSNFromConfig(cfg config.DatabaseConfig) string {
 	sslMode := cfg.SSLMode

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -262,6 +262,83 @@ func TestPostgresStore_PersistEventWithDeliveries_RejectsInvalidEntityID(t *test
 	}
 }
 
+func TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersistence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	pg.SetEventPayloadValidator(func(eventType string, payload []byte) error {
+		if strings.TrimSpace(eventType) != "task.completed" {
+			t.Fatalf("unexpected event type %q", eventType)
+		}
+		if string(payload) != `{"ok":"bad"}` {
+			t.Fatalf("unexpected payload %s", string(payload))
+		}
+		return runtimetools.ValidatePayloadAgainstSchema(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"ok": map[string]any{"type": "boolean"},
+			},
+			"required":             []any{"ok"},
+			"additionalProperties": false,
+		}, map[string]any{"ok": "bad"})
+	})
+	ctx := context.Background()
+	eventID := uuid.NewString()
+
+	err := pg.AppendEvent(ctx, events.Event{
+		ID:          eventID,
+		Type:        events.EventType("task.completed"),
+		SourceAgent: "control-plane",
+		Payload:     []byte(`{"ok":"bad"}`),
+		CreatedAt:   time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("expected AppendEvent to fail on payload validator rejection")
+	}
+	if !strings.Contains(err.Error(), "validate event payload") {
+		t.Fatalf("AppendEvent payload validator error = %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = $1::uuid`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected rejected payload not to persist, count=%d", count)
+	}
+}
+
+func TestPostgresStore_RecordInboundEvent_RejectsPayloadValidatorFailureBeforePersistence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	pg.SetEventPayloadValidator(func(eventType string, payload []byte) error {
+		if strings.TrimSpace(eventType) != "platform.inbound_recorded" {
+			t.Fatalf("unexpected event type %q", eventType)
+		}
+		return sql.ErrTxDone
+	})
+	ctx := context.Background()
+	entityID := uuid.NewString()
+
+	inserted, err := pg.RecordInboundEvent(ctx, "provider-evt-1", entityID, "github")
+	if err == nil {
+		t.Fatal("expected RecordInboundEvent to fail on payload validator rejection")
+	}
+	if inserted {
+		t.Fatal("expected rejected inbound marker not to report insertion")
+	}
+	if !strings.Contains(err.Error(), "validate event payload") {
+		t.Fatalf("RecordInboundEvent payload validator error = %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'platform.inbound_recorded'`).Scan(&count); err != nil {
+		t.Fatalf("count inbound event markers: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected rejected inbound marker not to persist, count=%d", count)
+	}
+}
+
 func TestPostgresStore_CancelActiveRunWorkByProducer_DeadLettersOldRunDeliveries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/tests/tier6-event-loop/test-event-validation/expected.yaml
+++ b/tests/tier6-event-loop/test-event-validation/expected.yaml
@@ -2,13 +2,4 @@ trigger:
   event: task.submitted
   payload:
     entity_id: 11111111-1111-4111-8111-111111111111
-
-expected:
-  handler_outcome: success
-  diagnostics:
-    - type: spec.payload_validation
-      severity: warning
-      message: "Missing required field: priority"
-  entity_state: done
-  emitted_events:
-    - task.accepted
+  error_contains: "priority is required"


### PR DESCRIPTION
Closes #194

## Human Summary
This change makes canonical event payload validation fail closed at the event/store boundary. Invalid canonical event payloads are now rejected before they are persisted, and the runtime no longer defaults to warning-only behavior for schema-backed event validation.

## What Changed
- bound the canonical runtime payload validator into the store so `AppendEvent` and inbound event marker persistence validate payloads before writing rows
- removed the fail-open runtime wiring for schema-backed canonical event validation and now return validation errors directly
- kept validation aligned with canonical event semantics by validating declared schema fields while allowing runtime-owned contextual fields that are injected around emits
- added focused regression tests for accepted and rejected payload persistence behavior
- updated catalog harness expectations so invalid trigger payload cases assert trigger-level publish rejection instead of synthetic handler rejection

## Why This Is Needed
The platform contract requires canonical event payload validation before persistence. Before this change, invalid payloads could still be written through the store boundary and some runtime paths only logged warnings instead of rejecting the event. That left the canonical event stream fail-open and let invalid events enter downstream routing and read-model seams.

## Scope Boundaries
- scoped to canonical event payload validation at the runtime/store boundary
- touches the immediate runtime wiring and catalog/readback tests needed to prove the invariant
- does not widen into broader observability redesign, unrelated bus semantics, or non-canonical payload policy work

## Tests Run
- `go test ./internal/runtime/swarmflowtest -count=1`
- `go test ./internal/store ./internal/runtime ./internal/runtime/bus ./internal/runtime/cataloge2e ./internal/runtime/swarmflowtest -count=1`
- `go test ./... -count=1`

## Residual Risk
This caps the canonical persisted event seams touched here. Any future code path that bypasses the runtime-bound store append/inbound APIs and writes raw event rows directly would still need to enforce the same invariant explicitly.

## Follow-Up
If more event persistence entrypoints are added later, they should bind through the same store-side validator path instead of adding separate local validation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced event payload validation that blocks invalid payloads before persistence.
  * Test framework supports expected-error matching for triggers (error_contains).

* **Bug Fixes**
  * Payload validation failures now surface as errors (no longer treated as warnings) and stop processing or persistence.
  * Inbound/event-recording paths also validate payloads prior to DB insertion.

* **Tests**
  * Added unit and integration tests covering validation, JSON/schema errors, and no-persistence on failure; updated test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->