### PR TITLE
[agent-d][issue #231] Collapse delivery-backed terminal transitions behind one canonical store helper

### DIFF
--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -126,6 +126,21 @@ type agentReceiptWriteState struct {
 	deliveryCode string
 }
 
+type lockedAgentDelivery struct {
+	retryCount      int
+	status          string
+	activeSessionID string
+	entityID        string
+	flowInstance    string
+	found           bool
+}
+
+type deliveryBackedTerminalTransitionRequest struct {
+	reasonCode   string
+	errorText    string
+	retryAdvance int
+}
+
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
@@ -134,12 +149,37 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 		}
 		defer func() { _ = tx.Rollback() }()
 
-		state, err := s.prepareAgentReceiptWriteStateTx(ctx, tx, eventID, agentID, status, errText)
+		delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
 		if err != nil {
 			return err
 		}
-		if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
-			return err
+		if delivery.found {
+			state := buildAgentReceiptWriteState(delivery.retryCount, true, status, errText)
+			if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
+				if _, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, eventID, agentID, delivery, deliveryBackedTerminalTransitionRequest{
+					reasonCode:   state.reasonCode,
+					errorText:    state.errorText,
+					retryAdvance: state.retryCount - delivery.retryCount,
+				}); err != nil {
+					return err
+				}
+			} else {
+				if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
+					return err
+				}
+				if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
+					return err
+				}
+			}
+		} else {
+			retryCount, err := s.lockAgentReceiptRetryCountTx(ctx, tx, eventID, agentID)
+			if err != nil {
+				return err
+			}
+			state := buildAgentReceiptWriteState(retryCount, false, status, errText)
+			if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
+				return err
+			}
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("commit event receipt tx: %w", err)
@@ -148,27 +188,18 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 	})
 }
 
-func (s *PostgresStore) prepareAgentReceiptWriteStateTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	eventID, agentID string,
+func buildAgentReceiptWriteState(
+	baseRetryCount int,
+	hasDelivery bool,
 	status runtimemanager.ReceiptStatus,
 	errText string,
-) (agentReceiptWriteState, error) {
+) agentReceiptWriteState {
 	state := agentReceiptWriteState{
 		finalStatus: status,
 		errorText:   strings.TrimSpace(errText),
+		hasDelivery: hasDelivery,
 	}
-	retryCount, hasDelivery, err := s.lockAgentDeliveryRetryCountTx(ctx, tx, eventID, agentID)
-	if err != nil {
-		return state, err
-	}
-	if !hasDelivery {
-		retryCount, err = s.lockAgentReceiptRetryCountTx(ctx, tx, eventID, agentID)
-		if err != nil {
-			return state, err
-		}
-	}
+	retryCount := baseRetryCount
 	if status == runtimemanager.ReceiptStatusError {
 		retryCount++
 	}
@@ -176,11 +207,9 @@ func (s *PostgresStore) prepareAgentReceiptWriteStateTx(
 	if status == runtimemanager.ReceiptStatusError && retryCount >= 2 {
 		finalStatus = runtimemanager.ReceiptStatusDeadLetter
 	}
-	reasonCode := managerReceiptReasonCode(finalStatus, state.errorText)
 	state.finalStatus = finalStatus
 	state.retryCount = retryCount
-	state.reasonCode = reasonCode
-	state.hasDelivery = hasDelivery
+	state.reasonCode = managerReceiptReasonCode(finalStatus, state.errorText)
 	state.deliveryCode = "delivered"
 	switch status {
 	case runtimemanager.ReceiptStatusError:
@@ -191,33 +220,78 @@ func (s *PostgresStore) prepareAgentReceiptWriteStateTx(
 	if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
 		state.deliveryCode = "dead_letter"
 	}
-	if !hasDelivery {
-		return state, nil
-	}
-	if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
-		return state, err
-	}
-	return state, nil
+	return state
 }
 
-func (s *PostgresStore) lockAgentDeliveryRetryCountTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (int, bool, error) {
-	var retryCount int
+func (s *PostgresStore) lockAgentDeliveryTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+) (lockedAgentDelivery, error) {
+	var delivery lockedAgentDelivery
 	err := tx.QueryRowContext(ctx, `
-		SELECT retry_count
-		FROM event_deliveries
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
+		SELECT
+			d.retry_count,
+			COALESCE(d.status, ''),
+			COALESCE(d.active_session_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			COALESCE(e.flow_instance, '')
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
 		FOR UPDATE
-	`, eventID, agentID).Scan(&retryCount)
+	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
-		return 0, false, nil
+		return lockedAgentDelivery{}, nil
 	case err != nil:
-		return 0, false, fmt.Errorf("lock event delivery retry_count: %w", err)
+		return lockedAgentDelivery{}, fmt.Errorf("lock event delivery row: %w", err)
 	default:
-		return retryCount, true, nil
+		delivery.found = true
+		return delivery, nil
 	}
+}
+
+func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	delivery lockedAgentDelivery,
+	req deliveryBackedTerminalTransitionRequest,
+) (runtimemanager.EventReceipt, error) {
+	if !delivery.found {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: delivery row required")
+	}
+	reasonCode := strings.TrimSpace(req.reasonCode)
+	if reasonCode == "" {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: reason_code required")
+	}
+	if req.retryAdvance < 0 {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: retry advance must be non-negative")
+	}
+	state := agentReceiptWriteState{
+		finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
+		retryCount:   delivery.retryCount + req.retryAdvance,
+		reasonCode:   reasonCode,
+		errorText:    strings.TrimSpace(req.errorText),
+		hasDelivery:  true,
+		deliveryCode: "dead_letter",
+	}
+	if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
+		return runtimemanager.EventReceipt{}, err
+	}
+	if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
+		return runtimemanager.EventReceipt{}, err
+	}
+	return runtimemanager.EventReceipt{
+		EventID:    strings.TrimSpace(eventID),
+		AgentID:    strings.TrimSpace(agentID),
+		Status:     runtimemanager.ReceiptStatusDeadLetter,
+		RetryCount: state.retryCount,
+		Error:      state.errorText,
+	}, nil
 }
 
 func (s *PostgresStore) lockAgentReceiptRetryCountTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (int, error) {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -444,6 +444,156 @@ func TestPostgresStore_CancelActiveRunWorkByProducer_DeadLettersOldRunDeliveries
 	}
 }
 
