### PR TITLE
[agent-a][issue #114] Align contract vocabularies to the platform spec

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1604,6 +1604,13 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Message:  fmt.Sprintf("node %s missing required field execution_type", nodeLabel),
 					Location: nodeLabel,
 				})
+			} else if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+				c.invalidFindings = append(c.invalidFindings, Finding{
+					CheckID:  "invalid_field_detection",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
+					Location: nodeLabel,
+				})
 			}
 			if len(c.source.NodeRuntimeSubscriptions(nodeID)) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
@@ -1706,6 +1713,13 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
 					Message:  fmt.Sprintf("node %s missing required field execution_type", nodeLabel),
+					Location: nodeLabel,
+				})
+			} else if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+				c.invalidFindings = append(c.invalidFindings, Finding{
+					CheckID:  "invalid_field_detection",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
 					Location: nodeLabel,
 				})
 			}
@@ -2009,15 +2023,13 @@ func (c *checkerContext) requiredAgentsMatch() []Finding {
 				})
 				continue
 			}
-			if flowRequiresStaticSubscriptionValidation(c.source, flowID) {
-				if diff := missingStrings(required.SubscribesTo, agentSubscriptions(agent)); diff != "" {
-					c.requiredFindings = append(c.requiredFindings, Finding{
-						CheckID:  "required_agents_match",
-						Severity: "error",
-						Message:  fmt.Sprintf("flow %s required agent %s subscriptions mismatch (%s)", flowID, agentID, diff),
-						Location: strings.TrimSpace(flowID),
-					})
-				}
+			if diff := missingStrings(required.SubscribesTo, agentSubscriptions(agent)); diff != "" {
+				c.requiredFindings = append(c.requiredFindings, Finding{
+					CheckID:  "required_agents_match",
+					Severity: "error",
+					Message:  fmt.Sprintf("flow %s required agent %s subscriptions mismatch (%s)", flowID, agentID, diff),
+					Location: strings.TrimSpace(flowID),
+				})
 			}
 			if diff := missingStrings(required.Emits, agent.EmitEvents); diff != "" {
 				c.requiredFindings = append(c.requiredFindings, Finding{
@@ -2049,6 +2061,14 @@ func (c *checkerContext) requiredAgentsMatch() []Finding {
 				Location: "root",
 			})
 			continue
+		}
+		if diff := missingStrings(required.SubscribesTo, agentSubscriptions(agent)); diff != "" {
+			c.requiredFindings = append(c.requiredFindings, Finding{
+				CheckID:  "required_agents_match",
+				Severity: "error",
+				Message:  fmt.Sprintf("root required agent %s subscriptions mismatch (%s)", agentID, diff),
+				Location: "root",
+			})
 		}
 		if diff := missingStrings(required.Emits, agent.EmitEvents); diff != "" {
 			c.requiredFindings = append(c.requiredFindings, Finding{
@@ -3223,21 +3243,6 @@ func normalizeRoleKey(raw string) string {
 	return raw
 }
 
-func flowRequiresStaticSubscriptionValidation(source semanticview.Source, flowID string) bool {
-	if source == nil {
-		return true
-	}
-	flowID = strings.TrimSpace(flowID)
-	if flowID == "" {
-		return true
-	}
-	schema, ok := source.FlowSchemaByID(flowID)
-	if !ok {
-		return true
-	}
-	return !strings.EqualFold(strings.TrimSpace(schema.Mode), "template")
-}
-
 func flowSchemaIsTemplate(source semanticview.Source, flowID string) bool {
 	if source == nil {
 		return false
@@ -3631,7 +3636,6 @@ func validateGuardOnFailLocal(onFail string) error {
 	}
 	switch parsed.Action {
 	case runtimeengine.GuardFailureReject,
-		runtimeengine.GuardFailureBlocked,
 		runtimeengine.GuardFailureDiscard,
 		runtimeengine.GuardFailureKill:
 		return nil
@@ -3772,27 +3776,11 @@ func normalizeWorkflowBuiltinActionID(id string) string {
 }
 
 func isSupportedWorkflowActionBuiltin(id string) bool {
-	switch normalizeWorkflowBuiltinActionID(id) {
-	case "increment_revision_count",
-		"record_state_change",
-		"update_state",
-		"cancel_state_timers",
-		"start_state_timers",
-		"record_evidence",
-		"create_flow_instance":
-		return true
-	default:
-		return false
-	}
+	return runtimecontracts.IsSupportedHandlerActionID(normalizeWorkflowBuiltinActionID(id))
 }
 
 func isSupportedWorkflowHandlerActionID(id string) bool {
-	switch normalizeWorkflowBuiltinActionID(id) {
-	case "create_flow_instance", "record_evidence":
-		return true
-	default:
-		return isSupportedWorkflowActionBuiltin(id)
-	}
+	return runtimecontracts.IsSupportedHandlerActionID(normalizeWorkflowBuiltinActionID(id))
 }
 
 func handlerActionExecutable(source semanticview.Source, actionID string) bool {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -284,6 +284,59 @@ func TestRun_MapsRequiredAgentMismatchToNamedError(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsRequiredAgentSubscriptionMismatchForTemplateFlow(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-pin-wiring"))
+	schema := bundle.FlowSchemas["child"]
+	schema.Mode = "template"
+	schema.RequiredAgents = []runtimecontracts.FlowRequiredAgent{{
+		Role:         "worker",
+		SubscribesTo: []string{"work.completed"},
+		Emits:        []string{"work.completed"},
+	}}
+	bundle.FlowSchemas["child"] = schema
+	bundle.Semantics.FlowAgents["child"] = append([]runtimecontracts.FlowRequiredAgent(nil), schema.RequiredAgents...)
+	bundle.Agents["worker"] = runtimecontracts.AgentRegistryEntry{
+		ID:               "worker",
+		Role:             "worker",
+		ModelTier:        "small",
+		ConversationMode: "task",
+		Subscriptions:    []string{"work.requested"},
+		EmitEvents:       []string{"work.completed"},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "required_agents_match", "subscriptions mismatch") {
+		t.Fatalf("expected template-flow required_agents_match subscriptions error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsRootRequiredAgentSubscriptionMismatch(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-success")
+	if bundle.RootSchema == nil {
+		bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{}
+	}
+	bundle.RootSchema.RequiredAgents = []runtimecontracts.FlowRequiredAgent{{
+		Role:         "worker",
+		SubscribesTo: []string{"task.completed"},
+		Emits:        []string{"task.completed"},
+	}}
+	bundle.Agents["worker"] = runtimecontracts.AgentRegistryEntry{
+		ID:               "worker",
+		Role:             "worker",
+		ModelTier:        "small",
+		ConversationMode: "task",
+		Subscriptions:    []string{"task.requested"},
+		EmitEvents:       []string{"task.completed"},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "required_agents_match", "root required agent worker subscriptions mismatch") {
+		t.Fatalf("expected root required_agents_match subscriptions error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsConditionPayloadMismatchToNamedError(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-condition-payload-mismatch")
 

--- a/internal/runtime/contracts/enums.go
+++ b/internal/runtime/contracts/enums.go
@@ -63,7 +63,7 @@ type ComputeOperation uint8
 const (
 	ComputeOpUnknown ComputeOperation = iota
 	ComputeOpWeightedAverage
-	ComputeOpWeightedSum
+	ComputeOpPickOrAverage
 	ComputeOpSum
 	ComputeOpMin
 	ComputeOpMax
@@ -74,8 +74,8 @@ func ParseComputeOperation(text string) (ComputeOperation, error) {
 	switch strings.ToLower(strings.TrimSpace(text)) {
 	case "weighted_average":
 		return ComputeOpWeightedAverage, nil
-	case "weighted_sum":
-		return ComputeOpWeightedSum, nil
+	case "pick_or_average":
+		return ComputeOpPickOrAverage, nil
 	case "sum":
 		return ComputeOpSum, nil
 	case "min":
@@ -95,8 +95,8 @@ func (o ComputeOperation) String() string {
 	switch o {
 	case ComputeOpWeightedAverage:
 		return "weighted_average"
-	case ComputeOpWeightedSum:
-		return "weighted_sum"
+	case ComputeOpPickOrAverage:
+		return "pick_or_average"
 	case ComputeOpSum:
 		return "sum"
 	case ComputeOpMin:

--- a/internal/runtime/contracts/errors.go
+++ b/internal/runtime/contracts/errors.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	ErrLoadValidation              = errors.New("contracts: bundle load validation failed")
+	ErrInvalidField                = errors.New("contracts: invalid field")
 	ErrConflictingCompletion       = errors.New("contracts: handler declares both on_complete and rules")
 	ErrDeprecatedGuardFallback     = errors.New("contracts: deprecated id-only guard")
 	ErrMultipleAuthoritativeOwners = errors.New("contracts: multiple authoritative system node owners")

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -55,6 +55,39 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsMultipleAuthoritati
 	}
 }
 
+func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidExecutionType(t *testing.T) {
+	bundle := loadCurrentWorkflowBundleForTest(t)
+
+	for nodeID, node := range bundle.Nodes {
+		node.ExecutionType = "workflow_node"
+		bundle.Nodes[nodeID] = node
+		break
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, "unsupported execution_type") {
+		t.Fatalf("unexpected load validation error: %v", err)
+	}
+}
+
+func TestValidateWorkflowContractBundleLoadConstraintsRejectsUnsupportedHandlerAction(t *testing.T) {
+	bundle := loadCurrentWorkflowBundleForTest(t)
+
+	nodeID, eventType, handler, ok := firstLoadedWorkflowHandler(bundle)
+	if !ok {
+		t.Fatal("expected workflow handler")
+	}
+	handler.Action = ActionSpec{ID: "increment_revision_count"}
+	node := bundle.Nodes[nodeID]
+	node.EventHandlers[eventType] = handler
+	bundle.Nodes[nodeID] = node
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, "action increment_revision_count is not in platform spec") {
+		t.Fatalf("unexpected load validation error: %v", err)
+	}
+}
+
 func TestLoadWorkflowContractBundle_PreservesEvidenceTarget(t *testing.T) {
 	bundle := loadCurrentWorkflowBundleForTest(t)
 	for _, node := range bundle.Nodes {

--- a/internal/runtime/contracts/system_node_contract_vocab.go
+++ b/internal/runtime/contracts/system_node_contract_vocab.go
@@ -1,0 +1,42 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+)
+
+const SystemNodeExecutionType = "system_node"
+
+func NormalizeHandlerActionID(id string) string {
+	return strings.TrimSpace(strings.ToLower(id))
+}
+
+func IsSupportedHandlerActionID(id string) bool {
+	switch NormalizeHandlerActionID(id) {
+	case "create_flow_instance", "record_evidence":
+		return true
+	default:
+		return false
+	}
+}
+
+func ParseHandlerActionID(id string) (string, error) {
+	normalized := NormalizeHandlerActionID(id)
+	if normalized == "" {
+		return "", nil
+	}
+	if !IsSupportedHandlerActionID(normalized) {
+		return "", fmt.Errorf("unsupported handler action %q", id)
+	}
+	return normalized, nil
+}
+
+func ValidateSystemNodeExecutionType(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("missing system node execution_type")
+	}
+	if strings.TrimSpace(strings.ToLower(raw)) != SystemNodeExecutionType {
+		return fmt.Errorf("unsupported execution_type %q", raw)
+	}
+	return nil
+}

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -128,6 +128,9 @@ func validateWorkflowContractBundleLoadConstraints(bundle *WorkflowContractBundl
 	errs := make([]error, 0, 8)
 	for nodeID, node := range bundle.Nodes {
 		nodeID = strings.TrimSpace(nodeID)
+		if err := ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+			errs = append(errs, fmt.Errorf("%w: node %s %v", ErrInvalidField, nodeID, err))
+		}
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
 			if workflowHandlerDeclaresConflictingCompletion(handler) {
@@ -135,6 +138,9 @@ func validateWorkflowContractBundleLoadConstraints(bundle *WorkflowContractBundl
 			}
 			if usesDeprecatedGuardFallback(handler.Guard) {
 				errs = append(errs, fmt.Errorf("%w: node %s handler %s uses deprecated id-only guard; migrate to check:", ErrDeprecatedGuardFallback, nodeID, eventType))
+			}
+			if strings.TrimSpace(handler.Action.ID) != "" && !IsSupportedHandlerActionID(handler.Action.ID) {
+				errs = append(errs, fmt.Errorf("%w: node %s handler %s action %s is not in platform spec", ErrInvalidField, nodeID, eventType, strings.TrimSpace(handler.Action.ID)))
 			}
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -159,8 +159,9 @@ type ComputeSpec struct {
 	Operation   ComputeOperation `yaml:"operation"`
 	Tiers       []ComputeTier    `yaml:"tiers"`
 	Keys        ComputeKeyConfig `yaml:"keys"`
+	Params      map[string]any   `yaml:"params"`
 	StoreAs     string           `yaml:"store_as"`
-	ItemsFrom   string           `yaml:"items_from"`
+	Description string           `yaml:"description"`
 	ValueField  string           `yaml:"value_field"`
 	WeightField string           `yaml:"weight_field"`
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -136,11 +136,9 @@ func (s *ComputeSpec) UnmarshalYAML(node *yaml.Node) error {
 		Operation   ComputeOperation `yaml:"operation"`
 		Tiers       []ComputeTier    `yaml:"tiers"`
 		Keys        ComputeKeyConfig `yaml:"keys"`
+		Params      map[string]any   `yaml:"params"`
 		StoreAs     string           `yaml:"store_as"`
-		ItemsFrom   string           `yaml:"items_from"`
-		ValueField  string           `yaml:"value_field"`
-		WeightField string           `yaml:"weight_field"`
-		OutputField string           `yaml:"output_field"`
+		Description string           `yaml:"description"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
@@ -149,19 +147,9 @@ func (s *ComputeSpec) UnmarshalYAML(node *yaml.Node) error {
 		Operation:   aux.Operation,
 		Tiers:       aux.Tiers,
 		Keys:        aux.Keys,
+		Params:      aux.Params,
 		StoreAs:     strings.TrimSpace(aux.StoreAs),
-		ItemsFrom:   strings.TrimSpace(aux.ItemsFrom),
-		ValueField:  strings.TrimSpace(aux.ValueField),
-		WeightField: strings.TrimSpace(aux.WeightField),
-	}
-	if s.StoreAs == "" {
-		if outputField := strings.TrimSpace(aux.OutputField); outputField != "" {
-			if strings.HasPrefix(outputField, "entity.") || strings.HasPrefix(outputField, "metadata.") {
-				s.StoreAs = outputField
-			} else {
-				s.StoreAs = "entity." + outputField
-			}
-		}
+		Description: strings.TrimSpace(aux.Description),
 	}
 	if err := validateTieredWeightedAverageSpec(*s); err != nil {
 		return err
@@ -174,14 +162,12 @@ func validateComputeFieldNodes(node *yaml.Node) error {
 		return nil
 	}
 	allowed := map[string]struct{}{
-		"operation":    {},
-		"tiers":        {},
-		"keys":         {},
-		"store_as":     {},
-		"items_from":   {},
-		"value_field":  {},
-		"weight_field": {},
-		"output_field": {},
+		"operation":   {},
+		"tiers":       {},
+		"keys":        {},
+		"params":      {},
+		"store_as":    {},
+		"description": {},
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -2,13 +2,10 @@ package contracts
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
-
-var legacyComputeExpressionPattern = regexp.MustCompile(`^\s*weighted_average\s*\(\s*accumulated\.([a-zA-Z0-9_]+)\s*,\s*accumulated\.([a-zA-Z0-9_]+)\s*\)\s*$`)
 
 func (r *HandlerRuleEntry) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind == yaml.ScalarNode {
@@ -132,6 +129,9 @@ func (s *ComputeSpec) UnmarshalYAML(node *yaml.Node) error {
 	if s == nil {
 		return nil
 	}
+	if err := validateComputeFieldNodes(node); err != nil {
+		return err
+	}
 	var aux struct {
 		Operation   ComputeOperation `yaml:"operation"`
 		Tiers       []ComputeTier    `yaml:"tiers"`
@@ -141,7 +141,6 @@ func (s *ComputeSpec) UnmarshalYAML(node *yaml.Node) error {
 		ValueField  string           `yaml:"value_field"`
 		WeightField string           `yaml:"weight_field"`
 		OutputField string           `yaml:"output_field"`
-		Expression  string           `yaml:"expression"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
@@ -164,22 +163,35 @@ func (s *ComputeSpec) UnmarshalYAML(node *yaml.Node) error {
 			}
 		}
 	}
-	if s.Operation == ComputeOpUnknown {
-		if valueField, weightField, ok := parseLegacyComputeExpression(strings.TrimSpace(aux.Expression)); ok {
-			s.Operation = ComputeOpWeightedAverage
-			if s.ItemsFrom == "" {
-				s.ItemsFrom = "accumulated.items"
-			}
-			if s.ValueField == "" {
-				s.ValueField = valueField
-			}
-			if s.WeightField == "" {
-				s.WeightField = weightField
-			}
-		}
-	}
 	if err := validateTieredWeightedAverageSpec(*s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateComputeFieldNodes(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"operation":    {},
+		"tiers":        {},
+		"keys":         {},
+		"store_as":     {},
+		"items_from":   {},
+		"value_field":  {},
+		"weight_field": {},
+		"output_field": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; ok {
+			continue
+		}
+		return fmt.Errorf("UNDEFINED-FIELD: compute field %q not in platform spec", key)
 	}
 	return nil
 }
@@ -195,22 +207,6 @@ func validateTieredWeightedAverageSpec(spec ComputeSpec) error {
 		return fmt.Errorf("invalid compute spec: weighted_average with tiers requires keys.score_keys")
 	}
 	return nil
-}
-
-func parseLegacyComputeExpression(expression string) (string, string, bool) {
-	match := legacyComputeExpressionPattern.FindStringSubmatch(expression)
-	if len(match) != 3 {
-		return "", "", false
-	}
-	return singularizeLegacyComputeField(match[1]), singularizeLegacyComputeField(match[2]), true
-}
-
-func singularizeLegacyComputeField(name string) string {
-	name = strings.TrimSpace(name)
-	if len(name) > 1 && strings.HasSuffix(name, "s") {
-		return strings.TrimSpace(strings.TrimSuffix(name, "s"))
-	}
-	return name
 }
 
 func (v *FlowVariable) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -473,7 +473,11 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 		if strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") || strings.TrimSpace(node.Value) == "" {
 			return ActionSpec{}, nil
 		}
-		return ActionSpec{ID: strings.TrimSpace(node.Value)}, nil
+		actionID, err := ParseHandlerActionID(node.Value)
+		if err != nil {
+			return ActionSpec{}, err
+		}
+		return ActionSpec{ID: actionID}, nil
 	case yaml.MappingNode:
 		var aux struct {
 			ID             string    `yaml:"id"`
@@ -484,12 +488,16 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 		if err := node.Decode(&aux); err != nil {
 			return ActionSpec{}, err
 		}
+		actionID, err := ParseHandlerActionID(aux.ID)
+		if err != nil {
+			return ActionSpec{}, err
+		}
 		configFrom, err := decodeConfigFromSpecNode(&aux.ConfigFrom)
 		if err != nil {
 			return ActionSpec{}, err
 		}
 		return ActionSpec{
-			ID:             strings.TrimSpace(aux.ID),
+			ID:             actionID,
 			Template:       strings.TrimSpace(aux.Template),
 			InstanceIDFrom: strings.TrimSpace(aux.InstanceIDFrom),
 			InstanceIDPath: paths.Parse(aux.InstanceIDFrom),

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -7,30 +7,51 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestHandlerRuleEntryDecode_PreservesLegacyComputeShorthand(t *testing.T) {
+func TestHandlerRuleEntryDecode_RejectsLegacyComputeExpressionShorthand(t *testing.T) {
 	var rule HandlerRuleEntry
-	if err := yaml.Unmarshal([]byte(`
+	err := yaml.Unmarshal([]byte(`
 condition: "else"
 compute:
   output_field: composite
   expression: "weighted_average(accumulated.scores, accumulated.weights)"
+`), &rule)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
+func TestHandlerRuleEntryDecode_AcceptsPickOrAverageOperation(t *testing.T) {
+	var rule HandlerRuleEntry
+	if err := yaml.Unmarshal([]byte(`
+condition: "else"
+compute:
+  operation: pick_or_average
+  store_as: entity.composite
+  keys:
+    numeric_keys: [score]
 `), &rule); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
 	if rule.Compute == nil {
 		t.Fatal("expected rule compute to be preserved")
 	}
-	if got := rule.Compute.Operation.String(); got != "weighted_average" {
+	if got := rule.Compute.Operation.String(); got != "pick_or_average" {
 		t.Fatalf("Compute.Operation = %q", got)
 	}
-	if got := rule.Compute.StoreAs; got != "entity.composite" {
-		t.Fatalf("Compute.StoreAs = %q", got)
-	}
-	if got := rule.Compute.ValueField; got != "score" {
-		t.Fatalf("Compute.ValueField = %q", got)
-	}
-	if got := rule.Compute.WeightField; got != "weight" {
-		t.Fatalf("Compute.WeightField = %q", got)
+}
+
+func TestHandlerRuleEntryDecode_RejectsWeightedSumOperation(t *testing.T) {
+	var rule HandlerRuleEntry
+	err := yaml.Unmarshal([]byte(`
+condition: "else"
+compute:
+  operation: weighted_sum
+  store_as: entity.composite
+  keys:
+    numeric_keys: [score]
+`), &rule)
+	if err == nil || !strings.Contains(err.Error(), "unsupported compute operation") {
+		t.Fatalf("yaml.Unmarshal error = %v, want unsupported compute operation", err)
 	}
 }
 
@@ -394,5 +415,15 @@ evidence_target: validation.results
 	}
 	if got := handler.EvidenceTarget; got != "validation.results" {
 		t.Fatalf("EvidenceTarget = %q", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnsupportedActionID(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action: increment_revision_count
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "unsupported handler action") {
+		t.Fatalf("yaml.Unmarshal error = %v, want unsupported handler action", err)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -12,11 +12,37 @@ func TestHandlerRuleEntryDecode_RejectsLegacyComputeExpressionShorthand(t *testi
 	err := yaml.Unmarshal([]byte(`
 condition: "else"
 compute:
-  output_field: composite
+  store_as: entity.composite
   expression: "weighted_average(accumulated.scores, accumulated.weights)"
 `), &rule)
 	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
 		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
+func TestHandlerRuleEntryDecode_AcceptsSpecComputeMetadataFields(t *testing.T) {
+	var rule HandlerRuleEntry
+	if err := yaml.Unmarshal([]byte(`
+condition: "else"
+compute:
+  operation: pick_or_average
+  description: choose the strongest score
+  params:
+    strategy: strict
+  store_as: entity.composite
+  keys:
+    numeric_keys: [score]
+`), &rule); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if rule.Compute == nil {
+		t.Fatal("expected rule compute to be preserved")
+	}
+	if got := rule.Compute.Description; got != "choose the strongest score" {
+		t.Fatalf("Compute.Description = %q", got)
+	}
+	if got := rule.Compute.Params["strategy"]; got != "strict" {
+		t.Fatalf("Compute.Params[strategy] = %#v", got)
 	}
 }
 
@@ -52,6 +78,21 @@ compute:
 `), &rule)
 	if err == nil || !strings.Contains(err.Error(), "unsupported compute operation") {
 		t.Fatalf("yaml.Unmarshal error = %v, want unsupported compute operation", err)
+	}
+}
+
+func TestHandlerRuleEntryDecode_RejectsLegacyOutputFieldAlias(t *testing.T) {
+	var rule HandlerRuleEntry
+	err := yaml.Unmarshal([]byte(`
+condition: "else"
+compute:
+  operation: pick_or_average
+  output_field: composite
+  keys:
+    numeric_keys: [score]
+`), &rule)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -284,7 +284,7 @@ evidence.recorded:
 	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
 audit-node:
   id: audit-node
-  execution_type: workflow_node
+  execution_type: system_node
   subscribes_to:
     - item.created
   produces:
@@ -328,6 +328,7 @@ mode: static
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "nodes.yaml"), `
 parent-node:
   id: parent-node
+  execution_type: system_node
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "events.yaml"), `
 parent.started:
@@ -360,6 +361,7 @@ mode: static
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "flows", "child", "nodes.yaml"), `
 child-node:
   id: child-node
+  execution_type: system_node
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "flows", "child", "events.yaml"), `
 child.completed:

--- a/internal/runtime/engine/enums.go
+++ b/internal/runtime/engine/enums.go
@@ -88,7 +88,6 @@ type GuardFailureAction uint8
 const (
 	GuardFailureUnknown GuardFailureAction = iota
 	GuardFailureReject
-	GuardFailureBlocked
 	GuardFailureDiscard
 	GuardFailureKill
 	GuardFailureEscalate
@@ -98,8 +97,6 @@ func (a GuardFailureAction) String() string {
 	switch a {
 	case GuardFailureReject:
 		return "reject"
-	case GuardFailureBlocked:
-		return "blocked"
 	case GuardFailureDiscard:
 		return "discard"
 	case GuardFailureKill:
@@ -121,8 +118,6 @@ func ParseGuardFailure(action string) (GuardFailure, error) {
 	switch normalized {
 	case "", "reject":
 		return GuardFailure{Action: GuardFailureReject}, nil
-	case "block", "blocked":
-		return GuardFailure{Action: GuardFailureBlocked}, nil
 	case "discard":
 		return GuardFailure{Action: GuardFailureDiscard}, nil
 	case "kill":

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1446,10 +1446,6 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, action string) error
 		frame.result.Status = OutcomeRejected
 		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "reject")
 		return nil
-	case GuardFailureBlocked:
-		frame.result.Status = OutcomeBlocked
-		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "blocked")
-		return nil
 	case GuardFailureDiscard:
 		frame.result.Status = OutcomeDiscarded
 		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "discard")

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -193,7 +193,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		return exec
 	}
 
-	blocked, err := newExecutor(50, false).Execute(context.Background(), ExecutionRequest{
+	rejected, err := newExecutor(50, false).Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
@@ -201,16 +201,16 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
-				OnFail: "blocked",
+				OnFail: "reject",
 			},
 			AdvancesTo: "approved",
 		},
 	})
 	if err != nil {
-		t.Fatalf("blocked Execute error: %v", err)
+		t.Fatalf("reject Execute error: %v", err)
 	}
-	if blocked.Status != OutcomeBlocked {
-		t.Fatalf("blocked Status = %q, want %q", blocked.Status, OutcomeBlocked)
+	if rejected.Status != OutcomeRejected {
+		t.Fatalf("rejected Status = %q, want %q", rejected.Status, OutcomeRejected)
 	}
 
 	passed, err := newExecutor(80, true).Execute(context.Background(), ExecutionRequest{
@@ -221,7 +221,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
-				OnFail: "blocked",
+				OnFail: "reject",
 			},
 			AdvancesTo: "approved",
 		},

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -857,8 +857,13 @@ func computeValue(acc *Accumulator, payload map[string]any, spec *runtimecontrac
 	switch spec.Operation {
 	case runtimecontracts.ComputeOpWeightedAverage:
 		return computeWeightedAverage(acc, spec), nil
-	case runtimecontracts.ComputeOpWeightedSum:
-		return computeWeightedPayload(payload, spec.Tiers), nil
+	case runtimecontracts.ComputeOpPickOrAverage:
+		return aggregateAccumulatorNumbers(acc, spec.Keys, func(current, next float64, idx int) float64 {
+			if idx == 0 || next > current {
+				return next
+			}
+			return current
+		}), nil
 	case runtimecontracts.ComputeOpSum:
 		return aggregateAccumulatorNumbers(acc, spec.Keys, func(current, next float64, idx int) float64 {
 			return current + next

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -417,6 +417,23 @@ func TestComputeValue(t *testing.T) {
 
 	acc = &Accumulator{
 		Items: []map[string]any{
+			{"payload": map[string]any{"score": 55.0}},
+			{"payload": map[string]any{"score": 81.0}},
+			{"payload": map[string]any{"score": 74.0}},
+		},
+	}
+	value, err = computeValue(acc, nil, &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpPickOrAverage,
+		Keys: runtimecontracts.ComputeKeyConfig{
+			NumericKeys: []string{"score"},
+		},
+	})
+	if err != nil || value.(float64) != 81 {
+		t.Fatalf("computeValue pick_or_average = %#v, %v", value, err)
+	}
+
+	acc = &Accumulator{
+		Items: []map[string]any{
 			{"payload": map[string]any{"score": 80.0, "weight": 0.5}},
 			{"payload": map[string]any{"score": 90.0, "weight": 0.3}},
 			{"payload": map[string]any{"score": 70.0, "weight": 0.2}},

--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -20,17 +20,13 @@ func TestCoordinatorHandlerExecutionEngineUsesRuntimeEnginePath(t *testing.T) {
 		t.Fatal("expected engine")
 	}
 	outcome, err := engine.ExecuteHandlerSteps(context.Background(), runtimecontracts.SystemNodeEventHandler{
-		Emits:  runtimecontracts.EventEmission{Single: "custom.emitted"},
-		Action: runtimecontracts.ActionSpec{ID: "increment_revision_count"},
+		Emits: runtimecontracts.EventEmission{Single: "custom.emitted"},
 	}, events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"))
 	if err != nil {
 		t.Fatalf("ExecuteHandlerSteps: %v", err)
 	}
 	if outcome == nil || !outcome.Handled {
 		t.Fatalf("handled outcome = %#v", outcome)
-	}
-	if len(outcome.ActionsExecuted) == 0 || outcome.ActionsExecuted[0] != "increment_revision_count" {
-		t.Fatalf("actions executed = %#v", outcome.ActionsExecuted)
 	}
 	if got := bus.publishedCount(); got != 1 {
 		t.Fatalf("bus published count = %d, want 1", got)

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -491,13 +491,13 @@ func (r pipelineEngineActionRegistry) HasAction(id identity.ActionKey) bool {
 	if r.registry != nil && r.registry.HasAction(id) {
 		return true
 	}
-	return isSupportedWorkflowHandlerActionID(id.String())
+	return runtimecontracts.IsSupportedHandlerActionID(id.String())
 }
 func (r pipelineEngineActionRegistry) IsExecutable(id identity.ActionKey) bool {
 	if r.registry != nil && r.registry.IsExecutable(id) {
 		return true
 	}
-	return isSupportedWorkflowHandlerActionID(id.String())
+	return runtimecontracts.IsSupportedHandlerActionID(id.String())
 }
 func (r pipelineEngineActionRegistry) Action(id identity.ActionKey) (runtimeregistry.ActionInstruction, bool) {
 	if r.registry != nil {
@@ -505,7 +505,7 @@ func (r pipelineEngineActionRegistry) Action(id identity.ActionKey) (runtimeregi
 			return instruction, true
 		}
 	}
-	if !isSupportedWorkflowHandlerActionID(id.String()) {
+	if !runtimecontracts.IsSupportedHandlerActionID(id.String()) {
 		return runtimeregistry.ActionInstruction{}, false
 	}
 	return runtimeregistry.ActionInstruction{
@@ -611,24 +611,11 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 	if pc == nil {
 		return false, nil
 	}
-	actionID := strings.TrimSpace(firstNonEmptyString(entry.Builtin, entry.Key.String(), action.ID))
+	actionID := runtimecontracts.NormalizeHandlerActionID(firstNonEmptyString(entry.Builtin, entry.Key.String(), action.ID))
 	if actionID == "" {
 		return false, nil
 	}
-	switch strings.TrimSpace(action.ID) {
-	case "increment_revision_count":
-		if pc.workflowStore != nil && pc.workflowStore.Enabled() {
-			_ = pc.workflowStore.Mutate(ctx, execCtx.Request.EntityID.String(), func(instance *WorkflowInstance) {
-				metadata := workflowMutableMetadata(instance)
-				metadata["revision_count"] = asInt(metadata["revision_count"]) + 1
-			})
-		}
-		return true, nil
-	case identity.ActionRecordStateChange.String(),
-		identity.ActionUpdateState.String(),
-		identity.ActionCancelStateTimers.String(),
-		identity.ActionStartStateTimers.String():
-		return true, nil
+	switch actionID {
 	case "record_evidence":
 		payload := parsePayloadMap(execCtx.Request.Event.Payload)
 		bucketID := pc.evidenceTargetForHandler(execCtx.Request.NodeID.String(), string(execCtx.Request.Event.Type))
@@ -643,7 +630,7 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 		plan := handlerExecutionPlan{
 			NodeID:         execCtx.Request.NodeID.String(),
 			EventType:      strings.TrimSpace(string(execCtx.Request.Event.Type)),
-			Action:         strings.TrimSpace(action.ID),
+			Action:         actionID,
 			Template:       strings.TrimSpace(action.Template),
 			InstanceIDFrom: strings.TrimSpace(action.InstanceIDFrom),
 			InstanceIDPath: action.InstanceIDPath,

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1000,7 +1000,7 @@ func TestPipelineEngineTimerApplierPersistsTimersAndDefersSchedulerToPostCommit(
 
 func TestPipelineEngineActionRegistry_SynthesizesSupportedBuiltinActions(t *testing.T) {
 	registry := pipelineEngineActionRegistry{}
-	id := identity.NormalizeActionKey("increment_revision_count")
+	id := identity.NormalizeActionKey("create_flow_instance")
 
 	if !registry.HasAction(id) {
 		t.Fatal("expected builtin action to be discoverable without explicit registry entry")
@@ -1012,7 +1012,22 @@ func TestPipelineEngineActionRegistry_SynthesizesSupportedBuiltinActions(t *test
 	if !ok {
 		t.Fatal("expected builtin action instruction")
 	}
-	if got := instruction.Builtin; got != "increment_revision_count" {
+	if got := instruction.Builtin; got != "create_flow_instance" {
 		t.Fatalf("Builtin = %q", got)
+	}
+}
+
+func TestPipelineEngineActionRegistry_DoesNotSynthesizeRemovedBuiltinActions(t *testing.T) {
+	registry := pipelineEngineActionRegistry{}
+	id := identity.NormalizeActionKey("increment_revision_count")
+
+	if registry.HasAction(id) {
+		t.Fatal("did not expect removed builtin action to be discoverable")
+	}
+	if registry.IsExecutable(id) {
+		t.Fatal("did not expect removed builtin action to be executable")
+	}
+	if _, ok := registry.Action(id); ok {
+		t.Fatal("did not expect removed builtin action instruction")
 	}
 }

--- a/internal/runtime/pipeline/guard_action_registry.go
+++ b/internal/runtime/pipeline/guard_action_registry.go
@@ -61,12 +61,7 @@ func isExecutableWorkflowActionEntry(entry runtimecontracts.GuardActionEntry) bo
 }
 
 func isSupportedWorkflowHandlerActionID(id string) bool {
-	switch normalizeWorkflowBuiltinActionID(id) {
-	case "create_flow_instance", "record_evidence":
-		return true
-	default:
-		return isSupportedWorkflowActionBuiltin(id)
-	}
+	return runtimecontracts.IsSupportedHandlerActionID(normalizeWorkflowBuiltinActionID(id))
 }
 
 type contractGuardRegistry struct {
@@ -181,16 +176,5 @@ func isSupportedWorkflowGuardBuiltin(id string) bool {
 }
 
 func isSupportedWorkflowActionBuiltin(id string) bool {
-	switch normalizeWorkflowBuiltinActionID(id) {
-	case "increment_revision_count",
-		"record_state_change",
-		"update_state",
-		"cancel_state_timers",
-		"start_state_timers",
-		"record_evidence",
-		"create_flow_instance":
-		return true
-	default:
-		return false
-	}
+	return runtimecontracts.IsSupportedHandlerActionID(normalizeWorkflowBuiltinActionID(id))
 }

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -920,7 +920,7 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 	}
 }
 
-func TestExecuteNodeContractHandlerExecutesHandlerActionInsideEngine(t *testing.T) {
+func TestExecuteNodeContractHandlerExecutesEmitInsideEngine(t *testing.T) {
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{
 		Module: NewGenericTestWorkflowModule(),
@@ -928,7 +928,7 @@ func TestExecuteNodeContractHandlerExecutesHandlerActionInsideEngine(t *testing.
 	entityID := "ent-1"
 
 	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
-		Action: runtimecontracts.ActionSpec{ID: "increment_revision_count"},
+		Emits: runtimecontracts.EventEmission{Single: "custom.emitted"},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID(entityID),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
@@ -939,10 +939,7 @@ func TestExecuteNodeContractHandlerExecutesHandlerActionInsideEngine(t *testing.
 	if !result.Handled {
 		t.Fatal("expected handled result")
 	}
-	if got := result.Outcome.ActionsExecuted; len(got) != 1 || got[0] != "increment_revision_count" {
-		t.Fatalf("actions executed = %#v, want [increment_revision_count]", got)
-	}
-	if got := bus.publishedCount(); got != 0 {
-		t.Fatalf("bus published count = %d, want 0", got)
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
 	}
 }

--- a/internal/runtime/pipeline/test_helpers_test.go
+++ b/internal/runtime/pipeline/test_helpers_test.go
@@ -86,7 +86,7 @@ item.reviewed:
 	writePipelineFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
 review-node:
   id: review-node
-  execution_type: workflow_node
+  execution_type: system_node
   subscribes_to:
     - item.created
   produces:

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -436,7 +436,7 @@ func (pc *PipelineCoordinator) BackgroundNodes(bus systemNodeBus, db *sql.DB) []
 	retryBase := workflowHandlerRetryBase(pc.SemanticSource())
 	out := make([]BackgroundNode, 0, 1)
 	for _, node := range pc.WorkflowNodes() {
-		if strings.TrimSpace(node.ExecutionType) != "workflow_node" {
+		if strings.TrimSpace(node.ExecutionType) != runtimecontracts.SystemNodeExecutionType {
 			continue
 		}
 		if executor := pc.backgroundWorkflowExecutor(strings.TrimSpace(node.ID)); executor != nil {

--- a/internal/runtime/swarmflowtest/catalog_runner_phase5_conformance_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_phase5_conformance_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestCatalogRunner_GuardOnFailBlockedPreservesStateAndSuppressesEmit(t *testing.T) {
+func TestCatalogRunner_GuardOnFailRejectPreservesStateAndSuppressesEmit(t *testing.T) {
 	dir := t.TempDir()
-	writeCatalogCaseFile(t, dir, "package.yaml", "name: guard-blocked\n")
+	writeCatalogCaseFile(t, dir, "package.yaml", "name: guard-reject\n")
 	writeCatalogCaseFixture(t, dir,
 		`
 initial_state: pending
@@ -30,7 +30,7 @@ test-node:
     check.requested:
       guard:
         check: "payload.score >= policy.minimum_score"
-        on_fail: blocked
+        on_fail: reject
       advances_to: done
       emits: check.passed
 `,
@@ -45,7 +45,7 @@ trigger:
     score: 12
 
 expected:
-  handler_outcome: blocked
+  handler_outcome: reject
   entity_state: pending
   emitted_events: []
 `,

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1352,8 +1352,19 @@ func catalogCollectBootIssues(bundle catalogBootBundle) []catalogBootIssue {
 				issues = append(issues, catalogBootIssue{Severity: "error", Category: "REQUIRED-AGENT", Message: fmt.Sprintf("%s: required role '%s' not in agents.yaml", scopeLabel, role)})
 				continue
 			}
+			schemaSubscriptions := catalogBootStringSet(required["subscribes_to"])
+			agentSubscriptions := catalogBootStringSet(agent["subscriptions"])
 			schemaEmits := catalogBootStringSet(required["emits"])
 			agentEmits := catalogBootStringSet(agent["emit_events"])
+			missingSubscriptions := make([]string, 0, len(schemaSubscriptions))
+			for _, ev := range catalogSortedSetKeys(schemaSubscriptions) {
+				if !catalogSetHas(agentSubscriptions, ev) {
+					missingSubscriptions = append(missingSubscriptions, ev)
+				}
+			}
+			if len(missingSubscriptions) > 0 {
+				issues = append(issues, catalogBootIssue{Severity: "error", Category: "SUBSCRIPTION-MISMATCH", Message: fmt.Sprintf("%s/%s: schema says subscribes_to %v but agent doesn't", scopeLabel, role, missingSubscriptions)})
+			}
 			missing := make([]string, 0, len(schemaEmits))
 			for _, ev := range catalogSortedSetKeys(schemaEmits) {
 				if !catalogSetHas(agentEmits, ev) {

--- a/internal/runtime/testdata/generic-swarm-bundle/agents.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/agents.yaml
@@ -5,6 +5,7 @@ control-plane:
   subscriptions:
     - item.review_requested
     - item.completed
+    - item.rejected
   emit_events:
     - item.created
 worker-a:
@@ -13,15 +14,21 @@ worker-a:
   manager_fallback: control-plane
   subscriptions:
     - item.review_requested
+    - item.processed
+    - item.completed
   emit_events:
     - item.processed
     - item.completed
+    - item.rejected
 worker-b:
   id: worker-b
   role: worker
   manager_fallback: control-plane
   subscriptions:
     - item.review_requested
+    - item.processed
+    - item.completed
   emit_events:
     - item.processed
     - item.completed
+    - item.rejected

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
@@ -1,6 +1,6 @@
 delivery-node:
   id: delivery-node
-  execution_type: workflow_node
+  execution_type: system_node
   idempotency_table: delivery_node_idempotency
   state_table: delivery_node_state
   subscribes_to:

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -1,6 +1,6 @@
 intake-router:
   id: intake-router
-  execution_type: workflow_node
+  execution_type: system_node
   idempotency_table: intake_router_idempotency
   state_table: intake_router_state
   subscribes_to:

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
@@ -1,6 +1,6 @@
 processing-node:
   id: processing-node
-  execution_type: workflow_node
+  execution_type: system_node
   idempotency_table: processing_node_idempotency
   state_table: processing_node_state
   subscribes_to:
@@ -14,7 +14,7 @@ processing-node:
       guard:
         id: delivery_enabled
         check: policy.delivery_enabled
-        on_fail: block
+        on_fail: reject
       branch:
         - condition: payload.priority == 'urgent'
           then:
@@ -22,7 +22,7 @@ processing-node:
           else:
             emits: item.rejected
       compute:
-        operation: weighted_sum
+        operation: pick_or_average
         store_as: score
         keys:
           numeric_keys:

--- a/internal/runtime/testdata/generic-swarm-bundle/hooks.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/hooks.yaml
@@ -7,8 +7,3 @@ guards:
     category: policy
     description: Delivery must remain enabled.
     policy_ref: delivery_enabled
-actions:
-  - id: record_state_change
-    category: bookkeeping
-    description: Records a generic state transition.
-    effect: store status and gate updates

--- a/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
@@ -1,8 +1,8 @@
 score.received:
   payload:
     entity_id: string
+    dimension: string
     score: float
-    weight: float
 scores.aggregated:
   payload:
     entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-with-compute/expected.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/expected.yaml
@@ -1,11 +1,11 @@
 trigger:
   sequence:
     - event: score.received
-      payload: { entity_id: 11111111-1111-4111-8111-111111111111, score: 80, weight: 0.5 }
+      payload: { entity_id: 11111111-1111-4111-8111-111111111111, dimension: a, score: 80 }
     - event: score.received
-      payload: { entity_id: 11111111-1111-4111-8111-111111111111, score: 90, weight: 0.3 }
+      payload: { entity_id: 11111111-1111-4111-8111-111111111111, dimension: b, score: 90 }
     - event: score.received
-      payload: { entity_id: 11111111-1111-4111-8111-111111111111, score: 70, weight: 0.2 }
+      payload: { entity_id: 11111111-1111-4111-8111-111111111111, dimension: c, score: 70 }
   entity_fields_before:
     expected_count: 3
 

--- a/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
@@ -10,8 +10,10 @@ test-node:
         completion: all
       on_complete:
         - compute:
+            operation: weighted_average
             output_field: composite
-            expression: "weighted_average(accumulated.scores, accumulated.weights)"
+            value_field: score
+            weight_field: weight
       advances_to: complete
       emits: scores.aggregated
   state_schema:

--- a/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
@@ -11,9 +11,17 @@ test-node:
       on_complete:
         - compute:
             operation: weighted_average
-            output_field: composite
-            value_field: score
-            weight_field: weight
+            store_as: entity.composite
+            keys:
+              dimension_key: dimension
+              score_keys: [score]
+            tiers:
+              - dimensions: [a]
+                weight: 0.5
+              - dimensions: [b]
+                weight: 0.3
+              - dimensions: [c]
+                weight: 0.2
       advances_to: complete
       emits: scores.aggregated
   state_schema:

--- a/tests/tier8-boot-verification/test-boot-emit-mismatch/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-emit-mismatch/nodes.yaml
@@ -1,6 +1,6 @@
 worker-node:
   id: worker-node
-  execution_type: agent_node
+  execution_type: system_node
   subscribes_to: [task.requested]
   produces: [task.completed]
   agent: worker

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/nodes.yaml
@@ -1,6 +1,6 @@
 stub-agent-node:
   id: stub-agent-node
-  execution_type: agent_node
+  execution_type: system_node
   subscribes_to: [task.requested]
   produces: [task.completed]
   agent: stub-agent


### PR DESCRIPTION
Closes #114

## Human Summary
This phase 2 change removes the remaining widened contract vocabulary and legacy loader interpretation identified in the prep audit, then migrates the affected fixtures atomically so boot/load/runtime all enforce the same platform-spec contract surface.

## What Changed
- narrowed guard `on_fail` handling to the spec set only: `reject`, `kill`, `discard`, `escalate:{event_name}`
- narrowed authored builtin handler actions to the spec set only: `create_flow_instance` and `record_evidence`
- aligned compute parsing to the spec enum set by removing authored `weighted_sum`, allowing authored `pick_or_average`, and deleting legacy compute-expression inference from the touched YAML loader path
- added explicit contract helpers for supported handler actions and required `execution_type: system_node`, then enforced them during bundle load/boot/runtime paths
- removed the required-agent subscription carve-outs so required agents must satisfy both subscription coverage and emit coverage for root and flow scopes
- migrated the invalidated generic bundle, tier2 accumulation, and tier8 boot fixtures in the same PR
- checked `/Users/youmew/swarm/empire/contracts` for widened builtin handler actions before narrowing; no live usage was found

## Why This Is Needed
The audited seams were still allowing authored values and loader behavior that are outside the platform spec. That left multiple semantic owners across contracts, boot verification, and runtime execution. This PR collapses those mismatches to the spec-defined vocabulary and removes the legacy authored-path behavior instead of preserving it behind compatibility branches.

## Scope Boundaries
- limited to the confirmed mismatches from issue #114 audit/review guidance
- no timer-trigger semantic changes beyond keeping affected regression surfaces green
- no spec edits
- no broader runtime redesign beyond the touched contract/boot/runtime enforcement seam

## Tests Run
- `rg -n "increment_revision_count|record_state_change|update_state|cancel_state_timers|start_state_timers" /Users/youmew/swarm/empire/contracts`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/pipeline ./internal/runtime/swarmflowtest -count=1`
- `go test ./... -count=1`

## Residual Risk
This deliberately drops authored contract values that were outside the platform spec. Any external contract set still using removed handler actions, `workflow_node`/`agent_node`, `weighted_sum`, or legacy compute-expression shorthand will now fail closed during load/boot until migrated.

## Follow-Up
No additional same-seam follow-up is required from this implementation. The timer-trigger vocabulary mismatch stayed out of change scope as directed and remains regression-only for this issue.