### PR TITLE
[agent-b][issue #186] Persist canonical terminal state in flow_instances for template flows

### DIFF
--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -815,6 +815,9 @@ func (pc *PipelineCoordinator) maybeDeactivateTerminalFlowInstance(ctx context.C
 	if !instanceIdentity.HasStoredPath {
 		return nil
 	}
+	if err := pc.workflowStore.MarkTerminated(ctx, instanceIdentity.InstancePath, time.Now().UTC()); err != nil {
+		return err
+	}
 	return pc.instanceDeactivator(ctx, FlowInstanceDeactivationRequest{
 		ContractBundle: source,
 		Instance:       instanceIdentity,

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -228,6 +228,92 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 	}
 }
 
+func TestMaybeDeactivateTerminalFlowInstance_PersistsCanonicalTerminalRegistryBeforeTeardown(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "root",
+			FlowTerminal: map[string][]string{
+				"review": {"done"},
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"review": {Mode: "template"},
+		},
+	}
+	storageRef := "review/inst-1"
+	entityID := FlowInstanceEntityID(storageRef)
+	seenDeactivation := false
+	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &pipelineFixtureWorkflowModule{
+			source:   semanticview.Wrap(bundle),
+			workflow: NewWorkflowDefinition("root", []WorkflowStage{{Name: "pending"}, {Name: "done", Terminal: true}}, nil),
+		},
+		InstanceDeactivator: func(_ context.Context, req FlowInstanceDeactivationRequest) error {
+			seenDeactivation = true
+			if got := req.Instance.InstancePath; got != storageRef {
+				t.Fatalf("instance path = %q, want %q", got, storageRef)
+			}
+			var (
+				status       string
+				terminatedAt time.Time
+			)
+			if err := db.QueryRowContext(context.Background(), `
+				SELECT status, terminated_at
+				FROM flow_instances
+				WHERE instance_id = $1
+			`, storageRef).Scan(&status, &terminatedAt); err != nil {
+				t.Fatalf("load flow_instances terminal row: %v", err)
+			}
+			if status != "terminated" {
+				t.Fatalf("flow_instances.status = %q, want terminated", status)
+			}
+			if terminatedAt.IsZero() {
+				t.Fatal("expected flow_instances.terminated_at to be set before teardown")
+			}
+			return nil
+		},
+	})
+
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		SubjectID:       "11111111-1111-1111-1111-111111111111",
+		StorageRef:      storageRef,
+		WorkflowName:    "review",
+		WorkflowVersion: "v-test",
+		CurrentState:    "pending",
+		Metadata: map[string]any{
+			"instance_id": entityID,
+			"flow_path":   storageRef,
+		},
+	}); err != nil {
+		t.Fatalf("seed template flow instance: %v", err)
+	}
+
+	if err := pc.maybeDeactivateTerminalFlowInstance(context.Background(), entityID, "done"); err != nil {
+		t.Fatalf("maybeDeactivateTerminalFlowInstance: %v", err)
+	}
+	if !seenDeactivation {
+		t.Fatal("expected template flow deactivation to run")
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load template flow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected template flow instance to persist")
+	}
+	if got := instance.RegistryStatus; got != "terminated" {
+		t.Fatalf("registry_status = %q, want terminated", got)
+	}
+	if instance.TerminatedAt.IsZero() {
+		t.Fatal("expected terminated_at on loaded workflow instance")
+	}
+}
+
 func TestProjectWorkflowSubjectGatesRequiresCanonicalEntityID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	store := NewWorkflowInstanceStore(db)

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -28,6 +28,8 @@ type WorkflowInstance struct {
 	StorageRef        string
 	WorkflowName      string
 	WorkflowVersion   string
+	RegistryStatus    string
+	TerminatedAt      time.Time
 	CurrentState      string
 	Config            map[string]any
 	EnteredStageAt    time.Time
@@ -176,18 +178,53 @@ func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
 	return fmt.Errorf("workflow instance deletion is unsupported: entity_state writes must stay on the mutation-logged upsert path")
 }
 
