### PR TITLE
[agent-b][issue #187] Align template-flow teardown with canonical flow_instances termination

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -161,7 +161,9 @@ func (eb *EventBus) AddFlowInstanceRoute(template runtimecontracts.SystemNodeCon
 	}
 	for _, route := range routes {
 		if err := persister.UpsertFlowInstanceRoute(context.Background(), route); err != nil {
-			_ = persister.DeleteFlowInstanceRoute(context.Background(), route.Identity)
+			if rollback, ok := eb.store.(FlowInstanceRouteRollbackPersistence); ok && rollback != nil {
+				_ = rollback.RollbackFlowInstanceRoute(context.Background(), route.Identity)
+			}
 			table.RemoveFlowInstanceRoute(route.Identity)
 			return err
 		}

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -36,7 +36,11 @@ func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 }
 
 type routePersistenceTestStore struct {
-	routes map[string]runtimebus.FlowInstanceRouteRecord
+	routes           map[string]runtimebus.FlowInstanceRouteRecord
+	upsertErr        error
+	deleteErr        error
+	rollbackCalls    []string
+	upsertAfterWrite bool
 }
 
 func (*routePersistenceTestStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -49,10 +53,26 @@ func (s *routePersistenceTestStore) UpsertFlowInstanceRoute(_ context.Context, r
 		s.routes = map[string]runtimebus.FlowInstanceRouteRecord{}
 	}
 	s.routes[route.Identity.ScopeKey+"/"+route.Identity.InstanceID] = route
+	if s.upsertAfterWrite && s.upsertErr != nil {
+		return s.upsertErr
+	}
+	if s.upsertErr != nil {
+		delete(s.routes, route.Identity.ScopeKey+"/"+route.Identity.InstanceID)
+		return s.upsertErr
+	}
+	return nil
+}
+
+func (s *routePersistenceTestStore) RollbackFlowInstanceRoute(_ context.Context, identity runtimeflowidentity.Route) error {
+	s.rollbackCalls = append(s.rollbackCalls, identity.ScopeKey+"/"+identity.InstanceID)
+	delete(s.routes, identity.ScopeKey+"/"+identity.InstanceID)
 	return nil
 }
 
 func (s *routePersistenceTestStore) DeleteFlowInstanceRoute(_ context.Context, identity runtimeflowidentity.Route) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	delete(s.routes, identity.ScopeKey+"/"+identity.InstanceID)
 	return nil
 }
@@ -86,6 +106,35 @@ func TestEventBusFlowInstanceRoutesPersistAcrossAddAndRemove(t *testing.T) {
 	}
 	if len(store.routes) != 0 {
 		t.Fatalf("persisted routes after remove = %#v, want none", store.routes)
+	}
+}
+
+func TestEventBusAddFlowInstanceRouteRollsBackPersistedRouteOnActiveInstallFailure(t *testing.T) {
+	store := &routePersistenceTestStore{
+		upsertErr:        context.DeadlineExceeded,
+		upsertAfterWrite: true,
+		deleteErr:        context.Canceled,
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	err = eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
+		ID:           "reviewer-{instance_id}",
+		Produces:     []string{"task.started"},
+		SubscribesTo: []string{"task.started"},
+	}, runtimeflowidentity.DeriveRoute("review", "inst-1"))
+	if err == nil {
+		t.Fatal("expected AddFlowInstanceRoute to fail")
+	}
+	if len(store.routes) != 0 {
+		t.Fatalf("persisted routes after rollback = %#v, want none", store.routes)
+	}
+	if len(store.rollbackCalls) != 1 || store.rollbackCalls[0] != "review/inst-1" {
+		t.Fatalf("rollback calls = %#v, want [review/inst-1]", store.rollbackCalls)
+	}
+	if got := eb.RouteTable().Resolve("review/inst-1/task.started"); len(got) != 0 {
+		t.Fatalf("resolved subscribers after failed add = %#v, want none", got)
 	}
 }
 

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -30,6 +30,10 @@ type FlowInstanceRoutePersistence interface {
 	ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error)
 }
 
