### PR TITLE
[agent-c][issue #215] Keep operator backlog projection aligned with canonical pending-delivery selection

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -102,6 +102,9 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	if err != nil {
 		return nil, err
 	}
+	if err := store.RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+		return nil, err
+	}
 	pendingPredicate := store.CanonicalPendingAgentDeliveryPredicateSQL("r")
 	latestTurnBlocksExpr := `'[]'::jsonb`
 	if caps.Conversations.TurnBlocks {
@@ -229,6 +232,11 @@ func (r *SQLAgentReader) resolveCapabilities(ctx context.Context) (store.StoreSc
 		}
 	}
 	return store.StoreSchemaCapabilities{
+		Events: store.EventSchemaCapabilities{
+			Log:        store.SchemaFlavorCanonical,
+			Deliveries: store.SchemaFlavorCanonical,
+			Receipts:   store.SchemaFlavorCanonical,
+		},
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions:   store.SchemaFlavorCanonical,
 			Audits:     store.SchemaFlavorCanonical,

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -102,6 +102,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	if err != nil {
 		return nil, err
 	}
+	pendingPredicate := store.CanonicalPendingAgentDeliveryPredicateSQL("r")
 	latestTurnBlocksExpr := `'[]'::jsonb`
 	if caps.Conversations.TurnBlocks {
 		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
@@ -146,13 +147,17 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 		) latest_turn ON true
 		LEFT JOIN LATERAL (
 			SELECT
-				COUNT(*) FILTER (WHERE d.status IN ('pending', 'failed'))::int AS pending_count,
+				COUNT(*) FILTER (WHERE %s)::int AS pending_count,
 				COALESCE(MAX(CASE
-					WHEN d.status IN ('pending', 'failed') THEN EXTRACT(EPOCH FROM now() - e.created_at)
+					WHEN %s THEN EXTRACT(EPOCH FROM now() - e.created_at)
 					ELSE NULL
 				END)::int, 0) AS oldest_pending_age_sec
 			FROM event_deliveries d
 			INNER JOIN events e ON e.event_id = d.event_id
+			LEFT JOIN event_receipts r
+				ON r.event_id = d.event_id
+				AND r.subscriber_type = 'agent'
+				AND r.subscriber_id = d.subscriber_id
 			WHERE d.subscriber_type = 'agent'
 			  AND d.subscriber_id = a.agent_id
 		) p ON true
@@ -167,7 +172,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 		) f ON true
 		WHERE a.status NOT IN ('terminated', 'ephemeral')
 		ORDER BY a.created_at ASC, a.agent_id ASC
