### PR TITLE
[agent-a][issue #130] Preserve retryable-vs-terminal receipt outcome in canonical operator surfaces

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -146,29 +146,24 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 		) latest_turn ON true
 		LEFT JOIN LATERAL (
 			SELECT
-				COUNT(*)::int AS pending_count,
-				COALESCE(MAX(EXTRACT(EPOCH FROM now() - e.created_at))::int, 0) AS oldest_pending_age_sec
+				COUNT(*) FILTER (WHERE d.status IN ('pending', 'failed'))::int AS pending_count,
+				COALESCE(MAX(CASE
+					WHEN d.status IN ('pending', 'failed') THEN EXTRACT(EPOCH FROM now() - e.created_at)
+					ELSE NULL
+				END)::int, 0) AS oldest_pending_age_sec
 			FROM event_deliveries d
 			INNER JOIN events e ON e.event_id = d.event_id
-			LEFT JOIN event_receipts r
-				ON r.event_id = d.event_id
-				AND r.subscriber_type = 'agent'
-				AND r.subscriber_id = d.subscriber_id
 			WHERE d.subscriber_type = 'agent'
 			  AND d.subscriber_id = a.agent_id
-			  AND (
-					r.event_id IS NULL
-					OR COALESCE(r.side_effects->>'manager_status', '') = 'error'
-				)
 		) p ON true
 		LEFT JOIN LATERAL (
 			SELECT
-				COUNT(*) FILTER (WHERE outcome = 'error')::int AS failures_24h,
-				COUNT(*) FILTER (WHERE outcome = 'dead_letter')::int AS dead_letters_24h
-			FROM event_receipts
+				COUNT(*) FILTER (WHERE status = 'failed')::int AS failures_24h,
+				COUNT(*) FILTER (WHERE status = 'dead_letter')::int AS dead_letters_24h
+			FROM event_deliveries
 			WHERE subscriber_type = 'agent'
 			  AND subscriber_id = a.agent_id
-			  AND processed_at >= now() - interval '24 hours'
+			  AND COALESCE(delivered_at, created_at) >= now() - interval '24 hours'
 		) f ON true
 		WHERE a.status NOT IN ('terminated', 'ephemeral')
 		ORDER BY a.created_at ASC, a.agent_id ASC

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/events"
@@ -22,6 +23,7 @@ import (
 	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
+	"swarm/internal/testutil"
 )
 
 type builderRPCResponse = builderpkg.RPCResponse
@@ -884,6 +886,89 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_PreservesRetryableVsTerminalDeliveryOutcome(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:     "agent-1",
+			Role:   "researcher",
+			Mode:   "global",
+			Type:   "managed",
+			Config: json.RawMessage(`{"system_prompt":"You are an operator agent."}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	failedEventID := uuid.NewString()
+	deadEventID := uuid.NewString()
+	for _, eventID := range []string{failedEventID, deadEventID} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'task.completed', 'global', '{}'::jsonb, 'runtime', 'agent', now() - interval '5 minutes'
+			)
+		`, eventID, runID); err != nil {
+			t.Fatalf("seed event %s: %v", eventID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, last_error, delivered_at, created_at
+		) VALUES
+			($1::uuid, $2::uuid, 'agent', 'agent-1', 'failed', 1, 'retryable-failure', now() - interval '2 minutes', now() - interval '5 minutes'),
+			($1::uuid, $3::uuid, 'agent', 'agent-1', 'dead_letter', 2, 'terminal-dead-letter', now() - interval '1 minute', now() - interval '6 minutes')
+	`, runID, failedEventID, deadEventID); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, side_effects, processed_at
+		) VALUES
+			($1::uuid, 'agent', 'agent-1', 'dead_letter', '{"manager_status":"error","retry_count":1,"error":"retryable-failure"}'::jsonb, now()),
+			($2::uuid, 'agent', 'agent-1', 'success', '{"manager_status":"dead_letter","retry_count":2,"error":"terminal-dead-letter"}'::jsonb, now())
+	`, failedEventID, deadEventID); err != nil {
+		t.Fatalf("seed conflicting receipts: %v", err)
+	}
+
+	reader := NewSQLAgentReader(db, pg, 12)
+	items, err := reader.ListGenericAgents(ctx)
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].PendingEvents != 1 {
+		t.Fatalf("pending_events = %d, want 1 retryable failed delivery", items[0].PendingEvents)
+	}
+	if items[0].Failures24h != 1 {
+		t.Fatalf("failures_24h = %d, want 1 failed delivery", items[0].Failures24h)
+	}
+	if items[0].DeadLetters24h != 1 {
+		t.Fatalf("dead_letters_24h = %d, want 1 dead-letter delivery", items[0].DeadLetters24h)
+	}
+	if items[0].State != "stuck" {
+		t.Fatalf("state = %q, want stuck", items[0].State)
 	}
 }
 

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -50,6 +50,73 @@ func TestUpsertEventReceipt_DeadLettersAfterOneRetry_V2(t *testing.T) {
 	}
 }
 
