### PR TITLE
[agent-a][issue #270] Unify verify and boot contract validation

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -27,7 +27,6 @@ import (
 	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
 	"swarm/internal/runtime"
-	runtimeauthority "swarm/internal/runtime/authority"
 	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -38,7 +37,6 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
-	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
 )
@@ -142,13 +140,15 @@ func main() {
 		slog.Error("configure credentials", "error", err)
 		os.Exit(1)
 	}
-	bootReport := runtimebootverify.Run(ctx, source, runtimebootverify.Options{
-		Credentials:       credentialStore,
-		CheckMCPReachable: true,
-	})
-	if bootReport.HasErrors() {
-		for _, finding := range bootReport.Errors() {
-			slog.Error("swarm boot verification failed", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
+	validation, err := runtime.ValidateWorkflowContractSurface(ctx, source, runtime.DefaultWorkflowContractValidationOptions(credentialStore))
+	bootReport := validation.BootReport
+	if err != nil {
+		if bootReport.HasErrors() {
+			for _, finding := range bootReport.Errors() {
+				slog.Error("swarm boot verification failed", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
+			}
+		} else {
+			slog.Error("workflow contract validation failed", "error", err)
 		}
 		os.Exit(1)
 	}
@@ -785,42 +785,12 @@ func verifyBundle(ctx context.Context, source semanticview.Source) error {
 	if source == nil {
 		return errors.New("semantic source is required")
 	}
-	if bundle, ok := semanticview.Bundle(source); ok {
-		if err := runtimecontracts.ValidatePromptSchemaGuardsForBundle(bundle); err != nil {
-			return fmt.Errorf("validate prompt schema guards: %w", err)
-		}
-	}
 	credentialStore, err := buildCredentialStore()
 	if err != nil {
 		return fmt.Errorf("configure credentials: %w", err)
 	}
-	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{
-		Credentials:       credentialStore,
-		CheckMCPReachable: true,
-	})
-	if report.HasErrors() {
-		lines := make([]string, 0, len(report.Errors()))
-		for _, finding := range report.Errors() {
-			lines = append(lines, fmt.Sprintf("%s [%s] %s", strings.TrimSpace(finding.CheckID), strings.TrimSpace(finding.Location), strings.TrimSpace(finding.Message)))
-		}
-		return fmt.Errorf("boot verification failed:\n%s", strings.Join(lines, "\n"))
-	}
-	return verifyEmitSchemaCoverage(source)
-}
-
-func verifyEmitSchemaCoverage(source semanticview.Source) error {
-	if source == nil {
-		return errors.New("semantic source is required")
-	}
-	registry := runtimetools.NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
-	if generated := registry.GeneratedEmitSchemasForAgentRoles(); len(generated) > 0 && envBool("SWARM_EMIT_SCHEMA_STRICT", true) {
-		sample := generated
-		if len(sample) > 10 {
-			sample = sample[:10]
-		}
-		return fmt.Errorf("emit schema strict mode enabled: %d agent-emitted schemas are missing explicit EventSchemaRegistry entries (sample: %s)", len(generated), strings.Join(sample, ", "))
-	}
-	return nil
+	_, err = runtime.ValidateWorkflowContractSurface(ctx, source, runtime.DefaultWorkflowContractValidationOptions(credentialStore))
+	return err
 }
 
 func loadRuntimeConfig(path string) (*config.Config, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -333,33 +333,71 @@ func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
 	}
 }
 
-func TestVerifyEmitSchemaCoverage_RejectsStrictMissingEmitSchemas(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"agent-1": {
-				ID:         "agent-1",
-				EmitEvents: []string{"missing.event"},
-			},
-		},
-	})
-	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
-	err := verifyEmitSchemaCoverage(source)
-	if err == nil || !strings.Contains(err.Error(), "emit schema strict mode enabled") {
-		t.Fatalf("verifyEmitSchemaCoverage error = %v, want strict emit schema error", err)
-	}
+func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
+	bundle := &runtimecontracts.WorkflowContractBundle{}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	return bundle
 }
 
