### PR TITLE
[agent-a][issue #137] Unify agent-visible tool availability across prompt and transport surfaces

### DIFF
--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 
@@ -185,7 +184,7 @@ func (a *LLMAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Even
 		}
 	}
 
-	input := formatEventForAgent(a.cfg, evt, a.authority)
+	input := formatEventForAgent(a.cfg, evt, a.conversation.Tools)
 	resp, err := a.conversation.Step(ctx, input)
 	if err != nil && a.shouldRetryAfterTaskScopeReset(err) {
 		a.conversation.Reset()
@@ -498,7 +497,7 @@ func (a *LLMAgent) BoardStep(ctx context.Context, directive string) (string, err
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx = runtimebus.WithEmittedEventsRecorder(ctx, recorder)
 	beforeMessages := len(a.conversation.Messages)
-	resp, err := a.conversation.Step(ctx, formatEventForAgent(a.cfg, evt, a.authority))
+	resp, err := a.conversation.Step(ctx, formatEventForAgent(a.cfg, evt, a.conversation.Tools))
 	if err != nil {
 		return "", err
 	}
@@ -739,50 +738,28 @@ func mergeTools(in []llm.ToolDefinition, extra []llm.ToolDefinition) []llm.ToolD
 	return out
 }
 
-func formatEventForAgent(cfg models.AgentConfig, evt events.Event, authority runtimeauthority.Provider) string {
+func formatEventForAgent(cfg models.AgentConfig, evt events.Event, tools []llm.ToolDefinition) string {
 	payload := strings.TrimSpace(string(evt.Payload))
 	if payload == "" {
 		payload = "{}"
 	}
-	allowed := extractEmitEvents(cfg)
-	if len(allowed) == 0 {
-		allowed = runtimeauthority.ProviderOrNoop(authority).ProducerEventsForRole(cfg.Role)
-	}
-	emitTools := make([]string, 0, len(allowed))
-	for _, evtType := range allowed {
-		emitTools = append(emitTools, runtimetools.EmitToolName(evtType))
-	}
+	surface := llm.AgentVisibleToolSurfaceForActor(cfg, tools)
 	toolsLine := "(none declared)"
-	if len(emitTools) > 0 {
-		toolsLine = strings.Join(emitTools, ", ")
+	if len(surface.EmitToolNames) > 0 {
+		toolsLine = strings.Join(surface.EmitToolNames, ", ")
 	}
-	allowedTools, _ := extractAllowedToolSet(cfg)
-	nonEmitTools := make([]string, 0, len(allowedTools))
-	for tool := range allowedTools {
-		if strings.TrimSpace(tool) == "" || strings.HasPrefix(tool, "emit_") {
-			continue
-		}
-		nonEmitTools = append(nonEmitTools, tool)
-	}
-	slices.Sort(nonEmitTools)
 	toolSummaryLine := ""
-	if len(nonEmitTools) > 0 {
-		toolSummaryLine = "\n- Available non-emit tools from your contract: " + strings.Join(nonEmitTools, ", ")
+	if len(surface.NonEmitToolNames) > 0 {
+		toolSummaryLine = "\n- Available non-emit tools in this turn: " + strings.Join(surface.NonEmitToolNames, ", ")
 	}
-	nativeTools := extractNativeToolConfig(cfg)
-	if len(nativeTools) > 0 {
-		nativeNames := make([]string, 0, len(nativeTools))
-		for _, name := range []string{"bash", "web_search", "file_io"} {
-			if nativeTools[name] {
-				nativeNames = append(nativeNames, name)
-			}
-		}
-		if len(nativeNames) > 0 {
-			toolSummaryLine += "\n- Native capabilities from your contract: " + strings.Join(nativeNames, ", ")
-		}
+	if len(surface.NativeBuiltinTools) > 0 {
+		toolSummaryLine += "\n- Available native CLI tools in this turn: " + strings.Join(surface.NativeBuiltinTools, ", ")
+	}
+	if len(surface.ControlToolNames) > 0 {
+		toolSummaryLine += "\n- Available control tools in this turn: " + strings.Join(surface.ControlToolNames, ", ")
 	}
 	return fmt.Sprintf(
-		"Agent: %s\nRole: %s\nMode: %s\nEvent:\n- id: %s\n- type: %s\n- source: %s\n- task_id: %s\n- entity_id: %s\n- payload: %s\n\nExecution contract (required):\n- Act via tools when needed.\n- Emit events by calling emit_* tools only.\n- Do not return JSON envelopes for event emission.\n- Available emit tools for your role: %s%s%s",
+		"Agent: %s\nRole: %s\nMode: %s\nEvent:\n- id: %s\n- type: %s\n- source: %s\n- task_id: %s\n- entity_id: %s\n- payload: %s\n\nExecution contract (required):\n- Act via tools when needed.\n- Emit events by calling emit_* tools only.\n- Do not return JSON envelopes for event emission.\n- Available emit tools in this turn: %s%s%s",
 		cfg.ID,
 		cfg.Role,
 		cfg.Mode,

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -755,9 +755,6 @@ func formatEventForAgent(cfg models.AgentConfig, evt events.Event, tools []llm.T
 	if len(surface.NativeBuiltinTools) > 0 {
 		toolSummaryLine += "\n- Available native CLI tools in this turn: " + strings.Join(surface.NativeBuiltinTools, ", ")
 	}
-	if len(surface.ControlToolNames) > 0 {
-		toolSummaryLine += "\n- Available control tools in this turn: " + strings.Join(surface.ControlToolNames, ", ")
-	}
 	return fmt.Sprintf(
 		"Agent: %s\nRole: %s\nMode: %s\nEvent:\n- id: %s\n- type: %s\n- source: %s\n- task_id: %s\n- entity_id: %s\n- payload: %s\n\nExecution contract (required):\n- Act via tools when needed.\n- Emit events by calling emit_* tools only.\n- Do not return JSON envelopes for event emission.\n- Available emit tools in this turn: %s%s%s",
 		cfg.ID,

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -21,7 +21,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 )
 
-func TestFormatEventForAgent_UsesConfiguredToolSummary(t *testing.T) {
+func TestFormatEventForAgent_UsesPostCompositionToolSurface(t *testing.T) {
 	cfg := models.AgentConfig{
 		ID:    "agent-1",
 		Role:  "operator",
@@ -36,9 +36,49 @@ func TestFormatEventForAgent_UsesConfiguredToolSummary(t *testing.T) {
 		Payload:     []byte(`{"item_id":"x"}`),
 	}).WithEntityID("entity-1")
 
-	formatted := formatEventForAgent(cfg, evt, nil)
-	if !strings.Contains(formatted, "Available non-emit tools from your contract: get_entity, schedule") {
-		t.Fatalf("expected configured tool summary, got %q", formatted)
+	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
+		{Name: "get_entity"},
+		{Name: "emit_example"},
+		{Name: "read_file"},
+	})
+	if !strings.Contains(formatted, "Available non-emit tools in this turn: get_entity, read_file") {
+		t.Fatalf("expected post-composition non-emit summary, got %q", formatted)
+	}
+	if strings.Contains(formatted, "schedule") {
+		t.Fatalf("expected raw contract-only tool to stay out of event summary, got %q", formatted)
+	}
+	if !strings.Contains(formatted, "Available emit tools in this turn: emit_example") {
+		t.Fatalf("expected emit tool summary, got %q", formatted)
+	}
+}
+
+func TestFormatEventForAgent_UsesCanonicalNativeBuiltinNames(t *testing.T) {
+	cfg := models.AgentConfig{
+		ID:   "agent-1",
+		Role: "operator",
+		Mode: "task",
+		NativeTools: models.NativeToolConfig{
+			FileIO: true,
+			Bash:   true,
+		},
+	}
+	evt := (events.Event{
+		ID:          "evt-1",
+		Type:        "item.created",
+		SourceAgent: "runtime",
+		TaskID:      "task-1",
+		Payload:     []byte(`{"item_id":"x"}`),
+	}).WithEntityID("entity-1")
+
+	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
+		{Name: "query_entities"},
+		{Name: "emit_example"},
+	})
+	if !strings.Contains(formatted, "Available native CLI tools in this turn: Bash, Edit, Read, Write") {
+		t.Fatalf("expected canonical native builtin summary, got %q", formatted)
+	}
+	if strings.Contains(formatted, "file_io") {
+		t.Fatalf("expected raw native contract flag to stay out of event summary, got %q", formatted)
 	}
 }
 

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -82,6 +82,31 @@ func TestFormatEventForAgent_UsesCanonicalNativeBuiltinNames(t *testing.T) {
 	}
 }
 
+func TestFormatEventForAgent_DoesNotAdvertiseCLIOnlyControlTools(t *testing.T) {
+	cfg := models.AgentConfig{
+		ID:   "agent-1",
+		Role: "operator",
+		Mode: "task",
+	}
+	evt := (events.Event{
+		ID:          "evt-1",
+		Type:        "item.created",
+		SourceAgent: "runtime",
+		TaskID:      "task-1",
+		Payload:     []byte(`{"item_id":"x"}`),
+	}).WithEntityID("entity-1")
+
+	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
+		{Name: "query_entities"},
+	})
+	if strings.Contains(formatted, "ExitPlanMode") {
+		t.Fatalf("expected non-CLI event formatting to omit CLI-only control tools, got %q", formatted)
+	}
+	if strings.Contains(formatted, "Available control tools in this turn") {
+		t.Fatalf("expected non-CLI event formatting to omit control tool summary, got %q", formatted)
+	}
+}
+
 func TestFilterTools_RetainsUniversalEntityToolsWhenConstrained(t *testing.T) {
 	allowed, constrained := extractAllowedToolSet(models.AgentConfig{
 		Tools: []string{"emit_example"},

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -133,6 +133,7 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 			return nil, err
 		}
 	}
+	actor, _ := runtimeactors.ActorFromContext(ctx)
 
 	s := &Session{
 		ID: ensurePlatformSessionID(func() string {
@@ -164,7 +165,7 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 			}
 			return ""
 		}(),
-		SystemPrompt: augmentCLISystemPrompt(systemPrompt, tools),
+		SystemPrompt: augmentCLISystemPrompt(systemPrompt, actor, tools),
 		Tools:        tools,
 		Messages:     nil,
 	}
@@ -187,7 +188,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 	actor, _ := runtimeactors.ActorFromContext(ctx)
 	entityID := actor.EffectiveEntityID()
 	scopeKey := budgetExecutionScopeKey(actor)
-	disallowedBuiltinTools := claudeDisallowedBuiltinToolsArgForActor(actor)
+	disallowedBuiltinTools := claudeDisallowedBuiltinToolsArgForActor(actor, s.Tools)
 	allowedToolsArg := claudeAllowedToolsArgForActor(actor, s.Tools)
 
 	// Spec v2.0 budget cap enforcement: at 100% (budget.emergency) we hard-stop

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -229,18 +229,97 @@ var claudeProviderBuiltinToolNames = []string{
 	"Write",
 }
 
-func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig) string {
-	allowed := map[string]struct{}{}
+type AgentVisibleToolSurface struct {
+	RuntimeToolNames    []string
+	EmitToolNames       []string
+	NonEmitToolNames    []string
+	NativeBuiltinTools  []string
+	ControlToolNames    []string
+	AllowedCLIToolNames []string
+}
+
+func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) AgentVisibleToolSurface {
+	runtimeNames := toolNames(tools)
+	slices.Sort(runtimeNames)
+
+	runtimeSet := make(map[string]struct{}, len(runtimeNames))
+	for _, name := range runtimeNames {
+		runtimeSet[name] = struct{}{}
+	}
+
+	emitNames := make([]string, 0, len(runtimeNames))
+	nonEmitNames := make([]string, 0, len(runtimeNames))
+	for _, name := range runtimeNames {
+		if strings.HasPrefix(strings.TrimSpace(name), "emit_") {
+			emitNames = append(emitNames, name)
+			continue
+		}
+		nonEmitNames = append(nonEmitNames, name)
+	}
+
+	nativeBuiltins := make([]string, 0, 5)
 	if actor.NativeTools.Bash {
-		allowed["Bash"] = struct{}{}
+		if _, ok := runtimeSet["bash"]; !ok {
+			nativeBuiltins = append(nativeBuiltins, "Bash")
+		}
 	}
 	if actor.NativeTools.WebSearch {
-		allowed["WebSearch"] = struct{}{}
+		if _, ok := runtimeSet["web_search"]; !ok {
+			nativeBuiltins = append(nativeBuiltins, "WebSearch")
+		}
 	}
 	if actor.NativeTools.FileIO {
-		allowed["Read"] = struct{}{}
-		allowed["Write"] = struct{}{}
-		allowed["Edit"] = struct{}{}
+		_, hasReadFallback := runtimeSet["read_file"]
+		_, hasWriteFallback := runtimeSet["write_file"]
+		if !hasReadFallback && !hasWriteFallback {
+			nativeBuiltins = append(nativeBuiltins, "Read", "Write", "Edit")
+		}
+	}
+	slices.Sort(nativeBuiltins)
+
+	controlTools := []string{"ExitPlanMode"}
+	allowedCLI := make([]string, 0, len(runtimeNames)+len(nativeBuiltins)+len(controlTools))
+	seen := make(map[string]struct{}, cap(allowedCLI))
+	addAllowed := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		allowedCLI = append(allowedCLI, name)
+	}
+	for _, name := range runtimeNames {
+		addAllowed(name)
+	}
+	for _, name := range nativeBuiltins {
+		addAllowed(name)
+	}
+	for _, name := range controlTools {
+		addAllowed(name)
+	}
+	slices.Sort(allowedCLI)
+
+	return AgentVisibleToolSurface{
+		RuntimeToolNames:    runtimeNames,
+		EmitToolNames:       emitNames,
+		NonEmitToolNames:    nonEmitNames,
+		NativeBuiltinTools:  nativeBuiltins,
+		ControlToolNames:    controlTools,
+		AllowedCLIToolNames: allowedCLI,
+	}
+}
+
+func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig, tools []ToolDefinition) string {
+	surface := AgentVisibleToolSurfaceForActor(actor, tools)
+	allowed := make(map[string]struct{}, len(surface.NativeBuiltinTools)+len(surface.ControlToolNames))
+	for _, name := range surface.NativeBuiltinTools {
+		allowed[name] = struct{}{}
+	}
+	for _, name := range surface.ControlToolNames {
+		allowed[name] = struct{}{}
 	}
 	names := make([]string, 0, len(claudeProviderBuiltinToolNames))
 	for _, name := range claudeProviderBuiltinToolNames {
@@ -254,44 +333,16 @@ func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig) string {
 }
 
 func claudeAllowedToolsArgForActor(actor models.AgentConfig, tools []ToolDefinition) string {
-	allowed := make([]string, 0, len(tools)+4)
-	seen := make(map[string]struct{}, len(tools)+4)
-	add := func(name string) {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			return
-		}
-		if _, ok := seen[name]; ok {
-			return
-		}
-		seen[name] = struct{}{}
-		allowed = append(allowed, name)
-	}
-	for _, tool := range tools {
-		add(tool.Name)
-	}
-	add("ExitPlanMode")
-	if actor.NativeTools.Bash {
-		add("Bash")
-	}
-	if actor.NativeTools.WebSearch {
-		add("WebSearch")
-	}
-	if actor.NativeTools.FileIO {
-		add("Read")
-		add("Write")
-		add("Edit")
-	}
-	if len(allowed) == 0 {
+	surface := AgentVisibleToolSurfaceForActor(actor, tools)
+	if len(surface.AllowedCLIToolNames) == 0 {
 		return ""
 	}
-	slices.Sort(allowed)
-	return strings.Join(allowed, ",")
+	return strings.Join(surface.AllowedCLIToolNames, ",")
 }
 
 const cliToolInvocationMarker = "## Swarm Tool Invocation"
 
-func augmentCLISystemPrompt(systemPrompt string, tools []ToolDefinition) string {
+func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools []ToolDefinition) string {
 	systemPrompt = strings.TrimSpace(systemPrompt)
 	if systemPrompt == "" {
 		return systemPrompt
@@ -299,31 +350,35 @@ func augmentCLISystemPrompt(systemPrompt string, tools []ToolDefinition) string 
 	if strings.Contains(systemPrompt, cliToolInvocationMarker) {
 		return systemPrompt
 	}
-	names := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		name := strings.TrimSpace(tool.Name)
-		if name == "" {
-			continue
-		}
-		names = append(names, name)
-	}
-	if len(names) == 0 {
+	surface := AgentVisibleToolSurfaceForActor(actor, tools)
+	if len(surface.RuntimeToolNames) == 0 && len(surface.NativeBuiltinTools) == 0 && len(surface.ControlToolNames) == 0 {
 		return systemPrompt
 	}
-	slices.Sort(names)
 	var b strings.Builder
 	b.WriteString(systemPrompt)
 	b.WriteString("\n\n")
 	b.WriteString(cliToolInvocationMarker)
 	b.WriteString("\n")
-	b.WriteString("Call Swarm tools by these exact names when you need them:\n")
-	for _, name := range names {
-		b.WriteString("- ")
-		b.WriteString(name)
-		b.WriteString("\n")
+	if len(surface.RuntimeToolNames) > 0 {
+		b.WriteString("Call Swarm runtime tools by these exact names when you need them:\n")
+		for _, name := range surface.RuntimeToolNames {
+			b.WriteString("- ")
+			b.WriteString(name)
+			b.WriteString("\n")
+		}
+		b.WriteString("If Claude CLI also shows MCP-prefixed variants like `mcp__runtime-tools__...`, they map to the same Swarm runtime tools.\n")
 	}
-	b.WriteString("If Claude CLI also shows MCP-prefixed variants like `mcp__runtime-tools__...`, they map to the same Swarm runtime tools.\n")
-	if hasToolPrefix(names, "emit_") {
+	if len(surface.NativeBuiltinTools) > 0 {
+		b.WriteString("Claude CLI native tools available in this turn: ")
+		b.WriteString(strings.Join(surface.NativeBuiltinTools, ", "))
+		b.WriteString(".\n")
+	}
+	if len(surface.ControlToolNames) > 0 {
+		b.WriteString("Claude CLI control tools available in this turn: ")
+		b.WriteString(strings.Join(surface.ControlToolNames, ", "))
+		b.WriteString(".\n")
+	}
+	if hasToolPrefix(surface.RuntimeToolNames, "emit_") {
 		b.WriteString("When you need to publish an event, call the matching `emit_*` tool directly. Emit tools may not appear as MCP-prefixed variants in Claude CLI; Swarm will execute the exact `emit_*` call locally. Do not write JSON files under `/workspace/events` as a substitute for emission.\n")
 	}
 	return strings.TrimSpace(b.String())

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -230,12 +230,10 @@ var claudeProviderBuiltinToolNames = []string{
 }
 
 type AgentVisibleToolSurface struct {
-	RuntimeToolNames    []string
-	EmitToolNames       []string
-	NonEmitToolNames    []string
-	NativeBuiltinTools  []string
-	ControlToolNames    []string
-	AllowedCLIToolNames []string
+	RuntimeToolNames   []string
+	EmitToolNames      []string
+	NonEmitToolNames   []string
+	NativeBuiltinTools []string
 }
 
 func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) AgentVisibleToolSurface {
@@ -277,9 +275,22 @@ func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 	}
 	slices.Sort(nativeBuiltins)
 
-	controlTools := []string{"ExitPlanMode"}
-	allowedCLI := make([]string, 0, len(runtimeNames)+len(nativeBuiltins)+len(controlTools))
-	seen := make(map[string]struct{}, cap(allowedCLI))
+	return AgentVisibleToolSurface{
+		RuntimeToolNames:   runtimeNames,
+		EmitToolNames:      emitNames,
+		NonEmitToolNames:   nonEmitNames,
+		NativeBuiltinTools: nativeBuiltins,
+	}
+}
+
+func claudeControlToolNames() []string {
+	return []string{"ExitPlanMode"}
+}
+
+func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	surface := AgentVisibleToolSurfaceForActor(actor, tools)
+	allowed := make([]string, 0, len(surface.RuntimeToolNames)+len(surface.NativeBuiltinTools)+len(claudeControlToolNames()))
+	seen := make(map[string]struct{}, cap(allowed))
 	addAllowed := func(name string) {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -289,36 +300,25 @@ func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 			return
 		}
 		seen[name] = struct{}{}
-		allowedCLI = append(allowedCLI, name)
+		allowed = append(allowed, name)
 	}
-	for _, name := range runtimeNames {
+	for _, name := range surface.RuntimeToolNames {
 		addAllowed(name)
 	}
-	for _, name := range nativeBuiltins {
+	for _, name := range surface.NativeBuiltinTools {
 		addAllowed(name)
 	}
-	for _, name := range controlTools {
+	for _, name := range claudeControlToolNames() {
 		addAllowed(name)
 	}
-	slices.Sort(allowedCLI)
-
-	return AgentVisibleToolSurface{
-		RuntimeToolNames:    runtimeNames,
-		EmitToolNames:       emitNames,
-		NonEmitToolNames:    nonEmitNames,
-		NativeBuiltinTools:  nativeBuiltins,
-		ControlToolNames:    controlTools,
-		AllowedCLIToolNames: allowedCLI,
-	}
+	slices.Sort(allowed)
+	return allowed
 }
 
 func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig, tools []ToolDefinition) string {
 	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	allowed := make(map[string]struct{}, len(surface.NativeBuiltinTools)+len(surface.ControlToolNames))
+	allowed := make(map[string]struct{}, len(surface.NativeBuiltinTools))
 	for _, name := range surface.NativeBuiltinTools {
-		allowed[name] = struct{}{}
-	}
-	for _, name := range surface.ControlToolNames {
 		allowed[name] = struct{}{}
 	}
 	names := make([]string, 0, len(claudeProviderBuiltinToolNames))
@@ -333,11 +333,11 @@ func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig, tools []T
 }
 
 func claudeAllowedToolsArgForActor(actor models.AgentConfig, tools []ToolDefinition) string {
-	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	if len(surface.AllowedCLIToolNames) == 0 {
+	allowed := claudeAllowedToolNamesForActor(actor, tools)
+	if len(allowed) == 0 {
 		return ""
 	}
-	return strings.Join(surface.AllowedCLIToolNames, ",")
+	return strings.Join(allowed, ",")
 }
 
 const cliToolInvocationMarker = "## Swarm Tool Invocation"
@@ -351,7 +351,8 @@ func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools
 		return systemPrompt
 	}
 	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	if len(surface.RuntimeToolNames) == 0 && len(surface.NativeBuiltinTools) == 0 && len(surface.ControlToolNames) == 0 {
+	controlTools := claudeControlToolNames()
+	if len(surface.RuntimeToolNames) == 0 && len(surface.NativeBuiltinTools) == 0 && len(controlTools) == 0 {
 		return systemPrompt
 	}
 	var b strings.Builder
@@ -373,9 +374,9 @@ func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools
 		b.WriteString(strings.Join(surface.NativeBuiltinTools, ", "))
 		b.WriteString(".\n")
 	}
-	if len(surface.ControlToolNames) > 0 {
+	if len(controlTools) > 0 {
 		b.WriteString("Claude CLI control tools available in this turn: ")
-		b.WriteString(strings.Join(surface.ControlToolNames, ", "))
+		b.WriteString(strings.Join(controlTools, ", "))
 		b.WriteString(".\n")
 	}
 	if hasToolPrefix(surface.RuntimeToolNames, "emit_") {

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -51,7 +51,7 @@ func TestShouldUseMCPBridge_CanDisable(t *testing.T) {
 }
 
 func TestClaudeDisallowedBuiltinToolsArgForActor_DefaultsToAllKnownBuiltins(t *testing.T) {
-	got := claudeDisallowedBuiltinToolsArgForActor(models.AgentConfig{})
+	got := claudeDisallowedBuiltinToolsArgForActor(models.AgentConfig{}, nil)
 	if got == "" {
 		t.Fatal("expected builtin tools to be blocked by default")
 	}
@@ -70,7 +70,7 @@ func TestClaudeDisallowedBuiltinToolsArgForActor_MapsNativeCapabilities(t *testi
 			WebSearch: true,
 			FileIO:    true,
 		},
-	})
+	}, nil)
 	gotNames := strings.Split(got, ",")
 	for _, name := range []string{"Bash", "Read", "Write", "Edit", "WebSearch"} {
 		if slices.Contains(gotNames, name) {
@@ -84,7 +84,7 @@ func TestClaudeDisallowedBuiltinToolsArgForActor_MapsNativeCapabilities(t *testi
 	}
 }
 
-func TestClaudeAllowedToolsArgForActor_IncludesContractAndNativeTools(t *testing.T) {
+func TestClaudeAllowedToolsArgForActor_IncludesPostCompositionAndNativeTools(t *testing.T) {
 	got := claudeAllowedToolsArgForActor(models.AgentConfig{
 		NativeTools: models.NativeToolConfig{FileIO: true},
 	}, []ToolDefinition{
@@ -110,6 +110,53 @@ func TestClaudeAllowedToolsArgForActor_IncludesContractAndNativeTools(t *testing
 		if slices.Contains(gotNames, name) {
 			t.Fatalf("did not expect %q in allowed tools %q", name, got)
 		}
+	}
+}
+
+func TestClaudeToolSurface_PrefersFallbackRuntimeToolsOverNativeBuiltins(t *testing.T) {
+	actor := models.AgentConfig{
+		NativeTools: models.NativeToolConfig{
+			FileIO: true,
+			Bash:   true,
+		},
+	}
+	tools := []ToolDefinition{
+		{Name: "read_file"},
+		{Name: "write_file"},
+		{Name: "bash"},
+		{Name: "emit_category_assessed"},
+	}
+
+	allowed := claudeAllowedToolsArgForActor(actor, tools)
+	allowedNames := strings.Split(allowed, ",")
+	for _, name := range []string{"read_file", "write_file", "bash", "emit_category_assessed", "ExitPlanMode"} {
+		if !slices.Contains(allowedNames, name) {
+			t.Fatalf("expected %q in allowed tools %q", name, allowed)
+		}
+	}
+	for _, name := range []string{"Read", "Write", "Edit", "Bash"} {
+		if slices.Contains(allowedNames, name) {
+			t.Fatalf("did not expect native builtin %q in allowed tools %q", name, allowed)
+		}
+	}
+
+	disallowed := claudeDisallowedBuiltinToolsArgForActor(actor, tools)
+	disallowedNames := strings.Split(disallowed, ",")
+	for _, name := range []string{"Read", "Write", "Edit", "Bash"} {
+		if !slices.Contains(disallowedNames, name) {
+			t.Fatalf("expected fallback-backed builtin %q in disallowed tools %q", name, disallowed)
+		}
+	}
+
+	prompt := augmentCLISystemPrompt("You are here.", actor, tools)
+	if !strings.Contains(prompt, "Call Swarm runtime tools by these exact names") {
+		t.Fatalf("expected runtime tool prompt section, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "read_file") || !strings.Contains(prompt, "write_file") || !strings.Contains(prompt, "bash") {
+		t.Fatalf("expected fallback runtime tools in prompt, got %q", prompt)
+	}
+	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
+		t.Fatalf("did not expect native builtin prompt section when fallback runtime tools own the surface, got %q", prompt)
 	}
 }
 


### PR DESCRIPTION
Closes #137

## Human Summary

This changes the touched agent-visible tool-availability seam so the event message, CLI system prompt, and Claude allowed-tools transport config all derive from the same canonical post-composition tool surface.

## What Changed

- introduced one canonical `AgentVisibleToolSurfaceForActor(...)` helper in `internal/runtime/llm/cli_runtime_helpers.go`
- switched CLI system-prompt augmentation to derive visible runtime, native, and control tools from the composed runtime tool set instead of raw contract flags
- switched Claude allowed/disallowed tool args to the same canonical surface, so fallback runtime tools like `read_file`/`write_file`/`bash` suppress conflicting native builtin exposure
- changed `formatEventForAgent(...)` in `internal/runtime/agents/agent_llm.go` to describe only the post-composition tool surface visible in the current turn
- added focused regressions proving prompt and transport stay aligned and that raw contract-only tools no longer leak into the agent-visible summary

## Why This Is Needed

Before this change, the same turn could tell the agent different stories about tool availability:

- event-message formatting still used raw contract config
- CLI prompt/transport used composed runtime tools
- native builtin allow/disallow handling could still contradict fallback runtime tools

That made prompt text a second semantic owner even though post-composition filtered tools are the real runtime truth.

## Scope Boundaries

- scoped to agent-visible tool availability in the touched prompt/transport seam
- does not redesign MCP broadly
- does not change unrelated gateway/tool-auth semantics
- does not change platform spec semantics

## Tests Run

- `go test ./internal/runtime/agents ./internal/runtime/llm -count=1`
- `go test ./internal/runtime/agents -run 'TestFormatEventForAgent_|TestNewLLMAgent_' -count=1`
- `go test ./internal/runtime/llm -run 'TestClaude(DisallowedBuiltinToolsArgForActor_|AllowedToolsArgForActor_|ToolSurface_)|TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools' -count=1`
- `go test ./... -count=1`

## Residual Risk

This makes the touched prompt and transport surfaces agree on the same post-composition tool set, but it does not redesign every possible downstream rendering of tool availability outside this seam. The canonical owner is now explicit here; other surfaces should consume it rather than re-assembling their own visibility view.

## Follow-Up

None identified in this seam after this change.