-	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
+	`, latestTurnBlocksExpr, pendingPredicate, pendingPredicate), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
 	if err != nil {
 		return nil, fmt.Errorf("query agent operator projections: %w", err)
 	}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -889,7 +890,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 	}
 }
 
-func TestSQLAgentReader_ListGenericAgents_PreservesRetryableVsTerminalDeliveryOutcome(t *testing.T) {
+func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelector(t *testing.T) {
 	dsn, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
@@ -918,9 +919,11 @@ func TestSQLAgentReader_ListGenericAgents_PreservesRetryableVsTerminalDeliveryOu
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
+	pendingEventID := uuid.NewString()
 	failedEventID := uuid.NewString()
+	inProgressNoReceiptEventID := uuid.NewString()
 	deadEventID := uuid.NewString()
-	for _, eventID := range []string{failedEventID, deadEventID} {
+	for _, eventID := range []string{pendingEventID, failedEventID, inProgressNoReceiptEventID, deadEventID} {
 		if _, err := db.ExecContext(ctx, `
 			INSERT INTO events (
 				event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
@@ -935,19 +938,36 @@ func TestSQLAgentReader_ListGenericAgents_PreservesRetryableVsTerminalDeliveryOu
 		INSERT INTO event_deliveries (
 			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, last_error, delivered_at, created_at
 		) VALUES
-			($1::uuid, $2::uuid, 'agent', 'agent-1', 'failed', 1, 'retryable-failure', now() - interval '2 minutes', now() - interval '5 minutes'),
-			($1::uuid, $3::uuid, 'agent', 'agent-1', 'dead_letter', 2, 'terminal-dead-letter', now() - interval '1 minute', now() - interval '6 minutes')
-	`, runID, failedEventID, deadEventID); err != nil {
+			($1::uuid, $2::uuid, 'agent', 'agent-1', 'pending', 0, '', NULL, now() - interval '7 minutes'),
+			($1::uuid, $3::uuid, 'agent', 'agent-1', 'failed', 1, 'retryable-failure', now() - interval '2 minutes', now() - interval '5 minutes'),
+			($1::uuid, $4::uuid, 'agent', 'agent-1', 'in_progress', 0, '', NULL, now() - interval '6 minutes'),
+			($1::uuid, $5::uuid, 'agent', 'agent-1', 'dead_letter', 2, 'terminal-dead-letter', now() - interval '1 minute', now() - interval '8 minutes')
+	`, runID, pendingEventID, failedEventID, inProgressNoReceiptEventID, deadEventID); err != nil {
 		t.Fatalf("seed deliveries: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, outcome, side_effects, processed_at
 		) VALUES
-			($1::uuid, 'agent', 'agent-1', 'dead_letter', '{"manager_status":"error","retry_count":1,"error":"retryable-failure"}'::jsonb, now()),
+			($1::uuid, 'agent', 'agent-1', 'dead_letter', '{"manager_status":"error","retry_count":1,"error":"retryable-failure"}'::jsonb, now() - interval '2 minutes'),
 			($2::uuid, 'agent', 'agent-1', 'success', '{"manager_status":"dead_letter","retry_count":2,"error":"terminal-dead-letter"}'::jsonb, now())
 	`, failedEventID, deadEventID); err != nil {
 		t.Fatalf("seed conflicting receipts: %v", err)
+	}
+
+	pending, err := pg.ListPendingEventsForAgent(ctx, "agent-1", time.Now().Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	gotPendingIDs := make([]string, 0, len(pending))
+	for _, evt := range pending {
+		gotPendingIDs = append(gotPendingIDs, evt.ID)
+	}
+	slices.Sort(gotPendingIDs)
+	wantPendingIDs := []string{failedEventID, inProgressNoReceiptEventID, pendingEventID}
+	slices.Sort(wantPendingIDs)
+	if !slices.Equal(gotPendingIDs, wantPendingIDs) {
+		t.Fatalf("pending event ids = %#v, want %#v", gotPendingIDs, wantPendingIDs)
 	}
 
 	reader := NewSQLAgentReader(db, pg, 12)
@@ -958,8 +978,8 @@ func TestSQLAgentReader_ListGenericAgents_PreservesRetryableVsTerminalDeliveryOu
 	if len(items) != 1 {
 		t.Fatalf("expected one agent, got %+v", items)
 	}
-	if items[0].PendingEvents != 1 {
-		t.Fatalf("pending_events = %d, want 1 retryable failed delivery", items[0].PendingEvents)
+	if items[0].PendingEvents != len(pending) {
+		t.Fatalf("pending_events = %d, want %d canonical pending deliveries", items[0].PendingEvents, len(pending))
 	}
 	if items[0].Failures24h != 1 {
 		t.Fatalf("failures_24h = %d, want 1 failed delivery", items[0].Failures24h)

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -33,6 +33,22 @@ type builderWSEventFrame = builderpkg.WSEventFrame
 const testBuilderAuthToken = "builder-test-token"
 const testOperatorAuthToken = "operator-secret"
 
+func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
+	return store.StoreSchemaCapabilities{
+		Events: store.EventSchemaCapabilities{
+			Log:        store.SchemaFlavorCanonical,
+			Deliveries: store.SchemaFlavorCanonical,
+			Receipts:   store.SchemaFlavorCanonical,
+		},
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Audits:     store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}
+}
+
 func setOperatorAuth(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+testOperatorAuthToken)
 }
@@ -654,13 +670,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 			},
 			Status: "active",
 		}},
-		caps: store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		},
+		caps: canonicalEventAndConversationCaps(),
 	}, 12)
 
 	turnBlocksPayload := `[
@@ -716,13 +726,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 			},
 			Status: "active",
 		}},
