### PR TITLE
[agent-d][issue #237] Collapse timer claim release behind canonical store-owned terminal helpers

### DIFF
--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1034,7 +1034,14 @@ func (s *recordingScheduleStore) CancelScheduleExact(_ context.Context, sc Sched
 	s.cancels = append(s.cancels, sc)
 	return nil
 }
+func (s *recordingScheduleStore) CancelScheduleExactTerminal(_ context.Context, sc Schedule) error {
+	s.cancels = append(s.cancels, sc)
+	return nil
+}
 func (s *recordingScheduleStore) MarkScheduleFiredExact(context.Context, Schedule) error { return nil }
+func (s *recordingScheduleStore) CompleteScheduleFireExact(context.Context, Schedule) error {
+	return nil
+}
 
 func TestPipelineEngineTimerApplierPersistsTimersAndDefersSchedulerToPostCommit(t *testing.T) {
 	store := &recordingScheduleStore{}

--- a/internal/runtime/pipeline/schedule_terminal_error.go
+++ b/internal/runtime/pipeline/schedule_terminal_error.go
@@ -1,0 +1,28 @@
+package pipeline
+
+import "errors"
+
+type ScheduleTerminalError struct {
+	Stage             string
+	TransitionApplied bool
+	Err               error
+}
+
+func (e *ScheduleTerminalError) Error() string {
+	if e == nil || e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+func (e *ScheduleTerminalError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func TerminalTransitionApplied(err error) bool {
+	var terminalErr *ScheduleTerminalError
+	return errors.As(err, &terminalErr) && terminalErr.TransitionApplied
+}

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -18,8 +18,10 @@ import (
 type SchedulePersistence interface {
 	UpsertSchedule(ctx context.Context, sc Schedule) error
 	CancelScheduleExact(ctx context.Context, sc Schedule) error
+	CancelScheduleExactTerminal(ctx context.Context, sc Schedule) error
 	LoadActiveSchedules(ctx context.Context) ([]Schedule, error)
 	MarkScheduleFiredExact(ctx context.Context, sc Schedule) error
+	CompleteScheduleFireExact(ctx context.Context, sc Schedule) error
 	ClaimSchedule(ctx context.Context, sc Schedule) (bool, error)
 	ReleaseSchedule(ctx context.Context, sc Schedule) error
 	ReleaseScheduleClaims(ctx context.Context) error

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -412,18 +412,12 @@ func (pc *PipelineCoordinator) cancelWorkflowTimerSchedule(ctx context.Context, 
 	if pc.timerScheduleStore == nil {
 		return
 	}
-	if err := pc.timerScheduleStore.CancelScheduleExact(ctx, sc); err != nil {
+	if err := pc.timerScheduleStore.CancelScheduleExactTerminal(ctx, sc); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 			"task_id": strings.TrimSpace(sc.TaskID),
 			"mode":    strings.TrimSpace(sc.Mode),
 		}, err)
 		return
-	}
-	if err := ReleaseOwnedSchedule(ctx, pc.timerScheduleStore, sc); err != nil {
-		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_release_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
-			"task_id": strings.TrimSpace(sc.TaskID),
-			"mode":    strings.TrimSpace(sc.Mode),
-		}, err)
 	}
 }
 
@@ -459,18 +453,12 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 		return
 	}
 	if pc.timerScheduleStore != nil {
-		if err := pc.timerScheduleStore.CancelScheduleExact(ctx, sc); err != nil {
+		if err := pc.timerScheduleStore.CancelScheduleExactTerminal(ctx, sc); err != nil {
 			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_cancel_persist_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
 			return
-		}
-		if err := ReleaseOwnedSchedule(ctx, pc.timerScheduleStore, sc); err != nil {
-			pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_release_failed", "", sc.EventType, sc.AgentID, sc.EffectiveEntityID(), map[string]any{
-				"task_id": strings.TrimSpace(sc.TaskID),
-				"mode":    strings.TrimSpace(sc.Mode),
-			}, err)
 		}
 	}
 	if pc.timerScheduler != nil {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -458,7 +458,9 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
-			return
+			if !TerminalTransitionApplied(err) {
+				return
+			}
 		}
 	}
 	if pc.timerScheduler != nil {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -19,6 +19,7 @@ type recordingSchedulePersistence struct {
 	cancels      []Schedule
 	releases     []Schedule
 	cancelExacts int
+	cancelOwned  int
 }
 
 func (s *recordingSchedulePersistence) UpsertSchedule(_ context.Context, sc Schedule) error {
@@ -49,7 +50,17 @@ func (s *recordingSchedulePersistence) CancelScheduleExact(_ context.Context, sc
 	return nil
 }
 
+func (s *recordingSchedulePersistence) CancelScheduleExactTerminal(_ context.Context, sc Schedule) error {
+	s.cancelOwned++
+	s.cancels = append(s.cancels, sc)
+	return nil
+}
+
 func (s *recordingSchedulePersistence) MarkScheduleFiredExact(context.Context, Schedule) error {
+	return nil
+}
+
+func (*recordingSchedulePersistence) CompleteScheduleFireExact(context.Context, Schedule) error {
 	return nil
 }
 
@@ -199,14 +210,11 @@ func TestPersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel(t *t
 
 	pc.persistWorkflowTimerCancellation(context.Background(), sc)
 
-	if got := store.cancelExacts; got != 1 {
-		t.Fatalf("cancel exact calls = %d, want 1", got)
+	if got := store.cancelOwned; got != 1 {
+		t.Fatalf("cancel owned calls = %d, want 1", got)
 	}
-	if len(store.releases) != 1 {
-		t.Fatalf("released schedules = %d, want 1", len(store.releases))
-	}
-	if store.releases[0].TaskID != sc.TaskID {
-		t.Fatalf("released task_id = %q, want %q", store.releases[0].TaskID, sc.TaskID)
+	if len(store.releases) != 0 {
+		t.Fatalf("caller-side releases = %d, want 0", len(store.releases))
 	}
 }
 
@@ -414,8 +422,8 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	if len(store.cancels) != 1 {
 		t.Fatalf("cancelled schedules = %d, want 1", len(store.cancels))
 	}
-	if store.cancelExacts != 1 {
-		t.Fatalf("CancelScheduleExact calls = %d, want 1", store.cancelExacts)
+	if store.cancelOwned != 1 {
+		t.Fatalf("CancelScheduleExactTerminal calls = %d, want 1", store.cancelOwned)
 	}
 	if got := store.cancels[0].TaskID; got != timeridentity.AccumulationTimeoutHandle(timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived")).TaskID() {
 		t.Fatalf("cancelled task_id = %q", got)

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -20,6 +20,7 @@ type recordingSchedulePersistence struct {
 	releases     []Schedule
 	cancelExacts int
 	cancelOwned  int
+	cancelErr    error
 }
 
 func (s *recordingSchedulePersistence) UpsertSchedule(_ context.Context, sc Schedule) error {
@@ -53,7 +54,7 @@ func (s *recordingSchedulePersistence) CancelScheduleExact(_ context.Context, sc
 func (s *recordingSchedulePersistence) CancelScheduleExactTerminal(_ context.Context, sc Schedule) error {
 	s.cancelOwned++
 	s.cancels = append(s.cancels, sc)
-	return nil
+	return s.cancelErr
 }
 
 func (s *recordingSchedulePersistence) MarkScheduleFiredExact(context.Context, Schedule) error {
@@ -215,6 +216,43 @@ func TestPersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel(t *t
 	}
 	if len(store.releases) != 0 {
 		t.Fatalf("caller-side releases = %d, want 0", len(store.releases))
+	}
+}
+
+func TestPersistWorkflowTimerCancellation_StillCancelsSchedulerWhenClaimReleaseFailsAfterPersist(t *testing.T) {
+	store := &recordingSchedulePersistence{
+		cancelErr: &ScheduleTerminalError{
+			Stage:             "release_claim",
+			TransitionApplied: true,
+			Err:               context.DeadlineExceeded,
+		},
+	}
+	scheduler := NewScheduler()
+	defer scheduler.Stop()
+	pc := &PipelineCoordinator{
+		timerScheduleStore: store,
+		timerScheduler:     scheduler,
+	}
+	sc := Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(time.Hour),
+		EntityID:     "ent-001",
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-a",
+	}
+	if err := scheduler.Register(sc); err != nil {
+		t.Fatalf("Register(schedule): %v", err)
+	}
+
+	pc.persistWorkflowTimerCancellation(context.Background(), sc)
+
+	if got := store.cancelOwned; got != 1 {
+		t.Fatalf("cancel owned calls = %d, want 1", got)
+	}
+	if got := len(scheduler.tasks); got != 0 {
+		t.Fatalf("scheduler tasks after partial failure = %d, want 0", got)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -298,17 +298,9 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			}
 		}
 		if stores.ScheduleStore != nil {
-			if err := stores.ScheduleStore.MarkScheduleFiredExact(callbackCtx, sc); err != nil {
+			if err := stores.ScheduleStore.CompleteScheduleFireExact(callbackCtx, sc); err != nil {
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("scheduler", "mark_fired_failed", rt.Logger.Error(callbackCtx, "scheduler", "mark_fired_failed", map[string]any{
-						"agent_id":   sc.AgentID,
-						"event_type": sc.EventType,
-						"entity_id":  sc.EffectiveEntityID(),
-					}, err))
-				}
-			} else if strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
-				if err := stores.ScheduleStore.ReleaseSchedule(callbackCtx, sc); err != nil && rt.Logger != nil {
-					handleRuntimeLogPersistenceError("scheduler", "release_ownership_failed", rt.Logger.Error(callbackCtx, "scheduler", "release_ownership_failed", map[string]any{
 						"agent_id":   sc.AgentID,
 						"event_type": sc.EventType,
 						"entity_id":  sc.EffectiveEntityID(),

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -104,6 +104,7 @@ type recordingRuntimeScheduleStore struct {
 	schedules  []runtimepipeline.Schedule
 	active     []runtimepipeline.Schedule
 	firedExact atomic.Int32
+	firedOwned atomic.Int32
 	fired      chan runtimepipeline.Schedule
 }
 
@@ -113,6 +114,10 @@ func (s *recordingRuntimeScheduleStore) UpsertSchedule(_ context.Context, sc run
 }
 
 func (*recordingRuntimeScheduleStore) CancelScheduleExact(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*recordingRuntimeScheduleStore) CancelScheduleExactTerminal(context.Context, runtimepipeline.Schedule) error {
 	return nil
 }
 
@@ -134,6 +139,17 @@ func (*recordingRuntimeScheduleStore) ReleaseScheduleClaims(context.Context) err
 
 func (s *recordingRuntimeScheduleStore) MarkScheduleFiredExact(_ context.Context, sc runtimepipeline.Schedule) error {
 	s.firedExact.Add(1)
+	if s.fired != nil {
+		select {
+		case s.fired <- sc:
+		default:
+		}
+	}
+	return nil
+}
+
+func (s *recordingRuntimeScheduleStore) CompleteScheduleFireExact(_ context.Context, sc runtimepipeline.Schedule) error {
+	s.firedOwned.Add(1)
 	if s.fired != nil {
 		select {
 		case s.fired <- sc:
@@ -219,7 +235,7 @@ func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing
 	}
 }
 
-func TestNewRuntime_SchedulerMarksSchedulesFiredThroughExactContract(t *testing.T) {
+func TestNewRuntime_SchedulerMarksSchedulesFiredThroughCanonicalTerminalHelper(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", "test-boot-success")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -261,8 +277,8 @@ func TestNewRuntime_SchedulerMarksSchedulesFiredThroughExactContract(t *testing.
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for exact schedule fire persistence")
 	}
-	if got := store.firedExact.Load(); got != 1 {
-		t.Fatalf("MarkScheduleFiredExact calls = %d, want 1", got)
+	if got := store.firedOwned.Load(); got != 1 {
+		t.Fatalf("CompleteScheduleFireExact calls = %d, want 1", got)
 	}
 }
 
@@ -331,7 +347,7 @@ func TestRuntime_StartRestoresExactSchedulesDistinctByFlowInstance(t *testing.T)
 			t.Fatalf("timed out waiting for restored exact schedules to fire; seen flow instances = %#v", seenFlows)
 		}
 	}
-	if got := store.firedExact.Load(); got != 2 {
-		t.Fatalf("MarkScheduleFiredExact calls = %d, want 2 for distinct restored flow instances", got)
+	if got := store.firedOwned.Load(); got != 2 {
+		t.Fatalf("CompleteScheduleFireExact calls = %d, want 2 for distinct restored flow instances", got)
 	}
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1808,20 +1808,14 @@ func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
 	var fired1, fired2 atomic.Int32
 	scheduler1 := runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		fired1.Add(1)
-		if err := pg1.MarkScheduleFiredExact(context.Background(), sc); err != nil {
-			t.Errorf("MarkScheduleFiredExact(pg1): %v", err)
-		}
-		if err := pg1.ReleaseSchedule(context.Background(), sc); err != nil {
-			t.Errorf("ReleaseSchedule(pg1): %v", err)
+		if err := pg1.CompleteScheduleFireExact(context.Background(), sc); err != nil {
+			t.Errorf("CompleteScheduleFireExact(pg1): %v", err)
 		}
 	})
 	scheduler2 := runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		fired2.Add(1)
-		if err := pg2.MarkScheduleFiredExact(context.Background(), sc); err != nil {
-			t.Errorf("MarkScheduleFiredExact(pg2): %v", err)
-		}
-		if err := pg2.ReleaseSchedule(context.Background(), sc); err != nil {
-			t.Errorf("ReleaseSchedule(pg2): %v", err)
+		if err := pg2.CompleteScheduleFireExact(context.Background(), sc); err != nil {
+			t.Errorf("CompleteScheduleFireExact(pg2): %v", err)
 		}
 	})
 	t.Cleanup(scheduler1.Stop)
@@ -1861,7 +1855,7 @@ func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
 	}
 }
 
-func TestSchedules_CancelAndReleaseAllowsSubsequentReclaim(t *testing.T) {
+func TestSchedules_CancelExactTerminalAllowsSubsequentReclaim(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	pgOwner := &PostgresStore{DB: db}
@@ -1888,11 +1882,8 @@ func TestSchedules_CancelAndReleaseAllowsSubsequentReclaim(t *testing.T) {
 		t.Fatal("expected owner to claim schedule")
 	}
 
-	if err := pgOwner.CancelScheduleExact(ctx, sc); err != nil {
-		t.Fatalf("CancelScheduleExact: %v", err)
-	}
-	if err := pgOwner.ReleaseSchedule(ctx, sc); err != nil {
-		t.Fatalf("ReleaseSchedule: %v", err)
+	if err := pgOwner.CancelScheduleExactTerminal(ctx, sc); err != nil {
+		t.Fatalf("CancelScheduleExactTerminal: %v", err)
 	}
 
 	claimed, err = pgSuccessor.ClaimSchedule(ctx, sc)
@@ -1912,6 +1903,57 @@ func TestSchedules_CancelAndReleaseAllowsSubsequentReclaim(t *testing.T) {
 	}
 	if !claimed {
 		t.Fatal("expected successor to claim recreated schedule after owner cancel+release")
+	}
+}
+
+func TestSchedules_CompleteScheduleFireExactReleasesClaimForRecreatedOnceTimer(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pgOwner := &PostgresStore{DB: db}
+	pgSuccessor := &PostgresStore{DB: db}
+
+	sc := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     uuid.NewString(),
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-fire-reclaim",
+		Payload:      []byte(`{"timer_id":"timer-fire-reclaim"}`),
+	}
+	if err := pgOwner.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+	claimed, err := pgOwner.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(owner): %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected owner to claim schedule")
+	}
+
+	if err := pgOwner.CompleteScheduleFireExact(ctx, sc); err != nil {
+		t.Fatalf("CompleteScheduleFireExact: %v", err)
+	}
+
+	claimed, err = pgSuccessor.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(successor after fire): %v", err)
+	}
+	if claimed {
+		t.Fatal("expected fired once schedule to remain unclaimable while inactive")
+	}
+
+	if err := pgOwner.UpsertSchedule(ctx, sc); err != nil {
+		t.Fatalf("UpsertSchedule(recreate): %v", err)
+	}
+	claimed, err = pgSuccessor.ClaimSchedule(ctx, sc)
+	if err != nil {
+		t.Fatalf("ClaimSchedule(successor after recreate): %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected successor to claim recreated once timer after canonical fire helper released ownership")
 	}
 }
 

--- a/internal/store/schedule_claims.go
+++ b/internal/store/schedule_claims.go
@@ -152,7 +152,11 @@ func (s *PostgresStore) applyScheduleTerminalTransition(
 		return nil
 	}
 	if err := s.ReleaseSchedule(ctx, sc); err != nil {
-		return err
+		return &runtimepipeline.ScheduleTerminalError{
+			Stage:             "release_claim",
+			TransitionApplied: true,
+			Err:               err,
+		}
 	}
 	return nil
 }

--- a/internal/store/schedule_claims.go
+++ b/internal/store/schedule_claims.go
@@ -93,6 +93,15 @@ func (s *PostgresStore) ReleaseSchedule(ctx context.Context, sc runtimepipeline.
 	return nil
 }
 
+func (s *PostgresStore) CancelScheduleExactTerminal(ctx context.Context, sc runtimepipeline.Schedule) error {
+	return s.applyScheduleTerminalTransition(ctx, sc, s.CancelScheduleExact, true)
+}
+
+func (s *PostgresStore) CompleteScheduleFireExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	release := strings.EqualFold(strings.TrimSpace(sc.Mode), "once")
+	return s.applyScheduleTerminalTransition(ctx, sc, s.MarkScheduleFiredExact, release)
+}
+
 func (s *PostgresStore) ReleaseScheduleClaims(ctx context.Context) error {
 	if s == nil {
 		return nil
@@ -126,6 +135,24 @@ func (s *PostgresStore) closeScheduleClaimConnLocked() error {
 	}
 	if err := conn.Close(); err != nil {
 		return fmt.Errorf("close schedule ownership connection: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) applyScheduleTerminalTransition(
+	ctx context.Context,
+	sc runtimepipeline.Schedule,
+	transition func(context.Context, runtimepipeline.Schedule) error,
+	release bool,
+) error {
+	if err := transition(ctx, sc); err != nil {
+		return err
+	}
+	if !release {
+		return nil
+	}
+	if err := s.ReleaseSchedule(ctx, sc); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #237

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.lifecycle`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`

## Human Summary
This collapses timer terminal claim release behind canonical store-owned helpers in the touched seam. Runtime scheduler fire callbacks and workflow timer cancellation no longer have to remember separate `ReleaseSchedule(...)` calls after terminal transitions.

## What Changed
- Added canonical store-owned terminal helpers to the schedule persistence seam:
  - `CancelScheduleExactTerminal(...)`
  - `CompleteScheduleFireExact(...)`
- Implemented those helpers in `internal/store/schedule_claims.go` through one shared store-owned transition path.
- Updated runtime scheduler fire callbacks to use `CompleteScheduleFireExact(...)`.
- Updated workflow timer cancellation paths to use `CancelScheduleExactTerminal(...)`.
- Kept non-terminal recurring fire semantics aligned by making `CompleteScheduleFireExact(...)` release claims only for terminal `once` timers.
- Updated focused runtime/pipeline/store tests to prove both terminal callers share the same store-owned release behavior.

## Why This Is Needed
The spec treats timer start, cancel, fire, and crash recovery as one durable lifecycle. In the touched seam, terminal state mutation and claim release were split between store methods and runtime callers, which left drift risk between startup restoration, workflow timer cancellation, and one-shot firing. This change gives that seam one canonical store-owned owner for terminal transition plus claim release.

## Scope Boundaries
In scope:
- store-owned terminal timer helpers
- runtime scheduler fire callback
- workflow timer cancellation paths
- focused store/runtime/pipeline regressions for aligned claim release

Out of scope:
- broader timer redesign
- non-terminal claim rollback during registration failure
- shutdown-wide claim release behavior
- spec changes

## Tests Run
- `go test ./internal/store -run 'TestSchedules_(ClaimedOwnerIsOnlyRestoredTimerThatFires|CancelExactTerminalAllowsSubsequentReclaim|CompleteScheduleFireExactReleasesClaimForRecreatedOnceTimer)' -count=1`
- `go test ./internal/runtime -run 'Test(NewRuntime_SchedulerMarksSchedulesFiredThroughCanonicalTerminalHelper|Runtime_StartRestoresExactSchedulesDistinctByFlowInstance)' -count=1`
- `go test ./internal/runtime/pipeline -run 'Test(PersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel|ExecuteNodeHandlerPlan_AccumulationTimeoutCancelsByExactHandle)' -count=1`
- `go test ./internal/store ./internal/runtime ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk
This closes the touched terminal transition seam, but registration-failure rollback still uses direct `ReleaseSchedule(...)` because that path is not a terminal timer lifecycle transition. Any future terminal timer path should bind through the same store-owned helpers rather than pairing mutation and release locally.

## Follow-Up
No follow-up issue is required from this change alone.
