### PR TITLE
[agent-d][issue #229] Unify retry-state ownership across agent receipt paths

### DIFF
--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -70,6 +70,9 @@ func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID s
 	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
 		return nil, err
 	}
+	if err := s.normalizeLegacyAgentRetryOwners(ctx, agentID, since); err != nil {
+		return nil, err
+	}
 	return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
 }
 
@@ -94,6 +97,9 @@ func (s *PostgresStore) ListPendingSubscribedEvents(
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
 	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+		return nil, err
+	}
+	if err := s.normalizeLegacyAgentRetryOwners(ctx, agentID, since); err != nil {
 		return nil, err
 	}
 	return s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit)
@@ -132,6 +138,15 @@ type lockedAgentDelivery struct {
 	entityID        string
 	flowInstance    string
 	found           bool
+}
+
+type lockedAgentReceiptState struct {
+	status      runtimemanager.ReceiptStatus
+	retryCount  int
+	reasonCode  string
+	errorText   string
+	processedAt time.Time
+	found       bool
 }
 
 type deliveryBackedTerminalTransitionRequest struct {
@@ -291,6 +306,10 @@ func (s *PostgresStore) ensureAgentDeliveryRetryOwnerTx(
 	tx *sql.Tx,
 	eventID, agentID string,
 ) (lockedAgentDelivery, error) {
+	receipt, err := s.lockAgentReceiptStateTx(ctx, tx, eventID, agentID)
+	if err != nil {
+		return lockedAgentDelivery{}, err
+	}
 	if err := s.insertEventDeliveriesSpec(ctx, caps, tx, eventID, []string{agentID}); err != nil {
 		return lockedAgentDelivery{}, err
 	}
@@ -301,7 +320,177 @@ func (s *PostgresStore) ensureAgentDeliveryRetryOwnerTx(
 	if !delivery.found {
 		return lockedAgentDelivery{}, fmt.Errorf("ensure agent delivery retry owner: event %s not found", strings.TrimSpace(eventID))
 	}
+	if err := s.backfillLegacyAgentDeliveryFromReceiptTx(ctx, tx, eventID, agentID, &delivery, receipt); err != nil {
+		return lockedAgentDelivery{}, err
+	}
 	return delivery, nil
+}
+
+func (s *PostgresStore) lockAgentReceiptStateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+) (lockedAgentReceiptState, error) {
+	var (
+		sideEffects []byte
+		receipt     lockedAgentReceiptState
+	)
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(side_effects, '{}'::jsonb),
+			COALESCE(reason_code, ''),
+			processed_at
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+		FOR UPDATE
+	`, eventID, agentID).Scan(&sideEffects, &receipt.reasonCode, &receipt.processedAt)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return lockedAgentReceiptState{}, nil
+	case err != nil:
+		return lockedAgentReceiptState{}, fmt.Errorf("lock event receipt row: %w", err)
+	}
+	payload, err := decodeAgentReceiptSideEffects(sideEffects)
+	if err != nil {
+		return lockedAgentReceiptState{}, fmt.Errorf("decode event receipt side effects: %w", err)
+	}
+	receipt.status = payload.ManagerStatus
+	receipt.retryCount = payload.RetryCount
+	receipt.errorText = payload.Error
+	if strings.TrimSpace(payload.ReasonCode) != "" {
+		receipt.reasonCode = payload.ReasonCode
+	}
+	if strings.TrimSpace(receipt.reasonCode) == "" {
+		receipt.reasonCode = managerReceiptReasonCode(receipt.status, receipt.errorText)
+	}
+	receipt.found = true
+	return receipt, nil
+}
+
+func legacyAgentDeliveryCode(status runtimemanager.ReceiptStatus) string {
+	switch status {
+	case runtimemanager.ReceiptStatusProcessed:
+		return "delivered"
+	case runtimemanager.ReceiptStatusError:
+		return "failed"
+	case runtimemanager.ReceiptStatusDeadLetter:
+		return "dead_letter"
+	default:
+		return ""
+	}
+}
+
+func (s *PostgresStore) backfillLegacyAgentDeliveryFromReceiptTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	delivery *lockedAgentDelivery,
+	receipt lockedAgentReceiptState,
+) error {
+	if delivery == nil || !delivery.found || !receipt.found {
+		return nil
+	}
+	deliveryCode := legacyAgentDeliveryCode(receipt.status)
+	if deliveryCode == "" {
+		return fmt.Errorf("backfill legacy agent delivery: invalid receipt status %q", receipt.status)
+	}
+	needsBackfill := delivery.retryCount < receipt.retryCount
+	if !needsBackfill && delivery.retryCount == receipt.retryCount {
+		switch strings.TrimSpace(delivery.status) {
+		case "", "pending", "in_progress":
+			needsBackfill = true
+		}
+	}
+	if !needsBackfill {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = $3,
+			retry_count = $4,
+			reason_code = NULLIF($5, ''),
+			last_error = NULLIF($6, ''),
+			active_session_id = NULL,
+			delivered_at = $7
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID, deliveryCode, receipt.retryCount, receipt.reasonCode, receipt.errorText, receipt.processedAt); err != nil {
+		return fmt.Errorf("backfill legacy agent delivery: %w", err)
+	}
+	delivery.retryCount = receipt.retryCount
+	delivery.status = deliveryCode
+	delivery.activeSessionID = ""
+	return nil
+}
+
+func (s *PostgresStore) normalizeLegacyAgentRetryOwners(ctx context.Context, agentID string, since time.Time) error {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT r.event_id::text
+		FROM event_receipts r
+		INNER JOIN events e ON e.event_id = r.event_id
+		LEFT JOIN event_deliveries d
+			ON d.event_id = r.event_id
+			AND d.subscriber_type = 'agent'
+			AND d.subscriber_id = r.subscriber_id
+		WHERE r.subscriber_type = 'agent'
+		  AND r.subscriber_id = $1
+		  AND e.created_at >= $2
+		  AND d.delivery_id IS NULL
+	`, agentID, since)
+	if err != nil {
+		return fmt.Errorf("query legacy agent retry owners: %w", err)
+	}
+	defer rows.Close()
+
+	var eventIDs []string
+	for rows.Next() {
+		var eventID string
+		if err := rows.Scan(&eventID); err != nil {
+			return fmt.Errorf("scan legacy agent retry owner event: %w", err)
+		}
+		eventIDs = append(eventIDs, strings.TrimSpace(eventID))
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate legacy agent retry owners: %w", err)
+	}
+	if len(eventIDs) == 0 {
+		return nil
+	}
+
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	for _, eventID := range eventIDs {
+		if err := withEventStoreRetry(ctx, nil, func() error {
+			tx, err := s.DB.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("begin legacy agent retry owner tx: %w", err)
+			}
+			defer func() { _ = tx.Rollback() }()
+
+			delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
+			if err != nil {
+				return err
+			}
+			if !delivery.found {
+				if _, err := s.ensureAgentDeliveryRetryOwnerTx(ctx, caps, tx, eventID, agentID); err != nil {
+					return err
+				}
+			}
+			if err := tx.Commit(); err != nil {
+				return fmt.Errorf("commit legacy agent retry owner tx: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *PostgresStore) updateAgentDeliveryRowTx(

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -122,7 +122,6 @@ type agentReceiptWriteState struct {
 	retryCount   int
 	reasonCode   string
 	errorText    string
-	hasDelivery  bool
 	deliveryCode string
 }
 
@@ -142,6 +141,10 @@ type deliveryBackedTerminalTransitionRequest struct {
 }
 
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
@@ -153,30 +156,25 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 		if err != nil {
 			return err
 		}
-		if delivery.found {
-			state := buildAgentReceiptWriteState(delivery.retryCount, true, status, errText)
-			if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
-				if _, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, eventID, agentID, delivery, deliveryBackedTerminalTransitionRequest{
-					reasonCode:   state.reasonCode,
-					errorText:    state.errorText,
-					retryAdvance: state.retryCount - delivery.retryCount,
-				}); err != nil {
-					return err
-				}
-			} else {
-				if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
-					return err
-				}
-				if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
-					return err
-				}
-			}
-		} else {
-			retryCount, err := s.lockAgentReceiptRetryCountTx(ctx, tx, eventID, agentID)
+		if !delivery.found {
+			delivery, err = s.ensureAgentDeliveryRetryOwnerTx(ctx, caps, tx, eventID, agentID)
 			if err != nil {
 				return err
 			}
-			state := buildAgentReceiptWriteState(retryCount, false, status, errText)
+		}
+		state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
+		if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
+			if _, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, eventID, agentID, delivery, deliveryBackedTerminalTransitionRequest{
+				reasonCode:   state.reasonCode,
+				errorText:    state.errorText,
+				retryAdvance: state.retryCount - delivery.retryCount,
+			}); err != nil {
+				return err
+			}
+		} else {
+			if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
+				return err
+			}
 			if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
 				return err
 			}
