### PR TITLE
[agent-b][issue #149] Match handler branch selection to spec write order

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -693,7 +693,6 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 }
 
 func (e *Executor) stepOnComplete(frame *executionFrame) error {
-	e.ensureTopLevelDataWritesApplied(frame)
 	rules := frame.req.Handler.OnComplete
 	if len(rules) == 0 && frame.req.Handler.Accumulate != nil {
 		rules = frame.req.Handler.Accumulate.OnComplete
@@ -721,7 +720,6 @@ func (e *Executor) stepRules(frame *executionFrame) error {
 	if frame.rule != nil {
 		return nil
 	}
-	e.ensureTopLevelDataWritesApplied(frame)
 	rule, err := e.selectRule(frame, frame.req.Handler.Rules)
 	if err != nil {
 		return err
@@ -1279,18 +1277,6 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 	if id := strings.TrimSpace(rule.ID); id != "" {
 		frame.result.RuleID = id
 	}
-}
-
-func (e *Executor) ensureTopLevelDataWritesApplied(frame *executionFrame) {
-	if frame.topLevelDataWritesApplied {
-		return
-	}
-	spec := frame.topLevelDataAccumulation
-	if !spec.HasWrites() && strings.TrimSpace(spec.SourceEvent) == "" {
-		return
-	}
-	e.applyDataAccumulation(frame, spec)
-	frame.topLevelDataWritesApplied = true
 }
 
 func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -53,6 +53,9 @@ type stubEvaluator struct {
 	bools map[string]bool
 	errs  map[string]error
 }
+type contextualBoolEvaluator struct {
+	bools map[string]func(BaseContext) (bool, error)
+}
 type stubGuardRegistry struct {
 	entries map[identity.GuardKey]runtimeregistry.GuardInstruction
 }
@@ -96,6 +99,13 @@ func (s stubEvaluator) EvalBool(expression string, _ BaseContext) (bool, error) 
 	return s.bools[expression], nil
 }
 func (s stubEvaluator) EvalValue(string, BaseContext) (any, error) { return nil, ErrNotImplemented }
+func (s contextualBoolEvaluator) EvalBool(expression string, base BaseContext) (bool, error) {
+	if fn, ok := s.bools[expression]; ok {
+		return fn(base)
+	}
+	return false, nil
+}
+func (s contextualBoolEvaluator) EvalValue(string, BaseContext) (any, error) { return nil, ErrNotImplemented }
 func (r stubGuardRegistry) HasGuard(id identity.GuardKey) bool     { _, ok := r.entries[id]; return ok }
 func (r stubGuardRegistry) IsExecutable(id identity.GuardKey) bool { _, ok := r.entries[id]; return ok }
 func (r stubGuardRegistry) Guard(id identity.GuardKey) (runtimeregistry.GuardInstruction, bool) {
@@ -808,6 +818,111 @@ func TestExecutor_RuleDataAccumulationRunsBeforeTopLevelWrites(t *testing.T) {
 	}
 	if got := result.StateMutation.Metadata["rule_only"]; got != "applied" {
 		t.Fatalf("rule_only = %#v, want applied", got)
+	}
+}
+
+func TestExecutor_RulesDoNotSeeCurrentHandlerTopLevelWritesBeforeSelection(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, contextualBoolEvaluator{bools: map[string]func(BaseContext) (bool, error){
+		`entity.branch_target == "handler"`: func(base BaseContext) (bool, error) {
+			return base.Entity.Raw()["branch_target"] == "handler", nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					TargetField: "branch_target",
+					Value:       runtimecontracts.LiteralExpression("handler"),
+				}},
+			},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "too-early",
+				Condition: `entity.branch_target == "handler"`,
+				DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+					Writes: []runtimecontracts.WorkflowDataWrite{{
+						TargetField: "rule_selected",
+						Value:       runtimecontracts.LiteralExpression(true),
+					}},
+				},
+			}},
+		},
+		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := strings.TrimSpace(result.RuleID); got != "" {
+		t.Fatalf("rule_id = %q, want empty when branch selection cannot see top-level writes", got)
+	}
+	if _, exists := result.StateMutation.Metadata["rule_selected"]; exists {
+		t.Fatalf("rule_selected unexpectedly present after rules evaluated before top-level writes: %#v", result.StateMutation.Metadata["rule_selected"])
+	}
+	if got := result.StateMutation.Metadata["branch_target"]; got != "handler" {
+		t.Fatalf("branch_target = %#v, want handler after data_accumulation step", got)
+	}
+}
+
+func TestExecutor_OnCompleteDoesNotSeeCurrentHandlerTopLevelWritesBeforeSelection(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, contextualBoolEvaluator{bools: map[string]func(BaseContext) (bool, error){
+		`entity.branch_target == "handler"`: func(base BaseContext) (bool, error) {
+			return base.Entity.Raw()["branch_target"] == "handler", nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					TargetField: "branch_target",
+					Value:       runtimecontracts.LiteralExpression("handler"),
+				}},
+			},
+			OnComplete: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "too-early",
+				Condition: `entity.branch_target == "handler"`,
+				Emits:     runtimecontracts.EventEmission{Single: "branch.selected"},
+			}},
+		},
+		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := strings.TrimSpace(result.RuleID); got != "" {
+		t.Fatalf("rule_id = %q, want empty when on_complete selection cannot see top-level writes", got)
+	}
+	if got := len(result.EmitIntents); got != 0 {
+		t.Fatalf("emit intents = %d, want 0 when on_complete branch is not selected early", got)
+	}
+	if got := result.StateMutation.Metadata["branch_target"]; got != "handler" {
+		t.Fatalf("branch_target = %#v, want handler after data_accumulation step", got)
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -105,7 +105,9 @@ func (s contextualBoolEvaluator) EvalBool(expression string, base BaseContext) (
 	}
 	return false, nil
 }
