### PR TITLE
[agent-b][issue #193] Introduce typed engine workflow state carrier

### DIFF
--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -22,11 +22,10 @@ type ContextBuilderInput struct {
 }
 
 func BuildBaseContext(input ContextBuilderInput) BaseContext {
-	normalizeSnapshotGates(&input.State)
 	base := values.NewContext()
 	base.Entity = values.Wrap(input.State.EntityContext())
-	base.Metadata = values.Wrap(cloneStringAnyMap(input.State.Metadata))
-	base.Gates = values.Wrap(boolMapToAnyMap(input.State.Gates))
+	base.Metadata = values.Wrap(cloneStringAnyMap(input.State.StateCarrier.Metadata))
+	base.Gates = values.Wrap(boolMapToAnyMap(input.State.StateCarrier.Gates))
 	base.Payload = values.Wrap(cloneStringAnyMap(input.Payload))
 	if input.Source != nil {
 		base.Policy = values.Wrap(policyDocumentToMap(input.Source.ResolvedPolicyForFlow(input.FlowID)))

--- a/internal/runtime/engine/context_builder_test.go
+++ b/internal/runtime/engine/context_builder_test.go
@@ -15,8 +15,7 @@ func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
 			WorkflowName:    "wf",
 			WorkflowVersion: "v1",
 			CurrentState:    "researching",
-			Metadata:        map[string]any{"k": "v"},
-			Gates:           map[string]bool{"review": true},
+			StateCarrier:    NewStateCarrier(map[string]any{"k": "v"}, map[string]bool{"review": true}, nil),
 		},
 		Payload: map[string]any{"p": "x"},
 	}
@@ -36,7 +35,7 @@ func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
 		t.Fatalf("gates bucket missing review: %#v", base.Gates.Raw())
 	}
 	input.Payload["p"] = "changed"
-	input.State.Metadata["k"] = "changed"
+	input.State.StateCarrier.Metadata["k"] = "changed"
 	if got := base.Payload.Raw()["p"]; got != "x" {
 		t.Fatalf("payload clone lost isolation: %#v", got)
 	}
