### PR TITLE
[agent-d][issue #151] Remove preview-backed non-success proof from runtime/store conformance cases

### DIFF
--- a/internal/runtime/cataloge2e/assertions.go
+++ b/internal/runtime/cataloge2e/assertions.go
@@ -28,6 +28,7 @@ func assertCatalogRuntimeOutcome(t testing.TB, h *runtimeHarness, expected catal
 			break
 		}
 	}
+	assertCatalogRecognizedHandlerOutcome(t, expected.Expected.HandlerOutcome)
 	if len(h.publishedIDs) > 0 && catalogAssertsAuthoritativeHandlerOutcome(expected.Expected.HandlerOutcome) {
 		assertHandlerOutcome(t, h, expected.Expected.HandlerOutcome, entityID, expected.Expected.ChainDepthExceeded)
 	}
@@ -123,6 +124,7 @@ func assertCatalogRuntimeEntities(t testing.TB, h *runtimeHarness, expected map[
 		if entityID == "" {
 			continue
 		}
+		assertCatalogRecognizedHandlerOutcome(t, want.HandlerOutcome)
 		if catalogAssertsAuthoritativeHandlerOutcome(want.HandlerOutcome) {
 			assertHandlerOutcomeForEntity(t, h, want.HandlerOutcome, entityID, false)
 		}
@@ -818,6 +820,22 @@ func assertHandlerOutcomeForEntity(t testing.TB, h *runtimeHarness, want, entity
 
 func catalogAssertsAuthoritativeHandlerOutcome(raw string) bool {
 	return strings.TrimSpace(strings.ToLower(raw)) == "success"
+}
+
+func assertCatalogRecognizedHandlerOutcome(t testing.TB, raw string) {
+	t.Helper()
+	if !catalogRecognizesHandlerOutcome(raw) {
+		t.Fatalf("cataloge2e does not recognize handler_outcome %q; supported values are success or explicit local-only non-success outcomes", strings.TrimSpace(raw))
+	}
+}
+
+func catalogRecognizesHandlerOutcome(raw string) bool {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", "success", "reject", "discard", "escalate", "kill", "dead_letter", "error", "terminal_reject", "blocked":
+		return true
+	default:
+		return false
+	}
 }
 
 func assertEntityDeadLetterOutcome(t testing.TB, db *sql.DB, since time.Time, entityID string) bool {

--- a/internal/runtime/cataloge2e/assertions.go
+++ b/internal/runtime/cataloge2e/assertions.go
@@ -28,7 +28,7 @@ func assertCatalogRuntimeOutcome(t testing.TB, h *runtimeHarness, expected catal
 			break
 		}
 	}
-	if len(h.publishedIDs) > 0 && strings.TrimSpace(expected.Expected.HandlerOutcome) != "" {
+	if len(h.publishedIDs) > 0 && catalogAssertsAuthoritativeHandlerOutcome(expected.Expected.HandlerOutcome) {
 		assertHandlerOutcome(t, h, expected.Expected.HandlerOutcome, entityID, expected.Expected.ChainDepthExceeded)
 	}
 	if entityID != "" && strings.TrimSpace(expected.Expected.EntityState) != "" {
@@ -123,7 +123,7 @@ func assertCatalogRuntimeEntities(t testing.TB, h *runtimeHarness, expected map[
 		if entityID == "" {
 			continue
 		}
-		if strings.TrimSpace(want.HandlerOutcome) != "" {
+		if catalogAssertsAuthoritativeHandlerOutcome(want.HandlerOutcome) {
 			assertHandlerOutcomeForEntity(t, h, want.HandlerOutcome, entityID, false)
 		}
 		if strings.TrimSpace(want.EntityState) != "" {
@@ -777,28 +777,16 @@ func assertHandlerOutcomeForEntity(t testing.TB, h *runtimeHarness, want, entity
 	if h == nil || h.db == nil {
 		t.Fatal("database is required for handler_outcome assertions")
 	}
+	_ = chainDepthExceeded
 	want = strings.TrimSpace(strings.ToLower(want))
 	entityID = strings.TrimSpace(entityID)
 	if want == "" {
 		return
 	}
-	if chainDepthExceeded && entityID != "" && (want == "error" || want == "kill" || want == "dead_letter") {
-		if assertEntityDeadLetterOutcome(t, h.db, h.startedAt, entityID) {
-			return
-		}
+	if !catalogAssertsAuthoritativeHandlerOutcome(want) {
+		t.Fatalf("cataloge2e does not authoritatively assert handler_outcome %q; assert runtime/store evidence instead", want)
 	}
 	eventIDs := h.publishedEventIDs(entityID)
-	if want != "success" && len(h.previews) > 0 {
-		for _, eventID := range eventIDs {
-			if preview, ok := h.previews[eventID]; ok {
-				got := strings.TrimSpace(strings.ToLower(string(preview.Status)))
-				if got != want {
-					t.Fatalf("handler_outcome = %q, want %q", got, want)
-				}
-				return
-			}
-		}
-	}
 	for _, eventID := range eventIDs {
 		var outcome string
 		err := h.db.QueryRowContext(context.Background(), `
@@ -820,33 +808,16 @@ func assertHandlerOutcomeForEntity(t testing.TB, h *runtimeHarness, want, entity
 			t.Fatalf("query handler_outcome for event %s: %v", eventID, err)
 		}
 		got := strings.TrimSpace(strings.ToLower(outcome))
-		switch want {
-		case "success":
-			if got != "success" {
-				t.Fatalf("handler_outcome = %q, want %q", got, want)
-			}
-		case "reject":
-			if got != "reject" {
-				t.Fatalf("handler_outcome = %q, want %q", got, want)
-			}
-		case "escalate":
-			if got != "escalate" {
-				t.Fatalf("handler_outcome = %q, want %q", got, want)
-			}
-		case "discard":
-			if got != "discard" {
-				t.Fatalf("handler_outcome = %q, want %q", got, want)
-			}
-		case "error", "kill", "dead_letter":
-			if got != "dead_letter" {
-				t.Fatalf("handler_outcome = %q, want %q", got, want)
-			}
-		default:
-			t.Fatalf("handler_outcome assertion for %q is not wired in cataloge2e yet", want)
+		if got != "success" {
+			t.Fatalf("handler_outcome = %q, want %q", got, want)
 		}
 		return
 	}
 	t.Fatalf("handler_outcome %q could not be asserted: no platform pipeline receipt found", want)
+}
+
+func catalogAssertsAuthoritativeHandlerOutcome(raw string) bool {
+	return strings.TrimSpace(strings.ToLower(raw)) == "success"
 }
 
 func assertEntityDeadLetterOutcome(t testing.TB, db *sql.DB, since time.Time, entityID string) bool {

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -3,7 +3,12 @@ package cataloge2e
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
 
@@ -49,4 +54,128 @@ func TestCatalogSubjectEntityIDs_UsesResolvedSubjectID(t *testing.T) {
 			t.Fatalf("child subject entity ids missing %s (%v)", candidate, gotFromChild)
 		}
 	}
+}
+
+func TestCatalogAssertsAuthoritativeHandlerOutcome_OnlySuccess(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "empty", raw: "", want: false},
+		{name: "success", raw: "success", want: true},
+		{name: "success trimmed case-insensitive", raw: " Success ", want: true},
+		{name: "reject", raw: "reject", want: false},
+		{name: "discard", raw: "discard", want: false},
+		{name: "escalate", raw: "escalate", want: false},
+		{name: "kill", raw: "kill", want: false},
+		{name: "terminal reject", raw: "terminal_reject", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := catalogAssertsAuthoritativeHandlerOutcome(tc.raw); got != tc.want {
+				t.Fatalf("catalogAssertsAuthoritativeHandlerOutcome(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof(t *testing.T) {
+	h := newCatalogAssertionHarness(t)
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+
+	insertCatalogAssertionEntityState(t, h, entityID, "pending")
+	seedCatalogAssertionPublishedEvent(h, eventID, entityID, runtimepipeline.HandlerOutcomeCompleted)
+
+	expected := catalogExpectedDocument{}
+	expected.Trigger.Event = "task.started"
+	expected.Trigger.Payload = map[string]any{"entity_id": entityID}
+	expected.Expected.HandlerOutcome = "reject"
+	expected.Expected.EntityState = "pending"
+	expected.Expected.EmittedEvents = []string{}
+
+	assertCatalogRuntimeOutcome(t, h, expected)
+}
+
+func TestAssertCatalogRuntimeOutcome_IgnoresEntityNonSuccessPreviewProof(t *testing.T) {
+	h := newCatalogAssertionHarness(t)
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+
+	insertCatalogAssertionEntityState(t, h, entityID, "active")
+	insertCatalogAssertionDeadLetterEvent(t, h, entityID)
+	seedCatalogAssertionPublishedEvent(h, eventID, entityID, runtimepipeline.HandlerOutcomeCompleted)
+
+	expected := catalogExpectedDocument{}
+	expected.Expected.Entities = map[string]catalogEntityExpected{
+		entityID: {
+			HandlerOutcome: "kill",
+			EntityState:    "active",
+			DeadLetter:     true,
+			EmittedEvents:  []string{"platform.dead_letter"},
+		},
+	}
+
+	assertCatalogRuntimeOutcome(t, h, expected)
+}
+
+func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	return &runtimeHarness{
+		t:              t,
+		ctx:            context.Background(),
+		db:             db,
+		pg:             &store.PostgresStore{DB: db},
+		workflow:       runtimepipeline.NewWorkflowInstanceStore(db),
+		startedAt:      time.Now().UTC(),
+		publishedIDs:   map[string]struct{}{},
+		publishedOrder: []string{},
+		eventEntityIDs: map[string]string{},
+		previews:       map[string]runtimepipeline.HandlerPreview{},
+	}
+}
+
+func insertCatalogAssertionEntityState(t *testing.T, h *runtimeHarness, entityID, state string) {
+	t.Helper()
+	if _, err := h.db.ExecContext(context.Background(), `
+		INSERT INTO entity_state (
+			entity_id, subject_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $1::uuid, 'root', 'default', $2,
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
+		)
+	`, entityID, state); err != nil {
+		t.Fatalf("insert entity_state %s: %v", entityID, err)
+	}
+}
+
+func insertCatalogAssertionDeadLetterEvent(t *testing.T, h *runtimeHarness, entityID string) {
+	t.Helper()
+	if err := h.pg.AppendEvent(context.Background(), (events.Event{
+		ID:          uuid.NewString(),
+		Type:        "platform.dead_letter",
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)); err != nil {
+		t.Fatalf("append platform.dead_letter event: %v", err)
+	}
+}
+
+func seedCatalogAssertionPublishedEvent(h *runtimeHarness, eventID, entityID string, status runtimepipeline.HandlerOutcomeStatus) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.publishedIDs[eventID] = struct{}{}
+	h.publishedOrder = append(h.publishedOrder, eventID)
+	h.eventEntityIDs[eventID] = entityID
+	h.previews[eventID] = runtimepipeline.HandlerPreview{Status: status}
 }

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -84,6 +84,34 @@ func TestCatalogAssertsAuthoritativeHandlerOutcome_OnlySuccess(t *testing.T) {
 	}
 }
 
+func TestCatalogRecognizesHandlerOutcome_RejectsTyposAndUnsupportedValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "empty", raw: "", want: true},
+		{name: "success", raw: "success", want: true},
+		{name: "reject", raw: "reject", want: true},
+		{name: "blocked", raw: "blocked", want: true},
+		{name: "terminal reject", raw: "terminal_reject", want: true},
+		{name: "success typo", raw: "succes", want: false},
+		{name: "unsupported", raw: "maybe", want: false},
+		{name: "trimmed unsupported", raw: " waiting ", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := catalogRecognizesHandlerOutcome(tc.raw); got != tc.want {
+				t.Fatalf("catalogRecognizesHandlerOutcome(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof(t *testing.T) {
 	h := newCatalogAssertionHarness(t)
 	entityID := uuid.NewString()


### PR DESCRIPTION
Closes #151

## Human Summary
This PR removes preview-backed non-success proof from the touched `cataloge2e` conformance seam. `cataloge2e` now treats only persisted `handler_outcome: success` as authoritative runtime/store evidence, while non-success cases must be proven by canonical state, emitted events, dead-letter evidence, or other durable runtime/store surfaces.

## What Changed
- restricted `cataloge2e` `handler_outcome` assertions to the one authoritative persisted case: `success`
- removed `cataloge2e`'s remaining non-success `handler_outcome` assertion path so it no longer claims runtime/store semantics from helper preview-style outcomes
- added focused regression tests proving:
  - top-level non-success cases pass based on authoritative state instead of preview-backed proof
  - entity-level dead-letter/non-success cases pass based on authoritative dead-letter evidence instead of preview-backed proof
  - only `success` remains an authoritative `cataloge2e` `handler_outcome` assertion
- kept shared fixture YAML unchanged so local `swarmflowtest` harness semantics remain local and explicit

## Why This Is Needed
The touched conformance seam was still letting helper preview output stand in for non-success runtime/store semantics. That created a false proof path for rejection, discard, kill, escalate, and terminal-style outcomes in tests that were supposed to be asserting durable runtime/store behavior. This PR aligns the conformance seam with the authoritative persisted/runtime owner instead of preserving parallel proof semantics.

## Scope Boundaries
In scope:
- `internal/runtime/cataloge2e` assertion behavior for touched `handler_outcome` cases
- focused regression coverage for the authoritative proof boundary

Out of scope:
- changing the platform spec
- broad fixture redesign
- changing local `swarmflowtest` preview semantics
- adding new runtime persistence surfaces for non-success handler outcomes

## Tests Run
- `go test ./internal/runtime/cataloge2e ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR keeps the scope narrow to the touched `cataloge2e` conformance seam. Shared fixture YAML still carries non-success `handler_outcome` values because `swarmflowtest` intentionally uses them as local preview semantics. If another runtime/store conformance seam later starts asserting non-success semantics from those values directly, it will need the same authoritative-boundary treatment instead of reusing preview-style proof.

## Follow-Up
No follow-up issue is required from this narrow seam. The remaining distinction is intentional: `swarmflowtest` is a local semantic harness, while `cataloge2e` now stays on authoritative runtime/store evidence for non-success cases.