@@ -188,16 +186,10 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 	})
 }
 
-func buildAgentReceiptWriteState(
-	baseRetryCount int,
-	hasDelivery bool,
-	status runtimemanager.ReceiptStatus,
-	errText string,
-) agentReceiptWriteState {
+func buildAgentReceiptWriteState(baseRetryCount int, status runtimemanager.ReceiptStatus, errText string) agentReceiptWriteState {
 	state := agentReceiptWriteState{
 		finalStatus: status,
 		errorText:   strings.TrimSpace(errText),
-		hasDelivery: hasDelivery,
 	}
 	retryCount := baseRetryCount
 	if status == runtimemanager.ReceiptStatusError {
@@ -276,7 +268,6 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 		retryCount:   delivery.retryCount + req.retryAdvance,
 		reasonCode:   reasonCode,
 		errorText:    strings.TrimSpace(req.errorText),
-		hasDelivery:  true,
 		deliveryCode: "dead_letter",
 	}
 	if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
@@ -294,27 +285,23 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 	}, nil
 }
 
-func (s *PostgresStore) lockAgentReceiptRetryCountTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (int, error) {
-	var sideEffectsRaw []byte
-	err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(side_effects, '{}'::jsonb)
-		FROM event_receipts
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-		FOR UPDATE
-	`, eventID, agentID).Scan(&sideEffectsRaw)
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		return 0, nil
-	case err != nil:
-		return 0, fmt.Errorf("load event receipt side effects: %w", err)
+func (s *PostgresStore) ensureAgentDeliveryRetryOwnerTx(
+	ctx context.Context,
+	caps StoreSchemaCapabilities,
+	tx *sql.Tx,
+	eventID, agentID string,
+) (lockedAgentDelivery, error) {
+	if err := s.insertEventDeliveriesSpec(ctx, caps, tx, eventID, []string{agentID}); err != nil {
+		return lockedAgentDelivery{}, err
 	}
-	payload, err := decodeAgentReceiptSideEffects(sideEffectsRaw)
+	delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
 	if err != nil {
-		return 0, fmt.Errorf("decode event receipt side effects: %w", err)
+		return lockedAgentDelivery{}, err
 	}
-	return payload.RetryCount, nil
+	if !delivery.found {
+		return lockedAgentDelivery{}, fmt.Errorf("ensure agent delivery retry owner: event %s not found", strings.TrimSpace(eventID))
+	}
+	return delivery, nil
 }
 
 func (s *PostgresStore) updateAgentDeliveryRowTx(

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -118,6 +118,90 @@ func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *tes
 	}
 }
 
+func TestUpsertEventReceipt_AlignsRetryOwnershipAcrossDeliveryBackedAndReceiptOnly_V2(t *testing.T) {
+	tests := []struct {
+		name           string
+		insertDelivery bool
+	}{
+		{name: "delivery_backed", insertDelivery: true},
+		{name: "receipt_only_normalized_to_delivery", insertDelivery: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg, cleanup := newTestPostgresStore(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+			evt := seedEvent(t, ctx, pg, entityID, "test.retry_alignment."+tt.name)
+			if tt.insertDelivery {
+				if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+					t.Fatalf("insert deliveries: %v", err)
+				}
+			}
+
+			if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+				t.Fatalf("upsert retryable error: %v", err)
+			}
+
+			var (
+				deliveryStatus string
+				deliveryRetry  int
+				reasonCode     string
+				managerStatus  string
+				receiptRetry   int
+			)
+			if err := pg.DB.QueryRowContext(ctx, `
+				SELECT
+					COALESCE(d.status, ''),
+					COALESCE(d.retry_count, 0),
+					COALESCE(d.reason_code, ''),
+					COALESCE(r.side_effects->>'manager_status', ''),
+					COALESCE((r.side_effects->>'retry_count')::int, 0)
+				FROM event_deliveries d
+				INNER JOIN event_receipts r
+					ON r.event_id = d.event_id
+					AND r.subscriber_type = 'agent'
+					AND r.subscriber_id = d.subscriber_id
+				WHERE d.event_id = $1::uuid
+				  AND d.subscriber_type = 'agent'
+				  AND d.subscriber_id = $2
+			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
+				t.Fatalf("query retryable aligned state: %v", err)
+			}
+			if deliveryStatus != "failed" || deliveryRetry != 1 || reasonCode != "handler_error" || managerStatus != "error" || receiptRetry != 1 {
+				t.Fatalf("retryable aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
+			}
+
+			if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+				t.Fatalf("upsert exhausted error: %v", err)
+			}
+			if err := pg.DB.QueryRowContext(ctx, `
+				SELECT
+					COALESCE(d.status, ''),
+					COALESCE(d.retry_count, 0),
+					COALESCE(d.reason_code, ''),
+					COALESCE(r.side_effects->>'manager_status', ''),
+					COALESCE((r.side_effects->>'retry_count')::int, 0)
+				FROM event_deliveries d
+				INNER JOIN event_receipts r
+					ON r.event_id = d.event_id
+					AND r.subscriber_type = 'agent'
+					AND r.subscriber_id = d.subscriber_id
+				WHERE d.event_id = $1::uuid
+				  AND d.subscriber_type = 'agent'
+				  AND d.subscriber_id = $2
+			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
+				t.Fatalf("query exhausted aligned state: %v", err)
+			}
+			if deliveryStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" || managerStatus != "dead_letter" || receiptRetry != 2 {
+				t.Fatalf("exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
+			}
+		})
+	}
+}
+
 func TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -199,6 +200,49 @@ func TestUpsertEventReceipt_AlignsRetryOwnershipAcrossDeliveryBackedAndReceiptOn
 				t.Fatalf("exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
 			}
 		})
+	}
+}
+
+func TestUpsertEventReceipt_PreservesLegacyReceiptOnlyRetryHistory_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.retry_legacy_receipt_only")
+	insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert exhausted legacy receipt-only error: %v", err)
+	}
+
+	var (
+		deliveryStatus string
+		deliveryRetry  int
+		reasonCode     string
+		managerStatus  string
+		receiptRetry   int
+	)
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.reason_code, ''),
+			COALESCE(r.side_effects->>'manager_status', ''),
+			COALESCE((r.side_effects->>'retry_count')::int, 0)
+		FROM event_deliveries d
+		INNER JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
+		t.Fatalf("query legacy exhausted aligned state: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" || managerStatus != "dead_letter" || receiptRetry != 2 {
+		t.Fatalf("legacy exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
 	}
 }
 
@@ -458,6 +502,66 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 	}
 }
 
+func TestPendingAgentEvents_NormalizesLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
+	tests := []struct {
+		name       string
+		subscribed bool
+	}{
+		{name: "direct", subscribed: false},
+		{name: "subscribed", subscribed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg, cleanup := newTestPostgresStore(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+			evt := seedEvent(t, ctx, pg, entityID, "test.pending_legacy_retry_owner."+tt.name)
+			insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+
+			var (
+				evts []events.Event
+				err  error
+			)
+			since := time.Now().Add(-2 * time.Hour)
+			if tt.subscribed {
+				evts, err = pg.ListPendingSubscribedEvents(ctx, agentID, []events.EventType{evt.Type}, since, 100)
+			} else {
+				evts, err = pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
+			}
+			if err != nil {
+				t.Fatalf("list pending legacy receipt-only event: %v", err)
+			}
+			if len(evts) != 1 || evts[0].ID != evt.ID {
+				t.Fatalf("pending legacy receipt-only event mismatch: got %d events, want 1 (%s)", len(evts), evt.ID)
+			}
+
+			var (
+				deliveryStatus string
+				deliveryRetry  int
+				reasonCode     string
+			)
+			if err := pg.DB.QueryRowContext(ctx, `
+				SELECT
+					COALESCE(status, ''),
+					COALESCE(retry_count, 0),
+					COALESCE(reason_code, '')
+				FROM event_deliveries
+				WHERE event_id = $1::uuid
+				  AND subscriber_type = 'agent'
+				  AND subscriber_id = $2
+			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode); err != nil {
+				t.Fatalf("query normalized legacy delivery: %v", err)
+			}
+			if deliveryStatus != "failed" || deliveryRetry != 1 || reasonCode != "handler_error" {
+				t.Fatalf("normalized legacy delivery mismatch: status=%q retry=%d reason=%q", deliveryStatus, deliveryRetry, reasonCode)
+			}
+		})
+	}
+}
+
 func TestListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()