+func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	storageRef = strings.TrimSpace(storageRef)
+	if storageRef == "" {
+		return fmt.Errorf("workflow instance storage_ref is required")
+	}
+	if terminatedAt.IsZero() {
+		terminatedAt = time.Now().UTC()
+	} else {
+		terminatedAt = terminatedAt.UTC()
+	}
+	result, err := dbExecContext(ctx, s.db, `
+		UPDATE flow_instances
+		SET
+			status = 'terminated',
+			terminated_at = COALESCE(terminated_at, $2)
+		WHERE instance_id = $1
+	`, storageRef, terminatedAt)
+	if err != nil {
+		return fmt.Errorf("mark flow instance terminated %s: %w", storageRef, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("mark flow instance terminated %s rows affected: %w", storageRef, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("flow instance registry row not found for %s", storageRef)
+	}
+	return nil
+}
+
 func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, forUpdate bool) (WorkflowInstance, bool, error) {
 	var (
-		item         WorkflowInstance
-		gatesRaw     []byte
-		fieldsRaw    []byte
-		configRaw    []byte
-		accRaw       []byte
-		subjectID    sql.NullString
-		flowInstance string
-		entityType   string
-		slug         sql.NullString
-		name         sql.NullString
+		item           WorkflowInstance
+		gatesRaw       []byte
+		fieldsRaw      []byte
+		configRaw      []byte
+		accRaw         []byte
+		subjectID      sql.NullString
+		registryStatus sql.NullString
+		terminatedAt   sql.NullTime
+		flowInstance   string
+		entityType     string
+		slug           sql.NullString
+		name           sql.NullString
 	)
 	query := `
 		SELECT
@@ -195,6 +232,8 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 			es.subject_id::text,
 			COALESCE(fi.flow_template, ''),
 			COALESCE(fi.config->>'workflow_version', ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
 			es.current_state,
 			es.entered_state_at,
 			COALESCE(es.gates, '{}'::jsonb),
@@ -221,6 +260,8 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		&subjectID,
 		&item.WorkflowName,
 		&item.WorkflowVersion,
+		&registryStatus,
+		&terminatedAt,
 		&item.CurrentState,
 		&item.EnteredStageAt,
 		&gatesRaw,
@@ -241,6 +282,10 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		return WorkflowInstance{}, false, err
 	}
 	item.SubjectID = strings.TrimSpace(subjectID.String)
+	item.RegistryStatus = strings.TrimSpace(registryStatus.String)
+	if terminatedAt.Valid {
+		item.TerminatedAt = terminatedAt.Time.UTC()
+	}
 	if err := json.Unmarshal(accRaw, &item.StateBuckets); err != nil {
 		return WorkflowInstance{}, false, err
 	}
@@ -269,6 +314,8 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			es.subject_id::text,
 			COALESCE(fi.flow_template, ''),
 			COALESCE(fi.config->>'workflow_version', ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
 			es.current_state,
 			es.entered_state_at,
 			COALESCE(es.gates, '{}'::jsonb),
@@ -292,22 +339,26 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 	out := make([]WorkflowInstance, 0, 32)
 	for rows.Next() {
 		var (
-			item         WorkflowInstance
-			gatesRaw     []byte
-			fieldsRaw    []byte
-			configRaw    []byte
-			accRaw       []byte
-			subjectID    sql.NullString
-			flowInstance string
-			entityType   string
-			slug         sql.NullString
-			name         sql.NullString
+			item           WorkflowInstance
+			gatesRaw       []byte
+			fieldsRaw      []byte
+			configRaw      []byte
+			accRaw         []byte
+			subjectID      sql.NullString
+			registryStatus sql.NullString
+			terminatedAt   sql.NullTime
+			flowInstance   string
+			entityType     string
+			slug           sql.NullString
+			name           sql.NullString
 		)
 		if err := rows.Scan(
 			&item.InstanceID,
 			&subjectID,
 			&item.WorkflowName,
 			&item.WorkflowVersion,
+			&registryStatus,
+			&terminatedAt,
 			&item.CurrentState,
 			&item.EnteredStageAt,
 			&gatesRaw,
@@ -324,6 +375,10 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			return nil, err
 		}
 		item.SubjectID = strings.TrimSpace(subjectID.String)
+		item.RegistryStatus = strings.TrimSpace(registryStatus.String)
+		if terminatedAt.Valid {
+			item.TerminatedAt = terminatedAt.Time.UTC()
+		}
 		if err := json.Unmarshal(accRaw, &item.StateBuckets); err != nil {
 			return nil, err
 		}
@@ -399,7 +454,8 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			flow_template = EXCLUDED.flow_template,
 			mode = EXCLUDED.mode,
 			config = EXCLUDED.config,
-			status = CASE WHEN flow_instances.status = 'terminated' THEN flow_instances.status ELSE 'active' END
+			status = CASE WHEN flow_instances.status = 'terminated' THEN flow_instances.status ELSE 'active' END,
+			terminated_at = CASE WHEN flow_instances.status = 'terminated' THEN flow_instances.terminated_at ELSE NULL END
 	`, storageRef, instance.WorkflowName, mode, jsonOrDefault(configJSON, "{}")); err != nil {
 		return err
 	}

--- a/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
@@ -296,3 +296,74 @@ func workflowEvidenceEntries(t *testing.T, instance WorkflowInstance, bucketID s
 	}
 	return out
 }
