### PR TITLE
[agent-a][issue #135] Collapse MCP and tool execution context into one typed transport contract

### DIFF
--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -15,19 +15,7 @@ import (
 )
 
 const (
-	mcpActorIDHeader      = "X-SWARM-Agent-Id"
-	mcpActorRoleHeader    = "X-SWARM-Agent-Role"
-	mcpActorModeHeader    = "X-SWARM-Agent-Mode"
-	mcpEntityIDHeader     = "X-SWARM-Entity-Id"
-	mcpAllowedToolsHeader = "X-SWARM-Allowed-Tools"
 	mcpContextTokenHeader = "X-SWARM-Context-Token"
-
-	mcpActorIDQuery      = "agent_id"
-	mcpActorRoleQuery    = "agent_role"
-	mcpActorModeQuery    = "agent_mode"
-	mcpEntityIDQuery     = "entity_id"
-	mcpAllowedToolsQuery = "allowed_tools"
-	mcpContextTokenQuery = "ctx_token"
 )
 
 func (r *ClaudeCLIRuntime) runWithPromptArg(ctx context.Context, args []string, target *workspace.Target, prompt string, meta MonitorTurnMeta) (*Response, error) {
@@ -70,7 +58,6 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), toolNames(s.Tools))
 	if contextToken != "" {
 		headers[mcpContextTokenHeader] = contextToken
-		serverURL = withMCPContextQuery(serverURL, contextToken)
 	}
 	return MCPHTTPBinding{
 		URL:          serverURL,
@@ -160,23 +147,6 @@ func normalizeMCPServerURL(raw string) string {
 	default:
 		// Respect explicit path when operator already targets a specific endpoint.
 	}
-	return strings.TrimSpace(u.String())
-}
-
-func withMCPContextQuery(rawURL string, contextToken string) string {
-	rawURL = strings.TrimSpace(rawURL)
-	if rawURL == "" {
-		return rawURL
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	q := u.Query()
-	if v := strings.TrimSpace(contextToken); v != "" {
-		q.Set(mcpContextTokenQuery, v)
-	}
-	u.RawQuery = q.Encode()
 	return strings.TrimSpace(u.String())
 }
 

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -167,32 +167,13 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	if got := headers[mcpContextTokenHeader]; got != contextToken {
 		t.Fatalf("context header = %#v, want %q", got, contextToken)
 	}
-	for _, key := range []string{
-		mcpActorIDHeader,
-		mcpActorRoleHeader,
-		mcpActorModeHeader,
-		mcpEntityIDHeader,
-		mcpAllowedToolsHeader,
-	} {
-		if got := headers[key]; got != nil {
-			t.Fatalf("unexpected gateway identity header %q = %#v", key, got)
-		}
-	}
 	urlRaw := runtimeTools["url"].(string)
 	legacyTraceQuery := "trace" + "_id="
 	if strings.Contains(urlRaw, legacyTraceQuery) {
 		t.Fatalf("url %q should not propagate legacy trace query params", urlRaw)
 	}
-	for _, key := range []string{
-		mcpActorIDQuery,
-		mcpActorRoleQuery,
-		mcpActorModeQuery,
-		mcpEntityIDQuery,
-		mcpAllowedToolsQuery,
-	} {
-		if strings.Contains(urlRaw, key+"=") {
-			t.Fatalf("url %q should not propagate %s", urlRaw, key)
-		}
+	if strings.Contains(urlRaw, "ctx_token=") {
+		t.Fatalf("url %q should not propagate context token query", urlRaw)
 	}
 }
 

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -119,7 +119,6 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 		WriteJSON(w, http.StatusBadRequest, ToolGatewayResponse{OK: false, Error: "invalid json body"})
 		return
 	}
