### PR TITLE
[agent-a][issue #136] Make managed-agent startup validation prove the real filtered tool transport path

### DIFF
--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"swarm/internal/config"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	workspace "swarm/internal/runtime/workspace"
 )
@@ -195,7 +196,14 @@ func readStreamLines(rc io.ReadCloser, monitor MonitorTurnWriter, stderr bool) [
 }
 
 func (r *ClaudeCLIRuntime) effectiveCLITimeout(ctx context.Context) time.Duration {
-	timeout := r.cfg.LLM.ClaudeCLI.Timeout
+	return effectiveCLITimeoutForConfig(ctx, r.cfg)
+}
+
+func effectiveCLITimeoutForConfig(ctx context.Context, cfg *config.Config) time.Duration {
+	timeout := time.Duration(0)
+	if cfg != nil {
+		timeout = cfg.LLM.ClaudeCLI.Timeout
+	}
 	if timeout <= 0 {
 		timeout = 120 * time.Second
 	}

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"swarm/internal/config"
 	models "swarm/internal/runtime/core/actors"
 	workspace "swarm/internal/runtime/workspace"
 )
@@ -38,45 +39,62 @@ func (r *ClaudeCLIRuntime) runWithPromptArg(ctx context.Context, args []string, 
 	return r.runWithInput(ctx, runArgs, target, "", meta)
 }
 
-func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (configJSON string, contextToken string, enabled bool, err error) {
+type MCPHTTPBinding struct {
+	URL          string
+	Headers      map[string]string
+	ContextToken string
+}
+
+func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnContextStore, s *Session, gatewayURL string, gatewayToken string) (binding MCPHTTPBinding, enabled bool, err error) {
 	if !shouldUseMCPBridge() || s == nil || len(s.Tools) == 0 {
-		return "", "", false, nil
+		return MCPHTTPBinding{}, false, nil
 	}
 	actor, _ := models.ActorFromContext(ctx)
 	if strings.TrimSpace(actor.ID) == "" {
 		actor.ID = strings.TrimSpace(s.AgentID)
 	}
 	if strings.TrimSpace(actor.ID) == "" {
-		return "", "", false, nil
+		return MCPHTTPBinding{}, false, nil
 	}
-	if r.mcpTurns == nil {
-		return "", "", false, errors.New("mcp turn context store is required for MCP bridge")
+	if turns == nil {
+		return MCPHTTPBinding{}, false, errors.New("mcp turn context store is required for MCP bridge")
 	}
+	serverURL := normalizeMCPServerURL(gatewayURL)
+	if serverURL == "" {
+		return MCPHTTPBinding{}, false, nil
+	}
+	headers := map[string]string{}
+	if token := strings.TrimSpace(gatewayToken); token != "" {
+		headers["Authorization"] = "Bearer " + token
+	}
+	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), toolNames(s.Tools))
+	if contextToken != "" {
+		headers[mcpContextTokenHeader] = contextToken
+		serverURL = withMCPContextQuery(serverURL, contextToken)
+	}
+	return MCPHTTPBinding{
+		URL:          serverURL,
+		Headers:      headers,
+		ContextToken: contextToken,
+	}, true, nil
+}
 
