### PR TITLE
[agent-c][issue #247] Promote typed flow instance identity in store callers

### DIFF
--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -1,6 +1,7 @@
 package flowidentity
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -19,6 +20,11 @@ type Instance struct {
 	SubjectID      string
 	ParentEntityID string
 	HasStoredPath  bool
+}
+
+type Persisted struct {
+	Instance
+	StorageRef string
 }
 
 type Route struct {
@@ -210,6 +216,49 @@ func Stored(
 		ParentEntityID: strings.TrimSpace(parentEntityID),
 		HasStoredPath:  materializedPath != "",
 	}
+}
+
+func StoredPersisted(
+	source semanticview.Source,
+	workflowName,
+	storageRef,
+	instancePath,
+	instanceID,
+	entityID,
+	subjectID,
+	parentEntityID string,
+) (Persisted, error) {
+	instance := Stored(source, workflowName, instancePath, instanceID, entityID, subjectID, parentEntityID)
+	storageRef = normalizeRef(storageRef)
+	if instance.InstancePath != "" {
+		if logical := LogicalInstanceID(instance.InstancePath); logical != "" && SemanticScopeFromInstancePath(instance.InstancePath) != "" {
+			if strings.TrimSpace(instance.InstanceID) != "" && strings.TrimSpace(instance.InstanceID) != logical {
+				return Persisted{}, fmt.Errorf("flow identity instance_id %q disagrees with flow_instance_path %q", instance.InstanceID, instance.InstancePath)
+			}
+		}
+	}
+	if storageRef == "" {
+		switch {
+		case instance.HasStoredPath && instance.InstancePath != "":
+			storageRef = instance.InstancePath
+		case strings.TrimSpace(entityID) != "":
+			storageRef = strings.TrimSpace(entityID)
+		default:
+			storageRef = strings.TrimSpace(instance.InstanceID)
+		}
+	}
+	return Persisted{
+		Instance:   instance,
+		StorageRef: storageRef,
+	}, nil
+}
+
+func (p Persisted) RowID() string {
+	return EntityID(p.StorageRef)
+}
+
+func (p Persisted) LookupKeys() []string {
+	return LookupKeys(p.StorageRef)
 }
 
 func IsDescendant(scopeKey, instancePath string) bool {

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -118,6 +118,35 @@ func TestStoredCoordinates_SeparateScopeFromConcretePath(t *testing.T) {
 	}
 }
 
+func TestStoredPersisted_KeepsStorageRefSeparateFromSemanticIdentity(t *testing.T) {
+	got, err := StoredPersisted(nil, "child", "11111111-1111-1111-1111-111111111111", "", "11111111-1111-1111-1111-111111111111", "", "", "")
+	if err != nil {
+		t.Fatalf("StoredPersisted(static): %v", err)
+	}
+	if got.StorageRef != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("StorageRef = %q, want preserved uuid storage ref", got.StorageRef)
+	}
+	if got.ScopeKey != "child" {
+		t.Fatalf("ScopeKey = %q, want child", got.ScopeKey)
+	}
+	if got.InstancePath != "child" {
+		t.Fatalf("InstancePath = %q, want child", got.InstancePath)
+	}
+	if got.InstanceID != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("InstanceID = %q, want preserved logical id", got.InstanceID)
+	}
+}
+
+func TestStoredPersisted_RejectsInstanceIDThatDisagreesWithConcretePath(t *testing.T) {
+	_, err := StoredPersisted(nil, "grandchild", "child/grandchild/inst-1", "child/grandchild/inst-1", "inst-2", "", "", "")
+	if err == nil {
+		t.Fatal("expected StoredPersisted to reject mismatched instance id")
+	}
+	if !strings.Contains(err.Error(), "disagrees with flow_instance_path") {
+		t.Fatalf("StoredPersisted error = %v, want disagreement message", err)
+	}
+}
+
 func TestStoredRoute_CanonicalizesScopeInstanceAndPath(t *testing.T) {
 	route := StoredRoute("", "", "child/grandchild/inst-1")
 	if !route.Valid() {

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -42,7 +42,7 @@ func workflowInstanceIdentity(source semanticview.Source, instance WorkflowInsta
 }
 
 func workflowInstancePersistedIdentity(source semanticview.Source, instance WorkflowInstance) (runtimeflowidentity.Persisted, error) {
-	flowPath := strings.TrimSpace(asString(instance.Metadata["flow_path"]))
+	flowPath := strings.Trim(strings.TrimSpace(asString(instance.Metadata["flow_path"])), "/")
 	instanceID := strings.TrimSpace(asString(instance.Metadata["instance_id"]))
 	if instanceID == "" && flowPath == "" {
 		instanceID = strings.TrimSpace(instance.InstanceID)

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -41,6 +41,28 @@ func workflowInstanceIdentity(source semanticview.Source, instance WorkflowInsta
 	return StoredFlowInstance(source, instance)
 }
 
+func workflowInstancePersistedIdentity(source semanticview.Source, instance WorkflowInstance) (runtimeflowidentity.Persisted, error) {
+	flowPath := strings.TrimSpace(asString(instance.Metadata["flow_path"]))
+	instanceID := strings.TrimSpace(asString(instance.Metadata["instance_id"]))
+	if instanceID == "" && flowPath == "" {
+		instanceID = strings.TrimSpace(instance.InstanceID)
+	}
+	entityID := strings.TrimSpace(asString(instance.Metadata["entity_id"]))
+	if entityID == "" && flowPath == "" {
+		entityID = strings.TrimSpace(firstNonEmptyString(instance.StorageRef, asString(instance.Metadata["storage_ref"]), instance.InstanceID))
+	}
+	return runtimeflowidentity.StoredPersisted(
+		source,
+		strings.TrimSpace(instance.WorkflowName),
+		strings.TrimSpace(firstNonEmptyString(instance.StorageRef, asString(instance.Metadata["storage_ref"]))),
+		flowPath,
+		instanceID,
+		entityID,
+		strings.TrimSpace(firstNonEmptyString(instance.SubjectID, asString(instance.Metadata["subject_id"]))),
+		asString(instance.Metadata["parent_entity_id"]),
+	)
+}
+
 func workflowInstanceScopeKey(source semanticview.Source, instance WorkflowInstance) string {
 	return workflowInstanceIdentity(source, instance).ScopeKey
 }

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -145,19 +145,27 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	}
 	instance.StorageRef = strings.TrimSpace(instance.StorageRef)
 	instance.SubjectID = strings.TrimSpace(firstNonEmptyString(instance.SubjectID, asString(instance.Metadata["subject_id"])))
-	storageRef := workflowInstanceStorageRef(instance)
-	if storageRef == "" {
+	identity, err := workflowInstancePersistedIdentity(nil, instance)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(identity.StorageRef) == "" {
 		return nil
 	}
-	rowID := workflowInstanceRowID(storageRef)
-	if rowID == "" {
+	if strings.TrimSpace(identity.RowID()) == "" {
 		return nil
 	}
-	if strings.TrimSpace(asString(instance.Metadata["instance_id"])) == "" {
-		instance.Metadata["instance_id"] = instance.InstanceID
+	if instance.Metadata == nil {
+		instance.Metadata = map[string]any{}
 	}
-	instance.Metadata["storage_ref"] = storageRef
-	return s.upsertSpec(ctx, rowID, storageRef, instance)
+	instance.StorageRef = identity.StorageRef
+	instance.InstanceID = identity.InstanceID
+	instance.Metadata["storage_ref"] = identity.StorageRef
+	instance.Metadata["instance_id"] = identity.InstanceID
+	if identity.InstancePath != "" {
+		instance.Metadata["flow_path"] = identity.InstancePath
+	}
+	return s.upsertSpec(ctx, identity.RowID(), identity.StorageRef, instance)
 }
 
 func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error {
@@ -341,8 +349,18 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 	item.StateBuckets = projection.Accumulator
 	item.Config = projection.Config
 	item.Metadata = projection.Metadata()
-	item.StorageRef = projection.Control.StorageRef
-	item.InstanceID = workflowInstanceLogicalID(item.InstanceID, item.Metadata)
+	persistedIdentity, err := workflowInstancePersistedIdentity(nil, WorkflowInstance{
+		InstanceID:   item.InstanceID,
+		StorageRef:   projection.Control.StorageRef,
+		WorkflowName: item.WorkflowName,
+		Metadata:     item.Metadata,
+		SubjectID:    item.SubjectID,
+	})
+	if err != nil {
+		return WorkflowInstance{}, false, err
+	}
+	item.StorageRef = persistedIdentity.StorageRef
+	item.InstanceID = persistedIdentity.InstanceID
 	timers, err := s.loadWorkflowTimersSpec(ctx, keys[0])
 	if err != nil {
 		return WorkflowInstance{}, false, err
@@ -443,10 +461,20 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 		item.StateBuckets = projection.Accumulator
 		item.Config = projection.Config
 		item.Metadata = projection.Metadata()
-		item.StorageRef = projection.Control.StorageRef
-		item.InstanceID = workflowInstanceLogicalID(item.InstanceID, item.Metadata)
+		persistedIdentity, err := workflowInstancePersistedIdentity(nil, WorkflowInstance{
+			InstanceID:   item.InstanceID,
+			StorageRef:   projection.Control.StorageRef,
+			WorkflowName: item.WorkflowName,
+			Metadata:     item.Metadata,
+			SubjectID:    item.SubjectID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		item.StorageRef = persistedIdentity.StorageRef
+		item.InstanceID = persistedIdentity.InstanceID
 		item.TransitionHistory = append([]WorkflowTransitionRecord{}, projection.Control.TransitionHistory...)
-		timers, err := s.loadWorkflowTimersSpec(ctx, runtimeflowidentity.EntityID(item.StorageRef))
+		timers, err := s.loadWorkflowTimersSpec(ctx, persistedIdentity.RowID())
 		if err != nil {
 			return nil, err
 		}
@@ -757,14 +785,21 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 		return workflowInstancePersistedProjection{}, err
 	}
 	delete(metadata, "gates")
+	persistedIdentity, err := workflowInstancePersistedIdentity(nil, instance)
+	if err != nil {
+		return workflowInstancePersistedProjection{}, err
+	}
+	if strings.TrimSpace(storageRef) != "" && strings.TrimSpace(persistedIdentity.StorageRef) != "" && strings.TrimSpace(storageRef) != strings.TrimSpace(persistedIdentity.StorageRef) {
+		return workflowInstancePersistedProjection{}, fmt.Errorf("workflow instance storage_ref %q disagrees with canonical storage_ref %q", storageRef, persistedIdentity.StorageRef)
+	}
 	control := workflowInstancePersistedControl{
 		SubjectID:         strings.TrimSpace(firstNonEmptyString(instance.SubjectID, asString(instance.Metadata["subject_id"]))),
-		StorageRef:        strings.TrimSpace(storageRef),
+		StorageRef:        strings.TrimSpace(persistedIdentity.StorageRef),
 		Slug:              strings.TrimSpace(asString(instance.Metadata["slug"])),
 		Name:              strings.TrimSpace(asString(instance.Metadata["name"])),
 		EntityType:        strings.TrimSpace(asString(instance.Metadata["entity_type"])),
-		InstanceID:        strings.TrimSpace(firstNonEmptyString(asString(instance.Metadata["instance_id"]), instance.InstanceID)),
-		FlowPath:          strings.TrimSpace(asString(instance.Metadata["flow_path"])),
+		InstanceID:        strings.TrimSpace(persistedIdentity.InstanceID),
+		FlowPath:          strings.TrimSpace(persistedIdentity.InstancePath),
 		InstanceKind:      strings.TrimSpace(asString(instance.Metadata["instance_kind"])),
 		TemplateVersion:   strings.TrimSpace(asString(instance.Metadata["template_version"])),
 		LastSourceEvent:   strings.TrimSpace(asString(instance.Metadata["last_source_event"])),
@@ -1057,35 +1092,6 @@ func shouldFallbackLegacyWorkflowInstanceSchema(err error) bool {
 		}
 	}
 	return false
-}
-
-func workflowInstanceStorageRef(instance WorkflowInstance) string {
-	if storageRef := strings.TrimSpace(instance.StorageRef); storageRef != "" {
-		return storageRef
-	}
-	if flowPath := strings.TrimSpace(asString(instance.Metadata["flow_path"])); flowPath != "" {
-		return flowPath
-	}
-	if storageRef := strings.TrimSpace(asString(instance.Metadata["storage_ref"])); storageRef != "" {
-		return storageRef
-	}
-	return strings.TrimSpace(instance.InstanceID)
-}
-
-func workflowInstanceLogicalID(fallback string, metadata map[string]any) string {
-	if logicalID := strings.TrimSpace(asString(metadata["instance_id"])); logicalID != "" {
-		return logicalID
-	}
-	if flowPath := strings.TrimSpace(asString(metadata["flow_path"])); flowPath != "" {
-		return runtimeflowidentity.LogicalInstanceID(flowPath)
-	}
-	if storageRef := strings.TrimSpace(asString(metadata["storage_ref"])); storageRef != "" {
-		if strings.Contains(storageRef, "/") {
-			return runtimeflowidentity.LogicalInstanceID(storageRef)
-		}
-		return storageRef
-	}
-	return strings.TrimSpace(fallback)
 }
 
 func workflowInstanceLookupKeys(ref string) []string {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -162,8 +162,10 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	instance.InstanceID = identity.InstanceID
 	instance.Metadata["storage_ref"] = identity.StorageRef
 	instance.Metadata["instance_id"] = identity.InstanceID
-	if identity.InstancePath != "" {
+	if identity.HasStoredPath && identity.InstancePath != "" {
 		instance.Metadata["flow_path"] = identity.InstancePath
+	} else {
+		delete(instance.Metadata, "flow_path")
 	}
 	return s.upsertSpec(ctx, identity.RowID(), identity.StorageRef, instance)
 }
@@ -799,13 +801,15 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 		Name:              strings.TrimSpace(asString(instance.Metadata["name"])),
 		EntityType:        strings.TrimSpace(asString(instance.Metadata["entity_type"])),
 		InstanceID:        strings.TrimSpace(persistedIdentity.InstanceID),
-		FlowPath:          strings.TrimSpace(persistedIdentity.InstancePath),
 		InstanceKind:      strings.TrimSpace(asString(instance.Metadata["instance_kind"])),
 		TemplateVersion:   strings.TrimSpace(asString(instance.Metadata["template_version"])),
 		LastSourceEvent:   strings.TrimSpace(asString(instance.Metadata["last_source_event"])),
 		Status:            strings.TrimSpace(asString(instance.Metadata["status"])),
 		ParentEntityID:    strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
 		TransitionHistory: append([]WorkflowTransitionRecord{}, instance.TransitionHistory...),
+	}
+	if persistedIdentity.HasStoredPath {
+		control.FlowPath = strings.TrimSpace(persistedIdentity.InstancePath)
 	}
 	for _, key := range []string{
 		"slug", "name", "entity_type", "subject_id", "parent_entity_id",

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/testutil"
 )
 
@@ -90,6 +91,9 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	if got := strings.TrimSpace(asString(loaded.Metadata["flow_path"])); got != "review/inst-1" {
 		t.Fatalf("Metadata flow_path = %#v, want review/inst-1", loaded.Metadata["flow_path"])
 	}
+	if got := strings.TrimSpace(asString(loaded.Metadata["storage_ref"])); got != storageRef {
+		t.Fatalf("Metadata storage_ref = %#v, want %q", loaded.Metadata["storage_ref"], storageRef)
+	}
 	if got := strings.TrimSpace(asString(loaded.Metadata["subject_id"])); got != subjectID {
 		t.Fatalf("Metadata subject_id = %#v, want %q", loaded.Metadata["subject_id"], subjectID)
 	}
@@ -106,6 +110,25 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	wantEvidence := `{"audit":[{"kind":"note","score":1}]}`
 	if got := mustCanonicalJSONString(t, gotEvidence); got != wantEvidence {
 		t.Fatalf("evidence = %s, want %s", got, wantEvidence)
+	}
+	identity, err := workflowInstancePersistedIdentity(nil, loaded)
+	if err != nil {
+		t.Fatalf("workflowInstancePersistedIdentity(loaded): %v", err)
+	}
+	if identity.StorageRef != storageRef {
+		t.Fatalf("identity.StorageRef = %q, want %q", identity.StorageRef, storageRef)
+	}
+	if identity.ScopeKey != "review" {
+		t.Fatalf("identity.ScopeKey = %q, want review", identity.ScopeKey)
+	}
+	if identity.InstancePath != "review/inst-1" {
+		t.Fatalf("identity.InstancePath = %q, want review/inst-1", identity.InstancePath)
+	}
+	if identity.InstanceID != "inst-1" {
+		t.Fatalf("identity.InstanceID = %q, want inst-1", identity.InstanceID)
+	}
+	if identity.EntityID != runtimeflowidentity.EntityID("review/inst-1") {
+		t.Fatalf("identity.EntityID = %q, want canonical id for review/inst-1", identity.EntityID)
 	}
 }
 
@@ -144,6 +167,13 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 			mutateKey:    "storage",
 			mutateArg:    `{"workflow_version":"1.0.0","instance_id":"inst-1","storage_ref":"storage-ref","transition_history":"bad"}`,
 			wantContains: "flow_instances.config transition_history must be an array of workflow transition records",
+		},
+		{
+			name:         "instance id disagrees with flow path",
+			mutateSQL:    `UPDATE flow_instances SET config = $2::jsonb WHERE instance_id = $1`,
+			mutateKey:    "storage",
+			mutateArg:    `{"workflow_version":"1.0.0","instance_id":"inst-2","storage_ref":"storage-ref","flow_path":"review/inst-1"}`,
+			wantContains: "disagrees with flow_instance_path",
 		},
 	}
 

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -132,6 +132,53 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	}
 }
 
+func TestWorkflowInstanceStoreProjection_StaticRowsDoNotGainMaterializedFlowPathOnRoundTrip(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	storageRef := uuid.NewString()
+	instance := WorkflowInstance{
+		InstanceID:      storageRef,
+		StorageRef:      storageRef,
+		WorkflowName:    "static-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"instance_id": storageRef,
+		},
+		StateBuckets: map[string]any{},
+	}
+
+	if err := store.Upsert(context.Background(), instance); err != nil {
+		t.Fatalf("upsert static workflow instance: %v", err)
+	}
+
+	loaded, ok, err := store.Load(context.Background(), storageRef)
+	if err != nil {
+		t.Fatalf("load static workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected static workflow instance to persist")
+	}
+	if got := strings.TrimSpace(asString(loaded.Metadata["flow_path"])); got != "" {
+		t.Fatalf("Metadata flow_path = %#v, want empty for static row", loaded.Metadata["flow_path"])
+	}
+	identity, err := workflowInstancePersistedIdentity(nil, loaded)
+	if err != nil {
+		t.Fatalf("workflowInstancePersistedIdentity(static): %v", err)
+	}
+	if identity.HasStoredPath {
+		t.Fatalf("identity.HasStoredPath = true, want false for static row")
+	}
+	if identity.ScopeKey != "static-flow" {
+		t.Fatalf("identity.ScopeKey = %q, want static-flow", identity.ScopeKey)
+	}
+	if identity.InstancePath != "static-flow" {
+		t.Fatalf("identity.InstancePath = %q, want canonical static path", identity.InstancePath)
+	}
+}
+
 func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -175,6 +222,13 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 			mutateArg:    `{"workflow_version":"1.0.0","instance_id":"inst-2","storage_ref":"storage-ref","flow_path":"review/inst-1"}`,
 			wantContains: "disagrees with flow_instance_path",
 		},
