### PR TITLE
[agent-a][issue #218] Replace startup probe text parsing with a typed runtime error contract

### DIFF
--- a/internal/runtime/mcp/errors.go
+++ b/internal/runtime/mcp/errors.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	runtimerterr "swarm/internal/runtime/rterrors"
 )
 
 const (
@@ -19,27 +22,53 @@ const (
 	ErrCodeStallDetected     = "mcp_stall_detected"
 )
 
-func RuntimeErrorCodeFromText(raw string) string {
-	meta := strings.TrimSpace(raw)
-	if meta == "" || !strings.HasPrefix(meta, "runtime_error") {
-		return ""
-	}
-	if idx := strings.Index(meta, ":"); idx >= 0 {
-		meta = strings.TrimSpace(meta[:idx])
-	}
-	for _, token := range strings.Fields(meta) {
-		if !strings.HasPrefix(token, "code=") {
-			continue
-		}
-		return strings.TrimSpace(strings.TrimPrefix(token, "code="))
-	}
-	return ""
+type RuntimeErrorPayload struct {
+	Code      string               `json:"code"`
+	Component string               `json:"component,omitempty"`
+	Operation string               `json:"operation,omitempty"`
+	Retryable bool                 `json:"retryable"`
+	Message   string               `json:"message,omitempty"`
+	Cause     *RuntimeErrorPayload `json:"cause,omitempty"`
 }
 
-func RuntimeErrorEnvelope(raw string) string {
-	code := RuntimeErrorCodeFromText(raw)
-	if strings.TrimSpace(code) == "" {
-		return strings.TrimSpace(raw)
+func RuntimeErrorPayloadFromError(err error) *RuntimeErrorPayload {
+	if err == nil {
+		return nil
 	}
-	return fmt.Sprintf("runtime_error code=%s", code)
+	runtimeErr, ok := runtimerterr.AsRuntimeError(err)
+	if !ok || runtimeErr == nil {
+		return nil
+	}
+	payload := &RuntimeErrorPayload{
+		Code:      strings.TrimSpace(runtimeErr.Code),
+		Component: strings.TrimSpace(runtimeErr.Component),
+		Operation: strings.TrimSpace(runtimeErr.Operation),
+		Retryable: runtimeErr.Retryable,
+		Message:   strings.TrimSpace(runtimeErr.Message),
+	}
+	if payload.Message == "" && runtimeErr.Cause != nil {
+		payload.Message = strings.TrimSpace(runtimeErr.Cause.Error())
+	}
+	if cause := RuntimeErrorPayloadFromError(runtimeErr.Cause); cause != nil {
+		payload.Cause = cause
+	}
+	return payload
+}
+
+func DecodeRuntimeErrorPayload(raw any) (*RuntimeErrorPayload, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("runtimeError payload is required")
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encode runtimeError payload: %w", err)
+	}
+	var payload RuntimeErrorPayload
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil, fmt.Errorf("decode runtimeError payload: %w", err)
+	}
+	if strings.TrimSpace(payload.Code) == "" {
+		return nil, fmt.Errorf("runtimeError.code is required")
+	}
+	return &payload, nil
 }

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -16,6 +16,7 @@ import (
 	"swarm/internal/runtime/core/toolidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	llm "swarm/internal/runtime/llm"
+	runtimerterr "swarm/internal/runtime/rterrors"
 )
 
 type GatewayHooks struct {
@@ -206,10 +207,8 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	case "tools/call":
 		if g.executor == nil {
-			WriteRPCResult(w, req.ID, map[string]any{
-				"content": []map[string]any{{"type": "text", "text": "tool executor unavailable"}},
-				"isError": true,
-			})
+			err := g.newRuntimeError(ErrCodeToolExecFailed, "mcp.tools.call.execute", false, nil, "tool executor unavailable")
+			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
 		toolName := strings.TrimSpace(asString(req.Params["name"]))
@@ -218,10 +217,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 			g.logMCP(r, "warn", "mcp.tools.call.invalid", err, map[string]any{
 				"method": "tools/call",
 			})
-			WriteRPCResult(w, req.ID, map[string]any{
-				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
-				"isError": true,
-			})
+			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
 		ctx, err := g.mcpExecutionContext(r, toolName)
@@ -230,10 +226,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 				"method":    "tools/call",
 				"tool_name": toolName,
 			})
-			WriteRPCResult(w, req.ID, map[string]any{
-				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
-				"isError": true,
-			})
+			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
 		r = r.WithContext(ctx)
@@ -244,10 +237,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 				"tool_name":    toolName,
 				"denial_layer": "gateway",
 			})
