### PR TITLE
[agent-d][issue #236] Make replay claims a required store contract in the recovery and sweeper seam

### DIFF
--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimeengine "swarm/internal/runtime/engine"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type engineOutbox struct {
@@ -115,7 +116,11 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		if !passthrough {
 			return nil
 		}
-		recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, intent.Event.ID)
+		recipientReader, err := runtimereplayclaim.RequireRecipientReader(d.bus.store)
+		if err != nil {
+			return err
+		}
+		recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, recipientReader, intent.Event.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -94,3 +94,4 @@ func (InMemoryEventStore) AppendEvent(_ context.Context, _ events.Event) error {
 func (InMemoryEventStore) InsertEventDeliveries(_ context.Context, _ string, _ []string) error {
 	return nil
 }
+func (InMemoryEventStore) SupportsPersistedReplay() bool { return false }

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -8,7 +8,7 @@ import (
 
 	"swarm/internal/events"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
-	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type EventStore interface {
@@ -82,17 +82,11 @@ type TransactionalEventStore interface {
 	UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error
 }
 
-type PipelineReceiptSweeperStore interface {
-	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
-}
+type PipelineReceiptSweeperStore = runtimereplayclaim.Lister
 
-type PipelineReplayClaimStore interface {
-	ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error)
-}
+type PipelineReplayClaimStore = runtimereplayclaim.Owner
 
-type EventDeliveryReader interface {
-	ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error)
-}
+type EventDeliveryReader = runtimereplayclaim.RecipientReader
 
 type InMemoryEventStore struct{}
 

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -76,9 +76,12 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if eb == nil || eb.store == nil {
 		return 0, nil
 	}
-	replayStore, err := runtimereplayclaim.RequireStore(eb.store)
+	replayStore, participates, err := runtimereplayclaim.RequireStore(eb.store)
 	if err != nil {
 		return 0, err
+	}
+	if !participates {
+		return 0, nil
 	}
 	recipientReader, err := runtimereplayclaim.RequireRecipientReader(eb.store)
 	if err != nil {

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	runtimeengine "swarm/internal/runtime/engine"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type OutboxSweeperConfig struct {
@@ -75,13 +76,13 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if eb == nil || eb.store == nil {
 		return 0, nil
 	}
-	reader, ok := eb.store.(PipelineReceiptSweeperStore)
-	if !ok {
-		return 0, nil
+	replayStore, err := runtimereplayclaim.RequireStore(eb.store)
+	if err != nil {
+		return 0, err
 	}
-	claimer, ok := eb.store.(PipelineReplayClaimStore)
-	if !ok {
-		return 0, errors.New("event bus store does not support explicit pipeline replay claims")
+	recipientReader, err := runtimereplayclaim.RequireRecipientReader(eb.store)
+	if err != nil {
+		return 0, err
 	}
 	if limit <= 0 {
 		limit = DefaultOutboxSweeperConfig().Limit
@@ -89,7 +90,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if lookback <= 0 {
 		lookback = DefaultOutboxSweeperConfig().Lookback
 	}
-	events, err := reader.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-lookback), limit)
+	events, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-lookback), limit)
 	if err != nil {
 		return 0, err
 	}
@@ -97,7 +98,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	redelivered := 0
 	for _, record := range events {
 		evt := record.Event
-		lease, claimed, err := claimer.ClaimPipelineReplay(ctx, evt.ID)
+		lease, claimed, err := replayStore.ClaimPipelineReplay(ctx, evt.ID)
 		if err != nil {
 			return redelivered, err
 		}
@@ -109,7 +110,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			_ = lease.Release(ctx)
 			continue
 		}
-		recipients, err := eb.authoritativeRecipientsForEvent(ctx, evt.ID)
+		recipients, err := eb.authoritativeRecipientsForEvent(ctx, recipientReader, evt.ID)
 		if err != nil {
 			eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
 			_ = lease.Release(ctx)
@@ -130,11 +131,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	return redelivered, nil
 }
 
-func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, eventID string) ([]string, error) {
-	reader, ok := eb.store.(EventDeliveryReader)
-	if !ok {
-		return nil, errors.New("event bus store does not support authoritative delivery recipient reads")
-	}
+func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, reader EventDeliveryReader, eventID string) ([]string, error) {
 	recipients, err := reader.ListEventDeliveryRecipients(ctx, eventID)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -304,3 +304,18 @@ func TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 		t.Fatalf("SweepUndispatched error = %q, want explicit replay claim owner failure", got)
 	}
 }
+
+func TestSweepUndispatched_NoopsWithoutPersistedReplayStore(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("swept count = %d, want 0", count)
+	}
+}

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -22,6 +22,11 @@ type sweeperTestStore struct {
 	releasing   chan struct{}
 }
 
