### PR TITLE
[agent-b][issue #143] Drain in-flight work before runtime shutdown

### DIFF
--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -39,6 +39,7 @@ type AgentManager struct {
 
 	runMu              sync.Mutex
 	running            bool
+	shuttingDown       bool
 	authBreakerTripped bool
 	runCtx             context.Context
 	cancelRun          context.CancelFunc

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -366,14 +366,13 @@ func (am *AgentManager) killPreviousRuns(ctx context.Context, producerID string)
 
 func (am *AgentManager) Run(ctx context.Context) {
 	am.runMu.Lock()
-	if am.running {
+	if am.running || am.shuttingDown {
 		am.runMu.Unlock()
 		return
 	}
 	runRoot := runtimebus.WithRuntimeEpoch(ctx, runtimebus.CurrentRuntimeEpoch())
 	am.runCtx, am.cancelRun = context.WithCancel(runRoot)
 	am.running = true
-	am.shuttingDown = false
 	am.authBreakerTripped = false
 	am.runMu.Unlock()
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -50,6 +50,23 @@ func (am *AgentManager) RestartAgent(agentID string) error {
 }
 
 func (am *AgentManager) Shutdown() error {
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), managerShutdownTimeout)
+	defer cancelDrain()
+
+	am.runMu.Lock()
+	if am.shuttingDown {
+		am.runMu.Unlock()
+		return am.waitForRunShutdown()
+	}
+	am.shuttingDown = true
+	am.running = false
+	am.runMu.Unlock()
+
+	var shutdownErr error
+	if err := am.WaitForQuiescence(drainCtx); err != nil {
+		shutdownErr = fmt.Errorf("agent manager shutdown drain timed out after %s", managerShutdownTimeout)
+	}
+
 	am.runMu.Lock()
 	if am.cancelRun != nil {
 		am.cancelRun()
@@ -59,20 +76,17 @@ func (am *AgentManager) Shutdown() error {
 		cancel()
 		delete(am.loopCancel, id)
 	}
-	am.running = false
 	am.runMu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		am.runWG.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-		return nil
-	case <-time.After(managerShutdownTimeout):
-		return fmt.Errorf("agent manager shutdown timed out after %s", managerShutdownTimeout)
+	if err := am.waitForRunShutdown(); err != nil {
+		if shutdownErr == nil {
+			shutdownErr = err
+		}
 	}
+	am.runMu.Lock()
+	am.shuttingDown = false
+	am.runMu.Unlock()
+	return shutdownErr
 }
 
 func (am *AgentManager) Count() int {
@@ -85,6 +99,29 @@ func (am *AgentManager) IsRunning() bool {
 	am.runMu.Lock()
 	defer am.runMu.Unlock()
 	return am.running
+}
+
+func (am *AgentManager) isShuttingDown() bool {
+	if am == nil {
+		return false
+	}
+	am.runMu.Lock()
+	defer am.runMu.Unlock()
+	return am.shuttingDown
+}
+
+func (am *AgentManager) waitForRunShutdown() error {
+	done := make(chan struct{})
+	go func() {
+		am.runWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(managerShutdownTimeout):
+		return fmt.Errorf("agent manager shutdown timed out after %s", managerShutdownTimeout)
+	}
 }
 
 func (am *AgentManager) GetAgentConfig(agentID string) (runtimeactors.AgentConfig, bool) {
@@ -336,6 +373,7 @@ func (am *AgentManager) Run(ctx context.Context) {
 	runRoot := runtimebus.WithRuntimeEpoch(ctx, runtimebus.CurrentRuntimeEpoch())
 	am.runCtx, am.cancelRun = context.WithCancel(runRoot)
 	am.running = true
+	am.shuttingDown = false
 	am.authBreakerTripped = false
 	am.runMu.Unlock()
 
@@ -467,6 +505,9 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 	am.mu.RUnlock()
 
 	for _, id := range ids {
+		if am.isShuttingDown() {
+			return nil
+		}
 		if am.isAuthBreakerTripped() {
 			return nil
 		}
@@ -488,6 +529,9 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) error {
 	if am.store == nil {
 		return fmt.Errorf("manager store unavailable")
+	}
+	if am.isShuttingDown() {
+		return nil
 	}
 	if am.isAuthBreakerTripped() {
 		return nil
@@ -691,6 +735,9 @@ func (am *AgentManager) startAgentLoop(parent context.Context, agent Agent) {
 						return
 					case evt, ok := <-ch:
 						if !ok {
+							return
+						}
+						if am.isShuttingDown() {
 							return
 						}
 						evtCtx := runtimecorrelation.WithInboundEvent(loopCtx, evt)

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -1,0 +1,215 @@
+package manager
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+)
+
+type shutdownTestAgent struct {
+	id            string
+	subscriptions []events.EventType
+	onEvent       func(context.Context, events.Event) ([]events.Event, error)
+}
+
+func (a shutdownTestAgent) ID() string { return a.id }
+func (shutdownTestAgent) Type() string { return "test" }
+func (a shutdownTestAgent) Subscriptions() []events.EventType {
+	return append([]events.EventType(nil), a.subscriptions...)
+}
+func (a shutdownTestAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Event, error) {
+	return a.onEvent(ctx, evt)
+}
+
+func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	outputs := bus.Subscribe("observer", events.EventType("test.out"))
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	ctxErrCh := make(chan error, 1)
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				ctxErrCh <- ctx.Err()
+				return nil, ctx.Err()
+			}
+			ctxErrCh <- ctx.Err()
+			return []events.Event{{
+				ID:          "evt-out-1",
+				Type:        events.EventType("test.out"),
+				SourceAgent: "agent-1",
+				CreatedAt:   time.Now().UTC(),
+			}}, nil
+		},
+	}
+
+	am := NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		if cfg.ID != agent.id {
+			t.Fatalf("unexpected agent id: %q", cfg.ID)
+		}
+		return agent, nil
+	})
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight work to start")
+	}
+
+	shutdownErrCh := make(chan error, 1)
+	go func() {
+		shutdownErrCh <- am.Shutdown()
+	}()
+
+	select {
+	case err := <-shutdownErrCh:
+		t.Fatalf("Shutdown returned before in-flight work drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-ctxErrCh:
+		if err != nil {
+			t.Fatalf("OnEvent context canceled during shutdown drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnEvent completion")
+	}
+
+	select {
+	case evt := <-outputs:
+		if got := string(evt.Type); got != "test.out" {
+			t.Fatalf("output event type = %q, want test.out", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for output publish during shutdown")
+	}
+
+	select {
+	case err := <-shutdownErrCh:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown to finish")
+	}
+}
+
+func TestShutdown_DoesNotStartQueuedWorkAfterDrainBegins(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	firstStarted := make(chan struct{}, 1)
+	releaseFirst := make(chan struct{})
+	var processed atomic.Int32
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			n := processed.Add(1)
+			if n == 1 {
+				select {
+				case firstStarted <- struct{}{}:
+				default:
+				}
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return nil, nil
+		},
+	}
+
+	am := NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	})
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	for _, eventID := range []string{"evt-in-1", "evt-in-2"} {
+		if err := bus.Publish(context.Background(), events.Event{
+			ID:          eventID,
+			Type:        events.EventType("test.in"),
+			SourceAgent: "tester",
+			CreatedAt:   time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("Publish(%s): %v", eventID, err)
+		}
+	}
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first event to start")
+	}
+
+	shutdownErrCh := make(chan error, 1)
+	go func() {
+		shutdownErrCh <- am.Shutdown()
+	}()
+
+	select {
+	case err := <-shutdownErrCh:
+		t.Fatalf("Shutdown returned before in-flight work drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	select {
+	case err := <-shutdownErrCh:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown to finish")
+	}
+
+	if got := processed.Load(); got != 1 {
+		t.Fatalf("processed events = %d, want 1 after shutdown drain", got)
+	}
+}

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -213,3 +213,103 @@ func TestShutdown_DoesNotStartQueuedWorkAfterDrainBegins(t *testing.T) {
 		t.Fatalf("processed events = %d, want 1 after shutdown drain", got)
 	}
 }
+
+func TestShutdown_DoesNotAllowRunToReplaceActiveRunContextDuringDrain(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	firstStarted := make(chan struct{}, 1)
+	releaseFirst := make(chan struct{})
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case firstStarted <- struct{}{}:
+			default:
+			}
+			select {
+			case <-releaseFirst:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, nil
+		},
+	}
+
+	am := NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	})
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	am.runMu.Lock()
+	initialRunCtx := am.runCtx
+	am.runMu.Unlock()
+	if initialRunCtx == nil {
+		t.Fatal("expected initial run context")
+	}
+
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first event to start")
+	}
+
+	shutdownErrCh := make(chan error, 1)
+	go func() {
+		shutdownErrCh <- am.Shutdown()
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !am.isShuttingDown() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for shutdown drain to begin")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	am.Run(context.Background())
+
+	am.runMu.Lock()
+	currentRunCtx := am.runCtx
+	running := am.running
+	shuttingDown := am.shuttingDown
+	am.runMu.Unlock()
+	if currentRunCtx != initialRunCtx {
+		t.Fatal("Run replaced the active run context during shutdown drain")
+	}
+	if running {
+		t.Fatal("Run reopened manager during shutdown drain")
+	}
+	if !shuttingDown {
+		t.Fatal("shutdown drain state was cleared by concurrent Run")
+	}
+
+	close(releaseFirst)
+
+	select {
+	case err := <-shutdownErrCh:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown to finish")
+	}
+}