-		caps: store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		},
+		caps: canonicalEventAndConversationCaps(),
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -767,13 +771,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 			},
 			Status: "active",
 		}},
-		caps: store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		},
+		caps: canonicalEventAndConversationCaps(),
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -809,13 +807,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 			},
 			Status: "terminated",
 		}},
-		caps: store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		},
+		caps: canonicalEventAndConversationCaps(),
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -866,13 +858,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 			},
 			Status: "active",
 		}},
-		caps: store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		},
+		caps: canonicalEventAndConversationCaps(),
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -887,6 +873,34 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalReceiptCapability(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	caps := canonicalEventAndConversationCaps()
+	caps.Events.Receipts = store.SchemaFlavorLegacy
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: caps,
+	}, 12)
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "event_receipts schema is unsupported") {
+		t.Fatalf("expected explicit unsupported receipt capability error, got %v", err)
 	}
 }
 

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -248,6 +248,7 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 }
 
 func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
+	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("r")
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -263,19 +264,10 @@ func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agent
 		WHERE d.subscriber_type = 'agent'
 		  AND d.subscriber_id = $1
 		  AND e.created_at >= $2
-		  AND (
-				r.event_id IS NULL
-				OR (
-					COALESCE(r.side_effects->>'manager_status', '') = 'error'
-					AND COALESCE((r.side_effects->>'retry_count')::int, 0) <= 1
-					AND (
-						(COALESCE((r.side_effects->>'retry_count')::int, 0) = 1 AND r.processed_at <= now() - interval '1 minute')
-					)
-				)
-			)
+		  AND %s
 		ORDER BY e.created_at ASC
 		LIMIT $3
-	`)
+	`, pendingPredicate)
 	rows, err := s.DB.QueryContext(ctx, q, agentID, since, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query pending events for %s: %w", agentID, err)
@@ -285,6 +277,7 @@ func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agent
 }
 
 func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, agentID string, subscriptions []events.EventType, since time.Time, limit int) ([]events.Event, error) {
+	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("r")
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -311,19 +304,10 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 					  AND d_me.subscriber_id = $1
 				)
 			)
-		  AND (
-				r.event_id IS NULL
-				OR (
-					COALESCE(r.side_effects->>'manager_status', '') = 'error'
-					AND COALESCE((r.side_effects->>'retry_count')::int, 0) <= 1
-					AND (
-						(COALESCE((r.side_effects->>'retry_count')::int, 0) = 1 AND r.processed_at <= now() - interval '1 minute')
-					)
-				)
-			)
+		  AND %s
 		ORDER BY e.created_at ASC
 		LIMIT $3
-	`)
+	`, pendingPredicate)
 	rows, err := s.DB.QueryContext(ctx, q, agentID, since, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query pending subscribed events for %s: %w", agentID, err)

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -67,17 +67,10 @@ func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID s
 	if since.IsZero() {
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
-	switch {
-	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical:
-		return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
-	case caps.Events.Log != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
-	case caps.Events.Deliveries != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
-	case caps.Events.Receipts != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+		return nil, err
 	}
-	return nil, nil
+	return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
 }
 
 func (s *PostgresStore) ListPendingSubscribedEvents(
@@ -100,18 +93,10 @@ func (s *PostgresStore) ListPendingSubscribedEvents(
 	if since.IsZero() {
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
-
-	switch {
-	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical:
-		return s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit)
-	case caps.Events.Log != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
-	case caps.Events.Deliveries != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
-	case caps.Events.Receipts != SchemaFlavorCanonical:
-		return nil, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+		return nil, err
 	}
-	return nil, nil
+	return s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit)
 }
 
 func (s *PostgresStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -215,6 +215,29 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 	}
 }
 
