### PR TITLE
[agent-c][issue #134] Stop dashboard conversation and turn APIs from widening typed persisted data into loose carriers

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -163,7 +163,7 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 		return ConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
 	item.Summary = runtimeState.Summary
-	item.Metadata = runtimeState.metadataMap()
+	item.Metadata = runtimeState.metadata()
 	return item, nil
 }
 
@@ -193,15 +193,26 @@ func scanConversationDetail(scanner rowScanner) (ConversationDetail, error) {
 		return ConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
 	item.Summary = runtimeState.Summary
-	item.RuntimeState = runtimeState.runtimeStateMap()
-	item.Messages, err = decodeJSONArray(messagesRaw)
+	item.RuntimeState = runtimeState.runtimeState()
+	item.Messages, err = decodeJSONArray[ConversationMessage](messagesRaw)
 	if err != nil {
 		return ConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)
 	}
 	if item.Messages == nil {
-		item.Messages = []any{}
+		item.Messages = []ConversationMessage{}
 	}
 	return item, nil
+}
+
+func decodeJSONObjectRaw(raw []byte) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return append(json.RawMessage(nil), raw...), nil
 }
 
 func decodeJSONMap(raw []byte) (map[string]any, error) {
@@ -215,11 +226,22 @@ func decodeJSONMap(raw []byte) (map[string]any, error) {
 	return out, nil
 }
 
-func decodeJSONArray(raw []byte) ([]any, error) {
+func decodeJSONArray[T any](raw []byte) ([]T, error) {
 	if len(raw) == 0 {
-		return []any{}, nil
+		return []T{}, nil
 	}
-	out := []any{}
+	out := []T{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeJSONStringMap(raw []byte) (map[string]string, error) {
+	if len(raw) == 0 {
+		return map[string]string{}, nil
+	}
+	out := map[string]string{}
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, err
 	}
@@ -431,32 +453,32 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 	if err != nil {
 		return ConversationTurn{}, err
 	}
-	if item.AvailableTools, err = decodeJSONArray(availableToolsRaw); err != nil {
+	if item.AvailableTools, err = decodeJSONArray[string](availableToolsRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn available_tools: %w", err)
 	}
-	if item.ToolCalls, err = decodeJSONArray(toolCallsRaw); err != nil {
+	if item.ToolCalls, err = decodeJSONArray[ConversationToolCall](toolCallsRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn tool_calls: %w", err)
 	}
-	if item.EmittedEvents, err = decodeJSONArray(emittedEventsRaw); err != nil {
+	if item.EmittedEvents, err = decodeJSONArray[string](emittedEventsRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn emitted_events: %w", err)
 	}
-	if item.MCPToolsListed, err = decodeJSONArray(mcpToolsListedRaw); err != nil {
+	if item.MCPToolsListed, err = decodeJSONArray[string](mcpToolsListedRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn mcp_tools_listed: %w", err)
 	}
-	if item.MCPToolsVisible, err = decodeJSONArray(mcpToolsVisibleRaw); err != nil {
+	if item.MCPToolsVisible, err = decodeJSONArray[string](mcpToolsVisibleRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn mcp_tools_visible: %w", err)
 	}
-	if item.MCPServers, err = decodeJSONMap(mcpServersRaw); err != nil {
+	if item.MCPServers, err = decodeJSONStringMap(mcpServersRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn mcp_servers: %w", err)
 	}
-	if item.RequestPayload, err = decodeJSONMap(requestPayloadRaw); err != nil {
+	if item.RequestPayload, err = decodeJSONObjectRaw(requestPayloadRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn request_payload: %w", err)
 	}
-	if item.ResponsePayload, err = decodeJSONMap(responsePayloadRaw); err != nil {
+	if item.ResponsePayload, err = decodeJSONObjectRaw(responsePayloadRaw); err != nil {
 		return ConversationTurn{}, fmt.Errorf("decode turn response_payload: %w", err)
 	}
 	if len(turnBlocksRaw) > 0 {
-		if item.TurnBlocks, err = decodeJSONArray(turnBlocksRaw); err != nil {
+		if item.TurnBlocks, err = decodeJSONArray[ConversationTurnBlock](turnBlocksRaw); err != nil {
 			return ConversationTurn{}, fmt.Errorf("decode turn turn_blocks: %w", err)
 		}
 	}
@@ -466,7 +488,7 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 	return item, nil
 }
 
-func summarizeConversationTurnBlocks(blocks []any) (string, string, []string, []string, []any) {
+func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, string, []string, []string, []ConversationToolResult) {
 	raw, err := json.Marshal(blocks)
 	if err != nil {
 		return "", "", nil, nil, nil

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -8,9 +8,11 @@ import (
 )
 
 type projectedConversationRuntimeState struct {
-	Summary  string
-	LastTurn *projectedConversationLastTurn
-	raw      map[string]any
+	Summary              string
+	LastTurn             *projectedConversationLastTurn
+	ProviderSessionID    string
+	RetryReason          string
+	RetriesFromSessionID string
 }
 
 type projectedConversationLastTurn struct {
@@ -20,30 +22,49 @@ type projectedConversationLastTurn struct {
 
 func decodeConversationRuntimeStateProjection(raw []byte) (projectedConversationRuntimeState, error) {
 	if len(raw) == 0 {
-		return projectedConversationRuntimeState{raw: map[string]any{}}, nil
-	}
-	var projected projectedConversationRuntimeState
-	if err := json.Unmarshal(raw, &projected.raw); err != nil {
-		return projectedConversationRuntimeState{}, err
+		return projectedConversationRuntimeState{}, nil
 	}
 	var typed struct {
-		Summary  string                         `json:"summary"`
-		LastTurn *projectedConversationLastTurn `json:"last_turn,omitempty"`
+		Summary              string                         `json:"summary"`
+		LastTurn             *projectedConversationLastTurn `json:"last_turn,omitempty"`
+		ProviderSessionID    string                         `json:"provider_session_id,omitempty"`
+		RetryReason          string                         `json:"retry_reason,omitempty"`
+		RetriesFromSessionID string                         `json:"retries_from_session_id,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &typed); err != nil {
 		return projectedConversationRuntimeState{}, err
 	}
-	projected.Summary = strings.TrimSpace(typed.Summary)
-	projected.LastTurn = typed.LastTurn
-	return projected, nil
+	return projectedConversationRuntimeState{
+		Summary:              strings.TrimSpace(typed.Summary),
+		LastTurn:             typed.LastTurn,
+		ProviderSessionID:    strings.TrimSpace(typed.ProviderSessionID),
+		RetryReason:          strings.TrimSpace(typed.RetryReason),
+		RetriesFromSessionID: strings.TrimSpace(typed.RetriesFromSessionID),
+	}, nil
 }
 
-func (p projectedConversationRuntimeState) metadataMap() map[string]any {
-	return omitKnownKeys(p.raw, "summary", "last_turn")
+func (p projectedConversationRuntimeState) metadata() ConversationSummaryMetadata {
+	return ConversationSummaryMetadata{
+		ProviderSessionID:    p.ProviderSessionID,
+		RetryReason:          p.RetryReason,
+		RetriesFromSessionID: p.RetriesFromSessionID,
+	}
 }
 
-func (p projectedConversationRuntimeState) runtimeStateMap() map[string]any {
-	return cloneAnyMap(p.raw)
+func (p projectedConversationRuntimeState) runtimeState() ConversationRuntimeState {
+	state := ConversationRuntimeState{
+		Summary:              p.Summary,
+		ProviderSessionID:    p.ProviderSessionID,
+		RetryReason:          p.RetryReason,
+		RetriesFromSessionID: p.RetriesFromSessionID,
+	}
+	if p.LastTurn != nil {
+		state.LastTurn = &ConversationRuntimeLastTurn{
+			TaskID:  strings.TrimSpace(p.LastTurn.TaskID),
+			ParseOK: p.LastTurn.ParseOK,
+		}
+	}
+	return state
 }
 
 type projectedTurnSummary struct {
@@ -55,9 +76,9 @@ type projectedTurnSummary struct {
 }
 
 type projectedTurnSummaryToolItem struct {
-	ToolName  string `json:"tool_name,omitempty"`
-	ToolUseID string `json:"tool_use_id,omitempty"`
-	Output    any    `json:"output,omitempty"`
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
 }
 
 type projectedTurnBlockEnvelope struct {
@@ -121,24 +142,24 @@ func (p projectedTurnSummary) isZero() bool {
 		len(p.ToolResults) == 0
 }
 
-func (p projectedTurnSummary) conversationFields() (string, string, []string, []string, []any) {
-	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), p.toolResultsAny()
+func (p projectedTurnSummary) conversationFields() (string, string, []string, []string, []ConversationToolResult) {
+	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), p.toolResultsTransport()
 }
 
-func (p projectedTurnSummary) toolResultsAny() []any {
+func (p projectedTurnSummary) toolResultsTransport() []ConversationToolResult {
 	if len(p.ToolResults) == 0 {
 		return nil
 	}
-	out := make([]any, 0, len(p.ToolResults))
+	out := make([]ConversationToolResult, 0, len(p.ToolResults))
 	for _, item := range p.ToolResults {
-		row := map[string]any{
-			"tool_name": item.ToolName,
+		row := ConversationToolResult{
+			ToolName: item.ToolName,
 		}
 		if item.ToolUseID != "" {
-			row["tool_use_id"] = item.ToolUseID
+			row.ToolUseID = item.ToolUseID
 		}
 		if item.Output != nil {
-			row["output"] = item.Output
+			row.Output = append(json.RawMessage(nil), item.Output...)
 		}
 		out = append(out, row)
 	}
@@ -158,39 +179,10 @@ func (p projectedTurnSummary) lastToolMap(parseOK bool) map[string]any {
 		"ok":   parseOK,
 	}
 	if last.Output != nil {
-		out["result"] = last.Output
-	}
-	return out
-}
-
-func cloneAnyMap(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]any, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
-	return out
-}
-
-func omitKnownKeys(in map[string]any, keys ...string) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
-	drop := map[string]struct{}{}
-	for _, key := range keys {
-		drop[key] = struct{}{}
-	}
-	out := map[string]any{}
-	for key, value := range in {
-		if _, skip := drop[key]; skip {
-			continue
+		var value any
+		if err := json.Unmarshal(last.Output, &value); err == nil {
+			out["result"] = value
 		}
-		out[key] = value
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -109,7 +109,7 @@ type ConversationRuntimeState struct {
 
 type ConversationRuntimeLastTurn struct {
 	TaskID  string `json:"task_id,omitempty"`
-	ParseOK bool   `json:"parse_ok,omitempty"`
+	ParseOK bool   `json:"parse_ok"`
 }
 
 type ConversationMessage struct {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -33,64 +33,109 @@ type InstanceReader interface {
 }
 
 type ConversationSummary struct {
-	SessionID   string         `json:"session_id,omitempty"`
-	AgentID     string         `json:"agent_id"`
-	Kind        string         `json:"kind,omitempty"`
-	ScopeKey    string         `json:"scope_key,omitempty"`
-	Scope       string         `json:"scope,omitempty"`
-	RuntimeMode string         `json:"runtime_mode,omitempty"`
-	Status      string         `json:"status,omitempty"`
-	TurnCount   int            `json:"turn_count,omitempty"`
-	Summary     string         `json:"summary,omitempty"`
-	UpdatedAt   string         `json:"updated_at,omitempty"`
-	Metadata    map[string]any `json:"metadata,omitempty"`
+	SessionID   string                      `json:"session_id,omitempty"`
+	AgentID     string                      `json:"agent_id"`
+	Kind        string                      `json:"kind,omitempty"`
+	ScopeKey    string                      `json:"scope_key,omitempty"`
+	Scope       string                      `json:"scope,omitempty"`
+	RuntimeMode string                      `json:"runtime_mode,omitempty"`
+	Status      string                      `json:"status,omitempty"`
+	TurnCount   int                         `json:"turn_count,omitempty"`
+	Summary     string                      `json:"summary,omitempty"`
+	UpdatedAt   string                      `json:"updated_at,omitempty"`
+	Metadata    ConversationSummaryMetadata `json:"metadata,omitempty"`
+}
+
+type ConversationSummaryMetadata struct {
+	ProviderSessionID    string `json:"provider_session_id,omitempty"`
+	RetryReason          string `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string `json:"retries_from_session_id,omitempty"`
 }
 
 type ConversationDetail struct {
-	AgentID      string             `json:"agent_id"`
-	SessionID    string             `json:"session_id,omitempty"`
-	Kind         string             `json:"kind,omitempty"`
-	ScopeKey     string             `json:"scope_key,omitempty"`
-	Scope        string             `json:"scope,omitempty"`
-	RuntimeMode  string             `json:"runtime_mode,omitempty"`
-	Status       string             `json:"status,omitempty"`
-	TurnCount    int                `json:"turn_count,omitempty"`
-	Summary      string             `json:"summary,omitempty"`
-	UpdatedAt    string             `json:"updated_at,omitempty"`
-	Messages     []any              `json:"messages"`
-	Turns        []ConversationTurn `json:"turns,omitempty"`
-	RuntimeState map[string]any     `json:"runtime_state,omitempty"`
+	AgentID      string                   `json:"agent_id"`
+	SessionID    string                   `json:"session_id,omitempty"`
+	Kind         string                   `json:"kind,omitempty"`
+	ScopeKey     string                   `json:"scope_key,omitempty"`
+	Scope        string                   `json:"scope,omitempty"`
+	RuntimeMode  string                   `json:"runtime_mode,omitempty"`
+	Status       string                   `json:"status,omitempty"`
+	TurnCount    int                      `json:"turn_count,omitempty"`
+	Summary      string                   `json:"summary,omitempty"`
+	UpdatedAt    string                   `json:"updated_at,omitempty"`
+	Messages     []ConversationMessage    `json:"messages"`
+	Turns        []ConversationTurn       `json:"turns,omitempty"`
+	RuntimeState ConversationRuntimeState `json:"runtime_state,omitempty"`
 }
 
 type ConversationTurn struct {
-	TurnID                 string         `json:"turn_id"`
-	AgentID                string         `json:"agent_id,omitempty"`
-	SessionID              string         `json:"session_id,omitempty"`
-	RuntimeMode            string         `json:"runtime_mode,omitempty"`
-	ScopeKey               string         `json:"scope_key,omitempty"`
-	EntityID               string         `json:"entity_id,omitempty"`
-	TriggerEventID         string         `json:"trigger_event_id,omitempty"`
-	TriggerEventType       string         `json:"trigger_event_type,omitempty"`
-	TaskID                 string         `json:"task_id,omitempty"`
-	AvailableTools         []any          `json:"available_tools,omitempty"`
-	ToolCalls              []any          `json:"tool_calls,omitempty"`
-	ToolResults            []any          `json:"tool_results,omitempty"`
-	TurnBlocks             []any          `json:"turn_blocks,omitempty"`
-	EmittedEvents          []any          `json:"emitted_events,omitempty"`
-	MCPServers             map[string]any `json:"mcp_servers,omitempty"`
-	MCPToolsListed         []any          `json:"mcp_tools_listed,omitempty"`
-	MCPToolsVisible        []any          `json:"mcp_tools_visible,omitempty"`
-	RequestPayload         map[string]any `json:"request_payload,omitempty"`
-	ResponsePayload        map[string]any `json:"response_payload,omitempty"`
-	AssistantVisibleOutput string         `json:"assistant_visible_output,omitempty"`
-	ReasoningBlocks        []string       `json:"reasoning_blocks,omitempty"`
-	ProgressUpdates        []string       `json:"progress_updates,omitempty"`
-	Outcome                string         `json:"outcome,omitempty"`
-	ParseOK                bool           `json:"parse_ok"`
-	LatencyMS              int            `json:"latency_ms,omitempty"`
-	RetryCount             int            `json:"retry_count,omitempty"`
-	Error                  string         `json:"error,omitempty"`
-	CreatedAt              string         `json:"created_at,omitempty"`
+	TurnID                 string                   `json:"turn_id"`
+	AgentID                string                   `json:"agent_id,omitempty"`
+	SessionID              string                   `json:"session_id,omitempty"`
+	RuntimeMode            string                   `json:"runtime_mode,omitempty"`
+	ScopeKey               string                   `json:"scope_key,omitempty"`
+	EntityID               string                   `json:"entity_id,omitempty"`
+	TriggerEventID         string                   `json:"trigger_event_id,omitempty"`
+	TriggerEventType       string                   `json:"trigger_event_type,omitempty"`
+	TaskID                 string                   `json:"task_id,omitempty"`
+	AvailableTools         []string                 `json:"available_tools,omitempty"`
+	ToolCalls              []ConversationToolCall   `json:"tool_calls,omitempty"`
+	ToolResults            []ConversationToolResult `json:"tool_results,omitempty"`
+	TurnBlocks             []ConversationTurnBlock  `json:"turn_blocks,omitempty"`
+	EmittedEvents          []string                 `json:"emitted_events,omitempty"`
+	MCPServers             map[string]string        `json:"mcp_servers,omitempty"`
+	MCPToolsListed         []string                 `json:"mcp_tools_listed,omitempty"`
+	MCPToolsVisible        []string                 `json:"mcp_tools_visible,omitempty"`
+	RequestPayload         json.RawMessage          `json:"request_payload,omitempty"`
+	ResponsePayload        json.RawMessage          `json:"response_payload,omitempty"`
+	AssistantVisibleOutput string                   `json:"assistant_visible_output,omitempty"`
+	ReasoningBlocks        []string                 `json:"reasoning_blocks,omitempty"`
+	ProgressUpdates        []string                 `json:"progress_updates,omitempty"`
+	Outcome                string                   `json:"outcome,omitempty"`
+	ParseOK                bool                     `json:"parse_ok"`
+	LatencyMS              int                      `json:"latency_ms,omitempty"`
+	RetryCount             int                      `json:"retry_count,omitempty"`
+	Error                  string                   `json:"error,omitempty"`
+	CreatedAt              string                   `json:"created_at,omitempty"`
+}
+
+type ConversationRuntimeState struct {
+	Summary              string                       `json:"summary,omitempty"`
+	LastTurn             *ConversationRuntimeLastTurn `json:"last_turn,omitempty"`
+	ProviderSessionID    string                       `json:"provider_session_id,omitempty"`
+	RetryReason          string                       `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string                       `json:"retries_from_session_id,omitempty"`
+}
+
+type ConversationRuntimeLastTurn struct {
+	TaskID  string `json:"task_id,omitempty"`
+	ParseOK bool   `json:"parse_ok,omitempty"`
+}
+
+type ConversationMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ConversationToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type ConversationToolResult struct {
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
+}
+
+type ConversationTurnBlock struct {
+	Kind     string          `json:"kind"`
+	Title    string          `json:"title,omitempty"`
+	Text     string          `json:"text,omitempty"`
+	ToolName string          `json:"tool_name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+	Output   json.RawMessage `json:"output,omitempty"`
+	Data     json.RawMessage `json:"data,omitempty"`
 }
 
 type ConversationReader interface {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -279,14 +279,14 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 					AgentID:   "agent-1",
 					SessionID: "sess-1",
 					UpdatedAt: now.Format(time.RFC3339),
-					Messages:  []any{map[string]any{"role": "assistant", "content": "hi"}},
+					Messages:  []ConversationMessage{{Role: "assistant", Content: "hi"}},
 					Turns: []ConversationTurn{{
 						TurnID:                 "turn-1",
 						AssistantVisibleOutput: "done",
 					}},
-					RuntimeState: map[string]any{
-						"summary":   "summarized",
-						"last_turn": map[string]any{"parse_ok": true},
+					RuntimeState: ConversationRuntimeState{
+						Summary:  "summarized",
+						LastTurn: &ConversationRuntimeLastTurn{ParseOK: true},
 					},
 				},
 			},
@@ -599,10 +599,10 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	if items[0].SessionID != "sess-1" || items[0].Kind != "live_session" {
 		t.Fatalf("unexpected summary identity: %+v", items[0])
 	}
-	if items[0].Metadata["provider_session_id"] != "sess-1" {
+	if items[0].Metadata.ProviderSessionID != "sess-1" {
 		t.Fatalf("expected metadata to retain provider_session_id: %+v", items[0].Metadata)
 	}
-	if items[0].Metadata["retry_reason"] != "session not found" || items[0].Metadata["retries_from_session_id"] != "sess-0" {
+	if items[0].Metadata.RetryReason != "session not found" || items[0].Metadata.RetriesFromSessionID != "sess-0" {
 		t.Fatalf("expected retry lineage metadata, got %+v", items[0].Metadata)
 	}
 
@@ -637,11 +637,10 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	if item.Kind != "live_session" {
 		t.Fatalf("expected live_session detail kind, got %+v", item)
 	}
-	lastTurn, ok := item.RuntimeState["last_turn"].(map[string]any)
-	if !ok || lastTurn["parse_ok"] != true {
+	if item.RuntimeState.LastTurn == nil || !item.RuntimeState.LastTurn.ParseOK {
 		t.Fatalf("expected runtime_state.last_turn parse_ok=true, got %+v", item.RuntimeState)
 	}
-	if item.RuntimeState["retry_reason"] != "session not found" || item.RuntimeState["retries_from_session_id"] != "sess-0" {
+	if item.RuntimeState.RetryReason != "session not found" || item.RuntimeState.RetriesFromSessionID != "sess-0" {
 		t.Fatalf("expected retry lineage in runtime_state, got %+v", item.RuntimeState)
 	}
 	if item.Turns[0].AssistantVisibleOutput != "" || item.Turns[0].Outcome != "" || len(item.Turns[0].ToolResults) != 0 {
@@ -1066,8 +1065,8 @@ func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {
 	if len(item.Turns[0].ToolResults) != 1 {
 		t.Fatalf("tool_results = %#v", item.Turns[0].ToolResults)
 	}
-	result, _ := item.Turns[0].ToolResults[0].(map[string]any)
-	if result["tool_name"] != "schedule" {
+	result := item.Turns[0].ToolResults[0]
+	if result.ToolName != "schedule" {
 		t.Fatalf("tool_result = %#v", result)
 	}
 
@@ -1260,11 +1259,54 @@ func TestSQLConversationReader_GetUsesCanonicalTurnSummaryProgress(t *testing.T)
 	}
 }
 
+func TestSQLConversationReader_GetFailsOnMalformedTypedTurnPayload(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(`{"summary":"brief"}`), []byte(`[{"role":"assistant","content":"hello"}]`), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "sess-1", "task", "global", "entity-1", "evt-1", "task.run", "",
+			[]byte(`["schedule"]`), []byte(`[{"name":"schedule","arguments":{"delay_seconds":1209600}}]`), []byte(`["workflow.started"]`), []byte(`{"runtime-tools":{"status":"connected"}}`), []byte(`["mcp__runtime-tools__schedule"]`), []byte(`["mcp__runtime-tools__schedule"]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[]`), true, 25, 0, "", now,
+		))
+
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil || !strings.Contains(err.Error(), "decode turn mcp_servers") {
+		t.Fatalf("expected malformed typed turn payload to fail closed, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSummarizeConversationTurnBlocks_FailsClosedOnEmptyCanonicalSummary(t *testing.T) {
-	blocks := []any{
-		map[string]any{"kind": "assistant_text", "text": "stale fallback text"},
-		map[string]any{"kind": "outcome", "text": "stale outcome"},
-		map[string]any{"kind": "turn_summary", "data": map[string]any{}},
+	blocks := []ConversationTurnBlock{
+		{Kind: "assistant_text", Text: "stale fallback text"},
+		{Kind: "outcome", Text: "stale outcome"},
+		{Kind: "turn_summary", Data: json.RawMessage(`{}`)},
 	}
 
 	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(blocks)
@@ -1283,12 +1325,10 @@ func TestSummarizeConversationTurnBlocks_FailsClosedOnEmptyCanonicalSummary(t *t
 }
 
 func TestSummarizeConversationTurnBlocks_DoesNotInferOutcomeWithoutCanonicalField(t *testing.T) {
-	blocks := []any{
-		map[string]any{"kind": "assistant_text", "text": "stale fallback text"},
-		map[string]any{"kind": "outcome", "text": "stale outcome"},
-		map[string]any{"kind": "turn_summary", "data": map[string]any{
-			"assistant_visible_output": "Parking for manual review.",
-		}},
+	blocks := []ConversationTurnBlock{
+		{Kind: "assistant_text", Text: "stale fallback text"},
+		{Kind: "outcome", Text: "stale outcome"},
+		{Kind: "turn_summary", Data: json.RawMessage(`{"assistant_visible_output":"Parking for manual review."}`)},
 	}
 
 	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(blocks)

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -472,6 +472,51 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 	}
 }
 
+func TestHandler_ConversationDetail_PreservesParseOKFalse(t *testing.T) {
+	now := time.Date(2026, 3, 17, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(Options{
+		AuthToken: testOperatorAuthToken,
+		Conversations: stubConversations{
+			bySession: map[string]ConversationDetail{
+				"sess-1": {
+					AgentID:   "agent-1",
+					SessionID: "sess-1",
+					UpdatedAt: now.Format(time.RFC3339),
+					Messages:  []ConversationMessage{{Role: "assistant", Content: "hi"}},
+					RuntimeState: ConversationRuntimeState{
+						Summary:  "summarized",
+						LastTurn: &ConversationRuntimeLastTurn{ParseOK: false},
+					},
+				},
+			},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/conversations/sess-1", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("conversation detail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal conversation detail: %v", err)
+	}
+	runtimeState, ok := payload["runtime_state"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime_state missing or invalid: %#v", payload["runtime_state"])
+	}
+	lastTurn, ok := runtimeState["last_turn"].(map[string]any)
+	if !ok {
+		t.Fatalf("last_turn missing or invalid: %#v", runtimeState["last_turn"])
+	}
+	if got, ok := lastTurn["parse_ok"].(bool); !ok || got {
+		t.Fatalf("last_turn.parse_ok = %#v, want false", lastTurn["parse_ok"])
+	}
+}
+
 func TestHandler_DashboardRoutesRequireAuthentication(t *testing.T) {
 	handler := NewHandler(Options{
 		Health: func(context.Context) (map[string]any, error) {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -93,9 +93,8 @@ func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *test
 	if len(turn.ToolResults) != 1 {
 		t.Fatalf("tool_results = %#v, want 1 canonical summary tool result", turn.ToolResults)
 	}
-	result, _ := turn.ToolResults[0].(map[string]any)
-	if strings.TrimSpace(readString(result["tool_name"])) != "schedule" {
-		t.Fatalf("tool_result.tool_name = %#v, want schedule", result["tool_name"])
+	if strings.TrimSpace(turn.ToolResults[0].ToolName) != "schedule" {
+		t.Fatalf("tool_result.tool_name = %#v, want schedule", turn.ToolResults[0].ToolName)
 	}
 }
 
@@ -380,11 +379,10 @@ func seedConformanceAgent(t *testing.T, ctx context.Context, pg *store.PostgresS
 	}
 }
 
-func countTurnSummaryBlocks(blocks []any) int {
+func countTurnSummaryBlocks(blocks []dashboardserver.ConversationTurnBlock) int {
 	count := 0
-	for _, raw := range blocks {
-		entry, _ := raw.(map[string]any)
-		if strings.TrimSpace(readString(entry["kind"])) == "turn_summary" {
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Kind) == "turn_summary" {
 			count++
 		}
 	}


### PR DESCRIPTION
Closes #134

## Human Summary
This stops the dashboard conversation and turn read boundary from widening canonical persisted/runtime data back into `[]any` and `map[string]any` carriers. The touched conversation APIs now expose explicit transport structs and keep opaque provider payloads as raw JSON instead of re-decoding them into loose maps.

## What Changed
- replaced loose conversation/turn transport carriers in `internal/dashboard/server/server.go` with explicit structs for:
  - conversation messages
  - runtime state / retry lineage
  - tool calls
  - tool results
  - turn blocks
  - typed string lists for tools, emitted events, and MCP visibility
- changed the conversation reader in `internal/dashboard/server/conversations_sql.go` to decode those typed transport structs directly from persisted JSON
- kept provider-owned request/response payloads explicit as `json.RawMessage` objects instead of widening them to `map[string]any`
- tightened the shared projection helper in `internal/dashboard/server/read_model_projection.go` so canonical summary tool results stay typed at the dashboard boundary
- updated focused dashboard and conformance tests to assert the typed surface and fail-closed malformed handling

## Why This Is Needed
The persisted/runtime side already has narrower ownership for messages, tool calls, MCP visibility, runtime state, and canonical turn-summary structure. The dashboard read layer was immediately re-widening that data into open `any` carriers, which made the read model a second semantic owner and reintroduced schema drift right after persistence.

## Scope Boundaries
- In scope:
  - dashboard conversation/turn read-model transport shapes
  - typed decoding at the dashboard read boundary
  - focused round-trip and malformed payload regressions
- Not in scope:
  - broader dashboard redesign
  - spec changes
  - unrelated conversation/session ownership work

## Tests Run
- `go test ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
The touched read boundary is now fail-closed for malformed typed payloads that previously would have flowed through as loose `any` values. If a producer has been writing non-canonical shapes into fields like `mcp_servers` or message arrays, the dashboard reader will now surface that mismatch explicitly.

## Follow-Up
No spec gap or contradiction surfaced.
If we later want to finish removing loose carriers from adjacent operator surfaces, that should be a separate issue; this PR stays scoped to the conversation/turn read-model seam.
