### PR TITLE
[agent-c][issue #198] Record retry reasons and predecessor lineage for retried sessions

### DIFF
--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -559,7 +559,7 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 		},
 	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
-	summaryState := `{"summary":"brief","last_turn":{"parse_ok":true},"provider_session_id":"sess-1"}`
+	summaryState := `{"summary":"brief","last_turn":{"parse_ok":true},"provider_session_id":"sess-1","retry_reason":"session not found","retries_from_session_id":"sess-0"}`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
 	toolCallsPayload := `[{"name":"schedule","arguments":{"delay_seconds":1209600}}]`
 	responsePayload := `{"result":"14-day review scheduled.","raw":"{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"status\\\":\\\"scheduled\\\"}\"}]}]}}\n{\"type\":\"result\",\"result\":\"14-day review scheduled.\"}"}`
@@ -582,6 +582,9 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 	if items[0].Metadata["provider_session_id"] != "sess-1" {
 		t.Fatalf("expected metadata to retain provider_session_id: %+v", items[0].Metadata)
+	}
+	if items[0].Metadata["retry_reason"] != "session not found" || items[0].Metadata["retries_from_session_id"] != "sess-0" {
+		t.Fatalf("expected retry lineage metadata, got %+v", items[0].Metadata)
 	}
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
@@ -618,6 +621,9 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	lastTurn, ok := item.RuntimeState["last_turn"].(map[string]any)
 	if !ok || lastTurn["parse_ok"] != true {
 		t.Fatalf("expected runtime_state.last_turn parse_ok=true, got %+v", item.RuntimeState)
+	}
+	if item.RuntimeState["retry_reason"] != "session not found" || item.RuntimeState["retries_from_session_id"] != "sess-0" {
+		t.Fatalf("expected retry lineage in runtime_state, got %+v", item.RuntimeState)
 	}
 	if item.Turns[0].AssistantVisibleOutput != "" || item.Turns[0].Outcome != "" || len(item.Turns[0].ToolResults) != 0 {
 		t.Fatalf("expected missing canonical summary to fail closed, got %+v", item.Turns[0])

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -109,6 +109,18 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 		ConversationMode: resolved.RuntimeMode.String(),
 		SessionScope:     resolved.Scope.String(),
 		ScopeKey:         resolved.ScopeKey,
+		RetryReason: func() string {
+			if lease != nil {
+				return lease.RetryReason
+			}
+			return ""
+		}(),
+		RetriesFromSessionID: func() string {
+			if lease != nil {
+				return lease.RetriesFromSessionID
+			}
+			return ""
+		}(),
 		ProviderSessionID: func() string {
 			if lease != nil {
 				return lease.ProviderSessionID
@@ -123,6 +135,8 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
+			s.RetryReason = strings.TrimSpace(rec.RetryReason)
+			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
 		}
 	}
 	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -152,14 +152,28 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 		ConversationMode: resolved.RuntimeMode.String(),
 		SessionScope:     resolved.Scope.String(),
 		ScopeKey:         resolved.ScopeKey,
-		SystemPrompt:     augmentCLISystemPrompt(systemPrompt, tools),
-		Tools:            tools,
-		Messages:         nil,
+		RetryReason: func() string {
+			if lease != nil {
+				return lease.RetryReason
+			}
+			return ""
+		}(),
+		RetriesFromSessionID: func() string {
+			if lease != nil {
+				return lease.RetriesFromSessionID
+			}
+			return ""
+		}(),
+		SystemPrompt: augmentCLISystemPrompt(systemPrompt, tools),
+		Tools:        tools,
+		Messages:     nil,
 	}
 	if r.conversations != nil && !resolved.Stateless {
 		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
 			s.Messages = rec.Messages
 			s.TurnCount = rec.TurnCount
+			s.RetryReason = strings.TrimSpace(rec.RetryReason)
+			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
 		}
 	}
 	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))