+type sweeperMissingClaimStore struct {
+	events     []events.PersistedReplayEvent
+	deliveries map[string][]string
+}
+
 func (s *sweeperTestStore) AppendEvent(context.Context, events.Event) error { return nil }
 func (s *sweeperTestStore) InsertEventDeliveries(context.Context, string, []string) error {
 	return nil
@@ -54,6 +59,17 @@ func (s *sweeperTestStore) ClaimPipelineReplay(_ context.Context, eventID string
 	}
 	s.claimed[eventID] = true
 	return sweeperClaimLease{store: s, eventID: eventID}, true, nil
+}
+
+func (s *sweeperMissingClaimStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (s *sweeperMissingClaimStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (s *sweeperMissingClaimStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.events...), nil
+}
+func (s *sweeperMissingClaimStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	return append([]string(nil), s.deliveries[eventID]...), nil
 }
 
 type sweeperClaimLease struct {
@@ -261,4 +277,30 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 		t.Fatal("expected claimed replay delivery")
 	}
 	waitForNoEvent(t, ch)
+}
+
+func TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
+	store := &sweeperMissingClaimStore{
+		events: []events.PersistedReplayEvent{
+			{Event: events.Event{
+				ID:        "evt-claim-missing",
+				Type:      events.EventType("custom.claimed"),
+				Payload:   []byte(`{"entity_id":"ent-claim"}`),
+				CreatedAt: time.Now().UTC(),
+			}},
+		},
+		deliveries: map[string][]string{"evt-claim-missing": {"agent-a"}},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	_, err = eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err == nil {
+		t.Fatal("expected SweepUndispatched to fail without replay claim owner")
+	}
+	if got := err.Error(); got != "store does not support explicit pipeline replay claims" {
+		t.Fatalf("SweepUndispatched error = %q, want explicit replay claim owner failure", got)
+	}
 }

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -16,6 +16,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 	"swarm/internal/runtime/core/toolcapabilities"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -439,6 +440,15 @@ func (*conformanceRecoveryBus) AppendEvent(context.Context, events.Event) error 
 func (*conformanceRecoveryBus) InsertEventDeliveries(context.Context, string, []string) error {
 	return nil
 }
+func (*conformanceRecoveryBus) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return []string{}, nil
+}
+func (*conformanceRecoveryBus) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	return conformanceRecoveryReplayLease{}, true, nil
+}
+func (*conformanceRecoveryBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return nil, nil
+}
 
 type conformanceRecoveryStore struct {
 	agents []runtimemanager.PersistedAgent
@@ -461,3 +471,9 @@ func (*conformanceRecoveryStore) ListPendingEventsForAgent(context.Context, stri
 func (*conformanceRecoveryStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
 	return nil, nil
 }
+
+type conformanceRecoveryReplayLease struct{}
+
+func (conformanceRecoveryReplayLease) Key() string                   { return "conformance-replay" }
+func (conformanceRecoveryReplayLease) Refresh(context.Context) error { return nil }
+func (conformanceRecoveryReplayLease) Release(context.Context) error { return nil }

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -49,9 +49,12 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if r == nil || r.store == nil || r.bus == nil {
 		return nil
 	}
-	replayStore, err := runtimereplayclaim.RequireStore(r.store)
+	replayStore, participates, err := runtimereplayclaim.RequireStore(r.store)
 	if err != nil {
 		return fmt.Errorf("recover pipeline receipts: %w", err)
+	}
+	if !participates {
+		return nil
 	}
 	window := r.window
 	if window <= 0 {

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -7,20 +7,8 @@ import (
 	"time"
 
 	"swarm/internal/events"
-	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
-
-type missingPipelineReceiptReader interface {
-	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
-}
-
-type pipelineReplayClaimer interface {
-	ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error)
-}
-
-type authoritativeDeliveryRecipientReader interface {
-	ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error)
-}
 
 type pipelineReceiptRecorder interface {
 	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
@@ -61,13 +49,9 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if r == nil || r.store == nil || r.bus == nil {
 		return nil
 	}
-	reader, ok := r.store.(missingPipelineReceiptReader)
-	if !ok {
-		return nil
-	}
-	claimer, ok := r.store.(pipelineReplayClaimer)
-	if !ok {
-		return fmt.Errorf("recover pipeline receipts: missing explicit replay claim owner")
+	replayStore, err := runtimereplayclaim.RequireStore(r.store)
+	if err != nil {
+		return fmt.Errorf("recover pipeline receipts: %w", err)
 	}
 	window := r.window
 	if window <= 0 {
@@ -77,14 +61,14 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if limit <= 0 {
 		limit = 500
 	}
-	eventsToReplay, err := reader.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-window), limit)
+	eventsToReplay, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-window), limit)
 	if err != nil {
 		return err
 	}
 	recorder, _ := r.store.(pipelineReceiptRecorder)
-	recipients, ok := r.store.(authoritativeDeliveryRecipientReader)
-	if !ok {
-		return fmt.Errorf("recover pipeline receipts: missing authoritative delivery recipient reader")
+	recipients, err := runtimereplayclaim.RequireRecipientReader(r.store)
+	if err != nil {
+		return fmt.Errorf("recover pipeline receipts: %w", err)
 	}
 	var firstErr error
 	for _, record := range eventsToReplay {
@@ -95,7 +79,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 		if strings.TrimSpace(evt.ID) == "" {
 			continue
 		}
-		lease, claimed, err := claimer.ClaimPipelineReplay(ctx, evt.ID)
+		lease, claimed, err := replayStore.ClaimPipelineReplay(ctx, evt.ID)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("claim replay event %s: %w", evt.ID, err)

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -519,3 +519,15 @@ func TestRecoveryManager_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 		t.Fatalf("Recover error = %q, want explicit replay claim owner failure", got)
 	}
 }
+
+func TestRecoveryManager_NoopsWithoutPersistedReplayStore(t *testing.T) {
+	capture := &recoveryCapturePublisher{}
+	rm := runtimepipeline.NewRecoveryManagerWith(runtimebus.InMemoryEventStore{}, capture)
+
+	if err := rm.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.published) != 0 || len(capture.direct) != 0 {
+		t.Fatalf("recovery capture = published:%#v direct:%#v, want no replay activity", capture.published, capture.direct)
+	}
+}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -21,6 +21,12 @@ type recoveryCapturePublisher struct {
 	direct    []events.Event
 }
 
