### PR TITLE
[agent-c][issue #253] Preserve package-backed flow ownership proof for session scope validation

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1664,7 +1664,7 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: agentLabel,
 				})
 			}
-			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, "", agentID, agent)
+			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, scope.OwningFlowID, agentID, agent)
 			if len(agent.Subscriptions) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
@@ -1775,7 +1775,7 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: agentLabel,
 				})
 			}
-			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, scope.ID, agentID, agent)
+			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, scope.OwningFlowID, agentID, agent)
 			if len(agent.Subscriptions) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -525,6 +525,60 @@ entity-agent:
 	}
 }
 
+func TestRun_AcceptsPackageBackedFlowSessionScopeDeclarations(t *testing.T) {
+	root := writePackageBackedSessionScopeValidationFixture(t, `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`, `
+flow-agent:
+  id: flow-agent
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+entity-agent:
+  id: entity-agent
+  model_tier: sonnet
+  conversation_mode: session_per_entity
+  session_scope: entity
+  subscriptions:
+    - support/item.created
+`)
+
+	source := loadSessionScopeValidationFixture(t, root)
+	report := Run(context.Background(), source, Options{})
+
+	for _, finding := range report.Errors() {
+		if finding.CheckID == "invalid_field_detection" && strings.Contains(finding.Message, "session_scope") {
+			t.Fatalf("unexpected package-backed session_scope error: %#v", report.Errors())
+		}
+	}
+}
+
+func TestRun_RejectsPackageBackedEntitySessionScopeInStatelessFlow(t *testing.T) {
+	root := writePackageBackedSessionScopeValidationFixture(t, `
+name: support
+`, `
+entity-agent:
+  id: entity-agent
+  model_tier: sonnet
+  conversation_mode: session_per_entity
+  session_scope: entity
+  subscriptions:
+    - support/item.created
+`)
+
+	report := Run(context.Background(), loadSessionScopeValidationFixture(t, root), Options{})
+
+	if !reportContains(report.Errors(), "invalid_field_detection", "session_scope entity requires stateful flow support") {
+		t.Fatalf("expected stateful flow session_scope error for package-backed flow, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsHandlerFieldComplianceToNamedError(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-success")
 	nodeID, eventType, handler, ok := firstBundleHandler(bundle)
@@ -1135,6 +1189,55 @@ support/item.created:
 `)
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), flowAgents)
 	}
+	return root
+}
+
+func writePackageBackedSessionScopeValidationFixture(t *testing.T, flowSchema, packageAgents string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), flowSchema)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support/item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), packageAgents)
 	return root
 }
 

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -1,7 +1,6 @@
 package semanticview
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -133,27 +132,55 @@ func owningFlowIDForProjectView(bundle *runtimecontracts.WorkflowContractBundle,
 	if bundle == nil {
 		return ""
 	}
-	projectDir := filepath.Clean(strings.TrimSpace(view.Paths.Dir))
-	if projectDir == "" || projectDir == "." {
+	return owningFlowIDForPackage(bundle, strings.TrimSpace(view.Paths.Key))
+}
+
+func owningFlowIDForPackage(bundle *runtimecontracts.WorkflowContractBundle, packageKey string) string {
+	packageKey = strings.TrimSpace(packageKey)
+	if bundle == nil || packageKey == "" {
 		return ""
 	}
-	bestFlowID := ""
-	bestDirLen := -1
-	for _, flow := range bundle.Paths.Flows {
-		flowID := strings.TrimSpace(flow.ID)
-		flowDir := filepath.Clean(strings.TrimSpace(flow.Dir))
-		if flowID == "" || flowDir == "" || flowDir == "." {
-			continue
-		}
-		if projectDir != flowDir && !strings.HasPrefix(projectDir, flowDir+string(os.PathSeparator)) {
-			continue
-		}
-		if len(flowDir) > bestDirLen {
-			bestFlowID = flowID
-			bestDirLen = len(flowDir)
+	pkg, ok := bundlePackageByKey(bundle, packageKey)
+	if !ok || strings.TrimSpace(pkg.ParentKey) == "" {
+		return ""
+	}
+	parent, ok := bundlePackageByKey(bundle, pkg.ParentKey)
+	if !ok {
+		return ""
+	}
+	if flowID := packageParentFlowID(parent, pkg); flowID != "" {
+		return flowID
+	}
+	return owningFlowIDForPackage(bundle, parent.Key)
+}
+
+func bundlePackageByKey(bundle *runtimecontracts.WorkflowContractBundle, packageKey string) (runtimecontracts.LoadedProjectPackage, bool) {
+	for _, pkg := range bundle.PackageTree {
+		if strings.TrimSpace(pkg.Key) == packageKey {
+			return pkg, true
 		}
 	}
-	return bestFlowID
+	return runtimecontracts.LoadedProjectPackage{}, false
+}
+
+func packageParentFlowID(parent, child runtimecontracts.LoadedProjectPackage) string {
+	childDir := filepath.Clean(strings.TrimSpace(child.Paths.Dir))
+	if childDir != "" && childDir != "." {
+		for _, flow := range parent.Paths.Flows {
+			flowID := strings.TrimSpace(flow.ID)
+			flowDir := filepath.Clean(strings.TrimSpace(flow.Dir))
+			if flowID == "" || flowDir == "" || flowDir == "." {
+				continue
+			}
+			if childDir == flowDir || strings.HasPrefix(childDir, flowDir+string(filepath.Separator)) {
+				return flowID
+			}
+		}
+	}
+	if len(parent.Paths.Flows) == 1 {
+		return strings.TrimSpace(parent.Paths.Flows[0].ID)
+	}
+	return ""
 }
 
 func (s bundleSource) FlowScopes() []FlowScope {

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -1,6 +1,8 @@
 package semanticview
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -112,19 +114,48 @@ func (s bundleSource) ProjectScopes() []ProjectScope {
 	out := make([]ProjectScope, 0, len(views))
 	for _, view := range views {
 		out = append(out, ProjectScope{
-			Key:        strings.TrimSpace(view.Paths.Key),
-			Depth:      view.Paths.Depth,
-			Manifest:   view.Manifest,
-			PromptsDir: strings.TrimSpace(view.Paths.ProjectPromptsDir),
-			Nodes:      view.Nodes,
-			Events:     view.Events,
-			Agents:     view.Agents,
-			Tools:      view.Tools,
-			Policy:     view.Policy,
+			Key:          strings.TrimSpace(view.Paths.Key),
+			OwningFlowID: owningFlowIDForProjectView(s.bundle, view),
+			Depth:        view.Paths.Depth,
+			Manifest:     view.Manifest,
+			PromptsDir:   strings.TrimSpace(view.Paths.ProjectPromptsDir),
+			Nodes:        view.Nodes,
+			Events:       view.Events,
+			Agents:       view.Agents,
+			Tools:        view.Tools,
+			Policy:       view.Policy,
 		})
 	}
 	return out
 }
+
+func owningFlowIDForProjectView(bundle *runtimecontracts.WorkflowContractBundle, view runtimecontracts.ProjectContractView) string {
+	if bundle == nil {
+		return ""
+	}
+	projectDir := filepath.Clean(strings.TrimSpace(view.Paths.Dir))
+	if projectDir == "" || projectDir == "." {
+		return ""
+	}
+	bestFlowID := ""
+	bestDirLen := -1
+	for _, flow := range bundle.Paths.Flows {
+		flowID := strings.TrimSpace(flow.ID)
+		flowDir := filepath.Clean(strings.TrimSpace(flow.Dir))
+		if flowID == "" || flowDir == "" || flowDir == "." {
+			continue
+		}
+		if projectDir != flowDir && !strings.HasPrefix(projectDir, flowDir+string(os.PathSeparator)) {
+			continue
+		}
+		if len(flowDir) > bestDirLen {
+			bestFlowID = flowID
+			bestDirLen = len(flowDir)
+		}
+	}
+	return bestFlowID
+}
+
 func (s bundleSource) FlowScopes() []FlowScope {
 	if s.bundle == nil {
 		return nil

--- a/internal/runtime/semanticview/scopes.go
+++ b/internal/runtime/semanticview/scopes.go
@@ -7,19 +7,21 @@ import (
 )
 
 type ProjectScope struct {
-	Key        string
-	Depth      int
-	Manifest   runtimecontracts.ProjectPackageDocument
-	PromptsDir string
-	Nodes      map[string]runtimecontracts.SystemNodeContract
-	Events     map[string]runtimecontracts.EventCatalogEntry
-	Agents     map[string]runtimecontracts.AgentRegistryEntry
-	Tools      map[string]runtimecontracts.ToolSchemaEntry
-	Policy     runtimecontracts.PolicyDocument
+	Key          string
+	OwningFlowID string
+	Depth        int
+	Manifest     runtimecontracts.ProjectPackageDocument
+	PromptsDir   string
+	Nodes        map[string]runtimecontracts.SystemNodeContract
+	Events       map[string]runtimecontracts.EventCatalogEntry
+	Agents       map[string]runtimecontracts.AgentRegistryEntry
+	Tools        map[string]runtimecontracts.ToolSchemaEntry
+	Policy       runtimecontracts.PolicyDocument
 }
 
 type FlowScope struct {
 	ID            string
+	OwningFlowID  string
 	Path          string
 	PackageKey    string
 	Mode          string
@@ -63,9 +65,25 @@ func flowModeFromView(view runtimecontracts.FlowContractView) string {
 	return strings.TrimSpace(view.Paths.Mode)
 }
 
+func owningFlowIDFromView(view *runtimecontracts.FlowContractView) string {
+	if view == nil {
+		return ""
+	}
+	if flowID := strings.TrimSpace(view.Paths.ID); flowID != "" {
+		return flowID
+	}
+	for parent := view.Parent; parent != nil; parent = parent.Parent {
+		if flowID := strings.TrimSpace(parent.Paths.ID); flowID != "" {
+			return flowID
+		}
+	}
+	return ""
+}
+
 func flowScopeFromView(view runtimecontracts.FlowContractView) FlowScope {
 	return FlowScope{
 		ID:            strings.TrimSpace(view.Paths.ID),
+		OwningFlowID:  owningFlowIDFromView(&view),
 		Path:          strings.Trim(strings.TrimSpace(view.Path), "/"),
 		PackageKey:    strings.TrimSpace(view.Paths.PackageKey),
 		Mode:          flowModeFromView(view),

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -85,6 +85,85 @@ flow-agent:
 	}
 }
 
+func TestProjectScopes_SoleParentFlowCarriesOwningFlowIDOutsideFlowDir(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: extras
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
+name: extras
+version: "1.0.0"
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "extras", "agents.yaml"), `
+flow-agent:
+  id: flow-agent
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	var packageScope ProjectScope
+	var found bool
+	for _, scope := range source.ProjectScopes() {
+		if scope.Key == "extras" && len(scope.Agents) > 0 {
+			packageScope = scope
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected extras project scope, got %#v", source.ProjectScopes())
+	}
+	if packageScope.OwningFlowID != "support" {
+		t.Fatalf("OwningFlowID = %q, want support", packageScope.OwningFlowID)
+	}
+}
+
 func writeSemanticviewFixtureFile(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -1,0 +1,96 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestProjectScopes_PackageBackedScopeCarriesOwningFlowID(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+flow-agent:
+  id: flow-agent
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	var packageScope ProjectScope
+	var found bool
+	for _, scope := range source.ProjectScopes() {
+		if scope.Key == "flows/support" && len(scope.Agents) > 0 {
+			packageScope = scope
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected package-backed support project scope, got %#v", source.ProjectScopes())
+	}
+	if packageScope.OwningFlowID != "support" {
+		t.Fatalf("OwningFlowID = %q, want support", packageScope.OwningFlowID)
+	}
+}
+
+func writeSemanticviewFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #253

## Human Summary
This preserves the canonical owning-flow proof for package-backed `flows/*` agents during boot verification. Package-backed project scopes now carry their owning declared flow identity, and the session-scope validator uses that explicit proof instead of treating those scopes as root.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`

## What Changed
- added explicit `OwningFlowID` to `ProjectScope` and `FlowScope` in the semantic view layer
- taught the bundle-backed semantic source to derive `ProjectScope.OwningFlowID` from declared flow-directory ancestry in the loaded contract tree
- updated boot verification session-scope validation to consume the explicit owning-flow proof from the scope instead of passing an empty flow owner for package-backed project scopes
- added focused bootverify coverage for real package-backed `flows/*` fixtures covering:
  - `conversation_mode: session` + `session_scope: flow`
  - `conversation_mode: session_per_entity` + `session_scope: entity`
  - stateless flow rejection for entity scope
- added a semanticview regression proving a package-backed project scope carries the owning flow ID explicitly

## Why This Is Needed
The runtime was stricter than the spec for package-backed flow contracts. Agents under `flows/*/agents.yaml` were being validated as project scopes with no owning-flow proof, so valid flow-scoped session declarations were rejected as if they were root-level agents. This blocks real Empire contracts even though their declarations are spec-valid.

## Scope Boundaries
- kept the fix narrow to the loader/tree identity and bootverify proof seam
- did not change broader session semantics, persistence, or runtime acquisition logic
- did not widen into unrelated Empire verify failures outside the session-scope class

## Tests Run
- `go test ./internal/runtime/bootverify ./internal/runtime/semanticview -count=1`
- `go test ./... -count=1`
- `go run ./cmd/swarm verify -contracts /Users/youmew/swarm/empire/contracts`
  - this still exits non-zero because of pre-existing `expression_field_reference_validation` errors
  - the targeted `session_scope ... requires flow-scoped declaration` errors are gone

## Residual Risk
The fix derives package-backed project ownership from declared flow directory ancestry in the loaded contract tree. That is explicit and scoped, but any future loader shape that introduces a different kind of package-backed flow container should add the same proof there rather than falling back to root semantics.

## Follow-Up
The remaining Empire `verify` failures are separate `expression_field_reference_validation` findings and should be handled in their own issue. This PR intentionally leaves them untouched.
