### PR TITLE
[agent-b][issue #132] Make CEL entity-field availability lifecycle-aware

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -488,12 +488,16 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 			nodeID = strings.TrimSpace(nodeID)
 			for eventType, handler := range node.EventHandlers {
 				eventType = strings.TrimSpace(eventType)
+				handlerWriters := handlerEntityFieldWriters(handler)
 				for _, expr := range handlerEntityExpressions(handler) {
-					for _, field := range entityReferences(expr.Expression) {
-						if bootverifyBuiltinEntityField(field) {
+					available := availableEntityFieldsForExpression(handler, expr)
+					guarded := runtimepipeline.WorkflowPresenceGuardedEntityFields(expr.Expression)
+					for _, ref := range runtimepipeline.WorkflowEntityReferences(expr.Expression) {
+						field := runtimepipeline.WorkflowEntityReferenceField(ref)
+						if runtimepipeline.WorkflowBuiltinEntityField(field) {
 							continue
 						}
-						if _, ok := writers[field]; ok {
+						if _, ok := guarded[field]; ok {
 							continue
 						}
 						key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, field}, "|")
@@ -501,6 +505,21 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 							continue
 						}
 						seen[key] = struct{}{}
+						if _, ok := available[field]; ok {
+							continue
+						}
+						if _, ok := handlerWriters[field]; ok {
+							c.entityRefFindings = append(c.entityRefFindings, Finding{
+								CheckID:  "expression_field_reference_validation",
+								Severity: "error",
+								Message:  fmt.Sprintf("flow %s node %s handler %s references entity.%s in %s before the handler lifecycle makes it available", flowID, nodeID, eventType, field, expr.Kind),
+								Location: nodeID,
+							})
+							continue
+						}
+						if _, ok := writers[field]; ok {
+							continue
+						}
 						c.entityRefFindings = append(c.entityRefFindings, Finding{
 							CheckID:  "expression_field_reference_validation",
 							Severity: "warning",
@@ -514,15 +533,6 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 	}
 
 	return c.entityRefFindings
-}
-
-func bootverifyBuiltinEntityField(field string) bool {
-	switch strings.TrimSpace(field) {
-	case "entity_id", "current_state", "workflow_name", "workflow_version", "gates":
-		return true
-	default:
-		return false
-	}
 }
 
 func (c *checkerContext) transitionOwnership() []Finding {
@@ -2720,6 +2730,7 @@ var bootverifyEntityReferencePattern = regexp.MustCompile(`entity\.([a-zA-Z_][a-
 type expressionReference struct {
 	Kind       string
 	Expression string
+	Phase      runtimepipeline.WorkflowEntityFieldLifecyclePhase
 }
 
 type handlerCondition struct {
@@ -2794,27 +2805,31 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	out := make([]expressionReference, 0, 16)
 	if handler.Guard != nil {
 		if check := strings.TrimSpace(handler.Guard.Check); check != "" {
-			out = append(out, expressionReference{Kind: "guard", Expression: check})
+			out = append(out, expressionReference{Kind: "guard", Expression: check, Phase: runtimepipeline.WorkflowEntityFieldLifecycleGuard})
 		}
 		for _, item := range handler.Guard.Checks {
 			if check := strings.TrimSpace(item.Check); check != "" {
-				out = append(out, expressionReference{Kind: "guard", Expression: check})
+				out = append(out, expressionReference{Kind: "guard", Expression: check, Phase: runtimepipeline.WorkflowEntityFieldLifecycleGuard})
 			}
 		}
 	}
 	if condition := strings.TrimSpace(handler.Condition); condition != "" && !strings.EqualFold(condition, "else") {
-		out = append(out, expressionReference{Kind: "condition", Expression: condition})
+		out = append(out, expressionReference{Kind: "condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleRule})
 	}
 	appendWriteExpressions := func(kind string, writes []runtimecontracts.WorkflowDataWrite) {
 		for _, write := range writes {
 			if expr := strings.TrimSpace(write.Value.CEL); expr != "" {
-				out = append(out, expressionReference{Kind: kind, Expression: expr})
+				out = append(out, expressionReference{Kind: kind, Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
 			}
 		}
 	}
 	appendRuleExpressions := func(kindPrefix string, rule runtimecontracts.HandlerRuleEntry) {
 		if condition := strings.TrimSpace(rule.Condition); condition != "" && !strings.EqualFold(condition, "else") {
-			out = append(out, expressionReference{Kind: kindPrefix + " condition", Expression: condition})
+			phase := runtimepipeline.WorkflowEntityFieldLifecycleRule
+			if strings.Contains(kindPrefix, "on_complete") {
+				phase = runtimepipeline.WorkflowEntityFieldLifecycleOnComplete
+			}
+			out = append(out, expressionReference{Kind: kindPrefix + " condition", Expression: condition, Phase: phase})
 		}
 		appendWriteExpressions(kindPrefix+" expression", rule.DataAccumulation.Writes)
 		if rule.FanOut != nil {
@@ -2839,15 +2854,15 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	}
 	if handler.Filter != nil {
 		if predicate := strings.TrimSpace(handler.Filter.Predicate); predicate != "" {
-			out = append(out, expressionReference{Kind: "filter predicate", Expression: predicate})
+			out = append(out, expressionReference{Kind: "filter predicate", Expression: predicate, Phase: runtimepipeline.WorkflowEntityFieldLifecycleFilter})
 		}
 		if condition := strings.TrimSpace(handler.Filter.Condition); condition != "" {
-			out = append(out, expressionReference{Kind: "filter condition", Expression: condition})
+			out = append(out, expressionReference{Kind: "filter condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleFilter})
 		}
 	}
 	if handler.Count != nil {
 		if condition := strings.TrimSpace(handler.Count.Condition); condition != "" {
-			out = append(out, expressionReference{Kind: "count condition", Expression: condition})
+			out = append(out, expressionReference{Kind: "count condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleCount})
 		}
 	}
 	if handler.Query != nil {
@@ -2856,13 +2871,13 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	if handler.Reduce != nil {
 		for key, value := range handler.Reduce.Params {
 			if expr := strings.TrimSpace(value.CEL); expr != "" {
-				out = append(out, expressionReference{Kind: "reduce param " + strings.TrimSpace(key), Expression: expr})
+				out = append(out, expressionReference{Kind: "reduce param " + strings.TrimSpace(key), Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleReduce})
 			}
 		}
 	}
 	for _, branch := range handler.Branch {
 		if condition := strings.TrimSpace(branch.Condition); condition != "" && !strings.EqualFold(condition, "else") {
-			out = append(out, expressionReference{Kind: "branch condition", Expression: condition})
+			out = append(out, expressionReference{Kind: "branch condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleRule})
 		}
 		if branch.Then != nil {
 			appendRuleExpressions("branch.then", *branch.Then)
@@ -2876,17 +2891,50 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 
 func appendQueryExpressions(out *[]expressionReference, query runtimecontracts.QuerySpec) {
 	if filter := strings.TrimSpace(query.Filter); filter != "" {
-		*out = append(*out, expressionReference{Kind: "query filter", Expression: filter})
+		*out = append(*out, expressionReference{Kind: "query filter", Expression: filter, Phase: runtimepipeline.WorkflowEntityFieldLifecycleGuard})
 	}
 	for _, nested := range query.Queries {
 		appendQueryExpressions(out, nested)
 	}
 }
 
+func availableEntityFieldsForExpression(handler runtimecontracts.SystemNodeEventHandler, expr expressionReference) map[string]struct{} {
+	switch expr.Phase {
+	case runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
+	case runtimepipeline.WorkflowEntityFieldLifecycleGuard:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextGuard)
+	case runtimepipeline.WorkflowEntityFieldLifecycleFilter:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextFilter)
+	case runtimepipeline.WorkflowEntityFieldLifecycleCount:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextCount)
+	case runtimepipeline.WorkflowEntityFieldLifecycleOnComplete:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextOnComplete)
+	case runtimepipeline.WorkflowEntityFieldLifecycleRule:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextRule)
+	case runtimepipeline.WorkflowEntityFieldLifecycleReduce:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
+	default:
+		return map[string]struct{}{}
+	}
+}
+
 func flowEntityFieldWriters(nodes map[string]runtimecontracts.SystemNodeContract) map[string]struct{} {
 	out := map[string]struct{}{}
+	for _, node := range nodes {
+		for _, handler := range node.EventHandlers {
+			for field := range handlerEntityFieldWriters(handler) {
+				out[field] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func handlerEntityFieldWriters(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
+	out := map[string]struct{}{}
 	addWriter := func(target string) {
-		if field, ok := entityFieldNameFromTarget(target); ok {
+		if field, ok := runtimepipeline.WorkflowEntityFieldNameFromTarget(target); ok {
 			out[field] = struct{}{}
 		}
 	}
@@ -2909,84 +2957,77 @@ func flowEntityFieldWriters(nodes map[string]runtimecontracts.SystemNodeContract
 			addQueryWriters(&query.Queries[i])
 		}
 	}
-	for _, node := range nodes {
-		for _, handler := range node.EventHandlers {
-			if gateNameLocal(handler.SetsGate) != "" {
-				out["gates"] = struct{}{}
-			}
-			for _, write := range handler.DataAccumulation.Writes {
-				addWriter(write.Target())
-			}
-			if handler.Compute != nil {
-				addWriter(handler.Compute.StoreAs)
-			}
-			if handler.GroupBy != nil {
-				addWriter(handler.GroupBy.StoreAs)
-			}
-			if handler.Filter != nil {
-				addWriter(handler.Filter.StoreAs)
-			}
-			if handler.Reduce != nil {
-				addWriter(handler.Reduce.StoreAs)
-			}
-			if handler.Count != nil {
-				addWriter(handler.Count.StoreAs)
-			}
-			if handler.Query != nil {
-				addQueryWriters(handler.Query)
-			}
-			if handler.Clear != nil {
-				addWriter(handler.Clear.Target)
-				for _, target := range handler.Clear.Targets {
-					addWriter(target)
-				}
-			}
-			for _, rule := range handler.Rules {
-				addRuleWriters(rule)
-			}
-			for _, rule := range handler.OnComplete {
-				addRuleWriters(rule)
-			}
-			if handler.Accumulate != nil {
-				for _, rule := range handler.Accumulate.OnComplete {
-					addRuleWriters(rule)
-				}
-				if handler.Accumulate.OnTimeout != nil {
-					addRuleWriters(*handler.Accumulate.OnTimeout)
-				}
-			}
-			for _, branch := range handler.Branch {
-				if branch.Then != nil {
-					addRuleWriters(*branch.Then)
-				}
-				if branch.Else != nil {
-					addRuleWriters(*branch.Else)
-				}
-			}
+	if gateNameLocal(handler.SetsGate) != "" {
+		out["gates"] = struct{}{}
+	}
+	for _, write := range handler.DataAccumulation.Writes {
+		addWriter(write.Target())
+	}
+	if handler.Compute != nil {
+		addWriter(handler.Compute.StoreAs)
+	}
+	if handler.GroupBy != nil {
+		addWriter(handler.GroupBy.StoreAs)
+	}
+	if handler.Filter != nil {
+		addWriter(handler.Filter.StoreAs)
+	}
+	if handler.Reduce != nil {
+		addWriter(handler.Reduce.StoreAs)
+	}
+	if handler.Count != nil {
+		addWriter(handler.Count.StoreAs)
+	}
+	if handler.Query != nil {
+		addQueryWriters(handler.Query)
+	}
+	if handler.Clear != nil {
+		addWriter(handler.Clear.Target)
+		for _, target := range handler.Clear.Targets {
+			addWriter(target)
+		}
+	}
+	for _, rule := range handler.Rules {
+		addRuleWriters(rule)
+	}
+	for _, rule := range handler.OnComplete {
+		addRuleWriters(rule)
+	}
+	if handler.Accumulate != nil {
+		for _, rule := range handler.Accumulate.OnComplete {
+			addRuleWriters(rule)
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			addRuleWriters(*handler.Accumulate.OnTimeout)
+		}
+	}
+	for _, branch := range handler.Branch {
+		if branch.Then != nil {
+			addRuleWriters(*branch.Then)
+		}
+		if branch.Else != nil {
+			addRuleWriters(*branch.Else)
 		}
 	}
 	return out
 }
 
-func entityFieldNameFromTarget(target string) (string, bool) {
-	target = strings.TrimSpace(target)
-	if target == "" {
-		return "", false
+func entityReferences(expression string) []string {
+	refs := runtimepipeline.WorkflowEntityReferences(expression)
+	out := make([]string, 0, len(refs))
+	seen := map[string]struct{}{}
+	for _, ref := range refs {
+		field := runtimepipeline.WorkflowEntityReferenceField(ref)
+		if field == "" {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		out = append(out, field)
 	}
-	if strings.HasPrefix(target, "entity.") {
-		target = strings.TrimPrefix(target, "entity.")
-	}
-	if idx := strings.IndexByte(target, '.'); idx >= 0 {
-		target = target[:idx]
-	}
-	target = strings.TrimSpace(target)
-	if target == "" {
-		return "", false
-	}
-	if !regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`).MatchString(target) {
-		return "", false
-	}
-	return target, true
+	return out
 }
 
 func policyReferences(expression string) []string {
@@ -3020,31 +3061,6 @@ func payloadReferences(expression string) []string {
 		return nil
 	}
 	matches := bootverifyPayloadReferencePattern.FindAllStringSubmatch(expression, -1)
-	out := make([]string, 0, len(matches))
-	seen := map[string]struct{}{}
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		ref := strings.TrimSpace(match[1])
-		if ref == "" {
-			continue
-		}
-		if _, ok := seen[ref]; ok {
-			continue
-		}
-		seen[ref] = struct{}{}
-		out = append(out, ref)
-	}
-	return out
-}
-
-func entityReferences(expression string) []string {
-	expression = strings.TrimSpace(expression)
-	if expression == "" {
-		return nil
-	}
-	matches := bootverifyEntityReferencePattern.FindAllStringSubmatch(expression, -1)
 	out := make([]string, 0, len(matches))
 	seen := map[string]struct{}{}
 	for _, match := range matches {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -737,6 +737,31 @@ func TestRun_ReportsExpressionFieldReferenceErrorForDataAccumulationExpressionTh
 	}
 }
 
+func TestRun_AllowsTopLevelDataAccumulationExpressionToReadRuleProducedField(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "payload.score >= 70",
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				TargetField: "base_score",
+				SourceField: "score",
+			}},
+		},
+	}}
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
+		TargetField: "adjusted_score",
+		Value:       runtimecontracts.CELExpression("entity.base_score + 1"),
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_SuppressesExpressionFieldReferenceFindingWhenComputeMakesFieldAvailableBeforeOnComplete(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -673,10 +673,10 @@ func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	}
 }
 