+func TestPostgresStore_CancelActiveRunWorkByProducer_PreservesExistingRetryCountViaSharedTerminalHelper(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'campaign-coordinator', 'agent', now())
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, active_session_id, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'market-research-agent', 'in_progress', 1, 'handler_error', 'boom', $3::uuid, now()
+		)
+	`, runID, eventID, sessionID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	transitions, err := pg.CancelActiveRunWorkByProducer(ctx, "campaign-coordinator")
+	if err != nil {
+		t.Fatalf("CancelActiveRunWorkByProducer: %v", err)
+	}
+	if len(transitions) != 1 {
+		t.Fatalf("transitions = %#v, want 1", transitions)
+	}
+	if transitions[0].RetryCount != 1 || transitions[0].Reason != "cancelled_by_kill_previous" {
+		t.Fatalf("transition = %#v", transitions[0])
+	}
+
+	var deliveryRetry int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(retry_count, 0)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'market-research-agent'
+	`, eventID).Scan(&deliveryRetry); err != nil {
+		t.Fatalf("load cancelled delivery retry_count: %v", err)
+	}
+	if deliveryRetry != 1 {
+		t.Fatalf("delivery retry_count = %d, want 1", deliveryRetry)
+	}
+
+	receipt, ok, err := pg.GetEventReceipt(ctx, eventID, "market-research-agent")
+	if err != nil {
+		t.Fatalf("GetEventReceipt(cancelled retried delivery): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cancelled retried delivery receipt to exist")
+	}
+	if receipt.Status != runtimemanager.ReceiptStatusDeadLetter || receipt.RetryCount != 1 {
+		t.Fatalf("receipt = %+v, want dead_letter retry_count=1", receipt)
+	}
+}
+
+func TestPostgresStore_CancelActiveRunWorkByProducer_RollsBackSharedTerminalHelperFailure(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'campaign-coordinator', 'agent', now())
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'market-research-agent', 'in_progress', now())
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION fail_cancel_terminal_receipt()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced cancel receipt failure';
+		END;
+		$$;
+	`); err != nil {
+		t.Fatalf("create trigger function: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER event_receipts_fail_cancel_terminal
+		BEFORE INSERT OR UPDATE ON event_receipts
+		FOR EACH ROW
+		EXECUTE FUNCTION fail_cancel_terminal_receipt()
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TRIGGER IF EXISTS event_receipts_fail_cancel_terminal ON event_receipts`)
+		_, _ = db.ExecContext(context.Background(), `DROP FUNCTION IF EXISTS fail_cancel_terminal_receipt()`)
+	})
+
+	_, err := pg.CancelActiveRunWorkByProducer(ctx, "campaign-coordinator")
+	if err == nil {
+		t.Fatal("expected shared terminal helper failure")
+	}
+	if !strings.Contains(err.Error(), "cancel kill_previous deliveries/receipts") {
+		t.Fatalf("CancelActiveRunWorkByProducer error = %v", err)
+	}
+
+	var (
+		deliveryStatus string
+		reasonCode     string
+		receiptCount   int
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'market-research-agent'
+	`, eventID).Scan(&deliveryStatus, &reasonCode); err != nil {
+		t.Fatalf("load delivery after rollback: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'market-research-agent'
+	`, eventID).Scan(&receiptCount); err != nil {
+		t.Fatalf("count receipts after rollback: %v", err)
+	}
+	if deliveryStatus != "in_progress" || reasonCode != "" || receiptCount != 0 {
+		t.Fatalf("rollback mismatch: delivery_status=%q reason=%q receipt_count=%d", deliveryStatus, reasonCode, receiptCount)
+	}
+}
+
 func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminalDelivery(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/trace_cancel.go
+++ b/internal/store/trace_cancel.go
@@ -68,110 +68,76 @@ func (s *PostgresStore) CancelActiveRunWorkByProducer(ctx context.Context, produ
 		return nil, nil
 	}
 
-	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects("dead_letter", "cancelled_by_kill_previous", 0, "cancelled by --kill-previous"))
-	if err != nil {
-		return nil, fmt.Errorf("marshal kill_previous receipt side effects: %w", err)
-	}
-
 	rows, err := tx.QueryContext(ctx, `
-		WITH targeted AS (
-			SELECT
-				d.delivery_id,
-				d.event_id,
-				d.subscriber_type,
-				d.subscriber_id,
-				d.status,
-				COALESCE(d.active_session_id::text, '') AS active_session_id,
-				e.entity_id,
-				e.flow_instance
-			FROM event_deliveries d
-			JOIN events e ON e.event_id = d.event_id
-			WHERE e.run_id::text = ANY($1::text[])
-			  AND d.status IN ('pending', 'in_progress')
-			FOR UPDATE OF d
-		),
-		updated AS (
-			UPDATE event_deliveries d
-			SET
-				status = 'dead_letter',
-				reason_code = 'cancelled_by_kill_previous',
-				last_error = 'cancelled by --kill-previous',
-				active_session_id = NULL,
-				delivered_at = now()
-			FROM targeted t
-			WHERE d.delivery_id = t.delivery_id
-			RETURNING t.event_id, t.subscriber_type, t.subscriber_id, t.status, t.active_session_id, t.entity_id, t.flow_instance
-		)
-		, receipts AS (
-			INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, reason_code, side_effects, processed_at
-			)
-			SELECT
-				u.event_id,
-				u.subscriber_type,
-				u.subscriber_id,
-				u.entity_id,
-				u.flow_instance,
-				'dead_letter',
-				'cancelled_by_kill_previous',
-				$2::jsonb,
-				now()
-			FROM updated u
-			ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-				entity_id = EXCLUDED.entity_id,
-				flow_instance = EXCLUDED.flow_instance,
-				outcome = EXCLUDED.outcome,
-				reason_code = EXCLUDED.reason_code,
-				side_effects = EXCLUDED.side_effects,
-				processed_at = now()
-			RETURNING event_id, subscriber_id
-		)
 		SELECT
-			u.event_id::text,
-			u.subscriber_id,
-			COALESCE(u.status, ''),
-			COALESCE(u.active_session_id, ''),
-			COALESCE(u.entity_id::text, ''),
-			COALESCE(u.flow_instance, '')
-		FROM updated u
-		JOIN receipts r ON r.event_id = u.event_id AND r.subscriber_id = u.subscriber_id
-		ORDER BY u.subscriber_id ASC, u.event_id::text ASC
-	`, pq.Array(runIDs), string(sideEffects))
+			d.event_id::text,
+			d.subscriber_id
+		FROM event_deliveries d
+		JOIN events e ON e.event_id = d.event_id
+		WHERE e.run_id::text = ANY($1::text[])
+		  AND d.subscriber_type = 'agent'
+		  AND d.status IN ('pending', 'in_progress')
+		ORDER BY d.event_id::text ASC, d.subscriber_id ASC
+	`, pq.Array(runIDs))
 	if err != nil {
-		return nil, fmt.Errorf("cancel kill_previous deliveries/receipts: %w", err)
+		return nil, fmt.Errorf("query kill_previous delivery targets: %w", err)
 	}
 	defer rows.Close()
 
-	transitions := make([]runtimedelivery.Transition, 0, 16)
+	type cancelTarget struct {
+		eventID string
+		agentID string
+	}
+	targets := make([]cancelTarget, 0, 16)
 	for rows.Next() {
 		var (
-			eventID         string
-			agentID         string
-			prevStatus      string
-			activeSessionID string
-			entityID        string
-			flowInstance    string
+			eventID string
+			agentID string
 		)
-		if err := rows.Scan(&eventID, &agentID, &prevStatus, &activeSessionID, &entityID, &flowInstance); err != nil {
-			return nil, fmt.Errorf("scan cancelled delivery transition: %w", err)
+		if err := rows.Scan(&eventID, &agentID); err != nil {
+			return nil, fmt.Errorf("scan kill_previous delivery target: %w", err)
 		}
-		prevState, _ := runtimedelivery.StateFromDelivery(prevStatus, activeSessionID)
-		_ = flowInstance
+		targets = append(targets, cancelTarget{
+			eventID: strings.TrimSpace(eventID),
+			agentID: strings.TrimSpace(agentID),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read kill_previous delivery targets: %w", err)
+	}
+
+	transitions := make([]runtimedelivery.Transition, 0, len(targets))
+	for _, target := range targets {
+		delivery, err := s.lockAgentDeliveryTx(ctx, tx, target.eventID, target.agentID)
+		if err != nil {
+			return nil, err
+		}
+		if !delivery.found {
+			continue
+		}
+		prevState, ok := runtimedelivery.StateFromDelivery(delivery.status, delivery.activeSessionID)
+		if !ok || (prevState != runtimedelivery.StateQueued && prevState != runtimedelivery.StateLaunching && prevState != runtimedelivery.StateActive) {
+			continue
+		}
+		receipt, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, target.eventID, target.agentID, delivery, deliveryBackedTerminalTransitionRequest{
+			reasonCode:   "cancelled_by_kill_previous",
+			errorText:    "cancelled by --kill-previous",
+			retryAdvance: 0,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cancel kill_previous deliveries/receipts: %w", err)
+		}
 		transitions = append(transitions, runtimedelivery.Transition{
-			EventID:         strings.TrimSpace(eventID),
-			AgentID:         strings.TrimSpace(agentID),
-			EntityID:        strings.TrimSpace(entityID),
+			EventID:         target.eventID,
+			AgentID:         target.agentID,
+			EntityID:        delivery.entityID,
 			State:           runtimedelivery.StateExhausted,
 			PreviousState:   prevState,
 			Reason:          "cancelled_by_kill_previous",
 			TerminalOutcome: "cancelled_by_kill_previous",
-			Error:           "cancelled by --kill-previous",
-			RetryCount:      0,
+			Error:           receipt.Error,
+			RetryCount:      receipt.RetryCount,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read cancelled delivery transitions: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
Closes #231

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: event_schema.routing_derivation.delivery_rules`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.dead_letter_schema`
- governing rule: delivery, retry, and dead-letter state in the delivery-backed seam must come from one canonical delivery owner; store/runtime surfaces must not re-encode alternate terminal transition semantics.

## Human Summary
This PR collapses delivery-backed terminal receipt and delivery updates behind one canonical store helper. Normal receipt exhaustion and `--kill-previous` cancellation now use the same transactional transition path, so terminal state, reason codes, retry counts, and receipt side effects cannot drift between the two callers.

## What Changed
- added one store-owned helper in `internal/store/event_receipt_store.go` for delivery-backed terminal dead-letter transitions
- rewired `UpsertEventReceipt(...)` to use that helper for delivery-backed terminal transitions while keeping receipt-only paths separate
- rewired `CancelActiveRunWorkByProducer(...)` to stop hand-writing delivery and receipt rows and instead call the same helper in deterministic row order
- added focused store tests for shared-helper retry-count preservation and rollback behavior on cancellation failures

## Why This Is Needed
`#223` already centralized delivery-backed receipt atomicity for the main receipt path, but `trace_cancel.go` still reimplemented the same terminal dead-letter transition independently. That duplication kept lock order, retry-count handling, reason codes, and receipt side effects vulnerable to drift. This PR removes that second semantic implementation.

