### PR TITLE
[agent-b][issue #264] Fail closed on computed declarative write errors

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -793,10 +793,14 @@ func (e *Executor) stepSetsGate(frame *executionFrame) error {
 func (e *Executor) stepDataWrites(frame *executionFrame) error {
 	ruleHasWrites := frame.rule != nil && (frame.rule.DataAccumulation.HasWrites() || strings.TrimSpace(frame.rule.DataAccumulation.SourceEvent) != "")
 	if ruleHasWrites {
-		e.applyDataAccumulation(frame, frame.rule.DataAccumulation)
+		if err := e.applyDataAccumulation(frame, frame.rule.DataAccumulation); err != nil {
+			return err
+		}
 	}
 	if (frame.topLevelDataAccumulation.HasWrites() || strings.TrimSpace(frame.topLevelDataAccumulation.SourceEvent) != "") && (!frame.topLevelDataWritesApplied || ruleHasWrites) {
-		e.applyDataAccumulation(frame, frame.topLevelDataAccumulation)
+		if err := e.applyDataAccumulation(frame, frame.topLevelDataAccumulation); err != nil {
+			return err
+		}
 		frame.topLevelDataWritesApplied = true
 	}
 	return nil
@@ -1275,11 +1279,14 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 	}
 }
 
-func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) {
-	applyDataAccumulationToState(e.currentContext(frame), frame.state, &frame.state.State, spec)
+func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) error {
+	if err := applyDataAccumulationToState(e.currentContext(frame), frame.state, &frame.state.State, spec); err != nil {
+		return err
+	}
 	frame.state.State.SetMetadata("last_data_accumulation_event", strings.TrimSpace(string(frame.req.Event.Type)))
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.result.StateMutation.DataAccumulation = spec
+	return nil
 }
 
 func (e *Executor) selectedCompute(frame *executionFrame) *runtimecontracts.ComputeSpec {

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -180,9 +180,9 @@ func normalizeStateField(field string) string {
 	}
 }
 
-func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapshot *StateSnapshot, spec runtimecontracts.WorkflowDataAccumulation) {
+func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapshot *StateSnapshot, spec runtimecontracts.WorkflowDataAccumulation) error {
 	if snapshot == nil || len(spec.Writes) == 0 {
-		return
+		return nil
 	}
 	for _, write := range spec.Writes {
 		target := normalizeStateField(write.Target())
@@ -195,7 +195,7 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 		case write.Value.HasCELValue():
 			value, err := evalDataAccumulationExpression(base, state, write.Value.CEL)
 			if err != nil {
-				continue
+				return fmt.Errorf("data_accumulation target %s: %w", strings.TrimSpace(write.Target()), err)
 			}
 			snapshot.SetMetadata(target, value)
 		default:
@@ -211,6 +211,7 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 	if sourceEvent := strings.TrimSpace(spec.SourceEvent); sourceEvent != "" {
 		snapshot.SetMetadata("last_data_accumulation_source", sourceEvent)
 	}
+	return nil
 }
 
 func evalDataAccumulationExpression(base BaseContext, state ExecutionState, expression string) (any, error) {

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"swarm/internal/events"
@@ -166,7 +167,9 @@ func TestApplyDataAccumulationToState_NormalizesTargets(t *testing.T) {
 		},
 	}
 
-	applyDataAccumulationToState(base, ExecutionState{FanOut: map[string]any{"count": 3}}, state, spec)
+	if err := applyDataAccumulationToState(base, ExecutionState{FanOut: map[string]any{"count": 3}}, state, spec); err != nil {
+		t.Fatalf("applyDataAccumulationToState(...) error = %v", err)
+	}
 
 	if got := state.StateCarrier.Metadata["score"]; got != 4 {
 		t.Fatalf("score = %#v", got)
@@ -244,7 +247,9 @@ func TestApplyDataAccumulationToState_AppliesExpressionOnlyWrites(t *testing.T) 
 		},
 	}
 
-	applyDataAccumulationToState(base, ExecutionState{}, state, spec)
+	if err := applyDataAccumulationToState(base, ExecutionState{}, state, spec); err != nil {
+		t.Fatalf("applyDataAccumulationToState(...) error = %v", err)
+	}
 
 	dimensions, ok := state.StateCarrier.Metadata["dimensions_requested"].([]any)
 	if !ok || len(dimensions) != 2 || dimensions[0] != "build_complexity" || dimensions[1] != "automation_completeness" {
@@ -271,10 +276,38 @@ func TestApplyDataAccumulationToState_EvaluatesArithmeticCELExpressions(t *testi
 		},
 	}
 
-	applyDataAccumulationToState(base, ExecutionState{}, state, spec)
+	if err := applyDataAccumulationToState(base, ExecutionState{}, state, spec); err != nil {
+		t.Fatalf("applyDataAccumulationToState(...) error = %v", err)
+	}
 
 	if got := state.StateCarrier.Metadata["revision_count"]; got != 1.0 && got != 1 {
 		t.Fatalf("revision_count = %#v, want 1", got)
+	}
+}
+
+func TestApplyDataAccumulationToState_FailsClosedOnCELRuntimeError(t *testing.T) {
+	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, nil)}
+	base := BaseContext{
+		Entity: values.Wrap(map[string]any{}),
+	}
+	spec := runtimecontracts.WorkflowDataAccumulation{
+		Writes: []runtimecontracts.WorkflowDataWrite{
+			{
+				TargetField: "entity.revision_count",
+				Value:       runtimecontracts.CELExpression("entity.revision_count + 1"),
+			},
+		},
+	}
+
+	err := applyDataAccumulationToState(base, ExecutionState{}, state, spec)
+	if err == nil {
+		t.Fatal("expected data accumulation CEL runtime error")
+	}
+	if !strings.Contains(err.Error(), "data_accumulation target entity.revision_count") {
+		t.Fatalf("error = %v, want data_accumulation target context", err)
+	}
+	if _, exists := state.StateCarrier.Metadata["revision_count"]; exists {
+		t.Fatalf("revision_count unexpectedly persisted after CEL runtime error: %#v", state.StateCarrier.Metadata["revision_count"])
 	}
 }
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -368,6 +368,143 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 	}
 }
 
