### PR TITLE
[agent-b][issue #145] Add explicit ownership for replay and restored timers

### DIFF
--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -8,6 +8,7 @@ import (
 
 	"swarm/internal/events"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 )
 
 type EventStore interface {
@@ -79,6 +80,10 @@ type TransactionalEventStore interface {
 
 type PipelineReceiptSweeperStore interface {
 	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
+}
+
+type PipelineReplayClaimStore interface {
+	ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error)
 }
 
 type EventDeliveryReader interface {

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -79,6 +79,10 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if !ok {
 		return 0, nil
 	}
+	claimer, ok := eb.store.(PipelineReplayClaimStore)
+	if !ok {
+		return 0, errors.New("event bus store does not support explicit pipeline replay claims")
+	}
 	if limit <= 0 {
 		limit = DefaultOutboxSweeperConfig().Limit
 	}
@@ -93,13 +97,22 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	redelivered := 0
 	for _, record := range events {
 		evt := record.Event
+		lease, claimed, err := claimer.ClaimPipelineReplay(ctx, evt.ID)
+		if err != nil {
+			return redelivered, err
+		}
+		if !claimed {
+			continue
+		}
 		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
 			eb.markPipelineReceipt(ctx, evt.ID, "error", replayErr)
+			_ = lease.Release(ctx)
 			continue
 		}
 		recipients, err := eb.authoritativeRecipientsForEvent(ctx, evt.ID)
 		if err != nil {
 			eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
+			_ = lease.Release(ctx)
 			return redelivered, err
 		}
 		intent := runtimeengine.EmitIntent{Event: evt, Recipients: recipients}
@@ -107,9 +120,11 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
 				eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
 			}
+			_ = lease.Release(ctx)
 			return redelivered, err
 		}
 		eb.markPipelineReceipt(ctx, evt.ID, "processed", "")
+		_ = lease.Release(ctx)
 		redelivered++
 	}
 	return redelivered, nil

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -2,11 +2,13 @@ package bus_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 )
 
 type sweeperTestStore struct {
@@ -14,6 +16,10 @@ type sweeperTestStore struct {
 	deliveries  map[string][]string
 	receipts    map[string]string
 	receiptErrs map[string]string
+	claimMu     sync.Mutex
+	claimed     map[string]bool
+	releaseGate chan struct{}
+	releasing   chan struct{}
 }
 
 func (s *sweeperTestStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -36,6 +42,42 @@ func (s *sweeperTestStore) ListEventsMissingPipelineReceipt(context.Context, tim
 }
 func (s *sweeperTestStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
 	return append([]string(nil), s.deliveries[eventID]...), nil
+}
+func (s *sweeperTestStore) ClaimPipelineReplay(_ context.Context, eventID string) (runtimeownership.Lease, bool, error) {
+	s.claimMu.Lock()
+	defer s.claimMu.Unlock()
+	if s.claimed == nil {
+		s.claimed = map[string]bool{}
+	}
+	if s.claimed[eventID] {
+		return nil, false, nil
+	}
+	s.claimed[eventID] = true
+	return sweeperClaimLease{store: s, eventID: eventID}, true, nil
+}
+
+type sweeperClaimLease struct {
+	store   *sweeperTestStore
+	eventID string
+}
+
+func (l sweeperClaimLease) Release(context.Context) error {
+	if l.store == nil {
+		return nil
+	}
+	if l.store.releasing != nil {
+		select {
+		case l.store.releasing <- struct{}{}:
+		default:
+		}
+	}
+	if l.store.releaseGate != nil {
+		<-l.store.releaseGate
+	}
+	l.store.claimMu.Lock()
+	delete(l.store.claimed, l.eventID)
+	l.store.claimMu.Unlock()
+	return nil
 }
 
 func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
@@ -159,4 +201,64 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected good swept delivery")
 	}
+}
+
+func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-claim",
+				Type:      events.EventType("custom.claimed"),
+				Payload:   []byte(`{"entity_id":"ent-claim"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-claim")},
+		},
+		deliveries:  map[string][]string{"evt-claim": {"agent-claim"}},
+		releaseGate: make(chan struct{}),
+		releasing:   make(chan struct{}, 1),
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("agent-claim")
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		if _, err := eb.SweepUndispatched(context.Background(), time.Hour, 10); err != nil {
+			t.Errorf("first SweepUndispatched: %v", err)
+		}
+	}()
+
+	select {
+	case <-store.releasing:
+	case <-time.After(time.Second):
+		t.Fatal("expected first sweep to reach claim release")
+	}
+
+	secondCount, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("second SweepUndispatched: %v", err)
+	}
+	if secondCount != 0 {
+		t.Fatalf("second swept count = %d, want 0 while claim is held", secondCount)
+	}
+
+	close(store.releaseGate)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first sweep to finish")
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.ID != "evt-claim" {
+			t.Fatalf("delivered event id = %q, want evt-claim", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected claimed replay delivery")
+	}
+	waitForNoEvent(t, ch)
 }

--- a/internal/runtime/core/ownership/lease.go
+++ b/internal/runtime/core/ownership/lease.go
@@ -1,0 +1,7 @@
+package ownership
+
+import "context"
+
+type Lease interface {
+	Release(ctx context.Context) error
+}

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
@@ -35,6 +36,9 @@ func (b *recoveryTestBus) AppendEvent(context.Context, events.Event) error      
 func (b *recoveryTestBus) InsertEventDeliveries(context.Context, string, []string) error { return nil }
 func (*recoveryTestBus) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return []string{}, nil
+}
+func (*recoveryTestBus) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	return recoveryTestReplayLease{}, true, nil
 }
 func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
 	return nil, nil
@@ -167,6 +171,10 @@ func TestRecover_UsesCanonicalLoadedAgentMetadata(t *testing.T) {
 }
 
 type recoveryTestAgent struct{ id string }
+
+type recoveryTestReplayLease struct{}
+
+func (recoveryTestReplayLease) Release(context.Context) error { return nil }
 
 func (a recoveryTestAgent) ID() string                      { return a.id }
 func (recoveryTestAgent) Type() string                      { return "generic" }

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -7,10 +7,15 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 )
 
 type missingPipelineReceiptReader interface {
 	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
+}
+
+type pipelineReplayClaimer interface {
+	ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error)
 }
 
 type authoritativeDeliveryRecipientReader interface {
@@ -60,6 +65,10 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
+	claimer, ok := r.store.(pipelineReplayClaimer)
+	if !ok {
+		return fmt.Errorf("recover pipeline receipts: missing explicit replay claim owner")
+	}
 	window := r.window
 	if window <= 0 {
 		window = 15 * time.Minute
@@ -86,11 +95,22 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 		if strings.TrimSpace(evt.ID) == "" {
 			continue
 		}
+		lease, claimed, err := claimer.ClaimPipelineReplay(ctx, evt.ID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("claim replay event %s: %w", evt.ID, err)
+			}
+			continue
+		}
+		if !claimed {
+			continue
+		}
 		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
 			if recorder == nil {
 				if firstErr == nil {
 					firstErr = fmt.Errorf("mark replay event %s error receipt: missing pipeline receipt recorder", evt.ID)
 				}
+				_ = lease.Release(ctx)
 				continue
 			}
 			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "error", replayErr); err != nil {
@@ -98,6 +118,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 					firstErr = fmt.Errorf("mark replay event %s error receipt: %w", evt.ID, err)
 				}
 			}
+			_ = lease.Release(ctx)
 			continue
 		}
 		persistedRecipients, err := recipients.ListEventDeliveryRecipients(ctx, evt.ID)
@@ -105,6 +126,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("load persisted recipients for replay event %s: %w", evt.ID, err)
 			}
+			_ = lease.Release(ctx)
 			continue
 		}
 		if len(persistedRecipients) == 0 {
@@ -112,6 +134,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 				if firstErr == nil {
 					firstErr = fmt.Errorf("mark replay event %s delivered receipt: missing pipeline receipt recorder", evt.ID)
 				}
+				_ = lease.Release(ctx)
 				continue
 			}
 			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil {
@@ -119,13 +142,22 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 					firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
 				}
 			}
+			_ = lease.Release(ctx)
 			continue
 		}
 		if err := r.bus.PublishDirect(ctx, evt, persistedRecipients); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("replay event %s: %w", evt.ID, err)
 			}
+			_ = lease.Release(ctx)
+			continue
 		}
+		if recorder != nil {
+			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
+			}
+		}
+		_ = lease.Release(ctx)
 	}
 	return firstErr
 }

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -2,6 +2,8 @@ package pipeline_test
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +29,23 @@ func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event
 func (p *recoveryCapturePublisher) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error {
 	p.direct = append(p.direct, evt)
 	return p.inner.PublishDirect(ctx, evt, recipients)
+}
+
+type blockingRecoveryPublisher struct {
+	mu      sync.Mutex
+	started chan struct{}
+	release chan struct{}
+	count   atomic.Int32
+}
+
+func (*blockingRecoveryPublisher) Publish(context.Context, events.Event) error { return nil }
+
+func (p *blockingRecoveryPublisher) PublishDirect(context.Context, events.Event, []string) error {
+	if p.count.Add(1) == 1 {
+		close(p.started)
+		<-p.release
+	}
+	return nil
 }
 
 func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
@@ -276,6 +295,96 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 	}
 	if reason != "pipeline_error" {
 		t.Fatalf("receipt reason = %q, want pipeline_error", reason)
+	}
+}
+
+func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg1 := &store.PostgresStore{DB: db}
+	pg2 := &store.PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	childID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if err := pg1.AppendEvent(ctx, events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg1.AppendEvent(ctx, events.Event{
+		ID:            childID,
+		Type:          events.EventType("system.recover"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	if err := pg1.InsertEventDeliveries(ctx, childID, []string{"agent-recovery"}); err != nil {
+		t.Fatalf("InsertEventDeliveries(child): %v", err)
+	}
+	if err := pg1.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+
+	publisher := &blockingRecoveryPublisher{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	rm1 := runtimepipeline.NewRecoveryManagerWith(pg1, publisher)
+	rm2 := runtimepipeline.NewRecoveryManagerWith(pg2, publisher)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- rm1.Recover(ctx)
+	}()
+
+	select {
+	case <-publisher.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first recovery replay to start")
+	}
+
+	if err := rm2.Recover(ctx); err != nil {
+		t.Fatalf("second Recover: %v", err)
+	}
+	if got := publisher.count.Load(); got != 1 {
+		t.Fatalf("replay publish count during overlap = %d, want 1", got)
+	}
+
+	close(publisher.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Recover: %v", err)
+	}
+	if got := publisher.count.Load(); got != 1 {
+		t.Fatalf("replay publish count after overlap = %d, want 1", got)
+	}
+
+	var receiptStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, childID).Scan(&receiptStatus); err != nil {
+		t.Fatalf("load pipeline receipt: %v", err)
+	}
+	if receiptStatus != "success" {
+		t.Fatalf("pipeline receipt outcome = %q, want success", receiptStatus)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -937,6 +937,11 @@ func (s *recordingScheduleStore) CancelSchedule(context.Context, string, string)
 func (s *recordingScheduleStore) LoadActiveSchedules(context.Context) ([]Schedule, error) {
 	return nil, nil
 }
+func (*recordingScheduleStore) ClaimSchedule(context.Context, Schedule) (bool, error) {
+	return true, nil
+}
+func (*recordingScheduleStore) ReleaseSchedule(context.Context, Schedule) error     { return nil }
+func (*recordingScheduleStore) ReleaseScheduleClaims(context.Context) error         { return nil }
 func (s *recordingScheduleStore) MarkScheduleFired(context.Context, Schedule) error { return nil }
 func (s *recordingScheduleStore) CancelScheduleExact(_ context.Context, sc Schedule) error {
 	s.cancels = append(s.cancels, sc)

--- a/internal/runtime/pipeline/schedule_ownership.go
+++ b/internal/runtime/pipeline/schedule_ownership.go
@@ -1,0 +1,39 @@
+package pipeline
+
+import "context"
+
+func ClaimAndRegisterSchedule(ctx context.Context, store SchedulePersistence, scheduler *Scheduler, sc Schedule) (bool, error) {
+	if scheduler == nil {
+		return false, nil
+	}
+	if store != nil {
+		claimed, err := store.ClaimSchedule(ctx, sc)
+		if err != nil {
+			return false, err
+		}
+		if !claimed {
+			return false, nil
+		}
+	}
+	if err := scheduler.Register(sc); err != nil {
+		if store != nil {
+			_ = store.ReleaseSchedule(ctx, sc)
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func ReleaseOwnedSchedule(ctx context.Context, store SchedulePersistence, sc Schedule) error {
+	if store == nil {
+		return nil
+	}
+	return store.ReleaseSchedule(ctx, sc)
+}
+
+func ReleaseAllOwnedSchedules(ctx context.Context, store SchedulePersistence) error {
+	if store == nil {
+		return nil
+	}
+	return store.ReleaseScheduleClaims(ctx)
+}

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -20,6 +20,9 @@ type SchedulePersistence interface {
 	CancelScheduleExact(ctx context.Context, sc Schedule) error
 	LoadActiveSchedules(ctx context.Context) ([]Schedule, error)
 	MarkScheduleFiredExact(ctx context.Context, sc Schedule) error
+	ClaimSchedule(ctx context.Context, sc Schedule) (bool, error)
+	ReleaseSchedule(ctx context.Context, sc Schedule) error
+	ReleaseScheduleClaims(ctx context.Context) error
 }
 
 type WorkflowInstance struct {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -464,6 +464,13 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
+			return
+		}
+		if err := ReleaseOwnedSchedule(ctx, pc.timerScheduleStore, sc); err != nil {
+			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_release_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
+				"task_id": strings.TrimSpace(sc.TaskID),
+				"mode":    strings.TrimSpace(sc.Mode),
+			}, err)
 		}
 	}
 	if pc.timerScheduler != nil {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -378,17 +378,18 @@ func (pc *PipelineCoordinator) registerWorkflowTimerSchedule(ctx context.Context
 	if pc == nil {
 		return
 	}
-	if pc.timerScheduler != nil {
-		if err := pc.timerScheduler.Register(sc); err != nil {
-			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_register_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
-				"task_id": strings.TrimSpace(sc.TaskID),
-				"mode":    strings.TrimSpace(sc.Mode),
-			}, err)
-		}
-	}
 	if pc.timerScheduleStore != nil {
 		if err := pc.timerScheduleStore.UpsertSchedule(ctx, sc); err != nil {
 			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
+				"task_id": strings.TrimSpace(sc.TaskID),
+				"mode":    strings.TrimSpace(sc.Mode),
+			}, err)
+			return
+		}
+	}
+	if pc.timerScheduler != nil {
+		if _, err := ClaimAndRegisterSchedule(ctx, pc.timerScheduleStore, pc.timerScheduler, sc); err != nil {
+			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_register_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
@@ -416,6 +417,13 @@ func (pc *PipelineCoordinator) cancelWorkflowTimerSchedule(ctx context.Context, 
 			"task_id": strings.TrimSpace(sc.TaskID),
 			"mode":    strings.TrimSpace(sc.Mode),
 		}, err)
+		return
+	}
+	if err := ReleaseOwnedSchedule(ctx, pc.timerScheduleStore, sc); err != nil {
+		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_release_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
+			"task_id": strings.TrimSpace(sc.TaskID),
+			"mode":    strings.TrimSpace(sc.Mode),
+		}, err)
 	}
 }
 
@@ -433,7 +441,7 @@ func (pc *PipelineCoordinator) persistWorkflowTimerSchedule(ctx context.Context,
 	}
 	if pc.timerScheduler != nil {
 		register := func() {
-			if err := pc.timerScheduler.Register(sc); err != nil {
+			if _, err := ClaimAndRegisterSchedule(ctx, pc.timerScheduleStore, pc.timerScheduler, sc); err != nil {
 				pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_register_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 					"task_id": strings.TrimSpace(sc.TaskID),
 					"mode":    strings.TrimSpace(sc.Mode),

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -17,6 +17,7 @@ import (
 type recordingSchedulePersistence struct {
 	schedules    []Schedule
 	cancels      []Schedule
+	releases     []Schedule
 	cancelExacts int
 }
 
@@ -33,7 +34,8 @@ func (*recordingSchedulePersistence) ClaimSchedule(context.Context, Schedule) (b
 	return true, nil
 }
 
-func (*recordingSchedulePersistence) ReleaseSchedule(context.Context, Schedule) error {
+func (s *recordingSchedulePersistence) ReleaseSchedule(_ context.Context, sc Schedule) error {
+	s.releases = append(s.releases, sc)
 	return nil
 }
 
@@ -178,6 +180,33 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	}
 	if got := store.schedules[0].EventType; got != "timer.check" {
 		t.Fatalf("scheduled event = %q, want timer.check", got)
+	}
+}
+
+func TestPersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel(t *testing.T) {
+	store := &recordingSchedulePersistence{}
+	pc := &PipelineCoordinator{
+		timerScheduleStore: store,
+	}
+	sc := Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		EntityID:     "ent-001",
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-a",
+	}
+
+	pc.persistWorkflowTimerCancellation(context.Background(), sc)
+
+	if got := store.cancelExacts; got != 1 {
+		t.Fatalf("cancel exact calls = %d, want 1", got)
+	}
+	if len(store.releases) != 1 {
+		t.Fatalf("released schedules = %d, want 1", len(store.releases))
+	}
+	if store.releases[0].TaskID != sc.TaskID {
+		t.Fatalf("released task_id = %q, want %q", store.releases[0].TaskID, sc.TaskID)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -29,6 +29,18 @@ func (s *recordingSchedulePersistence) LoadActiveSchedules(context.Context) ([]S
 	return nil, nil
 }
 
+func (*recordingSchedulePersistence) ClaimSchedule(context.Context, Schedule) (bool, error) {
+	return true, nil
+}
+
+func (*recordingSchedulePersistence) ReleaseSchedule(context.Context, Schedule) error {
+	return nil
+}
+
+func (*recordingSchedulePersistence) ReleaseScheduleClaims(context.Context) error {
+	return nil
+}
+
 func (s *recordingSchedulePersistence) CancelScheduleExact(_ context.Context, sc Schedule) error {
 	s.cancelExacts++
 	s.cancels = append(s.cancels, sc)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -306,6 +306,14 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 						"entity_id":  sc.EffectiveEntityID(),
 					}, err))
 				}
+			} else if strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
+				if err := stores.ScheduleStore.ReleaseSchedule(callbackCtx, sc); err != nil && rt.Logger != nil {
+					handleRuntimeLogPersistenceError("scheduler", "release_ownership_failed", rt.Logger.Error(callbackCtx, "scheduler", "release_ownership_failed", map[string]any{
+						"agent_id":   sc.AgentID,
+						"event_type": sc.EventType,
+						"entity_id":  sc.EffectiveEntityID(),
+					}, err))
+				}
 			}
 		}
 	})
@@ -584,7 +592,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 			return fmt.Errorf("load schedules failed: %w", err)
 		}
 		for _, sc := range schedules {
-			if err := rt.Scheduler.Register(sc); err != nil {
+			if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, rt.Stores.ScheduleStore, rt.Scheduler, sc); err != nil {
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("scheduler", "restore_schedule_failed", rt.Logger.Error(ctx, "scheduler", "restore_schedule_failed", map[string]any{
 						"agent_id":   sc.AgentID,
@@ -599,7 +607,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_lifecycle_failed", rt.Logger.Error(ctx, "scheduler", "ensure_lifecycle_failed", nil, err))
 			}
 		}
-		if err := ensureRecurringWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Pipeline); err != nil {
+		if err := ensureRecurringWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_recurring_failed", rt.Logger.Error(ctx, "scheduler", "ensure_recurring_failed", nil, err))
 			}
@@ -704,6 +712,13 @@ func (rt *Runtime) Shutdown() error {
 	if rt.Scheduler != nil {
 		rt.Scheduler.Stop()
 	}
+	if rt.Stores.ScheduleStore != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := rt.Stores.ScheduleStore.ReleaseScheduleClaims(releaseCtx); err != nil && shutdownErr == nil {
+			shutdownErr = err
+		}
+		cancel()
+	}
 	rt.lifecycleMu.Lock()
 	cancelStart := rt.cancelStart
 	lease := rt.ownershipLease
@@ -733,6 +748,11 @@ func (rt *Runtime) cleanupStartFailure() {
 	}
 	if rt.Scheduler != nil {
 		rt.Scheduler.Stop()
+	}
+	if rt.Stores.ScheduleStore != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = rt.Stores.ScheduleStore.ReleaseScheduleClaims(releaseCtx)
+		cancel()
 	}
 	rt.lifecycleMu.Lock()
 	cancelStart := rt.cancelStart
@@ -802,7 +822,7 @@ func (rt *Runtime) verifyBootPublished(ch <-chan events.Event) error {
 	return nil
 }
 
-func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, workflow runtimepipeline.WorkflowRuntime) error {
+func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime) error {
 	if store == nil || workflow == nil {
 		return nil
 	}
@@ -831,13 +851,17 @@ func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline
 		if !ok {
 			continue
 		}
-		if err := store.UpsertSchedule(ctx, runtimepipeline.Schedule{
+		sc := runtimepipeline.Schedule{
 			AgentID:   owner,
 			EventType: eventType,
 			Mode:      "cron",
 			Cron:      cron,
 			Payload:   recurringWorkflowTimerPayload(timer),
-		}); err != nil {
+		}
+		if err := store.UpsertSchedule(ctx, sc); err != nil {
+			return err
+		}
+		if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, store, scheduler, sc); err != nil {
 			return err
 		}
 	}
@@ -897,7 +921,7 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 				return err
 			}
 			if scheduler != nil {
-				if err := scheduler.Register(sc); err != nil {
+				if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, store, scheduler, sc); err != nil {
 					log.Printf("rehydrate lifecycle schedule failed agent=%s event=%s err=%v", sc.AgentID, sc.EventType, err)
 				}
 			}

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -120,6 +120,18 @@ func (s *recordingRuntimeScheduleStore) LoadActiveSchedules(context.Context) ([]
 	return append([]runtimepipeline.Schedule(nil), s.active...), nil
 }
 
+func (*recordingRuntimeScheduleStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
+	return true, nil
+}
+
+func (*recordingRuntimeScheduleStore) ReleaseSchedule(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*recordingRuntimeScheduleStore) ReleaseScheduleClaims(context.Context) error {
+	return nil
+}
+
 func (s *recordingRuntimeScheduleStore) MarkScheduleFiredExact(_ context.Context, sc runtimepipeline.Schedule) error {
 	s.firedExact.Add(1)
 	if s.fired != nil {
@@ -168,7 +180,7 @@ func TestEnsureRecurringWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *
 		t.Fatalf("load bundle: %v", err)
 	}
 	store := &recordingRuntimeScheduleStore{}
-	err = ensureRecurringWorkflowSchedules(context.Background(), store, semanticOnlyWorkflowRuntime{
+	err = ensureRecurringWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
 		source: semanticview.Wrap(bundle),
 	})
 	if err != nil {
@@ -193,7 +205,7 @@ func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing
 			}},
 		},
 	}
-	err := ensureRecurringWorkflowSchedules(context.Background(), store, semanticOnlyWorkflowRuntime{
+	err := ensureRecurringWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
 		source: semanticview.Wrap(bundle),
 	})
 	if err != nil {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 )
 
@@ -187,6 +188,49 @@ func (s *PostgresStore) ListEventsMissingPipelineReceipt(ctx context.Context, si
 		return nil, unsupportedSchemaCapability("events", caps.Events.Log)
 	}
 	return s.listEventsMissingPipelineReceiptSpec(ctx, caps, since, limit)
+}
+
+func (s *PostgresStore) ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil, false, fmt.Errorf("event_id is required")
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical || caps.Events.Log != SchemaFlavorCanonical {
+		if caps.Events.Receipts != SchemaFlavorCanonical {
+			return nil, false, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+		}
+		return nil, false, unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	lease, claimed, err := acquireAdvisoryLockLease(ctx, s.DB, replayClaimLockKey(eventID))
+	if err != nil || !claimed {
+		return nil, claimed, err
+	}
+	var pending bool
+	err = lease.conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events e
+			LEFT JOIN event_receipts r
+				ON r.event_id = e.event_id
+				AND r.subscriber_type = 'platform'
+				AND r.subscriber_id = 'pipeline'
+			WHERE e.event_id = $1::uuid
+			  AND r.event_id IS NULL
+		)
+	`, eventID).Scan(&pending)
+	if err != nil {
+		_ = lease.Release(ctx)
+		return nil, false, fmt.Errorf("claim pipeline replay: %w", err)
+	}
+	if !pending {
+		_ = lease.Release(ctx)
+		return nil, false, nil
+	}
+	return lease, true, nil
 }
 
 func (s *PostgresStore) EventExists(ctx context.Context, eventID string) (bool, error) {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -22,6 +22,10 @@ type PostgresStore struct {
 	schemaCapsBound bool
 
 	eventPayloadValidator EventPayloadValidator
+
+	scheduleClaimMu   sync.Mutex
+	scheduleClaimConn *sql.Conn
+	scheduleClaimKeys map[string]struct{}
 }
 
 type EventPayloadValidator func(eventType string, payload []byte) error

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1631,6 +1631,60 @@ func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
 	}
 }
 
