### PR TITLE
[agent-c][issue #233] Replace dashboard operator last_tool loose projection with typed fail-closed transport

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -94,7 +94,7 @@ type agentOperatorProjection struct {
 	TurnCount           int
 	Turns24h            int
 	CurrentTaskID       string
-	LastTool            map[string]any
+	LastTool            *AgentLastTool
 }
 
 func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[string]agentOperatorProjection, error) {
@@ -294,7 +294,10 @@ func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjec
 		return fmt.Errorf("decode latest agent turn turn_summary: %w", err)
 	}
 	if ok {
-		projection.LastTool = summary.lastToolMap(parseOK)
+		projection.LastTool, err = summary.lastToolTransport(parseOK)
+		if err != nil {
+			return fmt.Errorf("decode latest agent turn last_tool: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -166,25 +166,32 @@ func (p projectedTurnSummary) toolResultsTransport() []ConversationToolResult {
 	return out
 }
 
-func (p projectedTurnSummary) lastToolMap(parseOK bool) map[string]any {
+func (p projectedTurnSummary) lastToolTransport(parseOK bool) (*AgentLastTool, error) {
 	if len(p.ToolResults) == 0 {
-		return nil
+		return nil, nil
 	}
 	last := p.ToolResults[len(p.ToolResults)-1]
 	if last.ToolName == "" {
-		return nil
+		return nil, fmt.Errorf("latest canonical tool_result is missing tool_name")
 	}
-	out := map[string]any{
-		"name": last.ToolName,
-		"ok":   parseOK,
+	out := &AgentLastTool{
+		Name: last.ToolName,
+		OK:   parseOK,
+	}
+	if last.ToolUseID != "" {
+		out.ToolUseID = last.ToolUseID
 	}
 	if last.Output != nil {
-		var value any
-		if err := json.Unmarshal(last.Output, &value); err == nil {
-			out["result"] = value
+		trimmed := bytes.TrimSpace(last.Output)
+		if len(trimmed) == 0 {
+			return nil, fmt.Errorf("latest canonical tool_result output is empty")
 		}
+		if !json.Valid(trimmed) {
+			return nil, fmt.Errorf("latest canonical tool_result output is invalid JSON")
+		}
+		out.Result = append(json.RawMessage(nil), trimmed...)
 	}
-	return out
+	return out, nil
 }
 
 func trimStringSlice(in []string) []string {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -328,8 +328,15 @@ type genericAgent struct {
 	TotalTokens24h      int            `json:"total_tokens_24h,omitempty"`
 	NearBreaker         bool           `json:"near_breaker,omitempty"`
 	CurrentTaskID       string         `json:"current_task_id,omitempty"`
-	LastTool            map[string]any `json:"last_tool,omitempty"`
+	LastTool            *AgentLastTool `json:"last_tool,omitempty"`
 	StartedAt           string         `json:"started_at,omitempty"`
+}
+
+type AgentLastTool struct {
+	Name      string          `json:"name"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	OK        bool            `json:"ok"`
+	Result    json.RawMessage `json:"result,omitempty"`
 }
 
 type instanceAggregateGroup struct {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -738,15 +738,21 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	if items[0].CurrentTaskID != "task-1" {
 		t.Fatalf("current_task_id = %q", items[0].CurrentTaskID)
 	}
-	if items[0].LastTool["name"] != "schedule" {
+	if items[0].LastTool == nil || items[0].LastTool.Name != "schedule" {
 		t.Fatalf("last_tool = %#v", items[0].LastTool)
 	}
-	if items[0].LastTool["ok"] != true {
-		t.Fatalf("last_tool.ok = %#v", items[0].LastTool["ok"])
+	if items[0].LastTool.ToolUseID != "toolu_1" {
+		t.Fatalf("last_tool.tool_use_id = %#v", items[0].LastTool)
 	}
-	result, _ := items[0].LastTool["result"].(map[string]any)
+	if items[0].LastTool.OK != true {
+		t.Fatalf("last_tool.ok = %#v", items[0].LastTool.OK)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(items[0].LastTool.Result, &result); err != nil {
+		t.Fatalf("unmarshal last_tool.result: %v", err)
+	}
 	if result["status"] != "scheduled" {
-		t.Fatalf("last_tool.result = %#v", items[0].LastTool["result"])
+		t.Fatalf("last_tool.result = %#v", result)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -827,6 +833,42 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResult(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: canonicalEventAndConversationCaps(),
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
+		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
Closes #233

Spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_execution`
- governing rule: tool execution and results stay within the canonical agent-session/audit model; operator surfaces should project that canonical data rather than reinterpret it.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: native_tools`
- governing rule: tool capability/authorization is explicit in the agent contract; dashboard/operator transport should not invent a second loose semantic shape for tool execution state.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: emit_tool_convention`
- governing rule: tools exposed to agents and operators are canonical platform tool surfaces, not fallback read-model conventions.

## Human Summary

This replaces the operator `last_tool` dashboard surface with one explicit typed transport shape. The reader now preserves the canonical latest tool-result payload as raw JSON instead of widening it into `map[string]any`, and malformed canonical latest-tool items fail closed instead of being silently omitted.

## What Changed

- replaced `genericAgent.last_tool` from `map[string]any` to typed `AgentLastTool`
- replaced the loose `lastToolMap(...)` helper with `lastToolTransport(...)`
- preserved the canonical latest tool result as `json.RawMessage` instead of re-decoding it into a loose map
- made the operator projection fail when the latest canonical tool-result item is malformed for this transport seam, specifically when the latest item is missing `tool_name`
- updated dashboard operator tests to cover:
  - valid typed `last_tool` projection
  - missing canonical summary fail-closed behavior
  - malformed canonical turn-summary failure
  - malformed canonical latest-tool item failure

## Why This Is Needed

- the old `last_tool` projection widened canonical tool-result data back into an open `map[string]any`
- that made the dashboard reader a second semantic owner for tool-result meaning
- it also allowed malformed latest-tool projection state to be omitted instead of rejected explicitly

## Scope Boundaries

- In scope:
  - operator `last_tool` projection in the dashboard read-model seam
  - typed transport for the latest canonical tool result
  - fail-closed malformed latest-tool projection behavior
  - focused dashboard tests for this seam
- Not in scope:
  - broader runtime-state redesign
  - conversation/turn transport changes outside `last_tool`
  - new tool-result semantics beyond the cited spec-owned tool surfaces

## Tests Run

- `go test ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR keeps the existing operator `last_tool` meaning narrow: latest canonical tool name, tool use id, parse flag, and raw result payload
- if future operator surfaces need richer typed tool lifecycle detail, that should come from the canonical turn-summary/tool-result model rather than another local projection

## Follow-Up

- none needed for this seam