-			WriteRPCResult(w, req.ID, map[string]any{
-				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
-				"isError": true,
-			})
+			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
 		if toolIsKindInContext(ctx, toolName, toolcapabilities.KindEmit) {
@@ -278,10 +268,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 				"method":    "tools/call",
 				"tool_name": toolName,
 			})
-			WriteRPCResult(w, req.ID, map[string]any{
-				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
-				"isError": true,
-			})
+			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
 		g.logMCP(r, "debug", "mcp.tools.call.success", nil, map[string]any{
@@ -626,21 +613,22 @@ func (g *Gateway) formatError(err error) string {
 	return err.Error()
 }
 
+func (g *Gateway) writeToolCallErrorResult(w http.ResponseWriter, id any, err error) {
+	payload := map[string]any{
+		"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
+		"isError": true,
+	}
+	if runtimeErr := RuntimeErrorPayloadFromError(err); runtimeErr != nil {
+		payload["runtimeError"] = runtimeErr
+	}
+	WriteRPCResult(w, id, payload)
+}
+
 func (g *Gateway) newRuntimeError(code, operation string, retryable bool, cause error, format string, args ...any) error {
 	if g != nil && g.hooks.NewRuntimeError != nil {
 		return g.hooks.NewRuntimeError(code, operation, retryable, cause, format, args...)
 	}
-	message := strings.TrimSpace(fmt.Sprintf(format, args...))
-	if message == "" && cause != nil {
-		message = strings.TrimSpace(cause.Error())
-	}
-	if message == "" {
-		message = strings.TrimSpace(code)
-	}
-	if cause != nil {
-		return fmt.Errorf("%s: %w", message, cause)
-	}
-	return fmt.Errorf("%s", message)
+	return runtimerterr.WrapRuntimeError(code, "mcp-gateway", operation, retryable, cause, format, args...)
 }
 
 func asString(v any) string {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -16,6 +16,7 @@ import (
 	"swarm/internal/runtime/core/toolcapabilities"
 	"swarm/internal/runtime/core/toolidentity"
 	llm "swarm/internal/runtime/llm"
+	runtimerterr "swarm/internal/runtime/rterrors"
 )
 
 const testGatewayToken = "gateway-token"
@@ -31,6 +32,15 @@ func withContextToken(req *http.Request, token string) *http.Request {
 		req.Header.Set(contextTokenHeader, strings.TrimSpace(token))
 	}
 	return req
+}
+
+func mustRPCResponse(t *testing.T, rec *httptest.ResponseRecorder) RPCResponse {
+	t.Helper()
+	var resp RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return resp
 }
 
 func mustMCPToolsForRequest(t *testing.T, g *Gateway, req *http.Request) []ToolDef {
@@ -761,6 +771,62 @@ func TestGatewayHandleMCP_DoesNotLetCallerAllowlistGrantToolAccess(t *testing.T)
 	}
 	if denialLayer != "gateway" {
 		t.Fatalf("denial_layer = %q, want gateway", denialLayer)
+	}
+}
+
+func TestGatewayHandleMCP_ToolsCallIncludesStructuredRuntimeErrorPayload(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	g := NewGateway(testToolExecutor(func(_ context.Context, _ string, _ any) (any, error) {
+		return nil, runtimerterr.WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required")
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-runtime-error", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-runtime-error")
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	resp := mustRPCResponse(t, rec)
+	if resp.Error != nil {
+		t.Fatalf("rpc error = %#v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	if isError, _ := result["isError"].(bool); !isError {
+		t.Fatalf("isError = %#v, want true", result["isError"])
+	}
+	runtimeErr, err := DecodeRuntimeErrorPayload(result["runtimeError"])
+	if err != nil {
+		t.Fatalf("DecodeRuntimeErrorPayload: %v", err)
+	}
+	if runtimeErr.Code != ErrCodeToolExecFailed {
+		t.Fatalf("runtimeError.code = %q, want %q", runtimeErr.Code, ErrCodeToolExecFailed)
+	}
+	if runtimeErr.Cause == nil || runtimeErr.Cause.Code != "invalid_tool_input" {
+		t.Fatalf("runtimeError.cause = %#v, want invalid_tool_input", runtimeErr.Cause)
 	}
 }
 

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -30,14 +30,6 @@ func newMCPRuntimeError(code, operation string, retryable bool, cause error, for
 	return WrapRuntimeError(code, "mcp-gateway", operation, retryable, cause, format, args...)
 }
 
-func runtimeErrorCodeFromText(raw string) string {
-	return runtimemcp.RuntimeErrorCodeFromText(raw)
-}
-
-func runtimeErrorEnvelope(raw string) string {
-	return runtimemcp.RuntimeErrorEnvelope(raw)
-}
-
 func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
 	if emitRegistry == nil {
 		emitRegistry = runtimetools.NewEmitRegistry(nil, nil)

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -325,28 +325,31 @@ func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding 
 	if isError, _ := result["isError"].(bool); !isError {
 		return nil
 	}
-	message := strings.TrimSpace(startupMCPErrorText(result))
-	if message == "" {
-		return fmt.Errorf("tools/call returned error without content")
+	runtimeErr, err := runtimemcp.DecodeRuntimeErrorPayload(result["runtimeError"])
+	if err != nil {
+		return fmt.Errorf("tools/call returned invalid runtimeError payload: %w", err)
 	}
-	if startupProbeAllowsValidationError(message) {
+	if startupProbeAcceptsRuntimeValidation(runtimeErr) {
 		return nil
 	}
-	return fmt.Errorf(message)
+	message := strings.TrimSpace(startupMCPErrorText(result))
+	if message != "" {
+		return fmt.Errorf(message)
+	}
+	return fmt.Errorf("tools/call returned runtime error code=%s", strings.TrimSpace(runtimeErr.Code))
 }
 
-func startupProbeAllowsValidationError(message string) bool {
-	lowered := strings.ToLower(strings.TrimSpace(message))
-	switch {
-	case strings.Contains(lowered, "runtime tool input validation failed"):
-		return true
-	case strings.Contains(lowered, "invalid_tool_input"):
-		return true
-	case strings.Contains(lowered, "schema validation failed"):
-		return true
-	default:
+func startupProbeAcceptsRuntimeValidation(runtimeErr *runtimemcp.RuntimeErrorPayload) bool {
+	if runtimeErr == nil {
 		return false
 	}
+	if strings.TrimSpace(runtimeErr.Code) != runtimemcp.ErrCodeToolExecFailed {
+		return false
+	}
+	if runtimeErr.Cause == nil {
+		return false
+	}
+	return strings.TrimSpace(runtimeErr.Cause.Code) == "invalid_tool_input"
 }
 
 func startupMCPErrorText(result map[string]any) string {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -278,7 +278,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_ToleratesValidationStyleCallable
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 		execErrs: map[string]error{
-			"query_entities": errors.New("runtime tool input validation failed: schema validation failed: input.query is required"),
+			"query_entities": WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required"),
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
@@ -321,7 +321,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonVal
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 		execErrs: map[string]error{
-			"query_entities": errors.New("execution path must be enabled before use"),
+			"query_entities": errors.New("schema validation failed: execution path must be enabled before use"),
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")


### PR DESCRIPTION
Closes #218

Spec references:

- none; this issue is runtime safety / architecture hardening
- justification: no exact platform spec section governs startup probe implementation details or startup probe ownership. This PR hardens the runtime boundary without inventing new platform semantics.

## Human Summary

Managed-agent startup was still deciding whether the real `tools/call` seam was healthy by parsing free-form error text. This PR removes that text classification and makes startup trust one machine-readable `runtimeError` contract emitted by the MCP gateway.

## What Changed

- added a typed `runtimeError` payload for MCP `tools/call` error results
- made the gateway emit that payload for invalid request, context-denied, executor-unavailable, and execution-failure `tools/call` results
- made startup accept only one explicit validation-only proof shape:
  - outer `mcp_tool_execution_failed`
  - nested cause `invalid_tool_input`
- removed the startup string-matching branch that previously classified validation outcomes from free-form text
- added focused gateway/startup regressions for typed validation acceptance, explicit success, and fail-closed unexpected errors

## Why This Is Needed

- free-form error text is not a stable runtime contract
- startup should not infer semantic meaning from text in a fail-closed boundary
- the touched seam already had structured runtime errors internally; startup just was not consuming them directly

## Scope Boundaries

In scope:
- managed-agent Claude/MCP startup callable proof
- MCP `tools/call` error shaping directly required for startup to consume a typed outcome
- focused startup and gateway regressions for the touched seam

Not in scope:
- broad MCP redesign
- unrelated tool prompt/catalog cleanup
- general tool schema redesign
- unrelated gateway/operator surface work

## Tests Run

- `go test ./internal/runtime ./internal/runtime/llm ./internal/runtime/mcp -count=1`
- `go test ./... -count=1`

## Residual Risk

- startup still uses the safe empty-arguments probe strategy for the callable seam. This PR only changes how its outcome is classified: typed runtime error payloads now own that meaning instead of text parsing.

## Follow-Up

- none for this seam
