### PR TITLE
[agent-c][issue #150] Make task conversation persistence rollout-safe across legacy and canonical storage

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -388,10 +388,10 @@ func conversationQuerySources(caps store.StoreSchemaCapabilities) []string {
 			  AND runtime_mode IN ('session', 'session_per_entity')
 		`)
 	}
-	if caps.Conversations.Audits == store.SchemaFlavorCanonical {
-		sources = append(sources, `
+	if taskSource := store.CanonicalTaskConversationVisibilitySourceSQL(caps.Conversations); taskSource != "" {
+		sources = append(sources, fmt.Sprintf(`
 			SELECT
-				session_id::text AS session_id,
+				session_id,
 				agent_id,
 				'turn_audit' AS kind,
 				scope_key,
@@ -403,9 +403,10 @@ func conversationQuerySources(caps store.StoreSchemaCapabilities) []string {
 				conversation,
 				updated_at,
 				created_at
-			FROM agent_conversation_audits
-			WHERE status = 'active'
-		`)
+			FROM (
+				%s
+			) task_conversations
+		`, taskSource))
 	}
 	return sources
 }

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -150,6 +150,101 @@ func TestConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions(t *testi
 	}
 }
 
+func TestTaskConversationReader_ShowsLegacyTaskRowsDuringMixedRollout(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	sessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `ALTER TABLE agent_sessions DROP CONSTRAINT IF EXISTS agent_sessions_runtime_mode_check`); err != nil {
+		t.Fatalf("drop task-runtime_mode check for mixed-rollout fixture: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES (
+			$1::uuid,
+			'agent-1',
+			'',
+			'global',
+			'[{"role":"assistant","content":"legacy task"}]'::jsonb,
+			1,
+			'task',
+			'{"summary":"legacy task"}'::jsonb,
+			'active',
+			now() - interval '5 minutes',
+			now() - interval '5 minutes'
+		)
+	`, sessionID); err != nil {
+		t.Fatalf("seed legacy task session row: %v", err)
+	}
+
+	reader := dashboardserver.NewSQLConversationReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLConversationReader returned nil")
+	}
+	items, err := reader.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("List conversations: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("conversation count = %d, want 1", len(items))
+	}
+	if items[0].Kind != "turn_audit" || items[0].SessionID != sessionID || items[0].Summary != "legacy task" {
+		t.Fatalf("unexpected mixed-rollout summary: %+v", items[0])
+	}
+
+	item, ok, err := reader.Get(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Get conversation: %v", err)
+	}
+	if !ok {
+		t.Fatalf("conversation %s not found", sessionID)
+	}
+	if item.Kind != "turn_audit" || len(item.Messages) != 1 || item.Messages[0].Content != "legacy task" {
+		t.Fatalf("unexpected mixed-rollout detail: %+v", item)
+	}
+
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "agent-1",
+		Mode:      "task",
+		Messages: []runtimellm.Message{
+			{Role: "assistant", Content: "canonical task"},
+		},
+		Summary:   "canonical task",
+		TurnCount: 2,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	items, err = reader.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("List conversations after canonical write: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("conversation count after canonical write = %d, want 1", len(items))
+	}
+	if items[0].SessionID != sessionID || items[0].Summary != "canonical task" {
+		t.Fatalf("unexpected canonical mixed-rollout summary: %+v", items[0])
+	}
+
+	item, ok, err = reader.Get(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Get conversation after canonical write: %v", err)
+	}
+	if !ok {
+		t.Fatalf("canonical conversation %s not found", sessionID)
+	}
+	if len(item.Messages) != 1 || item.Messages[0].Content != "canonical task" || item.TurnCount != 2 {
+		t.Fatalf("unexpected canonical mixed-rollout detail: %+v", item)
+	}
+}
+
 func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -467,7 +467,9 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 		  AND agent_id = $2
 		  AND runtime_mode = 'task'
 		  AND status = 'active'
-		ON CONFLICT (session_id) DO NOTHING
+		ON CONFLICT (session_id) DO UPDATE SET
+			status = 'active',
+			updated_at = now()
 	`
 	adoptLegacyArgs := []any{rec.SessionID, rec.AgentID}
 	if caps.Conversations.AuditRunID && caps.Conversations.SessionRunID {
@@ -496,7 +498,10 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			  AND agent_id = $2
 			  AND runtime_mode = 'task'
 			  AND status = 'active'
-			ON CONFLICT (session_id) DO NOTHING
+			ON CONFLICT (session_id) DO UPDATE SET
+				run_id = COALESCE(agent_conversation_audits.run_id, EXCLUDED.run_id),
+				status = 'active',
+				updated_at = now()
 		`
 		adoptLegacyArgs = []any{rec.SessionID, rec.AgentID}
 	} else if caps.Conversations.AuditRunID {
@@ -525,7 +530,10 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			  AND agent_id = $2
 			  AND runtime_mode = 'task'
 			  AND status = 'active'
-			ON CONFLICT (session_id) DO NOTHING
+			ON CONFLICT (session_id) DO UPDATE SET
+				run_id = COALESCE(agent_conversation_audits.run_id, EXCLUDED.run_id),
+				status = 'active',
+				updated_at = now()
 		`
 		adoptLegacyArgs = []any{rec.SessionID, rec.AgentID, nullUUIDString(rec.RunID)}
 	}
@@ -556,7 +564,9 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			now(),
 			now()
 		)
-		ON CONFLICT (session_id) DO NOTHING
+		ON CONFLICT (session_id) DO UPDATE SET
+			status = 'active',
+			updated_at = now()
 	`
 	args := []any{
 		rec.SessionID,
@@ -588,7 +598,10 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 				now(),
 				now()
 			)
-			ON CONFLICT (session_id) DO NOTHING
+			ON CONFLICT (session_id) DO UPDATE SET
+				run_id = COALESCE(agent_conversation_audits.run_id, EXCLUDED.run_id),
+				status = 'active',
+				updated_at = now()
 		`
 		args = []any{
 			rec.SessionID,

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -434,6 +434,108 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 		return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 	}
 	scopeKey := strings.TrimSpace(rec.ScopeKey)
+	if caps.Conversations.AuditRunID {
+		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID); err != nil {
+			return err
+		}
+	}
+	execFn := s.DB.ExecContext
+	if tx != nil {
+		execFn = tx.ExecContext
+	}
+	adoptLegacyQuery := `
+		INSERT INTO agent_conversation_audits (
+			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		SELECT
+			session_id,
+			agent_id,
+			entity_id,
+			flow_instance,
+			NULLIF(scope_key, ''),
+			COALESCE(NULLIF(scope, ''), 'global'),
+			conversation,
+			turn_count,
+			runtime_mode,
+			runtime_state,
+			status,
+			created_at,
+			updated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+		  AND agent_id = $2
+		  AND runtime_mode = 'task'
+		  AND status = 'active'
+		ON CONFLICT (session_id) DO NOTHING
+	`
+	adoptLegacyArgs := []any{rec.SessionID, rec.AgentID}
+	if caps.Conversations.AuditRunID && caps.Conversations.SessionRunID {
+		adoptLegacyQuery = `
+			INSERT INTO agent_conversation_audits (
+				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+			)
+			SELECT
+				session_id,
+				run_id,
+				agent_id,
+				entity_id,
+				flow_instance,
+				NULLIF(scope_key, ''),
+				COALESCE(NULLIF(scope, ''), 'global'),
+				conversation,
+				turn_count,
+				runtime_mode,
+				runtime_state,
+				status,
+				created_at,
+				updated_at
+			FROM agent_sessions
+			WHERE session_id = $1::uuid
+			  AND agent_id = $2
+			  AND runtime_mode = 'task'
+			  AND status = 'active'
+			ON CONFLICT (session_id) DO NOTHING
+		`
+		adoptLegacyArgs = []any{rec.SessionID, rec.AgentID}
+	} else if caps.Conversations.AuditRunID {
+		adoptLegacyQuery = `
+			INSERT INTO agent_conversation_audits (
+				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+			)
+			SELECT
+				session_id,
+				NULLIF($3,'')::uuid,
+				agent_id,
+				entity_id,
+				flow_instance,
+				NULLIF(scope_key, ''),
+				COALESCE(NULLIF(scope, ''), 'global'),
+				conversation,
+				turn_count,
+				runtime_mode,
+				runtime_state,
+				status,
+				created_at,
+				updated_at
+			FROM agent_sessions
+			WHERE session_id = $1::uuid
+			  AND agent_id = $2
+			  AND runtime_mode = 'task'
+			  AND status = 'active'
+			ON CONFLICT (session_id) DO NOTHING
+		`
+		adoptLegacyArgs = []any{rec.SessionID, rec.AgentID, nullUUIDString(rec.RunID)}
+	}
+	res, err := execFn(ctx, adoptLegacyQuery, adoptLegacyArgs...)
+	if err != nil {
+		return fmt.Errorf("adopt legacy task conversation row: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows > 0 {
+		return nil
+	}
 	q := `
 		INSERT INTO agent_conversation_audits (
 			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -454,15 +556,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			now(),
 			now()
 		)
-		ON CONFLICT (session_id) DO UPDATE SET
-			agent_id = EXCLUDED.agent_id,
-			entity_id = EXCLUDED.entity_id,
-			flow_instance = EXCLUDED.flow_instance,
-			scope_key = EXCLUDED.scope_key,
-			scope = EXCLUDED.scope,
-			runtime_mode = EXCLUDED.runtime_mode,
-			status = 'active',
-			updated_at = now()
+		ON CONFLICT (session_id) DO NOTHING
 	`
 	args := []any{
 		rec.SessionID,
@@ -473,9 +567,6 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 		runtimesessions.RuntimeModeTask.String(),
 	}
 	if caps.Conversations.AuditRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID); err != nil {
-			return err
-		}
 		q = `
 			INSERT INTO agent_conversation_audits (
 				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -497,16 +588,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 				now(),
 				now()
 			)
-			ON CONFLICT (session_id) DO UPDATE SET
-				run_id = COALESCE(EXCLUDED.run_id, agent_conversation_audits.run_id),
-				agent_id = EXCLUDED.agent_id,
-				entity_id = EXCLUDED.entity_id,
-				flow_instance = EXCLUDED.flow_instance,
-				scope_key = EXCLUDED.scope_key,
-				scope = EXCLUDED.scope,
-				runtime_mode = EXCLUDED.runtime_mode,
-				status = 'active',
-				updated_at = now()
+			ON CONFLICT (session_id) DO NOTHING
 		`
 		args = []any{
 			rec.SessionID,
@@ -518,13 +600,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			runtimesessions.RuntimeModeTask.String(),
 		}
 	}
-	execFn := s.DB.ExecContext
-	if tx != nil {
-		execFn = tx.ExecContext
-	}
-	if _, err := execFn(ctx, q,
-		args...,
-	); err != nil {
+	if _, err := execFn(ctx, q, args...); err != nil {
 		return fmt.Errorf("ensure task conversation audit row: %w", err)
 	}
 	return nil

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2537,6 +2537,70 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	}
 }
 
+func TestManagerStore_AppendAgentTurn_TaskReactivatesExistingInactiveAuditRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "assistant", Content: "done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_conversation_audits
+		SET status = 'terminated', updated_at = now() - interval '1 minute'
+		WHERE session_id = $1::uuid
+	`, sessionID); err != nil {
+		t.Fatalf("terminate task audit row: %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task inactive audit): %v", err)
+	}
+
+	var status string
+	var parseOK bool
+	var turnCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			status,
+			COALESCE((runtime_state->'last_turn'->>'parse_ok')::boolean, false),
+			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid AND runtime_mode = 'task')
+		FROM agent_conversation_audits
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&status, &parseOK, &turnCount); err != nil {
+		t.Fatalf("load reactivated task audit row: %v", err)
+	}
+	if status != "active" {
+		t.Fatalf("expected inactive task audit row to be reactivated, got %q", status)
+	}
+	if !parseOK {
+		t.Fatal("expected reactivated task audit row to record last_turn telemetry")
+	}
+	if turnCount != 1 {
+		t.Fatalf("expected one task turn row after reactivation, got %d", turnCount)
+	}
+}
+
 func TestManagerStore_TaskConversationDoesNotPersistLiveSessionRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/task_conversation_visibility.go