+func TestSchedules_CancelAndReleaseAllowsSubsequentReclaim(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pgOwner := &PostgresStore{DB: db}
+	pgSuccessor := &PostgresStore{DB: db}
+
+	sc := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     uuid.NewString(),
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-cancel-reclaim",
+		Payload:      []byte(`{"timer_id":"timer-cancel-reclaim"}`),
+	}
+	if err := pgOwner.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+	claimed, err := pgOwner.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(owner): %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected owner to claim schedule")
+	}
+
+	if err := pgOwner.CancelScheduleExact(ctx, sc); err != nil {
+		t.Fatalf("CancelScheduleExact: %v", err)
+	}
+	if err := pgOwner.ReleaseSchedule(ctx, sc); err != nil {
+		t.Fatalf("ReleaseSchedule: %v", err)
+	}
+
+	claimed, err = pgSuccessor.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(successor after cancel): %v", err)
+	}
+	if claimed {
+		t.Fatal("expected cancelled schedule to remain unclaimable while inactive")
+	}
+
+	if err := pgOwner.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule(recreate): %v", err)
+	}
+	claimed, err = pgSuccessor.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(successor after recreate): %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected successor to claim recreated schedule after owner cancel+release")
+	}
+}
+
 func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1490,6 +1491,143 @@ func TestSchedules_MarkScheduleFiredExact_PreservesRecurringReplayAndFiresOnceSc
 	}
 	if onceFound {
 		t.Fatal("expected once exact schedule to be absent from active schedule restore after firing")
+	}
+}
+
+func TestSchedules_ClaimSchedule_IsExclusiveAcrossStores(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pg1 := &PostgresStore{DB: db}
+	pg2 := &PostgresStore{DB: db}
+
+	sc := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "cron",
+		Cron:         "@every 30m",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     uuid.NewString(),
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-recurring",
+		Payload:      []byte(`{"timer_id":"timer-recurring"}`),
+	}
+	if err := pg1.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+
+	claimed1, err := pg1.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(pg1): %v", err)
+	}
+	if !claimed1 {
+		t.Fatal("expected first store to claim schedule ownership")
+	}
+
+	claimed2, err := pg2.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(pg2): %v", err)
+	}
+	if claimed2 {
+		t.Fatal("expected second store to be denied overlapping schedule ownership")
+	}
+
+	if err := pg1.ReleaseSchedule(ctx, sc); err != nil {
+		t.Fatalf("ReleaseSchedule(pg1): %v", err)
+	}
+	claimed2, err = pg2.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(pg2 after release): %v", err)
+	}
+	if !claimed2 {
+		t.Fatal("expected second store to claim after first owner released")
+	}
+}
+
+func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pg1 := &PostgresStore{DB: db}
+	pg2 := &PostgresStore{DB: db}
+
+	sc := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(50 * time.Millisecond).UTC(),
+		EntityID:     uuid.NewString(),
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-once",
+		Payload:      []byte(`{"timer_id":"timer-once"}`),
+	}
+	if err := pg1.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+
+	active1, err := pg1.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules(pg1): %v", err)
+	}
+	active2, err := pg2.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules(pg2): %v", err)
+	}
+	if len(active1) != 1 || len(active2) != 1 {
+		t.Fatalf("restored schedules lens = (%d,%d), want (1,1)", len(active1), len(active2))
+	}
+
+	var fired1, fired2 atomic.Int32
+	scheduler1 := runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
+		fired1.Add(1)
+		if err := pg1.MarkScheduleFiredExact(context.Background(), sc); err != nil {
+			t.Errorf("MarkScheduleFiredExact(pg1): %v", err)
+		}
+		if err := pg1.ReleaseSchedule(context.Background(), sc); err != nil {
+			t.Errorf("ReleaseSchedule(pg1): %v", err)
+		}
+	})
+	scheduler2 := runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
+		fired2.Add(1)
+		if err := pg2.MarkScheduleFiredExact(context.Background(), sc); err != nil {
+			t.Errorf("MarkScheduleFiredExact(pg2): %v", err)
+		}
+		if err := pg2.ReleaseSchedule(context.Background(), sc); err != nil {
+			t.Errorf("ReleaseSchedule(pg2): %v", err)
+		}
+	})
+	t.Cleanup(scheduler1.Stop)
+	t.Cleanup(scheduler2.Stop)
+
+	claimed1, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, pg1, scheduler1, active1[0])
+	if err != nil {
+		t.Fatalf("ClaimAndRegisterSchedule(pg1): %v", err)
+	}
+	claimed2, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, pg2, scheduler2, active2[0])
+	if err != nil {
+		t.Fatalf("ClaimAndRegisterSchedule(pg2): %v", err)
+	}
+	if claimed1 == claimed2 {
+		t.Fatalf("claimed owners = (%v,%v), want exactly one owner", claimed1, claimed2)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for fired1.Load()+fired2.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for claimed restored timer to fire")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := fired1.Load() + fired2.Load(); got != 1 {
+		t.Fatalf("restored timer fire count = %d, want 1", got)
+	}
+
+	activeAfter, err := pg1.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules(after fire): %v", err)
+	}
+	if len(activeAfter) != 0 {
+		t.Fatalf("active schedules after claimed once fire = %d, want 0", len(activeAfter))
 	}
 }
 

