### PR TITLE
[agent-a][issue #255] Narrow bootverify self-target entity update validation

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -508,6 +508,9 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := available[field]; ok {
 							continue
 						}
+						if expr.SelfTargetField == field {
+							continue
+						}
 						if _, ok := handlerWriters[field]; ok {
 							c.entityRefFindings = append(c.entityRefFindings, Finding{
 								CheckID:  "expression_field_reference_validation",
@@ -2748,9 +2751,10 @@ var bootverifyPayloadReferencePattern = regexp.MustCompile(`payload\.([a-zA-Z_][
 var bootverifyEntityReferencePattern = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_]*)`)
 
 type expressionReference struct {
-	Kind       string
-	Expression string
-	Phase      runtimepipeline.WorkflowEntityFieldLifecyclePhase
+	Kind            string
+	Expression      string
+	Phase           runtimepipeline.WorkflowEntityFieldLifecyclePhase
+	SelfTargetField string
 }
 
 type handlerCondition struct {
@@ -2839,7 +2843,13 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	appendWriteExpressions := func(kind string, writes []runtimecontracts.WorkflowDataWrite) {
 		for _, write := range writes {
 			if expr := strings.TrimSpace(write.Value.CEL); expr != "" {
-				out = append(out, expressionReference{Kind: kind, Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
+				selfTarget, _ := runtimepipeline.WorkflowEntityFieldNameFromTarget(write.Target())
+				out = append(out, expressionReference{
+					Kind:            kind,
+					Expression:      expr,
+					Phase:           runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation,
+					SelfTargetField: selfTarget,
+				})
 			}
 		}
 	}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -504,7 +504,6 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := seen[key]; ok {
 							continue
 						}
-						seen[key] = struct{}{}
 						if _, ok := available[field]; ok {
 							continue
 						}
@@ -512,6 +511,7 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 							continue
 						}
 						if _, ok := handlerWriters[field]; ok {
+							seen[key] = struct{}{}
 							c.entityRefFindings = append(c.entityRefFindings, Finding{
 								CheckID:  "expression_field_reference_validation",
 								Severity: "error",
@@ -523,6 +523,7 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := writers[field]; ok {
 							continue
 						}
+						seen[key] = struct{}{}
 						c.entityRefFindings = append(c.entityRefFindings, Finding{
 							CheckID:  "expression_field_reference_validation",
 							Severity: "warning",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -803,6 +803,28 @@ func TestRun_AllowsExpressionFieldReferenceForSelfTargetEntityUpdate(t *testing.
 	}
 }
 
+func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{
+		{
+			TargetField: "base_score",
+			Value:       runtimecontracts.CELExpression("entity.base_score + 1"),
+		},
+		{
+			TargetField: "adjusted_score",
+			Value:       runtimecontracts.CELExpression("entity.base_score + 1"),
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
+		t.Fatalf("expected mixed-case sibling-write error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsTopLevelDataAccumulationExpressionToReadRuleProducedField(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -790,6 +790,19 @@ func TestRun_ReportsExpressionFieldReferenceErrorForDataAccumulationExpressionTh
 	}
 }
 
+func TestRun_AllowsExpressionFieldReferenceForSelfTargetEntityUpdate(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier9-composition-patterns", "test-compose-guard-counter-escalate"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.retry_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.retry_count") {
+		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_AllowsTopLevelDataAccumulationExpressionToReadRuleProducedField(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)


### PR DESCRIPTION
Closes #255

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dependency_graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: guards_see_pre_handler_state`

## Human Summary
This narrows boot verification so valid self-target entity updates like `entity.retry_count + 1` are treated as reading the prior persisted entity value, while sibling-write and later-lifecycle dependencies remain fail-closed.

## What Changed
- attached the write target field to expression-reference validation for data-accumulation expressions
- allowed only the exact self-target read-modify-write case when the expression reads the same entity field it is writing
- kept lifecycle-aware failures for sibling-write dependencies that still require another same-handler write to happen first
- added a real spec-valid regression fixture for `entity.retry_count + 1`

## Why This Is Needed
The current verifier rejects a spec-valid self-target update even though guards and expressions read pre-handler entity state and handler side effects commit atomically. That made boot verification stricter than the platform contract in a stop-ship validation seam.

## Scope Boundaries
- limited to `expression_field_reference_validation` in boot verification
- no change to runtime execution semantics
- no weakening of warnings for truly missing entity fields
- no relaxation of sibling-write or later-lifecycle dependency checks

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(ReportsExpressionFieldReferenceWarning|ReportsExpressionFieldReferenceErrorForDataAccumulationExpressionThatDependsOnSiblingWrite|AllowsExpressionFieldReferenceForSelfTargetEntityUpdate)' -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`

## Residual Risk
This intentionally narrows only the exact self-target data-accumulation write case. If another expression-bearing lifecycle phase needs the same treatment, that should be evaluated against the spec separately rather than inferred from this fix.

## Follow-Up
No follow-up issue is needed from this seam unless another off-spec lifecycle case is found.
