### PR TITLE
[agent-a][issue #138] Canonicalize CLI native capability truth

### DIFF
--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -282,24 +282,31 @@ func cliExecutionToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 	}
 
 	if actor.NativeTools.Bash {
-		addNativeCapabilityTool("bash")
 		if _, ok := runtimeSet["bash"]; !ok {
 			providerBuiltins = append(providerBuiltins, "Bash")
 		}
+		addNativeCapabilityTool("bash")
 	}
 	if actor.NativeTools.WebSearch {
-		addNativeCapabilityTool("web_search")
 		if _, ok := runtimeSet["web_search"]; !ok {
 			providerBuiltins = append(providerBuiltins, "WebSearch")
 		}
+		addNativeCapabilityTool("web_search")
 	}
 	if actor.NativeTools.FileIO {
-		addNativeCapabilityTool("read_file")
-		addNativeCapabilityTool("write_file")
 		_, hasReadFallback := runtimeSet["read_file"]
 		_, hasWriteFallback := runtimeSet["write_file"]
-		if !hasReadFallback && !hasWriteFallback {
-			providerBuiltins = append(providerBuiltins, "Read", "Write", "Edit")
+		if hasReadFallback {
+			addNativeCapabilityTool("read_file")
+		} else {
+			providerBuiltins = append(providerBuiltins, "Read")
+			addNativeCapabilityTool("read_file")
+		}
+		if hasWriteFallback {
+			addNativeCapabilityTool("write_file")
+		} else {
+			providerBuiltins = append(providerBuiltins, "Write", "Edit")
+			addNativeCapabilityTool("write_file")
 		}
 	}
 

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"swarm/internal/config"
 	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/sessions"
 	runtimesharedjson "swarm/internal/runtime/sharedjson"
@@ -111,7 +112,7 @@ func parseCLIResponse(raw []byte) *Response {
 						args = m["arguments"]
 					}
 					resp.ToolCalls = append(resp.ToolCalls, ToolCall{
-						Name:      name,
+						Name:      toolidentity.CanonicalName(name),
 						Arguments: args,
 					})
 				}
@@ -129,7 +130,7 @@ func parseCLIResponse(raw []byte) *Response {
 					args = m["input"]
 				}
 				resp.ToolCalls = append(resp.ToolCalls, ToolCall{
-					Name:      name,
+					Name:      toolidentity.CanonicalName(name),
 					Arguments: args,
 				})
 			}
@@ -236,9 +237,97 @@ type AgentVisibleToolSurface struct {
 	NativeBuiltinTools []string
 }
 
