### PR TITLE
[agent-a][issue #111] Unify tool transport context-token policy across /mcp and /tools

### DIFF
--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -194,7 +194,15 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	case "tools/list":
-		WriteRPCResult(w, req.ID, map[string]any{"tools": g.mcpToolsForRequest(r)})
+		tools, err := g.mcpToolsForRequest(r)
+		if err != nil {
+			g.logMCP(r, "warn", "mcp.tools.list.context_error", err, map[string]any{
+				"method": "tools/list",
+			})
+			WriteRPCError(w, req.ID, -32003, g.formatError(err))
+			return
+		}
+		WriteRPCResult(w, req.ID, map[string]any{"tools": tools})
 		return
 	case "tools/call":
 		if g.executor == nil {
@@ -296,60 +304,20 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (g *Gateway) mcpExecutionContext(r *http.Request, toolName string) (context.Context, error) {
-	toolName = normalizeGatewayToolName(toolName)
-	token := ContextTokenFromRequest(r)
-	if token == "" {
-		return nil, g.newRuntimeError(ErrCodeContextMissing, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
+func (g *Gateway) mcpExecutionContext(r *http.Request, _ string) (context.Context, error) {
+	turn, err := g.runtimeTurnContextForRequest(r, "mcp.context.resolve")
+	if err != nil {
+		return nil, err
 	}
-	turn, ok := g.resolveRuntimeTurnContext(token)
-	if !ok {
-		return nil, g.newRuntimeError(ErrCodeContextNotFound, "mcp.context.resolve", false, nil, "missing or invalid mcp context token")
-	}
-	ctx := context.Background()
-	if g.hooks.WithActor != nil {
-		ctx = g.hooks.WithActor(ctx, turn.Actor)
-	}
-	if g.hooks.WithCurrentRuntimeEpoch != nil {
-		ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-	}
-	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
-	if turn.HasInbound && g.hooks.WithInboundEvent != nil {
-		ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
-	}
-	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
-		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
-	}
-	ctx = g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
-	return ctx, nil
+	return g.contextForResolvedTurn(context.Background(), turn), nil
 }
 
-func (g *Gateway) toolExecutionContext(r *http.Request, toolName string) (context.Context, error) {
-	toolName = normalizeGatewayToolName(toolName)
-	token := ContextTokenFromRequest(r)
-	if token == "" {
-		return nil, g.newRuntimeError(ErrCodeContextMissing, "tool.context.resolve", false, nil, "missing or invalid mcp context token")
+func (g *Gateway) toolExecutionContext(r *http.Request, _ string) (context.Context, error) {
+	turn, err := g.runtimeTurnContextForRequest(r, "tool.context.resolve")
+	if err != nil {
+		return nil, err
 	}
-	turn, ok := g.resolveRuntimeTurnContext(token)
-	if !ok {
-		return nil, g.newRuntimeError(ErrCodeContextNotFound, "tool.context.resolve", false, nil, "missing or invalid mcp context token")
-	}
-	ctx := r.Context()
-	if g.hooks.WithActor != nil {
-		ctx = g.hooks.WithActor(ctx, turn.Actor)
-	}
-	if g.hooks.WithCurrentRuntimeEpoch != nil {
-		ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
-	}
-	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
-	if turn.HasInbound && g.hooks.WithInboundEvent != nil {
-		ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
-	}
-	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
-		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
-	}
-	ctx = g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
-	return ctx, nil
+	return g.contextForResolvedTurn(r.Context(), turn), nil
 }
 
 func (g *Gateway) withToolCapabilities(ctx context.Context, actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) context.Context {
@@ -421,9 +389,12 @@ func emitTurnDedupeKey(toolName string, arguments any) string {
 	return normalized + "\n" + string(encoded)
 }
 
-func (g *Gateway) mcpToolsForRequest(r *http.Request) []ToolDef {
-	actor, allowed, actorOK := g.actorForCatalogRequest(r)
-	return g.mcpToolsForActor(actor, allowed, actorOK)
+func (g *Gateway) mcpToolsForRequest(r *http.Request) ([]ToolDef, error) {
+	turn, err := g.runtimeTurnContextForRequest(r, "mcp.tools.list.context.resolve")
+	if err != nil {
+		return nil, err
+	}
+	return g.mcpToolsForActor(turn.Actor, turn.Allowed, true), nil
 }
 
 func (g *Gateway) MCPToolsForActor(actor models.AgentConfig) []ToolDef {
@@ -588,13 +559,33 @@ func (g *Gateway) resolveRuntimeTurnContext(token string) (TurnContext, bool) {
 	return turn, strings.TrimSpace(turn.Actor.ID) != ""
 }
 
-func (g *Gateway) actorForCatalogRequest(r *http.Request) (models.AgentConfig, map[string]struct{}, bool) {
-	if token := ContextTokenFromRequest(r); token != "" {
-		if turn, ok := g.resolveRuntimeTurnContext(token); ok {
-			return turn.Actor, turn.Allowed, true
-		}
+func (g *Gateway) runtimeTurnContextForRequest(r *http.Request, operation string) (TurnContext, error) {
+	token := ContextTokenFromRequest(r)
+	if token == "" {
+		return TurnContext{}, g.newRuntimeError(ErrCodeContextMissing, operation, false, nil, "missing or invalid mcp context token")
 	}
-	return models.AgentConfig{}, nil, false
+	turn, ok := g.resolveRuntimeTurnContext(token)
+	if !ok {
+		return TurnContext{}, g.newRuntimeError(ErrCodeContextNotFound, operation, false, nil, "missing or invalid mcp context token")
+	}
+	return turn, nil
+}
+
+func (g *Gateway) contextForResolvedTurn(ctx context.Context, turn TurnContext) context.Context {
+	if g.hooks.WithActor != nil {
+		ctx = g.hooks.WithActor(ctx, turn.Actor)
+	}
+	if g.hooks.WithCurrentRuntimeEpoch != nil {
+		ctx = g.hooks.WithCurrentRuntimeEpoch(ctx)
+	}
+	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(turn.Inbound.RunID))
+	if turn.HasInbound && g.hooks.WithInboundEvent != nil {
+		ctx = g.hooks.WithInboundEvent(ctx, turn.Inbound)
+	}
+	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
+		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
+	}
+	return g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
 }
 
 func (g *Gateway) AuthorizeForTest(r *http.Request) error {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -26,6 +26,15 @@ func authorizeGatewayRequest(req *http.Request) {
 	}
 }
 
+func mustMCPToolsForRequest(t *testing.T, g *Gateway, req *http.Request) []ToolDef {
+	t.Helper()
+	tools, err := g.mcpToolsForRequest(req)
+	if err != nil {
+		t.Fatalf("mcpToolsForRequest: %v", err)
+	}
+	return tools
+}
+
 type testToolExecutor func(context.Context, string, any) (any, error)
 
 func (f testToolExecutor) Execute(ctx context.Context, name string, input any) (any, error) {
@@ -322,7 +331,7 @@ func TestGatewayMCPToolsForRequest_UsesHydratedActorRoleForEmitTools(t *testing.
 	})
 
 	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-hydrated-role", nil)
-	tools := g.mcpToolsForRequest(req)
+	tools := mustMCPToolsForRequest(t, g, req)
 	for _, tool := range tools {
 		if tool.Name == "emit_scan_requested" {
 			return
@@ -363,7 +372,7 @@ func TestGatewayMCPToolsForRequest_KeepsEmitToolsForDirectMCPContext(t *testing.
 	})
 
 	req := httptest.NewRequest("POST", "/mcp?agent_id=campaign-coordinator&ctx_token=ctx-1", nil)
-	tools := g.mcpToolsForRequest(req)
+	tools := mustMCPToolsForRequest(t, g, req)
 	for _, tool := range tools {
 		if tool.Name == "emit_scan_requested" {
 			return
@@ -398,7 +407,7 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 	})
 
 	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-actor-scoped", nil)
-	tools := g.mcpToolsForRequest(req)
+	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 1 {
 		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
 	}
@@ -428,7 +437,7 @@ func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-ignore-allowlist&allowed_tools=Read", nil)
-	tools := g.mcpToolsForRequest(req)
+	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 2 {
 		t.Fatalf("tool count = %d, want 2 (%#v)", len(tools), tools)
 	}
@@ -459,7 +468,7 @@ func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing
 	})
 
 	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-unknown-allowlist&allowed_tools=does_not_exist", nil)
-	tools := g.mcpToolsForRequest(req)
+	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 1 {
 		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
 	}
@@ -468,21 +477,95 @@ func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing
 	}
 }
 
-func TestGatewayMCPToolsForRequest_DoesNotTrustCallerAgentIDWithoutTurnContext(t *testing.T) {
+func TestGatewayHandleMCP_ToolsListRejectsMissingOrInvalidContextToken(t *testing.T) {
+	for _, rawQuery := range []string{"", "?ctx_token=missing&agent_id=analysis-agent"} {
+		t.Run(rawQuery, func(t *testing.T) {
+			g := NewGateway(actorScopedToolExecutorStub{
+				actorDefs: []llm.ToolDefinition{
+					{Name: "query_entities", Description: "actor scoped"},
+				},
+			}, testGatewayToken, GatewayHooks{})
+
+			body, err := json.Marshal(map[string]any{
+				"id":     "req-1",
+				"method": "tools/list",
+				"params": map[string]any{},
+			})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/mcp"+rawQuery, strings.NewReader(string(body)))
+			authorizeGatewayRequest(req)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			var resp RPCResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.Error == nil {
+				t.Fatalf("response error = nil, want context error in %s", rec.Body.String())
+			}
+			if !strings.Contains(resp.Error.Message, "missing or invalid mcp context token") {
+				t.Fatalf("error message = %q", resp.Error.Message)
+			}
+		})
+	}
+}
+
+func TestGatewayHandleMCP_ToolsListUsesResolvedTurnContext(t *testing.T) {
+	registry := newTestTurnContextRegistry()
 	g := NewGateway(actorScopedToolExecutorStub{
 		actorDefs: []llm.ToolDefinition{
 			{Name: "query_entities", Description: "actor scoped"},
 		},
-	}, "", GatewayHooks{
-		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
-			return models.AgentConfig{ID: agentID, Role: "analysis"}, true
-		},
+	}, testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=analysis-agent", nil)
-	tools := g.mcpToolsForRequest(req)
-	if len(tools) != 0 {
-		t.Fatalf("tool count = %d, want 0 (%#v)", len(tools), tools)
+	putTestTurnContext(t, registry, "ctx-list", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/list",
+		"params": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-list", strings.NewReader(string(body)))
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("response error = %#v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	rawTools, ok := result["tools"].([]any)
+	if !ok || len(rawTools) != 1 {
+		t.Fatalf("tools = %#v, want one visible tool", result["tools"])
+	}
+	tool, ok := rawTools[0].(map[string]any)
+	if !ok || strings.TrimSpace(asString(tool["name"])) != "query_entities" {
+		t.Fatalf("tool payload = %#v", rawTools[0])
 	}
 }
 
@@ -969,6 +1052,112 @@ func TestGatewayHandleTool_AllowsLegitimateRuntimeOwnedActorContext(t *testing.T
 	}
 	if exec.callCount != 1 {
 		t.Fatalf("executor call count = %d, want 1", exec.callCount)
+	}
+}
+
+func TestGatewayTransports_AlignReadOnlyToolContextTokenFailures(t *testing.T) {
+	callCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{})
+
+	mcpBody, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"query": "kind = 'vertical'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal mcp request: %v", err)
+	}
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(mcpBody)))
+	authorizeGatewayRequest(mcpReq)
+	mcpRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(mcpRec, mcpReq)
+
+	toolBody, err := json.Marshal(ToolGatewayRequest{
+		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		Input: map[string]any{"query": "kind = 'vertical'"},
+	})
+	if err != nil {
+		t.Fatalf("marshal tool request: %v", err)
+	}
+	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities?ctx_token=missing", strings.NewReader(string(toolBody)))
+	authorizeGatewayRequest(toolReq)
+	toolRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(toolRec, toolReq)
+
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+	if !strings.Contains(mcpRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("mcp body = %s", mcpRec.Body.String())
+	}
+	if !strings.Contains(toolRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("tool body = %s", toolRec.Body.String())
+	}
+}
+
+func TestGatewayTransports_AlignReadOnlyToolSuccessWithResolvedTurnContext(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	callCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-query", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	mcpBody, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"query": "kind = 'vertical'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal mcp request: %v", err)
+	}
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-query", strings.NewReader(string(mcpBody)))
+	authorizeGatewayRequest(mcpReq)
+	mcpRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(mcpRec, mcpReq)
+
+	toolBody, err := json.Marshal(ToolGatewayRequest{
+		Input: map[string]any{"query": "kind = 'vertical'"},
+	})
+	if err != nil {
+		t.Fatalf("marshal tool request: %v", err)
+	}
+	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities?ctx_token=ctx-query", strings.NewReader(string(toolBody)))
+	authorizeGatewayRequest(toolReq)
+	toolRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(toolRec, toolReq)
+
+	if mcpRec.Code != http.StatusOK {
+		t.Fatalf("mcp status = %d, want 200", mcpRec.Code)
+	}
+	if toolRec.Code != http.StatusOK {
+		t.Fatalf("tool status = %d, want 200", toolRec.Code)
+	}
+	if callCount != 2 {
+		t.Fatalf("executor call count = %d, want 2", callCount)
+	}
+	if strings.Contains(mcpRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("mcp body = %s", mcpRec.Body.String())
+	}
+	if strings.Contains(toolRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("tool body = %s", toolRec.Body.String())
 	}
 }
 


### PR DESCRIPTION
Closes #111

## Human Summary
This PR makes context-token enforcement transport-agnostic in the touched gateway seam. /mcp and /tools/* now resolve canonical turn context through the same owner, and the same semantic operation now succeeds or fails for the same reason regardless of transport.

## What Changed
- introduced one shared gateway turn-context resolution path for the touched seam in internal/runtime/mcp/gateway.go
- made /mcp tools/list require the same canonical turn context that /mcp tools/call and /tools/* already require
- removed the /mcp tools/list empty-catalog degradation path on missing or invalid ctx_token
- reused the same resolved turn context to build execution context across both transports
- added focused gateway tests covering cross-transport failure and success alignment

## Why This Is Needed
Before this change, execution paths already failed closed on missing turn context, but /mcp tools/list could still return an empty catalog when the context token was missing or invalid. That made transport choice semantically significant. The runtime now has one canonical owner for the touched context-token contract, and the gateway fails closed instead of degrading.

## Scope Boundaries
In scope:
- MCP gateway context-token policy for /mcp and /tools/* in the touched seam
- shared turn-context resolution and focused transport tests

Out of scope:
- broad MCP redesign
- unrelated auth or startup validation cleanup
- spec changes

## Tests Run
- go test ./internal/runtime/mcp -count=1
- go test ./internal/runtime -run 'TestValidateClaude(MCPToolsForManagedAgents_|StartupConfig_|ManagedAgentWorkspaces_)' -count=1
- go test ./... -count=1

## Residual Risk
This keeps the change intentionally narrow to the gateway transport seam. Other MCP behaviors outside context-token enforcement are unchanged.

## Follow-Up
No same-seam follow-up is required from this change.