+type FlowInstanceRouteRollbackPersistence interface {
+	RollbackFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error
+}
+
 type ActiveAgentDescriptor struct {
 	AgentID      string
 	EntityID     string

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -22,6 +22,7 @@ import (
 type flowInstancePersistence interface {
 	Upsert(ctx context.Context, instance runtimepipeline.WorkflowInstance) error
 	MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error
+	Load(ctx context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error)
 }
 
 type flowInstanceRouteInstaller interface {
@@ -257,18 +258,31 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 	if templateID == "" || instanceID == "" || flowPath == "" || entityID == "" {
 		return fmt.Errorf("template_id, instance_id, flow_path, and entity_id are required")
 	}
-	flowEntityID := entityID
-	routeIdentity := instance.Route()
-	if !routeIdentity.Valid() {
-		return fmt.Errorf("derive route identity for flow path %s", flowPath)
-	}
 	if err := am.workflowInstances.MarkTerminated(ctx, flowPath, time.Now().UTC()); err != nil {
 		return fmt.Errorf("persist flow instance terminal state %s: %w", flowPath, err)
+	}
+	canonicalInstance, ok, err := am.workflowInstances.Load(ctx, flowPath)
+	if err != nil {
+		return fmt.Errorf("load canonical terminal flow instance %s: %w", flowPath, err)
+	}
+	if !ok {
+		return fmt.Errorf("load canonical terminal flow instance %s: not found", flowPath)
+	}
+	if strings.TrimSpace(canonicalInstance.Status) != "terminated" || canonicalInstance.TerminatedAt.IsZero() {
+		return fmt.Errorf("canonical terminal flow instance %s not persisted", flowPath)
+	}
+	canonicalFlowPath := strings.TrimSpace(canonicalInstance.StorageRef)
+	if canonicalFlowPath == "" {
+		return fmt.Errorf("canonical terminal flow instance %s missing storage_ref", flowPath)
+	}
+	canonicalRoute := runtimeflowidentity.StoredRoute("", "", canonicalFlowPath)
+	if !canonicalRoute.Valid() {
+		return fmt.Errorf("derive canonical route identity for flow path %s", canonicalFlowPath)
 	}
 	am.mu.RLock()
 	agentIDs := make([]string, 0, len(am.agentCfg))
 	for agentID, cfg := range am.agentCfg {
-		if strings.TrimSpace(cfg.EntityID) != flowEntityID {
+		if cfg.CanonicalFlowPath() != canonicalFlowPath {
 			continue
 		}
 		agentIDs = append(agentIDs, agentID)
@@ -281,9 +295,9 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 		}
 	}
 	if remover, ok := am.bus.(flowInstanceRouteRemover); ok && remover != nil {
-		return remover.RemoveFlowInstanceRoute(routeIdentity)
+		return remover.RemoveFlowInstanceRoute(canonicalRoute)
 	}
-	return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", flowPath)
+	return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", canonicalFlowPath)
 }
 
 func buildFlowAgentConfig(

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -9,22 +9,34 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
 )
 
+type flowActivationRouteStore interface {
+	UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error
+	DeleteFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error
+}
+
 type flowActivationTestBus struct {
 	addedPaths   []string
 	removedPairs []string
 	published    []events.Event
+	routeStore   flowActivationRouteStore
+}
+
+type flowActivationTestRouteStore struct {
+	statusByPath map[string]string
 }
 
 type flowActivationTestInstanceStore struct {
 	upserts          []runtimepipeline.WorkflowInstance
 	terminatedPaths  []string
 	terminatedAtSeen []time.Time
+	byStorageRef     map[string]runtimepipeline.WorkflowInstance
 }
 
 type flowActivationTestStore struct {
@@ -37,15 +49,54 @@ func newFlowActivationManager(bus Bus, instances flowInstancePersistence, stores
 	}, stores...)
 }
 
+func (s *flowActivationTestRouteStore) UpsertFlowInstanceRoute(_ context.Context, route runtimebus.FlowInstanceRouteRecord) error {
+	if s.statusByPath == nil {
+		s.statusByPath = map[string]string{}
+	}
+	s.statusByPath[strings.TrimSpace(route.Identity.InstancePath)] = "active"
+	return nil
+}
+
+func (s *flowActivationTestRouteStore) DeleteFlowInstanceRoute(_ context.Context, identity runtimeflowidentity.Route) error {
+	if s.statusByPath == nil {
+		s.statusByPath = map[string]string{}
+	}
+	s.statusByPath[strings.TrimSpace(identity.InstancePath)] = "inactive"
+	return nil
+}
+
 func (s *flowActivationTestInstanceStore) Upsert(_ context.Context, instance runtimepipeline.WorkflowInstance) error {
 	s.upserts = append(s.upserts, instance)
+	if s.byStorageRef == nil {
+		s.byStorageRef = map[string]runtimepipeline.WorkflowInstance{}
+	}
+	stored := instance
+	stored.StorageRef = strings.TrimSpace(stored.StorageRef)
+	if stored.StorageRef != "" {
+		stored.Status = "active"
+		s.byStorageRef[stored.StorageRef] = stored
+	}
 	return nil
 }
 
 func (s *flowActivationTestInstanceStore) MarkTerminated(_ context.Context, storageRef string, terminatedAt time.Time) error {
 	s.terminatedPaths = append(s.terminatedPaths, strings.TrimSpace(storageRef))
 	s.terminatedAtSeen = append(s.terminatedAtSeen, terminatedAt)
+	if s.byStorageRef != nil {
+		instance := s.byStorageRef[strings.TrimSpace(storageRef)]
+		instance.Status = "terminated"
+		instance.TerminatedAt = terminatedAt
+		s.byStorageRef[strings.TrimSpace(storageRef)] = instance
+	}
 	return nil
+}
+
+func (s *flowActivationTestInstanceStore) Load(_ context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error) {
+	if s.byStorageRef == nil {
+		return runtimepipeline.WorkflowInstance{}, false, nil
+	}
+	instance, ok := s.byStorageRef[strings.TrimSpace(instanceID)]
+	return instance, ok, nil
 }
 
 func (s *flowActivationTestStore) UpsertAgent(_ context.Context, rec PersistedAgent) error {
@@ -88,12 +139,33 @@ func (*flowActivationTestBus) LogRuntime(context.Context, runtimepipeline.Runtim
 
 func (b *flowActivationTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
 	b.addedPaths = append(b.addedPaths, identity.InstancePath)
+	if b.routeStore != nil {
+		return b.routeStore.UpsertFlowInstanceRoute(context.Background(), runtimebus.FlowInstanceRouteRecord{
+			Identity:       identity,
+			EventPattern:   identity.InstancePath + "/task.started",
+			SubscriberType: "agent",
+			SubscriberID:   "reviewer-" + identity.InstanceID,
+			SourceFlow:     identity.ScopeKey,
+		})
+	}
 	return nil
 }
 
 func (b *flowActivationTestBus) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error {
 	b.removedPairs = append(b.removedPairs, identity.ScopeKey+"/"+identity.InstanceID)
+	if b.routeStore != nil {
+		return b.routeStore.DeleteFlowInstanceRoute(context.Background(), identity)
+	}
 	return nil
+}
+
+type flowActivationStubAgent struct{ id string }
+
+func (a flowActivationStubAgent) ID() string                      { return a.id }
+func (flowActivationStubAgent) Type() string                      { return "generic" }
+func (flowActivationStubAgent) Subscriptions() []events.EventType { return nil }
+func (flowActivationStubAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	return nil, nil
 }
 
 func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
@@ -465,7 +537,8 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
-	bus := &flowActivationTestBus{}
+	routeStore := &flowActivationTestRouteStore{}
+	bus := &flowActivationTestBus{routeStore: routeStore}
 	store := runtimepipeline.NewWorkflowInstanceStore(db)
 	am := newFlowActivationManager(bus, store)
 	bundle := testFlowBundle("")
@@ -480,6 +553,14 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	}); err != nil {
 		t.Fatalf("Mutate: %v", err)
 	}
+	am.mu.Lock()
+	am.agents["shared-subject-agent"] = flowActivationStubAgent{id: "shared-subject-agent"}
+	am.agentCfg["shared-subject-agent"] = models.AgentConfig{
+		ID:       "shared-subject-agent",
+		EntityID: req.Instance.EntityID,
+		FlowPath: "review/other-inst",
+	}
+	am.mu.Unlock()
 
 	if err := am.DeactivateFlowInstanceModel(context.Background(), runtimepipeline.FlowInstanceDeactivationRequest{
 		ContractBundle: semanticview.Wrap(bundle),
@@ -506,6 +587,10 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	if terminatedAt.IsZero() {
 		t.Fatal("flow_instances.terminated_at is zero")
 	}
+	routeStatus := routeStore.statusByPath["review/inst-1"]
+	if strings.TrimSpace(routeStatus) != "inactive" {
+		t.Fatalf("routing_rules.status = %q, want inactive", routeStatus)
+	}
 
 	instance, ok, err := store.Load(context.Background(), req.Instance.EntityID)
 	if err != nil {
@@ -516,6 +601,18 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	}
 	if got := strings.TrimSpace(instance.CurrentState); got != "completed" {
 		t.Fatalf("current_state = %q, want completed", got)
+	}
+	if strings.TrimSpace(instance.Status) != "terminated" {
+		t.Fatalf("loaded workflow instance status = %q, want terminated", instance.Status)
+	}
+	if instance.TerminatedAt.IsZero() {
+		t.Fatal("loaded workflow instance terminated_at is zero")
+	}
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("expected flow-scoped agent teardown")
+	}
+	if _, ok := am.GetAgentConfig("shared-subject-agent"); !ok {
+		t.Fatal("expected unrelated flow agent to remain active")
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -31,6 +31,8 @@ type WorkflowInstance struct {
 	StorageRef        string
 	WorkflowName      string
 	WorkflowVersion   string
+	Status            string
+	TerminatedAt      time.Time
 	CurrentState      string
 	Config            map[string]any
 	EnteredStageAt    time.Time
@@ -263,6 +265,8 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		entityType   string
 		slug         sql.NullString
 		name         sql.NullString
+		status       sql.NullString
+		terminatedAt sql.NullTime
 	)
 	query := `
 		SELECT
@@ -270,6 +274,8 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 			es.subject_id::text,
 			COALESCE(fi.flow_template, ''),
 			COALESCE(fi.config->>'workflow_version', ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
 			es.current_state,
 			es.entered_state_at,
 			COALESCE(es.gates, '{}'::jsonb),
@@ -296,6 +302,8 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		&subjectID,
 		&item.WorkflowName,
 		&item.WorkflowVersion,
+		&status,
+		&terminatedAt,
 		&item.CurrentState,
 		&item.EnteredStageAt,
 		&gatesRaw,
@@ -316,6 +324,10 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		return WorkflowInstance{}, false, err
 	}
 	item.SubjectID = strings.TrimSpace(subjectID.String)
+	item.Status = strings.TrimSpace(status.String)
+	if terminatedAt.Valid {
+		item.TerminatedAt = terminatedAt.Time
+	}
 	projection, err := decodeWorkflowInstancePersistedProjection(fieldsRaw, gatesRaw, accRaw, configRaw, workflowInstancePersistedControl{
 		SubjectID:  item.SubjectID,
 		StorageRef: strings.TrimSpace(flowInstance),
@@ -353,6 +365,8 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			es.subject_id::text,
 			COALESCE(fi.flow_template, ''),
 			COALESCE(fi.config->>'workflow_version', ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
 			es.current_state,
 			es.entered_state_at,
 			COALESCE(es.gates, '{}'::jsonb),
@@ -386,12 +400,16 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			entityType   string
 			slug         sql.NullString
 			name         sql.NullString
+			status       sql.NullString
+			terminatedAt sql.NullTime
 		)
 		if err := rows.Scan(
 			&item.InstanceID,
 			&subjectID,
 			&item.WorkflowName,
 			&item.WorkflowVersion,
+			&status,
+			&terminatedAt,
 			&item.CurrentState,
 			&item.EnteredStageAt,
 			&gatesRaw,
@@ -408,6 +426,10 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			return nil, err
 		}
 		item.SubjectID = strings.TrimSpace(subjectID.String)
+		item.Status = strings.TrimSpace(status.String)
+		if terminatedAt.Valid {
+			item.TerminatedAt = terminatedAt.Time
+		}
 		projection, err := decodeWorkflowInstancePersistedProjection(fieldsRaw, gatesRaw, accRaw, configRaw, workflowInstancePersistedControl{
 			SubjectID:  item.SubjectID,
 			StorageRef: strings.TrimSpace(flowInstance),

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -89,6 +91,21 @@ func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, identity ru
 	if !identity.Valid() {
 		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
 	}
+	var status string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT status
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, identity.InstancePath).Scan(&status)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("flow instance not found for route removal: %s", identity.InstancePath)
+		}
+		return fmt.Errorf("load flow instance for route removal %s: %w", identity.InstancePath, err)
+	}
+	if strings.TrimSpace(status) != "terminated" {
+		return fmt.Errorf("flow instance route removal requires terminal flow_instances status for %s", identity.InstancePath)
+	}
 	if _, err := s.DB.ExecContext(ctx, `
 			UPDATE routing_rules
 			SET status = 'inactive'
@@ -110,8 +127,10 @@ func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimefl
 				COALESCE(NULLIF(source_flow, ''), ''),
 				flow_instance
 			FROM routing_rules
+			JOIN flow_instances fi ON fi.instance_id = routing_rules.flow_instance
 			WHERE is_materialized = true
-			  AND status = 'active'
+			  AND routing_rules.status = 'active'
+			  AND fi.status = 'active'
 			  AND flow_instance IS NOT NULL
 			GROUP BY flow_instance, source_flow
 			ORDER BY flow_instance ASC

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -118,6 +118,26 @@ func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, identity ru
 	return nil
 }
 
+func (s *PostgresStore) RollbackFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required for flow instance routes")
+	}
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+			UPDATE routing_rules
+			SET status = 'inactive'
+			WHERE flow_instance = $1
+			  AND is_materialized = true
+			  AND status = 'active'
+		`, identity.InstancePath); err != nil {
+		return fmt.Errorf("rollback flow instance route %s/%s: %w", identity.ScopeKey, identity.InstanceID, err)
+	}
+	return nil
+}
+
 func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required for flow instance routes")

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -2,38 +2,55 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"strings"
 	"testing"
+	"time"
 
 	runtimebus "swarm/internal/runtime/bus"
-	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/testutil"
 )
+
+func ensureFlowInstanceRouteTables(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS flow_instances (
+			instance_id TEXT PRIMARY KEY,
+			flow_template TEXT NOT NULL DEFAULT '',
+			mode TEXT NOT NULL DEFAULT 'template',
+			config JSONB NOT NULL DEFAULT '{}'::jsonb,
+			status TEXT NOT NULL DEFAULT 'active',
+			terminated_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("ensure flow_instances table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS routing_rules (
+			rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			event_pattern TEXT NOT NULL,
+			subscriber_type TEXT NOT NULL,
+			subscriber_id TEXT NOT NULL,
+			flow_instance TEXT,
+			source_flow TEXT,
+			is_wildcard BOOLEAN NOT NULL DEFAULT FALSE,
+			is_materialized BOOLEAN NOT NULL DEFAULT FALSE,
+			materialized_from UUID,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("ensure routing_rules table: %v", err)
+	}
+}
 
 func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules`); err != nil {
-		t.Fatalf("drop legacy routing_rules: %v", err)
-	}
-
-	var spec runtimecontracts.PlatformSpecDocument
-	spec.PlatformTables.Tables = map[string]struct {
-		Description string `yaml:"description"`
-		DDL         string `yaml:"ddl"`
-	}{
-		"routing_rules": {
-			DDL: "CREATE TABLE routing_rules (\n    rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    event_pattern TEXT NOT NULL,\n    subscriber_type TEXT NOT NULL,\n    subscriber_id TEXT NOT NULL,\n    flow_instance TEXT,\n    source_flow TEXT,\n    is_wildcard BOOLEAN NOT NULL DEFAULT FALSE,\n    is_materialized BOOLEAN NOT NULL DEFAULT FALSE,\n    materialized_from UUID,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
-		},
-	}
-	plans, err := GeneratePlatformTableDDLs(spec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
+	ensureFlowInstanceRouteTables(t, ctx, db)
 
 	route := runtimebus.FlowInstanceRouteRecord{
 		Identity:       runtimeflowidentity.DeriveRoute("review", "inst-1"),
@@ -41,6 +58,12 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 		SubscriberType: "node",
 		SubscriberID:   "reviewer-inst-1",
 		SourceFlow:     "review",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'review', 'template', '{}'::jsonb, 'active', NOW())
+	`, route.Identity.InstancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
 	}
 	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
 		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
@@ -52,6 +75,13 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	want := route.Identity
 	if len(routes) != 1 || routes[0] != want {
 		t.Fatalf("listed routes = %#v, want %#v", routes, want)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET status = 'terminated', terminated_at = $2
+		WHERE instance_id = $1
+	`, route.Identity.InstancePath, time.Now().UTC()); err != nil {
+		t.Fatalf("terminate flow_instance: %v", err)
 	}
 	if err := pg.DeleteFlowInstanceRoute(ctx, route.Identity); err != nil {
 		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
@@ -69,26 +99,7 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules`); err != nil {
-		t.Fatalf("drop legacy routing_rules: %v", err)
-	}
-
-	var spec runtimecontracts.PlatformSpecDocument
-	spec.PlatformTables.Tables = map[string]struct {
-		Description string `yaml:"description"`
-		DDL         string `yaml:"ddl"`
-	}{
-		"routing_rules": {
-			DDL: "CREATE TABLE routing_rules (\n    rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    event_pattern TEXT NOT NULL,\n    subscriber_type TEXT NOT NULL,\n    subscriber_id TEXT NOT NULL,\n    flow_instance TEXT,\n    source_flow TEXT,\n    is_wildcard BOOLEAN NOT NULL DEFAULT FALSE,\n    is_materialized BOOLEAN NOT NULL DEFAULT FALSE,\n    materialized_from UUID,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
-		},
-	}
-	plans, err := GeneratePlatformTableDDLs(spec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
+	ensureFlowInstanceRouteTables(t, ctx, db)
 
 	route := runtimebus.FlowInstanceRouteRecord{
 		Identity:       runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1"),
@@ -96,6 +107,12 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 		SubscriberType: "node",
 		SubscriberID:   "worker-inst-1",
 		SourceFlow:     "child/grandchild",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'grandchild', 'template', '{}'::jsonb, 'active', NOW())
+	`, route.Identity.InstancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
 	}
 	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
 		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
