### PR TITLE
[agent-d][issue #245] Expose canonical delivery lifecycle transitions

### DIFF
--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -104,6 +104,12 @@ type runtimeLogRecord struct {
 	DurationUS    int    `json:"duration_us,omitempty"`
 	Source        string `json:"source,omitempty"`
 	Message       string `json:"message,omitempty"`
+	DeliveryState string `json:"delivery_state,omitempty"`
+	PreviousState string `json:"delivery_previous_state,omitempty"`
+	Transition    string `json:"delivery_transition,omitempty"`
+	Reason        string `json:"delivery_reason,omitempty"`
+	Terminal      string `json:"delivery_terminal_outcome,omitempty"`
+	RetryCount    int    `json:"delivery_retry_count,omitempty"`
 	Detail        any    `json:"detail,omitempty"`
 	Correlation   any    `json:"correlation,omitempty"`
 }
@@ -347,6 +353,12 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 			COALESCE(e.payload->'details'->>'entity_id', ''),
 			COALESCE(e.payload->'details'->>'session_id', ''),
 			COALESCE(NULLIF(e.payload->'details'->>'duration_us', ''), '0')::int,
+			COALESCE(e.payload->'details'->>'delivery_state', ''),
+			COALESCE(e.payload->'details'->>'delivery_previous_state', ''),
+			COALESCE(e.payload->'details'->>'delivery_transition', ''),
+			COALESCE(e.payload->'details'->>'delivery_reason', ''),
+			COALESCE(e.payload->'details'->>'delivery_terminal_outcome', ''),
+			COALESCE(NULLIF(e.payload->'details'->>'retry_count', ''), '0')::int,
 			COALESCE(e.payload->'details', '{}'::jsonb),
 			COALESCE(e.payload->'details'->'correlation', '{}'::jsonb),
 			COALESCE(e.payload->>'message', '')
@@ -384,7 +396,7 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 			detailRaw      []byte
 			correlationRaw []byte
 		)