+
+func TestWorkflowInstanceStoreMarkTerminated_PersistsCanonicalRegistryState(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	storageRef := "review/inst-1"
+	entityID := FlowInstanceEntityID(storageRef)
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		SubjectID:       "11111111-1111-1111-1111-111111111111",
+		StorageRef:      storageRef,
+		WorkflowName:    "review",
+		WorkflowVersion: "v-test",
+		CurrentState:    "pending",
+		Metadata: map[string]any{
+			"instance_id": entityID,
+			"flow_path":   storageRef,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	terminatedAt := time.Unix(1700000000, 0).UTC()
+	if err := store.MarkTerminated(context.Background(), storageRef, terminatedAt); err != nil {
+		t.Fatalf("MarkTerminated: %v", err)
+	}
+
+	instance, ok, err := store.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load terminated workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to exist")
+	}
+	if got := instance.RegistryStatus; got != "terminated" {
+		t.Fatalf("registry_status = %q, want terminated", got)
+	}
+	if got := instance.TerminatedAt.UTC(); !got.Equal(terminatedAt) {
+		t.Fatalf("terminated_at = %v, want %v", got, terminatedAt)
+	}
+
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		SubjectID:       "11111111-1111-1111-1111-111111111111",
+		StorageRef:      storageRef,
+		WorkflowName:    "review",
+		WorkflowVersion: "v-test",
+		CurrentState:    "done",
+		Metadata: map[string]any{
+			"instance_id": entityID,
+			"flow_path":   storageRef,
+		},
+	}); err != nil {
+		t.Fatalf("upsert after termination: %v", err)
+	}
+
+	reloaded, ok, err := store.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("reload terminated workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance after reload")
+	}
+	if got := reloaded.RegistryStatus; got != "terminated" {
+		t.Fatalf("reloaded registry_status = %q, want terminated", got)
+	}
+	if got := reloaded.TerminatedAt.UTC(); !got.Equal(terminatedAt) {
+		t.Fatalf("reloaded terminated_at = %v, want %v", got, terminatedAt)
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -123,6 +123,11 @@ ensureAgents:
 	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
 		return err
 	}
+	if catalog.hasTable("flow_instances") && !catalog.hasColumns("flow_instances", "terminated_at") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE flow_instances ADD COLUMN IF NOT EXISTS terminated_at TIMESTAMPTZ`); err != nil {
+			return fmt.Errorf("ensure flow_instances.terminated_at column: %w", err)
+		}
+	}
 	if !catalog.hasTable("entity_state") {
 		return nil
 	}


### PR DESCRIPTION
Closes #186

## Human Summary

This PR makes template-flow completion persist a canonical terminal proof in `flow_instances` before teardown runs. When a template flow reaches a terminal stage, the runtime now writes `status='terminated'` and `terminated_at` in the durable flow-instance registry instead of relying on route removal and agent cleanup alone as evidence that the flow finished.

## What Changed

- added explicit terminal registry fields to the workflow-instance load model so the runtime can read `flow_instances.status` and `terminated_at`
- added `WorkflowInstanceStore.MarkTerminated(...)` as the canonical store-side write for template-flow terminal registry state
- updated the flow-instance upsert path to preserve canonical terminal registry state and `terminated_at` once a flow is terminated
- updated the template-flow terminal path in `maybeDeactivateTerminalFlowInstance(...)` to persist canonical terminal registry state before invoking teardown
- added a narrow schema-compatibility migration to ensure `flow_instances.terminated_at` exists on older databases
- added focused regressions for:
  - durable terminal registry state persistence in the store seam
  - terminal registry state being visible before template-flow teardown runs in the pipeline seam

## Why This Is Needed

- `flow_instances` should be the durable owner of template-flow lifecycle
- before this change, template-flow cleanup could happen without the registry row ever proving terminal completion
- teardown effects are not a durable source of truth; persisted terminal state is what makes later recovery, debugging, and follow-on teardown alignment coherent

## Scope Boundaries

- In scope:
  - template-flow terminal registry writes in `flow_instances`
  - `terminated_at` persistence for canonical terminal proof
  - focused runtime/store tests for terminal registry agreement in the touched seam
- Not in scope:
  - broader route or agent teardown parity work
  - general workflow lifecycle redesign
  - operator-surface read-model expansion

## Tests Run

- `go test ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR deliberately stops at canonical terminal registry proof; route teardown and flow-scoped agent cleanup still need the follow-on alignment work from `#187`
- the compatibility column addition is narrow, but environments with heavily drifted custom `flow_instances` schemas beyond `terminated_at` are still out of scope for this change

## Follow-Up

- `#187` should now align template-flow teardown with the canonical `flow_instances` terminal owner instead of inferred terminal behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Workflows now properly record termination status and timestamp in the system registry before deactivation completes, improving state tracking accuracy and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->