### PR TITLE
[agent-b][issue #188] Guard shared-store runtime startup ownership

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -151,13 +151,32 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
+
+	s.mu.RLock()
+	oldRT := s.currentRT
+	s.mu.RUnlock()
+	if oldRT != nil {
+		if err := oldRT.Shutdown(); err != nil {
+			return builderpkg.ProjectStatus{}, err
+		}
+	}
+
+	s.mu.Lock()
+	s.currentRoot = ""
+	s.currentSource = nil
+	s.currentBundle = nil
+	s.currentRT = nil
+	if s.ready != nil {
+		s.ready.Store(false)
+	}
+	s.mu.Unlock()
+
 	if err := newRT.Start(ctx); err != nil {
 		_ = newRT.Shutdown()
 		return builderpkg.ProjectStatus{}, err
 	}
 
 	s.mu.Lock()
-	oldRT := s.currentRT
 	s.currentRoot = resolvedRoot
 	s.currentSource = source
 	s.currentBundle = bundle
@@ -167,12 +186,6 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	}
 	status := s.projectStatusLocked()
 	s.mu.Unlock()
-
-	if oldRT != nil {
-		if err := oldRT.Shutdown(); err != nil {
-			slog.Warn("builder project supervisor shutdown previous runtime", "error", err)
-		}
-	}
 	slog.Info("builder project loaded", "project_dir", filepath.Clean(resolvedRoot), "workflow", strings.TrimSpace(status.WorkflowName))
 	return status, nil
 }

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -24,6 +24,8 @@ type runtimeProjectSupervisor struct {
 	cfg              *config.Config
 	stores           storeBundle
 	ready            *atomic.Bool
+	startRuntime     func(context.Context, *runtime.Runtime) error
+	shutdownRuntime  func(context.Context, *runtime.Runtime) error
 
 	mu            sync.RWMutex
 	currentRoot   string
@@ -49,10 +51,16 @@ func newRuntimeProjectSupervisor(
 		cfg:              cfg,
 		stores:           stores,
 		ready:            ready,
-		currentRoot:      strings.TrimSpace(initialRoot),
-		currentSource:    initialSource,
-		currentBundle:    initialBundle,
-		currentRT:        initialRT,
+		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
+			return rt.Start(ctx)
+		},
+		shutdownRuntime: func(_ context.Context, rt *runtime.Runtime) error {
+			return rt.Shutdown()
+		},
+		currentRoot:   strings.TrimSpace(initialRoot),
+		currentSource: initialSource,
+		currentBundle: initialBundle,
+		currentRT:     initialRT,
 	}
 }
 