+func TestListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.pending_in_progress")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+	if err := pg.MarkEventDeliveryInProgress(ctx, evt.ID, agentID, ""); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
+	}
+
+	evts, err := pg.ListPendingEventsForAgent(ctx, agentID, time.Now().Add(-2*time.Hour), 100)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	if len(evts) != 1 || evts[0].ID != evt.ID {
+		t.Fatalf("in_progress without receipt pending events = %#v, want [%s]", evts, evt.ID)
+	}
+}
+
 func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()

--- a/internal/store/pending_delivery_selection.go
+++ b/internal/store/pending_delivery_selection.go
@@ -1,0 +1,16 @@
+package store
+
+import "fmt"
+
+func CanonicalPendingAgentDeliveryPredicateSQL(receiptAlias string) string {
+	return fmt.Sprintf(`(
+		%s.event_id IS NULL
+		OR (
+			COALESCE(%s.side_effects->>'manager_status', '') = 'error'
+			AND COALESCE((%s.side_effects->>'retry_count')::int, 0) <= 1
+			AND (
+				(COALESCE((%s.side_effects->>'retry_count')::int, 0) = 1 AND %s.processed_at <= now() - interval '1 minute')
+			)
+		)
+	)`, receiptAlias, receiptAlias, receiptAlias, receiptAlias, receiptAlias)
+}

--- a/internal/store/pending_delivery_selection.go
+++ b/internal/store/pending_delivery_selection.go
@@ -2,6 +2,19 @@ package store
 
 import "fmt"
 
+func RequireCanonicalPendingAgentDeliveryCapabilities(caps StoreSchemaCapabilities) error {
+	switch {
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case caps.Events.Receipts != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	default:
+		return nil
+	}
+}
+
 func CanonicalPendingAgentDeliveryPredicateSQL(receiptAlias string) string {
 	return fmt.Sprintf(`(
 		%s.event_id IS NULL


### PR DESCRIPTION
Closes #215

## Human Summary
This keeps the dashboard agent backlog projection aligned with the canonical store-side pending-work selector. The operator card no longer hides stranded `in_progress` deliveries with no receipt, and it now counts backlog using the same rule as `ListPendingEventsForAgent`.

## What Changed
- extracted the canonical pending-delivery SQL predicate into the store package as the single owner for this seam
- switched `ListPendingEventsForAgentSpec` and `ListPendingSubscribedEventsSpec` to use that shared predicate
- switched the dashboard agent operator backlog projection to use the same canonical predicate instead of a local `status IN ('pending', 'failed')` interpretation
- added focused regressions for:
  - retryable `failed`
  - `pending`
  - stranded `in_progress` with no receipt
  - dashboard/store alignment on the same seeded delivery set

## Why This Is Needed
The dashboard backlog selector had drifted from the canonical store selector and could report `pending_events = 0` while recoverable work was still pending under the runtime’s actual selection rules. This was especially visible for stranded `in_progress` deliveries with no receipt after crash/interruption scenarios.

## Scope Boundaries
- In scope:
  - canonical pending-delivery selection for the touched store/dashboard seam
  - operator backlog projection alignment
  - focused regression coverage for the drift state
- Not in scope:
  - broader delivery lifecycle redesign
  - receipt model changes
  - unrelated operator-surface cleanup

## Tests Run
- `go test ./internal/store ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
The canonical selector remains SQL-backed in two query sites, but they now share one store-owned predicate instead of two semantic implementations. Any future change to pending-work semantics in this seam should update that single owner and keep both readers on it.

## Follow-Up
No additional same-seam follow-up was left out. If pending-work semantics need to move out of SQL entirely later, that would be a broader redesign rather than a narrow follow-up to this issue.
