### PR TITLE
[agent-d][issue #118] Add delivery lifecycle conformance suite

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -105,7 +105,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	if err := store.RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
 		return nil, err
 	}
-	pendingPredicate := store.CanonicalPendingAgentDeliveryPredicateSQL("r")
+	pendingPredicate := store.CanonicalPendingAgentDeliveryPredicateSQL("d", "r")
 	latestTurnBlocksExpr := `'[]'::jsonb`
 	if caps.Conversations.TurnBlocks {
 		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -1,0 +1,486 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestDeliveryLifecycleConformance(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		seed   func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string
+		expect deliveryLifecycleExpectation
+	}{
+		{
+			name: "pending_after_direct_publish",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				return fx.publishDirectEvent(t, ctx)
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "pending",
+				deliveryRetryCount: 0,
+				directPending:      true,
+				subscribedPending:  true,
+				receiptFound:       false,
+				recoveryReplays:    true,
+			},
+		},
+		{
+			name: "retryable_failed_delivery_after_backoff",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				eventID := fx.publishDirectEvent(t, ctx)
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(retryable error): %v", err)
+				}
+				fx.rewindDeliveryAttempt(t, ctx, eventID, time.Now().Add(-2*time.Minute))
+				return eventID
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "failed",
+				deliveryRetryCount: 1,
+				directPending:      true,
+				subscribedPending:  true,
+				receiptFound:       true,
+				receiptStatus:      runtimemanager.ReceiptStatusError,
+				receiptRetryCount:  1,
+				recoveryReplays:    true,
+			},
+		},
+		{
+			name: "dead_letter_is_terminal_everywhere",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				eventID := fx.publishDirectEvent(t, ctx)
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(first error): %v", err)
+				}
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(second error): %v", err)
+				}
+				return eventID
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "dead_letter",
+				deliveryRetryCount: 2,
+				directPending:      false,
+				subscribedPending:  false,
+				receiptFound:       true,
+				receiptStatus:      runtimemanager.ReceiptStatusDeadLetter,
+				receiptRetryCount:  2,
+				recoveryReplays:    false,
+			},
+		},
+		{
+			name: "stranded_in_progress_without_receipt_remains_replay_eligible",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				eventID := fx.publishDirectEvent(t, ctx)
+				if err := fx.pg.MarkEventDeliveryInProgress(ctx, eventID, fx.agentID, ""); err != nil {
+					t.Fatalf("MarkEventDeliveryInProgress: %v", err)
+				}
+				return eventID
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "in_progress",
+				deliveryRetryCount: 0,
+				directPending:      true,
+				subscribedPending:  true,
+				receiptFound:       false,
+				recoveryReplays:    true,
+			},
+		},
+		{
+			name: "delivery_dead_letter_overrides_retryable_receipt_drift",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				eventID := fx.publishDirectEvent(t, ctx)
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(first error): %v", err)
+				}
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(second error): %v", err)
+				}
+				fx.forceReceiptState(t, ctx, eventID, runtimemanager.ReceiptStatusError, 1, time.Now().Add(-2*time.Minute), "stale-retry")
+				return eventID
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "dead_letter",
+				deliveryRetryCount: 2,
+				directPending:      false,
+				subscribedPending:  false,
+				receiptFound:       true,
+				receiptStatus:      runtimemanager.ReceiptStatusDeadLetter,
+				receiptRetryCount:  2,
+				recoveryReplays:    false,
+			},
+		},
+		{
+			name: "retryable_delivery_overrides_dead_letter_receipt_drift",
+			seed: func(t *testing.T, ctx context.Context, fx *deliveryLifecycleFixture) string {
+				t.Helper()
+				eventID := fx.publishDirectEvent(t, ctx)
+				if err := fx.pg.UpsertEventReceipt(ctx, eventID, fx.agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(retryable error): %v", err)
+				}
+				fx.rewindDeliveryAttempt(t, ctx, eventID, time.Now().Add(-2*time.Minute))
+				fx.forceReceiptState(t, ctx, eventID, runtimemanager.ReceiptStatusDeadLetter, 2, time.Now().Add(-2*time.Minute), "stale-dead-letter")
+				return eventID
+			},
+			expect: deliveryLifecycleExpectation{
+				deliveryStatus:     "failed",
+				deliveryRetryCount: 1,
+				directPending:      true,
+				subscribedPending:  true,
+				receiptFound:       true,
+				receiptStatus:      runtimemanager.ReceiptStatusError,
+				receiptRetryCount:  1,
+				recoveryReplays:    true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newDeliveryLifecycleFixture(t, ctx)
+			eventID := tc.seed(t, ctx, fx)
+			got := fx.snapshot(t, ctx, eventID)
+			assertDeliveryLifecycleExpectation(t, got, tc.expect, eventID)
+		})
+	}
+}
+
+type deliveryLifecycleExpectation struct {
+	deliveryStatus     string
+	deliveryRetryCount int
+	directPending      bool
+	subscribedPending  bool
+	receiptFound       bool
+	receiptStatus      runtimemanager.ReceiptStatus
+	receiptRetryCount  int
+	recoveryReplays    bool
+}
+
+type deliveryLifecycleSnapshot struct {
+	deliveryStatus     string
+	deliveryRetryCount int
+	directPendingIDs   []string
+	subscribedPending  []string
+	receipt            runtimemanager.EventReceipt
+	receiptFound       bool
+	recoveredEventIDs  []string
+}
+
+type deliveryLifecycleFixture struct {
+	pg           *store.PostgresStore
+	bus          *runtimebus.EventBus
+	agentID      string
+	subscription events.EventType
+}
+
+func newDeliveryLifecycleFixture(t *testing.T, ctx context.Context) *deliveryLifecycleFixture {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	requireCanonicalDeliveryLifecycleSurface(t, ctx, pg)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	agentID := "delivery-conformance-agent"
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:            agentID,
+			Role:          "tester",
+			Type:          "stub",
+			Mode:          "global",
+			Subscriptions: []string{"review.*"},
+			Config:        []byte(`{"system_prompt":"x"}`),
+		},
+		Status:    "active",
+		HiredBy:   "delivery-conformance",
+		StartedAt: time.Now().Add(-24 * time.Hour).UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
+
+	return &deliveryLifecycleFixture{
+		pg:           pg,
+		bus:          bus,
+		agentID:      agentID,
+		subscription: events.EventType("review.*"),
+	}
+}
+
+func requireCanonicalDeliveryLifecycleSurface(t *testing.T, ctx context.Context, pg *store.PostgresStore) {
+	t.Helper()
+	caps, err := pg.BindSchemaCapabilities(ctx)
+	if err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	if caps.Events.Log != store.SchemaFlavorCanonical {
+		t.Fatalf("events capability = %s, want canonical", caps.Events.Log)
+	}
+	if caps.Events.Deliveries != store.SchemaFlavorCanonical {
+		t.Fatalf("event_deliveries capability = %s, want canonical", caps.Events.Deliveries)
+	}
+	if caps.Events.Receipts != store.SchemaFlavorCanonical {
+		t.Fatalf("event_receipts capability = %s, want canonical", caps.Events.Receipts)
+	}
+	requireTableColumns(t, ctx, pg.DB, "event_deliveries", "delivery_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count", "created_at", "delivered_at")
+	requireTableColumns(t, ctx, pg.DB, "event_receipts", "event_id", "subscriber_type", "subscriber_id", "outcome", "side_effects", "processed_at")
+}
+
+func (fx *deliveryLifecycleFixture) publishDirectEvent(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	eventID := uuid.NewString()
+	ch := fx.bus.Subscribe(fx.agentID)
+	defer fx.bus.Unsubscribe(fx.agentID)
+
+	evt := (events.Event{
+		ID:          eventID,
+		Type:        events.EventType("review.requested"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		CreatedAt:   time.Now().Add(-2 * time.Hour).UTC(),
+	}).WithEntityID(uuid.NewString())
+	if err := fx.bus.PublishDirect(ctx, evt, []string{fx.agentID}); err != nil {
+		t.Fatalf("PublishDirect: %v", err)
+	}
+	select {
+	case delivered := <-ch:
+		if delivered.ID != eventID {
+			t.Fatalf("delivered event id = %q, want %q", delivered.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected direct publish to fan out to live subscriber")
+	}
+	return eventID
+}
+
+func (fx *deliveryLifecycleFixture) rewindDeliveryAttempt(t *testing.T, ctx context.Context, eventID string, when time.Time) {
+	t.Helper()
+	if _, err := fx.pg.DB.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET delivered_at = $3
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, fx.agentID, when.UTC()); err != nil {
+		t.Fatalf("rewind event_deliveries.delivered_at: %v", err)
+	}
+	if _, err := fx.pg.DB.ExecContext(ctx, `
+		UPDATE event_receipts
+		SET processed_at = $3
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, fx.agentID, when.UTC()); err != nil {
+		t.Fatalf("rewind event_receipts.processed_at: %v", err)
+	}
+}
+
+func (fx *deliveryLifecycleFixture) forceReceiptState(
+	t *testing.T,
+	ctx context.Context,
+	eventID string,
+	status runtimemanager.ReceiptStatus,
+	retryCount int,
+	processedAt time.Time,
+	errText string,
+) {
+	t.Helper()
+	sideEffects, err := json.Marshal(map[string]any{
+		"manager_status": strings.TrimSpace(string(status)),
+		"retry_count":    retryCount,
+		"error":          strings.TrimSpace(errText),
+	})
+	if err != nil {
+		t.Fatalf("marshal receipt side effects: %v", err)
+	}
+	if _, err := fx.pg.DB.ExecContext(ctx, `
+		UPDATE event_receipts
+		SET outcome = $3,
+			side_effects = $4::jsonb,
+			processed_at = $5
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, fx.agentID, managerReceiptOutcome(status), string(sideEffects), processedAt.UTC()); err != nil {
+		t.Fatalf("force receipt state: %v", err)
+	}
+}
+
+func managerReceiptOutcome(status runtimemanager.ReceiptStatus) string {
+	switch status {
+	case runtimemanager.ReceiptStatusError, runtimemanager.ReceiptStatusDeadLetter:
+		return "dead_letter"
+	default:
+		return "success"
+	}
+}
+
+func (fx *deliveryLifecycleFixture) snapshot(t *testing.T, ctx context.Context, eventID string) deliveryLifecycleSnapshot {
+	t.Helper()
+
+	var got deliveryLifecycleSnapshot
+	if err := fx.pg.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(retry_count, 0)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, fx.agentID).Scan(&got.deliveryStatus, &got.deliveryRetryCount); err != nil {
+		t.Fatalf("load event_deliveries state: %v", err)
+	}
+
+	direct, err := fx.pg.ListPendingEventsForAgent(ctx, fx.agentID, time.Now().Add(-24*time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	for _, evt := range direct {
+		got.directPendingIDs = append(got.directPendingIDs, evt.ID)
+	}
+
+	subscribed, err := fx.pg.ListPendingSubscribedEvents(ctx, fx.agentID, []events.EventType{fx.subscription}, time.Now().Add(-24*time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListPendingSubscribedEvents: %v", err)
+	}
+	for _, evt := range subscribed {
+		got.subscribedPending = append(got.subscribedPending, evt.ID)
+	}
+
+	got.receipt, got.receiptFound, err = fx.pg.GetEventReceipt(ctx, eventID, fx.agentID)
+	if err != nil {
+		t.Fatalf("GetEventReceipt: %v", err)
+	}
+
+	got.recoveredEventIDs = fx.recoverSeenEventIDs(t, ctx)
+	return got
+}
+
+func (fx *deliveryLifecycleFixture) recoverSeenEventIDs(t *testing.T, ctx context.Context) []string {
+	t.Helper()
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	am := runtimemanager.NewAgentManager(fx.bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		subscriptions := make([]events.EventType, 0, len(cfg.Subscriptions))
+		for _, raw := range cfg.Subscriptions {
+			raw = strings.TrimSpace(raw)
+			if raw != "" {
+				subscriptions = append(subscriptions, events.EventType(raw))
+			}
+		}
+		return &deliveryLifecycleRecordingAgent{
+			id:            cfg.ID,
+			subscriptions: subscriptions,
+			record: func(evt events.Event) {
+				mu.Lock()
+				seen = append(seen, evt.ID)
+				mu.Unlock()
+			},
+		}, nil
+	}, fx.pg)
+	if err := am.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]string(nil), seen...)
+}
+
+type deliveryLifecycleRecordingAgent struct {
+	id            string
+	subscriptions []events.EventType
+	record        func(events.Event)
+}
+
+func (a *deliveryLifecycleRecordingAgent) ID() string { return a.id }
+
+func (*deliveryLifecycleRecordingAgent) Type() string { return "stub" }
+
+func (a *deliveryLifecycleRecordingAgent) Subscriptions() []events.EventType {
+	return append([]events.EventType(nil), a.subscriptions...)
+}
+
+func (a *deliveryLifecycleRecordingAgent) OnEvent(_ context.Context, evt events.Event) ([]events.Event, error) {
+	if a.record != nil {
+		a.record(evt)
+	}
+	return nil, errors.New("session currently leased")
+}
+
+func assertDeliveryLifecycleExpectation(t *testing.T, got deliveryLifecycleSnapshot, want deliveryLifecycleExpectation, eventID string) {
+	t.Helper()
+
+	if got.deliveryStatus != want.deliveryStatus || got.deliveryRetryCount != want.deliveryRetryCount {
+		t.Fatalf("delivery state = status:%q retry:%d, want status:%q retry:%d", got.deliveryStatus, got.deliveryRetryCount, want.deliveryStatus, want.deliveryRetryCount)
+	}
+
+	assertPendingContainsEvent(t, "direct pending", got.directPendingIDs, eventID, want.directPending)
+	assertPendingContainsEvent(t, "subscribed pending", got.subscribedPending, eventID, want.subscribedPending)
+
+	if got.receiptFound != want.receiptFound {
+		t.Fatalf("receiptFound = %v, want %v (receipt=%+v)", got.receiptFound, want.receiptFound, got.receipt)
+	}
+	if want.receiptFound {
+		if got.receipt.Status != want.receiptStatus {
+			t.Fatalf("receipt status = %q, want %q", got.receipt.Status, want.receiptStatus)
+		}
+		if got.receipt.RetryCount != want.receiptRetryCount {
+			t.Fatalf("receipt retry_count = %d, want %d", got.receipt.RetryCount, want.receiptRetryCount)
+		}
+	}
+
+	assertPendingContainsEvent(t, "recovered events", got.recoveredEventIDs, eventID, want.recoveryReplays)
+}
+
+func assertPendingContainsEvent(t *testing.T, label string, ids []string, eventID string, want bool) {
+	t.Helper()
+	has := slices.Contains(ids, eventID)
+	if has != want {
+		t.Fatalf("%s contains %s = %v, want %v (ids=%v)", label, eventID, has, want, ids)
+	}
+	if want && countMatches(ids, eventID) != 1 {
+		t.Fatalf("%s contains %s %d times, want 1 (ids=%v)", label, eventID, countMatches(ids, eventID), ids)
+	}
+}
+
+func countMatches(ids []string, want string) int {
+	count := 0
+	for _, id := range ids {
+		if strings.TrimSpace(id) == strings.TrimSpace(want) {
+			count++
+		}
+	}
+	return count
+}
+
+func (fx *deliveryLifecycleFixture) String() string {
+	return fmt.Sprintf("agent=%s subscription=%s", fx.agentID, fx.subscription)
+}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -324,7 +324,7 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 }
 
 func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