+type recoveryMissingClaimStore struct {
+	events      []events.PersistedReplayEvent
+	deliveries  map[string][]string
+	receiptByID map[string]string
+}
+
 func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event) error {
 	p.published = append(p.published, evt)
 	return p.inner.Publish(ctx, evt)
@@ -29,6 +35,24 @@ func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event
 func (p *recoveryCapturePublisher) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error {
 	p.direct = append(p.direct, evt)
 	return p.inner.PublishDirect(ctx, evt, recipients)
+}
+
+func (s *recoveryMissingClaimStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (s *recoveryMissingClaimStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (s *recoveryMissingClaimStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.events...), nil
+}
+func (s *recoveryMissingClaimStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	return append([]string(nil), s.deliveries[eventID]...), nil
+}
+func (s *recoveryMissingClaimStore) UpsertPipelineReceipt(_ context.Context, eventID, status, _ string) error {
+	if s.receiptByID == nil {
+		s.receiptByID = map[string]string{}
+	}
+	s.receiptByID[eventID] = status
+	return nil
 }
 
 type blockingRecoveryPublisher struct {
@@ -470,5 +494,28 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 	}
 	if receiptStatus != "success" {
 		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
+	}
+}
+
+func TestRecoveryManager_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
+	store := &recoveryMissingClaimStore{
+		events: []events.PersistedReplayEvent{
+			{Event: events.Event{
+				ID:        "evt-missing-claim",
+				Type:      events.EventType("system.recover"),
+				Payload:   []byte(`{"ok":true}`),
+				CreatedAt: time.Now().UTC(),
+			}},
+		},
+		deliveries: map[string][]string{"evt-missing-claim": {"agent-a"}},
+	}
+	rm := runtimepipeline.NewRecoveryManagerWith(store, &recoveryCapturePublisher{})
+
+	err := rm.Recover(context.Background())
+	if err == nil {
+		t.Fatal("expected Recover to fail without replay claim owner")
+	}
+	if got := err.Error(); got != "recover pipeline receipts: store does not support explicit pipeline replay claims" {
+		t.Fatalf("Recover error = %q, want explicit replay claim owner failure", got)
 	}
 }

--- a/internal/runtime/replayclaim/contracts.go
+++ b/internal/runtime/replayclaim/contracts.go
@@ -1,0 +1,61 @@
+package replayclaim
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"swarm/internal/events"
+	runtimeownership "swarm/internal/runtime/core/ownership"
+)
+
+var (
+	ErrMissingReplayEventReader            = errors.New("store does not support replay-eligible event reads")
+	ErrMissingReplayClaimOwner             = errors.New("store does not support explicit pipeline replay claims")
+	ErrMissingAuthoritativeRecipientReader = errors.New("store does not support authoritative delivery recipient reads")
+)
+
+type Lister interface {
+	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
+}
+
+type Owner interface {
+	ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error)
+}
+
+type Store interface {
+	Lister
+	Owner
+}
+
+type RecipientReader interface {
+	ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error)
+}
+
+type composedStore struct {
+	Lister
+	Owner
+}
+
+func RequireStore(store any) (Store, error) {
+	lister, ok := store.(Lister)
+	if !ok {
+		return nil, ErrMissingReplayEventReader
+	}
+	owner, ok := store.(Owner)
+	if !ok {
+		return nil, ErrMissingReplayClaimOwner
+	}
+	return composedStore{
+		Lister: lister,
+		Owner:  owner,
+	}, nil
+}
+
+func RequireRecipientReader(store any) (RecipientReader, error) {
+	reader, ok := store.(RecipientReader)
+	if !ok {
+		return nil, ErrMissingAuthoritativeRecipientReader
+	}
+	return reader, nil
+}