+++ b/internal/store/task_conversation_visibility.go
@@ -1,0 +1,53 @@
+package store
+
+// CanonicalTaskConversationVisibilitySourceSQL returns the explicit mixed-rollout
+// task-conversation visibility contract: canonical audit rows are authoritative,
+// and legacy task rows in agent_sessions are only visible until the same
+// session_id has been adopted into agent_conversation_audits.
+func CanonicalTaskConversationVisibilitySourceSQL(caps ConversationSchemaCapabilities) string {
+	if caps.Audits != SchemaFlavorCanonical {
+		return ""
+	}
+	auditSource := `
+		SELECT
+			session_id::text AS session_id,
+			agent_id,
+			COALESCE(scope_key, '') AS scope_key,
+			COALESCE(scope, '') AS scope,
+			COALESCE(runtime_mode, '') AS runtime_mode,
+			COALESCE(status, '') AS status,
+			COALESCE(turn_count, 0) AS turn_count,
+			COALESCE(runtime_state, '{}'::jsonb) AS runtime_state,
+			COALESCE(conversation, '[]'::jsonb) AS conversation,
+			updated_at,
+			created_at
+		FROM agent_conversation_audits
+		WHERE status = 'active'
+	`
+	if caps.Sessions != SchemaFlavorCanonical {
+		return auditSource
+	}
+	return auditSource + `
+		UNION ALL
+		SELECT
+			legacy.session_id::text AS session_id,
+			legacy.agent_id,
+			COALESCE(legacy.scope_key, '') AS scope_key,
+			COALESCE(legacy.scope, '') AS scope,
+			COALESCE(legacy.runtime_mode, '') AS runtime_mode,
+			COALESCE(legacy.status, '') AS status,
+			COALESCE(legacy.turn_count, 0) AS turn_count,
+			COALESCE(legacy.runtime_state, '{}'::jsonb) AS runtime_state,
+			COALESCE(legacy.conversation, '[]'::jsonb) AS conversation,
+			legacy.updated_at,
+			legacy.created_at
+		FROM agent_sessions legacy
+		WHERE legacy.status = 'active'
+		  AND legacy.runtime_mode = 'task'
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM agent_conversation_audits canonical
+			WHERE canonical.session_id = legacy.session_id
+		  )
+	`
+}