@@ -101,11 +100,11 @@ func TestStateSnapshotBucketHelpers(t *testing.T) {
 	if got := snapshot.MetadataBucket().String("status"); got != "ready" {
 		t.Fatalf("metadata string = %q", got)
 	}
-	if !snapshot.Gates["review"] {
-		t.Fatalf("snapshot gates missing: %#v", snapshot.Gates)
+	if !snapshot.StateCarrier.Gates["review"] {
+		t.Fatalf("snapshot gates missing: %#v", snapshot.StateCarrier.Gates)
 	}
-	if gates, ok := snapshot.MetadataBucket().Map("gates"); !ok || !gates.Bool("review") {
-		t.Fatalf("metadata gates missing: %#v, %v", gates.Raw(), ok)
+	if !snapshot.GatesBucket().Bool("review") {
+		t.Fatalf("typed gates missing: %#v", snapshot.GatesBucket().Raw())
 	}
 }
 
@@ -113,16 +112,16 @@ func TestStateMutationAndResultBucketHelpers(t *testing.T) {
 	var mutation StateMutation
 	mutation.SetMetadata("status", "ready")
 	mutation.SetGateValue("review", false)
-	mutation.SetStateBuckets(map[string]any{"node-1": map[string]any{"count": 2}})
+	mutation.SetStateBuckets(map[string]map[string]any{"node-1": {"count": 2}})
 
 	if got := mutation.MetadataBucket().String("status"); got != "ready" {
 		t.Fatalf("mutation metadata string = %q", got)
 	}
-	if mutation.Gates["review"] {
-		t.Fatalf("mutation gates wrong: %#v", mutation.Gates)
+	if mutation.StateCarrier.Gates["review"] {
+		t.Fatalf("mutation gates wrong: %#v", mutation.StateCarrier.Gates)
 	}
-	if gates, ok := mutation.MetadataBucket().Map("gates"); !ok || gates.Bool("review") {
-		t.Fatalf("mutation gates wrong: %#v, %v", gates.Raw(), ok)
+	if mutation.GatesBucket().Bool("review") {
+		t.Fatalf("mutation gates wrong: %#v", mutation.GatesBucket().Raw())
 	}
 	if bucket, ok := mutation.StateBucketsBucket().Map("node-1"); !ok || bucket.Int("count") != 2 {
 		t.Fatalf("state buckets wrong: %#v, %v", bucket.Raw(), ok)

--- a/internal/runtime/engine/declarative_node_test.go
+++ b/internal/runtime/engine/declarative_node_test.go
@@ -119,7 +119,7 @@ func TestDeclarativeNode_HandleUsesExplicitHandlerWithoutLookup(t *testing.T) {
 		EntityID: "entity-1",
 		Event:    events.Event{Type: "task.completed"},
 		Handler:  runtimecontracts.SystemNodeEventHandler{ClearGates: []string{"gate_a"}},
-		State:    StateSnapshot{Gates: map[string]bool{"gate_a": true}},
+		State:    StateSnapshot{StateCarrier: NewStateCarrier(nil, map[string]bool{"gate_a": true}, nil)},
 	})
 	if err != nil {
 		t.Fatalf("Handle error: %v", err)

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -241,7 +241,6 @@ func (e *Executor) loadState(ctx context.Context, req ExecutionRequest) (StateSn
 	if state.EntityID.IsZero() {
 		state.EntityID = req.EntityID
 	}
-	normalizeSnapshotGates(&state)
 	if req.EntityID.IsZero() {
 		return state, nil
 	}
@@ -257,12 +256,11 @@ func (e *Executor) loadState(ctx context.Context, req ExecutionRequest) (StateSn
 
 func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame {
 	state := req.State
-	if state.Metadata == nil {
-		state.Metadata = map[string]any{}
+	if state.StateCarrier.Metadata == nil {
+		state.StateCarrier.Metadata = map[string]any{}
 	}
-	normalizeSnapshotGates(&state)
-	if state.StateBuckets == nil {
-		state.StateBuckets = map[string]any{}
+	if state.StateCarrier.StateBuckets == nil {
+		state.StateCarrier.StateBuckets = map[string]map[string]any{}
 	}
 	payload := decodePayload(req.Event.Payload)
 	if len(payload) == 0 {
@@ -433,12 +431,12 @@ func (e *Executor) stepClearGates(frame *executionFrame) error {
 	}
 	frame.result.ClearGates = normalizeStrings(e.resolveClearGates(frame))
 	frame.result.StateMutation.ClearGates = append([]string{}, frame.result.ClearGates...)
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	for _, gate := range frame.result.ClearGates {
 		frame.state.State.SetGate(gate, false)
 		frame.result.StateMutation.SetGateValue(gate, false)
 	}
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	return nil
 }
 
@@ -512,7 +510,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	acc.LastSource = strings.TrimSpace(frame.req.Event.SourceAgent)
 	acc.LastReceivedAt = frame.req.Event.CreatedAt.UTC().Format(time.RFC3339Nano)
 	storeAccumulatorForBucket(&frame.state.State, bucketRef, acc)
-	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateBuckets)
+	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateCarrier.StateBuckets)
 	frame.state.Accumulated = accumulatorExpressionValue(acc)
 	if isAccumulationTimeoutEvent(frame.req.Event.Type) && spec.OnTimeout != nil {
 		frame.rule = spec.OnTimeout
@@ -615,7 +613,7 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 	frame.state.SetComputed(field, value)
 	frame.result.SetComputed(field, value)
 	frame.state.State.SetMetadata(field, value)
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.result.StateMutation.SetMetadata(field, value)
 	return nil
 }
@@ -785,10 +783,10 @@ func (e *Executor) stepSetsGate(frame *executionFrame) error {
 	}
 	frame.result.SetsGate = name
 	frame.result.StateMutation.SetGate = name
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.state.State.SetGate(name, true)
 	frame.result.StateMutation.SetGateValue(name, true)
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	return nil
 }
 
@@ -894,24 +892,23 @@ func (e *Executor) stepClear(frame *executionFrame) error {
 		switch target {
 		case "accumulator_state":
 			if !frame.req.NodeID.IsZero() {
-				root := frame.state.State.EnsureStateBucketsBucket()
-				if bucket, ok := root.Map(frame.req.NodeID.String()); ok {
+				if bucket, ok := frame.state.State.StateBucket(frame.req.NodeID.String()); ok {
 					delete(bucket.Raw(), handlerAccumulatorBucketKey)
 				}
 			}
-			delete(frame.state.State.Metadata, "accumulated_count")
-			delete(frame.state.State.Metadata, "accumulated_total")
-			delete(frame.state.State.Metadata, "received_items")
+			delete(frame.state.State.StateCarrier.Metadata, "accumulated_count")
+			delete(frame.state.State.StateCarrier.Metadata, "accumulated_total")
+			delete(frame.state.State.StateCarrier.Metadata, "received_items")
 		case "cycle_counters":
-			delete(frame.state.State.Metadata, "cycle_index")
+			delete(frame.state.State.StateCarrier.Metadata, "cycle_index")
 		case "pending_dedup":
-			delete(frame.state.State.Metadata, "dedup_key")
+			delete(frame.state.State.StateCarrier.Metadata, "dedup_key")
 		default:
 			e.clearStepValue(frame, target)
 		}
 	}
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
-	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateBuckets)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
+	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateCarrier.StateBuckets)
 	return nil
 }
 
@@ -938,11 +935,11 @@ func (e *Executor) buildTimerIntents(frame *executionFrame) []TimerIntent {
 }
 
 func (e *Executor) persist(ctx context.Context, frame executionFrame) error {
-	if frame.result.StateMutation.Metadata == nil {
-		frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	if frame.result.StateMutation.StateCarrier.Metadata == nil {
+		frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	}
-	if frame.result.StateMutation.StateBuckets == nil {
-		frame.result.StateMutation.SetStateBuckets(frame.state.State.StateBuckets)
+	if frame.result.StateMutation.StateCarrier.StateBuckets == nil {
+		frame.result.StateMutation.SetStateBuckets(frame.state.State.StateCarrier.StateBuckets)
 	}
 	if err := e.deps.StateRepo.SaveState(ctx, frame.req.EntityID, frame.result.StateMutation); err != nil {
 		return err
@@ -981,7 +978,7 @@ func (e *Executor) emitPersistencePrerequisites(frame executionFrame) EmitPersis
 			return
 		}
 		prerequisite := EmitPersistenceFieldPrerequisite{Field: field}
-		if expected, ok := lookupParsedPath(frame.state.State.Metadata, path); ok {
+		if expected, ok := lookupParsedPath(frame.state.State.StateCarrier.Metadata, path); ok {
 			prerequisite.Expected = expected
 			prerequisite.HasExpected = true
 		}
@@ -1091,19 +1088,18 @@ func mergeStateSnapshots(base, loaded StateSnapshot) StateSnapshot {
 	if out.EnteredStateAt.IsZero() {
 		out.EnteredStateAt = base.EnteredStateAt
 	}
-	if len(out.Metadata) == 0 {
-		out.Metadata = cloneStringAnyMap(base.Metadata)
+	if len(out.StateCarrier.Metadata) == 0 {
+		out.StateCarrier.Metadata = cloneStringAnyMap(base.StateCarrier.Metadata)
 	}
-	if len(out.Gates) == 0 && len(base.Gates) > 0 {
-		out.Gates = mapsClone(base.Gates)
+	if len(out.StateCarrier.Gates) == 0 && len(base.StateCarrier.Gates) > 0 {
+		out.StateCarrier.Gates = mapsClone(base.StateCarrier.Gates)
 	}
-	if len(out.StateBuckets) == 0 {
-		out.StateBuckets = cloneStringAnyMap(base.StateBuckets)
+	if len(out.StateCarrier.StateBuckets) == 0 {
+		out.StateCarrier.StateBuckets = cloneStateBucketSet(base.StateCarrier.StateBuckets)
 	}
 	if len(out.TimerState) == 0 && len(base.TimerState) > 0 {
 		out.TimerState = append([]TimerState(nil), base.TimerState...)
 	}
-	normalizeSnapshotGates(&out)
 	return out
 }
 
@@ -1111,8 +1107,8 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx := WithPayload(frame.base, frame.payload)
 	ctx = WithAccumulated(ctx, frame.state.Accumulated)
 	ctx = WithFanOutItem(ctx, frame.state.FanOut)
-	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.Metadata))
-	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.Gates))
+	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
+	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))
 	ctx.Entity = values.Wrap(frame.state.State.EntityContext())
 	ctx.Computed = values.Wrap(cloneStringAnyMap(frame.state.Computed))
 	return ctx
@@ -1133,18 +1129,18 @@ func (e *Executor) writeStepValue(frame *executionFrame, target string, value an
 	case paths.RootFanOut:
 		frame.state.SetFanOut(strings.Join(parsed.Segments, "."), value)
 	default:
-		if frame.state.State.Metadata == nil {
-			frame.state.State.Metadata = map[string]any{}
+		if frame.state.State.StateCarrier.Metadata == nil {
+			frame.state.State.StateCarrier.Metadata = map[string]any{}
 		}
 		switch {
 		case parsed.Root == paths.RootEntity || parsed.Root == paths.RootMetadata:
-			setParsedValuePath(frame.state.State.Metadata, paths.Path{Segments: parsed.Segments}, value)
+			setParsedValuePath(frame.state.State.StateCarrier.Metadata, paths.Path{Segments: parsed.Segments}, value)
 		case parsed.HasExplicitRoot():
-			setParsedValuePath(frame.state.State.Metadata, paths.Path{Segments: parsed.Segments}, value)
+			setParsedValuePath(frame.state.State.StateCarrier.Metadata, paths.Path{Segments: parsed.Segments}, value)
 		default:
-			setParsedValuePath(frame.state.State.Metadata, parsed, value)
+			setParsedValuePath(frame.state.State.StateCarrier.Metadata, parsed, value)
 		}
-		frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+		frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	}
 }
 
@@ -1155,7 +1151,7 @@ func (e *Executor) clearStepValue(frame *executionFrame, target string) {
 	}
 	parsed := paths.Parse(target)
 	if !parsed.HasExplicitRoot() {
-		executionDeletePath(frame.state.State.Metadata, strings.Split(target, "."))
+		executionDeletePath(frame.state.State.StateCarrier.Metadata, strings.Split(target, "."))
 		return
 	}
 	switch parsed.Root {
@@ -1167,9 +1163,9 @@ func (e *Executor) clearStepValue(frame *executionFrame, target string) {
 	case paths.RootFanOut:
 		delete(frame.state.FanOut, strings.Join(parsed.Segments, "."))
 	case paths.RootEntity, paths.RootMetadata:
-		executionDeletePath(frame.state.State.Metadata, parsed.Segments)
+		executionDeletePath(frame.state.State.StateCarrier.Metadata, parsed.Segments)
 	default:
-		delete(frame.state.State.Metadata, target)
+		delete(frame.state.State.StateCarrier.Metadata, target)
 	}
 }
 
@@ -1282,7 +1278,7 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) {
 	applyDataAccumulationToState(e.currentContext(frame), frame.state, &frame.state.State, spec)
 	frame.state.State.SetMetadata("last_data_accumulation_event", strings.TrimSpace(string(frame.req.Event.Type)))
-	frame.result.StateMutation.Metadata = cloneStringAnyMap(frame.state.State.Metadata)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.result.StateMutation.DataAccumulation = spec
 }
 
@@ -1425,10 +1421,10 @@ func (e *Executor) resolveClearGates(frame *executionFrame) []string {
 	if !slices.Contains(frame.req.Handler.ClearGates, "*") {
 		return frame.req.Handler.ClearGates
 	}
-	if len(frame.state.State.Gates) == 0 {
+	if len(frame.state.State.StateCarrier.Gates) == 0 {
 		return nil
 	}
-	return normalizeStrings(stringSliceFromAny(mapsKeys(boolMapToAnyMap(frame.state.State.Gates))))
+	return normalizeStrings(stringSliceFromAny(mapsKeys(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))))
 }
 
 func (e *Executor) applyGuardFailure(frame *executionFrame, action string) error {

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -36,10 +36,12 @@ func (r *persistentStateRepo) LoadState(context.Context, identity.EntityID) (Sta
 	return StateSnapshot{
 		EntityID:     r.snapshot.EntityID,
 		CurrentState: r.snapshot.CurrentState,
-		Metadata:     cloneStringAnyMap(r.snapshot.Metadata),
-		Gates:        cloneBoolMap(r.snapshot.Gates),
-		StateBuckets: cloneStringAnyMap(r.snapshot.StateBuckets),
-		TimerState:   append([]TimerState(nil), r.snapshot.TimerState...),
+		StateCarrier: NewStateCarrier(
+			r.snapshot.StateCarrier.Metadata,
+			r.snapshot.StateCarrier.Gates,
+			r.snapshot.StateCarrier.StateBuckets,
+		),
+		TimerState: append([]TimerState(nil), r.snapshot.TimerState...),
 	}, true, nil
 }
 
@@ -48,9 +50,7 @@ func (r *persistentStateRepo) SaveState(_ context.Context, entityID identity.Ent
 		r.found = true
 		r.snapshot = StateSnapshot{
 			EntityID:     entityID,
-			Metadata:     map[string]any{},
-			Gates:        map[string]bool{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, map[string]bool{}, map[string]map[string]any{}),
 		}
 	}
 	if !entityID.IsZero() {
@@ -59,14 +59,14 @@ func (r *persistentStateRepo) SaveState(_ context.Context, entityID identity.Ent
 	if next := mutation.NextState; next != "" {
 		r.snapshot.CurrentState = next
 	}
-	if mutation.Metadata != nil {
-		r.snapshot.Metadata = cloneStringAnyMap(mutation.Metadata)
+	if mutation.StateCarrier.Metadata != nil {
+		r.snapshot.StateCarrier.Metadata = cloneStringAnyMap(mutation.StateCarrier.Metadata)
 	}
-	if mutation.StateBuckets != nil {
-		r.snapshot.StateBuckets = cloneStringAnyMap(mutation.StateBuckets)
+	if mutation.StateCarrier.StateBuckets != nil {
+		r.snapshot.StateCarrier.StateBuckets = cloneStateBucketSet(mutation.StateCarrier.StateBuckets)
 	}
-	if mutation.Gates != nil {
-		r.snapshot.Gates = cloneBoolMap(mutation.Gates)
+	if mutation.StateCarrier.Gates != nil {
+		r.snapshot.StateCarrier.Gates = cloneBoolMap(mutation.StateCarrier.Gates)
 	}
 	return nil
 }
@@ -88,8 +88,7 @@ func TestExecutor_RejectsInvalidAdvancesToTransition(t *testing.T) {
 		found: true,
 		snapshot: StateSnapshot{
 			CurrentState: "pending",
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
 		},
 	}
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -130,8 +129,7 @@ func TestExecutor_GuardBlocksTransitionForTerminalState(t *testing.T) {
 		found: true,
 		snapshot: StateSnapshot{
 			CurrentState: "done",
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
 		},
 	}
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -178,7 +176,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 	newExecutor := func(score int, allowed bool) *Executor {
 		exec, err := NewExecutor(RuntimeDependencies{
 			Source:       stubSource(),
-			StateRepo:    &persistentStateRepo{found: true, snapshot: StateSnapshot{Metadata: map[string]any{"score": score}, StateBuckets: map[string]any{}}},
+			StateRepo:    &persistentStateRepo{found: true, snapshot: StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{"score": score}, nil, map[string]map[string]any{})}},
 			TxRunner:     stubRunner{},
 			Locker:       stubLocker{},
 			Outbox:       stubOutbox{},
@@ -243,8 +241,7 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 		snapshot: StateSnapshot{
 			EntityID:     "entity-1",
 			CurrentState: "collecting",
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
 		},
 	}
 	acc := &Accumulator{
@@ -326,8 +323,7 @@ func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {
 		found: true,
 		snapshot: StateSnapshot{
 			CurrentState: "pending",
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
 		},
 	}
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -368,7 +364,7 @@ func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {
 		State: StateSnapshot{
 			EntityID:     "ent-1",
 			CurrentState: "pending",
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(nil, nil, map[string]map[string]any{}),
 		},
 	})
 	if err != nil {
@@ -381,9 +377,9 @@ func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("LoadState = %v, ok=%v", err, ok)
 	}
-	got, ok := state.Metadata["composite"].(float64)
+	got, ok := state.StateCarrier.Metadata["composite"].(float64)
 	if !ok {
-		t.Fatalf("composite type = %T, want float64", state.Metadata["composite"])
+		t.Fatalf("composite type = %T, want float64", state.StateCarrier.Metadata["composite"])
 	}
 	if got != 0 {
 		t.Fatalf("composite = %v, want 0 for empty accumulator compute", got)
@@ -394,8 +390,7 @@ func TestExecutor_AccumulationDeduplicatesRepeatedEvent(t *testing.T) {
 	repo := &persistentStateRepo{
 		found: true,
 		snapshot: StateSnapshot{
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
 		},
 	}
 	exec, err := NewExecutor(RuntimeDependencies{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -76,7 +76,7 @@ func (r lockOrderStateRepo) LoadState(context.Context, identity.EntityID) (State
 	if r.order != nil {
 		*r.order = append(*r.order, "load")
 	}
-	return StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}}, true, nil
+	return testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}), true, nil
 }
 func (lockOrderStateRepo) SaveState(context.Context, identity.EntityID, StateMutation) error {
 	return nil
@@ -142,6 +142,13 @@ func (s *recordingPayloadShaper) ShapeEmitPayload(_ context.Context, req Executi
 type stubTx struct{ ctx context.Context }
 
 func (s stubTx) Context() context.Context { return s.ctx }
+
+func testStateSnapshot(currentState string, metadata map[string]any, gates map[string]bool, buckets map[string]map[string]any) StateSnapshot {
+	return StateSnapshot{
+		CurrentState: currentState,
+		StateCarrier: NewStateCarrier(metadata, gates, buckets),
+	}
+}
 
 func TestNewExecutor_DefaultsMaxChainDepth(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -304,10 +311,7 @@ func TestExecutor_LoadsStateInsideEntityLock(t *testing.T) {
 			Type:      events.EventType("test.event"),
 			CreatedAt: time.Now().UTC(),
 		}.WithEntityID("11111111-1111-1111-1111-111111111111"),
-		State: StateSnapshot{
-			Metadata:     map[string]any{},
-			StateBuckets: map[string]any{},
-		},
+		State: StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{})},
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -370,10 +374,9 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 		State: StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 			CurrentState: "discovered",
-			Metadata: map[string]any{
+			StateCarrier: NewStateCarrier(map[string]any{
 				"composite_score": 0,
-			},
-			StateBuckets: map[string]any{},
+			}, nil, map[string]map[string]any{}),
 		},
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Compute: &runtimecontracts.ComputeSpec{
@@ -405,7 +408,7 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 	if len(result.EmitIntents) != 1 {
 		t.Fatalf("emit intents = %d, want 1", len(result.EmitIntents))
 	}
-	if got := shaper.lastReq.State.Metadata["composite_score"]; got != 80.0 && got != 80 {
+	if got := shaper.lastReq.State.StateCarrier.Metadata["composite_score"]; got != 80.0 && got != 80 {
 		t.Fatalf("payload shaper saw composite_score = %#v, want 80", got)
 	}
 }
@@ -416,7 +419,7 @@ type orderedStateRepo struct {
 }
 
 func (r *orderedStateRepo) LoadState(context.Context, identity.EntityID) (StateSnapshot, bool, error) {
-	return StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}}, true, nil
+	return testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}), true, nil
 }
 
 func (r *orderedStateRepo) SaveState(_ context.Context, _ identity.EntityID, mutation StateMutation) error {
@@ -484,7 +487,7 @@ func TestExecutor_ExecuteUsesAtomicEnvelopeAndOrderedSteps(t *testing.T) {
 			Emits:      runtimecontracts.EventEmission{Single: "task.recorded"},
 			Action:     runtimecontracts.ActionSpec{ID: "record"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -532,10 +535,9 @@ func TestExecutor_ListPrimitivesMutateState(t *testing.T) {
 	}
 	initial := StateSnapshot{
 		CurrentState: "pending",
-		Metadata: map[string]any{
+		StateCarrier: NewStateCarrier(map[string]any{
 			"dedup_key": "dup-1",
-		},
-		StateBuckets: map[string]any{},
+		}, nil, map[string]map[string]any{}),
 	}
 	storeAccumulator(&initial, "node-1", "items.submitted", &Accumulator{
 		StartedAt:     "2026-03-14T00:00:00Z",
@@ -590,7 +592,7 @@ func TestExecutor_ListPrimitivesMutateState(t *testing.T) {
 	if _, ok := repo.mutation.Metadata["dedup_key"]; ok {
 		t.Fatalf("expected dedup_key to be cleared, metadata=%#v", repo.mutation.Metadata)
 	}
-	if nodeBucket, ok := repo.mutation.StateBuckets["node-1"].(map[string]any); ok {
+	if nodeBucket, ok := repo.mutation.StateBuckets["node-1"]; ok {
 		if _, ok := nodeBucket[handlerAccumulatorBucketKey]; ok {
 			t.Fatalf("expected accumulator state to be cleared, state_buckets=%#v", repo.mutation.StateBuckets)
 		}
@@ -628,7 +630,7 @@ func TestExecutor_QueryGroupByStoresCounts(t *testing.T) {
 				StoreAs: "entity.grouped",
 			},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -678,8 +680,7 @@ func TestExecutor_GuardRecursesAndUsesRegistryCheck(t *testing.T) {
 			},
 		},
 		State: StateSnapshot{
-			Metadata:     map[string]any{"allowed": true},
-			StateBuckets: map[string]any{},
+			StateCarrier: NewStateCarrier(map[string]any{"allowed": true}, nil, map[string]map[string]any{}),
 		},
 	})
 	if err != nil {
@@ -716,7 +717,7 @@ func TestExecutor_RulesUseFirstMatchAndSkipLaterEntries(t *testing.T) {
 				{ID: "rule-2", Condition: "else", AdvancesTo: "rejected"},
 			},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -757,7 +758,7 @@ func TestExecutor_RuleEmitsAugmentHandlerEmits(t *testing.T) {
 				Emits:     runtimecontracts.EventEmission{Single: "rule.emitted"},
 			}},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -810,7 +811,7 @@ func TestExecutor_RuleDataAccumulationRunsBeforeTopLevelWrites(t *testing.T) {
 				},
 			}},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -862,7 +863,7 @@ func TestExecutor_RulesDoNotSeeCurrentHandlerTopLevelWritesBeforeSelection(t *te
 				},
 			}},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -912,7 +913,7 @@ func TestExecutor_OnCompleteDoesNotSeeCurrentHandlerTopLevelWritesBeforeSelectio
 				Emits:     runtimecontracts.EventEmission{Single: "branch.selected"},
 			}},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -951,7 +952,7 @@ func TestExecutor_ChainDepthOverflowInterceptsEmitsButSucceeds(t *testing.T) {
 			AdvancesTo: "done",
 			Emits:      runtimecontracts.EventEmission{Single: "task.followup"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1002,7 +1003,7 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 			AdvancesTo: "processing",
 			Action:     runtimecontracts.ActionSpec{ID: "should_not_run"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1083,7 +1084,7 @@ func TestExecutor_PayloadTransformSeesDataAccumulationWrites(t *testing.T) {
 			},
 			Emits: runtimecontracts.EventEmission{Single: "scoring.requested"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1143,7 +1144,7 @@ func TestExecutor_PayloadTransformCELFailureReturnsError(t *testing.T) {
 			},
 			Emits: runtimecontracts.EventEmission{Single: "scoring.requested"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err == nil {
 		t.Fatal("expected payload transform CEL failure to return an error")
@@ -1177,7 +1178,7 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 			},
 			AdvancesTo: "scanning",
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1223,7 +1224,7 @@ func TestExecutor_FanOutStructuredEmitMappingSelectsEventByKeyField(t *testing.T
 				},
 			},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1267,7 +1268,7 @@ func TestExecutor_GuardKillTransitionsToKilledStateWhenDeclared(t *testing.T) {
 			AdvancesTo: "done",
 			Emits:      runtimecontracts.EventEmission{Single: "check.passed"},
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1308,7 +1309,7 @@ func TestExecutor_GroupByStoresGroupedItems(t *testing.T) {
 			},
 			AdvancesTo: "done",
 		},
-		State: StateSnapshot{CurrentState: "pending", Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1348,8 +1349,7 @@ func TestExecutor_ClearGatesWildcardUsesNodeGateSchema(t *testing.T) {
 			ClearGates: []string{"*"},
 		},
 		State: StateSnapshot{
-			Metadata: map[string]any{"note": "keep"},
-			Gates:    map[string]bool{"gate_a": true, "gate_b": true},
+			StateCarrier: NewStateCarrier(map[string]any{"note": "keep"}, map[string]bool{"gate_a": true, "gate_b": true}, nil),
 		},
 	})
 	if err != nil {
@@ -1361,9 +1361,8 @@ func TestExecutor_ClearGatesWildcardUsesNodeGateSchema(t *testing.T) {
 	if result.StateMutation.Gates["gate_a"] != false || result.StateMutation.Gates["gate_b"] != false {
 		t.Fatalf("typed gates not cleared: %#v", result.StateMutation.Gates)
 	}
-	gates, _ := result.StateMutation.Metadata["gates"].(map[string]any)
-	if gates["gate_a"] != false || gates["gate_b"] != false {
-		t.Fatalf("gate metadata not cleared: %#v", result.StateMutation.Metadata)
+	if result.StateMutation.Gates["gate_a"] != false || result.StateMutation.Gates["gate_b"] != false {
+		t.Fatalf("typed gate state not cleared: %#v", result.StateMutation.Gates)
 	}
 	if result.StateMutation.Metadata["note"] != "keep" {
 		t.Fatalf("non-gate metadata changed: %#v", result.StateMutation.Metadata)
@@ -1395,9 +1394,7 @@ func TestExecutor_ClearGatesRunsBeforeGuardEvaluation(t *testing.T) {
 				Check: "entity.gates.review == false",
 			},
 		},
-		State: StateSnapshot{
-			Gates: map[string]bool{"review": true},
-		},
+		State: StateSnapshot{StateCarrier: NewStateCarrier(nil, map[string]bool{"review": true}, nil)},
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1436,7 +1433,7 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "notify"},
 		},
-		State: StateSnapshot{Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -1480,7 +1477,7 @@ func TestExecutor_GuardOnFailEscalateCreatesEmitIntent(t *testing.T) {
 				OnFail: "escalate:guard.failed",
 			},
 		},
-		State: StateSnapshot{Metadata: map[string]any{}, StateBuckets: map[string]any{}},
+		State: testStateSnapshot("", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)

--- a/internal/runtime/engine/gates.go
+++ b/internal/runtime/engine/gates.go
@@ -1,9 +1,6 @@
 package engine
 
-import (
-	"strconv"
-	"strings"
-)
+import "strings"
 
 func boolMapToAnyMap(in map[string]bool) map[string]any {
 	if len(in) == 0 {
@@ -20,35 +17,6 @@ func boolMapToAnyMap(in map[string]bool) map[string]any {
 	return out
 }
 
-func anyMapToBoolMap(in map[string]any) map[string]bool {
-	if len(in) == 0 {
-		return map[string]bool{}
-	}
-	out := make(map[string]bool, len(in))
-	for key, raw := range in {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-		if value, ok := gateBool(raw); ok {
-			out[key] = value
-		}
-	}
-	return out
-}
-
-func gateBool(raw any) (bool, bool) {
-	switch t := raw.(type) {
-	case bool:
-		return t, true
-	case string:
-		parsed, err := strconv.ParseBool(strings.TrimSpace(t))
-		return parsed, err == nil
-	default:
-		return false, false
-	}
-}
-
 func mapsClone(in map[string]bool) map[string]bool {
 	if len(in) == 0 {
 		return map[string]bool{}
@@ -61,60 +29,4 @@ func mapsClone(in map[string]bool) map[string]bool {
 		}
 	}
 	return out
-}
-
-func ensureMetadataGates(metadata map[string]any) map[string]bool {
-	if metadata == nil {
-		metadata = map[string]any{}
-	}
-	current, _ := metadata["gates"].(map[string]any)
-	gates := anyMapToBoolMap(current)
-	metadata["gates"] = boolMapToAnyMap(gates)
-	return gates
-}
-
-func normalizeSnapshotGates(snapshot *StateSnapshot) {
-	if snapshot == nil {
-		return
-	}
-	if snapshot.Metadata == nil {
-		snapshot.Metadata = map[string]any{}
-	}
-	metadataGates := map[string]bool{}
-	if raw, ok := snapshot.Metadata["gates"].(map[string]any); ok {
-		metadataGates = anyMapToBoolMap(raw)
-	}
-	if len(snapshot.Gates) == 0 {
-		snapshot.Gates = metadataGates
-	} else {
-		for key, value := range metadataGates {
-			if _, ok := snapshot.Gates[key]; !ok {
-				snapshot.Gates[key] = value
-			}
-		}
-	}
-	snapshot.Metadata["gates"] = boolMapToAnyMap(snapshot.Gates)
-}
-
-func normalizeMutationGates(mutation *StateMutation) {
-	if mutation == nil {
-		return
-	}
-	if mutation.Metadata == nil {
-		mutation.Metadata = map[string]any{}
-	}
-	metadataGates := map[string]bool{}
-	if raw, ok := mutation.Metadata["gates"].(map[string]any); ok {
-		metadataGates = anyMapToBoolMap(raw)
-	}
-	if len(mutation.Gates) == 0 {
-		mutation.Gates = metadataGates
-	} else {
-		for key, value := range metadataGates {
-			if _, ok := mutation.Gates[key]; !ok {
-				mutation.Gates[key] = value
-			}
-		}
-	}
-	mutation.Metadata["gates"] = boolMapToAnyMap(mutation.Gates)
 }

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -337,8 +337,7 @@ func loadAccumulatorForBucket(state StateSnapshot, bucketRef timeridentity.Accum
 	if !bucketRef.Valid() {
 		return nil, false
 	}
-	root := state.EnsureStateBucketsBucket()
-	bucket, ok := root.Map(bucketRef.NodeID)
+	bucket, ok := state.StateBucket(bucketRef.NodeID)
 	if !ok {
 		return nil, false
 	}
@@ -378,8 +377,7 @@ func storeAccumulatorForBucket(state *StateSnapshot, bucketRef timeridentity.Acc
 	if state == nil || acc == nil || !bucketRef.Valid() {
 		return
 	}
-	root := state.EnsureStateBucketsBucket()
-	bucket := root.EnsureMap(bucketRef.NodeID)
+	bucket := state.EnsureStateBucket(bucketRef.NodeID)
 	accumulators := bucket.EnsureMap(handlerAccumulatorBucketKey)
 	received := map[string]any{}
 	keys := make([]string, 0, len(acc.Received))

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -150,7 +150,7 @@ func TestPayloadTransform_NormalizesWholeNumberJSONInputs(t *testing.T) {
 }
 
 func TestApplyDataAccumulationToState_NormalizesTargets(t *testing.T) {
-	state := &StateSnapshot{Metadata: map[string]any{}}
+	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, nil)}
 	payload := map[string]any{
 		"score":  4,
 		"nested": map[string]any{"value": "ok"},
@@ -168,19 +168,19 @@ func TestApplyDataAccumulationToState_NormalizesTargets(t *testing.T) {
 
 	applyDataAccumulationToState(base, ExecutionState{FanOut: map[string]any{"count": 3}}, state, spec)
 
-	if got := state.Metadata["score"]; got != 4 {
+	if got := state.StateCarrier.Metadata["score"]; got != 4 {
 		t.Fatalf("score = %#v", got)
 	}
-	if got := state.Metadata["status"]; got != "ok" {
+	if got := state.StateCarrier.Metadata["status"]; got != "ok" {
 		t.Fatalf("status = %#v", got)
 	}
-	if got := state.Metadata["literal"]; got != "fixed" {
+	if got := state.StateCarrier.Metadata["literal"]; got != "fixed" {
 		t.Fatalf("literal = %#v", got)
 	}
-	if got := state.Metadata["dispatch_count"]; got != 3 {
+	if got := state.StateCarrier.Metadata["dispatch_count"]; got != 3 {
 		t.Fatalf("dispatch_count = %#v", got)
 	}
-	if got := state.Metadata["last_data_accumulation_source"]; got != "task.completed" {
+	if got := state.StateCarrier.Metadata["last_data_accumulation_source"]; got != "task.completed" {
 		t.Fatalf("source event = %#v", got)
 	}
 }
@@ -197,9 +197,9 @@ func TestAccumulatorStoreLoad_PreservesHandlerAccumulatorBucketPath(t *testing.T
 
 	storeAccumulator(state, "node-1", events.EventType("task.completed"), acc)
 
-	nodeBucket, ok := state.StateBuckets["node-1"].(map[string]any)
+	nodeBucket, ok := state.StateCarrier.StateBuckets["node-1"]
 	if !ok {
-		t.Fatalf("node bucket missing: %#v", state.StateBuckets)
+		t.Fatalf("node bucket missing: %#v", state.StateCarrier.StateBuckets)
 	}
 	accBuckets, ok := nodeBucket[handlerAccumulatorBucketKey].(map[string]any)
 	if !ok {
@@ -219,7 +219,7 @@ func TestAccumulatorStoreLoad_PreservesHandlerAccumulatorBucketPath(t *testing.T
 }
 
 func TestApplyDataAccumulationToState_AppliesExpressionOnlyWrites(t *testing.T) {
-	state := &StateSnapshot{Metadata: map[string]any{}}
+	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, nil)}
 	base := BaseContext{
 		Entity: values.Wrap(map[string]any{
 			"mode": "corpus",
@@ -246,17 +246,17 @@ func TestApplyDataAccumulationToState_AppliesExpressionOnlyWrites(t *testing.T) 
 
 	applyDataAccumulationToState(base, ExecutionState{}, state, spec)
 
-	dimensions, ok := state.Metadata["dimensions_requested"].([]any)
+	dimensions, ok := state.StateCarrier.Metadata["dimensions_requested"].([]any)
 	if !ok || len(dimensions) != 2 || dimensions[0] != "build_complexity" || dimensions[1] != "automation_completeness" {
-		t.Fatalf("dimensions_requested = %#v", state.Metadata["dimensions_requested"])
+		t.Fatalf("dimensions_requested = %#v", state.StateCarrier.Metadata["dimensions_requested"])
 	}
-	if got := state.Metadata["scoring_rubric"]; got != "corpus_rubric" {
+	if got := state.StateCarrier.Metadata["scoring_rubric"]; got != "corpus_rubric" {
 		t.Fatalf("scoring_rubric = %#v", got)
 	}
 }
 
 func TestApplyDataAccumulationToState_EvaluatesArithmeticCELExpressions(t *testing.T) {
-	state := &StateSnapshot{Metadata: map[string]any{}}
+	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, nil)}
 	base := BaseContext{
 		Entity: values.Wrap(map[string]any{
 			"revision_count": 0,
@@ -273,7 +273,7 @@ func TestApplyDataAccumulationToState_EvaluatesArithmeticCELExpressions(t *testi
 
 	applyDataAccumulationToState(base, ExecutionState{}, state, spec)
 
-	if got := state.Metadata["revision_count"]; got != 1.0 && got != 1 {
+	if got := state.StateCarrier.Metadata["revision_count"]; got != 1.0 && got != 1 {
 		t.Fatalf("revision_count = %#v, want 1", got)
 	}
 }

--- a/internal/runtime/engine/state_carrier_test.go
+++ b/internal/runtime/engine/state_carrier_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import "testing"
+
+func TestStateCarrierFromPersistedRoundTrip(t *testing.T) {
+	carrier, err := StateCarrierFromPersisted(
+		map[string]any{
+			"subject_id": "ent-1",
+			"score":      91,
+			"gates": map[string]any{
+				"ready": true,
+			},
+		},
+		map[string]any{
+			"evidence": map[string]any{
+				"count": 2,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("StateCarrierFromPersisted error = %v", err)
+	}
+	if got := carrier.Metadata["score"]; got != 91 {
+		t.Fatalf("metadata score = %#v, want 91", got)
+	}
+	if _, exists := carrier.Metadata["gates"]; exists {
+		t.Fatalf("carrier metadata should exclude persisted gates: %#v", carrier.Metadata)
+	}
+	if !carrier.Gates["ready"] {
+		t.Fatalf("carrier gates = %#v, want ready=true", carrier.Gates)
+	}
+	if got := carrier.StateBuckets["evidence"]["count"]; got != 2 {
+		t.Fatalf("carrier state bucket evidence.count = %#v, want 2", got)
+	}
+
+	persistedMetadata := carrier.PersistedMetadata()
+	if gates, ok := persistedMetadata["gates"].(map[string]any); !ok || gates["ready"] != true {
+		t.Fatalf("persisted metadata gates = %#v", persistedMetadata["gates"])
+	}
+	persistedBuckets := carrier.PersistedStateBuckets()
+	evidence, ok := persistedBuckets["evidence"].(map[string]any)
+	if !ok || evidence["count"] != 2 {
+		t.Fatalf("persisted state buckets evidence = %#v", persistedBuckets["evidence"])
+	}
+}
+
+func TestStateCarrierFromPersistedRejectsMalformedShapes(t *testing.T) {
+	t.Run("gates", func(t *testing.T) {
+		_, err := StateCarrierFromPersisted(map[string]any{
+			"gates": map[string]any{
+				"ready": "true",
+			},
+		}, nil)
+		if err == nil {
+			t.Fatal("expected malformed gates error")
+		}
+	})
+
+	t.Run("state_buckets", func(t *testing.T) {
+		_, err := StateCarrierFromPersisted(nil, map[string]any{
+			"evidence": "bad",
+		})
+		if err == nil {
+			t.Fatal("expected malformed state bucket error")
+		}
+	})
+}

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,97 +13,186 @@ import (
 
 const DefaultMaxChainDepth = 50
 
+type StateCarrier struct {
+	Metadata     map[string]any
+	Gates        map[string]bool
+	StateBuckets map[string]map[string]any
+}
+
+func NewStateCarrier(metadata map[string]any, gates map[string]bool, stateBuckets map[string]map[string]any) StateCarrier {
+	return StateCarrier{
+		Metadata:     cloneStringAnyMap(metadata),
+		Gates:        mapsClone(gates),
+		StateBuckets: cloneStateBucketSet(stateBuckets),
+	}
+}
+
+func StateCarrierFromPersisted(metadata map[string]any, stateBuckets map[string]any) (StateCarrier, error) {
+	fields := cloneStringAnyMap(metadata)
+	gates, err := stateCarrierGatesFromMetadata(fields)
+	if err != nil {
+		return StateCarrier{}, err
+	}
+	delete(fields, "gates")
+	buckets, err := stateBucketSetFromRaw(stateBuckets)
+	if err != nil {
+		return StateCarrier{}, err
+	}
+	return StateCarrier{
+		Metadata:     fields,
+		Gates:        gates,
+		StateBuckets: buckets,
+	}, nil
+}
+
+func (c StateCarrier) MetadataBucket() values.Bucket {
+	return values.Wrap(c.Metadata)
+}
+
+func (c StateCarrier) GatesBucket() values.Bucket {
+	return values.Wrap(boolMapToAnyMap(c.Gates))
+}
+
+func (c StateCarrier) StateBucketsBucket() values.Bucket {
+	return values.Wrap(stateBucketSetAsRaw(c.StateBuckets))
+}
+
+func (c StateCarrier) EntityContext(entityID identity.EntityID, currentState, workflowName, workflowVersion string) map[string]any {
+	out := cloneStringAnyMap(c.Metadata)
+	if out == nil {
+		out = map[string]any{}
+	}
+	out["entity_id"] = entityID.String()
+	out["current_state"] = strings.TrimSpace(currentState)
+	out["workflow_name"] = strings.TrimSpace(workflowName)
+	out["workflow_version"] = strings.TrimSpace(workflowVersion)
+	out["gates"] = boolMapToAnyMap(c.Gates)
+	return out
+}
+
+func (c StateCarrier) PersistedMetadata() map[string]any {
+	out := cloneStringAnyMap(c.Metadata)
+	if out == nil {
+		out = map[string]any{}
+	}
+	if len(c.Gates) == 0 {
+		delete(out, "gates")
+		return out
+	}
+	out["gates"] = boolMapToAnyMap(c.Gates)
+	return out
+}
+
+func (c StateCarrier) PersistedStateBuckets() map[string]any {
+	return stateBucketSetAsRaw(c.StateBuckets)
+}
+
+func (c *StateCarrier) SetGate(name string, value bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	if c.Gates == nil {
+		c.Gates = map[string]bool{}
+	}
+	c.Gates[name] = value
+}
+
+func (c *StateCarrier) EnsureGatesMap() map[string]bool {
+	if c.Gates == nil {
+		c.Gates = map[string]bool{}
+	}
+	return c.Gates
+}
+
+func (c *StateCarrier) SetMetadata(key string, value any) {
+	if c.Metadata == nil {
+		c.Metadata = map[string]any{}
+	}
+	values.Wrap(c.Metadata).Set(key, value)
+}
+
+func (c *StateCarrier) EnsureMetadataMap(key string) values.Bucket {
+	if c.Metadata == nil {
+		c.Metadata = map[string]any{}
+	}
+	return values.Wrap(c.Metadata).EnsureMap(key)
+}
+
+func (c *StateCarrier) EnsureStateBucket(name string) values.Bucket {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return values.Wrap(map[string]any{})
+	}
+	if c.StateBuckets == nil {
+		c.StateBuckets = map[string]map[string]any{}
+	}
+	if c.StateBuckets[name] == nil {
+		c.StateBuckets[name] = map[string]any{}
+	}
+	return values.Wrap(c.StateBuckets[name])
+}
+
+func (c StateCarrier) StateBucket(name string) (values.Bucket, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" || c.StateBuckets == nil {
+		return values.Bucket{}, false
+	}
+	bucket, ok := c.StateBuckets[name]
+	if !ok || bucket == nil {
+		return values.Bucket{}, false
+	}
+	return values.Wrap(bucket), true
+}
+
 type StateSnapshot struct {
 	EntityID        identity.EntityID
 	WorkflowName    string
 	WorkflowVersion string
 	CurrentState    string
 	EnteredStateAt  time.Time
-	Metadata        map[string]any
-	Gates           map[string]bool
-	StateBuckets    map[string]any
-	TimerState      []TimerState
+	StateCarrier
+	TimerState []TimerState
 }
 
 func (s StateSnapshot) MetadataBucket() values.Bucket {
-	return values.Wrap(s.Metadata)
-}
-
-func (s StateSnapshot) StateBucketsBucket() values.Bucket {
-	return values.Wrap(s.StateBuckets)
+	return s.StateCarrier.MetadataBucket()
 }
 
 func (s StateSnapshot) GatesBucket() values.Bucket {
-	return values.Wrap(boolMapToAnyMap(s.Gates))
+	return s.StateCarrier.GatesBucket()
+}
+
+func (s StateSnapshot) StateBucketsBucket() values.Bucket {
+	return s.StateCarrier.StateBucketsBucket()
 }
 
 func (s StateSnapshot) EntityContext() map[string]any {
-	out := cloneStringAnyMap(s.Metadata)
-	if out == nil {
-		out = map[string]any{}
-	}
-	out["entity_id"] = s.EntityID.String()
-	out["current_state"] = strings.TrimSpace(s.CurrentState)
-	out["workflow_name"] = strings.TrimSpace(s.WorkflowName)
-	out["workflow_version"] = strings.TrimSpace(s.WorkflowVersion)
-	out["gates"] = boolMapToAnyMap(s.Gates)
-	return out
-}
-
-func (s *StateSnapshot) EnsureStateBucketsBucket() values.Bucket {
-	if s.StateBuckets == nil {
-		s.StateBuckets = map[string]any{}
-	}
-	return values.Wrap(s.StateBuckets)
+	return s.StateCarrier.EntityContext(s.EntityID, s.CurrentState, s.WorkflowName, s.WorkflowVersion)
 }
 
 func (s *StateSnapshot) SetGate(name string, value bool) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
-	}
-	if s.Gates == nil {
-		s.Gates = map[string]bool{}
-	}
-	s.Gates[name] = value
-	if s.Metadata == nil {
-		s.Metadata = map[string]any{}
-	}
-	s.Metadata["gates"] = boolMapToAnyMap(s.Gates)
+	s.StateCarrier.SetGate(name, value)
 }
 
 func (s *StateSnapshot) EnsureGatesMap() map[string]bool {
-	if s.Gates == nil {
-		s.Gates = map[string]bool{}
-	}
-	if s.Metadata == nil {
-		s.Metadata = map[string]any{}
-	}
-	metadataGates := map[string]bool{}
-	if raw, ok := s.Metadata["gates"].(map[string]any); ok {
-		metadataGates = anyMapToBoolMap(raw)
-	}
-	for key, value := range metadataGates {
-		if _, ok := s.Gates[key]; !ok {
-			s.Gates[key] = value
-		}
-	}
-	s.Metadata["gates"] = boolMapToAnyMap(s.Gates)
-	return s.Gates
+	return s.StateCarrier.EnsureGatesMap()
 }
 
 func (s *StateSnapshot) SetMetadata(key string, value any) {
-	if s.Metadata == nil {
-		s.Metadata = map[string]any{}
-	}
-	values.Wrap(s.Metadata).Set(key, value)
+	s.StateCarrier.SetMetadata(key, value)
 }
 
 func (s *StateSnapshot) EnsureMetadataMap(key string) values.Bucket {
-	if s.Metadata == nil {
-		s.Metadata = map[string]any{}
-	}
-	return values.Wrap(s.Metadata).EnsureMap(key)
+	return s.StateCarrier.EnsureMetadataMap(key)
+}
+
+func (s *StateSnapshot) EnsureStateBucket(name string) values.Bucket {
+	return s.StateCarrier.EnsureStateBucket(name)
+}
+
+func (s StateSnapshot) StateBucket(name string) (values.Bucket, bool) {
+	return s.StateCarrier.StateBucket(name)
 }
 
 type TimerState struct {
@@ -197,58 +287,39 @@ type TimerIntent struct {
 }
 
 type StateMutation struct {
-	NextState        string
-	Metadata         map[string]any
-	Gates            map[string]bool
-	StateBuckets     map[string]any
+	NextState string
+	StateCarrier
 	ClearGates       []string
 	SetGate          string
 	DataAccumulation runtimecontracts.WorkflowDataAccumulation
 }
 
 func (m StateMutation) MetadataBucket() values.Bucket {
-	return values.Wrap(m.Metadata)
-}
-
-func (m StateMutation) StateBucketsBucket() values.Bucket {
-	return values.Wrap(m.StateBuckets)
+	return m.StateCarrier.MetadataBucket()
 }
 
 func (m StateMutation) GatesBucket() values.Bucket {
-	return values.Wrap(boolMapToAnyMap(m.Gates))
+	return m.StateCarrier.GatesBucket()
+}
+
+func (m StateMutation) StateBucketsBucket() values.Bucket {
+	return m.StateCarrier.StateBucketsBucket()
 }
 
 func (m *StateMutation) SetMetadata(key string, value any) {
-	if m.Metadata == nil {
-		m.Metadata = map[string]any{}
-	}
-	values.Wrap(m.Metadata).Set(key, value)
+	m.StateCarrier.SetMetadata(key, value)
 }
 
 func (m *StateMutation) EnsureMetadataMap(key string) values.Bucket {
-	if m.Metadata == nil {
-		m.Metadata = map[string]any{}
-	}
-	return values.Wrap(m.Metadata).EnsureMap(key)
+	return m.StateCarrier.EnsureMetadataMap(key)
 }
 
 func (m *StateMutation) SetGateValue(name string, value bool) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
-	}
-	if m.Gates == nil {
-		m.Gates = map[string]bool{}
-	}
-	m.Gates[name] = value
-	if m.Metadata == nil {
-		m.Metadata = map[string]any{}
-	}
-	m.Metadata["gates"] = boolMapToAnyMap(m.Gates)
+	m.StateCarrier.SetGate(name, value)
 }
 
-func (m *StateMutation) SetStateBuckets(raw map[string]any) {
-	m.StateBuckets = cloneStringAnyMap(raw)
+func (m *StateMutation) SetStateBuckets(raw map[string]map[string]any) {
+	m.StateCarrier.StateBuckets = cloneStateBucketSet(raw)
 }
 
 type RuleMatch struct {
@@ -287,4 +358,83 @@ func (r *ExecutionResult) SetComputed(key string, value any) {
 		r.Computed = map[string]any{}
 	}
 	values.Wrap(r.Computed).Set(key, value)
+}
+
+func cloneStateBucketSet(in map[string]map[string]any) map[string]map[string]any {
+	if len(in) == 0 {
+		return map[string]map[string]any{}
+	}
+	out := make(map[string]map[string]any, len(in))
+	for key, bucket := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = cloneStringAnyMap(bucket)
+	}
+	return out
+}
+
+func stateCarrierGatesFromMetadata(metadata map[string]any) (map[string]bool, error) {
+	if len(metadata) == 0 {
+		return map[string]bool{}, nil
+	}
+	raw, ok := metadata["gates"]
+	if !ok || raw == nil {
+		return map[string]bool{}, nil
+	}
+	switch typed := raw.(type) {
+	case map[string]any:
+		out := make(map[string]bool, len(typed))
+		for key, rawValue := range typed {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			value, ok := rawValue.(bool)
+			if !ok {
+				return nil, fmt.Errorf("invalid workflow gates shape: gate %q = %T", key, rawValue)
+			}
+			out[key] = value
+		}
+		return out, nil
+	case map[string]bool:
+		return mapsClone(typed), nil
+	default:
+		return nil, fmt.Errorf("invalid workflow gates shape: %T", raw)
+	}
+}
+
+func stateBucketSetFromRaw(raw map[string]any) (map[string]map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]map[string]any{}, nil
+	}
+	out := make(map[string]map[string]any, len(raw))
+	for key, value := range raw {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		bucket, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid workflow state bucket %q: %T", key, value)
+		}
+		out[key] = cloneStringAnyMap(bucket)
+	}
+	return out, nil
+}
+
+func stateBucketSetAsRaw(in map[string]map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for key, bucket := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = cloneStringAnyMap(bucket)
+	}
+	return out
 }

--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"swarm/internal/events"
@@ -33,6 +34,20 @@ func TestCoordinatorHandlerExecutionEngineUsesRuntimeEnginePath(t *testing.T) {
 	}
 	if got := string(bus.publishedEvent(0).Type); got != "custom.emitted" {
 		t.Fatalf("published event type = %q, want custom.emitted", got)
+	}
+}
+
+func TestHandlerExecutionStateSnapshotRejectsMalformedPersistedGateShape(t *testing.T) {
+	_, err := handlerExecutionStateSnapshot(runtimecontracts.SystemNodeEventHandler{}, "ent-1", WorkflowState{
+		EntityID: "ent-1",
+		Stage:    WorkflowStateID("queued"),
+		Metadata: map[string]any{"gates": "invalid"},
+	})
+	if err == nil {
+		t.Fatal("expected malformed persisted gates to fail closed")
+	}
+	if !strings.Contains(err.Error(), "metadata.gates") {
+		t.Fatalf("error = %v, want metadata.gates context", err)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -124,12 +124,14 @@ func (r pipelineEngineStateRepo) LoadState(ctx context.Context, entityID identit
 		return runtimeengine.StateSnapshot{}, false, nil
 	}
 	state := r.coordinator.currentWorkflowState(ctx, entityID.String())
+	carrier, err := runtimeengine.StateCarrierFromPersisted(state.Metadata, nil)
+	if err != nil {
+		return runtimeengine.StateSnapshot{}, false, err
+	}
 	out := runtimeengine.StateSnapshot{
 		EntityID:     entityID,
 		CurrentState: strings.TrimSpace(string(state.Stage)),
-		Metadata:     cloneStringAnyMap(state.Metadata),
-		Gates:        workflowStateGatesAsBools(state.Metadata),
-		StateBuckets: map[string]any{},
+		StateCarrier: carrier,
 	}
 	if r.coordinator.workflowStore != nil && r.coordinator.workflowStore.Enabled() {
 		instance, ok, err := r.coordinator.workflowStore.Load(ctx, entityID.String())
@@ -139,20 +141,20 @@ func (r pipelineEngineStateRepo) LoadState(ctx context.Context, entityID identit
 		if ok {
 			out.WorkflowName = strings.TrimSpace(instance.WorkflowName)
 			out.WorkflowVersion = strings.TrimSpace(instance.WorkflowVersion)
-			out.Metadata = cloneStringAnyMap(instance.Metadata)
-			if out.Metadata == nil {
-				out.Metadata = map[string]any{}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				return runtimeengine.StateSnapshot{}, false, err
 			}
+			out.StateCarrier = carrier
 			if strings.TrimSpace(instance.SubjectID) != "" {
-				out.Metadata["subject_id"] = strings.TrimSpace(instance.SubjectID)
+				out.StateCarrier.Metadata["subject_id"] = strings.TrimSpace(instance.SubjectID)
 			}
 			out.CurrentState = strings.TrimSpace(instance.CurrentState)
-			out.Gates = workflowStateGatesForScope(
+			out.StateCarrier.Gates = workflowStateGatesForScope(
 				r.coordinator.SemanticSource(),
 				pipelineFlowScope(ctx),
-				out.Metadata,
+				out.StateCarrier.PersistedMetadata(),
 			)
-			out.StateBuckets = cloneStringAnyMap(instance.StateBuckets)
 			out.TimerState = make([]runtimeengine.TimerState, 0, len(instance.TimerState))
 			for _, timer := range instance.TimerState {
 				out.TimerState = append(out.TimerState, runtimeengine.TimerState{
@@ -188,7 +190,7 @@ func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identit
 		}); err != nil {
 			return err
 		}
-		if len(mutation.Gates) > 0 || len(mutation.ClearGates) > 0 || strings.TrimSpace(mutation.SetGate) != "" {
+		if len(mutation.StateCarrier.Gates) > 0 || len(mutation.ClearGates) > 0 || strings.TrimSpace(mutation.SetGate) != "" {
 			if err := r.coordinator.projectWorkflowSubjectGates(ctx, entityID.String()); err != nil {
 				return err
 			}
@@ -232,7 +234,7 @@ func (r pipelineEngineStateRepo) VerifyEmitPersistence(ctx context.Context, enti
 			missingExpected = append(missingExpected, field)
 			continue
 		}
-		actual, ok := workflowMetadataValue(persisted.Metadata, field)
+		actual, ok := workflowMetadataValue(persisted.StateCarrier.Metadata, field)
 		if !ok {
 			missingPersisted = append(missingPersisted, field)
 			continue
@@ -793,12 +795,14 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 	if instance.EnteredStageAt.IsZero() {
 		instance.EnteredStageAt = time.Now().UTC()
 	}
-	if len(mutation.Gates) > 0 || len(mutation.ClearGates) > 0 || strings.TrimSpace(mutation.SetGate) != "" {
-		if mutation.Metadata == nil {
-			mutation.Metadata = cloneStringAnyMap(instance.Metadata)
+	existingGates := workflowStateGatesAsBools(instance.Metadata)
+	if len(mutation.StateCarrier.Gates) > 0 || len(mutation.ClearGates) > 0 || strings.TrimSpace(mutation.SetGate) != "" {
+		if mutation.StateCarrier.Metadata == nil {
+			mutation.StateCarrier.Metadata = cloneStringAnyMap(instance.Metadata)
+			delete(mutation.StateCarrier.Metadata, "gates")
 		}
-		gates := workflowStateGatesAsBools(instance.Metadata)
-		for key, value := range mutation.Gates {
+		gates := workflowCloneBoolMap(existingGates)
+		for key, value := range mutation.StateCarrier.Gates {
 			key = workflowScopedGateKey(source, flowID, key)
 			if key != "" {
 				gates[key] = value
@@ -813,16 +817,19 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 		if gate := workflowScopedGateKey(source, flowID, mutation.SetGate); gate != "" {
 			gates[gate] = true
 		}
-		mutation.Metadata["gates"] = workflowBoolGatesAsMap(gates)
+		mutation.StateCarrier.Gates = gates
 	}
-	if mutation.Metadata != nil {
-		instance.Metadata = cloneStringAnyMap(mutation.Metadata)
+	if mutation.StateCarrier.Metadata != nil && len(mutation.StateCarrier.Gates) == 0 && len(existingGates) > 0 {
+		mutation.StateCarrier.Gates = workflowCloneBoolMap(existingGates)
+	}
+	if mutation.StateCarrier.Metadata != nil || len(mutation.StateCarrier.Gates) > 0 {
+		instance.Metadata = mutation.StateCarrier.PersistedMetadata()
 	}
 	if instance.Metadata != nil && strings.TrimSpace(instance.SubjectID) == "" {
 		instance.SubjectID = workflowInstanceIdentity(source, *instance).SubjectID
 	}
-	if mutation.StateBuckets != nil {
-		instance.StateBuckets = cloneStringAnyMap(mutation.StateBuckets)
+	if mutation.StateCarrier.StateBuckets != nil {
+		instance.StateBuckets = mutation.StateCarrier.PersistedStateBuckets()
 	}
 	if len(allowedFields) == 0 {
 		return
@@ -918,7 +925,7 @@ func workflowStateFromEngine(snapshot runtimeengine.StateSnapshot) *WorkflowStat
 	state := &WorkflowState{
 		EntityID: snapshot.EntityID.String(),
 		Stage:    NormalizeWorkflowStateID(snapshot.CurrentState),
-		Metadata: cloneStringAnyMap(snapshot.Metadata),
+		Metadata: snapshot.StateCarrier.PersistedMetadata(),
 	}
 	if state.Metadata == nil {
 		state.Metadata = map[string]any{}
@@ -1042,7 +1049,7 @@ func engineTriggerContext(req runtimeengine.ExecutionRequest) workflowTriggerCon
 		State: WorkflowState{
 			EntityID: req.EntityID.String(),
 			Stage:    NormalizeWorkflowStateID(req.State.CurrentState),
-			Metadata: cloneStringAnyMap(req.State.Metadata),
+			Metadata: req.State.StateCarrier.PersistedMetadata(),
 		},
 	}
 }

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -17,21 +17,31 @@ import (
 	"swarm/internal/testutil"
 )
 
+func testEngineStateMutation(metadata map[string]any, gates map[string]bool, buckets map[string]map[string]any) runtimeengine.StateMutation {
+	return runtimeengine.StateMutation{
+		StateCarrier: runtimeengine.NewStateCarrier(metadata, gates, buckets),
+	}
+}
+
+func testEngineStateSnapshot(metadata map[string]any, gates map[string]bool, buckets map[string]map[string]any) runtimeengine.StateSnapshot {
+	return runtimeengine.StateSnapshot{
+		StateCarrier: runtimeengine.NewStateCarrier(metadata, gates, buckets),
+	}
+}
+
 func TestApplyEngineStateMutationMirrorsDataAccumulationIntoEntityProjection(t *testing.T) {
 	instance := &WorkflowInstance{
 		Metadata:     map[string]any{"research_context": map[string]any{"summary": "done"}},
 		StateBuckets: map[string]any{},
 	}
-	mutation := runtimeengine.StateMutation{
-		Metadata: map[string]any{
-			"research_context":              map[string]any{"summary": "done"},
-			"last_data_accumulation_event":  "research.completed",
-			"last_data_accumulation_source": "research.completed",
-		},
-		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
-			Writes: []runtimecontracts.WorkflowDataWrite{
-				{TargetField: "research_context", SourceField: "research_context"},
-			},
+	mutation := testEngineStateMutation(map[string]any{
+		"research_context":              map[string]any{"summary": "done"},
+		"last_data_accumulation_event":  "research.completed",
+		"last_data_accumulation_source": "research.completed",
+	}, nil, nil)
+	mutation.DataAccumulation = runtimecontracts.WorkflowDataAccumulation{
+		Writes: []runtimecontracts.WorkflowDataWrite{
+			{TargetField: "research_context", SourceField: "research_context"},
 		},
 	}
 	applyEngineStateMutation(instance, mutation, map[string]struct{}{"research_context": {}}, nil, "")
@@ -55,12 +65,8 @@ func TestApplyEngineStateMutationMergesGateDeltasIntoExistingMetadata(t *testing
 			},
 		},
 	}
-	mutation := runtimeengine.StateMutation{
-		SetGate: "g_c",
-		Gates: map[string]bool{
-			"g_c": true,
-		},
-	}
+	mutation := testEngineStateMutation(nil, map[string]bool{"g_c": true}, nil)
+	mutation.SetGate = "g_c"
 
 	applyEngineStateMutation(instance, mutation, nil, nil, "")
 
@@ -88,12 +94,8 @@ func TestApplyEngineStateMutationScopesChildFlowGates(t *testing.T) {
 	instance := &WorkflowInstance{
 		Metadata: map[string]any{},
 	}
-	mutation := runtimeengine.StateMutation{
-		SetGate: "g_validated",
-		Gates: map[string]bool{
-			"g_validated": true,
-		},
-	}
+	mutation := testEngineStateMutation(nil, map[string]bool{"g_validated": true}, nil)
+	mutation.SetGate = "g_validated"
 
 	applyEngineStateMutation(instance, mutation, nil, source, "child")
 
@@ -103,6 +105,26 @@ func TestApplyEngineStateMutationScopesChildFlowGates(t *testing.T) {
 	}
 	if gates["g_validated"] {
 		t.Fatalf("raw unscoped child gate leaked into metadata: %#v", gates)
+	}
+}
+
+func TestApplyEngineStateMutationPreservesExistingMetadataOnGateOnlyMutation(t *testing.T) {
+	instance := &WorkflowInstance{
+		SubjectID: "11111111-1111-1111-1111-111111111111",
+		Metadata: map[string]any{
+			"flow_path": "child/inst-1",
+		},
+	}
+	mutation := testEngineStateMutation(nil, map[string]bool{"g_ready": true}, nil)
+	mutation.SetGate = "g_ready"
+
+	applyEngineStateMutation(instance, mutation, nil, nil, "")
+
+	if got := strings.TrimSpace(instance.SubjectID); got != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("SubjectID = %#v, want preserved canonical subject owner", got)
+	}
+	if !workflowStateGatesAsBools(instance.Metadata)["g_ready"] {
+		t.Fatalf("gates = %#v, want g_ready=true", instance.Metadata["gates"])
 	}
 }
 
@@ -564,14 +586,12 @@ func TestApplyEngineStateMutationInitializesWorkflowInstanceDefaults(t *testing.
 		},
 	})
 	instance := &WorkflowInstance{}
-	mutation := runtimeengine.StateMutation{
-		Metadata: map[string]any{
-			"name": "Test Vertical",
-		},
-		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
-			Writes: []runtimecontracts.WorkflowDataWrite{
-				{TargetField: "name", Value: runtimecontracts.LiteralExpression("Test Vertical")},
-			},
+	mutation := testEngineStateMutation(map[string]any{
+		"name": "Test Vertical",
+	}, nil, nil)
+	mutation.DataAccumulation = runtimecontracts.WorkflowDataAccumulation{
+		Writes: []runtimecontracts.WorkflowDataWrite{
+			{TargetField: "name", Value: runtimecontracts.LiteralExpression("Test Vertical")},
 		},
 	}
 
@@ -612,15 +632,16 @@ func TestApplyEngineStateMutationMirrorsAllowedMetadataFieldsWithoutDataAccumula
 	instance := &WorkflowInstance{
 		Metadata: map[string]any{
 			"composite_score": 0,
+			"gates": map[string]any{
+				"g_ready": true,
+			},
 		},
 		StateBuckets: map[string]any{},
 	}
-	mutation := runtimeengine.StateMutation{
-		Metadata: map[string]any{
-			"composite_score": 71,
-			"scoring_rubric":  "corpus_rubric",
-		},
-	}
+	mutation := testEngineStateMutation(map[string]any{
+		"composite_score": 71,
+		"scoring_rubric":  "corpus_rubric",
+	}, nil, nil)
 
 	applyEngineStateMutation(instance, mutation, map[string]struct{}{
 		"composite_score": {},
@@ -634,15 +655,16 @@ func TestApplyEngineStateMutationMirrorsAllowedMetadataFieldsWithoutDataAccumula
 	if got := entityProjection["scoring_rubric"]; got != "corpus_rubric" {
 		t.Fatalf("entity_projection scoring_rubric = %#v", got)
 	}
+	if !workflowStateGatesAsBools(instance.Metadata)["g_ready"] {
+		t.Fatalf("metadata-only mutation dropped existing gates: %#v", instance.Metadata["gates"])
+	}
 }
 
 func TestApplyEngineStateMutationCapturesSubjectIDFromMetadata(t *testing.T) {
 	instance := &WorkflowInstance{}
-	mutation := runtimeengine.StateMutation{
-		Metadata: map[string]any{
-			"subject_id": "11111111-1111-1111-1111-111111111111",
-		},
-	}
+	mutation := testEngineStateMutation(map[string]any{
+		"subject_id": "11111111-1111-1111-1111-111111111111",
+	}, nil, nil)
 
 	applyEngineStateMutation(instance, mutation, nil, nil, "")
 
@@ -708,12 +730,85 @@ func TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite(t *testing.T) {
 		},
 	}
 	ctx := withPipelineFlowScope(context.Background(), "flow-b")
-	err := repo.SaveState(ctx, identity.NormalizeEntityID(entityID), runtimeengine.StateMutation{
-		Metadata: map[string]any{"note": "bad write"},
-	})
+	err := repo.SaveState(ctx, identity.NormalizeEntityID(entityID), testEngineStateMutation(map[string]any{"note": "bad write"}, nil, nil))
 	if err == nil || !strings.Contains(err.Error(), "cross_flow_write_forbidden") {
 		t.Fatalf("expected cross_flow_write_forbidden, got %v", err)
 	}
+}
+
+func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	repo := pipelineEngineStateRepo{
+		coordinator: &PipelineCoordinator{
+			workflowStore: store,
+		},
+	}
+	entityID := identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111")
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID.String(),
+		StorageRef:      entityID.String(),
+		WorkflowName:    "root",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "pending",
+		Metadata:        map[string]any{},
+		StateBuckets:    map[string]any{},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	mutation := testEngineStateMutation(
+		map[string]any{"score": 91, "subject_id": "11111111-1111-1111-1111-111111111111"},
+		map[string]bool{"ready": true},
+		map[string]map[string]any{"evidence": {"count": 2}},
+	)
+
+	if err := repo.SaveState(context.Background(), entityID, mutation); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	loaded, ok, err := repo.LoadState(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected saved state to load")
+	}
+	if got := loaded.Metadata["score"]; got != 91 && got != 91.0 {
+		t.Fatalf("loaded metadata score = %#v, want 91", got)
+	}
+	if !loaded.Gates["ready"] {
+		t.Fatalf("loaded gates = %#v, want ready=true", loaded.Gates)
+	}
+	if got := loaded.StateBuckets["evidence"]["count"]; got != 2 && got != 2.0 {
+		t.Fatalf("loaded state bucket evidence.count = %#v, want 2", got)
+	}
+}
+
+func TestPipelineEngineStateRepoLoadStateRejectsMalformedPersistedCarrier(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	t.Run("state_buckets", func(t *testing.T) {
+		store := NewWorkflowInstanceStore(db)
+		if err := store.Upsert(context.Background(), WorkflowInstance{
+			InstanceID:      "22222222-2222-2222-2222-222222222222",
+			StorageRef:      "22222222-2222-2222-2222-222222222222",
+			WorkflowName:    "root",
+			WorkflowVersion: "1.0.0",
+			CurrentState:    "pending",
+			StateBuckets: map[string]any{
+				"evidence": "bad",
+			},
+		}); err != nil {
+			t.Fatalf("upsert malformed state bucket instance: %v", err)
+		}
+		repo := pipelineEngineStateRepo{coordinator: &PipelineCoordinator{workflowStore: store}}
+		_, _, err := repo.LoadState(context.Background(), identity.NormalizeEntityID("22222222-2222-2222-2222-222222222222"))
+		if err == nil || !strings.Contains(err.Error(), "invalid workflow state bucket") {
+			t.Fatalf("LoadState error = %v, want invalid workflow state bucket", err)
+		}
+	})
 }
 
 func TestRecordWorkflowEvidence_ReturnsWorkflowStoreMutationError(t *testing.T) {
@@ -842,12 +937,8 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 			Payload: json.RawMessage(`{"entity_id":"ent-child","step":"done"}`),
 		}.WithEntityID("ent-child"),
 		State: runtimeengine.StateSnapshot{
-			EntityID: identity.NormalizeEntityID("ent-child"),
-			Metadata: map[string]any{
-				"flow_path":        "child/inst-1",
-				"subject_id":       "ent-parent",
-				"parent_entity_id": "ent-parent",
-			},
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
 		},
 	}
 
@@ -896,12 +987,8 @@ func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputR
 			Payload: json.RawMessage(`{"entity_id":"ent-child"}`),
 		}.WithEntityID("ent-child"),
 		State: runtimeengine.StateSnapshot{
-			EntityID: identity.NormalizeEntityID("ent-child"),
-			Metadata: map[string]any{
-				"flow_path":        "child/inst-1",
-				"subject_id":       "ent-parent",
-				"parent_entity_id": "ent-parent",
-			},
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
 		},
 	}
 

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -193,6 +193,10 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, fmt.Errorf("build runtime engine: %w", err)
 	}
+	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, triggerCtx.State)
+	if err != nil {
+		return contractHandlerExecutionResult{}, err
+	}
 	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
 		EntityID:   identity.NormalizeEntityID(entityID),
 		NodeID:     identity.NormalizeNodeID(nodeID),
@@ -201,7 +205,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 		ChainDepth: triggerCtx.Event.ChainDepth,
 		Handler:    handler,
 		Preview:    preview,
-		State:      handlerExecutionStateSnapshot(handler, entityID, triggerCtx.State),
+		State:      stateSnapshot,
 	})
 	if err != nil {
 		return contractHandlerExecutionResult{}, err

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -209,7 +209,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if !preview {
 		pc.recordInterceptedEmitDeadLetters(ctx, triggerCtx.Event, nodeID, handlerOutcomeFromExecutionResult(result))
 	}
-	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, entityID, nodeID, handler, triggerCtx.Event, result.StateMutation.StateBuckets, result.Status == runtimeengine.OutcomeWaiting); err != nil {
+	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, entityID, nodeID, handler, triggerCtx.Event, result.StateMutation.StateCarrier.PersistedStateBuckets(), result.Status == runtimeengine.OutcomeWaiting); err != nil {
 		return contractHandlerExecutionResult{}, err
 	}
 	if collectLocally {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -636,11 +636,14 @@ func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClears
 }
 
 func TestHandlerExecutionStateSnapshotCreateEntityStartsClean(t *testing.T) {
-	snapshot := handlerExecutionStateSnapshot(runtimecontracts.SystemNodeEventHandler{CreateEntity: true}, "ent-child", WorkflowState{
+	snapshot, err := handlerExecutionStateSnapshot(runtimecontracts.SystemNodeEventHandler{CreateEntity: true}, "ent-child", WorkflowState{
 		EntityID: "ent-parent",
 		Stage:    WorkflowStateID("queued"),
 		Metadata: map[string]any{"subject_id": "ent-parent"},
 	})
+	if err != nil {
+		t.Fatalf("handlerExecutionStateSnapshot: %v", err)
+	}
 
 	if got := snapshot.EntityID.String(); got != "ent-child" {
 		t.Fatalf("snapshot entity_id = %q, want ent-child", got)
@@ -653,6 +656,28 @@ func TestHandlerExecutionStateSnapshotCreateEntityStartsClean(t *testing.T) {
 	}
 	if got := strings.TrimSpace(asString(snapshot.Metadata["subject_id"])); got != "ent-parent" {
 		t.Fatalf("snapshot subject_id = %q, want ent-parent", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerRejectsMalformedPersistedGateShape(t *testing.T) {
+	pc := &PipelineCoordinator{
+		bus:            &recordingPipelineBus{},
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"),
+		State: WorkflowState{
+			Stage:    WorkflowStateID("queued"),
+			Metadata: map[string]any{"gates": "invalid"},
+		},
+	}, false)
+	if err == nil {
+		t.Fatal("expected malformed persisted gates to fail closed")
+	}
+	if !strings.Contains(err.Error(), "metadata.gates") {
+		t.Fatalf("error = %v, want metadata.gates context", err)
 	}
 }
 

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -391,18 +391,26 @@ func handlerMaterializesEntity(source semanticview.Source, handler SystemNodeEve
 
 func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID string, state WorkflowState) runtimeengine.StateSnapshot {
 	snapshot := runtimeengine.StateSnapshot{
-		EntityID:     identity.NormalizeEntityID(entityID),
-		StateBuckets: map[string]any{},
+		EntityID: identity.NormalizeEntityID(entityID),
+		StateCarrier: runtimeengine.NewStateCarrier(
+			nil,
+			nil,
+			map[string]map[string]any{},
+		),
 	}
 	if handler.CreateEntity {
-		snapshot.Metadata = cloneStringAnyMap(state.Metadata)
-		if snapshot.Metadata == nil {
-			snapshot.Metadata = map[string]any{}
+		snapshot.StateCarrier.Metadata = cloneStringAnyMap(state.Metadata)
+		if snapshot.StateCarrier.Metadata == nil {
+			snapshot.StateCarrier.Metadata = map[string]any{}
 		}
 		return snapshot
 	}
 	snapshot.CurrentState = strings.TrimSpace(string(state.Stage))
-	snapshot.Metadata = cloneStringAnyMap(state.Metadata)
+	snapshot.StateCarrier.Metadata = cloneStringAnyMap(state.Metadata)
+	if gates, err := runtimeengine.StateCarrierFromPersisted(snapshot.StateCarrier.Metadata, nil); err == nil {
+		snapshot.StateCarrier.Gates = gates.Gates
+		delete(snapshot.StateCarrier.Metadata, "gates")
+	}
 	return snapshot
 }
 

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -303,6 +303,10 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		exec = tmpExec
 		node = runtimeengine.NewDeclarativeNode(strings.TrimSpace(e.nodeID), exec)
 	}
+	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, currentState)
+	if err != nil {
+		return nil, err
+	}
 	result, err := node.Handle(ctx, runtimeengine.ExecutionRequest{
 		EntityID:   identity.NormalizeEntityID(entityID),
 		NodeID:     identity.NormalizeNodeID(e.nodeID),
@@ -310,7 +314,7 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		Event:      evt,
 		ChainDepth: evt.ChainDepth,
 		Handler:    handler,
-		State:      handlerExecutionStateSnapshot(handler, entityID, currentState),
+		State:      stateSnapshot,
 	})
 	if err != nil {
 		return nil, err
@@ -389,7 +393,7 @@ func handlerMaterializesEntity(source semanticview.Source, handler SystemNodeEve
 	return false
 }
 
-func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID string, state WorkflowState) runtimeengine.StateSnapshot {
+func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID string, state WorkflowState) (runtimeengine.StateSnapshot, error) {
 	snapshot := runtimeengine.StateSnapshot{
 		EntityID: identity.NormalizeEntityID(entityID),
 		StateCarrier: runtimeengine.NewStateCarrier(
@@ -403,15 +407,17 @@ func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID stri
 		if snapshot.StateCarrier.Metadata == nil {
 			snapshot.StateCarrier.Metadata = map[string]any{}
 		}
-		return snapshot
+		return snapshot, nil
 	}
 	snapshot.CurrentState = strings.TrimSpace(string(state.Stage))
 	snapshot.StateCarrier.Metadata = cloneStringAnyMap(state.Metadata)
-	if gates, err := runtimeengine.StateCarrierFromPersisted(snapshot.StateCarrier.Metadata, nil); err == nil {
-		snapshot.StateCarrier.Gates = gates.Gates
-		delete(snapshot.StateCarrier.Metadata, "gates")
+	carrier, err := runtimeengine.StateCarrierFromPersisted(snapshot.StateCarrier.Metadata, nil)
+	if err != nil {
+		return runtimeengine.StateSnapshot{}, fmt.Errorf("workflow state metadata.gates: %w", err)
 	}
-	return snapshot
+	snapshot.StateCarrier.Metadata = carrier.Metadata
+	snapshot.StateCarrier.Gates = carrier.Gates
+	return snapshot, nil
 }
 
 func workflowDataWritesEntityFields(spec runtimecontracts.WorkflowDataAccumulation, allowedFields map[string]struct{}) bool {


### PR DESCRIPTION
Closes #193

Spec references:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dependency_graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_state`

## Human Summary

This change gives the runtime engine one explicit typed carrier for semantically important workflow state instead of treating loose metadata and state maps as the canonical owner in the execution seam.

## What Changed

- introduced `StateCarrier` in `internal/runtime/engine/types.go` and made `StateSnapshot` and `StateMutation` carry typed `Metadata`, `Gates`, and `StateBuckets`
- added fail-closed parsing helpers for persisted workflow state so malformed gate and bucket shapes are rejected explicitly at the engine/pipeline boundary
- updated the engine execution seam to read and write the typed carrier instead of treating open maps as the semantic owner
- updated the pipeline adapter to convert persisted workflow-instance metadata/state into the typed carrier and back out through one canonical path
- preserved canonical gate state across later metadata-only mutations so the typed carrier round-trips correctly through the touched seam
- added focused engine and pipeline tests for round-trip behavior and malformed-shape rejection

## Why This Is Needed

The current seam was letting semantically important workflow state ride through loose maps. That makes gates, metadata, and node-scoped state too easy to reinterpret differently across engine and pipeline code. This change narrows that seam to one engine-owned carrier and makes malformed persisted shapes fail for the right reason before execution continues.

## Scope Boundaries

In scope:
- engine-owned state carrier for `StateSnapshot` and `StateMutation`
- pipeline adapter conversion between persisted workflow-instance state and the engine-owned carrier
- malformed-shape rejection in the touched execution seam

Out of scope:
- store schema redesign
- broader read-model or persistence-surface cleanup
- unrelated workflow lifecycle changes

## Tests Run

- `go test ./internal/runtime/engine ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/pipeline ./internal/runtime/cataloge2e -run 'TestPipelineEngineStateRepo|TestApplyEngineStateMutationMirrorsAllowedMetadataFieldsWithoutDataAccumulation|TestTier7CompositionCatalogFixtures_RealRuntime|TestTier11FlowCompositionCatalogFixtures_RealRuntime' -count=1`
- `go test ./... -count=1`

## Residual Risk

Persisted workflow-instance metadata is still stored as open maps at the storage layer. This PR narrows the canonical engine execution seam, but it does not redesign the storage schema or broader read-model carriers.

## Follow-Up

No spec escalation was needed for this change.