## Scope Boundaries
- In scope:
  - delivery-backed terminal receipt/delivery transitions in `internal/store/event_receipt_store.go`
  - `--kill-previous` cancellation in `internal/store/trace_cancel.go`
  - focused store tests for aligned terminal behavior
- Not in scope:
  - receipt-only agent paths without an `event_deliveries` row
  - broader delivery lifecycle redesign
  - runtime/operator observability changes

## Tests Run
- `go test ./internal/store -run 'Test(UpsertEventReceipt_(DeadLettersAfterOneRetry_V2|PreservesRetryableVsTerminalDeliveryStatus_V2|ConcurrentErrorRetriesAdvanceAtomically_V2|RollsBackReceiptWhenDeliverySyncFails_V2)|PostgresStore_CancelActiveRunWorkByProducer_(DeadLettersOldRunDeliveries|PreservesExistingRetryCountViaSharedTerminalHelper|RollsBackSharedTerminalHelperFailure))' -count=1`
- `go test ./internal/store ./internal/runtime/manager ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
Receipt-only agent paths still keep their retry state in the receipt row because they do not have a delivery row to own terminal progression. This PR keeps that boundary explicit, but it does not redesign those receipt-only semantics.

## Follow-Up
No same-seam follow-up is required for this issue. If the repo later decides to eliminate receipt-only retry ownership as well, that should be a separate broader issue because it crosses the boundary intentionally left out of scope here.