-		if err := rows.Scan(&item.ID, &item.EventID, &item.TS, &item.Level, &item.Component, &item.Action, &item.EventType, &item.ParentEventID, &item.HandlerID, &item.Error, &item.ErrorCode, &item.AgentID, &item.Source, &item.EntityID, &item.SessionID, &item.DurationUS, &detailRaw, &correlationRaw, &item.Message); err != nil {
+		if err := rows.Scan(&item.ID, &item.EventID, &item.TS, &item.Level, &item.Component, &item.Action, &item.EventType, &item.ParentEventID, &item.HandlerID, &item.Error, &item.ErrorCode, &item.AgentID, &item.Source, &item.EntityID, &item.SessionID, &item.DurationUS, &item.DeliveryState, &item.PreviousState, &item.Transition, &item.Reason, &item.Terminal, &item.RetryCount, &detailRaw, &correlationRaw, &item.Message); err != nil {
 			return nil, fmt.Errorf("scan runtime log: %w", err)
 		}
 		detailMap, err := decodeJSONMap(detailRaw)

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -172,5 +173,57 @@ func TestHandler_EventDetailIncludesDeliveryLifecycle(t *testing.T) {
 	}
 	if lifecycle["pending"] != float64(1) || lifecycle["in_progress"] != float64(2) || lifecycle["delivered"] != float64(3) {
 		t.Fatalf("delivery_lifecycle = %#v", lifecycle)
+	}
+}
+
+func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	insertRuntimeLog := func(eventID, state, prev, reason, terminal string, retryCount int, createdAt time.Time) {
+		t.Helper()
+		payload := `{
+			"log_level":"debug",
+			"message":"delivery lifecycle",
+			"details":{
+				"component":"agent-manager",
+				"action":"delivery_lifecycle_transition",
+				"event_id":"` + eventID + `",
+				"agent_id":"agent-1",
+				"delivery_state":"` + state + `",
+				"delivery_previous_state":"` + prev + `",
+				"delivery_transition":"` + state + `",
+				"delivery_reason":"` + reason + `",
+				"delivery_terminal_outcome":"` + terminal + `",
+				"retry_count":` + fmt.Sprintf("%d", retryCount) + `
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', $2
+			)
+		`, payload, createdAt); err != nil {
+			t.Fatalf("insert runtime_log: %v", err)
+		}
+	}
+
+	insertRuntimeLog("evt-retry", "retrying", "active", "boom", "", 1, time.Unix(1700000100, 0).UTC())
+	insertRuntimeLog("evt-dead", "exhausted", "retrying", "boom", "retry_exhausted", 2, time.Unix(1700000200, 0).UTC())
+
+	rows, err := reader.ListRuntimeLogs(ctx, RuntimeLogFilter{Component: "agent-manager"}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows len = %d, want 2", len(rows))
+	}
+	if rows[0].DeliveryState != "exhausted" || rows[0].PreviousState != "retrying" || rows[0].Terminal != "retry_exhausted" || rows[0].RetryCount != 2 {
+		t.Fatalf("terminal runtime log = %#v", rows[0])
+	}
+	if rows[1].DeliveryState != "retrying" || rows[1].PreviousState != "active" || rows[1].Reason != "boom" || rows[1].RetryCount != 1 {
+		t.Fatalf("retry runtime log = %#v", rows[1])
 	}
 }

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -212,18 +212,22 @@ func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(
 
 	insertRuntimeLog("evt-retry", "retrying", "active", "boom", "", 1, time.Unix(1700000100, 0).UTC())
 	insertRuntimeLog("evt-dead", "exhausted", "retrying", "boom", "retry_exhausted", 2, time.Unix(1700000200, 0).UTC())
+	insertRuntimeLog("evt-cancel", "exhausted", "active", "cancelled_by_kill_previous", "cancelled_by_kill_previous", 0, time.Unix(1700000300, 0).UTC())
 
 	rows, err := reader.ListRuntimeLogs(ctx, RuntimeLogFilter{Component: "agent-manager"}, 10)
 	if err != nil {
 		t.Fatalf("ListRuntimeLogs: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("rows len = %d, want 2", len(rows))
+	if len(rows) != 3 {
+		t.Fatalf("rows len = %d, want 3", len(rows))
 	}
-	if rows[0].DeliveryState != "exhausted" || rows[0].PreviousState != "retrying" || rows[0].Terminal != "retry_exhausted" || rows[0].RetryCount != 2 {
-		t.Fatalf("terminal runtime log = %#v", rows[0])
+	if rows[0].DeliveryState != "exhausted" || rows[0].PreviousState != "active" || rows[0].Reason != "cancelled_by_kill_previous" || rows[0].Terminal != "cancelled_by_kill_previous" || rows[0].RetryCount != 0 {
+		t.Fatalf("cancel runtime log = %#v", rows[0])
 	}
-	if rows[1].DeliveryState != "retrying" || rows[1].PreviousState != "active" || rows[1].Reason != "boom" || rows[1].RetryCount != 1 {
-		t.Fatalf("retry runtime log = %#v", rows[1])
+	if rows[1].DeliveryState != "exhausted" || rows[1].PreviousState != "retrying" || rows[1].Terminal != "retry_exhausted" || rows[1].RetryCount != 2 {
+		t.Fatalf("terminal runtime log = %#v", rows[1])
+	}
+	if rows[2].DeliveryState != "retrying" || rows[2].PreviousState != "active" || rows[2].Reason != "boom" || rows[2].RetryCount != 1 {
+		t.Fatalf("retry runtime log = %#v", rows[2])
 	}
 }

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -111,22 +111,25 @@ func (eb *EventBus) Store() EventStore {
 	return eb.store
 }
 
-func (eb *EventBus) MarkDeliveryInProgress(ctx context.Context, agentID, sessionID string) error {
+func (eb *EventBus) MarkDeliveryInProgress(ctx context.Context, agentID, sessionID string) (bool, error) {
 	if eb == nil || eb.store == nil {
-		return nil
+		return false, nil
 	}
 	inbound, ok := runtimecorrelation.InboundEventFromContext(ctx)
 	if !ok || strings.TrimSpace(inbound.ID) == "" || strings.TrimSpace(agentID) == "" {
-		return nil
+		return false, nil
 	}
 	type deliveryProgressWriter interface {
 		MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error
 	}
 	writer, ok := eb.store.(deliveryProgressWriter)
 	if !ok || writer == nil {
-		return nil
+		return false, nil
 	}
-	return writer.MarkEventDeliveryInProgress(ctx, inbound.ID, agentID, sessionID)
+	if err := writer.MarkEventDeliveryInProgress(ctx, inbound.ID, agentID, sessionID); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (eb *EventBus) RouteTable() *RouteTable {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -12,6 +12,7 @@ import (
 	"swarm/internal/events"
 	"swarm/internal/runtime/core/eventidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
@@ -182,6 +183,7 @@ func (eb *EventBus) publishTransactional(
 
 	if passthrough {
 		if len(inboundPlan.Recipients) > 0 {
+			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
 			if err := eb.deliverToAgents(ctx, evt, inboundPlan.PersistedRecipients); err != nil {
 				return err
 			}
@@ -301,6 +303,7 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		return err
 	}
 	persisted = true
+	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
 	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
 	if err != nil {
 		return err
@@ -387,6 +390,7 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
 		return err
 	}
+	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
 	if len(plan.Recipients) > 0 {
 		if err := eb.deliverToAgents(ctx, evt, plan.PersistedRecipients); err != nil {
 			return err
@@ -433,6 +437,28 @@ func (eb *EventBus) logDelivery(ctx context.Context, evt events.Event, recipient
 		detail[k] = v
 	}
 	eb.logRuntime(ctx, "debug", "Event was delivered to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, detail, "", 0)
+}
+
+func (eb *EventBus) logQueuedDeliveries(ctx context.Context, evt events.Event, recipients []string, reason string, extra map[string]any) {
+	recipients = uniqueStrings(recipients)
+	if len(recipients) == 0 {
+		return
+	}
+	for _, recipient := range recipients {
+		detail := map[string]any{
+			"delivery_state":          string(runtimedelivery.StateQueued),
+			"delivery_transition":     string(runtimedelivery.StateQueued),
+			"delivery_previous_state": "",
+			"delivery_reason":         strings.TrimSpace(reason),
+			"subscriber_type":         "agent",
+			"subscriber_id":           strings.TrimSpace(recipient),
+			"parent_event_id":         strings.TrimSpace(evt.ParentEventID),
+		}
+		for k, v := range extra {
+			detail[k] = v
+		}
+		eb.logRuntime(ctx, "debug", "Delivery entered queued state", "eventbus", "delivery_lifecycle_transition", evt.ID, string(evt.Type), strings.TrimSpace(recipient), evt.EntityID(), "", nil, detail, "", 0)
+	}
 }
 
 func subscriberIDs(in []Subscriber) []string {
@@ -596,6 +622,7 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		return err
 	}
 	persisted = true
+	eb.logQueuedDeliveries(ctx, evt, recipients, "direct_publish", map[string]any{"direct": true})
 	if err := eb.deliverToAgents(ctx, evt, recipients); err != nil {
 		return err
 	}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -225,6 +225,48 @@ func assertSortedStringsEqual(t *testing.T, got, want []string) {
 	}
 }
 
+func TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition(t *testing.T) {
+	logger := &recordingLoggerHook{}
+	bus, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
+
+	evt := events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("task.requested"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1")
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delivered event")
+	}
+
+	var found bool
+	for _, entry := range logger.entries {
+		if entry.Action != "delivery_lifecycle_transition" {
+			continue
+		}
+		detail, ok := entry.Detail.(map[string]any)
+		if !ok {
+			t.Fatalf("detail type = %T", entry.Detail)
+		}
+		if detail["delivery_state"] == "queued" && detail["subscriber_id"] == "agent-1" && detail["delivery_reason"] == "matched_agent_subscription" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("queued delivery lifecycle transition not found in logs: %#v", logger.entries)
+	}
+}
+
 func TestEventBusPublish_UsesPayloadValidator(t *testing.T) {
 	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
 		PayloadValidator: func(eventType string, payload []byte) error {

--- a/internal/runtime/deliverylifecycle/model.go
+++ b/internal/runtime/deliverylifecycle/model.go
@@ -1,0 +1,34 @@
+package deliverylifecycle
+
+import "strings"
+
+type State string
+
+const (
+	StateQueued    State = "queued"
+	StateLaunching State = "launching"
+	StateActive    State = "active"
+	StateRetrying  State = "retrying"
+	StateDelivered State = "delivered"
+	StateExhausted State = "exhausted"
+)
+
+func StateFromDelivery(status, activeSessionID string) (State, bool) {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "pending":
+		return StateQueued, true
+	case "in_progress":
+		if strings.TrimSpace(activeSessionID) != "" {
+			return StateActive, true
+		}
+		return StateLaunching, true
+	case "failed":
+		return StateRetrying, true
+	case "delivered":
+		return StateDelivered, true
+	case "dead_letter":
+		return StateExhausted, true
+	default:
+		return "", false
+	}
+}

--- a/internal/runtime/deliverylifecycle/model.go
+++ b/internal/runtime/deliverylifecycle/model.go
@@ -13,6 +13,18 @@ const (
 	StateExhausted State = "exhausted"
 )
 
+type Transition struct {
+	EventID         string
+	AgentID         string
+	EntityID        string
+	State           State
+	PreviousState   State
+	Reason          string
+	TerminalOutcome string
+	Error           string
+	RetryCount      int
+}
+
 func StateFromDelivery(status, activeSessionID string) (State, bool) {
 	switch strings.TrimSpace(strings.ToLower(status)) {
 	case "pending":

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -59,7 +59,7 @@ func (NoopRuntime) PersistConversationSnapshot(context.Context, *Session) error 
 
 type EventPublisher interface {
 	Publish(ctx context.Context, evt events.Event) error
-	MarkDeliveryInProgress(ctx context.Context, agentID, sessionID string) error
+	MarkDeliveryInProgress(ctx context.Context, agentID, sessionID string) (bool, error)
 }
 
 func defaultLockOwner() string {

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	"swarm/internal/runtime/sessions"
 )
 
@@ -18,6 +19,15 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 	}
 	if err := publisher.MarkDeliveryInProgress(ctx, session.AgentID, session.ID); err != nil {
 		logPublisherRuntime(ctx, publisher, "error", "mark_delivery_in_progress_failed", "Marking the agent delivery in progress failed", session.AgentID, session.ID, "", nil, err)
+	} else {
+		logPublisherRuntime(ctx, publisher, "debug", "delivery_lifecycle_transition", "Delivery entered active state", session.AgentID, session.ID, "", map[string]any{
+			"delivery_state":          string(runtimedelivery.StateActive),
+			"delivery_transition":     string(runtimedelivery.StateActive),
+			"delivery_previous_state": string(runtimedelivery.StateLaunching),
+			"delivery_reason":         "session_started",
+			"subscriber_type":         "agent",
+			"subscriber_id":           strings.TrimSpace(session.AgentID),
+		}, nil)
 	}
 	actor, _ := runtimeactors.ActorFromContext(ctx)
 	payload := map[string]any{

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -17,9 +17,10 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 	if publisher == nil || session == nil || strings.TrimSpace(session.AgentID) == "" {
 		return
 	}
-	if err := publisher.MarkDeliveryInProgress(ctx, session.AgentID, session.ID); err != nil {
+	marked, err := publisher.MarkDeliveryInProgress(ctx, session.AgentID, session.ID)
+	if err != nil {
 		logPublisherRuntime(ctx, publisher, "error", "mark_delivery_in_progress_failed", "Marking the agent delivery in progress failed", session.AgentID, session.ID, "", nil, err)
-	} else {
+	} else if marked {
 		logPublisherRuntime(ctx, publisher, "debug", "delivery_lifecycle_transition", "Delivery entered active state", session.AgentID, session.ID, "", map[string]any{
 			"delivery_state":          string(runtimedelivery.StateActive),
 			"delivery_transition":     string(runtimedelivery.StateActive),

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -104,6 +104,16 @@ func TestAnthropicAPIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	if len(publisher.marks) != 1 {
 		t.Fatalf("expected 1 delivery mark, got %d", len(publisher.marks))
 	}
+	if len(publisher.runtimeLogs) != 1 {
+		t.Fatalf("expected 1 runtime log, got %d", len(publisher.runtimeLogs))
+	}
+	if publisher.runtimeLogs[0].Action != "delivery_lifecycle_transition" {
+		t.Fatalf("runtime log action = %q, want delivery_lifecycle_transition", publisher.runtimeLogs[0].Action)
+	}
+	detail := publisher.runtimeLogs[0].Detail.(map[string]any)
+	if detail["delivery_state"] != "active" || detail["delivery_previous_state"] != "launching" || detail["delivery_reason"] != "session_started" {
+		t.Fatalf("active delivery detail = %#v", detail)
+	}
 	evt := publisher.events[0]
 	if evt.Type != events.EventType("platform.agent_started") {
 		t.Fatalf("event type = %s, want platform.agent_started", evt.Type)
@@ -146,6 +156,12 @@ func TestClaudeCLIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	}
 	if len(publisher.marks) != 1 {
 		t.Fatalf("expected 1 delivery mark, got %d", len(publisher.marks))
+	}
+	if len(publisher.runtimeLogs) != 1 {
+		t.Fatalf("expected 1 runtime log, got %d", len(publisher.runtimeLogs))
+	}
+	if publisher.runtimeLogs[0].Action != "delivery_lifecycle_transition" {
+		t.Fatalf("runtime log action = %q, want delivery_lifecycle_transition", publisher.runtimeLogs[0].Action)
 	}
 	evt := publisher.events[0]
 	if evt.Type != events.EventType("platform.agent_started") {

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -24,6 +24,7 @@ type eventPublisherStub struct {
 	runtimeLogs []runtimepipeline.RuntimeLogEntry
 	publishErr  error
 	markErr     error
+	markChanged bool
 }
 
 func (s *eventPublisherStub) Publish(_ context.Context, evt events.Event) error {
@@ -34,12 +35,12 @@ func (s *eventPublisherStub) Publish(_ context.Context, evt events.Event) error 
 	return nil
 }
 
-func (s *eventPublisherStub) MarkDeliveryInProgress(_ context.Context, agentID, sessionID string) error {
+func (s *eventPublisherStub) MarkDeliveryInProgress(_ context.Context, agentID, sessionID string) (bool, error) {
 	if s.markErr != nil {
-		return s.markErr
+		return false, s.markErr
 	}
 	s.marks = append(s.marks, strings.TrimSpace(agentID)+"|"+strings.TrimSpace(sessionID))
-	return nil
+	return s.markChanged, nil
 }
 
 func (s *eventPublisherStub) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
@@ -104,15 +105,8 @@ func TestAnthropicAPIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	if len(publisher.marks) != 1 {
 		t.Fatalf("expected 1 delivery mark, got %d", len(publisher.marks))
 	}
-	if len(publisher.runtimeLogs) != 1 {
-		t.Fatalf("expected 1 runtime log, got %d", len(publisher.runtimeLogs))
-	}
-	if publisher.runtimeLogs[0].Action != "delivery_lifecycle_transition" {
-		t.Fatalf("runtime log action = %q, want delivery_lifecycle_transition", publisher.runtimeLogs[0].Action)
-	}
-	detail := publisher.runtimeLogs[0].Detail.(map[string]any)
-	if detail["delivery_state"] != "active" || detail["delivery_previous_state"] != "launching" || detail["delivery_reason"] != "session_started" {
-		t.Fatalf("active delivery detail = %#v", detail)
+	if len(publisher.runtimeLogs) != 0 {
+		t.Fatalf("expected no delivery lifecycle log without a real delivery mark, got %d", len(publisher.runtimeLogs))
 	}
 	evt := publisher.events[0]
 	if evt.Type != events.EventType("platform.agent_started") {
@@ -157,11 +151,8 @@ func TestClaudeCLIRuntime_StartSessionPublishesAgentStarted(t *testing.T) {
 	if len(publisher.marks) != 1 {
 		t.Fatalf("expected 1 delivery mark, got %d", len(publisher.marks))
 	}
-	if len(publisher.runtimeLogs) != 1 {
-		t.Fatalf("expected 1 runtime log, got %d", len(publisher.runtimeLogs))
-	}
-	if publisher.runtimeLogs[0].Action != "delivery_lifecycle_transition" {
-		t.Fatalf("runtime log action = %q, want delivery_lifecycle_transition", publisher.runtimeLogs[0].Action)
+	if len(publisher.runtimeLogs) != 0 {
+		t.Fatalf("expected no delivery lifecycle log without a real delivery mark, got %d", len(publisher.runtimeLogs))
 	}
 	evt := publisher.events[0]
 	if evt.Type != events.EventType("platform.agent_started") {
@@ -207,6 +198,35 @@ func TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools(t *test
 	}
 	if !strings.Contains(s.SystemPrompt, "Do not write JSON files under `/workspace/events`") {
 		t.Fatalf("expected emit workaround warning in system prompt, got %q", s.SystemPrompt)
+	}
+}
+
+func TestPublishAgentStarted_LogsActiveTransitionOnlyAfterRealDeliveryMark(t *testing.T) {
+	publisher := &eventPublisherStub{markChanged: true}
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID:       "agent-1",
+		EntityID: "entity-1",
+	})
+
+	publishAgentStarted(ctx, publisher, &Session{
+		ID:               "session-1",
+		AgentID:          "agent-1",
+		ConversationMode: sessions.RuntimeModeTask.String(),
+		RuntimeMode:      sessions.RuntimeModeTask.String(),
+	}, events.EventType("platform.agent_started"))
+
+	if len(publisher.runtimeLogs) != 1 {
+		t.Fatalf("expected 1 runtime log, got %d", len(publisher.runtimeLogs))
+	}
+	if publisher.runtimeLogs[0].Action != "delivery_lifecycle_transition" {
+		t.Fatalf("runtime log action = %q, want delivery_lifecycle_transition", publisher.runtimeLogs[0].Action)
+	}
+	detail, ok := publisher.runtimeLogs[0].Detail.(map[string]any)
+	if !ok {
+		t.Fatalf("runtime log detail = %#v", publisher.runtimeLogs[0].Detail)
+	}
+	if detail["delivery_state"] != "active" || detail["delivery_previous_state"] != "launching" || detail["delivery_reason"] != "session_started" {
+		t.Fatalf("active delivery detail = %#v", detail)
 	}
 }
 

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -374,13 +374,15 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			retryCtx, cancel := context.WithTimeout(context.WithoutCancel(writeCtx), receiptWriteTimeout)
 			retryErr := am.store.UpsertEventReceipt(retryCtx, eventID, agentID, status, errText)
-			cancel()
 			if retryErr == nil {
+				am.logDeliveryLifecycle(retryCtx, eventID, agentID, status, errText)
+				cancel()
 				if status == ReceiptStatusError {
 					am.maybeEscalateDeadLetter(context.WithoutCancel(writeCtx), eventID, agentID)
 				}
 				return
 			}
+			cancel()
 			err = retryErr
 		}
 		if am.bus != nil {

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -11,6 +11,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimerterr "swarm/internal/runtime/rterrors"
 )
@@ -59,6 +60,24 @@ func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt event
 					Error:     strings.TrimSpace(err.Error()),
 				})
 			}
+		} else if am.bus != nil {
+			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+				Level:     "debug",
+				Component: "agent-manager",
+				Action:    "delivery_lifecycle_transition",
+				EventID:   strings.TrimSpace(evt.ID),
+				EventType: strings.TrimSpace(string(evt.Type)),
+				AgentID:   agent.ID(),
+				EntityID:  strings.TrimSpace(evt.EntityID()),
+				Detail: map[string]any{
+					"delivery_state":          string(runtimedelivery.StateLaunching),
+					"delivery_transition":     string(runtimedelivery.StateLaunching),
+					"delivery_previous_state": string(runtimedelivery.StateQueued),
+					"delivery_reason":         "agent_processing",
+					"subscriber_type":         "agent",
+					"subscriber_id":           agent.ID(),
+				},
+			})
 		}
 	}
 	out, err := agent.OnEvent(ctx, evt)
@@ -379,12 +398,71 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 		}
 		return
 	}
+	am.logDeliveryLifecycle(writeCtx, eventID, agentID, status, errText)
 
 	// Spec v2.0: dead-letter events are escalated to the agent's manager. The manager
 	// decides whether to retry, skip, or escalate further.
 	if status == ReceiptStatusError {
 		am.maybeEscalateDeadLetter(ctx, eventID, agentID)
 	}
+}
+
+func (am *AgentManager) logDeliveryLifecycle(ctx context.Context, eventID, agentID string, requestedStatus ReceiptStatus, errText string) {
+	if am == nil || am.bus == nil || am.store == nil {
+		return
+	}
+	reader, ok := am.store.(eventReceiptReader)
+	if !ok || reader == nil {
+		return
+	}
+	receipt, found, err := reader.GetEventReceipt(ctx, eventID, agentID)
+	if err != nil || !found {
+		return
+	}
+	detail := map[string]any{
+		"subscriber_type": "agent",
+		"subscriber_id":   strings.TrimSpace(agentID),
+		"retry_count":     receipt.RetryCount,
+	}
+	entry := runtimepipeline.RuntimeLogEntry{
+		Level:     "debug",
+		Component: "agent-manager",
+		Action:    "delivery_lifecycle_transition",
+		EventID:   strings.TrimSpace(eventID),
+		AgentID:   strings.TrimSpace(agentID),
+		Detail:    detail,
+	}
+	switch receipt.Status {
+	case ReceiptStatusProcessed:
+		detail["delivery_state"] = string(runtimedelivery.StateDelivered)
+		detail["delivery_transition"] = string(runtimedelivery.StateDelivered)
+		detail["delivery_previous_state"] = string(runtimedelivery.StateActive)
+		detail["delivery_reason"] = "agent_processed"
+		entry.Message = "Delivery entered delivered state"
+	case ReceiptStatusError:
+		detail["delivery_state"] = string(runtimedelivery.StateRetrying)
+		detail["delivery_transition"] = string(runtimedelivery.StateRetrying)
+		detail["delivery_previous_state"] = string(runtimedelivery.StateActive)
+		detail["delivery_reason"] = strings.TrimSpace(errText)
+		entry.Message = "Delivery entered retrying state"
+		if strings.TrimSpace(receipt.Error) != "" {
+			entry.Error = strings.TrimSpace(receipt.Error)
+		}
+	case ReceiptStatusDeadLetter:
+		detail["delivery_state"] = string(runtimedelivery.StateExhausted)
+		detail["delivery_transition"] = string(runtimedelivery.StateExhausted)
+		detail["delivery_previous_state"] = string(runtimedelivery.StateRetrying)
+		detail["delivery_reason"] = strings.TrimSpace(errText)
+		detail["delivery_terminal_outcome"] = "retry_exhausted"
+		entry.Message = "Delivery entered exhausted state"
+		if strings.TrimSpace(receipt.Error) != "" {
+			entry.Error = strings.TrimSpace(receipt.Error)
+		}
+	default:
+		return
+	}
+	_ = requestedStatus
+	_ = am.bus.LogRuntime(ctx, entry)
 }
 
 func (am *AgentManager) maybeEscalateDeadLetter(ctx context.Context, eventID, agentID string) {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type recordingReceiptBus struct {
-	published    []events.Event
+	published   []events.Event
 	runtimeLogs []runtimepipeline.RuntimeLogEntry
 }
 
@@ -39,10 +39,10 @@ func (b *recordingReceiptBus) LogRuntime(_ context.Context, entry runtimepipelin
 }
 
 type receiptReaderStub struct {
-	receipt      EventReceipt
-	found        bool
-	upsertErrs   []error
-	upsertCalls  int
+	receipt     EventReceipt
+	found       bool
+	upsertErrs  []error
+	upsertCalls int
 }
 
 func (*receiptReaderStub) UpsertAgent(context.Context, PersistedAgent) error { return nil }

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -39,8 +39,10 @@ func (b *recordingReceiptBus) LogRuntime(_ context.Context, entry runtimepipelin
 }
 
 type receiptReaderStub struct {
-	receipt EventReceipt
-	found   bool
+	receipt      EventReceipt
+	found        bool
+	upsertErrs   []error
+	upsertCalls  int
 }
 
 func (*receiptReaderStub) UpsertAgent(context.Context, PersistedAgent) error { return nil }
@@ -49,8 +51,14 @@ func (*receiptReaderStub) LoadAgents(context.Context) ([]PersistedAgent, error) 
 }
 func (*receiptReaderStub) MarkAgentTerminated(context.Context, string) error { return nil }
 func (*receiptReaderStub) EnsureEntitySchema(context.Context, string) error  { return nil }
-func (*receiptReaderStub) UpsertEventReceipt(context.Context, string, string, ReceiptStatus, string) error {
-	return nil
+func (s *receiptReaderStub) UpsertEventReceipt(context.Context, string, string, ReceiptStatus, string) error {
+	s.upsertCalls++
+	if len(s.upsertErrs) == 0 {
+		return nil
+	}
+	err := s.upsertErrs[0]
+	s.upsertErrs = s.upsertErrs[1:]
+	return err
 }
 func (*receiptReaderStub) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
 	return nil, nil
@@ -360,5 +368,33 @@ func TestWriteReceipt_LogsRetryingAndExhaustedDeliveryLifecycleTransitions(t *te
 				t.Fatalf("delivery_terminal_outcome = %#v, want %q", got, tc.wantTerminal)
 			}
 		})
+	}
+}
+
+func TestWriteReceipt_RetryAfterContextCancellationStillLogsLifecycleTransition(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	store := &deliveryLifecycleStoreStub{}
+	store.receipt = EventReceipt{
+		EventID:    "evt-1",
+		AgentID:    "agent-a",
+		Status:     ReceiptStatusError,
+		RetryCount: 1,
+		Error:      "boom",
+	}
+	store.found = true
+	store.upsertErrs = []error{context.Canceled, nil}
+	am := NewAgentManager(bus, nil, store)
+
+	am.writeReceipt(context.Background(), "evt-1", "agent-a", ReceiptStatusError, "boom")
+
+	if store.upsertCalls != 2 {
+		t.Fatalf("upsert calls = %d, want 2", store.upsertCalls)
+	}
+	if len(bus.runtimeLogs) != 1 {
+		t.Fatalf("runtime logs = %d, want 1", len(bus.runtimeLogs))
+	}
+	detail := bus.runtimeLogs[0].Detail.(map[string]any)
+	if detail["delivery_state"] != "retrying" || detail["delivery_reason"] != "boom" {
+		t.Fatalf("retry lifecycle detail = %#v", detail)
 	}
 }

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,8 @@ import (
 )
 
 type recordingReceiptBus struct {
-	published []events.Event
+	published    []events.Event
+	runtimeLogs []runtimepipeline.RuntimeLogEntry
 }
 
 func (b *recordingReceiptBus) Publish(_ context.Context, evt events.Event) error {
@@ -31,7 +33,8 @@ func (*recordingReceiptBus) Subscribe(string, ...events.EventType) <-chan events
 func (*recordingReceiptBus) Unsubscribe(string)           {}
 func (*recordingReceiptBus) Store() runtimebus.EventStore { return runtimebus.InMemoryEventStore{} }
 func (*recordingReceiptBus) ResetInMemoryState() error    { return nil }
-func (*recordingReceiptBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
+func (b *recordingReceiptBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.runtimeLogs = append(b.runtimeLogs, entry)
 	return nil
 }
 
@@ -260,5 +263,102 @@ func TestProcessEvent_PropagatesInboundParentWithoutTraceSeeding(t *testing.T) {
 	}
 	if agent.parent != "evt-123" {
 		t.Fatalf("parent event = %q, want evt-123", agent.parent)
+	}
+}
+
+type deliveryLifecycleStoreStub struct {
+	receiptReaderStub
+	markCalls []string
+}
+
+func (s *deliveryLifecycleStoreStub) MarkEventDeliveryInProgress(_ context.Context, eventID, agentID, sessionID string) error {
+	s.markCalls = append(s.markCalls, strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)+"|"+strings.TrimSpace(sessionID))
+	return nil
+}
+
+func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	store := &deliveryLifecycleStoreStub{}
+	am := NewAgentManager(bus, nil, store)
+	evt := events.Event{ID: "evt-1", Type: events.EventType("task.started")}
+	agent := traceRecordingAgent{parent: ""}
+
+	if err := am.processEvent(context.Background(), &agent, evt); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+	if len(store.markCalls) != 1 {
+		t.Fatalf("mark calls = %d, want 1", len(store.markCalls))
+	}
+	if len(bus.runtimeLogs) == 0 {
+		t.Fatal("expected runtime logs")
+	}
+	entry := bus.runtimeLogs[0]
+	if entry.Action != "delivery_lifecycle_transition" {
+		t.Fatalf("action = %q, want delivery_lifecycle_transition", entry.Action)
+	}
+	detail := entry.Detail.(map[string]any)
+	if detail["delivery_state"] != "launching" || detail["delivery_previous_state"] != "queued" || detail["delivery_reason"] != "agent_processing" {
+		t.Fatalf("launching detail = %#v", detail)
+	}
+}
+
+func TestWriteReceipt_LogsRetryingAndExhaustedDeliveryLifecycleTransitions(t *testing.T) {
+	cases := []struct {
+		name          string
+		receipt       EventReceipt
+		wantState     string
+		wantTerminal  string
+		wantRetry     int
+		wantReasonRaw string
+	}{
+		{
+			name:          "retrying",
+			receipt:       EventReceipt{EventID: "evt-1", AgentID: "agent-a", Status: ReceiptStatusError, RetryCount: 1, Error: "boom"},
+			wantState:     "retrying",
+			wantTerminal:  "",
+			wantRetry:     1,
+			wantReasonRaw: "boom",
+		},
+		{
+			name:          "exhausted",
+			receipt:       EventReceipt{EventID: "evt-1", AgentID: "agent-a", Status: ReceiptStatusDeadLetter, RetryCount: 2, Error: "boom"},
+			wantState:     "exhausted",
+			wantTerminal:  "retry_exhausted",
+			wantRetry:     2,
+			wantReasonRaw: "boom",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := &recordingReceiptBus{}
+			store := &deliveryLifecycleStoreStub{}
+			store.receipt = tc.receipt
+			store.found = true
+			am := NewAgentManager(bus, nil, store)
+
+			am.writeReceipt(context.Background(), "evt-1", "agent-a", ReceiptStatusError, "boom")
+
+			if len(bus.runtimeLogs) != 1 {
+				t.Fatalf("runtime logs = %d, want 1", len(bus.runtimeLogs))
+			}
+			entry := bus.runtimeLogs[0]
+			if entry.Action != "delivery_lifecycle_transition" {
+				t.Fatalf("action = %q, want delivery_lifecycle_transition", entry.Action)
+			}
+			detail := entry.Detail.(map[string]any)
+			if detail["delivery_state"] != tc.wantState {
+				t.Fatalf("delivery_state = %#v, want %q", detail["delivery_state"], tc.wantState)
+			}
+			if detail["retry_count"] != tc.wantRetry {
+				t.Fatalf("retry_count = %#v, want %d", detail["retry_count"], tc.wantRetry)
+			}
+			if detail["delivery_reason"] != tc.wantReasonRaw {
+				t.Fatalf("delivery_reason = %#v, want %q", detail["delivery_reason"], tc.wantReasonRaw)
+			}
+			if got := detail["delivery_terminal_outcome"]; got != tc.wantTerminal && !(got == nil && tc.wantTerminal == "") {
+				t.Fatalf("delivery_terminal_outcome = %#v, want %q", got, tc.wantTerminal)
+			}
+		})
 	}
 }

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -16,6 +16,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
@@ -23,7 +24,7 @@ import (
 )
 
 type runCanceller interface {
-	CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]string, error)
+	CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]runtimedelivery.Transition, error)
 }
 
 func (am *AgentManager) RestartAgent(agentID string) error {
@@ -312,16 +313,46 @@ func (am *AgentManager) killPreviousRuns(ctx context.Context, producerID string)
 		return nil
 	}
 	var (
-		affectedAgents []string
-		err            error
+		transitions []runtimedelivery.Transition
+		err         error
 	)
 	if canceller, ok := am.store.(runCanceller); ok && canceller != nil {
-		affectedAgents, err = canceller.CancelActiveRunWorkByProducer(ctx, producerID)
+		transitions, err = canceller.CancelActiveRunWorkByProducer(ctx, producerID)
 		if err != nil {
 			return fmt.Errorf("cancel previous runs for %s: %w", producerID, err)
 		}
 	} else {
 		return nil
+	}
+	affectedAgents := make([]string, 0, len(transitions))
+	for _, transition := range transitions {
+		affectedAgents = append(affectedAgents, transition.AgentID)
+		if am.bus == nil {
+			continue
+		}
+		detail := map[string]any{
+			"delivery_state":          string(transition.State),
+			"delivery_transition":     string(transition.State),
+			"delivery_previous_state": string(transition.PreviousState),
+			"delivery_reason":         strings.TrimSpace(transition.Reason),
+			"subscriber_type":         "agent",
+			"subscriber_id":           strings.TrimSpace(transition.AgentID),
+			"retry_count":             transition.RetryCount,
+		}
+		if strings.TrimSpace(transition.TerminalOutcome) != "" {
+			detail["delivery_terminal_outcome"] = strings.TrimSpace(transition.TerminalOutcome)
+		}
+		_ = am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+			Level:     "debug",
+			Component: "agent-manager",
+			Action:    "delivery_lifecycle_transition",
+			Message:   "Delivery entered exhausted state",
+			EventID:   strings.TrimSpace(transition.EventID),
+			AgentID:   strings.TrimSpace(transition.AgentID),
+			EntityID:  strings.TrimSpace(transition.EntityID),
+			Error:     strings.TrimSpace(transition.Error),
+			Detail:    detail,
+		})
 	}
 	if killer, ok := am.workspaces.(workspace.OrphanKiller); ok && killer != nil {
 		if err := killer.KillOrphanProcesses(am.runtimeContext()); err != nil {

--- a/internal/runtime/manager/runtime_chat_test.go
+++ b/internal/runtime/manager/runtime_chat_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 )
 
 type chatTestAgent struct {
@@ -29,7 +30,7 @@ func (a *chatTestAgent) BoardStep(_ context.Context, directive string) (string, 
 type chatTestStore struct {
 	cancelCalls int
 	cancelFor   string
-	agents      []string
+	transitions []runtimedelivery.Transition
 }
 
 func (s *chatTestStore) UpsertAgent(context.Context, PersistedAgent) error { return nil }
@@ -47,10 +48,10 @@ func (s *chatTestStore) ListPendingEventsForAgent(context.Context, string, time.
 func (s *chatTestStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
 	return nil, nil
 }
-func (s *chatTestStore) CancelActiveRunWorkByProducer(_ context.Context, producerID string) ([]string, error) {
+func (s *chatTestStore) CancelActiveRunWorkByProducer(_ context.Context, producerID string) ([]runtimedelivery.Transition, error) {
 	s.cancelCalls++
 	s.cancelFor = producerID
-	return append([]string(nil), s.agents...), nil
+	return append([]runtimedelivery.Transition(nil), s.transitions...), nil
 }
 
 func TestAgentManager_ChatWithAgent_KillPreviousCancelsBeforeBoardStep(t *testing.T) {
@@ -85,5 +86,46 @@ func TestAgentManager_ChatWithAgent_WithoutKillPreviousSkipsCancellation(t *test
 	}
 	if store.cancelCalls != 0 {
 		t.Fatalf("cancel previous calls = %d, want 0", store.cancelCalls)
+	}
+}
+
+func TestAgentManager_ChatWithAgent_KillPreviousLogsForcedTerminalLifecycle(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	store := &chatTestStore{
+		transitions: []runtimedelivery.Transition{{
+			EventID:         "evt-1",
+			AgentID:         "market-research-agent",
+			EntityID:        "entity-1",
+			State:           runtimedelivery.StateExhausted,
+			PreviousState:   runtimedelivery.StateActive,
+			Reason:          "cancelled_by_kill_previous",
+			TerminalOutcome: "cancelled_by_kill_previous",
+			Error:           "cancelled by --kill-previous",
+		}},
+	}
+	agent := &chatTestAgent{id: "campaign-coordinator"}
+	am := NewAgentManager(bus, nil, store)
+	am.agents[agent.id] = agent
+	am.agents["market-research-agent"] = &chatTestAgent{id: "market-research-agent"}
+
+	if _, err := am.ChatWithAgent(context.Background(), agent.id, "run corpus", true); err != nil {
+		t.Fatalf("ChatWithAgent: %v", err)
+	}
+	if len(bus.runtimeLogs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.runtimeLogs))
+	}
+	entry := bus.runtimeLogs[0]
+	if entry.Action != "delivery_lifecycle_transition" {
+		t.Fatalf("action = %q, want delivery_lifecycle_transition", entry.Action)
+	}
+	detail, ok := entry.Detail.(map[string]any)
+	if !ok {
+		t.Fatalf("detail = %#v", entry.Detail)
+	}
+	if detail["delivery_state"] != "exhausted" || detail["delivery_previous_state"] != "active" {
+		t.Fatalf("delivery lifecycle detail = %#v", detail)
+	}
+	if detail["delivery_reason"] != "cancelled_by_kill_previous" || detail["delivery_terminal_outcome"] != "cancelled_by_kill_previous" {
+		t.Fatalf("terminal detail = %#v", detail)
 	}
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -387,12 +387,18 @@ func TestPostgresStore_CancelActiveRunWorkByProducer_DeadLettersOldRunDeliveries
 		t.Fatalf("seed deliveries: %v", err)
 	}
 
-	agents, err := pg.CancelActiveRunWorkByProducer(ctx, "campaign-coordinator")
+	transitions, err := pg.CancelActiveRunWorkByProducer(ctx, "campaign-coordinator")
 	if err != nil {
 		t.Fatalf("CancelActiveRunWorkByProducer: %v", err)
 	}
-	if len(agents) != 1 || agents[0] != "market-research-agent" {
-		t.Fatalf("affected agents = %#v", agents)
+	if len(transitions) != 1 {
+		t.Fatalf("cancelled transitions = %#v", transitions)
+	}
+	if transitions[0].AgentID != "market-research-agent" || transitions[0].EventID != childEventID {
+		t.Fatalf("transition = %#v", transitions[0])
+	}
+	if transitions[0].Reason != "cancelled_by_kill_previous" || transitions[0].TerminalOutcome != "cancelled_by_kill_previous" {
+		t.Fatalf("transition terminal outcome = %#v", transitions[0])
 	}
 
 	var (

--- a/internal/store/trace_cancel.go
+++ b/internal/store/trace_cancel.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 )
 
-func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]string, error) {
+func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]runtimedelivery.Transition, error) {
 	producerID = strings.TrimSpace(producerID)
 	if producerID == "" {
 		return nil, nil
@@ -67,47 +68,20 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 		return nil, nil
 	}
 
-	agentRows, err := tx.QueryContext(ctx, `
-		SELECT DISTINCT d.subscriber_id
-		FROM event_deliveries d
-		JOIN events e ON e.event_id = d.event_id
-		WHERE e.run_id::text = ANY($1::text[])
-		  AND d.subscriber_type = 'agent'
-		  AND d.status IN ('pending', 'in_progress')
-		ORDER BY d.subscriber_id ASC
-	`, pq.Array(runIDs))
-	if err != nil {
-		return nil, fmt.Errorf("query affected agents for runs: %w", err)
-	}
-	defer agentRows.Close()
-
-	affectedAgents := make([]string, 0, 16)
-	for agentRows.Next() {
-		var agentID string
-		if err := agentRows.Scan(&agentID); err != nil {
-			return nil, fmt.Errorf("scan affected agent: %w", err)
-		}
-		agentID = strings.TrimSpace(agentID)
-		if agentID != "" {
-			affectedAgents = append(affectedAgents, agentID)
-		}
-	}
-	if err := agentRows.Err(); err != nil {
-		return nil, fmt.Errorf("read affected agents: %w", err)
-	}
-
 	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects("dead_letter", "cancelled_by_kill_previous", 0, "cancelled by --kill-previous"))
 	if err != nil {
 		return nil, fmt.Errorf("marshal kill_previous receipt side effects: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `
+	rows, err := tx.QueryContext(ctx, `
 		WITH targeted AS (
 			SELECT
 				d.delivery_id,
 				d.event_id,
 				d.subscriber_type,
 				d.subscriber_id,
+				d.status,
+				COALESCE(d.active_session_id::text, '') AS active_session_id,
 				e.entity_id,
 				e.flow_instance
 			FROM event_deliveries d
@@ -126,37 +100,83 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 				delivered_at = now()
 			FROM targeted t
 			WHERE d.delivery_id = t.delivery_id
-			RETURNING t.event_id, t.subscriber_type, t.subscriber_id, t.entity_id, t.flow_instance
+			RETURNING t.event_id, t.subscriber_type, t.subscriber_id, t.status, t.active_session_id, t.entity_id, t.flow_instance
 		)
-		INSERT INTO event_receipts (
+		, receipts AS (
+			INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, side_effects, processed_at
+			)
+			SELECT
+				u.event_id,
+				u.subscriber_type,
+				u.subscriber_id,
+				u.entity_id,
+				u.flow_instance,
+				'dead_letter',
+				'cancelled_by_kill_previous',
+				$2::jsonb,
+				now()
+			FROM updated u
+			ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+				entity_id = EXCLUDED.entity_id,
+				flow_instance = EXCLUDED.flow_instance,
+				outcome = EXCLUDED.outcome,
+				reason_code = EXCLUDED.reason_code,
+				side_effects = EXCLUDED.side_effects,
+				processed_at = now()
+			RETURNING event_id, subscriber_id
 		)
 		SELECT
-			u.event_id,
-			u.subscriber_type,
+			u.event_id::text,
 			u.subscriber_id,
-			u.entity_id,
-			u.flow_instance,
-			'dead_letter',
-			'cancelled_by_kill_previous',
-			$2::jsonb,
-			now()
+			COALESCE(u.status, ''),
+			COALESCE(u.active_session_id, ''),
+			COALESCE(u.entity_id::text, ''),
+			COALESCE(u.flow_instance, '')
 		FROM updated u
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			entity_id = EXCLUDED.entity_id,
-			flow_instance = EXCLUDED.flow_instance,
-			outcome = EXCLUDED.outcome,
-			reason_code = EXCLUDED.reason_code,
-			side_effects = EXCLUDED.side_effects,
-			processed_at = now()
-	`, pq.Array(runIDs), string(sideEffects)); err != nil {
+		JOIN receipts r ON r.event_id = u.event_id AND r.subscriber_id = u.subscriber_id
+		ORDER BY u.subscriber_id ASC, u.event_id::text ASC
+	`, pq.Array(runIDs), string(sideEffects))
+	if err != nil {
 		return nil, fmt.Errorf("cancel kill_previous deliveries/receipts: %w", err)
+	}
+	defer rows.Close()
+
+	transitions := make([]runtimedelivery.Transition, 0, 16)
+	for rows.Next() {
+		var (
+			eventID         string
+			agentID         string
+			prevStatus      string
+			activeSessionID string
+			entityID        string
+			flowInstance    string
+		)
+		if err := rows.Scan(&eventID, &agentID, &prevStatus, &activeSessionID, &entityID, &flowInstance); err != nil {
+			return nil, fmt.Errorf("scan cancelled delivery transition: %w", err)
+		}
+		prevState, _ := runtimedelivery.StateFromDelivery(prevStatus, activeSessionID)
+		_ = flowInstance
+		transitions = append(transitions, runtimedelivery.Transition{
+			EventID:         strings.TrimSpace(eventID),
+			AgentID:         strings.TrimSpace(agentID),
+			EntityID:        strings.TrimSpace(entityID),
+			State:           runtimedelivery.StateExhausted,
+			PreviousState:   prevState,
+			Reason:          "cancelled_by_kill_previous",
+			TerminalOutcome: "cancelled_by_kill_previous",
+			Error:           "cancelled by --kill-previous",
+			RetryCount:      0,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read cancelled delivery transitions: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit cancel runs tx: %w", err)
 	}
 	committed = true
-	return affectedAgents, nil
+	return transitions, nil
 }


### PR DESCRIPTION
Closes #245

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: event_schema.routing_derivation.delivery_rules`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.dead_letter_schema`

## Human Summary
This PR exposes canonical delivery lifecycle transitions through the existing runtime diagnostics surface and the dashboard observability reader. Operators can now see when a delivery is queued, launching, active, retrying, delivered, or exhausted, along with the retry reason or terminal outcome that moved it there.

## What Changed
- added a narrow `deliverylifecycle` domain model for the canonical observable states used in this seam
- emitted `delivery_lifecycle_transition` runtime-log entries at the existing lifecycle decision points for queued, launching, active, retrying, delivered, and exhausted
- projected the delivery lifecycle fields through the dashboard observability runtime-log reader
- added focused tests for queued publish, launching handoff, active session start, retrying receipt, exhausted dead-letter, and observability projection

## Why This Is Needed
The underlying delivery semantics already existed in `event_deliveries`, retry policy, and dead-letter handling, but the touched debug/operator surface did not expose a coherent lifecycle model. That forced operators to reconstruct state changes manually from low-level receipts and logs. This change makes those transitions explicit through one canonical diagnostics surface.

## Scope Boundaries
- scoped to lifecycle observability in runtime logs and the immediate observability read path
- does not redesign delivery semantics, retry policy, or dead-letter ownership
- does not add a second operator-only lifecycle model or compatibility interpretation

## Tests Run
- `go test ./internal/runtime/bus -run TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition -count=1`
- `go test ./internal/runtime/manager -run 'Test(ProcessEvent_LogsLaunchingDeliveryLifecycleTransition|WriteReceipt_LogsRetryingAndExhaustedDeliveryLifecycleTransitions)' -count=1`
- `go test ./internal/runtime/llm -run 'Test(AnthropicAPIRuntime_StartSessionPublishesAgentStarted|ClaudeCLIRuntime_StartSessionPublishesAgentStarted)' -count=1`
- `go test ./internal/dashboard/server -run TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields -count=1`
- `go test ./internal/runtime/... ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR keeps scope to the runtime-log diagnostics/read seam. Other raw store/operator surfaces still expose underlying delivery rows directly; they are not reworked here into the richer transition model.

## Follow-Up
If review finds another touched operator/debug reader reconstructing delivery lifecycle from raw receipt or delivery rows, that should be handled as a separate canonical-read-surface issue rather than extending this PR into a broader operator redesign.