-func (s contextualBoolEvaluator) EvalValue(string, BaseContext) (any, error) { return nil, ErrNotImplemented }
+func (s contextualBoolEvaluator) EvalValue(string, BaseContext) (any, error) {
+	return nil, ErrNotImplemented
+}
 func (r stubGuardRegistry) HasGuard(id identity.GuardKey) bool     { _, ok := r.entries[id]; return ok }
 func (r stubGuardRegistry) IsExecutable(id identity.GuardKey) bool { _, ok := r.entries[id]; return ok }
 func (r stubGuardRegistry) Guard(id identity.GuardKey) (runtimeregistry.GuardInstruction, bool) {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -883,6 +883,43 @@ func TestExecuteNodeContractHandlerRuleMatchAugmentsDefaultEmit(t *testing.T) {
 	}
 }
 
+func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWritesEarly(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+	}
+
+	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "branch_target", Value: runtimecontracts.LiteralExpression("handler")},
+			},
+		},
+		OnComplete: []runtimecontracts.HandlerRuleEntry{
+			{ID: "too-early", Condition: `"branch_target" in entity && entity.branch_target == "handler"`, Emits: runtimecontracts.EventEmission{Single: "branch.selected"}},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type: events.EventType("custom.trigger"),
+		}.WithEntityID("ent-1"),
+		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := strings.TrimSpace(result.Outcome.RuleID); got != "" {
+		t.Fatalf("rule_id = %q, want empty when on_complete cannot see current-handler top-level writes", got)
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("published count = %d, want 0 when branch selection cannot see early top-level writes", got)
+	}
+}
+
 func TestExecuteNodeContractHandlerExecutesHandlerActionInsideEngine(t *testing.T) {
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{

--- a/tests/tier10-policy-patterns/test-policy-hard-gate-override/nodes.yaml
+++ b/tests/tier10-policy-patterns/test-policy-hard-gate-override/nodes.yaml
@@ -10,10 +10,10 @@ evaluator:
           - main_score
           - secondary_score
       on_complete:
-        - condition: "entity.main_score >= policy.high_mark AND entity.secondary_score >= policy.hard_floor"
+        - condition: "payload.main_score >= policy.high_mark AND payload.secondary_score >= policy.hard_floor"
           advances_to: promoted
           emits: result.promoted
-        - condition: "entity.main_score >= policy.low_mark"
+        - condition: "payload.main_score >= policy.low_mark"
           advances_to: demoted
           emits: result.demoted
         - condition: "else"

--- a/tests/tier10-policy-patterns/test-policy-threshold-three-way/nodes.yaml
+++ b/tests/tier10-policy-patterns/test-policy-threshold-three-way/nodes.yaml
@@ -9,10 +9,10 @@ classifier:
         writes:
           - score
       on_complete:
-        - condition: "entity.score >= policy.high_mark"
+        - condition: "payload.score >= policy.high_mark"
           advances_to: tier_a
           emits: eval.tier_a
-        - condition: "entity.score >= policy.low_mark"
+        - condition: "payload.score >= policy.low_mark"
           advances_to: tier_b
           emits: eval.tier_b
         - condition: "else"

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/nodes.yaml
@@ -10,10 +10,10 @@ scorer:
           - source_field: value
             target_field: score
       on_complete:
-        - condition: "entity.score >= 75"
+        - condition: "payload.value >= 75"
           advances_to: high
           emits: result.high
-        - condition: "entity.score >= 50"
+        - condition: "payload.value >= 50"
           advances_to: mid
           emits: result.mid
         - condition: "else"


### PR DESCRIPTION
Closes #149

## Human Summary
Top-level handler `data_accumulation` is no longer visible during same-handler `on_complete` or `rules` branch selection. The ordered runtime steps are now the single owner of that visibility boundary, so branch selection follows the spec order: `compute -> on_complete/rules -> data_accumulation`.

## What Changed
- removed the executor's early top-level `data_accumulation` application path from `stepOnComplete(...)` and `stepRules(...)`
- kept top-level handler writes visible only at the ordered `data_accumulation` step
- added focused engine regressions proving `rules` and `on_complete` cannot observe current-handler top-level writes before the data-write step
- added a pipeline regression proving the coordinator path does not select an `on_complete` branch from those too-early writes
- migrated the affected catalog fixtures to the spec shape by branching on current-event `payload.*` values while preserving later top-level `data_accumulation` persistence

## Why This Is Needed
The previous executor behavior widened visibility beyond the spec by applying top-level handler writes before branch selection. That let `on_complete` and `rules` conditions observe state that should not exist until the later `data_accumulation` step, which made branch outcomes drift from the platform-defined execution order.

## Scope Boundaries
- scoped to ordered handler execution for `on_complete` / `rules` visibility timing
- scoped fixture updates only to catalog cases that were depending on the widened behavior
- no broader workflow execution redesign
- no compatibility path for same-handler branch conditions that depended on early top-level writes

## Tests Run
- `go test ./internal/runtime/engine ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier(9|10).*RealRuntime' -count=1`
- `go test ./... -count=1`

## Residual Risk
This change is intentionally strict. Any remaining flow or fixture that branches on current-handler top-level `data_accumulation` rather than pre-existing entity state, `compute`, or current-event `payload` values will now change behavior to match the spec and must be migrated explicitly.

## Follow-Up
No separate follow-up is required from this seam. If more catalog coverage turns up the same anti-pattern, those fixtures should be migrated to spec-aligned branch inputs rather than reintroducing early visibility.
