### PR TITLE
[agent-a][issue #226] Move startup ownership behind store boundary

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -65,6 +65,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ConversationStore: s.ConversationStore,
 		ManagerStore:      s.ManagerStore,
 		ScheduleStore:     s.ScheduleStore,
+		StartupOwnership:  s.Postgres,
 		TurnStore:         s.TurnStore,
 	}
 }

--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -174,6 +174,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		SessionRegistry:   sessions.NewPostgresRegistry(db, cfg.LLM.Session.LockTTL),
 		ManagerStore:      pg,
 		ScheduleStore:     pg,
+		StartupOwnership:  pg,
 		MailboxStore:      pg,
 		ConversationStore: nil,
 		TurnStore:         nil,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -30,6 +30,7 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
+	runtimestartupownership "swarm/internal/runtime/startupownership"
 	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 )
@@ -41,6 +42,7 @@ type Stores struct {
 	ConversationStore llm.ConversationPersistence
 	ManagerStore      runtimemanager.ManagerPersistence
 	ScheduleStore     runtimepipeline.SchedulePersistence
+	StartupOwnership  runtimestartupownership.Store
 	MailboxStore      runtimetools.MailboxPersistence
 	InboundStore      InboundPersistence
 	TurnStore         llm.TurnPersistence
@@ -68,7 +70,7 @@ type Runtime struct {
 	lifecycleMu    sync.Mutex
 	startCtx       context.Context
 	cancelStart    context.CancelFunc
-	ownershipLease runtimeStoreOwnershipLease
+	ownershipLease runtimestartupownership.Lease
 	ownerID        string
 
 	Config         *config.Config
@@ -541,11 +543,15 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		return fmt.Errorf("runtime already started")
 	}
 	startCtx, cancelStart := context.WithCancel(ctx)
-	lease, err := acquireRuntimeStoreOwnership(ctx, rt.Stores.SQLDB, rt.ownerID)
-	if err != nil {
-		cancelStart()
-		rt.lifecycleMu.Unlock()
-		return err
+	var lease runtimestartupownership.Lease
+	if rt.Stores.StartupOwnership != nil {
+		var err error
+		lease, err = rt.Stores.StartupOwnership.AcquireRuntimeStartupOwnership(ctx, rt.ownerID)
+		if err != nil {
+			cancelStart()
+			rt.lifecycleMu.Unlock()
+			return err
+		}
 	}
 	rt.startCtx = startCtx
 	rt.cancelStart = cancelStart

--- a/internal/runtime/runtime_ownership.go
+++ b/internal/runtime/runtime_ownership.go
@@ -1,80 +1,12 @@
 package runtime
 
 import (
-	"context"
-	"database/sql"
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/google/uuid"
 )
-
-const runtimeSharedStoreOwnershipLock = "swarm:runtime:shared-store-owner"
-
-type runtimeStoreOwnershipLease interface {
-	Release(context.Context) error
-}
-
-type sqlRuntimeOwnershipLease struct {
-	mu       sync.Mutex
-	conn     *sql.Conn
-	released bool
-}
-
-func acquireRuntimeStoreOwnership(ctx context.Context, db *sql.DB, ownerID string) (runtimeStoreOwnershipLease, error) {
-	if db == nil {
-		return nil, nil
-	}
-	ownerID = strings.TrimSpace(ownerID)
-	if ownerID == "" {
-		return nil, fmt.Errorf("runtime owner id is required")
-	}
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("acquire runtime ownership connection: %w", err)
-	}
-	var acquired bool
-	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock(hashtext($1))`, runtimeSharedStoreOwnershipLock).Scan(&acquired); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("acquire shared runtime store ownership for %s: %w", ownerID, err)
-	}
-	if !acquired {
-		_ = conn.Close()
-		return nil, fmt.Errorf("shared runtime store already owned by another runtime instance")
-	}
-	return &sqlRuntimeOwnershipLease{conn: conn}, nil
-}
-
-func (l *sqlRuntimeOwnershipLease) Release(ctx context.Context) error {
-	if l == nil {
-		return nil
-	}
-	l.mu.Lock()
-	if l.released {
-		l.mu.Unlock()
-		return nil
-	}
-	l.released = true
-	conn := l.conn
-	l.conn = nil
-	l.mu.Unlock()
-	if conn == nil {
-		return nil
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_unlock(hashtext($1))`, runtimeSharedStoreOwnershipLock); err != nil {
-		_ = conn.Close()
-		return fmt.Errorf("release shared runtime store ownership: %w", err)
-	}
-	if err := conn.Close(); err != nil {
-		return fmt.Errorf("close runtime ownership connection: %w", err)
-	}
-	return nil
-}
 
 func newRuntimeOwnerID() string {
 	host, _ := os.Hostname()

--- a/internal/runtime/runtime_ownership_test.go
+++ b/internal/runtime/runtime_ownership_test.go
@@ -2,21 +2,48 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"swarm/internal/config"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
-	"swarm/internal/testutil"
+	runtimestartupownership "swarm/internal/runtime/startupownership"
 )
 
