### PR TITLE
[agent-d][issue #195] Align authoritative delivery markers and restart recovery with real subscriber fan-out

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -19,6 +19,23 @@ type pipelineTransitionSchemaCapabilityProvider interface {
 	CanonicalEventReceiptsCapability(context.Context) (bool, error)
 }
 
+func shouldPersistPipelineReceipt(persisted bool, publishErr error) bool {
+	if !persisted {
+		return false
+	}
+	return !errors.Is(publishErr, errAuthoritativeDeliveryIncomplete)
+}
+
+func pipelineReceiptStatus(ctx context.Context, publishErr error) (string, string) {
+	if publishErr != nil {
+		return "error", publishErr.Error()
+	}
+	if overrideStatus, overrideErr, ok := runtimepipeline.PipelineReceiptOverrideFromContext(ctx); ok {
+		return overrideStatus, overrideErr
+	}
+	return "processed", ""
+}
+
 func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
@@ -60,18 +77,10 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	passthrough := true
 	deferred := []events.Event{}
 	defer func() {
-		if !persisted {
+		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
-		status := "processed"
-		errText := ""
-		if err != nil {
-			status = "error"
-			errText = err.Error()
-		} else if overrideStatus, overrideErr, ok := runtimepipeline.PipelineReceiptOverrideFromContext(ictx); ok {
-			status = overrideStatus
-			errText = overrideErr
-		}
+		status, errText := pipelineReceiptStatus(ictx, err)
 		eb.markPipelineReceipt(ictx, evt.ID, status, errText)
 	}()
 
@@ -162,20 +171,10 @@ func (eb *EventBus) publishTransactional(
 	if err != nil {
 		return err
 	}
-	receiptStatus := "processed"
-	receiptErr := ""
-	if overrideStatus, overrideErr, ok := runtimepipeline.PipelineReceiptOverrideFromContext(txctx); ok {
-		receiptStatus = overrideStatus
-		receiptErr = overrideErr
-	}
-
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit publish tx: %w", err)
 	}
 	committed = true
-	if err := txStore.UpsertPipelineReceiptTx(ctx, nil, evt.ID, receiptStatus, receiptErr); err != nil {
-		return fmt.Errorf("persist pipeline receipt: %w", err)
-	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	if deferredTransitions != nil {
 		runtimepipeline.FlushDeferredPipelineTransitions(ctx, *deferredTransitions)
@@ -183,7 +182,9 @@ func (eb *EventBus) publishTransactional(
 
 	if passthrough {
 		if len(inboundPlan.Recipients) > 0 {
-			eb.deliverToAgents(ctx, evt, inboundPlan.Recipients)
+			if err := eb.deliverToAgents(ctx, evt, inboundPlan.PersistedRecipients); err != nil {
+				return err
+			}
 			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
 		}
 		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
@@ -201,6 +202,10 @@ func (eb *EventBus) publishTransactional(
 		if err := eb.publishDeferred(ctx, d); err != nil {
 			return err
 		}
+	}
+	status, errText := pipelineReceiptStatus(txctx, nil)
+	if err := txStore.UpsertPipelineReceiptTx(ctx, nil, evt.ID, status, errText); err != nil {
+		return fmt.Errorf("persist pipeline receipt: %w", err)
 	}
 	return nil
 }
@@ -281,18 +286,10 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 	}
 	persisted := false
 	defer func() {
-		if !persisted {
+		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
-		status := "processed"
-		errText := ""
-		if err != nil {
-			status = "error"
-			errText = err.Error()
-		} else if overrideStatus, overrideErr, ok := runtimepipeline.PipelineReceiptOverrideFromContext(ctx); ok {
-			status = overrideStatus
-			errText = overrideErr
-		}
+		status, errText := pipelineReceiptStatus(ctx, err)
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
 	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
@@ -310,7 +307,9 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 	}
 	if passthrough {
 		if len(plan.Recipients) > 0 {
-			eb.deliverToAgents(ctx, evt, plan.Recipients)
+			if err := eb.deliverToAgents(ctx, evt, plan.PersistedRecipients); err != nil {
+				return err
+			}
 			eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
 		}
 		if plan.BlockedByCycle && plan.CycleEscalation != nil {
@@ -357,18 +356,10 @@ func (eb *EventBus) publishDeferredNoIntercept(ctx context.Context, evt events.E
 	}
 	persisted := false
 	defer func() {
-		if !persisted {
+		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
-		status := "processed"
-		errText := ""
-		if err != nil {
-			status = "error"
-			errText = err.Error()
-		} else if overrideStatus, overrideErr, ok := runtimepipeline.PipelineReceiptOverrideFromContext(ctx); ok {
-			status = overrideStatus
-			errText = overrideErr
-		}
+		status, errText := pipelineReceiptStatus(ctx, err)
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
 	if err := eb.routeAndDeliver(ctx, evt); err != nil {
@@ -397,7 +388,9 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 		return err
 	}
 	if len(plan.Recipients) > 0 {
-		eb.deliverToAgents(ctx, evt, plan.Recipients)
+		if err := eb.deliverToAgents(ctx, evt, plan.PersistedRecipients); err != nil {
+			return err
+		}
 		eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
 	}
 	if plan.BlockedByCycle && plan.CycleEscalation != nil {
@@ -571,15 +564,10 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	start := time.Now()
 	persisted := false
 	defer func() {
-		if !persisted {
+		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
-		status := "processed"
-		errText := ""
-		if err != nil {
-			status = "error"
-			errText = err.Error()
-		}
+		status, errText := pipelineReceiptStatus(ctx, err)
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
 	recipients = uniqueStrings(recipients)
@@ -608,7 +596,9 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		return err
 	}
 	persisted = true
-	eb.deliverToAgents(ctx, evt, recipients)
+	if err := eb.deliverToAgents(ctx, evt, recipients); err != nil {
+		return err
+	}
 	eb.logRuntime(ctx, "debug", "Event was delivered directly to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
 		"direct":           true,
 		"recipients_count": len(recipients),

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -280,6 +281,53 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 	}, []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
+	}
+}
+
+func TestEventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	err = eb.PublishDirect(ctx, (events.Event{
+		ID:        eventID,
+		Type:      events.EventType("custom.direct"),
+		Payload:   []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(entityID), []string{"agent-a"})
+	if err == nil || !strings.Contains(err.Error(), "authoritative delivery incomplete") {
+		t.Fatalf("PublishDirect missing recipient error = %v, want authoritative delivery incomplete", err)
+	}
+
+	var eventCount, deliveryCount, receiptCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = $1::uuid`, eventID).Scan(&eventCount); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid`, eventID).Scan(&deliveryCount); err != nil {
+		t.Fatalf("count deliveries: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&receiptCount); err != nil {
+		t.Fatalf("count pipeline receipts: %v", err)
+	}
+	if eventCount != 1 || deliveryCount != 1 {
+		t.Fatalf("persisted rows = events:%d deliveries:%d, want 1 each", eventCount, deliveryCount)
+	}
+	if receiptCount != 0 {
+		t.Fatalf("pipeline receipt count = %d, want 0 before real fan-out", receiptCount)
 	}
 }
 
@@ -672,7 +720,9 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eb.Subscribe("direct-agent", events.EventType("producer/scan.requested"))
+	eb.Subscribe("scan-orchestrator")
 	defer eb.Unsubscribe("direct-agent")
+	defer eb.Unsubscribe("scan-orchestrator")
 
 	if err := eb.Publish(context.Background(), events.Event{
 		Type: events.EventType("producer/scan.requested"),
@@ -774,6 +824,8 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
+	eb.Subscribe("scan-orchestrator")
+	defer eb.Unsubscribe("scan-orchestrator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	if err := eb.Publish(ctx, (events.Event{
@@ -1162,6 +1214,8 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
+	eb.Subscribe("child-aggregator")
+	defer eb.Unsubscribe("child-aggregator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	if err := eb.Publish(ctx, (events.Event{
@@ -1219,6 +1273,8 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
+	eb.Subscribe("worker-inst-1")
+	defer eb.Unsubscribe("worker-inst-1")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	if err := eb.Publish(ctx, (events.Event{

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -2,6 +2,8 @@ package bus
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,6 +11,8 @@ import (
 	"swarm/internal/runtime/diaglog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
+
+var errAuthoritativeDeliveryIncomplete = errors.New("authoritative delivery incomplete")
 
 func (eb *EventBus) activeAgentDescriptors(ctx context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
 	lister, ok := eb.store.(ActiveAgentDescriptorLister)
@@ -98,19 +102,59 @@ func (eb *EventBus) resolveRoutedRecipients(eventType string) []string {
 	return out
 }
 
-func (eb *EventBus) deliverToAgents(ctx context.Context, evt events.Event, agentIDs []string) {
-	recipients := eb.snapshotRecipientChans(agentIDs)
+func (eb *EventBus) deliverToAgents(ctx context.Context, evt events.Event, agentIDs []string) error {
+	expected := uniqueStrings(agentIDs)
+	if len(expected) == 0 {
+		return nil
+	}
+	recipients := eb.snapshotRecipientChans(expected)
+	delivered := make([]string, 0, len(recipients))
+	seen := make(map[string]struct{}, len(recipients))
+	for _, recipient := range recipients {
+		seen[recipient.agentID] = struct{}{}
+	}
+	missing := make([]string, 0, len(expected))
+	for _, recipient := range expected {
+		if _, ok := seen[recipient]; !ok {
+			missing = append(missing, recipient)
+		}
+	}
+	timedOut := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
 		select {
 		case recipient.ch <- evt:
+			delivered = append(delivered, recipient.agentID)
 		case <-ctx.Done():
-			return
+			remaining := make([]string, 0, len(recipients)-len(delivered))
+			for _, candidate := range recipients {
+				if _, ok := seen[candidate.agentID]; ok {
+					delete(seen, candidate.agentID)
+				}
+			}
+			for _, recipient := range expected {
+				found := false
+				for _, sent := range delivered {
+					if sent == recipient {
+						found = true
+						break
+					}
+				}
+				if !found {
+					remaining = append(remaining, recipient)
+				}
+			}
+			return eb.logAuthoritativeDeliveryIncomplete(ctx, evt, expected, delivered, missing, remaining, ctx.Err())
 		case <-time.After(deliverySendTimeout):
+			timedOut = append(timedOut, recipient.agentID)
 			eb.logRuntime(ctx, "warn", "Event delivery to a recipient timed out", "eventbus", "delivery_timeout", evt.ID, string(evt.Type), recipient.agentID, evt.EntityID(), "", nil, map[string]any{
 				"timeout_ms": int(deliverySendTimeout / time.Millisecond),
 			}, "", 0)
 		}
 	}
+	if len(missing) > 0 || len(timedOut) > 0 {
+		return eb.logAuthoritativeDeliveryIncomplete(ctx, evt, expected, delivered, missing, timedOut, nil)
+	}
+	return nil
 }
 
 type agentRecipient struct {
@@ -144,7 +188,7 @@ func (eb *EventBus) deliverByType(evt events.Event) {
 		eb.resolveRoutedRecipients(string(evt.Type)),
 		eb.resolveSubscribedRecipients(string(evt.Type))...,
 	))
-	eb.deliverToAgents(context.Background(), evt, recipients)
+	_ = eb.deliverToAgents(context.Background(), evt, recipients)
 }
 
 func (eb *EventBus) resolveSubscribedRecipients(eventType string) []string {
@@ -237,6 +281,39 @@ func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, er
 			"status": status,
 		}, err.Error(), 0)
 	}
+}
+
+func (eb *EventBus) logAuthoritativeDeliveryIncomplete(ctx context.Context, evt events.Event, expected, delivered, missing, timedOut []string, cause error) error {
+	detail := map[string]any{
+		"expected_recipients":  expected,
+		"delivered_recipients": delivered,
+	}
+	if len(missing) > 0 {
+		detail["missing_recipients"] = missing
+	}
+	if len(timedOut) > 0 {
+		detail["timed_out_recipients"] = timedOut
+	}
+	errText := ""
+	if cause != nil {
+		errText = cause.Error()
+		detail["cause"] = errText
+	}
+	eb.logRuntime(ctx, "warn", "Authoritative delivery fan-out was incomplete", "eventbus", "delivery_incomplete", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, detail, errText, 0)
+	parts := make([]string, 0, 3)
+	if len(missing) > 0 {
+		parts = append(parts, "missing="+strings.Join(missing, ","))
+	}
+	if len(timedOut) > 0 {
+		parts = append(parts, "timed_out="+strings.Join(timedOut, ","))
+	}
+	if cause != nil {
+		parts = append(parts, cause.Error())
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "incomplete")
+	}
+	return fmt.Errorf("%w: %s", errAuthoritativeDeliveryIncomplete, strings.Join(parts, "; "))
 }
 
 func (eb *EventBus) logRuntime(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -90,7 +91,9 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 	}
 	for _, intent := range intents {
 		if err := d.dispatchIntent(ctx, intent); err != nil {
-			d.bus.markPipelineReceipt(ctx, intent.Event.ID, "error", err.Error())
+			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
+				d.bus.markPipelineReceipt(ctx, intent.Event.ID, "error", err.Error())
+			}
 			return err
 		}
 		d.bus.markPipelineReceipt(ctx, intent.Event.ID, "processed", "")
@@ -99,45 +102,34 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 }
 
 func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengine.EmitIntent) error {
-	if len(intent.Recipients) > 0 {
-		recipients := uniqueStrings(intent.Recipients)
-		if len(recipients) > 0 {
-			d.bus.deliverToAgents(ctx, intent.Event, recipients)
-			d.bus.logRuntime(ctx, "debug", "Deferred event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
-				"direct":           true,
-				"recipients_count": len(recipients),
-			}, "", 0)
-		}
-		return nil
-	}
-	passthrough, deferred, err := d.bus.runInterceptors(ctx, intent.Event)
-	if err != nil {
-		return err
-	}
-	for _, next := range deferred {
-		if err := d.bus.publishDeferred(ctx, next); err != nil {
+	if intent.Recipients == nil {
+		passthrough, deferred, err := d.bus.runInterceptors(ctx, intent.Event)
+		if err != nil {
 			return err
 		}
-	}
-	if !passthrough {
-		return nil
-	}
-	plan, err := d.bus.deliveryPlanner.Plan(ctx, intent.Event)
-	if err != nil {
-		return err
-	}
-	d.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
-	if len(plan.Recipients) > 0 {
-		d.bus.deliverToAgents(ctx, intent.Event, plan.Recipients)
-		d.bus.logDelivery(ctx, intent.Event, plan.Recipients, plan.ExtraDetail)
-	}
-	if plan.BlockedByCycle && plan.CycleEscalation != nil {
-		if err := d.bus.publishDeferred(ctx, *plan.CycleEscalation); err != nil {
+		for _, next := range deferred {
+			if err := d.bus.publishDeferred(ctx, next); err != nil {
+				return err
+			}
+		}
+		if !passthrough {
+			return nil
+		}
+		recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, intent.Event.ID)
+		if err != nil {
 			return err
 		}
+		intent.Recipients = recipients
 	}
-	if strings.TrimSpace(plan.ContradictionReason) != "" {
-		_ = d.bus.emitContradiction(ctx, intent.Event, plan.ContradictionReason)
+	recipients := uniqueStrings(intent.Recipients)
+	if len(recipients) > 0 {
+		if err := d.bus.deliverToAgents(ctx, intent.Event, recipients); err != nil {
+			return err
+		}
+		d.bus.logRuntime(ctx, "debug", "Deferred event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
+			"direct":           true,
+			"recipients_count": len(recipients),
+		}, "", 0)
 	}
 	return nil
 }

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -31,6 +31,10 @@ func (*recordingEventStore) InsertEventDeliveries(context.Context, string, []str
 	return nil
 }
 
+func (*recordingEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return []string{}, nil
+}
+
 func (s *recordingEventStore) eventTypes() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -96,14 +97,16 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			eb.markPipelineReceipt(ctx, evt.ID, "error", replayErr)
 			continue
 		}
-		recipients, err := eb.sweeperRecipients(ctx, evt.ID)
+		recipients, err := eb.authoritativeRecipientsForEvent(ctx, evt.ID)
 		if err != nil {
 			eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
 			return redelivered, err
 		}
 		intent := runtimeengine.EmitIntent{Event: evt, Recipients: recipients}
 		if err := dispatcher.dispatchIntent(ctx, intent); err != nil {
-			eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
+			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
+				eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
+			}
 			return redelivered, err
 		}
 		eb.markPipelineReceipt(ctx, evt.ID, "processed", "")
@@ -112,10 +115,10 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	return redelivered, nil
 }
 
-func (eb *EventBus) sweeperRecipients(ctx context.Context, eventID string) ([]string, error) {
+func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, eventID string) ([]string, error) {
 	reader, ok := eb.store.(EventDeliveryReader)
 	if !ok {
-		return nil, nil
+		return nil, errors.New("event bus store does not support authoritative delivery recipient reads")
 	}
 	recipients, err := reader.ListEventDeliveryRecipients(ctx, eventID)
 	if err != nil {
@@ -123,6 +126,9 @@ func (eb *EventBus) sweeperRecipients(ctx context.Context, eventID string) ([]st
 	}
 	for i := range recipients {
 		recipients[i] = strings.TrimSpace(recipients[i])
+	}
+	if recipients == nil {
+		return []string{}, nil
 	}
 	return uniqueStrings(recipients), nil
 }

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -76,7 +76,7 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	}
 }
 
-func TestSweepUndispatchedFallsBackToSubscribedRouting(t *testing.T) {
+func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
 			{Event: (events.Event{
@@ -104,14 +104,7 @@ func TestSweepUndispatchedFallsBackToSubscribedRouting(t *testing.T) {
 	if got := store.receipts["evt-2"]; got != "processed" {
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
-	select {
-	case evt := <-ch:
-		if evt.ID != "evt-2" {
-			t.Fatalf("delivered event id = %q, want evt-2", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected subscribed swept delivery")
-	}
+	waitForNoEvent(t, ch)
 }
 
 func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -33,6 +33,9 @@ func (*recoveryTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEn
 func (b *recoveryTestBus) Store() runtimebus.EventStore                                  { return b }
 func (b *recoveryTestBus) AppendEvent(context.Context, events.Event) error               { return nil }
 func (b *recoveryTestBus) InsertEventDeliveries(context.Context, string, []string) error { return nil }
+func (*recoveryTestBus) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return []string{}, nil
+}
 func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
 	return nil, nil
 }

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -13,6 +13,10 @@ type missingPipelineReceiptReader interface {
 	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
 }
 
+type authoritativeDeliveryRecipientReader interface {
+	ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error)
+}
+
 type pipelineReceiptRecorder interface {
 	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
 }
@@ -24,6 +28,7 @@ type EventStore interface {
 
 type Publisher interface {
 	Publish(ctx context.Context, evt events.Event) error
+	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
 }
 
 type RecoveryManager struct {
@@ -68,6 +73,10 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 		return err
 	}
 	recorder, _ := r.store.(pipelineReceiptRecorder)
+	recipients, ok := r.store.(authoritativeDeliveryRecipientReader)
+	if !ok {
+		return fmt.Errorf("recover pipeline receipts: missing authoritative delivery recipient reader")
+	}
 	var firstErr error
 	for _, record := range eventsToReplay {
 		evt := record.Event
@@ -91,8 +100,28 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			}
 			continue
 		}
-		if err := r.bus.Publish(ctx, evt); err != nil {
-			// Keep replaying remaining events; one poison/bad event should not block full recovery.
+		persistedRecipients, err := recipients.ListEventDeliveryRecipients(ctx, evt.ID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("load persisted recipients for replay event %s: %w", evt.ID, err)
+			}
+			continue
+		}
+		if len(persistedRecipients) == 0 {
+			if recorder == nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("mark replay event %s delivered receipt: missing pipeline receipt recorder", evt.ID)
+				}
+				continue
+			}
+			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
+				}
+			}
+			continue
+		}
+		if err := r.bus.PublishDirect(ctx, evt, persistedRecipients); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("replay event %s: %w", evt.ID, err)
 			}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -16,11 +16,17 @@ import (
 type recoveryCapturePublisher struct {
 	inner     runtimepipeline.Publisher
 	published []events.Event
+	direct    []events.Event
 }
 
 func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event) error {
 	p.published = append(p.published, evt)
 	return p.inner.Publish(ctx, evt)
+}
+
+func (p *recoveryCapturePublisher) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error {
+	p.direct = append(p.direct, evt)
+	return p.inner.PublishDirect(ctx, evt, recipients)
 }
 
 func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
@@ -34,6 +40,8 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	capture := &recoveryCapturePublisher{inner: bus}
+	recipientID := "agent-recovery"
+	recipientCh := bus.Subscribe(recipientID)
 
 	runID := uuid.NewString()
 	parentID := uuid.NewString()
@@ -63,6 +71,9 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	if err := pg.AppendEvent(ctx, child); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
+	if err := pg.InsertEventDeliveries(ctx, childID, []string{recipientID}); err != nil {
+		t.Fatalf("InsertEventDeliveries(child): %v", err)
+	}
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
@@ -76,10 +87,10 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	if err := rm.Recover(ctx); err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
-	if len(capture.published) != 1 {
-		t.Fatalf("published events = %#v, want one replayed event", capture.published)
+	if len(capture.direct) != 1 {
+		t.Fatalf("direct replayed events = %#v, want one replayed event", capture.direct)
 	}
-	replayed := capture.published[0]
+	replayed := capture.direct[0]
 	if replayed.ID != childID {
 		t.Fatalf("replayed event id = %q, want %q", replayed.ID, childID)
 	}
@@ -88,6 +99,14 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	}
 	if replayed.ParentEventID != parentID {
 		t.Fatalf("replayed parent_event_id = %q, want %q", replayed.ParentEventID, parentID)
+	}
+	select {
+	case delivered := <-recipientCh:
+		if delivered.ID != childID {
+			t.Fatalf("delivered event id = %q, want %q", delivered.ID, childID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected persisted recipient to receive replayed event")
 	}
 
 	var runsAfter int
@@ -129,6 +148,7 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	goodRunID := uuid.NewString()
 	goodParentID := uuid.NewString()
 	goodEventID := uuid.NewString()
+	goodRecipientID := "agent-good"
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
@@ -159,19 +179,31 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	}); err != nil {
 		t.Fatalf("AppendEvent(good child): %v", err)
 	}
+	if err := pg.InsertEventDeliveries(ctx, goodEventID, []string{goodRecipientID}); err != nil {
+		t.Fatalf("InsertEventDeliveries(good child): %v", err)
+	}
 	if err := pg.UpsertPipelineReceipt(ctx, goodParentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(good parent): %v", err)
 	}
+	goodRecipientCh := bus.Subscribe(goodRecipientID)
 
 	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
 	if err := rm.Recover(ctx); err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
-	if len(capture.published) != 1 {
-		t.Fatalf("published events = %#v, want one valid replay", capture.published)
+	if len(capture.direct) != 1 {
+		t.Fatalf("direct replayed events = %#v, want one valid replay", capture.direct)
 	}
-	if capture.published[0].ID != goodEventID {
-		t.Fatalf("published event id = %q, want %q", capture.published[0].ID, goodEventID)
+	if capture.direct[0].ID != goodEventID {
+		t.Fatalf("published event id = %q, want %q", capture.direct[0].ID, goodEventID)
+	}
+	select {
+	case delivered := <-goodRecipientCh:
+		if delivered.ID != goodEventID {
+			t.Fatalf("delivered event id = %q, want %q", delivered.ID, goodEventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected valid replay recipient to receive event")
 	}
 
 	var badOutcome, badReason string
@@ -225,8 +257,8 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 	if err := rm.Recover(ctx); err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
-	if len(capture.published) != 0 {
-		t.Fatalf("published events = %#v, want none", capture.published)
+	if len(capture.direct) != 0 {
+		t.Fatalf("direct replayed events = %#v, want none", capture.direct)
 	}
 
 	var outcome, reason string
@@ -244,5 +276,90 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 	}
 	if reason != "pipeline_error" {
 		t.Fatalf("receipt reason = %q, want pipeline_error", reason)
+	}
+}
+
+func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}.WithEntityID(entityID)); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+	child := (events.Event{
+		ID:            eventID,
+		Type:          events.EventType("system.recover.explicit"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"entity_id":"` + entityID + `"}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}).WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, child); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"agent-a"}); err != nil {
+		t.Fatalf("InsertEventDeliveries: %v", err)
+	}
+
+	agentA := bus.Subscribe("agent-a")
+	agentB := bus.Subscribe("agent-b", events.EventType("system.recover.explicit"))
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 1 || capture.direct[0].ID != eventID {
+		t.Fatalf("direct replayed events = %#v, want [%s]", capture.direct, eventID)
+	}
+	select {
+	case evt := <-agentA:
+		if evt.ID != eventID {
+			t.Fatalf("agent-a replayed event id = %q, want %q", evt.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected agent-a to receive replayed event")
+	}
+	select {
+	case evt := <-agentB:
+		t.Fatalf("agent-b should not receive replayed event from current subscription drift: %#v", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	var receiptStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&receiptStatus); err != nil {
+		t.Fatalf("load child receipt: %v", err)
+	}
+	if receiptStatus != "success" {
+		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
 	}
 }


### PR DESCRIPTION
Closes #195

## Human Summary
This change makes the platform pipeline receipt the canonical authoritative-delivery marker only after the persisted subscriber manifest has been fanned out to real live subscribers. Recovery and redelivery now use that same persisted recipient manifest instead of rerouting from current subscriptions.

## What Changed
- moved platform pipeline receipt writes so `processed` is recorded only after real fan-out succeeds
- added an explicit authoritative-delivery-incomplete failure when persisted recipients are missing live subscriber channels or delivery times out
- stopped sweeper and recovery from falling back to current subscription routing when a persisted delivery manifest already exists
- made recovery replay through `PublishDirect` with persisted recipients, or mark `processed` only when the authoritative persisted recipient set is explicitly empty
- kept post-commit dispatcher interceptors in the canonical path while using persisted recipients as the delivery owner
- added focused regression coverage for persisted-but-undelivered publishes, zero-recipient authoritative fan-out, and recovery drift against current subscriptions

## Why This Is Needed
Before this change, the runtime could persist a pipeline receipt before real subscriber fan-out happened, and recovery could re-route events using current subscriptions instead of the persisted delivery manifest. That let authoritative delivery markers drift away from the actual subscriber fan-out the event was supposed to have.

## Scope Boundaries
- scoped to authoritative delivery meaning in the bus/store/recovery seam
- no spec edits
- no compatibility shim for older fallback routing behavior
- no broader operator observability or flow-instance lifecycle redesign

## Tests Run
- `go test ./internal/runtime/bus -run 'Test(EventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut|SweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback)' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestRecoveryManager_(ReplaysPersistedCorrelationEnvelope|QuarantinesMissingPersistedRunIDAndContinues|QuarantinesMissingRunIDSchemaCapability|UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions)' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_PipelineReceipts_MissingEventsQuery|TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure' -count=1`
- `go test ./internal/store ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/manager -count=1`
- `go test ./internal/runtime/cataloge2e ./internal/runtime/swarmflowtest -count=1`
- `go test ./... -count=1`

## Residual Risk
This fixes the canonical bus/store/recovery seam. Any future code path that writes event rows or pipeline receipts outside these store and bus APIs would still need to honor the same authoritative delivery contract explicitly.

## Follow-Up
If additional replay or dispatch entrypoints are introduced later, they should bind to the persisted delivery manifest directly rather than adding another routing fallback path.