--- a/internal/store/schedule_claims.go
+++ b/internal/store/schedule_claims.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+func (s *PostgresStore) ClaimSchedule(ctx context.Context, sc runtimepipeline.Schedule) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+	if caps.Schedules != SchemaFlavorCanonical {
+		return false, unsupportedSchemaCapability("timers/schedules", caps.Schedules)
+	}
+	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
+		return false, fmt.Errorf("agent_id and event_type are required")
+	}
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	key := scheduleClaimLockKey(sc)
+
+	s.scheduleClaimMu.Lock()
+	defer s.scheduleClaimMu.Unlock()
+
+	if _, ok := s.scheduleClaimKeys[key]; ok {
+		return true, nil
+	}
+	conn, err := s.ensureScheduleClaimConnLocked(ctx)
+	if err != nil {
+		return false, err
+	}
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock(hashtext($1))`, key).Scan(&acquired); err != nil {
+		return false, fmt.Errorf("claim schedule ownership: %w", err)
+	}
+	if !acquired {
+		return false, nil
+	}
+	active, err := scheduleActiveOnConn(ctx, conn, sc)
+	if err != nil {
+		if _, unlockErr := conn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, key); unlockErr != nil {
+			_ = s.closeScheduleClaimConnLocked()
+		}
+		return false, err
+	}
+	if !active {
+		if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, key); err != nil {
+			_ = s.closeScheduleClaimConnLocked()
+			return false, fmt.Errorf("release inactive schedule claim: %w", err)
+		}
+		return false, nil
+	}
+	if s.scheduleClaimKeys == nil {
+		s.scheduleClaimKeys = map[string]struct{}{}
+	}
+	s.scheduleClaimKeys[key] = struct{}{}
+	return true, nil
+}
+
+func (s *PostgresStore) ReleaseSchedule(ctx context.Context, sc runtimepipeline.Schedule) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	key := scheduleClaimLockKey(sc)
+
+	s.scheduleClaimMu.Lock()
+	defer s.scheduleClaimMu.Unlock()
+
+	if _, ok := s.scheduleClaimKeys[key]; !ok {
+		return nil
+	}
+	if s.scheduleClaimConn == nil {
+		delete(s.scheduleClaimKeys, key)
+		return nil
+	}
+	if _, err := s.scheduleClaimConn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, key); err != nil {
+		return fmt.Errorf("release schedule ownership: %w", err)
+	}
+	delete(s.scheduleClaimKeys, key)
+	if len(s.scheduleClaimKeys) == 0 {
+		return s.closeScheduleClaimConnLocked()
+	}
+	return nil
+}
+
+func (s *PostgresStore) ReleaseScheduleClaims(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.scheduleClaimMu.Lock()
+	defer s.scheduleClaimMu.Unlock()
+	return s.closeScheduleClaimConnLocked()
+}
+
+func (s *PostgresStore) ensureScheduleClaimConnLocked(ctx context.Context) (*sql.Conn, error) {
+	if s.scheduleClaimConn != nil {
+		return s.scheduleClaimConn, nil
+	}
+	conn, err := s.DB.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open schedule ownership connection: %w", err)
+	}
+	s.scheduleClaimConn = conn
+	return conn, nil
+}
+
+func (s *PostgresStore) closeScheduleClaimConnLocked() error {
+	conn := s.scheduleClaimConn
+	s.scheduleClaimConn = nil
+	s.scheduleClaimKeys = nil
+	if conn == nil {
+		return nil
+	}
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close schedule ownership connection: %w", err)
+	}
+	return nil
+}
+
+func scheduleActiveOnConn(ctx context.Context, conn *sql.Conn, sc runtimepipeline.Schedule) (bool, error) {
+	var active bool
+	err := conn.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE owner_agent = $1
+			  AND fire_event = $2
+			  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
+			  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
+			  AND %s = $5
+			  AND status = 'active'
+		)
+	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)).Scan(&active)
+	if err != nil {
+		return false, fmt.Errorf("check active schedule ownership target: %w", err)
+	}
+	return active, nil
+}

--- a/internal/store/shared_store_claims.go
+++ b/internal/store/shared_store_claims.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+const (
+	pipelineReplayClaimNamespace = "swarm:pipeline-replay:"
+	scheduleClaimNamespace       = "swarm:schedule:"
+)
+
+type advisoryLockLease interface {
+	Release(context.Context) error
+}
+
+type sqlAdvisoryLockLease struct {
+	conn    *sql.Conn
+	lockKey string
+}
+
+func (l *sqlAdvisoryLockLease) Release(ctx context.Context) error {
+	if l == nil || l.conn == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := l.conn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, l.lockKey); err != nil {
+		_ = l.conn.Close()
+		l.conn = nil
+		return fmt.Errorf("release advisory lock: %w", err)
+	}
+	if err := l.conn.Close(); err != nil {
+		l.conn = nil
+		return fmt.Errorf("close advisory lock connection: %w", err)
+	}
+	l.conn = nil
+	return nil
+}
+
+func acquireAdvisoryLockLease(ctx context.Context, db *sql.DB, lockKey string) (*sqlAdvisoryLockLease, bool, error) {
+	if db == nil {
+		return nil, false, nil
+	}
+	lockKey = strings.TrimSpace(lockKey)
+	if lockKey == "" {
+		return nil, false, fmt.Errorf("advisory lock key is required")
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("acquire advisory lock connection: %w", err)
+	}
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock(hashtext($1))`, lockKey).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return nil, false, fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	if !acquired {
+		_ = conn.Close()
+		return nil, false, nil
+	}
+	return &sqlAdvisoryLockLease{conn: conn, lockKey: lockKey}, true, nil
+}
+
+func replayClaimLockKey(eventID string) string {
+	return pipelineReplayClaimNamespace + strings.TrimSpace(eventID)
+}
+
+func scheduleClaimLockKey(sc runtimepipeline.Schedule) string {
+	return scheduleClaimNamespace + strings.Join([]string{
+		strings.TrimSpace(sc.AgentID),
+		strings.TrimSpace(sc.EventType),
+		strings.TrimSpace(sc.EffectiveEntityID()),
+		strings.TrimSpace(sc.EffectiveFlowInstance()),
+		strings.TrimSpace(sc.TaskID),
+	}, "|")
+}


