### PR TITLE
[agent-a][issue #186] Persist canonical terminal state in flow_instances for template flows

### DIFF
--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -21,6 +21,7 @@ import (
 
 type flowInstancePersistence interface {
 	Upsert(ctx context.Context, instance runtimepipeline.WorkflowInstance) error
+	MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error
 }
 
 type flowInstanceRouteInstaller interface {
@@ -245,6 +246,9 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 	if am == nil {
 		return fmt.Errorf("agent manager is required")
 	}
+	if am.workflowInstances == nil {
+		return fmt.Errorf("workflow instance store is required")
+	}
 	instance := req.Instance
 	templateID := strings.TrimSpace(instance.TemplateID)
 	instanceID := strings.TrimSpace(instance.InstanceID)
@@ -257,6 +261,9 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 	routeIdentity := instance.Route()
 	if !routeIdentity.Valid() {
 		return fmt.Errorf("derive route identity for flow path %s", flowPath)
+	}
+	if err := am.workflowInstances.MarkTerminated(ctx, flowPath, time.Now().UTC()); err != nil {
+		return fmt.Errorf("persist flow instance terminal state %s: %w", flowPath, err)
 	}
 	am.mu.RLock()
 	agentIDs := make([]string, 0, len(am.agentCfg))

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -12,6 +12,7 @@ import (
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/testutil"
 )
 
 type flowActivationTestBus struct {
@@ -21,7 +22,9 @@ type flowActivationTestBus struct {
 }
 
 type flowActivationTestInstanceStore struct {
-	upserts []runtimepipeline.WorkflowInstance
+	upserts          []runtimepipeline.WorkflowInstance
+	terminatedPaths  []string
+	terminatedAtSeen []time.Time
 }
 
 type flowActivationTestStore struct {
@@ -36,6 +39,12 @@ func newFlowActivationManager(bus Bus, instances flowInstancePersistence, stores
 
 func (s *flowActivationTestInstanceStore) Upsert(_ context.Context, instance runtimepipeline.WorkflowInstance) error {
 	s.upserts = append(s.upserts, instance)
+	return nil
+}
+
+func (s *flowActivationTestInstanceStore) MarkTerminated(_ context.Context, storageRef string, terminatedAt time.Time) error {
+	s.terminatedPaths = append(s.terminatedPaths, strings.TrimSpace(storageRef))
+	s.terminatedAtSeen = append(s.terminatedAtSeen, terminatedAt)
 	return nil
 }
 
@@ -406,7 +415,8 @@ func TestActivateFlowInstanceResolvesAgentPermissions(t *testing.T) {
 
 func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
 	bundle := testFlowBundle("")
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
@@ -422,11 +432,18 @@ func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "review/inst-1" {
 		t.Fatalf("removed pairs = %#v, want [review/inst-1]", bus.removedPairs)
 	}
+	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "review/inst-1" {
+		t.Fatalf("terminated paths = %#v, want [review/inst-1]", instances.terminatedPaths)
+	}
+	if len(instances.terminatedAtSeen) != 1 || instances.terminatedAtSeen[0].IsZero() {
+		t.Fatalf("terminated_at seen = %#v, want one non-zero timestamp", instances.terminatedAtSeen)
+	}
 }
 
 func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
 	bundle := testNestedFlowBundle()
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "grandchild", "inst-1", "ent-1", "child/grandchild/inst-1"))
@@ -438,6 +455,67 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 	}
 	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "child/grandchild/inst-1" {
 		t.Fatalf("removed pairs = %#v, want [child/grandchild/inst-1]", bus.removedPairs)
+	}
+	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "child/grandchild/inst-1" {
+		t.Fatalf("terminated paths = %#v, want [child/grandchild/inst-1]", instances.terminatedPaths)
+	}
+}
+
+func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bus := &flowActivationTestBus{}
+	store := runtimepipeline.NewWorkflowInstanceStore(db)
+	am := newFlowActivationManager(bus, store)
+	bundle := testFlowBundle("")
+	const subjectID = "11111111-1111-1111-1111-111111111111"
+	req := testActivationRequest(bundle, "review", "inst-1", subjectID, "review/inst-1")
+
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if err := store.Mutate(context.Background(), req.Instance.EntityID, func(instance *runtimepipeline.WorkflowInstance) {
+		instance.CurrentState = "completed"
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	if err := am.DeactivateFlowInstanceModel(context.Background(), runtimepipeline.FlowInstanceDeactivationRequest{
+		ContractBundle: semanticview.Wrap(bundle),
+		Instance:       req.Instance,
+		FinalState:     "completed",
+	}); err != nil {
+		t.Fatalf("DeactivateFlowInstanceModel: %v", err)
+	}
+
+	var (
+		status       string
+		terminatedAt time.Time
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT status, terminated_at
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, "review/inst-1").Scan(&status, &terminatedAt); err != nil {
+		t.Fatalf("query flow_instances: %v", err)
+	}
+	if strings.TrimSpace(status) != "terminated" {
+		t.Fatalf("flow_instances.status = %q, want terminated", status)
+	}
+	if terminatedAt.IsZero() {
+		t.Fatal("flow_instances.terminated_at is zero")
+	}
+
+	instance, ok, err := store.Load(context.Background(), req.Instance.EntityID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance")
+	}
+	if got := strings.TrimSpace(instance.CurrentState); got != "completed" {
+		t.Fatalf("current_state = %q, want completed", got)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -228,6 +228,75 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 	}
 }
 
+func TestMaybeDeactivateTerminalFlowInstance_PassesTerminalStateToTemplateDeactivation(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "root",
+			InitialStage: "pending",
+			FlowTerminal: map[string][]string{
+				"review": {"completed"},
+			},
+			FlowPrefix: map[string]string{
+				"review": "review",
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"review": {Mode: "template"},
+		},
+	}
+	var got FlowInstanceDeactivationRequest
+	called := false
+	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &pipelineFixtureWorkflowModule{
+			source:   semanticview.Wrap(bundle),
+			workflow: NewWorkflowDefinition("root", []WorkflowStage{{Name: "pending"}, {Name: "completed", Terminal: true}}, nil),
+		},
+		InstanceDeactivator: func(_ context.Context, req FlowInstanceDeactivationRequest) error {
+			called = true
+			got = req
+			return nil
+		},
+	})
+
+	const flowPath = "review/inst-1"
+	entityID := FlowInstanceEntityID(flowPath)
+	const subjectID = "11111111-1111-1111-1111-111111111111"
+	const parentEntityID = "22222222-2222-2222-2222-222222222222"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      "inst-1",
+		SubjectID:       subjectID,
+		StorageRef:      flowPath,
+		WorkflowName:    "review",
+		WorkflowVersion: "v-test",
+		CurrentState:    "pending",
+		Metadata: map[string]any{
+			"entity_id":        entityID,
+			"instance_id":      "inst-1",
+			"flow_path":        flowPath,
+			"subject_id":       subjectID,
+			"parent_entity_id": parentEntityID,
+		},
+	}); err != nil {
+		t.Fatalf("seed template instance: %v", err)
+	}
+
+	if err := pc.maybeDeactivateTerminalFlowInstance(context.Background(), entityID, "completed"); err != nil {
+		t.Fatalf("maybeDeactivateTerminalFlowInstance: %v", err)
+	}
+	if !called {
+		t.Fatal("expected template flow deactivation")
+	}
+	if got.FinalState != "completed" {
+		t.Fatalf("FinalState = %q, want completed", got.FinalState)
+	}
+	if got.Instance.InstancePath != flowPath {
+		t.Fatalf("InstancePath = %q, want %q", got.Instance.InstancePath, flowPath)
+	}
+}
+
 func TestProjectWorkflowSubjectGatesRequiresCanonicalEntityID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	store := NewWorkflowInstanceStore(db)

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"strings"
+	"time"
 
 	"swarm/internal/events"
 	"swarm/internal/runtime/core/identity"