+func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.retry_delivery_status")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert retryable error: %v", err)
+	}
+
+	var (
+		deliveryStatus string
+		reasonCode     string
+		deliveryRetry  int
+		managerStatus  string
+	)
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(r.side_effects->>'manager_status', '')
+		FROM event_deliveries d
+		INNER JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &reasonCode, &deliveryRetry, &managerStatus); err != nil {
+		t.Fatalf("query retryable delivery status: %v", err)
+	}
+	if deliveryStatus != "failed" || managerStatus != "error" || deliveryRetry != 1 || reasonCode != "handler_error" {
+		t.Fatalf("retryable status mismatch: delivery=%q manager=%q retry=%d reason=%q", deliveryStatus, managerStatus, deliveryRetry, reasonCode)
+	}
+
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert terminal error: %v", err)
+	}
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(r.side_effects->>'manager_status', '')
+		FROM event_deliveries d
+		INNER JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &reasonCode, &deliveryRetry, &managerStatus); err != nil {
+		t.Fatalf("query terminal delivery status: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || managerStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" {
+		t.Fatalf("terminal status mismatch: delivery=%q manager=%q retry=%d reason=%q", deliveryStatus, managerStatus, deliveryRetry, reasonCode)
+	}
+}
+
 func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()


### PR DESCRIPTION
Closes #130

## Human Summary
Operator-visible agent failure surfaces now preserve retryable failure versus terminal dead-letter semantics instead of letting conflicting receipt rows collapse those meanings together.

## What Changed
- updated the dashboard agent operator projection to use `event_deliveries.status` as the canonical operator owner for backlog, retryable failure, and dead-letter counts
- removed the mixed receipt-side-effect / receipt-outcome logic from the agent card projection query
- added a store regression proving `UpsertEventReceipt` preserves retryable `failed` delivery state on first error and terminal `dead_letter` state only after retry exhaustion
- added a real-Postgres dashboard regression proving conflicting receipt rows no longer override the surfaced retryable-versus-terminal distinction

## Why This Is Needed
The operator surface had drifted into a split-owner model: observability already trusted delivery rows, while the agent card mixed receipt side effects and receipt outcome. Because the generic receipt outcome enum cannot represent retryable agent error directly, that split allowed retryable failure pressure to be flattened or contradicted on operator-visible cards. This change puts the touched operator readers on one canonical persisted owner path.

## Scope Boundaries
- In scope:
  - receipt/delivery parity for the touched operator-facing agent health/backlog surface
  - focused store and dashboard regressions for retryable-versus-terminal distinction
- Not in scope:
  - general delivery lifecycle redesign
  - unrelated dashboard cleanup
  - broader receipt model or spec changes

## Tests Run
- `go test ./internal/store -run 'TestUpsertEventReceipt_(DeadLettersAfterOneRetry_V2|PreservesRetryableVsTerminalDeliveryStatus_V2)$' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_ListGenericAgents_(PreservesRetryableVsTerminalDeliveryOutcome|UsesOperatorProjectionAsCanonicalOwner|FailsClosedWithoutOperatorProjection)$' -count=1`
- `go test ./internal/dashboard/server ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk
The agent card and observability event surfaces are now aligned on delivery status, but the generic `event_receipts.outcome` column still cannot encode retryable agent error under the current platform schema. That is why this PR keeps the distinction on the canonical operator read-model path instead of trying to invent a new outcome value.

## Follow-Up
No narrow same-seam follow-up is required for the touched operator surfaces after this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of agent delivery status tracking by refining how pending deliveries, failures, and dead-letter states are calculated in the dashboard.
  * Enhanced distinction between retryable and terminal delivery failures for clearer visibility into agent health and delivery outcomes.

* **Tests**
  * Added test coverage for delivery status preservation across retryable and terminal failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->