### PR TITLE
[agent-a][issue #184] Stop runtime diagnostics from inferring run_id from payload details

### DIFF
--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -221,9 +221,6 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 	detailMap := map[string]any{}
 	_ = json.Unmarshal(detail, &detailMap)
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
-	if runID == "" {
-		runID = strings.TrimSpace(asString(detailMap["run_id"]))
-	}
 	parentEventID := strings.TrimSpace(asString(detailMap["parent_event_id"]))
 	handlerID := strings.TrimSpace(runtimecorrelation.HandlerIDFromContext(ctx))
 	if handlerID == "" {
@@ -290,6 +287,9 @@ func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detai
 	for k, v := range detailMap {
 		key := strings.TrimSpace(k)
 		if key == "" {
+			continue
+		}
+		if key == "run_id" {
 			continue
 		}
 		details[key] = v

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
@@ -9,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/testutil"
 )
 
 type runtimeLogCapabilityStub struct {
@@ -213,6 +216,120 @@ func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestRuntimeLogger_Log_PersistsCanonicalRunOwnershipFromContext(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	runID := uuid.NewString()
+	spoofedRunID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+
+	if err := logger.Log(ctx, RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "canonical runtime log",
+		Component: "diagnostics",
+		Action:    "canonical_run_context",
+		Detail: map[string]any{
+			"run_id": spoofedRunID,
+			"note":   "context must win",
+		},
+	}); err != nil {
+		t.Fatalf("logger.Log() error = %v", err)
+	}
+
+	row := loadLatestRuntimeLogRow(t, db)
+	if row.RunID != runID {
+		t.Fatalf("persisted run_id = %q, want %q", row.RunID, runID)
+	}
+	if got := strings.TrimSpace(asString(row.Detail["run_id"])); got != runID {
+		t.Fatalf("payload details.run_id = %q, want %q", got, runID)
+	}
+	if got := strings.TrimSpace(asString(row.Detail["note"])); got != "context must win" {
+		t.Fatalf("payload details.note = %q, want context must win", got)
+	}
+	assertRunRowExists(t, db, runID, true)
+	assertRunRowExists(t, db, spoofedRunID, false)
+}
+
+func TestRuntimeLogger_Log_DoesNotInferRunOwnershipFromDetailPayload(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	payloadRunID := uuid.NewString()
+
+	if err := logger.Log(ctx, RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "uncorrelated runtime log",
+		Component: "diagnostics",
+		Action:    "payload_run_id_ignored",
+		Detail: map[string]any{
+			"run_id": payloadRunID,
+			"note":   "must remain unscoped",
+		},
+	}); err != nil {
+		t.Fatalf("logger.Log() error = %v", err)
+	}
+
+	row := loadLatestRuntimeLogRow(t, db)
+	if row.RunID != "" {
+		t.Fatalf("persisted run_id = %q, want empty", row.RunID)
+	}
+	if got := strings.TrimSpace(asString(row.Detail["run_id"])); got != "" {
+		t.Fatalf("payload details.run_id = %q, want empty", got)
+	}
+	if got := strings.TrimSpace(asString(row.Detail["note"])); got != "must remain unscoped" {
+		t.Fatalf("payload details.note = %q, want must remain unscoped", got)
+	}
+	assertRunRowExists(t, db, payloadRunID, false)
+}
+
+type persistedRuntimeLogRow struct {
+	RunID  string
+	Detail map[string]any
+}
+
+func loadLatestRuntimeLogRow(t *testing.T, db *sql.DB) persistedRuntimeLogRow {
+	t.Helper()
+	var (
+		runID      string
+		payloadRaw []byte
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(run_id::text, ''), payload
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&runID, &payloadRaw); err != nil {
+		t.Fatalf("load runtime log row: %v", err)
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(payloadRaw, &payload); err != nil {
+		t.Fatalf("decode runtime log payload: %v", err)
+	}
+	detail, _ := payload["details"].(map[string]any)
+	if detail == nil {
+		detail = map[string]any{}
+	}
+	return persistedRuntimeLogRow{
+		RunID:  strings.TrimSpace(runID),
+		Detail: detail,
+	}
+}
+
+func assertRunRowExists(t *testing.T, db *sql.DB, runID string, want bool) {
+	t.Helper()
+	var exists bool
+	if err := db.QueryRowContext(context.Background(), `SELECT EXISTS (SELECT 1 FROM runs WHERE run_id = $1::uuid)`, runID).Scan(&exists); err != nil {
+		t.Fatalf("check run row %s: %v", runID, err)
+	}
+	if exists != want {
+		t.Fatalf("run row exists = %v for %q, want %v", exists, runID, want)
 	}
 }
 


### PR DESCRIPTION
Closes #184

## Human Summary
Runtime diagnostics no longer treat `detail.run_id` as a source of truth for run ownership. Runtime-log rows now get run scope only from canonical runtime correlation context, and unscoped logs stay unscoped instead of silently claiming a run through payload shape.

## What Changed
- removed the diagnostics writer fallback that pulled `run_id` from runtime-log detail payloads when the correlation context had no canonical run owner
- stopped runtime-log payload assembly from copying caller-supplied `details.run_id` through to persisted runtime-log events
- added focused real-Postgres diagnostics tests proving canonical context-owned runtime logs still persist with the expected run lineage and payload shape
- added focused real-Postgres diagnostics tests proving payload-supplied `run_id` does not create a run row, does not scope the persisted event row, and does not survive into `details.run_id`

## Why This Is Needed
`run_id` is a canonical correlation owner, not a value diagnostics should reconstruct heuristically from arbitrary payload details. Allowing payload shape to backfill run ownership makes runtime-log lineage less trustworthy and opens a drift path between real run ownership and what operators see in persisted diagnostics.

## Scope Boundaries
- In scope:
  - diagnostics/runtime-log write-time run ownership in `internal/runtime/diagnostics.go`
  - focused diagnostics tests for canonical run-scoped and unscoped runtime-log persistence
- Not in scope:
  - broader operator-surface query cleanup
  - replay/recovery correlation work already covered elsewhere
  - unrelated runtime-log schema or reader redesign

## Tests Run
- `go test ./internal/runtime -run 'TestRuntimeLogger_Log_' -count=1`
- `go test ./internal/runtime/conformance -run 'TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader' -count=1`
- `go test ./... -count=1`

## Residual Risk
The runtime-log SQL reader still does not surface `events.run_id` directly, so operator-facing run filtering continues to depend on the reader surface that exists today. This PR closes the payload-derived ownership drift path in the writer and persisted payload, but it does not redesign the broader observability query model.

## Follow-Up
If operators need first-class run-scoped runtime-log querying, that should be a separate issue that exposes canonical `events.run_id` directly through the observability surface instead of inferring anything from payload details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime diagnostics to enforce proper run ownership tracking by using context-based run identification instead of payload-derived values, preventing run ID spoofing and eliminating duplication in logged events.

* **Tests**
  * Added test coverage for run ownership validation in runtime logging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->