-func TestVerifyEmitSchemaCoverage_AllowsMissingWhenStrictDisabled(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"agent-1": {
-				ID:         "agent-1",
-				EmitEvents: []string{"missing.event"},
-			},
+func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	cases := []struct {
+		name        string
+		bundle      *runtimecontracts.WorkflowContractBundle
+		errContains string
+		wantErr     bool
+	}{
+		{
+			name: "missing tool reference",
+			bundle: func() *runtimecontracts.WorkflowContractBundle {
+				bundle := testWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", Tools: []string{"missing_tool"}},
+				}
+				return bundle
+			}(),
+			wantErr: false,
 		},
-	})
-	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "false")
-	if err := verifyEmitSchemaCoverage(source); err != nil {
-		t.Fatalf("verifyEmitSchemaCoverage: %v", err)
+		{
+			name: "missing emit schema",
+			bundle: func() *runtimecontracts.WorkflowContractBundle {
+				bundle := testWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
+				}
+				return bundle
+			}(),
+			errContains: "emit schema strict mode enabled",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := semanticview.Wrap(tc.bundle)
+			verifyErr := verifyBundle(context.Background(), source)
+			if tc.wantErr {
+				if verifyErr == nil || !strings.Contains(verifyErr.Error(), tc.errContains) {
+					t.Fatalf("verifyBundle error = %v, want substring %q", verifyErr, tc.errContains)
+				}
+			} else if verifyErr != nil {
+				t.Fatalf("verifyBundle error = %v, want nil", verifyErr)
+			}
+
+			result, runtimeErr := runtimepkg.ValidateWorkflowContractSurface(context.Background(), source, runtimepkg.DefaultWorkflowContractValidationOptions(nil))
+			if tc.wantErr {
+				if runtimeErr == nil || !strings.Contains(runtimeErr.Error(), tc.errContains) {
+					t.Fatalf("ValidateWorkflowContractSurface error = %v, want substring %q", runtimeErr, tc.errContains)
+				}
+				return
+			}
+			if runtimeErr != nil {
+				t.Fatalf("ValidateWorkflowContractSurface error = %v, want nil", runtimeErr)
+			}
+			if warnings := result.BootReport.Warnings(); len(warnings) == 0 || !strings.Contains(warnings[0].Message, "missing tool missing_tool") {
+				t.Fatalf("BootReport warnings = %#v, want tool_resolution warning", warnings)
+			}
+		})
 	}
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -342,6 +342,7 @@ func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
 
 func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t *testing.T) {
 	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 	cases := []struct {
 		name        string
 		bundle      *runtimecontracts.WorkflowContractBundle
@@ -358,6 +359,20 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				return bundle
 			}(),
 			wantErr: false,
+		},
+		{
+			name: "tool implementation warning",
+			bundle: func() *runtimecontracts.WorkflowContractBundle {
+				bundle := testWorkflowValidationBundle()
+				bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+					"legacy_call": {
+						HandlerType: "api_call",
+					},
+				}
+				return bundle
+			}(),
+			errContains: "tool implementation warnings",
+			wantErr:     true,
 		},
 		{
 			name: "missing emit schema",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -173,27 +173,47 @@ func ensureWorkflowBootWiring(opts RuntimeOptions) error {
 			return fmt.Errorf("workspace validation failed: %w", err)
 		}
 	}
-	report := runtimebootverify.Run(context.Background(), opts.WorkflowModule.SemanticSource(), runtimebootverify.Options{
-		Credentials:       opts.Credentials,
-		CheckMCPReachable: true,
-	})
-	if !report.HasErrors() && !(bootWarningsFatal() && len(report.Warnings()) > 0) {
+	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(opts.Credentials))
+	if err != nil {
+		return err
+	}
+	if !bootWarningsFatal() {
 		return nil
 	}
