### PR TITLE
[agent-c][issue #201] Keep conversation and turn persistence as historical ownership

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -99,6 +99,58 @@ func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *test
 	}
 }
 
+func TestConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    uuid.NewString(),
+		AgentID:      "agent-1",
+		Mode:         "session",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Messages:     []runtimellm.Message{{Role: "assistant", Content: "should fail"}},
+		Summary:      "should fail",
+		TurnCount:    1,
+		Status:       "active",
+	})
+	if err == nil {
+		t.Fatal("expected live conversation persistence without a live session row to fail")
+	}
+
+	taskSessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: taskSessionID,
+		AgentID:   "agent-1",
+		Mode:      "task",
+		Messages:  []runtimellm.Message{{Role: "assistant", Content: "done"}},
+		Summary:   "done",
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	reader := dashboardserver.NewSQLConversationReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLConversationReader returned nil")
+	}
+	items, err := reader.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("List conversations: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("conversation count = %d, want 1", len(items))
+	}
+	if items[0].Kind != "turn_audit" || items[0].SessionID != taskSessionID {
+		t.Fatalf("unexpected conversation summary: %+v", items[0])
+	}
+}
+
 func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -184,8 +184,20 @@ func assertConversationPersistenceBoundary(t *testing.T, ctx context.Context, pg
 			t.Fatalf("seed persisted agent: %v", err)
 		}
 	}
+	sessionID := uuid.NewString()
+	if strings.TrimSpace(tc.persistErrContains) == "" && !conversationModeOrTask(tc.actor).IsStateless() {
+		registry := runtimesessions.NewPostgresRegistry(pg.DB, 30*time.Second)
+		lease, err := registry.Acquire(ctx, tc.actor.ID, conversationModeOrTask(tc.actor), runtimesessions.NormalizeSessionScope(tc.actor.SessionScope), "conformance", tc.scopeKey())
+		if err != nil {
+			t.Fatalf("seed live session lease: %v", err)
+		}
+		sessionID = lease.SessionID
+		if err := registry.Release(ctx, lease); err != nil {
+			t.Fatalf("release seeded live session lease: %v", err)
+		}
+	}
 	rec := runtimellm.ConversationRecord{
-		SessionID:    uuid.NewString(),
+		SessionID:    sessionID,
 		AgentID:      tc.actor.ID,
 		SessionScope: tc.actor.SessionScope,
 		ScopeKey:     tc.scopeKey(),

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -592,12 +592,12 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	}
 	summary := strings.ToValidUTF8(rec.Summary, "\uFFFD")
 	sessionID := strings.TrimSpace(rec.SessionID)