+type fakeRuntimeStartupOwnershipStore struct {
+	acquire func(context.Context, string) (runtimestartupownership.Lease, error)
+}
+
+func (f fakeRuntimeStartupOwnershipStore) AcquireRuntimeStartupOwnership(ctx context.Context, ownerID string) (runtimestartupownership.Lease, error) {
+	if f.acquire == nil {
+		return nil, nil
+	}
+	return f.acquire(ctx, ownerID)
+}
+
+type fakeRuntimeStartupOwnershipLease struct {
+	released atomic.Int32
+}
+
+func (f *fakeRuntimeStartupOwnershipLease) Release(context.Context) error {
+	f.released.Add(1)
+	return nil
+}
+
 func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
-	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+		StartupOwnership: fakeRuntimeStartupOwnershipStore{
+			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
+				return &fakeRuntimeStartupOwnershipLease{}, nil
+			},
+		},
+	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
@@ -29,7 +56,13 @@ func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = rt1.Shutdown() })
 
-	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+		StartupOwnership: fakeRuntimeStartupOwnershipStore{
+			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
+				return nil, fmt.Errorf("shared runtime store already owned by another runtime instance")
+			},
+		},
+	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
@@ -47,10 +80,16 @@ func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
 }
 
 func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
 	module := loadRuntimeOwnershipWorkflowModule(t)
+	lease := &fakeRuntimeStartupOwnershipLease{}
 
-	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+		StartupOwnership: fakeRuntimeStartupOwnershipStore{
+			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
+				return lease, nil
+			},
+		},
+	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
@@ -64,8 +103,17 @@ func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
 	if err := rt1.Shutdown(); err != nil {
 		t.Fatalf("Shutdown(rt1): %v", err)
 	}
+	if got := lease.released.Load(); got != 1 {
+		t.Fatalf("startup ownership lease release count = %d, want 1", got)
+	}
 
-	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{SQLDB: db}, RuntimeOptions{
+	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+		StartupOwnership: fakeRuntimeStartupOwnershipStore{
+			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
+				return &fakeRuntimeStartupOwnershipLease{}, nil
+			},
+		},
+	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},

--- a/internal/runtime/runtime_ownership_test.go
+++ b/internal/runtime/runtime_ownership_test.go
@@ -129,6 +129,31 @@ func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
 	}
 }
 
+func TestRuntimeCleanupStartFailure_ReleasesSharedStoreOwnership(t *testing.T) {
+	lease := &fakeRuntimeStartupOwnershipLease{}
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &Runtime{
+		startCtx:       ctx,
+		cancelStart:    cancel,
+		ownershipLease: lease,
+	}
+
+	rt.cleanupStartFailure()
+
+	if got := lease.released.Load(); got != 1 {
+		t.Fatalf("startup ownership lease release count = %d, want 1", got)
+	}
+	if rt.cancelStart != nil {
+		t.Fatal("cancelStart was not cleared")
+	}
+	if rt.startCtx != nil {
+		t.Fatal("startCtx was not cleared")
+	}
+	if rt.ownershipLease != nil {
+		t.Fatal("ownershipLease was not cleared")
+	}
+}
+
 func loadRuntimeOwnershipWorkflowModule(t *testing.T) semanticOnlyWorkflowRuntime {
 	t.Helper()
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/internal/runtime/startupownership/startupownership.go
+++ b/internal/runtime/startupownership/startupownership.go
@@ -1,0 +1,11 @@
+package startupownership
+
+import "context"
+
+type Lease interface {
+	Release(context.Context) error
+}
+
+type Store interface {
+	AcquireRuntimeStartupOwnership(context.Context, string) (Lease, error)
+}

--- a/internal/store/runtime_startup_ownership.go
+++ b/internal/store/runtime_startup_ownership.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	runtimestartupownership "swarm/internal/runtime/startupownership"
+)
+
+const runtimeSharedStoreOwnershipLock = "swarm:runtime:shared-store-owner"
+
+func (s *PostgresStore) AcquireRuntimeStartupOwnership(ctx context.Context, ownerID string) (runtimestartupownership.Lease, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil, fmt.Errorf("runtime owner id is required")
+	}
+	lease, acquired, err := acquireAdvisoryLockLease(ctx, s.DB, runtimeSharedStoreOwnershipLock)
+	if err != nil {
+		return nil, fmt.Errorf("acquire shared runtime store ownership for %s: %w", ownerID, err)
+	}
+	if !acquired {
+		return nil, fmt.Errorf("shared runtime store already owned by another runtime instance")
+	}
+	return lease, nil
+}