-func TestRun_SuppressesExpressionFieldReferenceWarningWhenWriterExists(t *testing.T) {
+func TestRun_ReportsExpressionFieldReferenceErrorWhenFieldIsWrittenTooLate(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
-	handler.Condition = "entity.missing_score >= 70"
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.missing_score >= 70"}
 	handler.DataAccumulation.Writes = append(handler.DataAccumulation.Writes, runtimecontracts.WorkflowDataWrite{
 		TargetField: "missing_score",
 		SourceField: "score",
@@ -685,7 +685,76 @@ func TestRun_SuppressesExpressionFieldReferenceWarningWhenWriterExists(t *testin
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.missing_score") {
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_score") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "before the handler lifecycle makes it available") {
+		t.Fatalf("expected lifecycle-aware expression error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsExpressionFieldReferenceErrorForFilterThatDependsOnLaterCompute(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Filter = &runtimecontracts.FilterSpec{
+		Source:    "payload.items",
+		ItemsFrom: "payload.items",
+		Condition: "entity.filtered_score >= 70",
+		StoreAs:   "entity.filtered_items",
+	}
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.filtered_score",
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.filtered_score") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsExpressionFieldReferenceErrorForDataAccumulationExpressionThatDependsOnSiblingWrite(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{
+		{
+			TargetField: "base_score",
+			SourceField: "score",
+		},
+		{
+			TargetField: "adjusted_score",
+			Value:       runtimecontracts.CELExpression("entity.base_score + 1"),
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_SuppressesExpressionFieldReferenceFindingWhenComputeMakesFieldAvailableBeforeOnComplete(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.composite_score",
+	}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.composite_score >= 0",
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.composite_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
 		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
 	}
 }

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -1,0 +1,237 @@
+package pipeline
+
+import (
+	"regexp"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+type WorkflowEntityFieldLifecyclePhase string
+
+const (
+	WorkflowEntityFieldLifecycleGuard            WorkflowEntityFieldLifecyclePhase = "guard"
+	WorkflowEntityFieldLifecycleAccumulate       WorkflowEntityFieldLifecyclePhase = "accumulate"
+	WorkflowEntityFieldLifecycleFilter           WorkflowEntityFieldLifecyclePhase = "filter"
+	WorkflowEntityFieldLifecycleGroupBy          WorkflowEntityFieldLifecyclePhase = "group_by"
+	WorkflowEntityFieldLifecycleReduce           WorkflowEntityFieldLifecyclePhase = "reduce"
+	WorkflowEntityFieldLifecycleCount            WorkflowEntityFieldLifecyclePhase = "count"
+	WorkflowEntityFieldLifecycleCompute          WorkflowEntityFieldLifecyclePhase = "compute"
+	WorkflowEntityFieldLifecycleFanOut           WorkflowEntityFieldLifecyclePhase = "fan_out"
+	WorkflowEntityFieldLifecycleOnComplete       WorkflowEntityFieldLifecyclePhase = "on_complete"
+	WorkflowEntityFieldLifecycleRule             WorkflowEntityFieldLifecyclePhase = "rule"
+	WorkflowEntityFieldLifecycleDataAccumulation WorkflowEntityFieldLifecyclePhase = "data_accumulation"
+)
+
+var workflowExpressionEntityReferencePattern = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+var workflowExpressionEntityPresencePattern = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
+
+func WorkflowEntityReferences(expression string) []string {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return nil
+	}
+	matches := workflowExpressionEntityReferencePattern.FindAllStringSubmatch(expression, -1)
+	out := make([]string, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		ref := strings.TrimSpace(match[1])
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func WorkflowEntityReferenceField(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(ref, '.'); idx >= 0 {
+		ref = ref[:idx]
+	}
+	return strings.TrimSpace(ref)
+}
+
+func WorkflowBuiltinEntityField(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "current_state", "workflow_name", "workflow_version", "gates":
+		return true
+	default:
+		return false
+	}
+}
+
+func WorkflowPresenceGuardedEntityFields(expression string) map[string]struct{} {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return nil
+	}
+	matches := workflowExpressionEntityPresencePattern.FindAllStringSubmatch(expression, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		field := strings.TrimSpace(match[1])
+		if field == "" {
+			continue
+		}
+		out[field] = struct{}{}
+	}
+	return out
+}
+
+func WorkflowEntityFieldsAvailableBeforeCondition(handler runtimecontracts.SystemNodeEventHandler, context WorkflowConditionContext) map[string]struct{} {
+	switch context {
+	case WorkflowConditionContextGuard:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleGuard)
+	case WorkflowConditionContextFilter:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleFilter)
+	case WorkflowConditionContextCount:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleCount)
+	case WorkflowConditionContextOnComplete:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleOnComplete)
+	case WorkflowConditionContextRule:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleRule)
+	default:
+		return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleGuard)
+	}
+}
+
+func WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
+	return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleDataAccumulation)
+}
+
+func WorkflowEntityFieldNameFromTarget(target string) (string, bool) {
+	return workflowEntityFieldNameFromTarget(target)
+}
+
+func workflowEntityFieldsAvailableBeforePhase(handler runtimecontracts.SystemNodeEventHandler, phase WorkflowEntityFieldLifecyclePhase) map[string]struct{} {
+	available := workflowBuiltinEntityFields()
+	addWriter := func(target string) {
+		if field, ok := workflowEntityFieldNameFromTarget(target); ok {
+			available[field] = struct{}{}
+		}
+	}
+	var addQueryWriter func(query *runtimecontracts.QuerySpec)
+	addQueryWriter = func(query *runtimecontracts.QuerySpec) {
+		if query == nil {
+			return
+		}
+		addWriter(query.StoreAs)
+		for i := range query.Queries {
+			addQueryWriter(&query.Queries[i])
+		}
+	}
+	addQueryWriter(handler.Query)
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleFilter) {
+		if handler.Filter != nil {
+			addWriter(handler.Filter.StoreAs)
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleGroupBy) {
+		if handler.GroupBy != nil {
+			addWriter(handler.GroupBy.StoreAs)
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleReduce) {
+		if handler.Reduce != nil {
+			addWriter(handler.Reduce.StoreAs)
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleCount) {
+		if handler.Count != nil {
+			addWriter(handler.Count.StoreAs)
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleCompute) {
+		if handler.Compute != nil {
+			addWriter(handler.Compute.StoreAs)
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleFanOut) {
+		if handler.FanOut != nil {
+			available["fan_out_count"] = struct{}{}
+		}
+	}
+	return available
+}
+
+func workflowBuiltinEntityFields() map[string]struct{} {
+	return map[string]struct{}{
+		"entity_id":        {},
+		"current_state":    {},
+		"workflow_name":    {},
+		"workflow_version": {},
+		"gates":            {},
+	}
+}
+
+func workflowEntityFieldNameFromTarget(target string) (string, bool) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", false
+	}
+	if strings.HasPrefix(target, "entity.") {
+		target = strings.TrimSpace(strings.TrimPrefix(target, "entity."))
+	} else if strings.HasPrefix(target, "metadata.") {
+		target = strings.TrimSpace(strings.TrimPrefix(target, "metadata."))
+	}
+	if target == "" {
+		return "", false
+	}
+	if idx := strings.IndexByte(target, '.'); idx >= 0 {
+		target = target[:idx]
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", false
+	}
+	return target, true
+}
+
+func phaseAfter(current, threshold WorkflowEntityFieldLifecyclePhase) bool {
+	return workflowEntityFieldLifecycleOrder(current) > workflowEntityFieldLifecycleOrder(threshold)
+}
+
+func workflowEntityFieldLifecycleOrder(phase WorkflowEntityFieldLifecyclePhase) int {
+	switch phase {
+	case WorkflowEntityFieldLifecycleGuard:
+		return 1
+	case WorkflowEntityFieldLifecycleAccumulate:
+		return 2
+	case WorkflowEntityFieldLifecycleFilter:
+		return 3
+	case WorkflowEntityFieldLifecycleGroupBy:
+		return 4
+	case WorkflowEntityFieldLifecycleReduce:
+		return 5
+	case WorkflowEntityFieldLifecycleCount:
+		return 6
+	case WorkflowEntityFieldLifecycleCompute:
+		return 7
+	case WorkflowEntityFieldLifecycleFanOut:
+		return 8
+	case WorkflowEntityFieldLifecycleOnComplete:
+		return 9
+	case WorkflowEntityFieldLifecycleRule:
+		return 10
+	case WorkflowEntityFieldLifecycleDataAccumulation:
+		return 11
+	default:
+		return 0
+	}
+}

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -27,7 +27,7 @@ var workflowExpressionEntityReferencePattern = regexp.MustCompile(`entity\.([a-z
 var workflowExpressionEntityPresencePattern = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
 
 func WorkflowEntityReferences(expression string) []string {
-	expression = strings.TrimSpace(expression)
+	expression = strings.TrimSpace(stripWorkflowExpressionStringLiterals(expression))
 	if expression == "" {
 		return nil
 	}
@@ -49,6 +49,54 @@ func WorkflowEntityReferences(expression string) []string {
 		out = append(out, ref)
 	}
 	return out
+}
+
+func stripWorkflowExpressionStringLiterals(expression string) string {
+	if expression == "" {
+		return ""
+	}
+	var out strings.Builder
+	out.Grow(len(expression))
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if escaped {
+			if inSingle || inDouble {
+				out.WriteByte(' ')
+			} else {
+				out.WriteByte(ch)
+			}
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			if inSingle || inDouble {
+				out.WriteByte(' ')
+			} else {
+				out.WriteByte(ch)
+			}
+			continue
+		}
+		if ch == '"' && !inSingle {
+			inDouble = !inDouble
+			out.WriteByte(' ')
+			continue
+		}
+		if ch == '\'' && !inDouble {
+			inSingle = !inSingle
+			out.WriteByte(' ')
+			continue
+		}
+		if inSingle || inDouble {
+			out.WriteByte(' ')
+			continue
+		}
+		out.WriteByte(ch)
+	}
+	return out.String()
 }
 
 func WorkflowEntityReferenceField(ref string) string {
@@ -126,6 +174,14 @@ func workflowEntityFieldsAvailableBeforePhase(handler runtimecontracts.SystemNod
 			available[field] = struct{}{}
 		}
 	}
+	addRuleWriters := func(rule runtimecontracts.HandlerRuleEntry) {
+		for _, write := range rule.DataAccumulation.Writes {
+			addWriter(write.Target())
+		}
+		if rule.Compute != nil {
+			addWriter(rule.Compute.StoreAs)
+		}
+	}
 	var addQueryWriter func(query *runtimecontracts.QuerySpec)
 	addQueryWriter = func(query *runtimecontracts.QuerySpec) {
 		if query == nil {
@@ -165,6 +221,30 @@ func workflowEntityFieldsAvailableBeforePhase(handler runtimecontracts.SystemNod
 	if phaseAfter(phase, WorkflowEntityFieldLifecycleFanOut) {
 		if handler.FanOut != nil {
 			available["fan_out_count"] = struct{}{}
+		}
+	}
+	if phaseAfter(phase, WorkflowEntityFieldLifecycleRule) {
+		for _, rule := range handler.Rules {
+			addRuleWriters(rule)
+		}
+		for _, rule := range handler.OnComplete {
+			addRuleWriters(rule)
+		}
+		if handler.Accumulate != nil {
+			for _, rule := range handler.Accumulate.OnComplete {
+				addRuleWriters(rule)
+			}
+			if handler.Accumulate.OnTimeout != nil {
+				addRuleWriters(*handler.Accumulate.OnTimeout)
+			}
+		}
+		for _, branch := range handler.Branch {
+			if branch.Then != nil {
+				addRuleWriters(*branch.Then)
+			}
+			if branch.Else != nil {
+				addRuleWriters(*branch.Else)
+			}
 		}
 	}
 	return available

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -1,0 +1,58 @@
+package pipeline
+
+import (
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestWorkflowEntityFieldsAvailableBeforeCondition_ExcludesLaterTopLevelDataWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "score", SourceField: "score"},
+			},
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforeCondition(handler, WorkflowConditionContextRule)
+	if _, ok := available["score"]; ok {
+		t.Fatalf("score unexpectedly available before rule selection: %#v", available)
+	}
+}
+
+func TestWorkflowEntityFieldsAvailableBeforeCondition_IncludesEarlierComputeWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.composite_score",
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforeCondition(handler, WorkflowConditionContextOnComplete)
+	if _, ok := available["composite_score"]; !ok {
+		t.Fatalf("composite_score missing from on_complete availability: %#v", available)
+	}
+}
+
+func TestWorkflowEntityFieldsAvailableBeforeDataAccumulation_IncludesEarlierComputeButNotSiblingWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.composite_score",
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "base_score", SourceField: "score"},
+			},
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
+	if _, ok := available["composite_score"]; !ok {
+		t.Fatalf("composite_score missing from data_accumulation availability: %#v", available)
+	}
+	if _, ok := available["base_score"]; ok {
+		t.Fatalf("base_score unexpectedly available before sibling data_accumulation write: %#v", available)
+	}
+}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -68,6 +68,9 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 	if normalized == "" {
 		return false, fmt.Errorf("workflow expression is empty")
 	}
+	if missing := missingEntityReferences(normalized, normalizedCtx.Entity); len(missing) > 0 {
+		return false, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
+	}
 	program, err := e.program(normalized)
 	if err != nil {
 		return false, err
@@ -88,6 +91,25 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 	default:
 		return false, fmt.Errorf("workflow expression returned non-bool %T", out)
 	}
+}
+
+func missingEntityReferences(expression string, entity map[string]any) []string {
+	refs := WorkflowEntityReferences(expression)
+	if len(refs) == 0 {
+		return nil
+	}
+	guarded := WorkflowPresenceGuardedEntityFields(expression)
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if _, ok := guarded[WorkflowEntityReferenceField(ref)]; ok {
+			continue
+		}
+		if _, ok := workflowExpressionLookupPath(entity, ref); ok {
+			continue
+		}
+		out = append(out, "entity."+ref)
+	}
+	return out
 }
 
 func (e *workflowExpressionEvaluator) program(expression string) (cel.Program, error) {

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -68,6 +68,21 @@ func TestWorkflowExpressionEvaluator_EvalBoolFailsClosedOnMissingEntityField(t *
 	}
 }
 
+func TestWorkflowExpressionEvaluator_EvalBoolIgnoresEntityRefsInsideStringLiterals(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`payload.label == "entity.score"`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{"label": "entity.score"},
+		Policy:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected quoted entity.* text to stay a string literal, not a missing entity ref")
+	}
+}
+
 func TestParseWorkflowEntityQueryPredicate_ResolvesPayloadReference(t *testing.T) {
 	predicate, err := parseWorkflowEntityQueryPredicate(
 		`name == payload.name`,

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -53,6 +53,21 @@ func TestNormalizeWorkflowExpression_RewritesQueryEntitiesCount(t *testing.T) {
 	}
 }
 
+func TestWorkflowExpressionEvaluator_EvalBoolFailsClosedOnMissingEntityField(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	_, err := eval.EvalBool(`entity.score >= 70`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{},
+		Policy:  map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected missing entity field to fail closed")
+	}
+	if got := err.Error(); got == "" || got == "no such key: score" {
+		t.Fatalf("expected explicit lifecycle-safe missing-field error, got %q", got)
+	}
+}
+
 func TestParseWorkflowEntityQueryPredicate_ResolvesPayloadReference(t *testing.T) {
 	predicate, err := parseWorkflowEntityQueryPredicate(
 		`name == payload.name`,


### PR DESCRIPTION
Closes #132

## Human Summary
This makes CEL validation and runtime evaluation agree on when `entity.*` fields are actually available. Boot verification now rejects expressions that try to read fields before the handler lifecycle can materialize them, and runtime evaluation now fails with an explicit entity-field availability error instead of surfacing a raw late CEL `no such key`.

## What Changed
- added a shared lifecycle-aware entity-field availability helper in `internal/runtime/pipeline`
- taught boot verification to reject same-handler entity-field references that occur before the ordered runtime steps can make those fields visible
- kept the broader flow-level writer warning for fields with no known writer, but promoted lifecycle-impossible local cases to explicit errors
- made workflow expression evaluation fail closed with an explicit missing `entity.*` field error instead of leaking a raw CEL missing-key failure
- preserved explicit presence-guarded expressions such as `"field" in entity && entity.field == ...`
- added focused regressions for too-early guard, filter, and data-accumulation references plus the valid compute-before-on_complete case

## Why This Is Needed
Before this change, contracts could pass parse/reference validation and still fail at runtime because entity fields were referenced before the current handler lifecycle could make them available. Validation and runtime were disagreeing about the same expression. This tightens the seam so impossible local timing cases are rejected before execution, and dynamic missing-field cases fail explicitly at runtime instead of failing incidentally inside CEL.

## Scope Boundaries
- In scope:
  - lifecycle-aware entity-field availability for the touched CEL validation/runtime seam
  - boot verification alignment for guards, checks, filters, count conditions, on_complete/rules, and top-level data-accumulation CEL expressions
  - explicit fail-closed runtime handling for missing `entity.*` references
- Not in scope:
  - broad CEL redesign
  - global proof that a schema field is materialized across all workflow histories
  - unrelated workflow lifecycle or routing work

## Tests Run
- `go test ./internal/runtime/pipeline ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`

## Residual Risk
This intentionally proves and rejects only the local lifecycle-impossible cases that the runtime can know from the ordered handler steps. It does not try to statically prove that an entity field has been materialized by every possible prior workflow history. Those cases still fail closed at runtime with an explicit missing-field error if the field is absent.

## Follow-Up
No spec escalation was needed for this PR. If we later want stronger static guarantees across multi-handler workflow histories, that should be a separate issue because it requires a broader materialization model than the local ordered-step lifecycle handled here.
