### PR TITLE
[agent-c][issue #234] Make conversation runtime_state a typed canonical session descriptor

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -158,12 +158,12 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 	); err != nil {
 		return ConversationSummary{}, err
 	}
-	runtimeState, err := decodeConversationRuntimeStateProjection(runtimeStateRaw)
+	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
 	if err != nil {
 		return ConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
 	item.Summary = runtimeState.Summary
-	item.Metadata = runtimeState.metadata()
+	item.Metadata = projectConversationSummaryMetadata(runtimeState)
 	return item, nil
 }
 
@@ -188,12 +188,12 @@ func scanConversationDetail(scanner rowScanner) (ConversationDetail, error) {
 	); err != nil {
 		return ConversationDetail{}, err
 	}
-	runtimeState, err := decodeConversationRuntimeStateProjection(runtimeStateRaw)
+	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
 	if err != nil {
 		return ConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
 	}
 	item.Summary = runtimeState.Summary
-	item.RuntimeState = runtimeState.runtimeState()
+	item.RuntimeState = projectConversationRuntimeState(runtimeState)
 	item.Messages, err = decodeJSONArray[ConversationMessage](messagesRaw)
 	if err != nil {
 		return ConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -5,45 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"swarm/internal/store"
 )
 
-type projectedConversationRuntimeState struct {
-	Summary              string
-	LastTurn             *projectedConversationLastTurn
-	ProviderSessionID    string
-	RetryReason          string
-	RetriesFromSessionID string
-}
-
-type projectedConversationLastTurn struct {
-	TaskID  string `json:"task_id,omitempty"`
-	ParseOK bool   `json:"parse_ok,omitempty"`
-}
-
-func decodeConversationRuntimeStateProjection(raw []byte) (projectedConversationRuntimeState, error) {
-	if len(raw) == 0 {
-		return projectedConversationRuntimeState{}, nil
-	}
-	var typed struct {
-		Summary              string                         `json:"summary"`
-		LastTurn             *projectedConversationLastTurn `json:"last_turn,omitempty"`
-		ProviderSessionID    string                         `json:"provider_session_id,omitempty"`
-		RetryReason          string                         `json:"retry_reason,omitempty"`
-		RetriesFromSessionID string                         `json:"retries_from_session_id,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &typed); err != nil {
-		return projectedConversationRuntimeState{}, err
-	}
-	return projectedConversationRuntimeState{
-		Summary:              strings.TrimSpace(typed.Summary),
-		LastTurn:             typed.LastTurn,
-		ProviderSessionID:    strings.TrimSpace(typed.ProviderSessionID),
-		RetryReason:          strings.TrimSpace(typed.RetryReason),
-		RetriesFromSessionID: strings.TrimSpace(typed.RetriesFromSessionID),
-	}, nil
-}
-
-func (p projectedConversationRuntimeState) metadata() ConversationSummaryMetadata {
+func projectConversationSummaryMetadata(p store.ConversationRuntimeStateDescriptor) ConversationSummaryMetadata {
 	return ConversationSummaryMetadata{
 		ProviderSessionID:    p.ProviderSessionID,
 		RetryReason:          p.RetryReason,
@@ -51,7 +17,7 @@ func (p projectedConversationRuntimeState) metadata() ConversationSummaryMetadat
 	}
 }
 
-func (p projectedConversationRuntimeState) runtimeState() ConversationRuntimeState {
+func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor) ConversationRuntimeState {
 	state := ConversationRuntimeState{
 		Summary:              p.Summary,
 		ProviderSessionID:    p.ProviderSessionID,
@@ -60,7 +26,7 @@ func (p projectedConversationRuntimeState) runtimeState() ConversationRuntimeSta
 	}
 	if p.LastTurn != nil {
 		state.LastTurn = &ConversationRuntimeLastTurn{
-			TaskID:  strings.TrimSpace(p.LastTurn.TaskID),
+			TaskID:  p.LastTurn.TaskID,
 			ParseOK: p.LastTurn.ParseOK,
 		}
 	}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1464,6 +1464,35 @@ func TestSQLConversationReader_ListFailsOnMalformedCanonicalRuntimeState(t *test
 	}
 }
 
+func TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorCanonical,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":123}`), []byte(`[]`), time.Now().UTC()))
+
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil {
+		t.Fatal("expected malformed canonical runtime_state to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetFailsOnMalformedCanonicalTurnSummary(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/store/conversation_runtime_state.go
+++ b/internal/store/conversation_runtime_state.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type ConversationRuntimeStateDescriptor struct {
+	Summary              string                                 `json:"summary,omitempty"`
+	LastTurn             *ConversationRuntimeLastTurnDescriptor `json:"last_turn,omitempty"`
+	ProviderSessionID    string                                 `json:"provider_session_id,omitempty"`
+	RetryReason          string                                 `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string                                 `json:"retries_from_session_id,omitempty"`
+}
+
+type ConversationRuntimeLastTurnDescriptor struct {
+	TaskID  string `json:"task_id,omitempty"`
+	ParseOK bool   `json:"parse_ok"`
+}
+
+func DecodeConversationRuntimeStateDescriptor(raw []byte) (ConversationRuntimeStateDescriptor, error) {
+	var payload ConversationRuntimeStateDescriptor
+	if len(raw) == 0 {
+		return payload, nil
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ConversationRuntimeStateDescriptor{}, err
+	}
+	payload.Summary = strings.TrimSpace(payload.Summary)
+	payload.ProviderSessionID = strings.TrimSpace(payload.ProviderSessionID)
+	payload.RetryReason = strings.TrimSpace(payload.RetryReason)
+	payload.RetriesFromSessionID = strings.TrimSpace(payload.RetriesFromSessionID)
+	if payload.LastTurn != nil {
+		payload.LastTurn.TaskID = strings.TrimSpace(payload.LastTurn.TaskID)
+	}
+	return payload, nil
+}

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -914,9 +914,7 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 			session_id::text,
 			scope_key,
 			COALESCE(conversation, '[]'::jsonb),
-			COALESCE(runtime_state->>'summary', ''),
-			COALESCE(runtime_state->>'retry_reason', ''),
-			COALESCE(runtime_state->>'retries_from_session_id', ''),
+			COALESCE(runtime_state, '{}'::jsonb),
 			COALESCE(turn_count, 0),
 			COALESCE(status, 'active')
 		FROM agent_sessions
@@ -933,14 +931,12 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 	rec.Mode = resolvedMode.String()
 	rec.SessionScope = resolved.Scope.String()
 
-	var rawMessages []byte
+	var rawMessages, runtimeStateRaw []byte
 	err = s.DB.QueryRowContext(ctx, q, agentID, resolvedMode.String(), resolved.ScopeKey).Scan(
 		&rec.SessionID,
 		&rec.ScopeKey,
 		&rawMessages,
-		&rec.Summary,
-		&rec.RetryReason,
-		&rec.RetriesFromSessionID,
+		&runtimeStateRaw,
 		&rec.TurnCount,
 		&rec.Status,
 	)
@@ -950,6 +946,13 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 		}
 		return runtimellm.ConversationRecord{}, false, fmt.Errorf("load active conversation: %w", err)
 	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, fmt.Errorf("decode conversation runtime_state: %w", err)
+	}
+	rec.Summary = runtimeState.Summary
+	rec.RetryReason = runtimeState.RetryReason
+	rec.RetriesFromSessionID = runtimeState.RetriesFromSessionID
 	if len(rawMessages) > 0 {
 		var msgs []runtimellm.Message
 		if json.Unmarshal(rawMessages, &msgs) == nil {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2339,6 +2339,29 @@ func TestManagerStore_LoadActiveConversationIncludesRetryLineage(t *testing.T) {
 	}
 }
 
+func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = '{"summary":123}'::jsonb
+		WHERE session_id = $1::uuid
+	`, sessionID); err != nil {
+		t.Fatalf("seed malformed runtime_state: %v", err)
+	}
+
+	if _, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global"); err == nil || ok {
+		t.Fatalf("expected malformed canonical runtime_state to fail, ok=%v err=%v", ok, err)
+	} else if !strings.Contains(err.Error(), "decode conversation runtime_state") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestManagerStore_Conversations_AndAgentTurns_PersistRunIDWhenColumnsExist(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #234

## Human Summary
This replaces the touched conversation `runtime_state` reader seam with one shared typed descriptor owned at the store boundary. The dashboard conversation reader and the active-conversation store loader now decode the same canonical runtime-state shape instead of each selectively pulling a local subset of JSON keys.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_conversation_audits`

## What Changed
- added a shared typed `ConversationRuntimeStateDescriptor` in `internal/store/conversation_runtime_state.go`
- changed the dashboard conversation summary/detail reader to decode that shared descriptor instead of a dashboard-local selective-key projection
- changed `LoadActiveConversation` to read full persisted `runtime_state` and decode the same descriptor instead of extracting individual keys in SQL
- added focused regressions for malformed canonical `runtime_state` in both the dashboard detail path and the store active-conversation loader

## Why This Is Needed
The current seam let the dashboard and store loader each reinterpret `runtime_state` by selectively decoding only the keys they cared about. That made semantic drift cheap and let malformed persisted shape be partially tolerated. The canonical persisted session/audit `runtime_state` should have one explicit typed owner, and malformed shape should fail closed.

## Scope Boundaries
- kept the change narrow to the touched conversation/session `runtime_state` read seam
- did not redesign broader session persistence or runtime-state write behavior outside the touched boundary
- did not widen into runtime session registry loading, which remains a separate seam

## Tests Run
- `go test ./internal/dashboard/server ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk
The canonical descriptor is now shared for the touched dashboard and active-conversation loader paths, but other runtime/session consumers that still read individual `runtime_state` keys remain outside this issue’s scope and could be cleaned up separately.

## Follow-Up
A logical follow-up is to move the remaining runtime/session readers that still query individual `runtime_state` keys onto the same typed descriptor so the session runtime-state seam has one owner end to end.
