### PR TITLE
[agent-a][issue #246] Replace engine fallback operand search with explicit scope evaluation

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -368,10 +368,14 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 		items = executionItems(entityValue)
 	}
 	if filter := strings.TrimSpace(spec.Filter); filter != "" {
+		compiled, err := compileExecutionCondition(filter)
+		if err != nil {
+			return err
+		}
 		filtered := make([]any, 0, len(items))
 		for _, item := range items {
 			scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
-			passed, err := executionEvalCondition(filter, scope)
+			passed, err := compiled.Eval(scope)
 			if err != nil {
 				return err
 			}
@@ -545,10 +549,14 @@ func (e *Executor) stepFilter(frame *executionFrame) error {
 	current := e.currentContext(frame)
 	sourceValue, _ := resolveContractPath(current, frame.state, spec.ItemsPath, firstNonEmpty(spec.ItemsFrom, spec.Source))
 	items := executionItems(sourceValue)
+	compiled, err := compileExecutionCondition(strings.TrimSpace(spec.Condition))
+	if err != nil {
+		return err
+	}
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
 		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
-		passed, err := executionEvalCondition(strings.TrimSpace(spec.Condition), scope)
+		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
 		}
@@ -581,14 +589,18 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 	current := e.currentContext(frame)
 	sourceValue, _ := resolveContractPath(current, frame.state, spec.ItemsPath, firstNonEmpty(spec.ItemsFrom, spec.Source))
 	items := executionItems(sourceValue)
+	compiled, err := compileExecutionCondition(strings.TrimSpace(spec.Condition))
+	if err != nil {
+		return err
+	}
 	count := 0
 	for _, item := range items {
-		if strings.TrimSpace(spec.Condition) == "" {
+		if compiled == nil {
 			count++
 			continue
 		}
 		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
-		passed, err := executionEvalCondition(strings.TrimSpace(spec.Condition), scope)
+		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
 		}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -370,12 +370,12 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 	if filter := strings.TrimSpace(spec.Filter); filter != "" {
 		filtered := make([]any, 0, len(items))
 		for _, item := range items {
-			if executionEvalCondition(filter, map[string]any{
-				"item":    item,
-				"payload": frame.payload,
-				"entity":  frame.state.State.EntityContext(),
-				"policy":  current.Policy.Raw(),
-			}) {
+			scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+			passed, err := executionEvalCondition(filter, scope)
+			if err != nil {
+				return err
+			}
+			if passed {
 				filtered = append(filtered, item)
 			}
 		}
@@ -386,12 +386,12 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 	case strings.TrimSpace(spec.GroupBy) != "":
 		grouped := map[string]any{}
 		for _, item := range items {
-			key := strings.TrimSpace(asString(executionResolveOperand(strings.TrimSpace(spec.GroupBy), map[string]any{
-				"item":    item,
-				"payload": frame.payload,
-				"entity":  frame.state.State.EntityContext(),
-				"policy":  current.Policy.Raw(),
-			})))
+			scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+			resolved, err := scope.resolveOperand(strings.TrimSpace(spec.GroupBy), executionOperandDefaultItem)
+			if err != nil {
+				return err
+			}
+			key := strings.TrimSpace(asString(resolved))
 			if key == "" {
 				key = "unknown"
 			}
@@ -547,12 +547,12 @@ func (e *Executor) stepFilter(frame *executionFrame) error {
 	items := executionItems(sourceValue)
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
-		if executionEvalCondition(strings.TrimSpace(spec.Condition), map[string]any{
-			"item":    item,
-			"payload": frame.payload,
-			"entity":  frame.state.State.EntityContext(),
-			"policy":  current.Policy.Raw(),
-		}) {
+		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		passed, err := executionEvalCondition(strings.TrimSpace(spec.Condition), scope)
+		if err != nil {
+			return err
+		}
+		if passed {
 			filtered = append(filtered, item)
 		}
 	}
@@ -583,12 +583,16 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 	items := executionItems(sourceValue)
 	count := 0
 	for _, item := range items {
-		if strings.TrimSpace(spec.Condition) == "" || executionEvalCondition(strings.TrimSpace(spec.Condition), map[string]any{
-			"item":    item,
-			"payload": frame.payload,
-			"entity":  frame.state.State.EntityContext(),
-			"policy":  current.Policy.Raw(),
-		}) {
+		if strings.TrimSpace(spec.Condition) == "" {
+			count++
+			continue
+		}
+		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		passed, err := executionEvalCondition(strings.TrimSpace(spec.Condition), scope)
+		if err != nil {
+			return err
+		}
+		if passed {
 			count++
 		}
 	}
@@ -674,12 +678,12 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 	current := e.currentContext(frame)
 	grouped := make(map[string]any)
 	for _, item := range items {
-		key := strings.TrimSpace(asString(executionResolveOperand(strings.TrimSpace(spec.Key), map[string]any{
-			"item":    item,
-			"payload": frame.payload,
-			"entity":  frame.state.State.EntityContext(),
-			"policy":  current.Policy.Raw(),
-		})))
+		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		resolved, err := scope.resolveOperand(strings.TrimSpace(spec.Key), executionOperandDefaultItem)
+		if err != nil {
+			return err
+		}
+		key := strings.TrimSpace(asString(resolved))
 		if key == "" {
 			key = "unknown"
 		}

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -19,6 +19,14 @@ func stubSource() semanticview.Source {
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
 }
 
+func sourceWithPolicy(values map[string]any) semanticview.Source {
+	policy := runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{}}
+	for key, value := range values {
+		policy.Values[key] = runtimecontracts.PolicyValue{Value: value}
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Policy: policy})
+}
+
 func sourceWithKilledState() semanticview.Source {
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
@@ -641,6 +649,76 @@ func TestExecutor_QueryGroupByStoresCounts(t *testing.T) {
 	}
 	if grouped["queued"] != 2 || grouped["done"] != 1 {
 		t.Fatalf("grouped counts = %#v", grouped)
+	}
+}
+
+func TestExecutor_QueryFilterUsesExplicitCollidingScopes(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     sourceWithPolicy(map[string]any{"score": 6}),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-2", Type: "digest.requested", Payload: json.RawMessage(`{"score":5,"items":[{"score":7},{"score":5}]}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Query: &runtimecontracts.QuerySpec{
+				Source:  "payload.items",
+				Filter:  "item.score > payload.score && item.score > entity.score && item.score > policy.score",
+				StoreAs: "entity.query_rows",
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{"score": 4}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	rows, ok := result.StateMutation.Metadata["query_rows"].([]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("query_rows = %#v", result.StateMutation.Metadata["query_rows"])
+	}
+	item, _ := rows[0].(map[string]any)
+	if item["score"] != 7.0 {
+		t.Fatalf("query_rows[0] = %#v", item)
+	}
+}
+
+func TestExecutor_FilterRejectsUnqualifiedConditionField(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     sourceWithPolicy(map[string]any{"score": 1}),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "items.submitted", Payload: json.RawMessage(`{"score":5,"items":[{"score":7}]}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Filter: &runtimecontracts.FilterSpec{
+				ItemsFrom: "payload.items",
+				Condition: "score > 5",
+				StoreAs:   "entity.filtered",
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{"score": 4}, nil, map[string]map[string]any{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "undeclared reference") {
+		t.Fatalf("Execute error = %v, want undeclared reference", err)
 	}
 }
 
@@ -1325,6 +1403,56 @@ func TestExecutor_GroupByStoresGroupedItems(t *testing.T) {
 	}
 	if result.NextState != "done" {
 		t.Fatalf("NextState = %q", result.NextState)
+	}
+}
+
+func TestExecutor_GroupByBareKeyUsesItemScopeWithoutFallbackAcrossRoots(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     sourceWithPolicy(map[string]any{"category": "policy"}),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "items.submitted", Payload: json.RawMessage(`{"category":"payload","items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			GroupBy: &runtimecontracts.GroupBySpec{
+				ItemsFrom: "payload.items",
+				Key:       "category",
+				StoreAs:   "entity.grouped",
+			},
+			AdvancesTo: "done",
+		},
+		State: testStateSnapshot("pending", map[string]any{"category": "entity"}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	grouped, ok := result.StateMutation.Metadata["grouped"].(map[string]any)
+	if !ok {
+		t.Fatalf("grouped metadata = %#v", result.StateMutation.Metadata["grouped"])
+	}
+	xItems, _ := grouped["x"].([]any)
+	yItems, _ := grouped["y"].([]any)
+	if len(xItems) != 2 || len(yItems) != 1 {
+		t.Fatalf("grouped metadata = %#v", grouped)
+	}
+	if _, ok := grouped["payload"]; ok {
+		t.Fatalf("grouped metadata unexpectedly used payload scope: %#v", grouped)
+	}
+	if _, ok := grouped["entity"]; ok {
+		t.Fatalf("grouped metadata unexpectedly used entity scope: %#v", grouped)
+	}
+	if _, ok := grouped["policy"]; ok {
+		t.Fatalf("grouped metadata unexpectedly used policy scope: %#v", grouped)
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -25,6 +25,10 @@ var (
 	dataExpressionEnvOnce sync.Once
 	dataExpressionEnv     *cel.Env
 	dataExpressionEnvErr  error
+
+	executionConditionEnvOnce sync.Once
+	executionConditionEnvRef  *cel.Env
+	executionConditionEnvErr  error
 )
 
 type Accumulator struct {
@@ -537,191 +541,158 @@ func executionItems(value any) []any {
 	return sliceFromAny(value)
 }
 
-func executionEvalCondition(expr string, roots map[string]any) bool {
+type executionScope struct {
+	Item    any
+	Payload map[string]any
+	Entity  map[string]any
+	Policy  map[string]any
+}
+
+type executionOperandDefaultScope string
+
+const (
+	executionOperandDefaultNone executionOperandDefaultScope = ""
+	executionOperandDefaultItem executionOperandDefaultScope = "item"
+)
+
+func newExecutionScope(item any, payload, entity, policy map[string]any) executionScope {
+	return executionScope{
+		Item:    normalizeCELValue(item),
+		Payload: normalizedCELInputMap(payload),
+		Entity:  normalizedCELInputMap(entity),
+		Policy:  normalizedCELInputMap(policy),
+	}
+}
+
+func (s executionScope) activation() map[string]any {
+	return map[string]any{
+		"item":    s.Item,
+		"payload": s.Payload,
+		"entity":  s.Entity,
+		"policy":  s.Policy,
+	}
+}
+
+func executionConditionEnv() (*cel.Env, error) {
+	executionConditionEnvOnce.Do(func() {
+		executionConditionEnvRef, executionConditionEnvErr = cel.NewEnv(
+			cel.Variable("item", cel.DynType),
+			cel.Variable("payload", cel.DynType),
+			cel.Variable("entity", cel.DynType),
+			cel.Variable("policy", cel.DynType),
+		)
+	})
+	return executionConditionEnvRef, executionConditionEnvErr
+}
+
+func executionEvalCondition(expr string, scope executionScope) (bool, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
-		return true
+		return true, nil
 	}
-	expr = executionTrimOuterParens(expr)
-	if parts := executionSplitTopLevel(expr, " OR "); len(parts) > 1 {
-		for _, part := range parts {
-			if executionEvalCondition(part, roots) {
-				return true
-			}
-		}
-		return false
+	env, err := executionConditionEnv()
+	if err != nil {
+		return false, err
 	}
-	if parts := executionSplitTopLevel(expr, " AND "); len(parts) > 1 {
-		for _, part := range parts {
-			if !executionEvalCondition(part, roots) {
-				return false
-			}
-		}
-		return true
+	ast, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return false, issues.Err()
 	}
-	for _, op := range []string{">=", "<=", "!=", "==", ">", "<"} {
-		if parts := executionSplitTopLevel(expr, " "+op+" "); len(parts) == 2 {
-			left := executionResolveOperand(parts[0], roots)
-			right := executionResolveOperand(parts[1], roots)
-			return executionCompareValues(left, right, op)
-		}
+	program, err := env.Program(ast)
+	if err != nil {
+		return false, err
 	}
-	return truthy(executionResolveOperand(expr, roots))
+	out, _, err := program.Eval(scope.activation())
+	if err != nil {
+		return false, err
+	}
+	value := normalizeCELValue(out)
+	boolean, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("condition %q did not evaluate to bool", expr)
+	}
+	return boolean, nil
 }
 
-func executionSplitTopLevel(expr, sep string) []string {
-	if strings.TrimSpace(expr) == "" {
-		return nil
-	}
-	depth := 0
-	quote := rune(0)
-	parts := make([]string, 0, 4)
-	start := 0
-	for i, r := range expr {
-		switch r {
-		case '\'', '"':
-			if quote == 0 {
-				quote = r
-			} else if quote == r {
-				quote = 0
-			}
-		case '(':
-			if quote == 0 {
-				depth++
-			}
-		case ')':
-			if quote == 0 {
-				depth--
-			}
-		}
-		if quote == 0 && depth == 0 && strings.HasPrefix(expr[i:], sep) {
-			parts = append(parts, strings.TrimSpace(expr[start:i]))
-			start = i + len(sep)
-			i += len(sep) - 1
-		}
-	}
-	if len(parts) == 0 {
-		return []string{expr}
-	}
-	parts = append(parts, strings.TrimSpace(expr[start:]))
-	return parts
-}
-
-func executionTrimOuterParens(expr string) string {
-	expr = strings.TrimSpace(expr)
-	for strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") {
-		depth := 0
-		quote := rune(0)
-		wrapped := true
-		for i, r := range expr {
-			switch r {
-			case '\'', '"':
-				if quote == 0 {
-					quote = r
-				} else if quote == r {
-					quote = 0
-				}
-			case '(':
-				if quote == 0 {
-					depth++
-				}
-			case ')':
-				if quote == 0 {
-					depth--
-					if depth == 0 && i != len(expr)-1 {
-						wrapped = false
-					}
-				}
-			}
-		}
-		if !wrapped {
-			return expr
-		}
-		expr = strings.TrimSpace(expr[1 : len(expr)-1])
-	}
-	return expr
-}
-
-func executionResolveOperand(expr string, roots map[string]any) any {
+func (s executionScope) resolveOperand(expr string, defaultScope executionOperandDefaultScope) (any, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
-		return nil
+		return nil, nil
 	}
 	if strings.EqualFold(expr, "true") {
-		return true
+		return true, nil
 	}
 	if strings.EqualFold(expr, "false") {
-		return false
+		return false, nil
 	}
 	if strings.EqualFold(expr, "null") {
-		return nil
+		return nil, nil
 	}
 	if (strings.HasPrefix(expr, "\"") && strings.HasSuffix(expr, "\"")) || (strings.HasPrefix(expr, "'") && strings.HasSuffix(expr, "'")) {
-		return strings.Trim(expr, "\"'")
+		return strings.Trim(expr, "\"'"), nil
 	}
 	if n, err := strconv.Atoi(expr); err == nil {
-		return n
+		return n, nil
 	}
 	if f, err := strconv.ParseFloat(expr, 64); err == nil {
-		return f
+		return f, nil
 	}
-	segments := strings.Split(expr, ".")
-	if len(segments) == 1 {
-		for _, rootName := range []string{"item", "payload", "entity", "policy"} {
-			if rootMap, ok := roots[rootName].(map[string]any); ok {
-				if value, ok := rootMap[segments[0]]; ok {
-					return value
-				}
-			}
-		}
-		return expr
-	}
-	current, ok := roots[strings.TrimSpace(segments[0])]
-	if !ok {
-		return nil
-	}
-	for _, segment := range segments[1:] {
-		object, ok := asObject(current)
+	if strings.HasPrefix(expr, "item.") {
+		value, ok := lookupExecutionOperandPath(s.Item, strings.Split(strings.TrimPrefix(expr, "item."), "."))
 		if !ok {
-			return nil
+			return nil, fmt.Errorf("operand %q is unavailable in item scope", expr)
 		}
-		current, ok = object[strings.TrimSpace(segment)]
-		if !ok {
-			return nil
-		}
+		return value, nil
 	}
-	return current
+	parsed := paths.Parse(expr)
+	if parsed.HasExplicitRoot() {
+		value, ok := s.lookupExplicitRoot(parsed.Root, parsed.Segments)
+		if !ok {
+			return nil, fmt.Errorf("operand %q is unavailable in %s scope", expr, parsed.Root.String())
+		}
+		return value, nil
+	}
+	if defaultScope == executionOperandDefaultItem {
+		value, ok := lookupExecutionOperandPath(s.Item, parsed.Segments)
+		if !ok {
+			return nil, fmt.Errorf("operand %q is unavailable in item scope", expr)
+		}
+		return value, nil
+	}
+	return nil, fmt.Errorf("operand %q requires explicit scope", expr)
 }
 
-func executionCompareValues(left, right any, op string) bool {
-	lf, lok := asFloat(left)
-	rf, rok := asFloat(right)
-	if lok && rok {
-		switch op {
-		case ">=":
-			return lf >= rf
-		case "<=":
-			return lf <= rf
-		case ">":
-			return lf > rf
-		case "<":
-			return lf < rf
-		case "==":
-			return lf == rf
-		case "!=":
-			return lf != rf
-		}
-	}
-	ls := strings.TrimSpace(asString(left))
-	rs := strings.TrimSpace(asString(right))
-	switch op {
-	case "==":
-		return ls == rs
-	case "!=":
-		return ls != rs
+func (s executionScope) lookupExplicitRoot(root paths.PathRoot, segments []string) (any, bool) {
+	switch root {
+	case paths.RootPayload:
+		return lookupExecutionOperandPath(s.Payload, segments)
+	case paths.RootEntity:
+		return lookupExecutionOperandPath(s.Entity, segments)
+	case paths.RootPolicy:
+		return lookupExecutionOperandPath(s.Policy, segments)
 	default:
-		return false
+		return nil, false
 	}
+}
+
+func lookupExecutionOperandPath(root any, segments []string) (any, bool) {
+	current := root
+	if len(segments) == 0 {
+		return current, current != nil
+	}
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		object, ok := asObject(current)
+		if !ok {
+			return nil, false
+		}
+		next, ok := object[segment]
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
 }
 
 func executionReduceValue(items []any, operation string) any {

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -555,6 +555,11 @@ const (
 	executionOperandDefaultItem executionOperandDefaultScope = "item"
 )
 
+type compiledExecutionCondition struct {
+	expression string
+	program    cel.Program
+}
+
 func newExecutionScope(item any, payload, entity, policy map[string]any) executionScope {
 	return executionScope{
 		Item:    normalizeCELValue(item),
@@ -585,31 +590,52 @@ func executionConditionEnv() (*cel.Env, error) {
 	return executionConditionEnvRef, executionConditionEnvErr
 }
 
-func executionEvalCondition(expr string, scope executionScope) (bool, error) {
+func compileExecutionCondition(expr string) (*compiledExecutionCondition, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
-		return true, nil
+		return nil, nil
 	}
 	env, err := executionConditionEnv()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	ast, issues := env.Compile(expr)
 	if issues != nil && issues.Err() != nil {
-		return false, issues.Err()
+		return nil, issues.Err()
 	}
 	program, err := env.Program(ast)
 	if err != nil {
+		return nil, err
+	}
+	return &compiledExecutionCondition{
+		expression: expr,
+		program:    program,
+	}, nil
+}
+
+func executionEvalCondition(expr string, scope executionScope) (bool, error) {
+	compiled, err := compileExecutionCondition(expr)
+	if err != nil {
 		return false, err
 	}
-	out, _, err := program.Eval(scope.activation())
+	if compiled == nil {
+		return true, nil
+	}
+	return compiled.Eval(scope)
+}
+
+func (c *compiledExecutionCondition) Eval(scope executionScope) (bool, error) {
+	if c == nil {
+		return true, nil
+	}
+	out, _, err := c.program.Eval(scope.activation())
 	if err != nil {
 		return false, err
 	}
 	value := normalizeCELValue(out)
 	boolean, ok := value.(bool)
 	if !ok {
-		return false, fmt.Errorf("condition %q did not evaluate to bool", expr)
+		return false, fmt.Errorf("condition %q did not evaluate to bool", c.expression)
 	}
 	return boolean, nil
 }


### PR DESCRIPTION
Closes #246

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_context`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: data_accumulation.write_item_forms.computed`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_language`

## Human Summary
This replaces the touched engine mini-interpreter with one explicit scoped evaluation model so filter and grouping behavior no longer depends on fallback search across `item`, `payload`, `entity`, and `policy`.

## What Changed
- replaced the touched condition helper with CEL-backed evaluation over one explicit execution scope (`item`, `payload`, `entity`, `policy`)
- replaced grouping operand fallback search with one scoped operand model that only resolves explicit roots or the canonical item-default grouping scope
- removed the old literal/ref/number/root-search fallback ordering from the touched helper path
- added executor regressions for explicit multi-scope conditions, fail-closed unqualified conditions, and colliding-name grouping behavior

## Why This Is Needed
The previous helper guessed meaning by searching multiple roots in order. That let colliding names silently change meaning depending on fallback order, which is off-spec for expression-context semantics and made the touched engine seam harder to reason about.

## Scope Boundaries
- In scope:
  - engine query/filter/count/group_by condition and operand evaluation in the touched seam
  - explicit scope ownership for `item`, `payload`, `entity`, and `policy` in that path
- Not in scope:
  - broader MCP/runtime transport work
  - unrelated guard/action evaluator redesign
  - any platform spec edits

## Tests Run
- `go test ./internal/runtime/engine -run 'TestExecutor_(QueryFilterUsesExplicitCollidingScopes|FilterRejectsUnqualifiedConditionField|GroupByBareKeyUsesItemScopeWithoutFallbackAcrossRoots|QueryGroupByStoresCounts|GroupByStoresGroupedItems|ListPrimitivesMutateState)' -count=1`
- `go test ./internal/runtime/engine -count=1`
- `go test ./... -count=1`

## Residual Risk
This keeps the patch narrow by treating bare grouping keys as item-scoped shorthand in the touched grouping path. If another engine seam still interprets rootless references under the same spec rule, it should be handled explicitly there rather than inferred from this change.

## Follow-Up
No immediate follow-up issue is needed from this seam if review agrees the touched consumers are the full local failure class under `#246`.