@@ -326,10 +340,15 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		oldParseFailures := s.ParseFailures
 		checkpoint := BuildRotationCheckpoint(rotateReason, s)
 		if !resolved.Stateless {
-			rotated, rotateErr := r.sessions.Rotate(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, checkpoint, resolved.ScopeKey)
+			rotated, rotateErr := r.sessions.Rotate(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, sessions.RotationMetadata{
+				CheckpointSummary: checkpoint,
+				RetryReason:       rotateReason,
+			}, resolved.ScopeKey)
 			if rotateErr == nil && rotated != nil {
 				s.ID = rotated.SessionID
 				s.ProviderSessionID = rotated.ProviderSessionID
+				s.RetryReason = rotated.RetryReason
+				s.RetriesFromSessionID = rotated.RetriesFromSessionID
 				s.TurnCount = 0
 				if len(s.Messages) > 0 {
 					s.Messages = []Message{{Role: "system", Content: "Session rotated due to CLI runtime recovery."}}

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -138,17 +138,19 @@ func mcpListedToolsForSession(tools []ToolDefinition) []string {
 const runtimeToolsMCPPrefix = "mcp__runtime-tools__"
 
 type ConversationRecord struct {
-	SessionID    string
-	AgentID      string
-	SessionScope string
-	ScopeKey     string
-	RunID        string
-	TaskID       string
-	Mode         string
-	Messages     []Message
-	Summary      string
-	TurnCount    int
-	Status       string
+	SessionID            string
+	AgentID              string
+	SessionScope         string
+	ScopeKey             string
+	RetryReason          string
+	RetriesFromSessionID string
+	RunID                string
+	TaskID               string
+	Mode                 string
+	Messages             []Message
+	Summary              string
+	TurnCount            int
+	Status               string
 }
 
 type ConversationPersistence interface {

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -60,6 +60,8 @@ func (s *failingConversationStore) LoadActiveConversation(context.Context, strin
 
 type captureConversationStore struct {
 	record ConversationRecord
+	load   ConversationRecord
+	loadOK bool
 }
 
 func (s *captureConversationStore) UpsertConversation(_ context.Context, rec ConversationRecord) error {
@@ -68,7 +70,7 @@ func (s *captureConversationStore) UpsertConversation(_ context.Context, rec Con
 }
 
 func (s *captureConversationStore) LoadActiveConversation(context.Context, string, string, string, string) (ConversationRecord, bool, error) {
-	return ConversationRecord{}, false, nil
+	return s.load, s.loadOK, nil
 }
 
 type failingTurnStore struct {
@@ -321,6 +323,35 @@ func TestClaudeCLIRuntime_PersistConversationIncludesSessionScope(t *testing.T) 
 
 	if store.record.SessionScope != sessions.SessionScopeEntity.String() {
 		t.Fatalf("SessionScope = %q, want %q", store.record.SessionScope, sessions.SessionScopeEntity)
+	}
+}
+
+func TestClaudeCLIRuntime_StartSessionLoadsRetryLineage(t *testing.T) {
+	store := &captureConversationStore{
+		load: ConversationRecord{
+			SessionID:            "session-previous",
+			Messages:             []Message{{Role: "assistant", Content: "hello again"}},
+			TurnCount:            2,
+			RetryReason:          "session not found",
+			RetriesFromSessionID: "session-original",
+		},
+		loadOK: true,
+	}
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, store, nil)
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeGlobal.String(), "global")
+
+	s, err := runtime.StartSession(ctx, "agent-4", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if s.RetryReason != "session not found" {
+		t.Fatalf("RetryReason = %q, want session not found", s.RetryReason)
+	}
+	if s.RetriesFromSessionID != "session-original" {
+		t.Fatalf("RetriesFromSessionID = %q, want session-original", s.RetriesFromSessionID)
+	}
+	if s.TurnCount != 2 || len(s.Messages) != 1 {
+		t.Fatalf("unexpected restored session: %+v", s)
 	}
 }
 

--- a/internal/runtime/llm/session_rotation.go
+++ b/internal/runtime/llm/session_rotation.go
@@ -20,7 +20,9 @@ func MaybeRotateAfterTurn(ctx context.Context, s *Session, runtimeMode sessions.
 	oldTurnCount := s.TurnCount
 	oldParseFailures := s.ParseFailures
 	summary := BuildRotationCheckpoint(fmt.Sprintf("turn_limit_reached:%d", rotateAfter), s)
-	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
+	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, sessions.RotationMetadata{
+		CheckpointSummary: summary,
+	}, strings.TrimSpace(s.ScopeKey))
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +60,9 @@ func MaybeRotateAfterParseFailures(ctx context.Context, s *Session, runtimeMode 
 	oldTurnCount := s.TurnCount
 	oldParseFailures := s.ParseFailures
 	summary := BuildRotationCheckpoint(fmt.Sprintf("parse_failures_threshold:%d", threshold), s)
-	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, summary, strings.TrimSpace(s.ScopeKey))
+	lease, err := registry.Rotate(ctx, s.AgentID, runtimeMode, sessions.NormalizeSessionScope(s.SessionScope), lockOwner, sessions.RotationMetadata{
+		CheckpointSummary: summary,
+	}, strings.TrimSpace(s.ScopeKey))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -28,18 +28,20 @@ type Response struct {
 }
 
 type Session struct {
-	ID                string
-	ProviderSessionID string
-	AgentID           string
-	RuntimeMode       string
-	ConversationMode  string
-	SessionScope      string
-	ScopeKey          string
-	TurnCount         int
-	ParseFailures     int
-	SystemPrompt      string
-	Tools             []ToolDefinition
-	Messages          []Message
+	ID                   string
+	ProviderSessionID    string
+	AgentID              string
+	RuntimeMode          string
+	ConversationMode     string
+	SessionScope         string
+	ScopeKey             string
+	RetryReason          string
+	RetriesFromSessionID string
+	TurnCount            int
+	ParseFailures        int
+	SystemPrompt         string
+	Tools                []ToolDefinition
+	Messages             []Message
 }
 
 type UsageTokens struct {

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -342,7 +342,9 @@ func (am *AgentManager) ReconfigureAgent(agentID string, cfg models.AgentConfig)
 			return fmt.Errorf("agent reconfigure session rotation failed: agent=%s runtime=%s: %w", agentID, conversationMode, err)
 		}
 		rotationCtx := models.WithActor(am.runtimeContext(), updated)
-		rotated, err := sessionRegistry.Rotate(rotationCtx, agentID, runtimeMode, sessions.NormalizeSessionScope(updated.SessionScope), "reconfigure", "agent reconfigured", scopeKey)
+		rotated, err := sessionRegistry.Rotate(rotationCtx, agentID, runtimeMode, sessions.NormalizeSessionScope(updated.SessionScope), "reconfigure", sessions.RotationMetadata{
+			CheckpointSummary: "agent reconfigured",
+		}, scopeKey)
 		if err != nil {
 			return fmt.Errorf("agent reconfigure session rotation failed: agent=%s runtime=%s: %w", agentID, conversationMode, err)
 		} else if rotated != nil {

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -56,6 +56,8 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 		scopeKey          string
 		status            string
 		providerSessionID sql.NullString
+		retryReason       sql.NullString
+		retriesFrom       sql.NullString
 		leaseHolder       sql.NullString
 		leaseExpires      sql.NullTime
 	}
@@ -66,6 +68,8 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 			scope_key,
 			status,
 			NULLIF(runtime_state->>'provider_session_id', ''),
+			NULLIF(runtime_state->>'retry_reason', ''),
+			NULLIF(runtime_state->>'retries_from_session_id', ''),
 			lease_holder,
 			lease_expires_at
 		FROM agent_sessions
@@ -80,6 +84,8 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 		&r.scopeKey,
 		&r.status,
 		&r.providerSessionID,
+		&r.retryReason,
+		&r.retriesFrom,
 		&r.leaseHolder,
 		&r.leaseExpires,
 	)
@@ -111,13 +117,15 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 			return nil, fmt.Errorf("commit acquire new: %w", err)
 		}
 		return &Lease{
-			SessionID:    r.sessionID,
-			AgentID:      agentID,
-			RuntimeMode:  resolved.RuntimeMode,
-			SessionScope: resolved.Scope,
-			LockOwner:    lockOwner,
-			ScopeKey:     r.scopeKey,
-			ExpiresAt:    expires,
+			SessionID:            r.sessionID,
+			AgentID:              agentID,
+			RuntimeMode:          resolved.RuntimeMode,
+			SessionScope:         resolved.Scope,
+			RetryReason:          "",
+			RetriesFromSessionID: "",
+			LockOwner:            lockOwner,
+			ScopeKey:             r.scopeKey,
+			ExpiresAt:            expires,
 		}, nil
 	}
 
@@ -149,13 +157,15 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 			return nil, fmt.Errorf("commit acquire recycled: %w", err)
 		}
 		return &Lease{
-			SessionID:    r.sessionID,
-			AgentID:      agentID,
-			RuntimeMode:  resolved.RuntimeMode,
-			SessionScope: resolved.Scope,
-			LockOwner:    lockOwner,
-			ScopeKey:     r.scopeKey,
-			ExpiresAt:    expires,
+			SessionID:            r.sessionID,
+			AgentID:              agentID,
+			RuntimeMode:          resolved.RuntimeMode,
+			SessionScope:         resolved.Scope,
+			RetryReason:          "",
+			RetriesFromSessionID: "",
+			LockOwner:            lockOwner,
+			ScopeKey:             r.scopeKey,
+			ExpiresAt:            expires,
 		}, nil
 	}
 
@@ -180,14 +190,16 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 	}
 
 	return &Lease{
-		SessionID:         r.sessionID,
-		ProviderSessionID: strings.TrimSpace(r.providerSessionID.String),
-		AgentID:           agentID,
-		RuntimeMode:       resolved.RuntimeMode,
-		SessionScope:      resolved.Scope,
-		LockOwner:         lockOwner,
-		ScopeKey:          resolved.ScopeKey,
-		ExpiresAt:         expires,
+		SessionID:            r.sessionID,
+		ProviderSessionID:    strings.TrimSpace(r.providerSessionID.String),
+		AgentID:              agentID,
+		RuntimeMode:          resolved.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          strings.TrimSpace(r.retryReason.String),
+		RetriesFromSessionID: strings.TrimSpace(r.retriesFrom.String),
+		LockOwner:            lockOwner,
+		ScopeKey:             resolved.ScopeKey,
+		ExpiresAt:            expires,
 	}, nil
 }
 