+		{
+			name:         "slash-only flow path normalizes before fallback",
+			mutateSQL:    `UPDATE flow_instances SET config = $2::jsonb WHERE instance_id = $1`,
+			mutateKey:    "storage",
+			mutateArg:    `{"workflow_version":"1.0.0","instance_id":"inst-1","storage_ref":"storage-ref","flow_path":"/"}`,
+			wantContains: "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -206,7 +260,19 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 				t.Fatalf("mutate malformed persisted shape: %v", err)
 			}
 
-			_, _, err := store.Load(context.Background(), storageRef)
+			loaded, ok, err := store.Load(context.Background(), storageRef)
+			if tc.wantContains == "" {
+				if err != nil {
+					t.Fatalf("load with slash-only flow_path: %v", err)
+				}
+				if !ok {
+					t.Fatal("expected slash-only flow_path row to load")
+				}
+				if got := strings.TrimSpace(asString(loaded.Metadata["instance_id"])); got != "inst-1" {
+					t.Fatalf("loaded Metadata instance_id = %#v, want inst-1", loaded.Metadata["instance_id"])
+				}
+				return
+			}
 			if err == nil {
 				t.Fatal("expected load to fail on malformed persisted shape")
 			}


### PR DESCRIPTION
Closes #247

## Human Summary
This PR promotes one typed flow-instance carrier to the canonical owner for the touched workflow-instance store/pipeline identity seam. The store load/upsert path no longer reconstructs semantic scope, concrete instance path, and logical instance id independently from `flow_path`, `storage_ref`, and local fallback ladders.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: flow_identity`

## What Changed
- added `flowidentity.Persisted`, a typed carrier that keeps semantic flow identity (`ScopeKey`, `InstancePath`, `InstanceID`) separate from the persistence locator (`StorageRef`)
- made the workflow-instance store upsert/load/list path consume that typed carrier instead of local `workflowInstanceStorageRef` and `workflowInstanceLogicalID` fallback helpers
- made canonical instance-id derivation for instanced rows come from explicit `instance_id` or concrete `flow_path`, not from unrelated `storage_ref` or overloaded struct-field fallback
- added fail-closed rejection for malformed persisted shapes where `flow_path` and `instance_id` disagree
- added focused tests proving store and pipeline callers converge on the same scope key, instance path, instance id, entity id, and storage ref for the same persisted instance

## Why This Is Needed
The spec makes `flow_scope_key` and `flow_instance_path` distinct, non-interchangeable identities. The touched callers were still rebuilding instance meaning independently from `flow_path`, `storage_ref`, and local precedence rules, which kept semantic identity and persistence locator semantics coupled and drift-prone.

## Scope Boundaries
- fixes the workflow-instance identity seam in `core/flowidentity`, `flow_instance_identity.go`, and `workflow_instance_store.go`
- does not redesign all runtime flow-instance callers or remove `storage_ref` from unrelated persistence seams
- does not widen into route retargeting, subscriber matching, or deactivation cleanup beyond this first slice

## Tests Run
- `go test ./internal/runtime/core/flowidentity ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk
Other runtime callers outside this first slice still read raw `flow_path` or `storage_ref` directly. This PR narrows the highest-value store/pipeline seam, but it does not yet retarget every downstream caller onto the typed carrier.

## Follow-Up
If we continue `#164`, the next slice should move the remaining activation/deactivation and route persistence callers that still touch raw `flow_path` or `storage_ref` directly onto the same typed carrier.