-func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) AgentVisibleToolSurface {
+type CLIExecutionToolSurface struct {
+	CanonicalVisibleTools []string
+	RuntimeToolNames      []string
+	PromptRuntimeTools    []string
+	ProviderBuiltinTools  []string
+}
+
+func cliExecutionToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) CLIExecutionToolSurface {
 	runtimeNames := toolNames(tools)
 	slices.Sort(runtimeNames)
+
+	runtimeSet := make(map[string]struct{}, len(runtimeNames))
+	for _, name := range runtimeNames {
+		runtimeSet[name] = struct{}{}
+	}
+
+	canonicalVisible := make([]string, 0, len(runtimeNames)+4)
+	visibleSet := make(map[string]struct{}, len(runtimeNames)+4)
+	addCanonicalVisible := func(name string) {
+		name = toolidentity.CanonicalName(name)
+		if name == "" {
+			return
+		}
+		if _, ok := visibleSet[name]; ok {
+			return
+		}
+		visibleSet[name] = struct{}{}
+		canonicalVisible = append(canonicalVisible, name)
+	}
+	for _, name := range runtimeNames {
+		addCanonicalVisible(name)
+	}
+
+	providerBuiltins := make([]string, 0, 5)
+	nativeCapabilityTools := make(map[string]struct{}, 4)
+	addNativeCapabilityTool := func(name string) {
+		name = toolidentity.CanonicalName(name)
+		if name == "" {
+			return
+		}
+		nativeCapabilityTools[name] = struct{}{}
+		addCanonicalVisible(name)
+	}
+
+	if actor.NativeTools.Bash {
+		addNativeCapabilityTool("bash")
+		if _, ok := runtimeSet["bash"]; !ok {
+			providerBuiltins = append(providerBuiltins, "Bash")
+		}
+	}
+	if actor.NativeTools.WebSearch {
+		addNativeCapabilityTool("web_search")
+		if _, ok := runtimeSet["web_search"]; !ok {
+			providerBuiltins = append(providerBuiltins, "WebSearch")
+		}
+	}
+	if actor.NativeTools.FileIO {
+		addNativeCapabilityTool("read_file")
+		addNativeCapabilityTool("write_file")
+		_, hasReadFallback := runtimeSet["read_file"]
+		_, hasWriteFallback := runtimeSet["write_file"]
+		if !hasReadFallback && !hasWriteFallback {
+			providerBuiltins = append(providerBuiltins, "Read", "Write", "Edit")
+		}
+	}
+
+	promptRuntime := make([]string, 0, len(runtimeNames))
+	for _, name := range runtimeNames {
+		if _, ok := nativeCapabilityTools[name]; ok {
+			continue
+		}
+		promptRuntime = append(promptRuntime, name)
+	}
+
+	slices.Sort(providerBuiltins)
+	slices.Sort(canonicalVisible)
+	slices.Sort(promptRuntime)
+
+	return CLIExecutionToolSurface{
+		CanonicalVisibleTools: canonicalVisible,
+		RuntimeToolNames:      runtimeNames,
+		PromptRuntimeTools:    promptRuntime,
+		ProviderBuiltinTools:  providerBuiltins,
+	}
+}
+
+func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) AgentVisibleToolSurface {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	runtimeNames := append([]string(nil), surface.CanonicalVisibleTools...)
+	runtimeNames = runtimeNames[:0]
+	runtimeNames = append(runtimeNames, surface.RuntimeToolNames...)
 
 	runtimeSet := make(map[string]struct{}, len(runtimeNames))
 	for _, name := range runtimeNames {
@@ -255,31 +344,11 @@ func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 		nonEmitNames = append(nonEmitNames, name)
 	}
 
-	nativeBuiltins := make([]string, 0, 5)
-	if actor.NativeTools.Bash {
-		if _, ok := runtimeSet["bash"]; !ok {
-			nativeBuiltins = append(nativeBuiltins, "Bash")
-		}
-	}
-	if actor.NativeTools.WebSearch {
-		if _, ok := runtimeSet["web_search"]; !ok {
-			nativeBuiltins = append(nativeBuiltins, "WebSearch")
-		}
-	}
-	if actor.NativeTools.FileIO {
-		_, hasReadFallback := runtimeSet["read_file"]
-		_, hasWriteFallback := runtimeSet["write_file"]
-		if !hasReadFallback && !hasWriteFallback {
-			nativeBuiltins = append(nativeBuiltins, "Read", "Write", "Edit")
-		}
-	}
-	slices.Sort(nativeBuiltins)
-
 	return AgentVisibleToolSurface{
 		RuntimeToolNames:   runtimeNames,
 		EmitToolNames:      emitNames,
 		NonEmitToolNames:   nonEmitNames,
-		NativeBuiltinTools: nativeBuiltins,
+		NativeBuiltinTools: append([]string(nil), surface.ProviderBuiltinTools...),
 	}
 }
 
@@ -288,8 +357,8 @@ func claudeControlToolNames() []string {
 }
 
 func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