-	if sessionID == "" {
-		sessionID = uuid.NewString()
-	}
 	runID := nullUUIDString(rec.RunID)
 
 	if resolved.Stateless {
+		if sessionID == "" {
+			sessionID = uuid.NewString()
+		}
 		if err := s.ensureConversationAuditTable(ctx); err != nil {
 			return err
 		}
@@ -721,105 +721,65 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if caps.Conversations.Sessions != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 	}
+	if sessionID == "" {
+		return fmt.Errorf("session_id is required for live session conversation persistence")
+	}
 
 	q := `
-		INSERT INTO agent_sessions (
-			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
-			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
-		)
-		VALUES (
-			COALESCE(NULLIF($11,''), gen_random_uuid()::text)::uuid,
-			$1,
-			NULLIF($2,'')::uuid,
-			NULLIF($3,''),
-			$4,
-			$5,
-			$6::jsonb,
-			$7,
-			$8,
-			jsonb_build_object('summary', NULLIF($9,'')),
-					$10,
-			now(),
-			now()
-		)
-		ON CONFLICT (agent_id, scope_key) DO UPDATE SET
-			entity_id = EXCLUDED.entity_id,
-			flow_instance = EXCLUDED.flow_instance,
-			scope = EXCLUDED.scope,
-			conversation = EXCLUDED.conversation,
-			turn_count = EXCLUDED.turn_count,
-			runtime_mode = EXCLUDED.runtime_mode,
-			runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($9,'')),
-			status = EXCLUDED.status,
+		UPDATE agent_sessions
+		SET conversation = $1::jsonb,
+			turn_count = $2,
+			runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($3,'')),
 			updated_at = now()
+		WHERE session_id = $4::uuid
+		  AND agent_id = $5
+		  AND scope_key = $6
+		  AND runtime_mode = $7
+		  AND status = 'active'
 	`
 	args := []any{
-		rec.AgentID,
-		resolved.EntityID,
-		resolved.FlowInstance,
-		resolved.ScopeKey,
-		resolved.Scope.String(),
 		string(msgJSON),
 		rec.TurnCount,
-		mode.String(),
 		summary,
-		status,
 		sessionID,
+		rec.AgentID,
+		resolved.ScopeKey,
+		mode.String(),
 	}
 	if caps.Conversations.SessionRunID {
 		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
 			return err
 		}
 		q = `
-			INSERT INTO agent_sessions (
-				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
-				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
-			)
-			VALUES (
-				COALESCE(NULLIF($12,''), gen_random_uuid()::text)::uuid,
-				NULLIF($11,'')::uuid,
-				$1,
-				NULLIF($2,'')::uuid,
-				NULLIF($3,''),
-				$4,
-				$5,
-				$6::jsonb,
-				$7,
-				$8,
-				jsonb_build_object('summary', NULLIF($9,'')),
-				$10,
-				now(),
-				now()
-			)
-			ON CONFLICT (agent_id, scope_key) DO UPDATE SET
-				run_id = COALESCE(EXCLUDED.run_id, agent_sessions.run_id),
-				entity_id = EXCLUDED.entity_id,
-				flow_instance = EXCLUDED.flow_instance,
-				scope = EXCLUDED.scope,
-				conversation = EXCLUDED.conversation,
-				turn_count = EXCLUDED.turn_count,
-				runtime_mode = EXCLUDED.runtime_mode,
-				runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($9,'')),
-				status = EXCLUDED.status,
+			UPDATE agent_sessions
+			SET conversation = $1::jsonb,
+				turn_count = $2,
+				runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($3,'')),
+				run_id = COALESCE(NULLIF($4,'')::uuid, run_id),
 				updated_at = now()
+			WHERE session_id = $5::uuid
+			  AND agent_id = $6
+			  AND scope_key = $7
+			  AND runtime_mode = $8
+			  AND status = 'active'
 		`
 		args = []any{
-			rec.AgentID,
-			resolved.EntityID,
-			resolved.FlowInstance,
-			resolved.ScopeKey,
-			resolved.Scope.String(),
 			string(msgJSON),
 			rec.TurnCount,
-			mode.String(),
 			summary,
-			status,
 			runID,
 			sessionID,
+			rec.AgentID,
+			resolved.ScopeKey,
+			mode.String(),
 		}
 	}
-	if _, err := s.DB.ExecContext(ctx, q, args...); err != nil {
-		return fmt.Errorf("upsert conversation: %w", err)
+	res, err := s.DB.ExecContext(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("update live conversation: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", rec.AgentID, sessionID, mode.String(), resolved.ScopeKey)
 	}
 	return nil
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -51,6 +51,19 @@ func resetAgentSessionsSpecTable(t *testing.T, ctx context.Context, pg *Postgres
 	}
 }
 
+func acquireLiveTestSession(t *testing.T, ctx context.Context, db *sql.DB, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, scopeKey string) string {
+	t.Helper()
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	lease, err := registry.Acquire(ctx, agentID, runtimeMode, sessionScope, "test-owner", scopeKey)
+	if err != nil {
+		t.Fatalf("Acquire(%s,%s,%s): %v", agentID, runtimeMode, scopeKey, err)
+	}
+	if err := registry.Release(ctx, lease); err != nil {
+		t.Fatalf("Release(%s,%s): %v", agentID, lease.SessionID, err)
+	}
+	return lease.SessionID
+}
+
 func seedSpecEntityState(t *testing.T, ctx context.Context, db execer, entityID, flowInstance, slug, name, state string) {
 	t.Helper()
 	if strings.TrimSpace(flowInstance) == "" {
@@ -1786,8 +1799,10 @@ func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
 	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
 		AgentID:      "a1",
 		Mode:         "session",
 		SessionScope: "global",
@@ -1812,16 +1827,6 @@ func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
 
 	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{AgentID: "a1", RuntimeMode: "session", SessionID: uuid.NewString()}); err == nil {
 		t.Fatalf("expected missing session row error")
-	}
-	var sessionID string
-	if err := db.QueryRowContext(ctx, `
-		SELECT session_id::text
-		FROM agent_sessions
-		WHERE agent_id = 'a1' AND scope_key = 'global'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`).Scan(&sessionID); err != nil {
-		t.Fatalf("load seeded agent_session: %v", err)
 	}
 	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
 		AgentID:        "a1",
@@ -1870,8 +1875,10 @@ func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t
 		FlowPath: "review/inst-1",
 		EntityID: entityID,
 	})
+	sessionID := acquireLiveTestSession(t, ctx, db, "entity-agent", runtimesessions.RuntimeModeSessionPerEntity, runtimesessions.SessionScopeEntity, entityID)
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
 		AgentID:      "entity-agent",
 		Mode:         "session_per_entity",
 		SessionScope: "entity",
