### PR TITLE
[agent-b][issue #197] Expose canonical delivery lifecycle states in dashboard events

### DIFF
--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -43,20 +43,47 @@ type eventDeliveryRecord struct {
 	RetryCount int    `json:"retry_count,omitempty"`
 }
 
+type deliveryLifecycleSummary struct {
+	Pending    int `json:"pending,omitempty"`
+	InProgress int `json:"in_progress,omitempty"`
+	Delivered  int `json:"delivered,omitempty"`
+	Failed     int `json:"failed,omitempty"`
+	DeadLetter int `json:"dead_letter,omitempty"`
+}
+
+func (s *deliveryLifecycleSummary) record(status string) {
+	if s == nil {
+		return
+	}
+	switch strings.TrimSpace(status) {
+	case "pending":
+		s.Pending++
+	case "in_progress":
+		s.InProgress++
+	case "delivered":
+		s.Delivered++
+	case "failed":
+		s.Failed++
+	case "dead_letter":
+		s.DeadLetter++
+	}
+}
+
 type eventRecord struct {
-	ID            string                `json:"id"`
-	EventID       string                `json:"event_id,omitempty"`
-	Type          string                `json:"type,omitempty"`
-	CreatedAt     string                `json:"created_at,omitempty"`
-	SourceAgent   string                `json:"source_agent,omitempty"`
-	EntityID      string                `json:"entity_id,omitempty"`
-	Scope         string                `json:"scope,omitempty"`
-	ParentEventID string                `json:"parent_event_id,omitempty"`
-	Payload       any                   `json:"payload,omitempty"`
-	Deliveries    []eventDeliveryRecord `json:"deliveries,omitempty"`
-	ErrorCount    int                   `json:"error_count,omitempty"`
-	DeadCount     int                   `json:"dead_count,omitempty"`
-	PendingCount  int                   `json:"pending_count,omitempty"`
+	ID                string                   `json:"id"`
+	EventID           string                   `json:"event_id,omitempty"`
+	Type              string                   `json:"type,omitempty"`
+	CreatedAt         string                   `json:"created_at,omitempty"`
+	SourceAgent       string                   `json:"source_agent,omitempty"`
+	EntityID          string                   `json:"entity_id,omitempty"`
+	Scope             string                   `json:"scope,omitempty"`
+	ParentEventID     string                   `json:"parent_event_id,omitempty"`
+	Payload           any                      `json:"payload,omitempty"`
+	DeliveryLifecycle deliveryLifecycleSummary `json:"delivery_lifecycle,omitempty"`
+	Deliveries        []eventDeliveryRecord    `json:"deliveries,omitempty"`
+	ErrorCount        int                      `json:"error_count,omitempty"`
+	DeadCount         int                      `json:"dead_count,omitempty"`
+	PendingCount      int                      `json:"pending_count,omitempty"`
 }
 
 type runtimeLogRecord struct {
@@ -105,6 +132,16 @@ func NewSQLObservabilityReader(db *sql.DB) *SQLObservabilityReader {
 	return &SQLObservabilityReader{db: db}
 }
 
+func applyDeliveryLifecycle(record *eventRecord, lifecycle deliveryLifecycleSummary) {
+	if record == nil {
+		return
+	}
+	record.DeliveryLifecycle = lifecycle
+	record.PendingCount = lifecycle.Pending
+	record.ErrorCount = lifecycle.Failed
+	record.DeadCount = lifecycle.DeadLetter
+}
+
 func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFilter, limit int) ([]eventRecord, error) {
 	if r == nil || r.db == nil {
 		return []eventRecord{}, nil
@@ -122,28 +159,22 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 			COALESCE(e.scope, ''),
 			COALESCE(e.source_event_id::text, '') AS parent_event_id,
 			COALESCE(e.payload, '{}'::jsonb),
-			COALESCE((
-				SELECT COUNT(*)::int
-				FROM event_receipts r
-				WHERE r.event_id = e.event_id
-				  AND r.outcome = 'dead_letter'
-			), 0) AS dead_count,
-			COALESCE((
-				SELECT COUNT(*)::int
-				FROM event_receipts r
-				WHERE r.event_id = e.event_id
-				  AND r.outcome IN ('reject', 'kill', 'escalate')
-			), 0) AS error_count,
-			COALESCE((
-				SELECT COUNT(*)::int
-				FROM event_deliveries d
-				LEFT JOIN event_receipts r
-					ON r.event_id = d.event_id
-					AND r.subscriber_id = d.subscriber_id
-				WHERE d.event_id = e.event_id
-				  AND r.receipt_id IS NULL
-			), 0) AS pending_count
+			COALESCE(dl.pending_count, 0),
+			COALESCE(dl.in_progress_count, 0),
+			COALESCE(dl.delivered_count, 0),
+			COALESCE(dl.failed_count, 0),
+			COALESCE(dl.dead_letter_count, 0)
 		FROM events e
+		LEFT JOIN LATERAL (
+			SELECT
+				COUNT(*) FILTER (WHERE d.status = 'pending')::int AS pending_count,
+				COUNT(*) FILTER (WHERE d.status = 'in_progress')::int AS in_progress_count,
+				COUNT(*) FILTER (WHERE d.status = 'delivered')::int AS delivered_count,
+				COUNT(*) FILTER (WHERE d.status = 'failed')::int AS failed_count,
+				COUNT(*) FILTER (WHERE d.status = 'dead_letter')::int AS dead_letter_count
+			FROM event_deliveries d
+			WHERE d.event_id = e.event_id
+		) dl ON TRUE
 		WHERE e.event_name <> 'platform.runtime_log'
 		  AND ($1 = '' OR e.event_name = $1)
 		  AND ($2 = '' OR COALESCE(e.produced_by, '') = $2)
@@ -168,8 +199,23 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 		var (
 			item       eventRecord
 			payloadRaw []byte
+			lifecycle  deliveryLifecycleSummary
 		)
-		if err := rows.Scan(&item.ID, &item.Type, &item.CreatedAt, &item.SourceAgent, &item.EntityID, &item.Scope, &item.ParentEventID, &payloadRaw, &item.DeadCount, &item.ErrorCount, &item.PendingCount); err != nil {
+		if err := rows.Scan(
+			&item.ID,
+			&item.Type,
+			&item.CreatedAt,
+			&item.SourceAgent,
+			&item.EntityID,
+			&item.Scope,
+			&item.ParentEventID,
+			&payloadRaw,
+			&lifecycle.Pending,
+			&lifecycle.InProgress,
+			&lifecycle.Delivered,
+			&lifecycle.Failed,
+			&lifecycle.DeadLetter,
+		); err != nil {
 			return nil, fmt.Errorf("scan event: %w", err)
 		}
 		item.EventID = item.ID
@@ -181,6 +227,7 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 		if strings.TrimSpace(item.EntityID) == "" {
 			item.EntityID = readString(payloadMap["entity_id"])
 		}
+		applyDeliveryLifecycle(&item, lifecycle)
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -230,57 +277,45 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 		item.EntityID = readString(payloadMap["entity_id"])
 	}
 
-	deliveries, deadCount, errorCount, pendingCount, err := r.loadEventDeliveries(ctx, id)
+	deliveries, lifecycle, err := r.loadEventDeliveries(ctx, id)
 	if err != nil {
 		return eventRecord{}, false, err
 	}
 	item.Deliveries = deliveries
-	item.DeadCount = deadCount
-	item.ErrorCount = errorCount
-	item.PendingCount = pendingCount
+	applyDeliveryLifecycle(&item, lifecycle)
 	return item, true, nil
 }
 
-func (r *SQLObservabilityReader) loadEventDeliveries(ctx context.Context, id string) ([]eventDeliveryRecord, int, int, int, error) {
+func (r *SQLObservabilityReader) loadEventDeliveries(ctx context.Context, id string) ([]eventDeliveryRecord, deliveryLifecycleSummary, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			d.subscriber_id,
-			COALESCE(r.outcome, d.status, 'pending'),
-			COALESCE(r.side_effects->>'error', d.last_error, ''),
-			COALESCE((r.side_effects->>'retry_count')::int, d.retry_count, 0)
+			COALESCE(d.status, 'pending'),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0)
 		FROM event_deliveries d
-		LEFT JOIN event_receipts r
-			ON r.event_id = d.event_id
-			AND r.subscriber_id = d.subscriber_id
 		WHERE d.event_id::text = $1
 		ORDER BY d.created_at ASC, d.subscriber_id ASC
 	`, id)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("load event deliveries: %w", err)
+		return nil, deliveryLifecycleSummary{}, fmt.Errorf("load event deliveries: %w", err)
 	}
 	defer rows.Close()
 
 	out := []eventDeliveryRecord{}
-	var deadCount, errorCount, pendingCount int
+	var lifecycle deliveryLifecycleSummary
 	for rows.Next() {
 		var item eventDeliveryRecord
 		if err := rows.Scan(&item.AgentID, &item.Status, &item.Error, &item.RetryCount); err != nil {
-			return nil, 0, 0, 0, fmt.Errorf("scan event delivery: %w", err)
+			return nil, deliveryLifecycleSummary{}, fmt.Errorf("scan event delivery: %w", err)
 		}
-		switch strings.TrimSpace(item.Status) {
-		case "dead_letter":
-			deadCount++
-		case "reject", "kill", "escalate", "error", "failed":
-			errorCount++
-		case "pending":
-			pendingCount++
-		}
+		lifecycle.record(item.Status)
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("event delivery rows: %w", err)
+		return nil, deliveryLifecycleSummary{}, fmt.Errorf("event delivery rows: %w", err)
 	}
-	return out, deadCount, errorCount, pendingCount, nil
+	return out, lifecycle, nil
 }
 
 func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter RuntimeLogFilter, limit int) ([]runtimeLogRecord, error) {

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'task.completed', $3::uuid, 'entity', '{"entity_id": "`+entityID+`"}'::jsonb, 'runtime', 'agent', $4
+		)
+	`, eventID, runID, entityID, time.Unix(1700000000, 0).UTC()); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	seedDelivery := func(subscriberID, status string, retryCount int, errText string, createdAt time.Time) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status, retry_count, last_error, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'agent', $3, $4, $5, NULLIF($6, ''), $7
+			)
+		`, runID, eventID, subscriberID, status, retryCount, errText, createdAt); err != nil {
+			t.Fatalf("seed delivery %s: %v", subscriberID, err)
+		}
+	}
+
+	now := time.Unix(1700000000, 0).UTC()
+	seedDelivery("agent-pending", "pending", 0, "", now)
+	seedDelivery("agent-progress", "in_progress", 0, "", now.Add(time.Second))
+	seedDelivery("agent-delivered", "delivered", 0, "", now.Add(2*time.Second))
+	seedDelivery("agent-failed", "failed", 1, "delivery-failed", now.Add(3*time.Second))
+	seedDelivery("agent-dead", "dead_letter", 2, "delivery-dead", now.Add(4*time.Second))
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, side_effects, processed_at
+		) VALUES
+			($1::uuid, 'agent', 'agent-pending', 'dead_letter', '{"retry_count":9,"error":"receipt-should-not-win"}'::jsonb, now()),
+			($1::uuid, 'agent', 'agent-failed', 'success', '{"retry_count":0,"error":"receipt-success"}'::jsonb, now())
+	`, eventID); err != nil {
+		t.Fatalf("seed conflicting receipts: %v", err)
+	}
+
+	rows, err := reader.ListEvents(ctx, EventFilter{Type: "task.completed"}, 10)
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.DeliveryLifecycle.Pending != 1 || got.DeliveryLifecycle.InProgress != 1 || got.DeliveryLifecycle.Delivered != 1 || got.DeliveryLifecycle.Failed != 1 || got.DeliveryLifecycle.DeadLetter != 1 {
+		t.Fatalf("delivery lifecycle = %#v", got.DeliveryLifecycle)
+	}
+	if got.PendingCount != 1 || got.ErrorCount != 1 || got.DeadCount != 1 {
+		t.Fatalf("legacy counts = pending=%d error=%d dead=%d", got.PendingCount, got.ErrorCount, got.DeadCount)
+	}
+}
+
+func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'task.completed', 'global', '{}'::jsonb, 'runtime', 'agent', now()
+		)
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, last_error, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', 1, 'delivery-wins', now()
+		)
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, side_effects, processed_at
+		) VALUES (
+			$1::uuid, 'agent', 'agent-a', 'dead_letter', '{"retry_count":7,"error":"receipt-loses"}'::jsonb, now()
+		)
+	`, eventID); err != nil {
+		t.Fatalf("seed conflicting receipt: %v", err)
+	}
+
+	got, ok, err := reader.GetEvent(ctx, eventID)
+	if err != nil {
+		t.Fatalf("GetEvent: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected event to exist")
+	}
+	if got.DeliveryLifecycle.Pending != 1 || got.DeliveryLifecycle.DeadLetter != 0 {
+		t.Fatalf("delivery lifecycle = %#v", got.DeliveryLifecycle)
+	}
+	if len(got.Deliveries) != 1 {
+		t.Fatalf("deliveries len = %d, want 1", len(got.Deliveries))
+	}
+	if item := got.Deliveries[0]; item.AgentID != "agent-a" || item.Status != "pending" || item.RetryCount != 1 || item.Error != "delivery-wins" {
+		t.Fatalf("delivery = %#v", item)
+	}
+}
+
+func TestHandler_EventDetailIncludesDeliveryLifecycle(t *testing.T) {
+	handler := NewHandler(Options{
+		AuthToken: testOperatorAuthToken,
+		Observability: stubObservability{
+			eventDetail: map[string]eventRecord{
+				"evt-1": {
+					ID:      "evt-1",
+					EventID: "evt-1",
+					Type:    "task.completed",
+					DeliveryLifecycle: deliveryLifecycleSummary{
+						Pending:    1,
+						InProgress: 2,
+						Delivered:  3,
+					},
+				},
+			},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/events/evt-1", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("event detail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal event detail: %v", err)
+	}
+	lifecycle, ok := payload["delivery_lifecycle"].(map[string]any)
+	if !ok {
+		t.Fatalf("delivery_lifecycle = %#v", payload["delivery_lifecycle"])
+	}
+	if lifecycle["pending"] != float64(1) || lifecycle["in_progress"] != float64(2) || lifecycle["delivered"] != float64(3) {
+		t.Fatalf("delivery_lifecycle = %#v", lifecycle)
+	}
+}


### PR DESCRIPTION
Closes #197

## Human Summary

This PR exposes the first explicit delivery lifecycle states in the dashboard event surfaces. Event list and event detail responses now project delivery lifecycle directly from the canonical `event_deliveries` owner instead of reconstructing lifecycle from nearby receipt outcomes or receipt absence.

## What Changed

- added a typed `delivery_lifecycle` summary to dashboard event records with explicit `pending`, `in_progress`, `delivered`, `failed`, and `dead_letter` counts
- changed `SQLObservabilityReader.ListEvents` to aggregate lifecycle state from `event_deliveries.status`
- changed `SQLObservabilityReader.GetEvent` and its delivery-row loader to read per-delivery status, retry count, and error from canonical `event_deliveries` columns instead of joining `event_receipts`
- kept the existing `pending_count`, `error_count`, and `dead_count` fields, but now derive them from the canonical lifecycle summary instead of a second heuristic model
- added focused Postgres-backed regressions proving conflicting `event_receipts` rows no longer change surfaced lifecycle state in the touched dashboard seam
- added a handler-level JSON shape test proving the new `delivery_lifecycle` field is exposed through the event detail API

## Why This Is Needed

- operators need to see delivery lifecycle state directly without reconstructing it from indirect receipt rows or missing-row heuristics
- `event_deliveries` is the canonical touched owner for delivery lifecycle state in this seam
- the old dashboard event surface could drift because it mixed receipt outcomes with “no receipt means pending” inference instead of projecting the canonical owner directly

## Scope Boundaries

- In scope:
  - dashboard event list/detail delivery lifecycle projection
  - canonical delivery-lifecycle summary for the touched observability surface
  - focused regression coverage for canonical-owner agreement
- Not in scope:
  - CLI run-status reshaping
  - broader observability redesign
  - changes to canonical delivery persistence semantics outside this surface

## Tests Run

- `go test ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

- this is the first explicit delivery lifecycle surface, not a full cross-surface rollout; other operator surfaces still need separate work if they want the same typed lifecycle projection
- legacy consumers of `error_count` now see canonical failed-delivery counts from `event_deliveries.status` rather than receipt-outcome-derived counts; that is the intended convergence, but it is still a behavioral change in the touched dashboard response

## Follow-Up

- if CLI or additional dashboard views need delivery lifecycle summaries later, they should consume the same canonical `event_deliveries` owner instead of rebuilding lifecycle from receipts or absence checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of delivery lifecycle status tracking in the observability dashboard, with refined counts for pending, in-progress, delivered, failed, and dead-letter statuses.
  * Enhanced reliability of event delivery metrics through better data aggregation.

* **Tests**
  * Added comprehensive test coverage for delivery lifecycle tracking and event detail reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->