-	lines := make([]string, 0, len(report.Errors())+len(report.Warnings()))
-	for _, finding := range report.Errors() {
-		lines = append(lines, strings.TrimSpace(finding.Message))
+	warnings := bootWarningsExcludingCheckIDs(result.BootReport.Warnings(), "tool_resolution")
+	if len(warnings) == 0 {
+		return nil
 	}
-	if bootWarningsFatal() {
-		for _, finding := range report.Warnings() {
-			lines = append(lines, strings.TrimSpace(finding.Message))
-		}
+	lines := make([]string, 0, len(warnings))
+	for _, finding := range warnings {
+		lines = append(lines, strings.TrimSpace(finding.Message))
 	}
 	return fmt.Errorf(strings.Join(lines, "\n"))
 }
 
 func bootWarningsFatal() bool {
 	return runtimeEnvBool("SWARM_BOOT_WARNINGS_FATAL", true)
+}
+
+func bootWarningsExcludingCheckIDs(findings []runtimebootverify.Finding, checkIDs ...string) []runtimebootverify.Finding {
+	if len(findings) == 0 {
+		return nil
+	}
+	skip := make(map[string]struct{}, len(checkIDs))
+	for _, checkID := range checkIDs {
+		checkID = strings.TrimSpace(checkID)
+		if checkID != "" {
+			skip[checkID] = struct{}{}
+		}
+	}
+	out := make([]runtimebootverify.Finding, 0, len(findings))
+	for _, finding := range findings {
+		if _, excluded := skip[strings.TrimSpace(finding.CheckID)]; excluded {
+			continue
+		}
+		out = append(out, finding)
+	}
+	return out
 }
 
 func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.PromptResolver, error) {
@@ -225,22 +245,6 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	authorityProvider := runtimeauthority.NewSourceProvider(source)
 	emitRegistry := runtimetools.NewEmitRegistry(source, authorityProvider)
-	if warnings, err := runtimetools.ValidateToolImplementations(source); err != nil {
-		return nil, fmt.Errorf("tool implementation validation failed: %w", err)
-	} else {
-		if bootWarningsFatal() && len(warnings) > 0 {
-			parts := make([]string, 0, len(warnings))
-			for _, warning := range warnings {
-				parts = append(parts, strings.TrimSpace(warning.Error()))
-			}
-			sort.Strings(parts)
-			return nil, fmt.Errorf("tool implementation validation warnings are fatal: %s", strings.Join(parts, "; "))
-		}
-		for _, warning := range warnings {
-			slog.Warn("tool implementation validation warning", "warning", warning.Error())
-		}
-	}
-
 	rt := &Runtime{
 		ownerID:        newRuntimeOwnerID(),
 		Config:         cfg,
@@ -415,20 +419,6 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			slog.Warn("credential requirement warning", "key", item.Key, "required_by", strings.Join(requiredBy, ", "))
 		}
 	}