@@ -46,6 +47,7 @@ type WorkflowInstancePersistence interface {
 	Load(ctx context.Context, instanceID string) (WorkflowInstance, bool, error)
 	List(ctx context.Context) ([]WorkflowInstance, error)
 	Upsert(ctx context.Context, instance WorkflowInstance) error
+	MarkTerminated(ctx context.Context, instanceID string, terminatedAt time.Time) error
 	Mutate(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error
 	Delete(ctx context.Context, instanceID string) error
 }

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -172,6 +172,54 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 	return nil
 }
 
+func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	storageRef = strings.TrimSpace(storageRef)
+	if storageRef == "" {
+		return fmt.Errorf("workflow instance storage_ref is required")
+	}
+	if terminatedAt.IsZero() {
+		terminatedAt = time.Now().UTC()
+	}
+	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	committed := !ownedTx
+	if ownedTx {
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+	}
+	result, err := tx.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET status = 'terminated',
+		    terminated_at = COALESCE(terminated_at, $2)
+		WHERE instance_id = $1
+	`, storageRef, terminatedAt)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("flow instance not found: %s", storageRef)
+	}
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		committed = true
+	}
+	return nil
+}
+
 func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
 	return fmt.Errorf("workflow instance deletion is unsupported: entity_state writes must stay on the mutation-logged upsert path")
 }


### PR DESCRIPTION
Closes #186

## Human Summary
Template-flow terminal lifecycle now persists canonical terminal state directly into `flow_instances` instead of leaving terminal truth implicit in teardown behavior.

## What Changed
- added `MarkTerminated` to the workflow-instance persistence contract used by template-flow deactivation
- updated template-flow deactivation to persist `flow_instances.status = 'terminated'` and `terminated_at` before route/agent teardown
- implemented the terminal-state write in `WorkflowInstanceStore`
- added focused manager and pipeline regression coverage for terminal persistence and terminal deactivation handoff

## Why This Is Needed
Template flows could reach a real terminal outcome while `flow_instances` remained effectively active, forcing adjacent behavior to infer termination from teardown side effects. This change makes the canonical lifecycle owner write durable terminal truth into `flow_instances` in the terminal deactivation seam.

## Scope Boundaries
- scoped only to template-flow terminal persistence in the deactivation / workflow-instance-store seam
- does not redesign broader teardown flow
- does not add compatibility fallback or operator-surface cleanup

## Tests Run
- `go test ./internal/runtime/manager ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk
This change persists canonical terminal truth for the template-flow path covered here. If another unrelated seam bypasses template-flow deactivation entirely, it would still need its own explicit terminal-state write rather than relying on reconstruction.

## Follow-Up
No same-seam follow-up is required for this path after this change.