-	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("r")
+	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("d", "r")
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -353,7 +353,7 @@ func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agent
 }
 
 func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, agentID string, subscriptions []events.EventType, since time.Time, limit int) ([]events.Event, error) {
-	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("r")
+	pendingPredicate := CanonicalPendingAgentDeliveryPredicateSQL("d", "r")
 	q := fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -361,6 +361,10 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 			e.payload, e.created_at,
 			COALESCE(e.source_event_id::text, '')
 		FROM events e
+		LEFT JOIN event_deliveries d
+			ON d.event_id = e.event_id
+			AND d.subscriber_type = 'agent'
+			AND d.subscriber_id = $1
 		LEFT JOIN event_receipts r
 			ON r.event_id = e.event_id
 			AND r.subscriber_type = 'agent'

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -298,7 +298,9 @@ func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
 		t.Fatalf("list pending (no receipt): got %v events, want 1 (%s)", len(evts), evt.ID)
 	}
 
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "error", 1, time.Now().Add(-30*time.Second))
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert retryable receipt: %v", err)
+	}
 	evts, err = pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
 	if err != nil {
 		t.Fatalf("list pending (retry=1 not ready): %v", err)
@@ -307,7 +309,7 @@ func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
 		t.Fatalf("list pending (retry=1 not ready): got %d events, want 0", len(evts))
 	}
 
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "error", 1, time.Now().Add(-2*time.Minute))
+	rewindCanonicalDeliveryAttempt(t, ctx, pg, evt.ID, agentID, time.Now().Add(-2*time.Minute))
 	evts, err = pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
 	if err != nil {
 		t.Fatalf("list pending (retry=1 ready): %v", err)
@@ -317,22 +319,15 @@ func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
 	}
 
 	// After retries are exhausted, the event should not be pending.
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "error", 2, time.Now().Add(-2*time.Hour))
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert dead_letter receipt: %v", err)
+	}
 	evts, err = pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
 	if err != nil {
 		t.Fatalf("list pending (retry=2 exhausted): %v", err)
 	}
 	if len(evts) != 0 {
 		t.Fatalf("list pending (retry=2 exhausted): got %d events, want 0", len(evts))
-	}
-
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "dead_letter", 2, time.Now().Add(-2*time.Hour))
-	evts, err = pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
-	if err != nil {
-		t.Fatalf("list pending (dead_letter): %v", err)
-	}
-	if len(evts) != 0 {
-		t.Fatalf("list pending (dead_letter): got %d events, want 0", len(evts))
 	}
 }
 