@@ -647,4 +751,47 @@ func seedEvent(t *testing.T, ctx context.Context, pg *store.PostgresStore, entit
 		t.Fatalf("append event: %v", err)
 	}
 	return evt
+}
+
+func insertLegacyAgentReceiptState(
+	t *testing.T,
+	ctx context.Context,
+	pg *store.PostgresStore,
+	eventID, agentID string,
+	status runtimemanager.ReceiptStatus,
+	retryCount int,
+	reasonCode, errText string,
+	processedAt time.Time,
+) {
+	t.Helper()
+
+	outcome := "processed"
+	switch status {
+	case runtimemanager.ReceiptStatusError:
+		outcome = "dead_letter"
+	case runtimemanager.ReceiptStatusDeadLetter:
+		outcome = "dead_letter"
+	default:
+		outcome = "success"
+	}
+	sideEffects := fmt.Sprintf(
+		`{"manager_status":%q,"reason_code":%q,"retry_count":%d,"error":%q}`,
+		string(status),
+		strings.TrimSpace(reasonCode),
+		retryCount,
+		strings.TrimSpace(errText),
+	)
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'agent', $2, e.entity_id, e.flow_instance,
+			$3, NULLIF($4, ''), $5::jsonb, $6
+		FROM events e
+		WHERE e.event_id = $1::uuid
+	`, eventID, agentID, outcome, strings.TrimSpace(reasonCode), sideEffects, processedAt.UTC()); err != nil {
+		t.Fatalf("insert legacy agent receipt state: %v", err)
+	}
 }

--- a/internal/store/pending_delivery_selection.go
+++ b/internal/store/pending_delivery_selection.go
@@ -30,14 +30,7 @@ func CanonicalPendingAgentDeliveryPredicateSQL(deliveryAlias, receiptAlias strin
 		)
 		OR (
 			%s.delivery_id IS NULL
-			AND (
-				%s.event_id IS NULL
-				OR (
-					COALESCE(%s.side_effects->>'manager_status', '') = 'error'
-					AND COALESCE((%s.side_effects->>'retry_count')::int, 0) < 2
-					AND %s.processed_at <= now() - interval '1 minute'
-				)
-			)
+			AND %s.event_id IS NULL
 		)
 	)`,
 		deliveryAlias,
@@ -47,9 +40,6 @@ func CanonicalPendingAgentDeliveryPredicateSQL(deliveryAlias, receiptAlias strin
 		deliveryAlias,
 		deliveryAlias,
 		deliveryAlias,
-		receiptAlias,
-		receiptAlias,
-		receiptAlias,
 		receiptAlias,
 	)
 }