--- a/internal/runtime/replayclaim/contracts.go
+++ b/internal/runtime/replayclaim/contracts.go
@@ -15,6 +15,10 @@ var (
 	ErrMissingAuthoritativeRecipientReader = errors.New("store does not support authoritative delivery recipient reads")
 )
 
+type Participation interface {
+	SupportsPersistedReplay() bool
+}
+
 type Lister interface {
 	ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error)
 }
@@ -37,19 +41,30 @@ type composedStore struct {
 	Owner
 }
 
-func RequireStore(store any) (Store, error) {
+func SupportsPersistedReplay(store any) bool {
+	support, ok := store.(Participation)
+	if !ok {
+		return true
+	}
+	return support.SupportsPersistedReplay()
+}
+
+func RequireStore(store any) (Store, bool, error) {
+	if !SupportsPersistedReplay(store) {
+		return nil, false, nil
+	}
 	lister, ok := store.(Lister)
 	if !ok {
-		return nil, ErrMissingReplayEventReader
+		return nil, true, ErrMissingReplayEventReader
 	}
 	owner, ok := store.(Owner)
 	if !ok {
-		return nil, ErrMissingReplayClaimOwner
+		return nil, true, ErrMissingReplayClaimOwner
 	}
 	return composedStore{
 		Lister: lister,
 		Owner:  owner,
-	}, nil
+	}, true, nil
 }
 
 func RequireRecipientReader(store any) (RecipientReader, error) {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -67,6 +67,8 @@ func (s *PostgresStore) Ping(ctx context.Context) error {
 	return s.DB.PingContext(ctx)
 }
 
+func (*PostgresStore) SupportsPersistedReplay() bool { return true }
+
 func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for schema ddl")


### PR DESCRIPTION
Closes #236

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: event_schema.routing_derivation.delivery_rules`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`

## Human Summary
This makes replay claim ownership a required store contract in the recovery and sweeper seam. The runtime now fails closed if replay-eligible event reads, replay claiming, or authoritative delivery-recipient reads are mis-wired in that seam instead of discovering them opportunistically.

## What Changed
- Added `internal/runtime/replayclaim` as the single runtime-owned contract helper for replay-eligible event reads, replay claim ownership, and authoritative recipient reads.
- Updated `internal/runtime/bus/sweeper.go` to require the replay-claim contract and authoritative recipient reader before sweeping undispatched events.
- Updated `internal/runtime/pipeline/coordinator_recovery.go` to require the same replay-claim contract and recipient reader before recovery runs.
- Kept replay-claim ownership and authoritative recipient reads as distinct required contracts rather than merging their meaning.
- Added focused fail-closed tests in sweeper and recovery, and updated the conformance recovery harness so it satisfies the now-required replay contract explicitly.

## Why This Is Needed
Replay claim ownership is already canonical for this seam. Leaving it behind optional interface assertions creates a fallback-shaped mis-wiring path where recovery or sweeper can appear wired but silently omit the required replay owner. This change removes that ambiguity and makes the seam fail explicitly for the right reason.

## Scope Boundaries
In scope:
- replay claim ownership and authoritative recipient contract wiring in the recovery/sweeper seam
- focused regressions for fail-closed mis-wiring
- adjacent conformance harness updates required by the stricter contract

Out of scope:
- broader delivery lifecycle redesign
- recipient-read ownership redesign beyond making the required contract explicit here
- spec changes

## Tests Run
- `go test ./internal/runtime/bus -run 'Test(SweepUndispatched_UsesPersistedDeliveryRecipients|SweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback|SweepUndispatched_SkipsMalformedReplayRowsAndContinues|SweepUndispatched_ClaimsReplayOwnershipBeforeDispatch|SweepUndispatched_FailsClosedWithoutReplayClaimOwner)' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestRecoveryManager_(ReplaysPersistedCorrelationEnvelope|QuarantinesMissingPersistedRunIDAndContinues|QuarantinesMissingRunIDSchemaCapability|ClaimsReplayOwnershipUnderOverlap|UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions|FailsClosedWithoutReplayClaimOwner)' -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
This closes the runtime recovery/sweeper seam, but any future caller that constructs its own replay-capable store abstraction outside these canonical paths would still need to require the same contracts explicitly.

## Follow-Up
No follow-up issue is required from this change alone.