@@ -355,7 +350,10 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 		t.Fatalf("list subscribed pending (no receipt): got %v events, want 1 (%s)", len(evts), evt.ID)
 	}
 
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "error", 1, time.Now().Add(-2*time.Minute))
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert retryable receipt: %v", err)
+	}
+	rewindCanonicalDeliveryAttempt(t, ctx, pg, evt.ID, agentID, time.Now().Add(-2*time.Minute))
 	evts, err = pg.ListPendingSubscribedEvents(ctx, agentID, subs, since, 100)
 	if err != nil {
 		t.Fatalf("list subscribed pending (retry=1 ready): %v", err)
@@ -364,7 +362,9 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 		t.Fatalf("list subscribed pending (retry=1 ready): got %v events, want 1 (%s)", len(evts), evt.ID)
 	}
 
-	insertOrUpdateReceipt(t, ctx, pg, evt.ID, agentID, "dead_letter", 2, time.Now().Add(-2*time.Hour))
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert dead_letter receipt: %v", err)
+	}
 	evts, err = pg.ListPendingSubscribedEvents(ctx, agentID, subs, since, 100)
 	if err != nil {
 		t.Fatalf("list subscribed pending (dead_letter): %v", err)
@@ -467,42 +467,25 @@ func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
 	}
 }
 
