### PR TITLE
[agent-c][issue #255] Fix pre-handler entity read lifecycle validation

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -510,6 +510,11 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if expr.SelfTargetField == field {
 							continue
 						}
+						if runtimepipeline.WorkflowEntityReadsPersistedStateBeforeHandlerWrites(expr.Phase) {
+							if _, ok := handlerWriters[field]; ok {
+								continue
+							}
+						}
 						if _, ok := handlerWriters[field]; ok {
 							seen[key] = struct{}{}
 							c.entityRefFindings = append(c.entityRefFindings, Finding{

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -780,7 +780,7 @@ func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	}
 }
 
-func TestRun_ReportsExpressionFieldReferenceErrorWhenFieldIsWrittenTooLate(t *testing.T) {
+func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenSameHandlerWritesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.missing_score >= 70"}
@@ -792,15 +792,15 @@ func TestRun_ReportsExpressionFieldReferenceErrorWhenFieldIsWrittenTooLate(t *te
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_score") {
-		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
 	}
-	if !reportContains(report.Errors(), "expression_field_reference_validation", "before the handler lifecycle makes it available") {
-		t.Fatalf("expected lifecycle-aware expression error, got %#v", report.Errors())
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.missing_score") {
+		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
 	}
 }
 
-func TestRun_ReportsExpressionFieldReferenceErrorForFilterThatDependsOnLaterCompute(t *testing.T) {
+func TestRun_AllowsFilterReferenceToPersistedFieldEvenWhenSameHandlerComputesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.Filter = &runtimecontracts.FilterSpec{
@@ -817,8 +817,11 @@ func TestRun_ReportsExpressionFieldReferenceErrorForFilterThatDependsOnLaterComp
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.filtered_score") {
-		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.filtered_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.filtered_score") {
+		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
 	}
 }
 
@@ -857,6 +860,49 @@ func TestRun_AllowsExpressionFieldReferenceForSelfTargetEntityUpdate(t *testing.
 	}
 }
 
+func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenHandlerWritesFieldLater(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.retry_count < 3"}
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
+		TargetField: "retry_count",
+		Value:       runtimecontracts.CELExpression("entity.retry_count + 1"),
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.retry_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.retry_count") {
+		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_AllowsOnCompleteReferenceToPersistedFieldEvenWhenHandlerWritesFieldLater(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
+		TargetField: "revision_count",
+		Value:       runtimecontracts.CELExpression("entity.revision_count + 1"),
+	}}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
+		ID:        "retry",
+		Condition: "entity.revision_count < 3",
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
@@ -876,6 +922,40 @@ func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t
 
 	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
 		t.Fatalf("expected mixed-case sibling-write error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_PreservesSiblingWriteErrorWhenGuardAlsoReadsPersistedField(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.retry_count < 3"}
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{
+		{
+			TargetField: "retry_count",
+			Value:       runtimecontracts.CELExpression("entity.retry_count + 1"),
+		},
+		{
+			TargetField: "adjusted_score",
+			Value:       runtimecontracts.CELExpression("entity.retry_count + entity.base_score"),
+		},
+		{
+			TargetField: "base_score",
+			SourceField: "score",
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	for _, item := range report.Errors() {
+		if item.CheckID == "expression_field_reference_validation" &&
+			strings.Contains(item.Message, "entity.retry_count") &&
+			strings.Contains(item.Message, "in guard") {
+			t.Fatalf("unexpected guard expression_field_reference_validation error, got %#v", report.Errors())
+		}
+	}
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
+		t.Fatalf("expected sibling-write dependency error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -163,6 +163,19 @@ func WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler runtimecontract
 	return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleDataAccumulation)
 }
 
+func WorkflowEntityReadsPersistedStateBeforeHandlerWrites(phase WorkflowEntityFieldLifecyclePhase) bool {
+	switch phase {
+	case WorkflowEntityFieldLifecycleGuard,
+		WorkflowEntityFieldLifecycleFilter,
+		WorkflowEntityFieldLifecycleCount,
+		WorkflowEntityFieldLifecycleOnComplete,
+		WorkflowEntityFieldLifecycleRule:
+		return true
+	default:
+		return false
+	}
+}
+
 func WorkflowEntityFieldNameFromTarget(target string) (string, bool) {
 	return workflowEntityFieldNameFromTarget(target)
 }

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -56,3 +56,27 @@ func TestWorkflowEntityFieldsAvailableBeforeDataAccumulation_IncludesEarlierComp
 		t.Fatalf("base_score unexpectedly available before sibling data_accumulation write: %#v", available)
 	}
 }
+
+func TestWorkflowEntityReadsPersistedStateBeforeHandlerWrites(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase WorkflowEntityFieldLifecyclePhase
+		want  bool
+	}{
+		{name: "guard", phase: WorkflowEntityFieldLifecycleGuard, want: true},
+		{name: "filter", phase: WorkflowEntityFieldLifecycleFilter, want: true},
+		{name: "count", phase: WorkflowEntityFieldLifecycleCount, want: true},
+		{name: "rule", phase: WorkflowEntityFieldLifecycleRule, want: true},
+		{name: "on_complete", phase: WorkflowEntityFieldLifecycleOnComplete, want: true},
+		{name: "data_accumulation", phase: WorkflowEntityFieldLifecycleDataAccumulation, want: false},
+		{name: "reduce", phase: WorkflowEntityFieldLifecycleReduce, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WorkflowEntityReadsPersistedStateBeforeHandlerWrites(tt.phase); got != tt.want {
+				t.Fatalf("WorkflowEntityReadsPersistedStateBeforeHandlerWrites(%q) = %v, want %v", tt.phase, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #255

## Human Summary
Boot verification was still treating some spec-valid pre-handler entity reads as if they depended on later writes from the same handler. This PR fixes that broader lifecycle seam, not just the original self-target write symptom.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dependency_graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: guards_see_pre_handler_state`

## What Changed
- added one shared lifecycle helper that marks which expression phases read persisted pre-handler entity state
- updated `expression_field_reference_validation` to use that canonical lifecycle proof instead of treating any same-handler write as a lifecycle violation
- kept strict rejection for true sibling-write dependencies in data-accumulation expression phases
- expanded bootverify and pipeline lifecycle tests to cover guards, filter conditions, on-complete selection, self-target read-modify-write, and mixed valid/invalid cases

## Why This Is Needed
The spec makes guard and related pre-handler selection contexts observe persisted pre-handler entity state. Boot verification was still rejecting those reads when the same handler later wrote the same field, which made verification stricter than the runtime lifecycle model and blocked Empire contracts.

## Scope Boundaries
- fixes the lifecycle-validation seam in bootverify and the adjacent lifecycle helper only
- does not redesign broader expression validation or change runtime mutation ordering
- does not relax sibling-write dependency checks in data-accumulation expressions

## Tests Run
- `go test ./internal/runtime/pipeline ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Residual Risk
The validation seam is still heuristic where the platform intentionally only has flow-local write knowledge, so references to entity fields that are persisted for reasons outside the current flow can still only be warned about, not proved exhaustively. This PR only removes the off-spec same-handler rejection in pre-handler phases.

## Follow-Up
None.