-	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	allowed := make([]string, 0, len(surface.RuntimeToolNames)+len(surface.NativeBuiltinTools)+len(claudeControlToolNames()))
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	allowed := make([]string, 0, len(surface.RuntimeToolNames)+len(surface.ProviderBuiltinTools)+len(claudeControlToolNames()))
 	seen := make(map[string]struct{}, cap(allowed))
 	addAllowed := func(name string) {
 		name = strings.TrimSpace(name)
@@ -305,7 +374,7 @@ func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefini
 	for _, name := range surface.RuntimeToolNames {
 		addAllowed(name)
 	}
-	for _, name := range surface.NativeBuiltinTools {
+	for _, name := range surface.ProviderBuiltinTools {
 		addAllowed(name)
 	}
 	for _, name := range claudeControlToolNames() {
@@ -316,9 +385,9 @@ func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefini
 }
 
 func claudeDisallowedBuiltinToolsArgForActor(actor models.AgentConfig, tools []ToolDefinition) string {
-	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	allowed := make(map[string]struct{}, len(surface.NativeBuiltinTools))
-	for _, name := range surface.NativeBuiltinTools {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	allowed := make(map[string]struct{}, len(surface.ProviderBuiltinTools))
+	for _, name := range surface.ProviderBuiltinTools {
 		allowed[name] = struct{}{}
 	}
 	names := make([]string, 0, len(claudeProviderBuiltinToolNames))
@@ -350,9 +419,9 @@ func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools
 	if strings.Contains(systemPrompt, cliToolInvocationMarker) {
 		return systemPrompt
 	}
-	surface := AgentVisibleToolSurfaceForActor(actor, tools)
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	controlTools := claudeControlToolNames()
-	if len(surface.RuntimeToolNames) == 0 && len(surface.NativeBuiltinTools) == 0 && len(controlTools) == 0 {
+	if len(surface.PromptRuntimeTools) == 0 && len(controlTools) == 0 {
 		return systemPrompt
 	}
 	var b strings.Builder
@@ -360,26 +429,21 @@ func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools
 	b.WriteString("\n\n")
 	b.WriteString(cliToolInvocationMarker)
 	b.WriteString("\n")
-	if len(surface.RuntimeToolNames) > 0 {
+	if len(surface.PromptRuntimeTools) > 0 {
 		b.WriteString("Call Swarm runtime tools by these exact names when you need them:\n")
-		for _, name := range surface.RuntimeToolNames {
+		for _, name := range surface.PromptRuntimeTools {
 			b.WriteString("- ")
 			b.WriteString(name)
 			b.WriteString("\n")
 		}
 		b.WriteString("If Claude CLI also shows MCP-prefixed variants like `mcp__runtime-tools__...`, they map to the same Swarm runtime tools.\n")
 	}
-	if len(surface.NativeBuiltinTools) > 0 {
-		b.WriteString("Claude CLI native tools available in this turn: ")
-		b.WriteString(strings.Join(surface.NativeBuiltinTools, ", "))
-		b.WriteString(".\n")
-	}
 	if len(controlTools) > 0 {
 		b.WriteString("Claude CLI control tools available in this turn: ")
 		b.WriteString(strings.Join(controlTools, ", "))
 		b.WriteString(".\n")
 	}
-	if hasToolPrefix(surface.RuntimeToolNames, "emit_") {
+	if hasToolPrefix(surface.PromptRuntimeTools, "emit_") {
 		b.WriteString("When you need to publish an event, call the matching `emit_*` tool directly. Emit tools may not appear as MCP-prefixed variants in Claude CLI; Swarm will execute the exact `emit_*` call locally. Do not write JSON files under `/workspace/events` as a substitute for emission.\n")
 	}
 	return strings.TrimSpace(b.String())

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -363,6 +363,51 @@ func claudeControlToolNames() []string {
 	return []string{"ExitPlanMode"}
 }
 
+func isCLIControlToolName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for _, control := range claudeControlToolNames() {
+		if name == control {
+			return true
+		}
+	}
+	return false
+}
+
+func filterCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition, observed []string) []string {
+	if len(observed) == 0 {
+		return nil
+	}
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	if len(surface.CanonicalVisibleTools) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(surface.CanonicalVisibleTools))
+	for _, name := range surface.CanonicalVisibleTools {
+		allowed[strings.TrimSpace(name)] = struct{}{}
+	}
+	filtered := make([]string, 0, len(observed))
+	seen := make(map[string]struct{}, len(observed))
+	for _, name := range observed {
+		name = toolidentity.CanonicalName(name)
+		if name == "" || isCLIControlToolName(name) {
+			continue
+		}
+		if _, ok := allowed[name]; !ok {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		filtered = append(filtered, name)
+	}
+	slices.Sort(filtered)
+	return filtered
+}
+
 func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	allowed := make([]string, 0, len(surface.RuntimeToolNames)+len(surface.ProviderBuiltinTools)+len(claudeControlToolNames()))

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -152,11 +152,37 @@ func TestClaudeToolSurface_PrefersFallbackRuntimeToolsOverNativeBuiltins(t *test
 	if !strings.Contains(prompt, "Call Swarm runtime tools by these exact names") {
 		t.Fatalf("expected runtime tool prompt section, got %q", prompt)
 	}
-	if !strings.Contains(prompt, "read_file") || !strings.Contains(prompt, "write_file") || !strings.Contains(prompt, "bash") {
-		t.Fatalf("expected fallback runtime tools in prompt, got %q", prompt)
+	if !strings.Contains(prompt, "emit_category_assessed") {
+		t.Fatalf("expected non-native runtime tools in prompt, got %q", prompt)
+	}
+	for _, name := range []string{"read_file", "write_file", "bash"} {
+		if strings.Contains(prompt, name) {
+			t.Fatalf("did not expect native capability tool %q in prompt, got %q", name, prompt)
+		}
 	}
 	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
 		t.Fatalf("did not expect native builtin prompt section when fallback runtime tools own the surface, got %q", prompt)
+	}
+}
+
+func TestCLIExecutionToolSurface_CanonicalizesProviderBuiltins(t *testing.T) {
+	surface := cliExecutionToolSurfaceForActor(models.AgentConfig{
+		NativeTools: models.NativeToolConfig{
+			FileIO:    true,
+			WebSearch: true,
+		},
+	}, []ToolDefinition{
+		{Name: "emit_category_assessed"},
+	})
+
+	if !slices.Equal(surface.CanonicalVisibleTools, []string{"emit_category_assessed", "read_file", "web_search", "write_file"}) {
+		t.Fatalf("canonical visible tools = %#v", surface.CanonicalVisibleTools)
+	}
+	if !slices.Equal(surface.ProviderBuiltinTools, []string{"Edit", "Read", "WebSearch", "Write"}) {
+		t.Fatalf("provider builtin tools = %#v", surface.ProviderBuiltinTools)
+	}
+	if !slices.Equal(surface.PromptRuntimeTools, []string{"emit_category_assessed"}) {
+		t.Fatalf("prompt runtime tools = %#v", surface.PromptRuntimeTools)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -186,6 +186,24 @@ func TestCLIExecutionToolSurface_CanonicalizesProviderBuiltins(t *testing.T) {
 	}
 }
 
+func TestCLIExecutionToolSurface_FileIOMixedFallbacksStayExecutable(t *testing.T) {
+	surface := cliExecutionToolSurfaceForActor(models.AgentConfig{
+		NativeTools: models.NativeToolConfig{
+			FileIO: true,
+		},
+	}, []ToolDefinition{
+		{Name: "read_file"},
+		{Name: "emit_category_assessed"},
+	})
+
+	if !slices.Equal(surface.CanonicalVisibleTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
+		t.Fatalf("canonical visible tools = %#v", surface.CanonicalVisibleTools)
+	}
+	if !slices.Equal(surface.ProviderBuiltinTools, []string{"Edit", "Write"}) {
+		t.Fatalf("provider builtin tools = %#v", surface.ProviderBuiltinTools)
+	}
+}
+
 func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:18082")

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+
+	"swarm/internal/runtime/core/toolidentity"
 )
 
 type cliStreamAccumulator struct {
@@ -17,6 +19,7 @@ type cliStreamAccumulator struct {
 	pending          map[int]*cliPendingToolCall
 	completedToolIDs map[string]struct{}
 	mcpServers       map[string]string
+	visibleTools     []string
 	mcpVisibleTools  []string
 }
 
@@ -186,7 +189,7 @@ func (a *cliStreamAccumulator) mergeStreamEvent(obj map[string]any) {
 			a.streamedCalls = append(a.streamedCalls, cliRecordedToolCall{
 				ID: strings.TrimSpace(call.ID),
 				Call: ToolCall{
-					Name:      call.Name,
+					Name:      toolidentity.CanonicalName(call.Name),
 					Arguments: args,
 				},
 			})
@@ -209,6 +212,9 @@ func (a *cliStreamAccumulator) captureDiagnostics(obj map[string]any) {
 			}
 		case "tools":
 			for _, name := range parseVisibleToolNames(value) {
+				a.appendVisibleTool(name)
+			}
+			for _, name := range parseMCPVisibleToolNames(value) {
 				a.appendVisibleTool(name)
 			}
 		}
@@ -262,6 +268,37 @@ func parseVisibleToolNames(value any) []string {
 	for _, item := range list {
 		switch typed := item.(type) {
 		case string:
+			name := toolidentity.CanonicalName(typed)
+			if name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					out = append(out, name)
+				}
+			}
+		case map[string]any:
+			name := toolidentity.CanonicalName(asString(typed["name"]))
+			if name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					out = append(out, name)
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseMCPVisibleToolNames(value any) []string {
+	list, ok := value.([]any)
+	if !ok || len(list) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		switch typed := item.(type) {
+		case string:
 			name := strings.TrimSpace(typed)
 			if strings.HasPrefix(name, runtimeToolsMCPPrefix) {
 				if _, ok := seen[name]; !ok {
@@ -279,6 +316,7 @@ func parseVisibleToolNames(value any) []string {
 			}
 		}
 	}
+	sort.Strings(out)
 	return out
 }
 
@@ -287,6 +325,19 @@ func (a *cliStreamAccumulator) appendVisibleTool(name string) {
 		return
 	}
 	name = strings.TrimSpace(name)
+	if canonical := toolidentity.CanonicalName(name); canonical != "" {
+		found := false
+		for _, existing := range a.visibleTools {
+			if existing == canonical {
+				found = true
+				break
+			}
+		}
+		if !found {
+			a.visibleTools = append(a.visibleTools, canonical)
+			sort.Strings(a.visibleTools)
+		}
+	}
 	if !strings.HasPrefix(name, runtimeToolsMCPPrefix) {
 		return
 	}
@@ -334,6 +385,7 @@ func (a *cliStreamAccumulator) Response() *Response {
 		ToolCalls:       dedupeToolCalls(toolCalls),
 		SessionID:       strings.TrimSpace(a.sessionID),
 		Raw:             bytes.TrimSpace(a.raw.Bytes()),
+		VisibleTools:    append([]string(nil), a.visibleTools...),
 		MCPServers:      a.mcpServers,
 		MCPVisibleTools: append([]string(nil), a.mcpVisibleTools...),
 	}

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -201,39 +201,20 @@ func (a *cliStreamAccumulator) captureDiagnostics(obj map[string]any) {
 	if a == nil || len(obj) == 0 {
 		return
 	}
-	walkCLIVisibilityPayload(obj, func(key string, value any) {
-		switch key {
-		case "mcp_servers":
-			for name, status := range parseMCPServers(value) {
-				if a.mcpServers == nil {
-					a.mcpServers = map[string]string{}
-				}
-				a.mcpServers[name] = status
+	if value, ok := obj["mcp_servers"]; ok {
+		for name, status := range parseMCPServers(value) {
+			if a.mcpServers == nil {
+				a.mcpServers = map[string]string{}
 			}
-		case "tools":
-			for _, name := range parseVisibleToolNames(value) {
-				a.appendVisibleTool(name)
-			}
-			for _, name := range parseMCPVisibleToolNames(value) {
-				a.appendVisibleTool(name)
-			}
+			a.mcpServers[name] = status
 		}
-	})
-}
-
-func walkCLIVisibilityPayload(value any, visit func(key string, value any)) {
-	switch typed := value.(type) {
-	case map[string]any:
-		for rawKey, nested := range typed {
-			key := strings.TrimSpace(strings.ToLower(rawKey))
-			if key != "" {
-				visit(key, nested)
-			}
-			walkCLIVisibilityPayload(nested, visit)
+	}
+	if value, ok := obj["tools"]; ok {
+		for _, name := range parseVisibleToolNames(value) {
+			a.appendVisibleTool(name)
 		}
-	case []any:
-		for _, nested := range typed {
-			walkCLIVisibilityPayload(nested, visit)
+		for _, name := range parseMCPVisibleToolNames(value) {
+			a.appendVisibleTool(name)
 		}
 	}
 }

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -306,7 +306,13 @@ func (a *cliStreamAccumulator) appendVisibleTool(name string) {
 		return
 	}
 	name = strings.TrimSpace(name)
+	if isCLIControlToolName(name) {
+		return
+	}
 	if canonical := toolidentity.CanonicalName(name); canonical != "" {
+		if isCLIControlToolName(canonical) {
+			return
+		}
 		found := false
 		for _, existing := range a.visibleTools {
 			if existing == canonical {

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -132,3 +132,14 @@ func TestParseCLIResponse_NormalizesBuiltinToolCallNames(t *testing.T) {
 		t.Fatalf("second tool call = %#v", resp.ToolCalls[1])
 	}
 }
+
+func TestCLIStreamAccumulator_IgnoresNestedToolArgumentListsForVisibility(t *testing.T) {
+	acc := newCLIStreamAccumulator()
+	acc.AddLine([]byte(`{"type":"system","subtype":"init","session_id":"sess-nested","tools":["Read"]}`))
+	acc.AddLine([]byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"agent_hire","input":{"tools":["bash","web_search"]}}]}}`))
+
+	resp := acc.Response()
+	if len(resp.VisibleTools) != 1 || resp.VisibleTools[0] != "read_file" {
+		t.Fatalf("visible tools = %#v", resp.VisibleTools)
+	}
+}

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -56,11 +56,14 @@ func TestCLIStreamAccumulator_ReconstructsStreamedToolInput(t *testing.T) {
 	if got := args["score"]; got != float64(65) {
 		t.Fatalf("unexpected score: %#v", got)
 	}
-	if resp.ToolCalls[1].Name != "mcp__runtime-tools__emit_category_assessed" {
+	if resp.ToolCalls[1].Name != "emit_category_assessed" {
 		t.Fatalf("unexpected second tool name: %+v", resp.ToolCalls[1])
 	}
 	if got := resp.MCPServers["runtime-tools"]; got != "connected" {
 		t.Fatalf("mcp servers = %#v", resp.MCPServers)
+	}
+	if len(resp.VisibleTools) != 3 || resp.VisibleTools[0] != "emit_category_assessed" || resp.VisibleTools[1] != "query_metrics" || resp.VisibleTools[2] != "read_file" {
+		t.Fatalf("visible tools = %#v", resp.VisibleTools)
 	}
 	if len(resp.MCPVisibleTools) != 2 || resp.MCPVisibleTools[0] != "mcp__runtime-tools__emit_category_assessed" || resp.MCPVisibleTools[1] != "mcp__runtime-tools__query_metrics" {
 		t.Fatalf("mcp visible tools = %#v", resp.MCPVisibleTools)
@@ -111,5 +114,21 @@ func TestSummarizeMonitorEventLine_Assistant(t *testing.T) {
 	want := "assistant: working tools=emit_event"
 	if got != want {
 		t.Fatalf("unexpected monitor summary: got=%q want=%q", got, want)
+	}
+}
+
+func TestParseCLIResponse_NormalizesBuiltinToolCallNames(t *testing.T) {
+	resp := parseCLIResponse([]byte(`{"content":[{"type":"tool_use","name":"Read","input":{"path":"/tmp/a.txt"}},{"type":"tool_use","name":"Edit","input":{"path":"/tmp/a.txt","content":"x"}}]}`))
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %#v", resp.ToolCalls)
+	}
+	if resp.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("first tool call = %#v", resp.ToolCalls[0])
+	}
+	if resp.ToolCalls[1].Name != "write_file" {
+		t.Fatalf("second tool call = %#v", resp.ToolCalls[1])
 	}
 }

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -143,3 +143,13 @@ func TestCLIStreamAccumulator_IgnoresNestedToolArgumentListsForVisibility(t *tes
 		t.Fatalf("visible tools = %#v", resp.VisibleTools)
 	}
 }
+
+func TestCLIStreamAccumulator_IgnoresCLIControlToolsForVisibility(t *testing.T) {
+	acc := newCLIStreamAccumulator()
+	acc.AddLine([]byte(`{"type":"system","subtype":"init","session_id":"sess-control","tools":["Read","ExitPlanMode","mcp__runtime-tools__emit_category_assessed"]}`))
+
+	resp := acc.Response()
+	if len(resp.VisibleTools) != 2 || resp.VisibleTools[0] != "emit_category_assessed" || resp.VisibleTools[1] != "read_file" {
+		t.Fatalf("visible tools = %#v", resp.VisibleTools)
+	}
+}

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -70,7 +70,8 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		rec.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
 	}
 	if resp != nil && len(rec.AvailableTools) == 0 && len(resp.VisibleTools) > 0 {
-		rec.AvailableTools = append([]string(nil), resp.VisibleTools...)
+		actor, _ := runtimeactors.ActorFromContext(ctx)
+		rec.AvailableTools = append([]string(nil), filterCanonicalVisibleToolsForActor(actor, sessionTools(s), resp.VisibleTools)...)
 	}
 	if resp != nil && len(rec.MCPToolsVisible) == 0 {
 		rec.MCPToolsVisible = append([]string(nil), resp.MCPVisibleTools...)
@@ -111,6 +112,13 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		rec.AvailableTools = append([]string(nil), cliExecutionToolSurfaceForActor(actor, s.Tools).CanonicalVisibleTools...)
 	}
 	return rec
+}
+
+func sessionTools(s *Session) []ToolDefinition {
+	if s == nil {
+		return nil
+	}
+	return s.Tools
 }
 
 func mcpListedToolsForSession(tools []ToolDefinition) []string {

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 )
 
@@ -47,15 +48,6 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		if strings.TrimSpace(rec.ScopeKey) == "" {
 			rec.ScopeKey = strings.TrimSpace(s.ScopeKey)
 		}
-		if len(rec.AvailableTools) == 0 && len(s.Tools) > 0 {
-			rec.AvailableTools = make([]string, 0, len(s.Tools))
-			for _, tool := range s.Tools {
-				name := strings.TrimSpace(tool.Name)
-				if name != "" {
-					rec.AvailableTools = append(rec.AvailableTools, name)
-				}
-			}
-		}
 		if len(rec.MCPToolsListed) == 0 {
 			rec.MCPToolsListed = mcpListedToolsForSession(s.Tools)
 		}
@@ -76,6 +68,9 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	}
 	if resp != nil && len(rec.ToolCalls) == 0 {
 		rec.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+	}
+	if resp != nil && len(rec.AvailableTools) == 0 && len(resp.VisibleTools) > 0 {
+		rec.AvailableTools = append([]string(nil), resp.VisibleTools...)
 	}
 	if resp != nil && len(rec.MCPToolsVisible) == 0 {
 		rec.MCPToolsVisible = append([]string(nil), resp.MCPVisibleTools...)
@@ -110,6 +105,10 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		if eventRec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && eventRec != nil {
 			rec.FlightRecorder = append([]runtimebus.FlightRecorderEntry(nil), eventRec.SnapshotFlightRecorder()...)
 		}
+	}
+	if len(rec.AvailableTools) == 0 && s != nil {
+		actor, _ := runtimeactors.ActorFromContext(ctx)
+		rec.AvailableTools = append([]string(nil), cliExecutionToolSurfaceForActor(actor, s.Tools).CanonicalVisibleTools...)
 	}
 	return rec
 }

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -183,10 +184,68 @@ func TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools(t *test
 		t.Fatalf("expected emit tool name in system prompt, got %q", s.SystemPrompt)
 	}
 	if !strings.Contains(s.SystemPrompt, "read_file") {
-		t.Fatalf("expected native fallback tool name in system prompt, got %q", s.SystemPrompt)
+		t.Fatalf("expected runtime tool name in system prompt, got %q", s.SystemPrompt)
+	}
+	if strings.Contains(s.SystemPrompt, "Claude CLI native tools available in this turn") {
+		t.Fatalf("did not expect native builtin prompt section, got %q", s.SystemPrompt)
 	}
 	if !strings.Contains(s.SystemPrompt, "Do not write JSON files under `/workspace/events`") {
 		t.Fatalf("expected emit workaround warning in system prompt, got %q", s.SystemPrompt)
+	}
+}
+
+func TestEnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+		NativeTools: runtimeactors.NativeToolConfig{
+			FileIO: true,
+			Bash:   true,
+		},
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, nil)
+
+	if len(rec.AvailableTools) != 4 {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+	if !slices.Equal(rec.AvailableTools, []string{"bash", "emit_category_assessed", "read_file", "write_file"}) {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+}
+
+func TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble(t *testing.T) {
+	actor := runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+		NativeTools: runtimeactors.NativeToolConfig{
+			FileIO: true,
+			Bash:   true,
+		},
+	}
+	prompt := augmentCLISystemPrompt("base prompt", actor, []ToolDefinition{
+		{Name: "emit_market_research_scan_complete"},
+		{Name: "read_file"},
+		{Name: "write_file"},
+		{Name: "bash"},
+	})
+
+	if !strings.Contains(prompt, "emit_market_research_scan_complete") {
+		t.Fatalf("expected non-native runtime tool in prompt, got %q", prompt)
+	}
+	for _, name := range []string{"read_file", "write_file", "bash"} {
+		if strings.Contains(prompt, name) {
+			t.Fatalf("did not expect native capability tool %q in prompt, got %q", name, prompt)
+		}
+	}
+	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
+		t.Fatalf("did not expect native builtin prompt section, got %q", prompt)
 	}
 }
 

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -221,6 +221,31 @@ func TestEnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities(t *test
 	}
 }
 
+func TestEnrichTurnRecord_FiltersCLIControlToolsFromObservedVisibleTools(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+		NativeTools: runtimeactors.NativeToolConfig{
+			FileIO: true,
+		},
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, &Response{
+		VisibleTools: []string{"ExitPlanMode", "emit_category_assessed", "read_file", "write_file"},
+	})
+
+	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+}
+
 func TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble(t *testing.T) {
 	actor := runtimeactors.AgentConfig{
 		ID: "analysis-agent",

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -23,6 +23,7 @@ type Response struct {
 	ToolCalls       []ToolCall        `json:"tool_calls,omitempty"`
 	SessionID       string            `json:"session_id,omitempty"`
 	Raw             []byte            `json:"raw,omitempty"`
+	VisibleTools    []string          `json:"visible_tools,omitempty"`
 	MCPServers      map[string]string `json:"mcp_servers,omitempty"`
 	MCPVisibleTools []string          `json:"mcp_visible_tools,omitempty"`
 }


### PR DESCRIPTION
Closes #138

Spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_execution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: native_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: emit_tool_convention`
- governing rule: tool availability, execution, audit, and operator surfaces must align to the canonical agent-session/tool-execution model rather than loose projections or fallback visibility rules.

## Human Summary
This PR makes the CLI native-capability path tell one coherent story. Native capability authorization, the tool names Claude CLI is allowed to use, the visibility recorded from CLI output, and the persisted turn audit now reconcile through one canonical CLI execution surface instead of mixing provider builtin names, fallback runtime names, and MCP-prefixed names.

## What Changed
- introduced a CLI-specific execution surface that owns canonical visible tool names, runtime tool names, prompt-visible runtime tool names, and provider builtin allowlist names
- kept Claude transport args provider-specific where required (`Read`, `Edit`, `Bash`, etc.) but normalized persisted visibility and recorded tool usage to canonical runtime names (`read_file`, `write_file`, `bash`, etc.)
- stopped describing native capabilities in the CLI postamble; prompt augmentation now excludes native-capability tools from the prompt-owned runtime tool list in this seam
- taught the CLI stream parser to capture both:
  - canonical visible tools for audit/persistence
  - raw MCP-prefixed visible tools for the MCP-specific subset
- made persisted `available_tools` prefer the actual canonical visible surface observed from the CLI response and otherwise fall back to the same canonical CLI execution surface
- normalized parsed builtin tool-call names so recorded usage no longer drifts from the canonical visible/authorized surface

## Why This Is Needed
Before this change, the touched CLI path had multiple conflicting truth surfaces:
- provider builtins used raw names like `Read` / `Edit`
- fallback runtime tools used canonical names like `read_file` / `write_file`
- persisted `available_tools` only recorded session runtime tools
- `mcp_tools_visible` only captured the MCP-prefixed subset
- the CLI prompt could advertise native fallback tools separately from the spec-owned tool-definition path

That made it hard to answer one basic question consistently: what native capability was authorized, actually exposed to the agent, and actually used?

## Scope Boundaries
- In scope:
  - CLI native capability visibility/authorization/recording reconciliation in the touched execution seam
  - CLI prompt augmentation only where needed to remove native-capability-specific visibility drift
  - canonical parsing/persistence of visible tool names and used tool names in the CLI path
- Not in scope:
  - broad MCP transport redesign
  - non-CLI runtime behavior
  - general dashboard/operator redesign beyond the persisted turn surfaces touched here

## Tests Run
- `go test ./internal/runtime/llm ./internal/runtime/tools -count=1`
- `go test ./... -count=1`

## Residual Risk
The touched seam now records canonical native tool truth even when Claude exposes provider-specific builtin names, but it does not redesign every downstream consumer of `available_tools` / `mcp_tools_visible`. Surfaces outside this seam that choose to privilege the raw MCP subset over the canonical `available_tools` surface could still present a narrower view unless they are updated to consume the canonical owner.

## Follow-Up
No spec escalation was needed.
No same-seam follow-up is required for this PR.