### PR DESCRIPTION
Closes #150

## Human Summary

This PR makes task conversation visibility rollout-safe during the mixed old-writer/new-reader window. Canonical task conversations still belong to `agent_conversation_audits`, but current readers now explicitly surface unmigrated legacy task rows from `agent_sessions` until that same `session_id` has been adopted into the canonical audit table.

## What Changed

- added a store-owned mixed-rollout task visibility source in `internal/store/task_conversation_visibility.go`
- updated `internal/dashboard/server/conversations_sql.go` to consume that store-owned task visibility source instead of reading only `agent_conversation_audits`
- tightened `internal/store/llm_store.go` so task audit row synthesis first adopts an existing legacy task row by `session_id` before falling back to an empty synthesized audit row
- added real Postgres-backed regression coverage in `internal/runtime/conformance/persisted_surfaces_test.go` for:
  - legacy task row visibility through the dashboard reader during mixed rollout
  - canonical audit precedence once the same `session_id` is written canonically

## Why This Is Needed

- older writers can still leave active task conversations in `agent_sessions`
- newer readers had already switched to `agent_conversation_audits` as canonical and could temporarily hide those active task conversations
- this PR makes the mixed-storage window explicit instead of leaving runtime/store/dashboard to disagree about what is visible

## Scope Boundaries

- In scope:
  - mixed-storage task conversation visibility between `agent_sessions` and `agent_conversation_audits`
  - dashboard conversation reader alignment to the canonical store-owned visibility contract
  - narrow task audit adoption behavior when a current writer touches a legacy task row
- Not in scope:
  - broad conversation redesign
  - spec changes
  - live session ownership changes

## Tests Run

- `go test ./internal/store ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk

- the mixed-rollout tolerance is intentionally limited to task conversation visibility; it does not preserve legacy `agent_sessions` as a second canonical owner
- legacy task rows are only visible until the same `session_id` exists in `agent_conversation_audits`, after which the canonical audit row wins

## Follow-Up

- none identified in this seam