-	if generated := rt.EmitRegistry.GeneratedEmitSchemasForAgentRoles(); len(generated) > 0 {
-		if runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true) {
-			return nil, fmt.Errorf("emit schema strict mode enabled: %d agent-emitted schemas are missing explicit EventSchemaRegistry entries", len(generated))
-		}
-		sample := generated
-		if len(sample) > 10 {
-			sample = sample[:10]
-		}
-		slog.Warn("emit schema hardening: agent-emitted event schemas missing explicit definitions",
-			"count", len(generated),
-			"sample", strings.Join(sample, ", "),
-		)
-	}
-
 	factory := runtimeagents.NewLLMAgentFactory(rt.LLM, rt.ToolExecutor, rt.ToolExecutor.ToolDefinitions(), runtimeagents.LLMAgentOptions{
 		PromptResolver:    rt.PromptResolver,
 		AuthorityProvider: rt.Authority,

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -14,9 +14,10 @@ import (
 )
 
 type WorkflowContractValidationOptions struct {
-	Credentials       runtimecredentials.Store
-	CheckMCPReachable bool
-	StrictEmitSchemas bool
+	Credentials                    runtimecredentials.Store
+	CheckMCPReachable              bool
+	StrictEmitSchemas              bool
+	FatalToolImplementationWarning bool
 }
 
 type WorkflowContractValidationResult struct {
@@ -27,9 +28,10 @@ type WorkflowContractValidationResult struct {
 
 func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Store) WorkflowContractValidationOptions {
 	return WorkflowContractValidationOptions{
-		Credentials:       credentials,
-		CheckMCPReachable: true,
-		StrictEmitSchemas: runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true),
+		Credentials:                    credentials,
+		CheckMCPReachable:              true,
+		StrictEmitSchemas:              runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true),
+		FatalToolImplementationWarning: bootWarningsFatal(),
 	}
 }
 
@@ -59,6 +61,9 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	if err != nil {
 		return result, fmt.Errorf("tool implementation validation failed: %w", err)
 	}
+	if opts.FatalToolImplementationWarning && len(warnings) > 0 {
+		return result, fmt.Errorf("tool implementation warnings:\n%s", formatValidationErrors(warnings))
+	}
 
 	emitRegistry := runtimetools.NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
 	result.MissingEmitSchemaEventTypes = emitRegistry.GeneratedEmitSchemasForAgentRoles()
@@ -77,6 +82,17 @@ func formatWorkflowValidationFindings(findings []runtimebootverify.Finding) stri
 	lines := make([]string, 0, len(findings))
 	for _, finding := range findings {
 		lines = append(lines, fmt.Sprintf("%s [%s] %s", strings.TrimSpace(finding.CheckID), strings.TrimSpace(finding.Location), strings.TrimSpace(finding.Message)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatValidationErrors(errs []error) string {
+	lines := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		lines = append(lines, strings.TrimSpace(err.Error()))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -1,0 +1,82 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	runtimeauthority "swarm/internal/runtime/authority"
+	runtimebootverify "swarm/internal/runtime/bootverify"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecredentials "swarm/internal/runtime/credentials"
+	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+type WorkflowContractValidationOptions struct {
+	Credentials       runtimecredentials.Store
+	CheckMCPReachable bool
+	StrictEmitSchemas bool
+}
+
+type WorkflowContractValidationResult struct {
+	BootReport                  runtimebootverify.Report
+	ToolImplementationWarnings  []error
+	MissingEmitSchemaEventTypes []string
+}
+
+func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Store) WorkflowContractValidationOptions {
+	return WorkflowContractValidationOptions{
+		Credentials:       credentials,
+		CheckMCPReachable: true,
+		StrictEmitSchemas: runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true),
+	}
+}
+
+// ValidateWorkflowContractSurface is the canonical verify/boot contract-validation entrypoint
+// for prompt guards, bootverify errors, tool implementation validation, and explicit emit-schema coverage.
+func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.Source, opts WorkflowContractValidationOptions) (WorkflowContractValidationResult, error) {
+	result := WorkflowContractValidationResult{}
+	if source == nil {
+		return result, fmt.Errorf("semantic source is required")
+	}
+	if bundle, ok := semanticview.Bundle(source); ok {
+		if err := runtimecontracts.ValidatePromptSchemaGuardsForBundle(bundle); err != nil {
+			return result, fmt.Errorf("validate prompt schema guards: %w", err)
+		}
+	}
+
+	result.BootReport = runtimebootverify.Run(ctx, source, runtimebootverify.Options{
+		Credentials:       opts.Credentials,
+		CheckMCPReachable: opts.CheckMCPReachable,
+	})
+	if result.BootReport.HasErrors() {
+		return result, fmt.Errorf("boot verification failed:\n%s", formatWorkflowValidationFindings(result.BootReport.Errors()))
+	}
+
+	warnings, err := runtimetools.ValidateToolImplementations(source)
+	result.ToolImplementationWarnings = warnings
+	if err != nil {
+		return result, fmt.Errorf("tool implementation validation failed: %w", err)
+	}
+
+	emitRegistry := runtimetools.NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+	result.MissingEmitSchemaEventTypes = emitRegistry.GeneratedEmitSchemasForAgentRoles()
+	if opts.StrictEmitSchemas && len(result.MissingEmitSchemaEventTypes) > 0 {
+		sample := result.MissingEmitSchemaEventTypes
+		if len(sample) > 10 {
+			sample = sample[:10]
+		}
+		return result, fmt.Errorf("emit schema strict mode enabled: %d agent-emitted schemas are missing explicit EventSchemaRegistry entries (sample: %s)", len(result.MissingEmitSchemaEventTypes), strings.Join(sample, ", "))
+	}
+
+	return result, nil
+}
+
+func formatWorkflowValidationFindings(findings []runtimebootverify.Finding) string {
+	lines := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		lines = append(lines, fmt.Sprintf("%s [%s] %s", strings.TrimSpace(finding.CheckID), strings.TrimSpace(finding.Location), strings.TrimSpace(finding.Message)))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -1,0 +1,93 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func testRuntimeWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
+	bundle := &runtimecontracts.WorkflowContractBundle{}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	return bundle
+}
+
+func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	cases := []struct {
+		name        string
+		source      semanticview.Source
+		errContains string
+		wantErr     bool
+	}{
+		{
+			name: "tool resolution warning",
+			source: func() semanticview.Source {
+				bundle := testRuntimeWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", Tools: []string{"missing_tool"}},
+				}
+				return semanticview.Wrap(bundle)
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "missing emit schema",
+			source: func() semanticview.Source {
+				bundle := testRuntimeWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
+				}
+				return semanticview.Wrap(bundle)
+			}(),
+			errContains: "emit schema strict mode enabled",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ensureWorkflowBootWiring(RuntimeOptions{
+				WorkflowModule: semanticOnlyWorkflowRuntime{source: tc.source},
+			})
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("ensureWorkflowBootWiring error = %v, want substring %q", err, tc.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("ensureWorkflowBootWiring error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+		"agent-1": {ID: "agent-1", EmitEvents: []string{"ready.event"}},
+	}
+	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
+		"ready.event": {
+			Payload: runtimecontracts.EventPayloadSpec{
+				Properties: map[string]runtimecontracts.EventFieldSpec{
+					"id": {Type: "string"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+
+	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
+	if err != nil {
+		t.Fatalf("ValidateWorkflowContractSurface: %v", err)
+	}
+	if len(result.MissingEmitSchemaEventTypes) != 0 {
+		t.Fatalf("MissingEmitSchemaEventTypes = %#v, want none", result.MissingEmitSchemaEventTypes)
+	}
+}

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -37,6 +37,20 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 			wantErr: false,
 		},
 		{
+			name: "tool implementation warning",
+			source: func() semanticview.Source {
+				bundle := testRuntimeWorkflowValidationBundle()
+				bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+					"legacy_call": {
+						HandlerType: "api_call",
+					},
+				}
+				return semanticview.Wrap(bundle)
+			}(),
+			errContains: "tool implementation warnings",
+			wantErr:     true,
+		},
+		{
 			name: "missing emit schema",
 			source: func() semanticview.Source {
 				bundle := testRuntimeWorkflowValidationBundle()
@@ -89,5 +103,21 @@ func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T
 	}
 	if len(result.MissingEmitSchemaEventTypes) != 0 {
 		t.Fatalf("MissingEmitSchemaEventTypes = %#v, want none", result.MissingEmitSchemaEventTypes)
+	}
+}
+
+func TestValidateWorkflowContractSurface_FatalToolImplementationWarningsFollowSharedOptions(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"legacy_call": {
+			HandlerType: "api_call",
+		},
+	}
+	source := semanticview.Wrap(bundle)
+
+	_, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
+	if err == nil || !strings.Contains(err.Error(), "tool implementation warnings") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want tool implementation warning failure", err)
 	}
 }


### PR DESCRIPTION
Closes #270

Spec references:

- docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: contract_formats.event_schema
- docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.platform_builtin_tools
- docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.agent_tool_filtering
- docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_verification
- governing rule: contract validation, event-schema coverage, and tool availability must be derived from one canonical platform model; the runtime must not accept a contract set in targeted verification and then reject it during boot for the same semantic class.

## Human Summary

Targeted `verify` and runtime boot were assembling different validation subsets for the same contract/tool/event seam. This PR gives both surfaces one shared validation entrypoint so tool-registry and explicit emit-schema checks agree instead of drifting between `verify` and boot.

## What Changed

- added `runtime.ValidateWorkflowContractSurface(...)` as the canonical validation entrypoint for the touched seam
- moved prompt-guard validation, bootverify error handling, tool implementation validation, and explicit emit-schema strict checks into that shared path
- made `cmd/swarm verify` consume the shared validator instead of hand-assembling its own subset
- made runtime boot wiring consume the same shared validator instead of re-running a narrower/different subset later in startup
- preserved spec-defined warning semantics for unresolved tool references/tool implementations while still centralizing the validation owner
- added parity tests proving:
  - missing tool references remain warnings and do not cause verify-vs-boot drift
  - missing explicit emit schemas fail both surfaces consistently
  - runtime boot is actually wired through the shared path

## Why This Is Needed

- the old split let `verify` report success while runtime boot later failed on the same authored contract set
- the issue was symptom-shaped: tool validation drift was directly reproduced, and event-schema strictness was duplicated in the same local seam
- centralizing the owner removes the hand-assembled subset problem and gives the repo a concrete regression guard against reintroducing it

## Scope Boundaries

In scope:
- targeted `verify` vs runtime boot contract/tool/event validation parity
- shared validation ownership for the touched seam
- focused parity/agreement regressions

Not in scope:
- broad boot redesign
- unrelated runtime startup validation
- product-specific allowances
- changing platform spec semantics

## Tests Run

- `go test ./cmd/swarm ./internal/runtime ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`

## Residual Risk

- event-schema drift was the same local class and is included here because it was already duplicated between `verify` and boot in the touched seam
- boot-only warning fatality still exists for other non-touched boot checks; this PR only removes drift for the tool/event validation class covered by `#270`

## Follow-Up

- none for this seam