+func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (configJSON string, contextToken string, enabled bool, err error) {
 	gatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
 	if gatewayURL == "" {
 		gatewayURL = "http://orchestrator:8090"
 	}
-	serverURL := normalizeMCPServerURL(gatewayURL)
-	if serverURL == "" {
-		return "", "", false, nil
+	binding, enabled, err := BuildMCPHTTPBinding(ctx, r.cfg, r.mcpTurns, s, gatewayURL, strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")))
+	if err != nil || !enabled {
+		return "", "", enabled, err
 	}
-	allowedTools := toolNames(s.Tools)
-	headers := map[string]string{}
-	if token := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); token != "" {
-		headers["Authorization"] = "Bearer " + token
-	}
-	contextToken = r.mcpTurns.RegisterTurnContextWithAllowedTools(ctx, r.mcpContextTokenTTL(ctx), allowedTools)
-	if contextToken != "" {
-		headers[mcpContextTokenHeader] = contextToken
-	}
-	serverURL = withMCPContextQuery(serverURL, contextToken)
+	contextToken = binding.ContextToken
 	cfg := map[string]any{
 		"mcpServers": map[string]any{
 			"runtime-tools": map[string]any{
 				"type":    "http",
-				"url":     serverURL,
-				"headers": headers,
+				"url":     binding.URL,
+				"headers": binding.Headers,
 			},
 		},
 	}
@@ -92,7 +110,11 @@ func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (c
 }
 
 func (r *ClaudeCLIRuntime) mcpContextTokenTTL(ctx context.Context) time.Duration {
-	timeout := r.effectiveCLITimeout(ctx)
+	return mcpContextTokenTTLForConfig(ctx, r.cfg)
+}
+
+func mcpContextTokenTTLForConfig(ctx context.Context, cfg *config.Config) time.Duration {
+	timeout := effectiveCLITimeoutForConfig(ctx, cfg)
 	if timeout <= 0 {
 		timeout = 15 * time.Minute
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -625,7 +625,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	if err := validateClaudeManagedAgentWorkspaces(ctx, rt.Config, rt.Workspace, rt.Manager); err != nil {
 		return fmt.Errorf("claude runtime workspace validation failed: %w", err)
 	}
-	if err := validateClaudeMCPToolsForManagedAgents(rt.Config, rt.ToolGateway, rt.Options.ToolGatewayToken, rt.Manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)
 	}
 	if rt.Manager != nil {

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -344,10 +344,6 @@ func startupProbeAllowsValidationError(message string) bool {
 		return true
 	case strings.Contains(lowered, "schema validation failed"):
 		return true
-	case strings.Contains(lowered, " is required"):
-		return true
-	case strings.Contains(lowered, " must be "):
-		return true
 	default:
 		return false
 	}

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -325,16 +325,31 @@ func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding 
 	if isError, _ := result["isError"].(bool); !isError {
 		return nil
 	}
-	message := strings.ToLower(strings.TrimSpace(startupMCPErrorText(result)))
-	switch {
-	case strings.Contains(message, "tool is not allowed"),
-		strings.Contains(message, "tool executor unavailable"),
-		strings.Contains(message, "tool name is required"),
-		strings.Contains(message, "missing actor context"),
-		strings.Contains(message, "missing authorization"):
-		return fmt.Errorf(strings.TrimSpace(startupMCPErrorText(result)))
-	default:
+	message := strings.TrimSpace(startupMCPErrorText(result))
+	if message == "" {
+		return fmt.Errorf("tools/call returned error without content")
+	}
+	if startupProbeAllowsValidationError(message) {
 		return nil
+	}
+	return fmt.Errorf(message)
+}
+
+func startupProbeAllowsValidationError(message string) bool {
+	lowered := strings.ToLower(strings.TrimSpace(message))
+	switch {
+	case strings.Contains(lowered, "runtime tool input validation failed"):
+		return true
+	case strings.Contains(lowered, "invalid_tool_input"):
+		return true
+	case strings.Contains(lowered, "schema validation failed"):
+		return true
+	case strings.Contains(lowered, " is required"):
+		return true
+	case strings.Contains(lowered, " must be "):
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -1,16 +1,22 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"swarm/internal/config"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
 	llm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
-	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 )
 
@@ -55,48 +61,335 @@ func validateClaudeManagedAgentWorkspaces(ctx context.Context, cfg *config.Confi
 	return nil
 }
 
-func validateClaudeMCPToolsForManagedAgents(cfg *config.Config, gateway *runtimemcp.Gateway, toolGatewayToken string, manager *runtimemanager.AgentManager) error {
+type claudeStartupToolSource interface {
+	ToolDefinitionsForActor(runtimeactors.AgentConfig) []llm.ToolDefinition
+	ToolCapabilitiesForActor(runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
+}
+
+func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
 	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
 		return nil
 	}
-	if gateway == nil {
-		return fmt.Errorf("tool gateway is required for claude cli runtime")
+	if turnStore == nil {
+		return fmt.Errorf("mcp turn context store is required for claude cli runtime")
+	}
+	if tools == nil {
+		return fmt.Errorf("tool executor is required for claude cli runtime")
 	}
 	if manager == nil {
 		return fmt.Errorf("agent manager is required for claude cli runtime")
 	}
-	if strings.TrimSpace(toolGatewayToken) == "" {
-		return fmt.Errorf("tool gateway token must be configured for claude cli runtime")
+	gatewayURL := strings.TrimSpace(runtimeConfiguredMCPGatewayURL())
+	if gatewayURL == "" {
+		return fmt.Errorf("SWARM_TOOL_GATEWAY_URL is required for claude cli runtime")
 	}
+	gatewayToken := strings.TrimSpace(runtimeConfiguredMCPGatewayToken())
+	if gatewayToken == "" {
+		return fmt.Errorf("SWARM_TOOL_GATEWAY_TOKEN is required for claude cli runtime")
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
 	for _, agentCfg := range manager.ListAgentConfigs() {
 		agentID := strings.TrimSpace(agentCfg.ID)
 		if agentID == "" {
 			continue
 		}
-		tools := gateway.MCPToolsForActor(agentCfg)
-		if len(tools) == 0 {
-			return fmt.Errorf("mcp tools/list returned no tools for agent %s", agentID)
+		sessionTools := tools.ToolDefinitionsForActor(agentCfg)
+		if len(sessionTools) == 0 {
+			return fmt.Errorf("managed-agent startup probe found no declared tools for agent %s", agentID)
 		}
-		toolNames := make(map[string]struct{}, len(tools))
-		for _, tool := range tools {
-			name := strings.TrimSpace(tool.Name)
-			if name == "" {
-				continue
+		agentCtx := runtimeactors.WithActor(ctx, agentCfg)
+		binding, enabled, err := llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
+			AgentID: agentID,
+			Tools:   sessionTools,
+		}, gatewayURL, gatewayToken)
+		if err != nil {
+			return fmt.Errorf("build mcp startup probe transport for agent %s: %w", agentID, err)
+		}
+		if !enabled {
+			return fmt.Errorf("mcp startup probe transport is disabled for agent %s", agentID)
+		}
+		if strings.TrimSpace(binding.ContextToken) == "" {
+			return fmt.Errorf("mcp startup probe missing turn context token for agent %s", agentID)
+		}
+		actualTools, err := startupProbeMCPToolsList(agentCtx, client, binding)
+		turnStore.UnregisterTurnContext(binding.ContextToken)
+		if err != nil {
+			return fmt.Errorf("mcp tools/list startup probe failed for agent %s: %w", agentID, err)
+		}
+		expectedNames, capabilities, err := expectedStartupMCPTools(agentCfg, tools, sessionTools)
+		if err != nil {
+			return fmt.Errorf("mcp startup probe expected tools for agent %s: %w", agentID, err)
+		}
+		if len(expectedNames) == 0 {
+			return fmt.Errorf("mcp startup probe found no visible tools for agent %s", agentID)
+		}
+		actualNames := startupToolNames(actualTools)
+		if !equalSortedStrings(actualNames, expectedNames) {
+			return fmt.Errorf("mcp tools/list returned unexpected tool surface for agent %s: expected [%s], got [%s]", agentID, strings.Join(expectedNames, ", "), strings.Join(actualNames, ", "))
+		}
+		if probeName, ok := selectStartupCallableTool(actualTools, capabilities); ok {
+			binding, enabled, err = llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
+				AgentID: agentID,
+				Tools:   sessionTools,
+			}, gatewayURL, gatewayToken)
+			if err != nil {
+				return fmt.Errorf("build mcp startup call probe transport for agent %s: %w", agentID, err)
 			}
-			toolNames[name] = struct{}{}
-		}
-		missingEmitTools := make([]string, 0)
-		for _, eventType := range agentCfg.EmitEvents {
-			name := runtimetools.EmitToolName(eventType)
-			if _, ok := toolNames[name]; ok {
-				continue
+			if !enabled || strings.TrimSpace(binding.ContextToken) == "" {
+				return fmt.Errorf("mcp startup call probe missing transport binding for agent %s", agentID)
 			}
-			missingEmitTools = append(missingEmitTools, name)
-		}
-		if len(missingEmitTools) > 0 {
-			sort.Strings(missingEmitTools)
-			return fmt.Errorf("mcp tools/list missing required emit tools for agent %s: %s", agentID, strings.Join(missingEmitTools, ", "))
+			err = startupProbeMCPToolsCall(agentCtx, client, binding, probeName)
+			turnStore.UnregisterTurnContext(binding.ContextToken)
+			if err != nil {
+				return fmt.Errorf("mcp tools/call startup probe failed for agent %s tool %s: %w", agentID, probeName, err)
+			}
 		}
 	}
 	return nil
+}
+
+func runtimeConfiguredMCPGatewayURL() string {
+	return strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
+}
+
+func runtimeConfiguredMCPGatewayToken() string {
+	return strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
+}
+
+func expectedStartupMCPTools(agentCfg runtimeactors.AgentConfig, tools claudeStartupToolSource, sessionTools []llm.ToolDefinition) ([]string, toolcapabilities.Set, error) {
+	names := startupSessionToolNames(sessionTools)
+	allowed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		allowed[name] = struct{}{}
+	}
+	caps := tools.ToolCapabilitiesForActor(agentCfg, names, allowed)
+	if len(caps.ByName) == 0 {
+		return nil, toolcapabilities.Set{}, fmt.Errorf("tool capability set is required")
+	}
+	visible := make([]string, 0, len(names))
+	for _, name := range names {
+		capability, ok := caps.Capability(name)
+		if !ok {
+			return nil, toolcapabilities.Set{}, fmt.Errorf("missing tool capability for %s", name)
+		}
+		if capability.Visible {
+			visible = append(visible, name)
+		}
+	}
+	sort.Strings(visible)
+	return visible, caps, nil
+}
+
+func startupSessionToolNames(tools []llm.ToolDefinition) []string {
+	names := make([]string, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func startupToolNames(tools []runtimemcp.ToolDef) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if name := strings.TrimSpace(tool.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func equalSortedStrings(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if strings.TrimSpace(left[i]) != strings.TrimSpace(right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapabilities.Set) (string, bool) {
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		capability, ok := capabilities.Capability(name)
+		if !ok || !capability.Callable || capability.Kind == toolcapabilities.KindEmit {
+			continue
+		}
+		if !schemaRequiresObjectFields(tool.InputSchema) {
+			continue
+		}
+		return name, true
+	}
+	return "", false
+}
+
+func schemaRequiresObjectFields(schema any) bool {
+	typed, ok := schema.(map[string]any)
+	if !ok {
+		return false
+	}
+	if strings.TrimSpace(asString(typed["type"])) != "object" {
+		return false
+	}
+	required, ok := typed["required"].([]any)
+	if !ok || len(required) == 0 {
+		return false
+	}
+	return true
+}
+
+func startupProbeMCPToolsList(ctx context.Context, client *http.Client, binding llm.MCPHTTPBinding) ([]runtimemcp.ToolDef, error) {
+	if _, err := startupCallMCP(ctx, client, binding, runtimemcp.RPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		Params: map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "swarm-startup",
+				"version": "1.0.0",
+			},
+		},
+		ID: "startup-initialize",
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := startupCallMCP(ctx, client, binding, runtimemcp.RPCRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+		Params:  map[string]any{},
+	}); err != nil {
+		return nil, err
+	}
+	resp, err := startupCallMCP(ctx, client, binding, runtimemcp.RPCRequest{
+		JSONRPC: "2.0",
+		Method:  "tools/list",
+		Params:  map[string]any{},
+		ID:      "startup-tools-list",
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("tools/list returned invalid result payload")
+	}
+	rawTools, ok := result["tools"]
+	if !ok {
+		return nil, fmt.Errorf("tools/list returned no tools array")
+	}
+	encoded, err := json.Marshal(rawTools)
+	if err != nil {
+		return nil, err
+	}
+	var tools []runtimemcp.ToolDef
+	if err := json.Unmarshal(encoded, &tools); err != nil {
+		return nil, fmt.Errorf("decode tools/list payload: %w", err)
+	}
+	return tools, nil
+}
+
+func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding llm.MCPHTTPBinding, name string) error {
+	resp, err := startupCallMCP(ctx, client, binding, runtimemcp.RPCRequest{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      strings.TrimSpace(name),
+			"arguments": map[string]any{},
+		},
+		ID: "startup-tools-call",
+	})
+	if err != nil {
+		return err
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		return fmt.Errorf("tools/call returned invalid result payload")
+	}
+	if isError, _ := result["isError"].(bool); !isError {
+		return nil
+	}
+	message := strings.ToLower(strings.TrimSpace(startupMCPErrorText(result)))
+	switch {
+	case strings.Contains(message, "tool is not allowed"),
+		strings.Contains(message, "tool executor unavailable"),
+		strings.Contains(message, "tool name is required"),
+		strings.Contains(message, "missing actor context"),
+		strings.Contains(message, "missing authorization"):
+		return fmt.Errorf(strings.TrimSpace(startupMCPErrorText(result)))
+	default:
+		return nil
+	}
+}
+
+func startupMCPErrorText(result map[string]any) string {
+	content, ok := result["content"].([]any)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(content))
+	for _, item := range content {
+		typed, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if text := strings.TrimSpace(asString(typed["text"])); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, " | ")
+}
+
+func startupCallMCP(ctx context.Context, client *http.Client, binding llm.MCPHTTPBinding, req runtimemcp.RPCRequest) (runtimemcp.RPCResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return runtimemcp.RPCResponse{}, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSpace(binding.URL), bytes.NewReader(body))
+	if err != nil {
+		return runtimemcp.RPCResponse{}, err
+	}
+	httpReq.Header.Set("content-type", "application/json")
+	httpReq.Header.Set("mcp-protocol-version", "2025-03-26")
+	for key, value := range binding.Headers {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		httpReq.Header.Set(key, value)
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return runtimemcp.RPCResponse{}, err
+	}
+	defer resp.Body.Close()
+	var decoded runtimemcp.RPCResponse
+	if resp.StatusCode >= 400 {
+		return runtimemcp.RPCResponse{}, fmt.Errorf("mcp transport returned status %d", resp.StatusCode)
+	}
+	if req.Method == "notifications/initialized" {
+		return decoded, nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return runtimemcp.RPCResponse{}, err
+	}
+	if decoded.Error != nil {
+		return runtimemcp.RPCResponse{}, fmt.Errorf(strings.TrimSpace(decoded.Error.Message))
+	}
+	return decoded, nil
 }

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -309,3 +309,25 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableP
 		t.Fatalf("expected unexpected callable probe error, got %v", err)
 	}
 }
+
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonValidationProbeError(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+		execErrs: map[string]error{
+			"query_entities": errors.New("execution path must be enabled before use"),
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "execution path must be enabled before use") {
+		t.Fatalf("expected generic phrase non-validation probe error, got %v", err)
+	}
+}

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -101,11 +101,16 @@ type startupProbeToolExecutor struct {
 	defs     []llm.ToolDefinition
 	caps     map[string]toolcapabilities.Capability
 	executed []string
+	execErrs map[string]error
 }
 
 func (s *startupProbeToolExecutor) Execute(_ context.Context, name string, _ any) (any, error) {
-	s.executed = append(s.executed, strings.TrimSpace(name))
-	return map[string]any{"ok": true, "tool": strings.TrimSpace(name)}, nil
+	name = strings.TrimSpace(name)
+	s.executed = append(s.executed, name)
+	if err, ok := s.execErrs[name]; ok {
+		return nil, err
+	}
+	return map[string]any{"ok": true, "tool": name}, nil
 }
 
 func (s *startupProbeToolExecutor) ToolDefinitions() []llm.ToolDefinition {
@@ -259,5 +264,48 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "found no visible tools") {
 		t.Fatalf("expected empty visible tools error, got %v", err)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_ToleratesValidationStyleCallableProbeErrors(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+		execErrs: map[string]error{
+			"query_entities": errors.New("runtime tool input validation failed: schema validation failed: input.query is required"),
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
+		t.Fatalf("expected validation-style probe error to be tolerated, got %v", err)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableProbeError(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+		execErrs: map[string]error{
+			"query_entities": errors.New("unexpected tool failure"),
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "unexpected tool failure") {
+		t.Fatalf("expected unexpected callable probe error, got %v", err)
 	}
 }

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -95,53 +97,95 @@ func TestValidateClaudeManagedAgentWorkspaces_AcceptsContainerTargets(t *testing
 	}
 }
 
-type startupProbeToolExecutor struct{}
-
-func (startupProbeToolExecutor) Execute(context.Context, string, any) (any, error) {
-	return map[string]any{"ok": true}, nil
-}
-func (startupProbeToolExecutor) ToolDefinitions() []llm.ToolDefinition {
-	return []llm.ToolDefinition{{Name: "query_entities"}}
+type startupProbeToolExecutor struct {
+	defs     []llm.ToolDefinition
+	caps     map[string]toolcapabilities.Capability
+	executed []string
 }
 
-func (startupProbeToolExecutor) ToolDefinitionsForActor(runtimeactors.AgentConfig) []llm.ToolDefinition {
-	return []llm.ToolDefinition{{Name: "query_entities"}}
+func (s *startupProbeToolExecutor) Execute(_ context.Context, name string, _ any) (any, error) {
+	s.executed = append(s.executed, strings.TrimSpace(name))
+	return map[string]any{"ok": true, "tool": strings.TrimSpace(name)}, nil
 }
 
-func (startupProbeToolExecutor) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+func (s *startupProbeToolExecutor) ToolDefinitions() []llm.ToolDefinition {
+	return append([]llm.ToolDefinition(nil), s.defs...)
+}
+
+func (s *startupProbeToolExecutor) ToolDefinitionsForActor(runtimeactors.AgentConfig) []llm.ToolDefinition {
+	return append([]llm.ToolDefinition(nil), s.defs...)
+}
+
+func (s *startupProbeToolExecutor) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
 	caps := make([]toolcapabilities.Capability, 0, len(names))
 	for _, name := range names {
-		caps = append(caps, toolcapabilities.Capability{
-			Name:               name,
+		capability, ok := s.caps[strings.TrimSpace(name)]
+		if !ok {
+			capability = toolcapabilities.Capability{
+				Name:               strings.TrimSpace(name),
+				Visible:            true,
+				Callable:           true,
+				ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+			}
+		}
+		caps = append(caps, capability)
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func startupProbeDefs() []llm.ToolDefinition {
+	return []llm.ToolDefinition{
+		{
+			Name:        "hidden_tool",
+			Description: "Hidden from filtered MCP catalog",
+			Schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				"required":   []any{"query"},
+			},
+		},
+		{
+			Name:        "query_entities",
+			Description: "Query entities",
+			Schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				"required":   []any{"query"},
+			},
+		},
+	}
+}
+
+func startupProbeCaps() map[string]toolcapabilities.Capability {
+	return map[string]toolcapabilities.Capability{
+		"hidden_tool": {
+			Name:               "hidden_tool",
+			Visible:            false,
+			Callable:           true,
+			ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+		},
+		"query_entities": {
+			Name:               "query_entities",
 			Visible:            true,
 			Callable:           true,
 			ContextRequirement: toolcapabilities.ContextRequirementActorContext,
-		})
+		},
 	}
-	return toolcapabilities.NewSet(caps)
 }
 
-type emptyStartupProbeToolExecutor struct{}
-
-func (emptyStartupProbeToolExecutor) Execute(context.Context, string, any) (any, error) {
-	return map[string]any{"ok": true}, nil
+func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManager, exec *startupProbeToolExecutor, gatewayToken string) *runtimemcp.TurnContextRegistry {
+	t.Helper()
+	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, turns))
+	server := httptest.NewServer(gateway.Handler())
+	t.Cleanup(server.Close)
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", server.URL)
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", gatewayToken)
+	return turns
 }
 
-func (emptyStartupProbeToolExecutor) ToolDefinitions() []llm.ToolDefinition { return nil }
-
-func (emptyStartupProbeToolExecutor) ToolDefinitionsForActor(runtimeactors.AgentConfig) []llm.ToolDefinition {
-	return nil
-}
-
-func (emptyStartupProbeToolExecutor) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
-	caps := make([]toolcapabilities.Capability, 0, len(names))
-	for _, name := range names {
-		caps = append(caps, toolcapabilities.Capability{Name: name})
-	}
-	return toolcapabilities.NewSet(caps)
-}
-
-func TestValidateClaudeMCPToolsForManagedAgents_AcceptsVisibleTools(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	manager := runtimemanager.NewAgentManager(nil, nil)
@@ -152,43 +196,68 @@ func TestValidateClaudeMCPToolsForManagedAgents_AcceptsVisibleTools(t *testing.T
 	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
-	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil))
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(cfg, gateway, "gateway-token", manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(exec.executed, []string{"query_entities"}) {
+		t.Fatalf("executed = %#v, want query_entities tools/call smoke", exec.executed)
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_FailsWhenRequiredEmitToolsMissing(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTokenMismatch(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	manager := runtimemanager.NewAgentManager(nil, nil)
 	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
-		ID:         "market-research-agent",
-		Role:       "market_research",
-		EmitEvents: []string{"discovery/category.assessed", "discovery/market_research.scan_complete"},
+		ID:   "market-research-agent",
+		Role: "market_research",
 	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
-	gateway := runtimemcp.NewGateway(startupProbeToolExecutor{}, "gateway-token", RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil))
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "wrong-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(cfg, gateway, "gateway-token", manager)
-	if err == nil || !strings.Contains(err.Error(), "missing required emit tools") {
-		t.Fatalf("expected missing emit tools error, got %v", err)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("expected invalid token error, got %v", err)
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyToolList(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	manager := runtimemanager.NewAgentManager(nil, nil)
 	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
-	gateway := runtimemcp.NewGateway(emptyStartupProbeToolExecutor{}, "gateway-token", runtimemcp.GatewayHooks{})
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{{
+			Name:   "query_entities",
+			Schema: map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}, "required": []any{"query"}},
+		}},
+		caps: map[string]toolcapabilities.Capability{
+			"query_entities": {
+				Name:               "query_entities",
+				Visible:            false,
+				Callable:           true,
+				ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+			},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(cfg, gateway, "gateway-token", manager)
-	if err == nil || !strings.Contains(err.Error(), "returned no tools") {
-		t.Fatalf("expected empty tools error, got %v", err)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "found no visible tools") {
+		t.Fatalf("expected empty visible tools error, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #136

## Human Summary

Managed-agent startup validation now proves the same MCP tool transport path the runtime actually uses. Instead of checking an in-process catalog surrogate, startup builds a real turn-context-bound MCP transport, hits the configured gateway URL over HTTP, verifies the filtered `tools/list` surface, and smokes one callable tool path when the declared schema makes that safe.

## What Changed

- extracted a shared `llm.BuildMCPHTTPBinding(...)` helper so runtime startup and Claude CLI transport use the same context-token-bound MCP HTTP binding
- changed managed-agent startup validation to:
  - build the same filtered MCP transport binding the CLI runtime uses
  - call the configured gateway URL/token over real HTTP MCP
  - verify the returned `tools/list` surface matches the canonical visible tool capability set for the actor
  - smoke a real `tools/call` path for one non-emit callable tool when the declared schema requires input fields, so the probe stays side-effect-safe
- removed the old startup proof that only called `gateway.MCPToolsForActor(...)`
- added focused startup regressions for:
  - real filtered transport success
  - fail-closed auth mismatch on the configured gateway token
  - fail-closed empty visible tool surface

## Why This Is Needed

- the old startup check could go green on a weaker in-process path while the real MCP HTTP boundary was still broken
- it did not prove the configured gateway URL/token, turn-context registration, or the filtered tool surface the runtime session actually depends on
- that left managed-agent boot vulnerable to transport/auth drift that would only show up later during real execution

## Scope Boundaries

- In scope:
  - managed-agent Claude startup validation
  - shared MCP HTTP binding used by startup and Claude CLI runtime transport
  - focused startup transport tests
- Not in scope:
  - general MCP redesign
  - unrelated tool prompt/catalog cleanup
  - broader gateway architecture changes outside this startup proof seam

## Tests Run

- `go test ./internal/runtime ./internal/runtime/llm -count=1`
- `go test ./internal/runtime -run 'TestValidateClaude(MCPToolsForManagedAgents_|StartupConfig_|ManagedAgentWorkspaces_)' -count=1`
- `go test ./... -count=1`

## Residual Risk

- the callable smoke intentionally only probes non-emit tools whose declared schema requires object fields, so it can exercise real `tools/call` transport without introducing startup side effects. Agents whose filtered tool surface has no such safe callable candidate still get full real-transport `tools/list` validation but not an execution smoke.

## Follow-Up

- none for this seam; broader MCP transport redesign remains separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool gateway startup validation with clearer error reporting for connectivity issues
  * Enhanced timeout calculation and handling for CLI operations
  * More robust tool definitions discovery and validation

* **Refactor**
  * Restructured internal MCP HTTP binding and timeout management logic for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->