-func insertOrUpdateReceipt(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID, status string, retryCount int, processedAt time.Time) {
+func rewindCanonicalDeliveryAttempt(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string, when time.Time) {
 	t.Helper()
-	// Upsert-style helper for tests; the production upsert also mutates retry_count which isn't what we want
-	// for time-window filtering tests.
-	const q = `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, side_effects, processed_at
-		)
-		SELECT
-			e.event_id, 'agent', $2, e.entity_id, e.flow_instance, $3, $4::jsonb, $5
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			processed_at = EXCLUDED.processed_at,
-			outcome = EXCLUDED.outcome,
-			side_effects = EXCLUDED.side_effects
-	`
-	sideEffects, err := json.Marshal(map[string]any{
-		"manager_status": status,
-		"retry_count":    retryCount,
-		"error":          "boom",
-	})
-	if err != nil {
-		t.Fatalf("marshal side effects: %v", err)
+	if _, err := pg.DB.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET delivered_at = $3
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID, when.UTC()); err != nil {
+		t.Fatalf("rewind event_deliveries.delivered_at: %v", err)
 	}
-	outcome := "success"
-	switch status {
-	case "error", "dead_letter":
-		outcome = status
-	}
-	if outcome == "error" {
-		outcome = "dead_letter"
-	}
-	if _, err := pg.DB.ExecContext(ctx, q, eventID, agentID, outcome, string(sideEffects), processedAt); err != nil {
-		t.Fatalf("upsert receipt: %v", err)
+	if _, err := pg.DB.ExecContext(ctx, `
+		UPDATE event_receipts
+		SET processed_at = $3
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID, when.UTC()); err != nil {
+		t.Fatalf("rewind event_receipts.processed_at: %v", err)
 	}
 }
 

--- a/internal/store/pending_delivery_selection.go
+++ b/internal/store/pending_delivery_selection.go
@@ -15,15 +15,41 @@ func RequireCanonicalPendingAgentDeliveryCapabilities(caps StoreSchemaCapabiliti
 	}
 }
 
-func CanonicalPendingAgentDeliveryPredicateSQL(receiptAlias string) string {
+func CanonicalPendingAgentDeliveryPredicateSQL(deliveryAlias, receiptAlias string) string {
 	return fmt.Sprintf(`(
-		%s.event_id IS NULL
-		OR (
-			COALESCE(%s.side_effects->>'manager_status', '') = 'error'
-			AND COALESCE((%s.side_effects->>'retry_count')::int, 0) <= 1
+		(
+			%s.delivery_id IS NOT NULL
 			AND (
-				(COALESCE((%s.side_effects->>'retry_count')::int, 0) = 1 AND %s.processed_at <= now() - interval '1 minute')
+				%s.status IN ('pending', 'in_progress')
+				OR (
+					%s.status = 'failed'
+					AND COALESCE(%s.retry_count, 0) < 2
+					AND COALESCE(%s.delivered_at, %s.created_at) <= now() - interval '1 minute'
+				)
 			)
 		)
-	)`, receiptAlias, receiptAlias, receiptAlias, receiptAlias, receiptAlias)
+		OR (
+			%s.delivery_id IS NULL
+			AND (
+				%s.event_id IS NULL
+				OR (
+					COALESCE(%s.side_effects->>'manager_status', '') = 'error'
+					AND COALESCE((%s.side_effects->>'retry_count')::int, 0) < 2
+					AND %s.processed_at <= now() - interval '1 minute'
+				)
+			)
+		)
+	)`,
+		deliveryAlias,
+		deliveryAlias,
+		deliveryAlias,
+		deliveryAlias,
+		deliveryAlias,
+		deliveryAlias,
+		deliveryAlias,
+		receiptAlias,
+		receiptAlias,
+		receiptAlias,
+		receiptAlias,
+	)
 }


### PR DESCRIPTION
Closes #118

## Human Summary
This adds one reusable cross-boundary delivery lifecycle conformance suite for delivery-backed agent work and aligns pending/replay selection to the same durable owner. Delivery-backed pending and replay eligibility now follow `event_deliveries` when a delivery row exists, with `event_receipts` remaining the derived acknowledgement surface.

## What Changed
- added `internal/runtime/conformance/delivery_lifecycle_conformance_test.go` as the reusable invariant suite covering publish, receipt writes, retry exhaustion, dead-letter terminality, stranded `in_progress`, recovery replay, and drift counterexamples
- changed `CanonicalPendingAgentDeliveryPredicateSQL(...)` to prefer `event_deliveries.status` / `retry_count` / `delivered_at` when a delivery row exists, and only fall back to receipt-side state when there is no delivery owner
- wired the touched pending readers through that canonical predicate in store and dashboard operator projections
- updated adjacent retry-policy tests to use the canonical receipt writer plus timestamp rewinds instead of a receipt-only helper that bypassed delivery ownership

## Why This Is Needed
The delivery lifecycle semantics had started to split: some reads already treated `event_deliveries` as authoritative while pending/replay selection still derived retry eligibility from `event_receipts.side_effects`. That allows publish, receipt writes, retry exhaustion, and restart replay to disagree about the same event. This PR makes the delivery-backed owner explicit and adds one reusable suite that fails if those surfaces drift again.

## Scope Boundaries
- scoped to delivery lifecycle conformance and the immediate pending/replay owner needed to make the suite meaningful
- no spec changes
- no compatibility shims or fallback preservation for delivery-backed state
- no broader receipt-model redesign beyond the touched delivery-backed seam

## Tests Run
- `go test ./internal/runtime/conformance -run TestDeliveryLifecycleConformance -count=1`
- `go test ./internal/store -run 'Test(ListPendingEventsForAgent_RetryBackoff_V2|ListPendingSubscribedEvents_RetryBackoff_V2|ListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending|EventReceipts_RetryToDeadLetter_AndPendingQueries)' -count=1`
- `go test ./internal/store ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/manager ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
Receipt-only paths without an `event_deliveries` row still use receipt-side state because there is no delivery owner there. This PR keeps that boundary explicit but does not redesign those receipt-only seams.

## Follow-Up
None required for this issue. The conformance suite should catch future delivery-backed drift if another read path starts preferring `event_receipts` over `event_deliveries` again.