### PR DESCRIPTION
Closes #145

## Human Summary

This PR makes shared-store replay and restored timer ownership explicit instead of letting overlapping runtime paths infer ownership from timing. Replayed pipeline work now has a canonical claim-before-dispatch owner, and restored schedules are only registered by the runtime that successfully claims schedule ownership from the shared store.

## What Changed

- added a canonical replay claim lease at the store boundary and required the sweeper and recovery manager to claim a replay row before dispatch
- made recovery mark the canonical pipeline receipt after a successful replay so claimed replay work is durably closed out
- added canonical schedule ownership methods to the schedule store seam: claim, release, and release-all
- wired runtime startup, workflow timer registration, lifecycle schedule restoration, and scheduler shutdown through the schedule ownership seam
- released one-shot schedule ownership only after canonical fired persistence succeeds; cancelled schedules release ownership after canonical cancel persistence succeeds
- added focused overlap regressions for sweeper claims, recovery overlap, exclusive restored schedule claims, and single-owner restored timer firing

## Why This Is Needed

- shared-store replay, sweeper, and restored timers could all select the same persisted work without claiming it first
- that made duplicate execution depend on timing and overlap behavior instead of one explicit owner
- this change makes the touched shared-store seams fail closed under overlap: if ownership is already claimed, the second path skips execution instead of best-effort retrying into the same work

## Scope Boundaries

- In scope:
  - explicit ownership for replayed pipeline work in recovery/sweeper paths
  - explicit ownership for restored and newly registered schedules in the touched scheduler/store seam
  - focused duplicate-work prevention tests for those seams
- Not in scope:
  - broad clustering or partitioning redesign
  - unrelated runtime-start ownership work beyond the touched replay/timer seams
  - crash-after-side-effect idempotence redesign outside the current claim-before-dispatch boundary

## Tests Run

- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store -count=1`
- `go test ./internal/runtime ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

- replay ownership is explicit for overlap, but it still does not make publish side effects transactional with pipeline receipt persistence; if a process crashes after dispatch and before receipt write, replay can still happen later
- recurring timer ownership now has one canonical claimant in the touched seam, but the lock is operational rather than spec-visible persisted state

## Follow-Up

- broader crash-consistency or cluster-wide runtime partitioning remains separate if we later need transactional replay completion beyond overlap safety