--- a/internal/store/runtime_startup_ownership_test.go
+++ b/internal/store/runtime_startup_ownership_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_AcquireRuntimeStartupOwnership_DeniesCompetingOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	lease1, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-1")
+	if err != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership(runtime-1): %v", err)
+	}
+	t.Cleanup(func() { _ = lease1.Release(context.Background()) })
+
+	lease2, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-2")
+	if lease2 != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership(runtime-2) lease = %#v, want nil", lease2)
+	}
+	if err == nil || !strings.Contains(err.Error(), "shared runtime store already owned by another runtime instance") {
+		t.Fatalf("AcquireRuntimeStartupOwnership(runtime-2) error = %v, want explicit ownership denial", err)
+	}
+}
+
+func TestPostgresStore_AcquireRuntimeStartupOwnership_ReleaseAllowsSuccessor(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	lease1, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-1")
+	if err != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership(runtime-1): %v", err)
+	}
+	if err := lease1.Release(context.Background()); err != nil {
+		t.Fatalf("Release(runtime-1): %v", err)
+	}
+
+	lease2, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-2")
+	if err != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership(runtime-2): %v", err)
+	}
+	if err := lease2.Release(context.Background()); err != nil {
+		t.Fatalf("Release(runtime-2): %v", err)
+	}
+}


### PR DESCRIPTION
Closes #226

## Human Summary

This moves shared-store runtime startup ownership behind a single store-owned acquire/release contract. Runtime startup and shutdown now depend on that canonical lease boundary instead of embedding Postgres advisory-lock SQL locally.

## What Changed

- added a small canonical startup-ownership lease/store contract in `internal/runtime/startupownership`
- moved the Postgres shared-store startup ownership acquire/release implementation onto `PostgresStore`
- removed runtime-local advisory-lock SQL from `internal/runtime/runtime_ownership.go`
- updated runtime startup/shutdown to consume only the store-owned ownership interface
- wired canonical constructors that start real runtimes (`cmd/swarm` and the catalog runtime harness) to pass the Postgres startup-ownership store explicitly
- added focused runtime and store tests for competing ownership denial and release-on-shutdown behavior across the moved boundary

## Why This Is Needed

Issue #221 fixed the correctness bug by making startup ownership explicit and fail-closed, but the advisory-lock mechanism still lived in runtime. That left shared-store startup admission split between runtime and store. This change gives the touched seam one canonical owner while preserving the existing fail-fast behavior.

## Scope Boundaries

In scope:
- shared-store startup ownership acquire/release in runtime startup/shutdown
- Postgres advisory-lock implementation for that startup admission seam
- focused tests proving denial/release behavior is preserved across the boundary move

Out of scope:
- broader post-startup work ownership changes tracked elsewhere
- clustering/partitioning redesign
- unrelated store abstraction cleanup

## Tests Run

- `go test ./internal/runtime -run 'TestRuntime(Start_FailsWhenSharedStoreOwnershipAlreadyHeld|Shutdown_ReleasesSharedStoreOwnership)$' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_AcquireRuntimeStartupOwnership_' -count=1`
- `go test ./internal/runtime ./internal/store ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`

## Residual Risk

Low. The runtime boundary is now narrower, but this PR intentionally does not redesign any other startup/shutdown ownership paths outside the shared-store admission seam.

## Follow-Up

None needed in this seam from this change. If broader startup/work ownership refactoring is needed later, it should build on this canonical store-owned admission contract rather than reintroducing runtime-local SQL locking.

## Spec References

- none by design for this issue
- binding context is the issue body/thread runtime-hardening guidance, which explicitly states no exact platform spec section governs this startup ownership seam
