### PR TITLE
[agent-c][issue #202] Narrow live session runtime state ownership

### DIFF
--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -144,6 +144,41 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			rec.Error,
 		}
 	}
+	if !runtimeMode.IsStateless() {
+		updateQ = `
+			UPDATE agent_sessions
+			SET updated_at = now()
+			WHERE agent_id = $1
+			  AND runtime_mode = $2
+			  AND session_id = $3::uuid
+			  AND status = 'active'
+		`
+		updateArgs = []any{
+			rec.AgentID,
+			runtimeMode,
+			rec.SessionID,
+		}
+		if hasConversationRunID {
+			if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+				return err
+			}
+			updateQ = `
+				UPDATE agent_sessions
+				SET run_id = COALESCE(NULLIF($4,'')::uuid, run_id),
+				    updated_at = now()
+				WHERE agent_id = $1
+				  AND runtime_mode = $2
+				  AND session_id = $3::uuid
+				  AND status = 'active'
+			`
+			updateArgs = []any{
+				rec.AgentID,
+				runtimeMode,
+				rec.SessionID,
+				nullUUIDString(runID),
+			}
+		}
+	}
 	res, err := tx.ExecContext(ctx, updateQ,
 		updateArgs...,
 	)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2646,7 +2646,7 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 	}
 }
 
-func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRow(t *testing.T) {
+func TestManagerStore_AppendAgentTurn_LeavesLiveSessionRuntimeStateForLiveOwnershipAndPersistsTurnRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -2687,8 +2687,8 @@ func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRo
 	`, sessionID).Scan(&parseOK); err != nil {
 		t.Fatalf("load session runtime_state: %v", err)
 	}
-	if !parseOK {
-		t.Fatal("expected session last_turn telemetry to be persisted")
+	if parseOK {
+		t.Fatal("did not expect live session row to persist last_turn telemetry")
 	}
 
 	var turnCount int
@@ -2701,6 +2701,54 @@ func TestManagerStore_AppendAgentTurn_AtomicallyPersistsSessionLastTurnAndTurnRo
 	}
 	if turnCount != 1 {
 		t.Fatalf("expected one session-mode agent_turn row, got %d", turnCount)
+	}
+}
+
+func TestManagerStore_AppendAgentTurn_PreservesLiveSessionRetryLineageRuntimeState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = jsonb_build_object(
+			'provider_session_id', 'provider-1',
+			'retry_reason', 'session not found',
+			'retries_from_session_id', 'session-old'
+		)
+		WHERE session_id = $1::uuid
+	`, sessionID); err != nil {
+		t.Fatalf("seed live runtime_state: %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "session",
+		SessionID:      sessionID,
+		RequestPayload: []byte(`{"kind":"session"}`),
+		ResponseRaw:    []byte(`{"result":"done"}`),
+		ParseOK:        true,
+		Latency:        10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn: %v", err)
+	}
+
+	var providerID, retryReason, retriesFrom string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(runtime_state->>'provider_session_id', ''),
+			COALESCE(runtime_state->>'retry_reason', ''),
+			COALESCE(runtime_state->>'retries_from_session_id', '')
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&providerID, &retryReason, &retriesFrom); err != nil {
+		t.Fatalf("load live runtime_state lineage: %v", err)
+	}
+	if providerID != "provider-1" || retryReason != "session not found" || retriesFrom != "session-old" {
+		t.Fatalf("unexpected live runtime_state after append: provider=%q reason=%q from=%q", providerID, retryReason, retriesFrom)
 	}
 }
 


### PR DESCRIPTION
Closes #202

## Human Summary
This PR narrows the first live-session ownership slice in `agent_sessions`. Live session rows keep canonical continuation state, but they no longer back-project per-turn `last_turn` audit telemetry into `runtime_state` on every append.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_conversation_audits`

## What Changed
- removed `runtime_state.last_turn` writes from the live `agent_sessions` append path
- kept task-mode `agent_conversation_audits` as the canonical owner for `last_turn` audit telemetry in the touched seam
- preserved live-session runtime-state fields actually used for continuation, including provider session id and retry lineage
- added focused regressions proving live session append no longer mutates `last_turn`, while task-mode audit append still does

## Why This Is Needed
The spec distinguishes live reusable sessions from task-mode audit snapshots. `agent_sessions` should answer what is active now, not also serve as the first per-turn audit surface. Persisting `last_turn` into live session rows mixed audit/history semantics back into the live owner and made the seam less canonical.

## Scope Boundaries
- narrows only the first covered live-session ownership slice in `agent_sessions`
- does not redesign broader conversation/session persistence or remove live `conversation`, `turn_count`, or summary state from this table
- does not change dashboard/read-model behavior outside what naturally follows from the live-session owner no longer carrying `last_turn`

## Tests Run
- `go test ./internal/store ./internal/runtime/llm ./internal/runtime/sessions -count=1`
- `go test ./... -count=1`

## Residual Risk
Other audit-leaning fields still remain on the live session row in this broader seam. This PR only removes the first clear per-turn audit back-projection.

## Follow-Up
If we continue this ownership cleanup, the next slice should evaluate whether live-session summary data should remain in `agent_sessions` or move to a clearer non-live projection owner.
