### PR TITLE
[agent-d][issue #144] Make receipt retry-count advancement atomic

### DIFF
--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -132,26 +132,57 @@ func (s *PostgresStore) GetEventReceipt(ctx context.Context, eventID, agentID st
 	}
 }
 
+type agentReceiptWriteState struct {
+	finalStatus  runtimemanager.ReceiptStatus
+	retryCount   int
+	reasonCode   string
+	errorText    string
+	hasDelivery  bool
+	deliveryCode string
+}
+
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
-	var sideEffectsRaw []byte
-	err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(side_effects, '{}'::jsonb)
-		FROM event_receipts
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-	`, eventID, agentID).Scan(&sideEffectsRaw)
-	var retryCount int
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-	case err != nil:
-		return fmt.Errorf("load event receipt side effects: %w", err)
-	default:
-		payload, err := decodeAgentReceiptSideEffects(sideEffectsRaw)
+	return withEventStoreRetry(ctx, nil, func() error {
+		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("decode event receipt side effects: %w", err)
+			return fmt.Errorf("begin event receipt tx: %w", err)
 		}
-		retryCount = payload.RetryCount
+		defer func() { _ = tx.Rollback() }()
+
+		state, err := s.prepareAgentReceiptWriteStateTx(ctx, tx, eventID, agentID, status, errText)
+		if err != nil {
+			return err
+		}
+		if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit event receipt tx: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *PostgresStore) prepareAgentReceiptWriteStateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	status runtimemanager.ReceiptStatus,
+	errText string,
+) (agentReceiptWriteState, error) {
+	state := agentReceiptWriteState{
+		finalStatus: status,
+		errorText:   strings.TrimSpace(errText),
+	}
+	retryCount, hasDelivery, err := s.lockAgentDeliveryRetryCountTx(ctx, tx, eventID, agentID)
+	if err != nil {
+		return state, err
+	}
+	if !hasDelivery {
+		retryCount, err = s.lockAgentReceiptRetryCountTx(ctx, tx, eventID, agentID)
+		if err != nil {
+			return state, err
+		}
 	}
 	if status == runtimemanager.ReceiptStatusError {
 		retryCount++
@@ -160,12 +191,104 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 	if status == runtimemanager.ReceiptStatusError && retryCount >= 2 {
 		finalStatus = runtimemanager.ReceiptStatusDeadLetter
 	}
-	reasonCode := managerReceiptReasonCode(finalStatus, errText)
-	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(finalStatus, reasonCode, retryCount, errText))
+	reasonCode := managerReceiptReasonCode(finalStatus, state.errorText)
+	state.finalStatus = finalStatus
+	state.retryCount = retryCount
+	state.reasonCode = reasonCode
+	state.hasDelivery = hasDelivery
+	state.deliveryCode = "delivered"
+	switch status {
+	case runtimemanager.ReceiptStatusError:
+		state.deliveryCode = "failed"
+	case runtimemanager.ReceiptStatusDeadLetter:
+		state.deliveryCode = "dead_letter"
+	}
+	if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
+		state.deliveryCode = "dead_letter"
+	}
+	if !hasDelivery {
+		return state, nil
+	}
+	if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
+		return state, err
+	}
+	return state, nil
+}
+
+func (s *PostgresStore) lockAgentDeliveryRetryCountTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (int, bool, error) {
+	var retryCount int
+	err := tx.QueryRowContext(ctx, `
+		SELECT retry_count
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+		FOR UPDATE
+	`, eventID, agentID).Scan(&retryCount)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, false, nil
+	case err != nil:
+		return 0, false, fmt.Errorf("lock event delivery retry_count: %w", err)
+	default:
+		return retryCount, true, nil
+	}
+}
+
+func (s *PostgresStore) lockAgentReceiptRetryCountTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (int, error) {
+	var sideEffectsRaw []byte
+	err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(side_effects, '{}'::jsonb)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+		FOR UPDATE
+	`, eventID, agentID).Scan(&sideEffectsRaw)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, nil
+	case err != nil:
+		return 0, fmt.Errorf("load event receipt side effects: %w", err)
+	}
+	payload, err := decodeAgentReceiptSideEffects(sideEffectsRaw)
+	if err != nil {
+		return 0, fmt.Errorf("decode event receipt side effects: %w", err)
+	}
+	return payload.RetryCount, nil
+}
+
+func (s *PostgresStore) updateAgentDeliveryRowTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	state agentReceiptWriteState,
+) error {
+	const q = `
+		UPDATE event_deliveries
+		SET
+			status = $3,
+			retry_count = $4,
+			reason_code = NULLIF($5, ''),
+			last_error = NULLIF($6, ''),
+			active_session_id = NULL,
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`
+	if _, err := tx.ExecContext(ctx, q, eventID, agentID, state.deliveryCode, state.retryCount, state.reasonCode, state.errorText); err != nil {
+		return fmt.Errorf("sync event delivery: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) upsertAgentReceiptRowTx(ctx context.Context, tx *sql.Tx, eventID, agentID string, state agentReceiptWriteState) error {
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
 	if err != nil {
 		return fmt.Errorf("marshal event receipt side effects: %w", err)
 	}
-	outcome := mapManagerReceiptStatusToOutcome(finalStatus)
+	outcome := mapManagerReceiptStatusToOutcome(state.finalStatus)
 	const q = `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
@@ -184,45 +307,13 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 			side_effects = EXCLUDED.side_effects,
 			processed_at = now()
 	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, outcome, reasonCode, string(sideEffects)); err != nil {
+	result, err := tx.ExecContext(ctx, q, eventID, agentID, outcome, state.reasonCode, string(sideEffects))
+	if err != nil {
 		return fmt.Errorf("upsert event receipt: %w", err)
 	}
-	if err := s.syncAgentDeliverySpec(ctx, eventID, agentID, finalStatus, reasonCode, retryCount, errText); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *PostgresStore) syncAgentDeliverySpec(
-	ctx context.Context,
-	eventID, agentID string,
-	status runtimemanager.ReceiptStatus,
-	reasonCode string,
-	retryCount int,
-	errText string,
-) error {
-	deliveryStatus := "delivered"
-	switch status {
-	case runtimemanager.ReceiptStatusError:
-		deliveryStatus = "failed"
-	case runtimemanager.ReceiptStatusDeadLetter:
-		deliveryStatus = "dead_letter"
-	}
-	const q = `
-		UPDATE event_deliveries
-		SET
-			status = $3,
-			retry_count = $4,
-			reason_code = NULLIF($5, ''),
-			last_error = NULLIF($6, ''),
-			active_session_id = NULL,
-			delivered_at = now()
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, deliveryStatus, retryCount, reasonCode, strings.TrimSpace(errText)); err != nil {
-		return fmt.Errorf("sync event delivery: %w", err)
+	rows, err := result.RowsAffected()
+	if err == nil && rows == 0 {
+		return fmt.Errorf("upsert event receipt: event %s not found", strings.TrimSpace(eventID))
 	}
 	return nil
 }
@@ -347,16 +438,30 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 
 func (s *PostgresStore) getEventReceiptSpec(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
 	var (
-		outcome     string
-		sideEffects []byte
+		outcome      string
+		sideEffects  []byte
+		delivery     string
+		deliveryErr  string
+		deliverySeen bool
+		retryCount   sql.NullInt64
 	)
 	if err := s.DB.QueryRowContext(ctx, `
-		SELECT outcome, COALESCE(side_effects, '{}'::jsonb)
-		FROM event_receipts
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-	`, eventID, agentID).Scan(&outcome, &sideEffects); err != nil {
+		SELECT
+			r.outcome,
+			COALESCE(r.side_effects, '{}'::jsonb),
+			COALESCE(d.status, ''),
+			COALESCE(d.last_error, ''),
+			d.retry_count,
+			CASE WHEN d.delivery_id IS NULL THEN FALSE ELSE TRUE END
+		FROM event_receipts r
+		LEFT JOIN event_deliveries d
+			ON d.event_id = r.event_id
+			AND d.subscriber_type = 'agent'
+			AND d.subscriber_id = r.subscriber_id
+		WHERE r.event_id = $1::uuid
+		  AND r.subscriber_type = 'agent'
+		  AND r.subscriber_id = $2
+	`, eventID, agentID).Scan(&outcome, &sideEffects, &delivery, &deliveryErr, &retryCount, &deliverySeen); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return runtimemanager.EventReceipt{}, false, nil
 		}
@@ -375,6 +480,19 @@ func (s *PostgresStore) getEventReceiptSpec(ctx context.Context, eventID, agentI
 		receipt.Status = payload.ManagerStatus
 		receipt.RetryCount = payload.RetryCount
 		receipt.Error = payload.Error
+	}
+	if deliverySeen {
+		mappedStatus, ok := mapDeliveryStatusToManagerReceiptStatus(delivery)
+		if !ok {
+			return runtimemanager.EventReceipt{}, false, fmt.Errorf("get event receipt: invalid delivery status %q", strings.TrimSpace(delivery))
+		}
+		receipt.Status = mappedStatus
+		if retryCount.Valid {
+			receipt.RetryCount = int(retryCount.Int64)
+		}
+		if strings.TrimSpace(deliveryErr) != "" {
+			receipt.Error = strings.TrimSpace(deliveryErr)
+		}
 	}
 	return receipt, true, nil
 }
@@ -451,6 +569,19 @@ func mapOutcomeToManagerReceiptStatus(outcome string) runtimemanager.ReceiptStat
 		return runtimemanager.ReceiptStatusDeadLetter
 	default:
 		return runtimemanager.ReceiptStatusProcessed
+	}
+}
+
+func mapDeliveryStatusToManagerReceiptStatus(status string) (runtimemanager.ReceiptStatus, bool) {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "delivered":
+		return runtimemanager.ReceiptStatusProcessed, true
+	case "failed":
+		return runtimemanager.ReceiptStatusError, true
+	case "dead_letter":
+		return runtimemanager.ReceiptStatusDeadLetter, true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -482,16 +482,18 @@ func (s *PostgresStore) getEventReceiptSpec(ctx context.Context, eventID, agentI
 		receipt.Error = payload.Error
 	}
 	if deliverySeen {
-		mappedStatus, ok := mapDeliveryStatusToManagerReceiptStatus(delivery)
-		if !ok {
-			return runtimemanager.EventReceipt{}, false, fmt.Errorf("get event receipt: invalid delivery status %q", strings.TrimSpace(delivery))
+		mappedStatus, override, err := terminalManagerReceiptStatusFromDelivery(delivery)
+		if err != nil {
+			return runtimemanager.EventReceipt{}, false, fmt.Errorf("get event receipt: %w", err)
 		}
-		receipt.Status = mappedStatus
-		if retryCount.Valid {
-			receipt.RetryCount = int(retryCount.Int64)
-		}
-		if strings.TrimSpace(deliveryErr) != "" {
-			receipt.Error = strings.TrimSpace(deliveryErr)
+		if override {
+			receipt.Status = mappedStatus
+			if retryCount.Valid {
+				receipt.RetryCount = int(retryCount.Int64)
+			}
+			if strings.TrimSpace(deliveryErr) != "" {
+				receipt.Error = strings.TrimSpace(deliveryErr)
+			}
 		}
 	}
 	return receipt, true, nil
@@ -572,16 +574,18 @@ func mapOutcomeToManagerReceiptStatus(outcome string) runtimemanager.ReceiptStat
 	}
 }
 
-func mapDeliveryStatusToManagerReceiptStatus(status string) (runtimemanager.ReceiptStatus, bool) {
+func terminalManagerReceiptStatusFromDelivery(status string) (runtimemanager.ReceiptStatus, bool, error) {
 	switch strings.TrimSpace(strings.ToLower(status)) {
 	case "delivered":
-		return runtimemanager.ReceiptStatusProcessed, true
+		return runtimemanager.ReceiptStatusProcessed, true, nil
 	case "failed":
-		return runtimemanager.ReceiptStatusError, true
+		return runtimemanager.ReceiptStatusError, true, nil
 	case "dead_letter":
-		return runtimemanager.ReceiptStatusDeadLetter, true
+		return runtimemanager.ReceiptStatusDeadLetter, true, nil
+	case "pending", "in_progress", "":
+		return "", false, nil
 	default:
-		return "", false
+		return "", false, fmt.Errorf("invalid delivery status %q", strings.TrimSpace(status))
 	}
 }
 

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -114,6 +115,164 @@ func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *tes
 	}
 	if deliveryStatus != "dead_letter" || managerStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" {
 		t.Fatalf("terminal status mismatch: delivery=%q manager=%q retry=%d reason=%q", deliveryStatus, managerStatus, deliveryRetry, reasonCode)
+	}
+}
+
+func TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.concurrent_retry_upsert")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+
+	lockTx, err := pg.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if _, err := lockTx.ExecContext(ctx, `
+		SELECT 1
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+		FOR UPDATE
+	`, evt.ID, agentID); err != nil {
+		t.Fatalf("lock delivery row: %v", err)
+	}
+
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			errCh <- pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom")
+		}()
+	}
+	time.Sleep(150 * time.Millisecond)
+	if err := lockTx.Commit(); err != nil {
+		t.Fatalf("release delivery row lock: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("concurrent upsert #%d: %v", i+1, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for concurrent receipt upserts")
+		}
+	}
+
+	var (
+		deliveryStatus string
+		deliveryRetry  int
+		managerStatus  string
+		receiptRetry   int
+	)
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(r.side_effects->>'manager_status', ''),
+			COALESCE((r.side_effects->>'retry_count')::int, 0)
+		FROM event_deliveries d
+		INNER JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &managerStatus, &receiptRetry); err != nil {
+		t.Fatalf("query concurrent retry state: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryRetry != 2 || managerStatus != "dead_letter" || receiptRetry != 2 {
+		t.Fatalf("concurrent retry state mismatch: delivery=%q retry=%d manager=%q receipt_retry=%d", deliveryStatus, deliveryRetry, managerStatus, receiptRetry)
+	}
+}
+
+func TestUpsertEventReceipt_RollsBackReceiptWhenDeliverySyncFails_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.receipt_delivery_atomicity")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+	var originalReasonCode string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&originalReasonCode); err != nil {
+		t.Fatalf("load original delivery reason: %v", err)
+	}
+
+	if _, err := pg.DB.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION fail_receipt_delivery_sync()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced delivery sync failure';
+		END;
+		$$;
+	`); err != nil {
+		t.Fatalf("create trigger function: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		CREATE TRIGGER event_deliveries_fail_sync
+		BEFORE UPDATE ON event_deliveries
+		FOR EACH ROW
+		EXECUTE FUNCTION fail_receipt_delivery_sync()
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusProcessed, "")
+	if err == nil {
+		t.Fatal("expected delivery sync failure")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "sync event delivery") {
+		t.Fatalf("upsert receipt error = %v, want sync event delivery failure", err)
+	}
+
+	var receiptCount int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&receiptCount); err != nil {
+		t.Fatalf("count receipts after rollback: %v", err)
+	}
+	if receiptCount != 0 {
+		t.Fatalf("receipt count after rollback = %d, want 0", receiptCount)
+	}
+
+	var (
+		deliveryStatus string
+		retryCount     int
+		reasonCode     string
+	)
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(retry_count, 0), COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &retryCount, &reasonCode); err != nil {
+		t.Fatalf("load delivery after rollback: %v", err)
+	}
+	if deliveryStatus != "pending" || retryCount != 0 || reasonCode != originalReasonCode {
+		t.Fatalf("delivery after rollback = status:%q retry:%d reason:%q want reason:%q", deliveryStatus, retryCount, reasonCode, originalReasonCode)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -413,6 +413,17 @@ func TestPostgresStore_CancelActiveRunWorkByProducer_DeadLettersOldRunDeliveries
 		t.Fatalf("cancelled delivery last_error = %q", lastError)
 	}
 
+	receipt, ok, err := pg.GetEventReceipt(ctx, childEventID, "market-research-agent")
+	if err != nil {
+		t.Fatalf("GetEventReceipt(cancelled delivery): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cancelled delivery receipt to exist")
+	}
+	if receipt.Status != runtimemanager.ReceiptStatusDeadLetter || receipt.RetryCount != 0 {
+		t.Fatalf("cancelled receipt = %+v, want dead_letter retry_count=0", receipt)
+	}
+
 	var untouchedStatus string
 	if err := db.QueryRowContext(ctx, `
 		SELECT status
@@ -423,6 +434,69 @@ func TestPostgresStore_CancelActiveRunWorkByProducer_DeadLettersOldRunDeliveries
 	}
 	if untouchedStatus != "pending" {
 		t.Fatalf("untouched delivery status = %q, want pending", untouchedStatus)
+	}
+}
+
+func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminalDelivery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	entityID := uuid.NewString()
+	seedSpecAgent(t, ctx, pg, "a1", "", "*")
+	eventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, (events.Event{
+		ID:          eventID,
+		Type:        "system.started",
+		SourceAgent: "runtime",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now(),
+	}).WithEntityID(entityID)); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"a1"}); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'in_progress',
+			reason_code = 'agent_processing',
+			active_session_id = $2::uuid
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'a1'
+	`, eventID, uuid.NewString()); err != nil {
+		t.Fatalf("set in_progress delivery: %v", err)
+	}
+
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(runtimemanager.ReceiptStatusDeadLetter, "retry_exhausted", 2, "boom"))
+	if err != nil {
+		t.Fatalf("marshal side effects: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'agent', 'a1', e.entity_id, e.flow_instance,
+			'dead_letter', 'retry_exhausted', $2::jsonb, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+	`, eventID, string(sideEffects)); err != nil {
+		t.Fatalf("insert receipt: %v", err)
+	}
+
+	receipt, ok, err := pg.GetEventReceipt(ctx, eventID, "a1")
+	if err != nil {
+		t.Fatalf("GetEventReceipt(in_progress delivery): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected receipt to be found")
+	}
+	if receipt.Status != runtimemanager.ReceiptStatusDeadLetter || receipt.RetryCount != 2 || receipt.Error != "boom" {
+		t.Fatalf("receipt = %+v, want dead_letter retry_count=2 error=boom", receipt)
 	}
 }
 

--- a/internal/store/trace_cancel.go
+++ b/internal/store/trace_cancel.go
@@ -102,24 +102,47 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 	}
 
 	if _, err := tx.ExecContext(ctx, `
+		WITH targeted AS (
+			SELECT
+				d.delivery_id,
+				d.event_id,
+				d.subscriber_type,
+				d.subscriber_id,
+				e.entity_id,
+				e.flow_instance
+			FROM event_deliveries d
+			JOIN events e ON e.event_id = d.event_id
+			WHERE e.run_id::text = ANY($1::text[])
+			  AND d.status IN ('pending', 'in_progress')
+			FOR UPDATE OF d
+		),
+		updated AS (
+			UPDATE event_deliveries d
+			SET
+				status = 'dead_letter',
+				reason_code = 'cancelled_by_kill_previous',
+				last_error = 'cancelled by --kill-previous',
+				active_session_id = NULL,
+				delivered_at = now()
+			FROM targeted t
+			WHERE d.delivery_id = t.delivery_id
+			RETURNING t.event_id, t.subscriber_type, t.subscriber_id, t.entity_id, t.flow_instance
+		)
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, side_effects, processed_at
 		)
 		SELECT
-			e.event_id,
-			d.subscriber_type,
-			d.subscriber_id,
-			e.entity_id,
-			e.flow_instance,
+			u.event_id,
+			u.subscriber_type,
+			u.subscriber_id,
+			u.entity_id,
+			u.flow_instance,
 			'dead_letter',
 			'cancelled_by_kill_previous',
 			$2::jsonb,
 			now()
-		FROM event_deliveries d
-		JOIN events e ON e.event_id = d.event_id
-		WHERE e.run_id::text = ANY($1::text[])
-		  AND d.status IN ('pending', 'in_progress')
+		FROM updated u
 		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
 			entity_id = EXCLUDED.entity_id,
 			flow_instance = EXCLUDED.flow_instance,
@@ -128,23 +151,7 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 			side_effects = EXCLUDED.side_effects,
 			processed_at = now()
 	`, pq.Array(runIDs), string(sideEffects)); err != nil {
-		return nil, fmt.Errorf("upsert kill_previous receipts: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries d
-		SET
-			status = 'dead_letter',
-			reason_code = 'cancelled_by_kill_previous',
-			last_error = 'cancelled by --kill-previous',
-			active_session_id = NULL,
-			delivered_at = now()
-		FROM events e
-		WHERE e.event_id = d.event_id
-		  AND e.run_id::text = ANY($1::text[])
-		  AND d.status IN ('pending', 'in_progress')
-	`, pq.Array(runIDs)); err != nil {
-		return nil, fmt.Errorf("mark kill_previous deliveries dead_letter: %w", err)
+		return nil, fmt.Errorf("cancel kill_previous deliveries/receipts: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
Closes #144

## Human Summary
This change makes agent receipt retry advancement and delivery-state synchronization happen in one transactional store write path. The receipt row can no longer advance independently of the delivery row in the touched seam, so concurrent retry updates and mid-write failures do not lose increments or leave the two tables disagreeing.

## What Changed
- moved `UpsertEventReceipt` onto one transactional canonical write path in `internal/store/event_receipt_store.go`
- made `event_deliveries.retry_count` the canonical retry counter for agent deliveries in this seam
- locked the delivery row with `FOR UPDATE`, advanced retry state there, then derived the receipt payload from that state in the same transaction
- kept receipt-only retry counting explicitly coordinated by locking the existing receipt row when no delivery row exists
- made `GetEventReceipt` prefer the coordinated delivery row for status/retry count when one exists
- added focused regression tests for concurrent retry advancement and rollback on delivery-sync failure

## Why This Is Needed
Before this change, the store loaded retry count from receipt JSON, wrote the receipt in one statement, then synchronized `event_deliveries` in a second statement. That left two real bugs:
- concurrent retry errors could lose increments because both writers could read the same old retry count
- a failure after the receipt write but before the delivery update could leave `event_receipts` and `event_deliveries` disagreeing

## Scope Boundaries
- In scope:
  - agent receipt retry advancement in `internal/store/event_receipt_store.go`
  - atomic coordination between receipt writes and delivery-state updates in the touched seam
  - focused store regression tests for lost increments and rollback consistency
- Not in scope:
  - broader receipt/read-model redesign
  - platform spec changes
  - unrelated runtime retry policy cleanup

## Tests Run
- `go test ./internal/store -run 'TestUpsertEventReceipt_(DeadLettersAfterOneRetry_V2|PreservesRetryableVsTerminalDeliveryStatus_V2|ConcurrentErrorRetriesAdvanceAtomically_V2|RollsBackReceiptWhenDeliverySyncFails_V2)' -count=1`
- `go test ./internal/store ./internal/runtime/manager -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
This fixes the canonical agent receipt/delivery seam in the store. Receipt-only paths without an `event_deliveries` row still exist and keep their retry count in the receipt row because there is no delivery row to own that state in those cases.

## Follow-Up
If the platform wants one universal retry owner across both direct-delivery and receipt-only agent paths, that needs a separate issue to decide whether receipt-only agent processing should be eliminated or normalized onto persisted delivery rows everywhere.