@@ -1901,6 +1908,39 @@ func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t
 	}
 	if flowInstance != "review/inst-1" {
 		t.Fatalf("flow_instance = %q, want review/inst-1", flowInstance)
+	}
+}
+
+func TestManagerStore_LiveConversationPersistenceRequiresCanonicalLiveSession(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    uuid.NewString(),
+		AgentID:      "a1",
+		Mode:         "session",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Messages:     []llm.Message{{Role: "assistant", Content: "hello"}},
+		TurnCount:    1,
+		Status:       "active",
+	})
+	if err == nil {
+		t.Fatal("expected live conversation persistence without a live session row to fail")
+	}
+	if !strings.Contains(err.Error(), "no active live session row found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_sessions WHERE agent_id = 'a1'`).Scan(&count); err != nil {
+		t.Fatalf("count agent_sessions: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no live session rows to be created by conversation persistence, got %d", count)
 	}
 }
 
@@ -2090,8 +2130,10 @@ func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRo
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
 	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
 		AgentID:      "a1",
 		Mode:         "session",
 		SessionScope: "global",
@@ -2101,17 +2143,6 @@ func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRo
 		Status:       "active",
 	}); err != nil {
 		t.Fatalf("UpsertConversation(session): %v", err)
-	}
-
-	var sessionID string
-	if err := db.QueryRowContext(ctx, `
-		SELECT session_id::text
-		FROM agent_sessions
-		WHERE agent_id = 'a1' AND scope_key = 'global'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`).Scan(&sessionID); err != nil {
-		t.Fatalf("load seeded agent_session: %v", err)
 	}
 
 	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
@@ -2269,8 +2300,10 @@ func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
 		t.Fatalf("ensureConversationAuditTable: %v", err)
 	}
 	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
 		AgentID:      "a1",
 		Mode:         "session",
 		SessionScope: "global",
@@ -2282,17 +2315,6 @@ func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
 		Status:    "active",
 	}); err != nil {
 		t.Fatalf("UpsertConversation(session): %v", err)
-	}
-
-	var sessionID string
-	if err := db.QueryRowContext(ctx, `
-		SELECT session_id::text
-		FROM agent_sessions
-		WHERE agent_id = 'a1' AND runtime_mode = 'session'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`).Scan(&sessionID); err != nil {
-		t.Fatalf("load session row: %v", err)
 	}
 
 	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
@@ -2879,6 +2901,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	}
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
 		AgentID:      ceoID,
 		TaskID:       "",
 		Mode:         "session",
@@ -3001,6 +3024,7 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	}
 
 	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    acquireLiveTestSession(t, ctx, db, "agent-cleanup-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global"),
 		AgentID:      "agent-cleanup-1",
 		Mode:         "session",
 		SessionScope: "global",


### PR DESCRIPTION
Closes #201

## Human Summary
Session-bearing conversation persistence no longer creates or retargets live session rows. Live session ownership now stays with the canonical `agent_sessions` row created by the session registry, while task-mode audit persistence still writes historical records normally.

## What Changed
- changed live-session `UpsertConversation` to update only an existing active `agent_sessions` row by canonical live session identity
- removed the insert/upsert path that let session-bearing conversation persistence create or overwrite live session rows by `(agent_id, scope_key)`
- kept task-mode audit persistence unchanged as insert/upsert-driven historical storage in `agent_conversation_audits`
- updated store/conformance tests to seed live sessions through the canonical session registry before persisting session-mode conversation state
- added a cross-boundary regression proving failed live persistence does not surface as a dashboard live session while task audit persistence still appears as `turn_audit`

## Why This Is Needed
Before this change, historical conversation persistence could manufacture or retarget the live session owner, which blurred the ownership boundary between “what is active now” and “what happened”. The touched seam now fails closed unless the canonical live session row already exists.

## Scope Boundaries
- In scope:
  - session-bearing conversation persistence ownership at the store boundary
  - focused conformance/store coverage for the live-versus-audit split in this seam
  - dashboard reader verification that audit persistence still surfaces as audit only
- Not in scope:
  - broader `agent_sessions` redesign
  - unrelated dashboard cleanup
  - turn-history/live-state separation beyond this first ownership seam

## Tests Run
- `go test ./internal/store ./internal/runtime/conformance ./internal/dashboard/server ./internal/runtime/llm -count=1`
- `go test ./... -count=1`

## Residual Risk
- any caller that was incorrectly depending on session-mode `UpsertConversation` to create a live session row will now fail closed until it goes through the canonical session registry path first
- the live row still stores conversation and last-turn history; this PR only stops that historical write path from owning live session creation/retargeting

## Follow-Up
- broader narrowing of `agent_sessions` toward live-session ownership only remains separate work
- additional operator-surface cleanup around historical versus live fields should stay in a later issue unless it becomes a blocking same-seam dependency