+func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: &runtimecontracts.WorkflowContractBundle{
+			Semantics: runtimecontracts.WorkflowSemanticView{
+				Name:    "validation",
+				Version: "v-test",
+				EntitySchema: runtimecontracts.EntitySchema{
+					Groups: []runtimecontracts.EntitySchemaGroup{
+						{
+							Name: "tracking",
+							Fields: []runtimecontracts.EntitySchemaField{
+								{Name: "revision_count", Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+		}},
+	})
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"subject_id":     entityID,
+			"revision_count": 0,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "revision_count", Value: runtimecontracts.CELExpression("entity.revision_count + 1")},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
+		State: pc.currentWorkflowState(context.Background(), entityID),
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("workflow instance missing after declarative write")
+	}
+	switch got := instance.Metadata["revision_count"].(type) {
+	case int:
+		if got != 1 {
+			t.Fatalf("revision_count = %d, want 1", got)
+		}
+	case float64:
+		if got != 1 {
+			t.Fatalf("revision_count = %v, want 1", got)
+		}
+	default:
+		t.Fatalf("revision_count = %#v (%T), want 1", instance.Metadata["revision_count"], instance.Metadata["revision_count"])
+	}
+}
+
+func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: &runtimecontracts.WorkflowContractBundle{
+			Semantics: runtimecontracts.WorkflowSemanticView{
+				Name:    "validation",
+				Version: "v-test",
+				EntitySchema: runtimecontracts.EntitySchema{
+					Groups: []runtimecontracts.EntitySchemaGroup{
+						{
+							Name: "tracking",
+							Fields: []runtimecontracts.EntitySchemaField{
+								{Name: "revision_count", Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+		}},
+	})
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"subject_id": entityID,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "revision_count", Value: runtimecontracts.CELExpression("entity.revision_count + 1")},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
+		State: pc.currentWorkflowState(context.Background(), entityID),
+	}, false)
+	if err == nil {
+		t.Fatal("expected executeNodeContractHandler to fail on data accumulation CEL runtime error")
+	}
+	if !strings.Contains(err.Error(), "data_accumulation target revision_count") && !strings.Contains(err.Error(), "data_accumulation target entity.revision_count") {
+		t.Fatalf("error = %v, want data_accumulation target context", err)
+	}
+
+	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	if loadErr != nil {
+		t.Fatalf("load workflow instance: %v", loadErr)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to remain available")
+	}
+	if _, exists := instance.Metadata["revision_count"]; exists {
+		t.Fatalf("revision_count unexpectedly persisted after CEL runtime error: %#v", instance.Metadata["revision_count"])
+	}
+}
+
 func TestResolveHandlerEntityIDForFlowKeepsSameFlowEntity(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{


### PR DESCRIPTION
Closes #264

Spec references:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_context`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: data_accumulation.write_item_forms.computed`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_language`
- governing rule: computed `data_accumulation` writes are CEL expressions evaluated against the explicit handler context, and missing/invalid referenced fields are runtime errors rather than ignorable no-ops.

## Human Summary

This PR makes computed declarative `data_accumulation` writes fail closed when CEL evaluation hits a runtime error. Valid arithmetic and other CEL-backed writes still persist normally, but invalid computed writes now stop handler execution instead of being silently ignored.

## What Changed

- changed the shared engine-owned `applyDataAccumulationToState(...)` path to return an error when CEL evaluation for a computed write fails
- propagated that error through the engine executor so declarative handler execution aborts instead of silently continuing
- added focused engine coverage for the fail-closed helper behavior
- added focused declarative pipeline regressions that prove:
  - valid arithmetic computed writes still persist evaluated values
  - missing-field CEL runtime errors now fail through the real `executeNodeContractHandler(...)` path without persisting the field

## Why This Is Needed

The spec says `data_accumulation.expression` is CEL against the explicit handler namespaces and that referencing a field that does not exist is a runtime error. The current engine seam still swallowed those runtime CEL errors with a silent `continue`, which let handlers complete while dropping the computed write. This patch restores one canonical fail-closed interpretation in the engine-owned declarative write path.

## Scope Boundaries

In scope:
- fail-closed behavior for computed declarative `data_accumulation` writes in the shared engine owner
- propagation through the real declarative pipeline execution path
- focused regressions for valid and invalid computed-write cases

Not in scope:
- broader accumulation redesign
- unrelated expression-context validation changes
- other CEL-governed seams that already fail closed through different owners

## Tests Run

- `go test ./internal/runtime/engine ./internal/runtime/pipeline -run 'Test(ApplyDataAccumulationToState_(NormalizesTargets|AppliesExpressionOnlyWrites|EvaluatesArithmeticCELExpressions|FailsClosedOnCELRuntimeError)|ExecuteNodeContractHandler(PersistsArithmeticDataAccumulationExpression|FailsClosedOnDataAccumulationCELRuntimeError))' -count=1`
- `go test ./internal/runtime/engine ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR stays narrow to computed declarative write evaluation in the shared engine owner. Reviewers should still watch adjacent CEL-governed seams that use different owners, but I did not find another off-spec fail-open path in this touched owner slice after checking the nearby payload-transform and declarative pipeline usage.

## Follow-Up

No spec escalation was needed for this change.