@@ -220,7 +232,7 @@ func (sr *PostgresRegistry) Release(ctx context.Context, lease *Lease) error {
 	return nil
 }
 
-func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
+func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner string, rotation RotationMetadata, scopeKey string) (*Lease, error) {
 	if agentID == "" || runtimeMode == "" || lockOwner == "" {
 		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
 	}
@@ -269,6 +281,11 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 	}
 
 	newSessionID := uuid.NewString()
+	retryReason := strings.TrimSpace(rotation.RetryReason)
+	retriesFromSessionID := ""
+	if retryReason != "" {
+		retriesFromSessionID = currentSessionID
+	}
 	var expiresAt time.Time
 	if err := tx.QueryRowContext(ctx, `
 		UPDATE agent_sessions
@@ -279,14 +296,18 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 		    conversation = '[]'::jsonb,
 		    turn_count = 0,
 		    runtime_mode = $5,
-		    runtime_state = jsonb_build_object('checkpoint_summary', NULLIF($6,'')),
-		    lease_holder = $7,
-		    lease_expires_at = $8,
+		    runtime_state = jsonb_strip_nulls(jsonb_build_object(
+		    	'checkpoint_summary', NULLIF($6,''),
+		    	'retry_reason', NULLIF($7,''),
+		    	'retries_from_session_id', NULLIF($8,'')
+		    )),
+		    lease_holder = $9,
+		    lease_expires_at = $10,
 		    status = 'active',
 		    updated_at = now()
-		WHERE session_id = $9::uuid
+		WHERE session_id = $11::uuid
 		RETURNING lease_expires_at
-	`, newSessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, summary, lockOwner, now.Add(sr.lockTTL), currentSessionID).Scan(&expiresAt); err != nil {
+	`, newSessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, strings.TrimSpace(rotation.CheckpointSummary), retryReason, retriesFromSessionID, lockOwner, now.Add(sr.lockTTL), currentSessionID).Scan(&expiresAt); err != nil {
 		return nil, fmt.Errorf("rotate session row: %w", err)
 	}
 
@@ -295,13 +316,15 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 	}
 
 	return &Lease{
-		SessionID:    newSessionID,
-		AgentID:      agentID,
-		RuntimeMode:  resolved.RuntimeMode,
-		SessionScope: resolved.Scope,
-		LockOwner:    lockOwner,
-		ScopeKey:     resolved.ScopeKey,
-		ExpiresAt:    expiresAt,
+		SessionID:            newSessionID,
+		AgentID:              agentID,
+		RuntimeMode:          resolved.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          retryReason,
+		RetriesFromSessionID: retriesFromSessionID,
+		LockOwner:            lockOwner,
+		ScopeKey:             resolved.ScopeKey,
+		ExpiresAt:            expiresAt,
 	}, nil
 }
 

--- a/internal/runtime/sessions/postgres_test.go
+++ b/internal/runtime/sessions/postgres_test.go
@@ -40,8 +40,8 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
 		WithArgs("a1", "global", RuntimeModeSession).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "lease_holder", "lease_expires_at"}).
-			AddRow("sess-1", "global", "active", nil, "owner-1", fixedNow.Add(30*time.Second)))
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "retry_reason", "retries_from_session_id", "lease_holder", "lease_expires_at"}).
+			AddRow("sess-1", "global", "active", nil, "session not found", "sess-0", "owner-1", fixedNow.Add(30*time.Second)))
 	mock.ExpectQuery("UPDATE agent_sessions\\s+SET lease_holder = \\$1,").
 		WithArgs("owner-1", fixedNow.Add(30*time.Second), "sess-1").
 		WillReturnRows(sqlmock.NewRows([]string{"lease_expires_at"}).AddRow(fixedNow.Add(30 * time.Second)))
@@ -53,6 +53,9 @@ func TestPostgresSessionRegistry_AcquireNewAndExistingAndRelease(t *testing.T) {
 	}
 	if lease2.SessionID != "sess-1" || lease2.ScopeKey != "global" {
 		t.Fatalf("unexpected session lease: %+v", lease2)
+	}
+	if lease2.RetryReason != "session not found" || lease2.RetriesFromSessionID != "sess-0" {
+		t.Fatalf("unexpected retry lineage: %+v", lease2)
 	}
 
 	mock.ExpectExec("UPDATE agent_sessions\\s+SET lease_holder = NULL").
@@ -87,8 +90,8 @@ func TestPostgresSessionRegistry_AcquireLeasedByOtherReturnsErrLeased(t *testing
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
 		WithArgs("a1", "global", RuntimeModeSession).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "lease_holder", "lease_expires_at"}).
-			AddRow("sess-1", "global", "active", nil, "someone-else", fixedNow.Add(10*time.Second)))
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "retry_reason", "retries_from_session_id", "lease_holder", "lease_expires_at"}).
+			AddRow("sess-1", "global", "active", nil, nil, nil, "someone-else", fixedNow.Add(10*time.Second)))
 
 	_, err = sr.Acquire(context.Background(), "a1", RuntimeModeSession, SessionScopeGlobal, "owner-1", "global")
 	if err != ErrSessionLeased {
@@ -117,16 +120,22 @@ func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "owner-1", fixedNow.Add(10*time.Second)))
 	mock.ExpectQuery("UPDATE agent_sessions\\s+SET session_id = \\$1::uuid,").
-		WithArgs(sqlmock.AnyArg(), "", "", "global", RuntimeModeSession, "sum", "owner-1", fixedNow.Add(30*time.Second), "sess-1").
+		WithArgs(sqlmock.AnyArg(), "", "", "global", RuntimeModeSession, "sum", "session not found", "sess-1", "owner-1", fixedNow.Add(30*time.Second), "sess-1").
 		WillReturnRows(sqlmock.NewRows([]string{"lease_expires_at"}).AddRow(fixedNow.Add(30 * time.Second)))
 	mock.ExpectCommit()
 
-	lease, err := sr.Rotate(context.Background(), "a1", RuntimeModeSession, SessionScopeGlobal, "owner-1", "sum", "global")
+	lease, err := sr.Rotate(context.Background(), "a1", RuntimeModeSession, SessionScopeGlobal, "owner-1", RotationMetadata{
+		CheckpointSummary: "sum",
+		RetryReason:       "session not found",
+	}, "global")
 	if err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
 	if lease.SessionID == "" || lease.AgentID != "a1" || lease.ScopeKey != "global" {
 		t.Fatalf("unexpected lease: %+v", lease)
+	}
+	if lease.RetryReason != "session not found" || lease.RetriesFromSessionID != "sess-1" {
+		t.Fatalf("unexpected retry lineage: %+v", lease)
 	}
 
 	mock.ExpectExec("UPDATE agent_sessions\\s+SET turn_count = turn_count \\+ 1").

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -14,7 +14,7 @@ import (
 type Registry interface {
 	Acquire(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, scopeKey string) (*Lease, error)
 	Release(ctx context.Context, lease *Lease) error
-	Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error)
+	Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner string, rotation RotationMetadata, scopeKey string) (*Lease, error)
 	IncrementTurn(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, sessionID, scopeKey string) error
 }
 
@@ -23,28 +23,37 @@ type Resetter interface {
 }
 
 type Lease struct {
-	SessionID         string
-	ProviderSessionID string
-	AgentID           string
-	RuntimeMode       RuntimeMode
-	SessionScope      SessionScope
-	LockOwner         string
-	ScopeKey          string
-	ExpiresAt         time.Time
+	SessionID            string
+	ProviderSessionID    string
+	AgentID              string
+	RuntimeMode          RuntimeMode
+	SessionScope         SessionScope
+	RetryReason          string
+	RetriesFromSessionID string
+	LockOwner            string
+	ScopeKey             string
+	ExpiresAt            time.Time
+}
+
+type RotationMetadata struct {
+	CheckpointSummary string
+	RetryReason       string
 }
 
 type Record struct {
-	SessionID         string
-	ProviderSessionID string
-	AgentID           string
-	RuntimeMode       RuntimeMode
-	ScopeKey          string
-	Status            string
-	TurnCount         int
-	CheckpointSummary string
-	LockOwner         string
-	LockExpiresAt     time.Time
-	LastUsedAt        time.Time
+	SessionID            string
+	ProviderSessionID    string
+	AgentID              string
+	RuntimeMode          RuntimeMode
+	ScopeKey             string
+	Status               string
+	TurnCount            int
+	CheckpointSummary    string
+	RetryReason          string
+	RetriesFromSessionID string
+	LockOwner            string
+	LockExpiresAt        time.Time
+	LastUsedAt           time.Time
 }
 
 // InMemoryRegistry is the process-local bootstrap implementation.
@@ -111,14 +120,16 @@ func (sr *InMemoryRegistry) Acquire(ctx context.Context, agentID string, runtime
 	rec.LastUsedAt = now
 
 	return &Lease{
-		SessionID:         rec.SessionID,
-		ProviderSessionID: rec.ProviderSessionID,
-		AgentID:           rec.AgentID,
-		RuntimeMode:       rec.RuntimeMode,
-		SessionScope:      resolved.Scope,
-		LockOwner:         rec.LockOwner,
-		ScopeKey:          rec.ScopeKey,
-		ExpiresAt:         rec.LockExpiresAt,
+		SessionID:            rec.SessionID,
+		ProviderSessionID:    rec.ProviderSessionID,
+		AgentID:              rec.AgentID,
+		RuntimeMode:          rec.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          rec.RetryReason,
+		RetriesFromSessionID: rec.RetriesFromSessionID,
+		LockOwner:            rec.LockOwner,
+		ScopeKey:             rec.ScopeKey,
+		ExpiresAt:            rec.LockExpiresAt,
 	}, nil
 }
 
@@ -145,7 +156,7 @@ func (sr *InMemoryRegistry) Release(_ context.Context, lease *Lease) error {
 	return nil
 }
 
-func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner, summary, scopeKey string) (*Lease, error) {
+func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeMode RuntimeMode, sessionScope SessionScope, lockOwner string, rotation RotationMetadata, scopeKey string) (*Lease, error) {
 	resolved, err := ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
 	if err != nil {
 		return nil, err
@@ -168,8 +179,15 @@ func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 		return nil, fmt.Errorf("cannot rotate: leased by %s", rec.LockOwner)
 	}
 
+	retryReason := strings.TrimSpace(rotation.RetryReason)
+	retriesFromSessionID := ""
+	if retryReason != "" {
+		retriesFromSessionID = rec.SessionID
+	}
 	rec.Status = "rotating"
-	rec.CheckpointSummary = summary
+	rec.CheckpointSummary = strings.TrimSpace(rotation.CheckpointSummary)
+	rec.RetryReason = retryReason
+	rec.RetriesFromSessionID = retriesFromSessionID
 	rec.SessionID = uuid.NewString()
 	rec.ProviderSessionID = ""
 	rec.Status = "active"
@@ -179,14 +197,16 @@ func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 	rec.LastUsedAt = now
 
 	return &Lease{
-		SessionID:         rec.SessionID,
-		ProviderSessionID: rec.ProviderSessionID,
-		AgentID:           rec.AgentID,
-		RuntimeMode:       rec.RuntimeMode,
-		SessionScope:      resolved.Scope,
-		LockOwner:         rec.LockOwner,
-		ScopeKey:          rec.ScopeKey,
-		ExpiresAt:         rec.LockExpiresAt,
+		SessionID:            rec.SessionID,
+		ProviderSessionID:    rec.ProviderSessionID,
+		AgentID:              rec.AgentID,
+		RuntimeMode:          rec.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          rec.RetryReason,
+		RetriesFromSessionID: rec.RetriesFromSessionID,
+		LockOwner:            rec.LockOwner,
+		ScopeKey:             rec.ScopeKey,
+		ExpiresAt:            rec.LockExpiresAt,
 	}, nil
 }
 

--- a/internal/runtime/sessions/registry_test.go
+++ b/internal/runtime/sessions/registry_test.go
@@ -39,12 +39,28 @@ func TestInMemorySessionRegistryRotate(t *testing.T) {
 	}
 	old := lease.SessionID
 
-	rotated, err := sr.Rotate(context.Background(), "agent-a", RuntimeModeSession, SessionScopeGlobal, "worker-a", "checkpoint", "global")
+	rotated, err := sr.Rotate(context.Background(), "agent-a", RuntimeModeSession, SessionScopeGlobal, "worker-a", RotationMetadata{
+		CheckpointSummary: "checkpoint",
+		RetryReason:       "session not found",
+	}, "global")
 	if err != nil {
 		t.Fatalf("rotate: %v", err)
 	}
 	if rotated.SessionID == old {
 		t.Fatalf("expected new session id after rotate")
+	}
+	if rotated.RetryReason != "session not found" {
+		t.Fatalf("RetryReason = %q, want session not found", rotated.RetryReason)
+	}
+	if rotated.RetriesFromSessionID != old {
+		t.Fatalf("RetriesFromSessionID = %q, want %q", rotated.RetriesFromSessionID, old)
+	}
+	rec, ok := sr.Snapshot("agent-a")
+	if !ok {
+		t.Fatal("expected snapshot record")
+	}
+	if rec.RetryReason != "session not found" || rec.RetriesFromSessionID != old {
+		t.Fatalf("unexpected retry lineage in record: %+v", rec)
 	}
 }
 

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -862,9 +862,12 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 
 	const q = `
 		SELECT
+			session_id::text,
 			scope_key,
 			COALESCE(conversation, '[]'::jsonb),
 			COALESCE(runtime_state->>'summary', ''),
+			COALESCE(runtime_state->>'retry_reason', ''),
+			COALESCE(runtime_state->>'retries_from_session_id', ''),
 			COALESCE(turn_count, 0),
 			COALESCE(status, 'active')
 		FROM agent_sessions
@@ -883,9 +886,12 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 
 	var rawMessages []byte
 	err = s.DB.QueryRowContext(ctx, q, agentID, resolvedMode.String(), resolved.ScopeKey).Scan(
+		&rec.SessionID,
 		&rec.ScopeKey,
 		&rawMessages,
 		&rec.Summary,
+		&rec.RetryReason,
+		&rec.RetriesFromSessionID,
 		&rec.TurnCount,
 		&rec.Status,
 	)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -17,6 +17,7 @@ import (
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/testutil"
 )
@@ -1900,6 +1901,58 @@ func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t
 	}
 	if flowInstance != "review/inst-1" {
 		t.Fatalf("flow_instance = %q, want review/inst-1", flowInstance)
+	}
+}
+
+func TestManagerStore_LoadActiveConversationIncludesRetryLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	lease, err := registry.Acquire(ctx, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "worker-1", "global")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	rotated, err := registry.Rotate(ctx, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "worker-1", runtimesessions.RotationMetadata{
+		CheckpointSummary: "rotation_reason=session not found",
+		RetryReason:       "session not found",
+	}, "global")
+	if err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if rotated.RetriesFromSessionID != lease.SessionID {
+		t.Fatalf("RetriesFromSessionID = %q, want %q", rotated.RetriesFromSessionID, lease.SessionID)
+	}
+
+	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global")
+	if err != nil || !ok {
+		t.Fatalf("LoadActiveConversation ok=%v err=%v", ok, err)
+	}
+	if rec.SessionID != rotated.SessionID {
+		t.Fatalf("SessionID = %q, want %q", rec.SessionID, rotated.SessionID)
+	}
+	if rec.RetryReason != "session not found" {
+		t.Fatalf("RetryReason = %q, want session not found", rec.RetryReason)
+	}
+	if rec.RetriesFromSessionID != lease.SessionID {
+		t.Fatalf("RetriesFromSessionID = %q, want %q", rec.RetriesFromSessionID, lease.SessionID)
+	}
+
+	var gotReason, gotFrom string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(runtime_state->>'retry_reason', ''),
+			COALESCE(runtime_state->>'retries_from_session_id', '')
+		FROM agent_sessions
+		WHERE agent_id = 'a1' AND scope_key = 'global' AND runtime_mode = 'session' AND status = 'active'
+	`).Scan(&gotReason, &gotFrom); err != nil {
+		t.Fatalf("load runtime_state retry lineage: %v", err)
+	}
+	if gotReason != "session not found" || gotFrom != lease.SessionID {
+		t.Fatalf("unexpected runtime_state retry lineage: reason=%q from=%q", gotReason, gotFrom)
 	}
 }
 


### PR DESCRIPTION
Closes #198

## Human Summary
Retried live sessions now persist their retry reason and predecessor session ID as canonical session state, and the same lineage shows up again through recovery and operator-facing conversation readers instead of being reconstructed from checkpoint text or logs.

## What Changed
- replaced the loose session rotation `summary` input with typed `sessions.RotationMetadata`
- persisted `retry_reason` and `retries_from_session_id` on `agent_sessions.runtime_state` during retry rotations
- exposed retry lineage back through session acquisition leases and `LoadActiveConversation`
- restored retry lineage into API/CLI `Session` objects during session start/recovery
- added focused registry, store, runtime, and dashboard tests for retry lineage persistence and exposure

## Why This Is Needed
Before this change, retried sessions only carried retry reason implicitly inside checkpoint text and runtime logs, and there was no canonical persisted predecessor lineage. That made recovery and operator/debug readers infer or lose session retry history. The session row now owns that state explicitly.

## Scope Boundaries
- scoped to retried live-session lineage and retry-reason persistence
- no broader session-model redesign
- no orphaned/superseded marker work
- no unrelated observability cleanup beyond exposing the new canonical fields through the existing conversation reader path

## Tests Run
- `go test ./internal/runtime/sessions ./internal/runtime/llm ./internal/store ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
- existing historical session rows are not backfilled; only newly retried sessions will carry canonical retry lineage
- dashboard exposure still rides through `runtime_state` metadata/runtime-state maps rather than a new dedicated response field, but it is now reading canonical persisted state rather than reconstructing it locally

## Follow-Up
- superseded/orphaned session marking after restart remains separate work
- if operator APIs eventually want first-class typed retry-lineage fields instead of generic runtime-state metadata, that should be a separate read-model issue