@@ -92,19 +100,10 @@ func (s *runtimeProjectSupervisor) ReloadProject(ctx context.Context, projectDir
 }
 
 func (s *runtimeProjectSupervisor) CloseProject(context.Context) (builderpkg.ProjectStatus, error) {
-	s.mu.Lock()
-	oldRT := s.currentRT
-	s.currentRoot = ""
-	s.currentSource = nil
-	s.currentBundle = nil
-	s.currentRT = nil
-	if s.ready != nil {
-		s.ready.Store(false)
-	}
-	s.mu.Unlock()
+	oldRT := s.detachCurrentRuntime()
 
 	if oldRT != nil {
-		if err := oldRT.Shutdown(); err != nil {
+		if err := s.shutdownCurrentRuntime(context.Background(), oldRT); err != nil {
 			return builderpkg.ProjectStatus{}, err
 		}
 	}
@@ -152,16 +151,38 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return builderpkg.ProjectStatus{}, err
 	}
 
-	s.mu.RLock()
-	oldRT := s.currentRT
-	s.mu.RUnlock()
+	status, err := s.replaceCurrentRuntime(ctx, resolvedRoot, source, bundle, newRT)
+	if err != nil {
+		return builderpkg.ProjectStatus{}, err
+	}
+	slog.Info("builder project loaded", "project_dir", filepath.Clean(resolvedRoot), "workflow", strings.TrimSpace(status.WorkflowName))
+	return status, nil
+}
+
+func (s *runtimeProjectSupervisor) replaceCurrentRuntime(
+	ctx context.Context,
+	resolvedRoot string,
+	source semanticview.Source,
+	bundle *runtimecontracts.WorkflowContractBundle,
+	newRT *runtime.Runtime,
+) (builderpkg.ProjectStatus, error) {
+	oldRT := s.detachCurrentRuntime()
 	if oldRT != nil {
-		if err := oldRT.Shutdown(); err != nil {
+		if err := s.shutdownCurrentRuntime(ctx, oldRT); err != nil {
 			return builderpkg.ProjectStatus{}, err
 		}
 	}
+	if err := s.startCurrentRuntime(ctx, newRT); err != nil {
+		_ = s.shutdownCurrentRuntime(context.Background(), newRT)
+		return builderpkg.ProjectStatus{}, err
+	}
+	return s.attachCurrentRuntime(resolvedRoot, source, bundle, newRT), nil
+}
 
+func (s *runtimeProjectSupervisor) detachCurrentRuntime() *runtime.Runtime {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	oldRT := s.currentRT
 	s.currentRoot = ""
 	s.currentSource = nil
 	s.currentBundle = nil
@@ -169,25 +190,45 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if s.ready != nil {
 		s.ready.Store(false)
 	}
-	s.mu.Unlock()
+	return oldRT
+}
 
-	if err := newRT.Start(ctx); err != nil {
-		_ = newRT.Shutdown()
-		return builderpkg.ProjectStatus{}, err
-	}
-
+func (s *runtimeProjectSupervisor) attachCurrentRuntime(
+	resolvedRoot string,
+	source semanticview.Source,
+	bundle *runtimecontracts.WorkflowContractBundle,
+	newRT *runtime.Runtime,
+) builderpkg.ProjectStatus {
 	s.mu.Lock()
-	s.currentRoot = resolvedRoot
+	defer s.mu.Unlock()
+	s.currentRoot = strings.TrimSpace(resolvedRoot)
 	s.currentSource = source
 	s.currentBundle = bundle
 	s.currentRT = newRT
 	if s.ready != nil {
 		s.ready.Store(true)
 	}
-	status := s.projectStatusLocked()
-	s.mu.Unlock()
-	slog.Info("builder project loaded", "project_dir", filepath.Clean(resolvedRoot), "workflow", strings.TrimSpace(status.WorkflowName))
-	return status, nil
+	return s.projectStatusLocked()
+}
+
+func (s *runtimeProjectSupervisor) startCurrentRuntime(ctx context.Context, rt *runtime.Runtime) error {
+	if s == nil || rt == nil {
+		return nil
+	}
+	if s.startRuntime != nil {
+		return s.startRuntime(ctx, rt)
+	}
+	return rt.Start(ctx)
+}
+
+func (s *runtimeProjectSupervisor) shutdownCurrentRuntime(ctx context.Context, rt *runtime.Runtime) error {
+	if s == nil || rt == nil {
+		return nil
+	}
+	if s.shutdownRuntime != nil {
+		return s.shutdownRuntime(ctx, rt)
+	}
+	return rt.Shutdown()
 }
 
 func (s *runtimeProjectSupervisor) projectStatusLocked() builderpkg.ProjectStatus {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	runtimepkg "swarm/internal/runtime"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShutdown(t *testing.T) {
+	oldRT := &runtimepkg.Runtime{}
+	newRT := &runtimepkg.Runtime{}
+	var ready atomic.Bool
+	ready.Store(true)
+
+	supervisor := &runtimeProjectSupervisor{
+		ready:         &ready,
+		currentRoot:   "/tmp/old-project",
+		currentBundle: &runtimecontracts.WorkflowContractBundle{},
+		currentSource: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		currentRT:     oldRT,
+	}
+
+	shutdownCalled := false
+	startCalled := false
+	supervisor.shutdownRuntime = func(_ context.Context, rt *runtimepkg.Runtime) error {
+		shutdownCalled = true
+		if rt != oldRT {
+			t.Fatalf("shutdown runtime = %p, want old runtime %p", rt, oldRT)
+		}
+		if got := supervisor.CurrentRuntime(); got != nil {
+			t.Fatalf("CurrentRuntime during shutdown = %p, want nil", got)
+		}
+		if got := supervisor.CurrentProject(); got.Loaded {
+			t.Fatalf("CurrentProject.Loaded during shutdown = true, want false")
+		}
+		if ready.Load() {
+			t.Fatal("ready flag remained true during shutdown")
+		}
+		return nil
+	}
+	supervisor.startRuntime = func(_ context.Context, rt *runtimepkg.Runtime) error {
+		startCalled = true
+		if rt != newRT {
+			t.Fatalf("start runtime = %p, want new runtime %p", rt, newRT)
+		}
+		if got := supervisor.CurrentRuntime(); got != nil {
+			t.Fatalf("CurrentRuntime before attach = %p, want nil", got)
+		}
+		if ready.Load() {
+			t.Fatal("ready flag became true before new runtime attached")
+		}
+		return nil
+	}
+
+	status, err := supervisor.replaceCurrentRuntime(
+		context.Background(),
+		"/tmp/new-project",
+		semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		&runtimecontracts.WorkflowContractBundle{},
+		newRT,
+	)
+	if err != nil {
+		t.Fatalf("replaceCurrentRuntime: %v", err)
+	}
+	if !shutdownCalled {
+		t.Fatal("expected shutdown to be called")
+	}
+	if !startCalled {
+		t.Fatal("expected start to be called")
+	}
+	if !ready.Load() {
+		t.Fatal("ready flag = false after attach, want true")
+	}
+	if got := supervisor.CurrentRuntime(); got != newRT {
+		t.Fatalf("CurrentRuntime after attach = %p, want new runtime %p", got, newRT)
+	}
+	if !status.Loaded {
+		t.Fatal("status.Loaded = false, want true")
+	}
+	if status.ProjectDir != "/tmp/new-project" {
+		t.Fatalf("status.ProjectDir = %q, want /tmp/new-project", status.ProjectDir)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -64,6 +65,12 @@ type RuntimeOptions struct {
 }
 
 type Runtime struct {
+	lifecycleMu    sync.Mutex
+	startCtx       context.Context
+	cancelStart    context.CancelFunc
+	ownershipLease runtimeStoreOwnershipLease
+	ownerID        string
+
 	Config         *config.Config
 	Stores         Stores
 	Options        RuntimeOptions
@@ -235,6 +242,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	}
 
 	rt := &Runtime{
+		ownerID:        newRuntimeOwnerID(),
 		Config:         cfg,
 		Stores:         stores,
 		Options:        opts,
@@ -537,12 +545,37 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	if rt == nil {
 		return fmt.Errorf("runtime is nil")
 	}
+	rt.lifecycleMu.Lock()
+	if rt.cancelStart != nil || rt.ownershipLease != nil {
+		rt.lifecycleMu.Unlock()
+		return fmt.Errorf("runtime already started")
+	}
+	startCtx, cancelStart := context.WithCancel(ctx)
+	lease, err := acquireRuntimeStoreOwnership(ctx, rt.Stores.SQLDB, rt.ownerID)
+	if err != nil {
+		cancelStart()
+		rt.lifecycleMu.Unlock()
+		return err
+	}
+	rt.startCtx = startCtx
+	rt.cancelStart = cancelStart
+	rt.ownershipLease = lease
+	rt.lifecycleMu.Unlock()
+
+	started := false
+	defer func() {
+		if started {
+			return
+		}
+		rt.cleanupStartFailure()
+	}()
+
 	if rt.Pipeline != nil {
-		go rt.Pipeline.RunMaintenance(ctx)
+		go rt.Pipeline.RunMaintenance(startCtx)
 	}
 	for _, node := range rt.SystemNodes {
 		if node != nil {
-			go node.Run(ctx)
+			go node.Run(startCtx)
 		}
 	}
 	if rt.Scheduler != nil && rt.Stores.ScheduleStore != nil {
@@ -619,7 +652,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		}
 	}
 	if rt.Bus != nil {
-		rt.Bus.StartOutboxSweeper(ctx, runtimebus.DefaultOutboxSweeperConfig())
+		rt.Bus.StartOutboxSweeper(startCtx, runtimebus.DefaultOutboxSweeperConfig())
 	}
 	if rt.Manager != nil {
 		if err := rt.Manager.EnsureStaticAgents(ctx, rt.Options.WorkflowModule.SemanticSource()); err != nil {
@@ -638,7 +671,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)
 	}
 	if rt.Manager != nil {
-		rt.Manager.Run(ctx)
+		rt.Manager.Run(startCtx)
 	}
 	if rt.Stores.SQLDB != nil && rt.Logger != nil {
 	}
@@ -654,6 +687,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 			return fmt.Errorf("self-check failed: %w", err)
 		}
 	}
+	started = true
 	return nil
 }
 
@@ -670,7 +704,51 @@ func (rt *Runtime) Shutdown() error {
 	if rt.Scheduler != nil {
 		rt.Scheduler.Stop()
 	}
+	rt.lifecycleMu.Lock()
+	cancelStart := rt.cancelStart
+	lease := rt.ownershipLease
+	rt.cancelStart = nil
+	rt.startCtx = nil
+	rt.ownershipLease = nil
+	rt.lifecycleMu.Unlock()
+	if cancelStart != nil {
+		cancelStart()
+	}
+	if lease != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := lease.Release(releaseCtx); err != nil && shutdownErr == nil {
+			shutdownErr = err
+		}
+		cancel()
+	}
 	return shutdownErr
+}
+
+func (rt *Runtime) cleanupStartFailure() {
+	if rt == nil {
+		return
+	}
+	if rt.Manager != nil {
+		_ = rt.Manager.Shutdown()
+	}
+	if rt.Scheduler != nil {
+		rt.Scheduler.Stop()
+	}
+	rt.lifecycleMu.Lock()
+	cancelStart := rt.cancelStart
+	lease := rt.ownershipLease
+	rt.cancelStart = nil
+	rt.startCtx = nil
+	rt.ownershipLease = nil
+	rt.lifecycleMu.Unlock()
+	if cancelStart != nil {
+		cancelStart()
+	}
+	if lease != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = lease.Release(releaseCtx)
+		cancel()
+	}
 }
 
 func (rt *Runtime) Wait(ctx context.Context) {

--- a/internal/runtime/runtime_ownership.go
+++ b/internal/runtime/runtime_ownership.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+const runtimeSharedStoreOwnershipLock = "swarm:runtime:shared-store-owner"
+
+type runtimeStoreOwnershipLease interface {
+	Release(context.Context) error
+}
+
+type sqlRuntimeOwnershipLease struct {
+	mu       sync.Mutex
+	conn     *sql.Conn
+	released bool
+}
+
+func acquireRuntimeStoreOwnership(ctx context.Context, db *sql.DB, ownerID string) (runtimeStoreOwnershipLease, error) {
+	if db == nil {
+		return nil, nil
+	}
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil, fmt.Errorf("runtime owner id is required")
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire runtime ownership connection: %w", err)
+	}
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock(hashtext($1))`, runtimeSharedStoreOwnershipLock).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("acquire shared runtime store ownership for %s: %w", ownerID, err)
+	}
+	if !acquired {
+		_ = conn.Close()
+		return nil, fmt.Errorf("shared runtime store already owned by another runtime instance")
+	}
+	return &sqlRuntimeOwnershipLease{conn: conn}, nil
+}
+
+func (l *sqlRuntimeOwnershipLease) Release(ctx context.Context) error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	if l.released {
+		l.mu.Unlock()
+		return nil
+	}
+	l.released = true
+	conn := l.conn
+	l.conn = nil
+	l.mu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, runtimeSharedStoreOwnershipLock); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("release shared runtime store ownership: %w", err)
+	}
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close runtime ownership connection: %w", err)
+	}
+	return nil
+}
+
+func newRuntimeOwnerID() string {
+	host, _ := os.Hostname()
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = "unknown-host"
+	}
+	return fmt.Sprintf("%s:%d:%s", host, os.Getpid(), uuid.NewString())
+}

--- a/internal/runtime/runtime_ownership_test.go
+++ b/internal/runtime/runtime_ownership_test.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/testutil"
+)
+
+func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	module := loadRuntimeOwnershipWorkflowModule(t)
+
+	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime(rt1): %v", err)
+	}
+	if err := rt1.Start(context.Background()); err != nil {
+		t.Fatalf("Start(rt1): %v", err)
+	}
+	t.Cleanup(func() { _ = rt1.Shutdown() })
+
+	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime(rt2): %v", err)
+	}
+	err = rt2.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected second runtime start to fail when shared-store ownership is already held")
+	}
+	if !strings.Contains(err.Error(), "shared runtime store already owned by another runtime instance") {
+		t.Fatalf("Start(rt2) error = %v, want explicit shared-store ownership denial", err)
+	}
+}
+
+func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	module := loadRuntimeOwnershipWorkflowModule(t)
+
+	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime(rt1): %v", err)
+	}
+	if err := rt1.Start(context.Background()); err != nil {
+		t.Fatalf("Start(rt1): %v", err)
+	}
+	if err := rt1.Shutdown(); err != nil {
+		t.Fatalf("Shutdown(rt1): %v", err)
+	}
+
+	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime(rt2): %v", err)
+	}
+	if err := rt2.Start(context.Background()); err != nil {
+		t.Fatalf("Start(rt2) after shutdown release: %v", err)
+	}
+	if err := rt2.Shutdown(); err != nil {
+		t.Fatalf("Shutdown(rt2): %v", err)
+	}
+}
+
+func loadRuntimeOwnershipWorkflowModule(t *testing.T) semanticOnlyWorkflowRuntime {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", "test-boot-success")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	return semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)}
+}


### PR DESCRIPTION
Closes #188

## Human Summary

This PR adds one explicit shared-store runtime ownership guard at startup. A runtime that uses the shared Postgres store now has to acquire the canonical startup ownership lease before it starts recovery, timers, background nodes, or manager work. If another runtime instance already holds that ownership, startup fails immediately instead of silently running split-brain against the same store.

## What Changed

- added a dedicated shared-store runtime ownership lease in `internal/runtime/runtime_ownership.go`
  - uses a dedicated Postgres connection plus an advisory lock held for the runtime lifetime
- updated `Runtime.Start()` to acquire that ownership before startup work begins
- updated `Runtime.Start()` to use a runtime-owned start context for background startup work so shutdown can stop those runtime-owned goroutines before releasing ownership
- updated `Runtime.Shutdown()` to cancel the runtime-owned start context and release the ownership lease explicitly
- added startup cleanup so a failed start does not leave the shared-store ownership lease behind
- updated builder project reload ordering so it shuts down the currently running runtime before starting the replacement runtime against the same store
- added focused runtime tests proving:
  - a second runtime against the same shared Postgres store is rejected explicitly
  - shutdown releases ownership so a successor runtime can start cleanly

## Why This Is Needed

- the runtime currently behaved as if only one instance owned recovery, timers, and related shared-store startup work, but nothing actually proved that
- accidental double-start or overlap against the same store could let two runtimes both believe they were the active owner
- this change makes startup fail fast and fail closed instead of relying on an implicit single-instance assumption

## Scope Boundaries

- In scope:
  - one explicit shared-store startup ownership guard
  - runtime startup/shutdown wiring needed to hold and release that ownership coherently
  - narrow same-seam builder reload ordering needed to avoid intentional runtime overlap in one process
  - focused runtime startup tests for concurrent ownership denial
- Not in scope:
  - broad clustering
  - distributed work partitioning
  - redesign of deeper replay/timer ownership semantics beyond the startup guard

## Tests Run

- `go test ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR establishes only the startup ownership guard; deeper shared-store ownership follow-up for replayed deliveries and restored timers remains separate under `#145`
- the canonical owner in this PR is Postgres-backed shared-store startup. Runtimes without a shared SQL store still remain outside this guard by design because there is no shared-store boundary to arbitrate there

## Follow-Up

- `#145` remains the broader follow-up for deeper shared-store work ownership after startup
