### PR TITLE
[agent-a][issue #129] Introduce one canonical operator projection for agent health and backlog

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -48,19 +48,20 @@ func (r *SQLAgentReader) ListGenericAgents(ctx context.Context) ([]genericAgent,
 	if r == nil || r.db == nil || len(items) == 0 {
 		return items, nil
 	}
-	aggregates, err := r.loadAggregates(ctx)
+	projections, err := r.loadOperatorProjections(ctx)
 	if err != nil {
 		return nil, err
 	}
-	for i := range items {
-		aggregate, ok := aggregates[items[i].ID]
+	out := make([]genericAgent, 0, len(items))
+	for _, item := range items {
+		projection, ok := projections[item.ID]
 		if !ok {
-			items[i].State = deriveGenericAgentState(items[i], agentRuntimeAggregate{})
-			continue
+			return nil, fmt.Errorf("missing agent operator projection: %s", strings.TrimSpace(item.ID))
 		}
-		applyAggregate(&items[i], aggregate, r.turnLimit)
+		applyOperatorProjection(&item, projection, r.turnLimit)
+		out = append(out, item)
 	}
-	return items, nil
+	return out, nil
 }
 
 func (r *SQLAgentReader) GetGenericAgent(ctx context.Context, id string) (genericAgent, bool, error) {
@@ -80,7 +81,8 @@ func (r *SQLAgentReader) GetGenericAgent(ctx context.Context, id string) (generi
 	return genericAgent{}, false, nil
 }
 
-type agentRuntimeAggregate struct {
+type agentOperatorProjection struct {
+	Status              string
 	PendingEvents       int
 	OldestPendingAgeSec int
 	LockOwner           string
@@ -95,7 +97,7 @@ type agentRuntimeAggregate struct {
 	LastTool            map[string]any
 }
 
-func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRuntimeAggregate, error) {
+func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[string]agentOperatorProjection, error) {
 	caps, err := r.resolveCapabilities(ctx)
 	if err != nil {
 		return nil, err
@@ -107,6 +109,7 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			a.agent_id,
+			COALESCE(a.status, 'active'),
 			COALESCE(sess.turn_count, 0),
 			COALESCE(sess.lease_holder, ''),
 			sess.lease_expires_at,
@@ -171,15 +174,15 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 		ORDER BY a.created_at ASC, a.agent_id ASC
 	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
 	if err != nil {
-		return nil, fmt.Errorf("query agent aggregates: %w", err)
+		return nil, fmt.Errorf("query agent operator projections: %w", err)
 	}
 	defer rows.Close()
 
-	out := map[string]agentRuntimeAggregate{}
+	out := map[string]agentOperatorProjection{}
 	for rows.Next() {
 		var (
 			id            string
-			aggregate     agentRuntimeAggregate
+			projection    agentOperatorProjection
 			lockExpiresAt sql.NullTime
 			latestTaskID  string
 			latestParseOK bool
@@ -187,33 +190,34 @@ func (r *SQLAgentReader) loadAggregates(ctx context.Context) (map[string]agentRu
 		)
 		if err := rows.Scan(
 			&id,
-			&aggregate.TurnCount,
-			&aggregate.LockOwner,
+			&projection.Status,
+			&projection.TurnCount,
+			&projection.LockOwner,
 			&lockExpiresAt,
-			&aggregate.PendingEvents,
-			&aggregate.OldestPendingAgeSec,
-			&aggregate.Failures24h,
-			&aggregate.DeadLetters24h,
-			&aggregate.Turns24h,
+			&projection.PendingEvents,
+			&projection.OldestPendingAgeSec,
+			&projection.Failures24h,
+			&projection.DeadLetters24h,
+			&projection.Turns24h,
 			&latestTaskID,
 			&latestParseOK,
 			&latestTurnRaw,
 		); err != nil {
-			return nil, fmt.Errorf("scan agent aggregate: %w", err)
+			return nil, fmt.Errorf("scan agent operator projection: %w", err)
 		}
 		if lockExpiresAt.Valid {
-			aggregate.LockExpiresAt = lockExpiresAt.Time
-			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(aggregate.LockOwner) != "" {
-				aggregate.InFlightTurn = true
+			projection.LockExpiresAt = lockExpiresAt.Time
+			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(projection.LockOwner) != "" {
+				projection.InFlightTurn = true
 			}
 		}
-		if err := enrichAgentAggregateFromLatestTurn(&aggregate, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
+		if err := enrichAgentOperatorProjectionFromLatestTurn(&projection, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
 			return nil, err
 		}
-		out[strings.TrimSpace(id)] = aggregate
+		out[strings.TrimSpace(id)] = projection
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read agent aggregate rows: %w", err)
+		return nil, fmt.Errorf("read agent operator projection rows: %w", err)
 	}
 	return out, nil
 }
@@ -234,54 +238,55 @@ func (r *SQLAgentReader) resolveCapabilities(ctx context.Context) (store.StoreSc
 	}, nil
 }
 
-func applyAggregate(agent *genericAgent, aggregate agentRuntimeAggregate, turnLimit int) {
+func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjection, turnLimit int) {
 	if agent == nil {
 		return
 	}
-	agent.PendingEvents = aggregate.PendingEvents
-	agent.OldestPendingAgeSec = aggregate.OldestPendingAgeSec
-	agent.LockOwner = strings.TrimSpace(aggregate.LockOwner)
-	agent.LockExpiresAt = formatTime(aggregate.LockExpiresAt)
-	agent.InFlightTurn = aggregate.InFlightTurn
-	agent.InFlightSeconds = aggregate.InFlightSeconds
-	agent.Failures24h = aggregate.Failures24h
-	agent.DeadLetters24h = aggregate.DeadLetters24h
-	agent.TurnCount = aggregate.TurnCount
+	agent.Status = strings.TrimSpace(projection.Status)
+	agent.PendingEvents = projection.PendingEvents
+	agent.OldestPendingAgeSec = projection.OldestPendingAgeSec
+	agent.LockOwner = strings.TrimSpace(projection.LockOwner)
+	agent.LockExpiresAt = formatTime(projection.LockExpiresAt)
+	agent.InFlightTurn = projection.InFlightTurn
+	agent.InFlightSeconds = projection.InFlightSeconds
+	agent.Failures24h = projection.Failures24h
+	agent.DeadLetters24h = projection.DeadLetters24h
+	agent.TurnCount = projection.TurnCount
 	agent.TurnLimit = maxInt(turnLimit, 0)
-	agent.Turns24h = maxInt(aggregate.Turns24h, 0)
-	agent.CurrentTaskID = strings.TrimSpace(aggregate.CurrentTaskID)
-	agent.LastTool = aggregate.LastTool
+	agent.Turns24h = maxInt(projection.Turns24h, 0)
+	agent.CurrentTaskID = strings.TrimSpace(projection.CurrentTaskID)
+	agent.LastTool = projection.LastTool
 	if agent.TurnLimit > 0 {
 		agent.NearBreaker = agent.TurnCount*100 >= agent.TurnLimit*85
 	}
-	agent.State = deriveGenericAgentState(*agent, aggregate)
+	agent.State = projection.state()
 }
 
-func deriveGenericAgentState(agent genericAgent, aggregate agentRuntimeAggregate) string {
-	status := strings.ToLower(strings.TrimSpace(agent.Status))
+func (p agentOperatorProjection) state() string {
+	status := strings.ToLower(strings.TrimSpace(p.Status))
 	if status == "terminated" {
 		return "terminated"
 	}
-	if aggregate.InFlightTurn {
+	if p.InFlightTurn {
 		return "running"
 	}
-	if aggregate.DeadLetters24h > 0 || aggregate.Failures24h > 0 {
+	if p.DeadLetters24h > 0 || p.Failures24h > 0 {
 		return "stuck"
 	}
 	return "idle"
 }
 
-func enrichAgentAggregateFromLatestTurn(aggregate *agentRuntimeAggregate, taskID string, parseOK bool, turnBlocksRaw []byte) error {
-	if aggregate == nil {
+func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjection, taskID string, parseOK bool, turnBlocksRaw []byte) error {
+	if projection == nil {
 		return nil
 	}
-	aggregate.CurrentTaskID = strings.TrimSpace(taskID)
+	projection.CurrentTaskID = strings.TrimSpace(taskID)
 	summary, ok, err := decodeTurnSummaryProjection(turnBlocksRaw)
 	if err != nil {
 		return fmt.Errorf("decode latest agent turn turn_summary: %w", err)
 	}
 	if ok {
-		aggregate.LastTool = summary.lastToolMap(parseOK)
+		projection.LastTool = summary.lastToolMap(parseOK)
 	}
 	return nil
 }

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -667,9 +667,9 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
 			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(turnBlocksPayload)))
+		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -725,9 +725,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
 			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -776,14 +776,112 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
 			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "terminated",
+		}},
+		caps: store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", 7, "lease-owner", time.Now().Add(time.Minute), 2, 45, 0, 0, 0, "task-7", false, []byte(`[]`)))
+
+	items, err := reader.ListGenericAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].Status != "active" {
+		t.Fatalf("status = %q, want active from operator projection", items[0].Status)
+	}
+	if items[0].State != "running" {
+		t.Fatalf("state = %q, want running from operator projection", items[0].State)
+	}
+	if items[0].PendingEvents != 2 {
+		t.Fatalf("pending_events = %d, want 2", items[0].PendingEvents)
+	}
+	if items[0].CurrentTaskID != "task-7" {
+		t.Fatalf("current_task_id = %q, want task-7", items[0].CurrentTaskID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: store.StoreSchemaCapabilities{
+			Conversations: store.ConversationSchemaCapabilities{
+				Sessions:   store.SchemaFlavorCanonical,
+				Turns:      store.SchemaFlavorCanonical,
+				TurnBlocks: true,
+			},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}))
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent operator projection") {
+		t.Fatalf("expected missing agent operator projection error, got %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}


### PR DESCRIPTION
Closes #129

## Human Summary
The dashboard agent card now reads health, backlog, current task, and last tool from one explicit operator projection instead of mixing a base agent row with separate SQL runtime fragments.

## What Changed
- replaced the old aggregate/fallback assembly in `SQLAgentReader` with one explicit `agentOperatorProjection` owner
- moved operator-card status/state, backlog, lease, failure, current-task, and last-tool fields behind that projection
- removed the fallback that derived card state from the base `PersistedAgent` row when SQL operator data was missing
- made the reader fail closed if a listed agent has no operator projection
- added focused regressions proving projection precedence and missing-projection failure behavior

## Why This Is Needed
The old path mixed live session lease data, backlog counters, receipt outcomes, and latest-turn details from SQL with card state derived partly from the base agent row. That allowed stale or contradictory combinations to surface on one operator-visible card. This change gives the touched agent health/backlog surface one canonical projection owner.

## Scope Boundaries
- In scope:
  - `internal/dashboard/server/agents_sql.go`
  - focused dashboard/server tests for agent operator projection behavior
- Not in scope:
  - general dashboard redesign
  - receipt or delivery surface cleanup outside this agent card seam
  - broader operator read-model refactors

## Tests Run
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_ListGenericAgents_' -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
This unifies the touched operator-card seam, but it still relies on the underlying SQL subqueries against sessions, turns, deliveries, and receipts. If the project later wants one persisted operator read model instead of one SQL projection, that would be a broader follow-up.

## Follow-Up
No narrow same-seam follow-up is required for this card projection path after this change.