@@ -107,6 +124,13 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	want := route.Identity
 	if len(routes) != 1 || routes[0] != want {
 		t.Fatalf("listed routes = %#v, want %#v", routes, want)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET status = 'terminated', terminated_at = $2
+		WHERE instance_id = $1
+	`, route.Identity.InstancePath, time.Now().UTC()); err != nil {
+		t.Fatalf("terminate flow_instance: %v", err)
 	}
 	if err := pg.DeleteFlowInstanceRoute(ctx, route.Identity); err != nil {
 		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
@@ -124,26 +148,7 @@ func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules`); err != nil {
-		t.Fatalf("drop legacy routing_rules: %v", err)
-	}
-
-	var spec runtimecontracts.PlatformSpecDocument
-	spec.PlatformTables.Tables = map[string]struct {
-		Description string `yaml:"description"`
-		DDL         string `yaml:"ddl"`
-	}{
-		"routing_rules": {
-			DDL: "CREATE TABLE routing_rules (\n    rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    event_pattern TEXT NOT NULL,\n    subscriber_type TEXT NOT NULL,\n    subscriber_id TEXT NOT NULL,\n    flow_instance TEXT,\n    source_flow TEXT,\n    is_wildcard BOOLEAN NOT NULL DEFAULT FALSE,\n    is_materialized BOOLEAN NOT NULL DEFAULT FALSE,\n    materialized_from UUID,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
-		},
-	}
-	plans, err := GeneratePlatformTableDDLs(spec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
+	ensureFlowInstanceRouteTables(t, ctx, db)
 
 	instancePath := "child/grandchild/inst-1"
 	route := runtimebus.FlowInstanceRouteRecord{
@@ -153,6 +158,12 @@ func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t
 		EventPattern:   instancePath + "/micro.started",
 		SubscriberType: "node",
 		SubscriberID:   "worker-inst-1",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'grandchild', 'template', '{}'::jsonb, 'active', NOW())
+	`, instancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
 	}
 	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
 		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
@@ -166,6 +177,13 @@ func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t
 	if len(routes) != 1 || routes[0] != want {
 		t.Fatalf("listed routes = %#v, want %#v", routes, want)
 	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET status = 'terminated', terminated_at = $2
+		WHERE instance_id = $1
+	`, instancePath, time.Now().UTC()); err != nil {
+		t.Fatalf("terminate flow_instance: %v", err)
+	}
 
 	if err := pg.DeleteFlowInstanceRoute(ctx, runtimeflowidentity.Route{InstancePath: instancePath}); err != nil {
 		t.Fatalf("DeleteFlowInstanceRoute: %v", err)
@@ -176,5 +194,102 @@ func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t
 	}
 	if len(routes) != 0 {
 		t.Fatalf("listed routes after delete = %#v, want none", routes)
+	}
+}
+
+func TestPostgresStoreFlowInstanceRouteDeletionRequiresCanonicalTermination(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	const instancePath = "review/inst-1"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'review', 'template', '{}'::jsonb, 'active', NOW())
+	`, instancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	route := runtimebus.FlowInstanceRouteRecord{
+		Identity:       runtimeflowidentity.StoredRoute("", "", instancePath),
+		EventPattern:   instancePath + "/task.started",
+		SubscriberType: "agent",
+		SubscriberID:   "reviewer-inst-1",
+		SourceFlow:     "review",
+	}
+	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
+		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
+	}
+
+	err := pg.DeleteFlowInstanceRoute(ctx, route.Identity)
+	if err == nil || !strings.Contains(err.Error(), "requires terminal flow_instances status") {
+		t.Fatalf("DeleteFlowInstanceRoute err = %v, want terminal-status denial", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET status = 'terminated', terminated_at = $2
+		WHERE instance_id = $1
+	`, instancePath, time.Now().UTC()); err != nil {
+		t.Fatalf("terminate flow_instance: %v", err)
+	}
+	if err := pg.DeleteFlowInstanceRoute(ctx, route.Identity); err != nil {
+		t.Fatalf("DeleteFlowInstanceRoute after termination: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM routing_rules
+		WHERE flow_instance = $1
+	`, instancePath).Scan(&status); err != nil {
+		t.Fatalf("query routing_rules: %v", err)
+	}
+	if strings.TrimSpace(status) != "inactive" {
+		t.Fatalf("routing_rules.status = %q, want inactive", status)
+	}
+}
+
+func TestPostgresStoreListFlowInstanceRoutesFiltersTerminatedInstances(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('review/inst-active', 'review', 'template', '{}'::jsonb, 'active', NOW()),
+			('review/inst-terminated', 'review', 'template', '{}'::jsonb, 'terminated', NOW())
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	for _, route := range []runtimebus.FlowInstanceRouteRecord{
+		{
+			Identity:       runtimeflowidentity.StoredRoute("", "", "review/inst-active"),
+			EventPattern:   "review/inst-active/task.started",
+			SubscriberType: "agent",
+			SubscriberID:   "reviewer-active",
+			SourceFlow:     "review",
+		},
+		{
+			Identity:       runtimeflowidentity.StoredRoute("", "", "review/inst-terminated"),
+			EventPattern:   "review/inst-terminated/task.started",
+			SubscriberType: "agent",
+			SubscriberID:   "reviewer-terminated",
+			SourceFlow:     "review",
+		},
+	} {
+		if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
+			t.Fatalf("UpsertFlowInstanceRoute(%s): %v", route.Identity.InstancePath, err)
+		}
+	}
+
+	routes, err := pg.ListFlowInstanceRoutes(ctx)
+	if err != nil {
+		t.Fatalf("ListFlowInstanceRoutes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].InstancePath != "review/inst-active" {
+		t.Fatalf("listed routes = %#v, want only active flow-instance route", routes)
 	}
 }


### PR DESCRIPTION
Closes #187

Spec references:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dynamic_instance_lifecycle.termination`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: routing_rules.lifecycle`

## Human Summary

This change makes template-flow teardown follow the persisted terminal `flow_instances` record instead of treating route removal and flow-agent shutdown as independent proof that the instance is done.

## What Changed

- made `DeactivateFlowInstanceModel(...)` persist terminal `flow_instances` state first, then reload the canonical instance and use its stored terminal status and flow path as the teardown owner
- changed flow-scoped agent cleanup to match the canonical flow path instead of using `EntityID` as a looser proxy
- extended `WorkflowInstance` loading to surface `flow_instances.status` and `terminated_at` to the manager seam
- tightened route teardown so `DeleteFlowInstanceRoute(...)` fails unless the backing `flow_instances` row is already `terminated`
- tightened route restoration so `ListFlowInstanceRoutes(...)` only returns materialized routes whose backing `flow_instances` row is still `active`
- added focused manager/store agreement tests for terminal registry state, route inactivation, and flow-scoped agent teardown

## Why This Is Needed

The spec makes terminal `flow_instances` state the canonical owner for template-flow termination. Before this change, route teardown and agent cleanup could proceed from adjacent request data or route rows alone. That left multiple local proofs of completion in the seam. This patch makes the touched teardown effects agree with the persisted terminal owner.

## Scope Boundaries

In scope:
- template-flow terminal teardown agreement in manager/store
- canonical `flow_instances` termination readback for the touched cleanup path
- materialized route teardown agreement with terminal `flow_instances` state
- focused agreement tests for terminal state, route teardown, and flow-scoped agent cleanup

Out of scope:
- broad route-management redesign
- unrelated workflow lifecycle cleanup
- new clustering or ownership semantics outside template-flow termination

## Tests Run

- `go test ./internal/runtime/manager ./internal/store -run 'TestDeactivateFlowInstance|TestPostgresStoreFlowInstanceRoute' -count=1`
- `go test ./internal/runtime/manager ./internal/runtime/pipeline ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR tightens the termination seam that already persists and tears down template flows. It does not redesign broader route bootstrapping or non-template lifecycle handling. If another path can mark or clear template-flow runtime state without going through this termination seam, that remains a separate issue.

## Follow-Up

No spec escalation was needed for this change.