### PR DESCRIPTION
Closes #229

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: event_schema.routing_derivation.delivery_rules`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.dead_letter_schema`
- governing rule: delivery, retry, pending, and dead-letter behavior in the touched seam must come from one canonical delivery owner rather than separate receipt-side and delivery-side retry interpretations.

## Human Summary
This PR removes the split retry owner for the first covered agent receipt slice. Agent receipt failures now normalize onto a delivery row before retry progression is evaluated, so equivalent retryable and exhausted cases reach the same canonical state whether the event started delivery-backed or not.

## What Changed
- normalized agent receipt retry progression onto `event_deliveries` inside `UpsertEventReceipt(...)`
- removed the receipt-only pending retry/backoff branch from canonical pending selection
- added focused coverage proving delivery-backed and previously receipt-only agent paths now land on the same retryable and exhausted outcomes

## Why This Is Needed
The touched seam was still letting retry-state meaning split between `event_deliveries.retry_count` and receipt-side `side_effects.retry_count`. That made retryable vs exhausted behavior depend on which path handled the failure. This PR gives the first covered slice one clearer canonical retry owner and aligns the store/runtime meaning around it.

## Scope Boundaries
- keeps the change narrow to the touched agent receipt retry seam
- does not redesign receipt-only non-agent paths
- does not broaden into delivery lifecycle observability or other recovery semantics beyond the retry-owner slice needed here

## Tests Run
- `go test ./internal/store -run 'Test(UpsertEventReceipt_(PreservesRetryableVsTerminalDeliveryStatus_V2|AlignsRetryOwnershipAcrossDeliveryBackedAndReceiptOnly_V2)|ListPendingEventsForAgent_RetryBackoff_V2|ListPendingSubscribedEvents_RetryBackoff_V2)' -count=1`
- `go test ./internal/store ./internal/runtime/manager -count=1`
- `go test ./... -count=1`

## Residual Risk
Receipt-only paths that are not agent delivery-backed still keep their own semantics because they do not participate in `event_deliveries`. This PR makes that boundary sharper for the first covered agent slice, but it does not redesign every receipt surface.

## Follow-Up
If additional agent paths still bypass delivery ownership entirely, they should be normalized onto the same canonical delivery-backed retry owner rather than reintroducing receipt-side retry progression.
