### PR TITLE
[agent-b][issue #162] Audit mutation-log completeness for entity_state write paths

### DIFF
--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -12,6 +13,10 @@ import (
 )
 
 var syntheticRunNamespace = uuid.MustParse("7e7e89e6-0d4f-4eeb-a8a0-99a3e8ec2ef1")
+
+func ErrInvalidMutationLogWriter(message string) error {
+	return fmt.Errorf("mutation log completeness violation: %s", strings.TrimSpace(message))
+}
 
 type DBTX interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
@@ -42,14 +47,14 @@ type EntityStateProjection struct {
 
 func Insert(ctx context.Context, db DBTX, rec Record) error {
 	if db == nil {
-		return nil
+		return ErrInvalidMutationLogWriter("mutation log DB is required")
 	}
 	entityID := strings.TrimSpace(rec.EntityID)
 	field := strings.TrimSpace(rec.Field)
 	writerType := strings.TrimSpace(rec.WriterType)
 	writerID := strings.TrimSpace(rec.WriterID)
 	if entityID == "" || field == "" || writerType == "" || writerID == "" {
-		return nil
+		return ErrInvalidMutationLogWriter("entity_id, field, writer_type, and writer_id are required")
 	}
 
 	runID := normalizeRunID(runtimecorrelation.RunIDFromContext(ctx))
@@ -90,42 +95,61 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	return err
 }
 
-func InsertEntityStateDiff(ctx context.Context, db DBTX, entityID string, before, after EntityStateProjection, writer Writer) error {
+func BuildEntityStateDiffRecords(entityID string, before, after EntityStateProjection, writer Writer) ([]Record, error) {
 	entityID = strings.TrimSpace(entityID)
-	if db == nil || entityID == "" {
-		return nil
+	if entityID == "" {
+		return nil, ErrInvalidMutationLogWriter("entity_id is required")
 	}
 	writerType := strings.TrimSpace(writer.Type)
 	writerID := strings.TrimSpace(writer.ID)
 	if writerType == "" || writerID == "" {
-		return nil
+		return nil, ErrInvalidMutationLogWriter("writer_type and writer_id are required")
 	}
+	handlerStep := strings.TrimSpace(writer.HandlerStep)
+	records := make([]Record, 0, 8)
 	if strings.TrimSpace(before.CurrentState) != strings.TrimSpace(after.CurrentState) {
-		if err := Insert(ctx, db, Record{
+		records = append(records, Record{
 			EntityID:    entityID,
 			Field:       "current_state",
 			OldValue:    stringOrNil(before.CurrentState),
 			NewValue:    stringOrNil(after.CurrentState),
 			WriterType:  writerType,
 			WriterID:    writerID,
-			HandlerStep: strings.TrimSpace(writer.HandlerStep),
-		}); err != nil {
+			HandlerStep: handlerStep,
+		})
+	}
+	fieldRecords, err := diffMapRecords(entityID, "", before.Fields, after.Fields, writerType, writerID, handlerStep)
+	if err != nil {
+		return nil, err
+	}
+	records = append(records, fieldRecords...)
+	gateRecords, err := diffMapRecords(entityID, "gates.", before.Gates, after.Gates, writerType, writerID, handlerStep)
+	if err != nil {
+		return nil, err
+	}
+	records = append(records, gateRecords...)
+	accRecords, err := diffMapRecords(entityID, "accumulator.", before.Accumulator, after.Accumulator, writerType, writerID, handlerStep)
+	if err != nil {
+		return nil, err
+	}
+	records = append(records, accRecords...)
+	return records, nil
+}
+
+func InsertEntityStateDiff(ctx context.Context, db DBTX, entityID string, before, after EntityStateProjection, writer Writer) error {
+	records, err := BuildEntityStateDiffRecords(entityID, before, after, writer)
+	if err != nil {
+		return err
+	}
+	for _, rec := range records {
+		if err := Insert(ctx, db, rec); err != nil {
 			return err
 		}
-	}
-	if err := insertMapDiff(ctx, db, entityID, "", before.Fields, after.Fields, writer); err != nil {
-		return err
-	}
-	if err := insertMapDiff(ctx, db, entityID, "gates.", before.Gates, after.Gates, writer); err != nil {
-		return err
-	}
-	if err := insertMapDiff(ctx, db, entityID, "accumulator.", before.Accumulator, after.Accumulator, writer); err != nil {
-		return err
 	}
 	return nil
 }
 
-func insertMapDiff(ctx context.Context, db DBTX, entityID, prefix string, before, after map[string]any, writer Writer) error {
+func diffMapRecords(entityID, prefix string, before, after map[string]any, writerType, writerID, handlerStep string) ([]Record, error) {
 	keys := make([]string, 0, len(before)+len(after))
 	seen := map[string]struct{}{}
 	for key := range before {
@@ -151,6 +175,7 @@ func insertMapDiff(ctx context.Context, db DBTX, entityID, prefix string, before
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	records := make([]Record, 0, len(keys))
 	for _, key := range keys {
 		oldValue, oldOK := before[key]
 		newValue, newOK := after[key]
@@ -162,24 +187,22 @@ func insertMapDiff(ctx context.Context, db DBTX, entityID, prefix string, before
 		}
 		same, err := jsonValuesEqual(oldValue, newValue)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if same {
 			continue
 		}
-		if err := Insert(ctx, db, Record{
+		records = append(records, Record{
 			EntityID:    entityID,
 			Field:       strings.TrimSpace(prefix + key),
 			OldValue:    oldValue,
 			NewValue:    newValue,
-			WriterType:  strings.TrimSpace(writer.Type),
-			WriterID:    strings.TrimSpace(writer.ID),
-			HandlerStep: strings.TrimSpace(writer.HandlerStep),
-		}); err != nil {
-			return err
-		}
+			WriterType:  writerType,
+			WriterID:    writerID,
+			HandlerStep: handlerStep,
+		})
 	}
-	return nil
+	return records, nil
 }
 
 func jsonValuesEqual(left, right any) (bool, error) {

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -140,6 +140,165 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
 }
 
+func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	entityID := uuid.NewString()
+	pc := testMutationLoggingCoordinator(db)
+	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+
+	if err := pc.applyWorkflowGateMutation(context.Background(), entityID, "workflow.ready", "g_ready", false); err != nil {
+		t.Fatalf("applyWorkflowGateMutation: %v", err)
+	}
+
+	fields := mutationFieldsForEntity(t, db, entityID)
+	if !containsMutationField(fields, "gates.g_ready") {
+		t.Fatalf("mutation fields missing gates.g_ready: %v", fields)
+	}
+	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+}
+
+func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	entityID := uuid.NewString()
+	pc := testMutationLoggingCoordinator(db)
+	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+
+	if err := pc.recordWorkflowEvidence(context.Background(), entityID, "research", map[string]any{"summary": "done"}); err != nil {
+		t.Fatalf("recordWorkflowEvidence: %v", err)
+	}
+
+	fields := mutationFieldsForEntity(t, db, entityID)
+	if !containsMutationField(fields, "accumulator.evidence") {
+		t.Fatalf("mutation fields missing accumulator.evidence: %v", fields)
+	}
+	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+}
+
+func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *testing.T) {
+	t.Run("state transition", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		entityID := uuid.NewString()
+		pc := testMutationLoggingCoordinator(db)
+		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+		dropEntityMutationsTable(t, db)
+
+		err := pc.updateEntityState(context.Background(), entityID, "done", "flow.transitioned")
+		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
+			t.Fatalf("updateEntityState err = %v, want entity_mutations failure", err)
+		}
+		assertCurrentState(t, db, entityID, "queued")
+	})
+
+	t.Run("gate mutation", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		entityID := uuid.NewString()
+		pc := testMutationLoggingCoordinator(db)
+		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+		dropEntityMutationsTable(t, db)
+
+		err := pc.applyWorkflowGateMutation(context.Background(), entityID, "workflow.ready", "g_ready", false)
+		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
+			t.Fatalf("applyWorkflowGateMutation err = %v, want entity_mutations failure", err)
+		}
+		assertEntityGates(t, db, entityID, map[string]any{})
+	})
+
+	t.Run("evidence write", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		entityID := uuid.NewString()
+		pc := testMutationLoggingCoordinator(db)
+		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+		dropEntityMutationsTable(t, db)
+
+		err := pc.recordWorkflowEvidence(context.Background(), entityID, "research", map[string]any{"summary": "done"})
+		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
+			t.Fatalf("recordWorkflowEvidence err = %v, want entity_mutations failure", err)
+		}
+		assertAccumulatorBucketMissing(t, db, entityID, "evidence")
+	})
+}
+
+func testMutationLoggingCoordinator(db *sql.DB) *PipelineCoordinator {
+	return &PipelineCoordinator{
+		workflowStore: NewWorkflowInstanceStore(db),
+		module: &previewWorkflowModule{
+			bundle: &runtimecontracts.WorkflowContractBundle{
+				Semantics: runtimecontracts.WorkflowSemanticView{
+					Name:    "mutation-flow",
+					Version: "1.0.0",
+				},
+			},
+		},
+	}
+}
+
+func seedMutationLoggingInstance(t *testing.T, store *WorkflowInstanceStore, entityID string) {
+	t.Helper()
+	if err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "mutation-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+}
+
+func dropEntityMutationsTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `DROP TABLE entity_mutations`); err != nil {
+		t.Fatalf("drop entity_mutations: %v", err)
+	}
+}
+
+func assertCurrentState(t *testing.T, db *sql.DB, entityID, want string) {
+	t.Helper()
+	var currentState string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(current_state, '')
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+	`, entityID).Scan(&currentState); err != nil {
+		t.Fatalf("load current_state: %v", err)
+	}
+	if got := strings.TrimSpace(currentState); got != want {
+		t.Fatalf("current_state = %q, want %q", got, want)
+	}
+}
+
+func assertEntityGates(t *testing.T, db *sql.DB, entityID string, want map[string]any) {
+	t.Helper()
+	var gatesRaw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(gates, '{}'::jsonb)
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+	`, entityID).Scan(&gatesRaw); err != nil {
+		t.Fatalf("load gates: %v", err)
+	}
+	got := decodeJSONMap(t, gatesRaw)
+	if mustCanonicalJSON(t, got) != mustCanonicalJSON(t, want) {
+		t.Fatalf("gates = %s, want %s", mustCanonicalJSON(t, got), mustCanonicalJSON(t, want))
+	}
+}
+
+func assertAccumulatorBucketMissing(t *testing.T, db *sql.DB, entityID, bucket string) {
+	t.Helper()
+	var accRaw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(accumulator, '{}'::jsonb)
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+	`, entityID).Scan(&accRaw); err != nil {
+		t.Fatalf("load accumulator: %v", err)
+	}
+	acc := decodeJSONMap(t, accRaw)
+	if _, ok := acc[strings.TrimSpace(bucket)]; ok {
+		t.Fatalf("accumulator = %s, expected bucket %q to be absent", mustCanonicalJSON(t, acc), bucket)
+	}
+}
+
 func mutationFieldsForEntity(t *testing.T, db *sql.DB, entityID string) []string {
 	t.Helper()
 	rows, err := db.QueryContext(context.Background(), `


### PR DESCRIPTION
Closes #162

Spec references:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dependency_graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_state`

## Human Summary

This change tightens the first covered canonical `entity_state` write paths so visible workflow state changes no longer succeed silently when their mutation trail cannot be recorded.

## What Changed

- tightened the canonical mutation-log helper in `internal/runtime/mutationlog/mutationlog.go` so missing DB or missing writer metadata is now an explicit completeness error instead of a silent no-op
- added explicit diff-record construction for canonical `entity_state` changes so the covered write seam has one concrete interpretation of what must be logged
- added focused pipeline regressions for the first high-value write seams:
  - `updateEntityState(...)`
  - `applyWorkflowGateMutation(...)`
  - `recordWorkflowEvidence(...)`
- added fail-closed tests proving those writes roll back instead of committing visible state when `entity_mutations` is unavailable

## Why This Is Needed

The spec requires one atomic, trustworthy entity-state model. If `entity_state` can change while `entity_mutations` silently disappears, the runtime ends up with two conflicting truths: visible state and incomplete mutation history. This patch makes the first covered canonical write seams fail loudly instead.

## Scope Boundaries

In scope:
- canonical mutation-log completeness for the first covered `entity_state` write paths under pipeline
- explicit completeness failure when mutation-log persistence is unavailable in those paths
- focused invariant coverage for state, gate, and evidence writes

Out of scope:
- broad store redesign
- full coverage of every possible entity-writing subsystem
- unrelated persistence-surface cleanup

## Tests Run

- `go test ./internal/runtime/pipeline ./internal/runtime/mutationlog -run 'Test(UpdateEntityState|ApplyWorkflowGateMutation|RecordWorkflowEvidence|MutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable)|TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLog' -count=1`
- `go test ./internal/runtime/pipeline ./internal/runtime/tools ./internal/runtime/mutationlog ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR covers the first high-value pipeline-owned `entity_state` write seams. Other subsystems that write entity state through different owners still need their own completeness audit instead of assuming this slice proves the whole system.

## Follow-Up

No spec escalation was needed for this change.