-	req.NormalizeEntityID()
 	ctx, err := g.toolExecutionContext(r, toolName)
 	if err != nil {
 		g.logMCP(r, "warn", "tool.context_error", err, map[string]any{
@@ -128,6 +127,7 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 		WriteJSON(w, http.StatusBadRequest, ToolGatewayResponse{OK: false, Error: g.formatError(err)})
 		return
 	}
+	r = r.WithContext(ctx)
 	if !toolAllowedInContext(ctx, toolName) {
 		err := g.newRuntimeError(ErrCodeToolNotAllowed, "tool.execute.authorize_tool", false, nil, "tool is not allowed for this agent: %s", toolName)
 		g.logMCP(r, "warn", "tool.execute.denied", err, map[string]any{
@@ -236,6 +236,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		r = r.WithContext(ctx)
 		if !toolAllowedInContext(ctx, toolName) {
 			err := g.newRuntimeError(ErrCodeToolNotAllowed, "mcp.tools.call.authorize_tool", false, nil, "tool is not allowed for this agent: %s", toolName)
 			g.logMCP(r, "warn", "mcp.tools.call.denied", err, map[string]any{
@@ -361,23 +362,6 @@ func toolCapabilityInContext(ctx context.Context, toolName string) (toolcapabili
 
 func normalizeGatewayToolName(name string) string {
 	return toolidentity.CanonicalName(name)
-}
-
-func (g *Gateway) logContextFallback(r *http.Request, action, toolName, reason, token string, used bool, fallbackAllowed bool) {
-	if g == nil || r == nil {
-		return
-	}
-	g.logMCP(r, "warn", action, nil, map[string]any{
-		"tool_name":         strings.TrimSpace(toolName),
-		"reason":            strings.TrimSpace(reason),
-		"context_token":     strings.TrimSpace(token),
-		"fallback_used":     used,
-		"fallback_allowed":  fallbackAllowed,
-		"require_ctx_token": RequireContextToken(),
-		"fallback_on_miss":  AllowContextFallbackOnMiss(),
-		"request_path":      strings.TrimSpace(r.URL.Path),
-		"request_method":    strings.TrimSpace(r.Method),
-	})
 }
 
 func emitTurnDedupeKey(toolName string, arguments any) string {
@@ -610,14 +594,14 @@ func (g *Gateway) logMCP(r *http.Request, level, action string, err error, detai
 	if g == nil || g.hooks.Log == nil || r == nil {
 		return
 	}
-	agentID := FirstNonEmpty(
-		headerValue(r, actorIDHeader),
-		strings.TrimSpace(r.URL.Query().Get(actorIDQuery)),
-	)
-	entityID := FirstNonEmpty(
-		headerValue(r, entityIDHeader),
-		strings.TrimSpace(r.URL.Query().Get(entityIDQuery)),
-	)
+	agentID := ""
+	entityID := ""
+	if g.hooks.ActorFromContext != nil {
+		if actor, ok := g.hooks.ActorFromContext(r.Context()); ok {
+			agentID = strings.TrimSpace(actor.ID)
+			entityID = strings.TrimSpace(actor.EntityID)
+		}
+	}
 	errText := ""
 	if err != nil {
 		errText = g.formatError(err)

--- a/internal/runtime/mcp/gateway_protocol.go
+++ b/internal/runtime/mcp/gateway_protocol.go
@@ -4,46 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
-	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolidentity"
 )
 
 const (
-	actorIDHeader      = "X-SWARM-Agent-Id"
-	actorRoleHeader    = "X-SWARM-Agent-Role"
-	actorModeHeader    = "X-SWARM-Agent-Mode"
-	entityIDHeader     = "X-SWARM-Entity-Id"
-	allowedToolsHeader = "X-SWARM-Allowed-Tools"
 	contextTokenHeader = "X-SWARM-Context-Token"
-
-	actorIDQuery      = "agent_id"
-	actorRoleQuery    = "agent_role"
-	actorModeQuery    = "agent_mode"
-	entityIDQuery     = "entity_id"
-	allowedToolsQuery = "allowed_tools"
-	contextTokenQuery = "ctx_token"
 )
 
 type ToolGatewayRequest struct {
-	Actor     models.AgentConfig `json:"actor"`
-	AgentID   string             `json:"agent_id"`
-	AgentRole string             `json:"agent_role"`
-	EntityID  string             `json:"entity_id"`
-	Mode      string             `json:"mode"`
-	Input     any                `json:"input"`
-}
-
-func (r ToolGatewayRequest) EffectiveEntityID() string { return strings.TrimSpace(r.EntityID) }
-
-func (r *ToolGatewayRequest) NormalizeEntityID() {
-	if r == nil {
-		return
-	}
-	entityID := r.EffectiveEntityID()
-	r.EntityID = entityID
+	Input any `json:"input"`
 }
 
 type ToolGatewayResponse struct {
@@ -77,51 +48,6 @@ type ToolDef struct {
 	InputSchema any    `json:"inputSchema"`
 }
 
-func RequireContextToken() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv("SWARM_MCP_REQUIRE_CONTEXT_TOKEN")))
-	if v == "" {
-		return true
-	}
-	return v == "1" || v == "true" || v == "yes"
-}
-
-func AllowContextFallbackOnMiss() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv("SWARM_MCP_CONTEXT_FALLBACK_ON_MISS")))
-	if v == "" {
-		return true
-	}
-	return v == "1" || v == "true" || v == "yes"
-}
-
-func ActorFromRequest(r *http.Request) (models.AgentConfig, bool) {
-	if r == nil {
-		return models.AgentConfig{}, false
-	}
-	actor := models.AgentConfig{
-		ID: FirstNonEmpty(
-			headerValue(r, actorIDHeader),
-			strings.TrimSpace(r.URL.Query().Get(actorIDQuery)),
-		),
-		Role: FirstNonEmpty(
-			headerValue(r, actorRoleHeader),
-			strings.TrimSpace(r.URL.Query().Get(actorRoleQuery)),
-		),
-		EntityID: FirstNonEmpty(
-			headerValue(r, entityIDHeader),
-			strings.TrimSpace(r.URL.Query().Get(entityIDQuery)),
-		),
-		Mode: FirstNonEmpty(
-			headerValue(r, actorModeHeader),
-			strings.TrimSpace(r.URL.Query().Get(actorModeQuery)),
-		),
-	}
-	actor.NormalizeEntityID()
-	if strings.TrimSpace(actor.ID) == "" {
-		return models.AgentConfig{}, false
-	}
-	return actor, true
-}
-
 func ParseToolListHeader(raw string) map[string]struct{} {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -138,19 +64,8 @@ func ParseToolListHeader(raw string) map[string]struct{} {
 	return out
 }
 
-func ParseAllowedToolsFromRequest(r *http.Request) map[string]struct{} {
-	allowed := ParseToolListHeader(headerValue(r, allowedToolsHeader))
-	if len(allowed) > 0 {
-		return allowed
-	}
-	return ParseToolListHeader(strings.TrimSpace(r.URL.Query().Get(allowedToolsQuery)))
-}
-
 func ContextTokenFromRequest(r *http.Request) string {
-	if token := headerValue(r, contextTokenHeader); token != "" {
-		return token
-	}
-	return strings.TrimSpace(r.URL.Query().Get(contextTokenQuery))
+	return headerValue(r, contextTokenHeader)
 }
 
 func ToolResultText(v any) string {
@@ -214,13 +129,4 @@ func WriteRPCError(w http.ResponseWriter, id any, code int, message string) {
 	w.Header().Set("mcp-protocol-version", "2025-03-26")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(raw)
-}
-
-func FirstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -26,6 +26,13 @@ func authorizeGatewayRequest(req *http.Request) {
 	}
 }
 
+func withContextToken(req *http.Request, token string) *http.Request {
+	if req != nil {
+		req.Header.Set(contextTokenHeader, strings.TrimSpace(token))
+	}
+	return req
+}
+
 func mustMCPToolsForRequest(t *testing.T, g *Gateway, req *http.Request) []ToolDef {
 	t.Helper()
 	tools, err := g.mcpToolsForRequest(req)
@@ -330,7 +337,7 @@ func TestGatewayMCPToolsForRequest_UsesHydratedActorRoleForEmitTools(t *testing.
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-hydrated-role", nil)
+	req := withContextToken(httptest.NewRequest("POST", "/mcp", nil), "ctx-hydrated-role")
 	tools := mustMCPToolsForRequest(t, g, req)
 	for _, tool := range tools {
 		if tool.Name == "emit_scan_requested" {
@@ -371,7 +378,7 @@ func TestGatewayMCPToolsForRequest_KeepsEmitToolsForDirectMCPContext(t *testing.
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?agent_id=campaign-coordinator&ctx_token=ctx-1", nil)
+	req := withContextToken(httptest.NewRequest("POST", "/mcp", nil), "ctx-1")
 	tools := mustMCPToolsForRequest(t, g, req)
 	for _, tool := range tools {
 		if tool.Name == "emit_scan_requested" {
@@ -406,7 +413,7 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-actor-scoped", nil)
+	req := withContextToken(httptest.NewRequest("POST", "/mcp", nil), "ctx-actor-scoped")
 	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 1 {
 		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
@@ -436,7 +443,7 @@ func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-ignore-allowlist&allowed_tools=Read", nil)
+	req := withContextToken(httptest.NewRequest("POST", "/mcp?allowed_tools=Read", nil), "ctx-ignore-allowlist")
 	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 2 {
 		t.Fatalf("tool count = %d, want 2 (%#v)", len(tools), tools)
@@ -467,7 +474,7 @@ func TestGatewayMCPToolsForRequest_DoesNotTrustUnknownCallerAllowlist(t *testing
 		ExpiresAt: time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest("POST", "/mcp?ctx_token=ctx-unknown-allowlist&allowed_tools=does_not_exist", nil)
+	req := withContextToken(httptest.NewRequest("POST", "/mcp?allowed_tools=does_not_exist", nil), "ctx-unknown-allowlist")
 	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 1 {
 		t.Fatalf("tool count = %d, want 1 (%#v)", len(tools), tools)
@@ -540,7 +547,7 @@ func TestGatewayHandleMCP_ToolsListUsesResolvedTurnContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-list", strings.NewReader(string(body)))
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-list")
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -634,7 +641,7 @@ func TestGatewayHandleMCP_AllowsDistinctEmitPayloadsPerTurn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal request: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-emit-gateway", strings.NewReader(string(body)))
+		req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-emit-gateway")
 		authorizeGatewayRequest(req)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
@@ -687,7 +694,7 @@ func TestGatewayHandleMCP_AllowsPrefixedToolNameFromRuntimeOwnedTurnContext(t *t
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-prefixed-emit&allowed_tools=query_entities", strings.NewReader(string(body)))
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp?allowed_tools=query_entities", strings.NewReader(string(body))), "ctx-prefixed-emit")
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -735,7 +742,7 @@ func TestGatewayHandleMCP_DoesNotLetCallerAllowlistGrantToolAccess(t *testing.T)
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-denied-allowlist&allowed_tools=emit_score_dimension_complete", strings.NewReader(string(body)))
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp?allowed_tools=emit_score_dimension_complete", strings.NewReader(string(body))), "ctx-denied-allowlist")
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -775,7 +782,7 @@ func TestGatewayHandleMCP_RejectsToolWhenContextTokenMisses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/mcp?agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -793,7 +800,7 @@ func TestGatewayHandleMCP_RejectsToolWhenContextTokenMisses(t *testing.T) {
 
 func TestGatewayMCPExecutionContext_RejectsPrefixedMutatingToolOnContextMiss(t *testing.T) {
 	g := NewGateway(nil, "", GatewayHooks{})
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp?agent_id=analysis-agent&agent_role=analysis", nil)
 	if _, err := g.mcpExecutionContext(req, "mcp__runtime-tools__emit_score_dimension_complete"); err == nil {
 		t.Fatal("expected context miss error for prefixed mutating tool")
 	}
@@ -821,7 +828,7 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-trace", nil)
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-trace")
 	ctx, err := g.mcpExecutionContext(req, "get_entity")
 	if err != nil {
 		t.Fatalf("mcpExecutionContext: %v", err)
@@ -849,7 +856,7 @@ func TestGatewayMCPExecutionContext_KeepsOtherRegistryTokensValidAfterGlobalEpoc
 	runtimebus.EnterRuntimeResetMode()
 	runtimebus.ExitRuntimeResetMode()
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-b", nil)
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-b")
 	ctx, err := gatewayB.mcpExecutionContext(req, "query_entities")
 	if err != nil {
 		t.Fatalf("mcpExecutionContext after unrelated reset: %v", err)
@@ -905,7 +912,7 @@ func TestGatewayHandleMCP_RejectsReadOnlyToolWhenContextTokenMisses(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/mcp?agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -929,7 +936,6 @@ func TestGatewayHandleTool_RejectsMutatingToolWithoutContextToken(t *testing.T) 
 	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
-		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		Input: map[string]any{"dimension": "build_complexity", "score": 72},
 	})
 	if err != nil {
@@ -959,7 +965,6 @@ func TestGatewayHandleTool_RejectsReadOnlyToolWithoutContextToken(t *testing.T) 
 	}), testGatewayToken, GatewayHooks{})
 
 	body, err := json.Marshal(ToolGatewayRequest{
-		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		Input: map[string]any{"query": "kind = 'vertical'"},
 	})
 	if err != nil {
@@ -995,19 +1000,12 @@ func TestGatewayHandleTool_IgnoresCallerSuppliedPrivilegeFields(t *testing.T) {
 	})
 
 	body, err := json.Marshal(ToolGatewayRequest{
-		Actor: models.AgentConfig{
-			ID:          "analysis-agent",
-			Role:        "campaign_coordinator",
-			Tools:       []string{"emit_score_dimension_complete"},
-			Permissions: []string{"schedule"},
-			EmitEvents:  []string{"score_dimension.complete"},
-		},
 		Input: map[string]any{"dimension": "build_complexity", "score": 72},
 	})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete?ctx_token=ctx-analysis", strings.NewReader(string(body)))
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete", strings.NewReader(string(body))), "ctx-analysis")
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -1042,7 +1040,7 @@ func TestGatewayHandleTool_AllowsLegitimateRuntimeOwnedActorContext(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete?ctx_token=ctx-coordinator", strings.NewReader(string(body)))
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/tools/emit_score_dimension_complete", strings.NewReader(string(body))), "ctx-coordinator")
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -1073,19 +1071,72 @@ func TestGatewayTransports_AlignReadOnlyToolContextTokenFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal mcp request: %v", err)
 	}
-	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(mcpBody)))
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(mcpBody)))
 	authorizeGatewayRequest(mcpReq)
 	mcpRec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(mcpRec, mcpReq)
 
 	toolBody, err := json.Marshal(ToolGatewayRequest{
-		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		Input: map[string]any{"query": "kind = 'vertical'"},
 	})
 	if err != nil {
 		t.Fatalf("marshal tool request: %v", err)
 	}
-	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities?ctx_token=missing", strings.NewReader(string(toolBody)))
+	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(string(toolBody)))
+	authorizeGatewayRequest(toolReq)
+	toolRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(toolRec, toolReq)
+
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+	if !strings.Contains(mcpRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("mcp body = %s", mcpRec.Body.String())
+	}
+	if !strings.Contains(toolRec.Body.String(), "missing or invalid mcp context token") {
+		t.Fatalf("tool body = %s", toolRec.Body.String())
+	}
+}
+
+func TestGatewayTransports_RejectLegacyQueryContextTokenCarrier(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	callCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-query-only", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	mcpBody, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"query": "kind = 'vertical'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal mcp request: %v", err)
+	}
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-query-only", strings.NewReader(string(mcpBody)))
+	authorizeGatewayRequest(mcpReq)
+	mcpRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(mcpRec, mcpReq)
+
+	toolBody, err := json.Marshal(ToolGatewayRequest{
+		Input: map[string]any{"query": "kind = 'vertical'"},
+	})
+	if err != nil {
+		t.Fatalf("marshal tool request: %v", err)
+	}
+	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities?ctx_token=ctx-query-only", strings.NewReader(string(toolBody)))
 	authorizeGatewayRequest(toolReq)
 	toolRec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(toolRec, toolReq)
@@ -1128,7 +1179,7 @@ func TestGatewayTransports_AlignReadOnlyToolSuccessWithResolvedTurnContext(t *te
 	if err != nil {
 		t.Fatalf("marshal mcp request: %v", err)
 	}
-	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=ctx-query", strings.NewReader(string(mcpBody)))
+	mcpReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(mcpBody))), "ctx-query")
 	authorizeGatewayRequest(mcpReq)
 	mcpRec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(mcpRec, mcpReq)
@@ -1139,7 +1190,7 @@ func TestGatewayTransports_AlignReadOnlyToolSuccessWithResolvedTurnContext(t *te
 	if err != nil {
 		t.Fatalf("marshal tool request: %v", err)
 	}
-	toolReq := httptest.NewRequest(http.MethodPost, "/tools/query_entities?ctx_token=ctx-query", strings.NewReader(string(toolBody)))
+	toolReq := withContextToken(httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(string(toolBody))), "ctx-query")
 	authorizeGatewayRequest(toolReq)
 	toolRec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(toolRec, toolReq)
@@ -1182,7 +1233,7 @@ func TestGatewayHandleMCP_DoesNotLogFallbackUsedReason(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp?ctx_token=missing&agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/mcp?agent_id=analysis-agent&agent_role=analysis", strings.NewReader(string(body)))
 	authorizeGatewayRequest(req)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
@@ -1206,7 +1257,6 @@ func TestGatewayHandleTool_DoesNotLogFallbackBlockedReason(t *testing.T) {
 	})
 
 	body, err := json.Marshal(ToolGatewayRequest{
-		Actor: models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
 		Input: map[string]any{"dimension": "build_complexity", "score": 72},
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #135

## Human Summary
This PR collapses the touched MCP and /tools execution-context seam onto one explicit transport contract: a runtime-owned turn-context token carried in the X-SWARM-Context-Token header. Actor identity, tool scope, and turn context now come only from the resolved runtime turn context instead of being reconstructed from overlapping body, header, query, and env-driven carriers.

## What Changed
- reduced the gateway execution-context transport contract to a single context-token header in internal/runtime/mcp/gateway_protocol.go
- removed request-body actor and entity fields from ToolGatewayRequest because the gateway no longer accepts caller-owned identity for tool execution
- removed legacy actor/allowlist/entity query and header parsing from the touched gateway transport seam
- removed env-governed context fallback remnants that no longer owned canonical behavior in the gateway path
- updated gateway logging to read actor identity from resolved runtime context instead of request carriers
- updated Claude MCP HTTP binding to send the context token only via header, not duplicated into the server URL query string
- added focused regressions proving valid header-based requests succeed, missing context fails closed, and a valid legacy query-only token is still rejected

## Why This Is Needed
Before this change, execution-context semantics were split across request body fields, duplicated header/query carriers, and old fallback-oriented helpers. That kept the transport contract ambiguous even after runtime semantics had already moved to canonical turn-context ownership. This PR removes those duplicate interpretations so the touched seam has one explicit owner and one fail-closed contract.

## Scope Boundaries
In scope:
- touched MCP and /tools execution-context ownership in the gateway seam
- Claude MCP HTTP binding changes required to align with the canonical header contract
- focused transport tests for canonical success and invalid/missing context behavior

Out of scope:
- broad MCP redesign
- unrelated auth cleanup
- startup probe redesign beyond the touched transport contract
- spec changes

## Tests Run
- go test ./internal/runtime/mcp ./internal/runtime/llm ./internal/runtime -count=1
- go test ./... -count=1

## Residual Risk
The change is intentionally narrow to the execution-context contract. Other MCP surface differences, such as broader response-shape divergence between /mcp and /tools, are unchanged here.

## Follow-Up
No new issue is needed from this PR. The broader remaining transport-contract cleanup is already tracked by issue #111 and this issue itself covered the touched carrier collapse work.