### PR DESCRIPTION
Closes #143

## Human Summary

This PR changes the runtime shutdown path so active agent work is allowed to finish before shutdown tears down the manager loop context. Instead of canceling agent loop contexts immediately, shutdown now enters a drain phase, lets the currently in-flight callback finish, and only then completes loop cancellation and shutdown.

## What Changed

- added explicit `shuttingDown` manager state for the shutdown drain phase
- updated `AgentManager.Shutdown()` to:
  - enter drain mode
  - wait for the tracked in-flight event set to reach zero
  - only then cancel the run context and wait for loop teardown
- updated agent loop processing to stop starting new work after shutdown drain begins
- updated pending replay paths to stop starting backlog work once shutdown is in progress
- added focused regressions for:
  - active `OnEvent` work finishing without its loop context being canceled during shutdown
  - queued follow-up work not starting once shutdown drain begins

## Why This Is Needed

- the old shutdown path canceled the manager run context immediately
- that meant active `OnEvent` work could observe cancellation while runtime shutdown was tearing down the manager dependencies underneath it
- draining the in-flight set first makes shutdown ordering explicit and removes the active-work-versus-shutdown race in the touched seam

## Scope Boundaries

- In scope:
  - agent-manager shutdown ordering
  - preventing new manager work from starting once shutdown drain begins
  - focused shutdown regressions for active and queued work in the touched seam
- Not in scope:
  - general runtime lifecycle redesign
  - backlog/operator surface changes
  - broader queue semantics outside manager shutdown

## Tests Run

- `go test ./internal/runtime/manager -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR keeps the fix at the manager shutdown seam; other runtime components that may need their own explicit drain/stop contracts should be handled separately if they surface as independent shutdown owners
- queued in-memory deliveries that are not started before shutdown are intentionally not processed in this runtime; they remain outside this PR's scope unless a canonical restart/replay contract for that exact path is required

## Follow-Up

- if another shutdown owner outside the manager seam still tears down dependencies without an explicit drain contract, that should be addressed as a separate lifecycle issue rather than folded into this PR
