### PR TITLE
[agent-b][issue #180] Materialize flow-entity schema initial values at creation

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -148,11 +148,26 @@ contract_formats:
       derives database DDL from this schema at boot.
     format:
       groups: Schema is organized into named groups (e.g., intake_phase, processing_phase).
-      fields: 'Each field is declared as: field_name: type_description'
+      fields: 'Each field is declared in one of two forms.'
+      scalar_form:
+        shape: 'field_name: type_description'
+        meaning: Type-only declaration. No initial value. The field remains sparse until first explicit write.
+      mapping_form:
+        shape: 'field_name: { type: string, initial: value, nullable: bool, description: string }'
+        required_fields:
+          type: string — same type vocabulary as scalar form
+        optional_fields:
+          initial: Constant value materialized once at create_entity time. Type must match the declared type.
+          nullable: Boolean. Defaults to false. If true, the field may later be set to null without re-materializing the initial value.
+          description: Human-readable annotation, not parsed.
       types: text, integer, numeric(precision,scale), boolean, jsonb, timestamp, uuid
       annotations: Parenthetical notes after the type are human-readable, not machine-parsed.
-    example: "entity_schema:\n  identity:\n    order_id: uuid (primary key)\n    name: text\n  processing_phase:\n    total_amount:\
-      \ numeric(10,2)\n    order_type: text"
+      invalid_forms:
+        string_with_initial_suffix: 'revision_count: integer initial 0 — REJECTED. Use mapping form when declaring an initial value.'
+        mapping_without_type: 'field_name: { initial: 0 } — REJECTED. type is required in mapping form.'
+    example: "entity_schema:\n  identity:\n    order_id: uuid (primary key)\n    name: text\n  processing_phase:\n    revision_count:\n      type:\
+      \ integer\n      initial: 0\n    is_duplicate:\n      type: boolean\n      initial: false\n    total_amount: numeric(10,2)\n\
+      \    order_type: text"
   event_schema:
     description: Each workflow defines event payload schemas in events.yaml. Events are keyed by event name. Each entry contains
       a payload object mapping field names to types (string, integer, object, array, boolean). The platform uses these schemas
@@ -267,7 +282,8 @@ handler_specification:
       type: boolean
       purpose: When true, the handler mints a fresh entity_id before any other processing. All subsequent handler steps
         (guard, data_accumulation, advances_to, emits, etc.) operate on the NEW entity. The inbound event's entity_id is
-        ignored for state operations — the new entity starts with a clean state at the flow's initial_state. The original
+        ignored for state operations — the new entity starts at the flow's initial_state with schema-declared initial values
+        already materialized. The original
         event entity_id is preserved in the event payload for reference.
       default: false — handler operates on the inbound event's entity_id (inherit)
       when_to_use: When an event arriving from outside the flow represents a new entity entering this flow's lifecycle.
@@ -279,17 +295,20 @@ handler_specification:
         entity_id: Auto-generated UUID
         initial_state: From the flow's schema.yaml initial_state
         flow_instance: Current flow instance path
-        fields: Empty (clean slate). The handler's data_accumulation writes the initial field values.
+        fields: Schema-declared initial values materialized once at create_entity time. Fields without declared initial values remain sparse until first explicit write.
       interactions:
         with_accumulate: 'PROHIBITED. create_entity mints a new entity_id on every handler invocation. Accumulate receives
           multiple events for the same entity. Combining them would create a different entity on each accumulation event.
           Boot error if both are declared on the same handler.'
         with_fan_out: 'ALLOWED. create_entity creates ONE entity, then fan_out emits multiple events all carrying that entity_id.
           Fan_out items share the new entity.'
-        with_guard: 'ALLOWED but guards evaluate against the NEWLY CREATED entity state (empty fields, initial_state). Guards
-          on create_entity handlers should check payload fields, not entity fields.'
-        with_on_complete: ALLOWED. on_complete evaluates after data_accumulation writes to the new entity.
-        with_rules: ALLOWED. Rules evaluate against payload, which is unaffected by create_entity.
+        with_guard: 'ALLOWED. Guards evaluate against the NEWLY CREATED entity state after schema initial values materialize.
+          Guards may read schema-initialized fields directly. Sparse fields still require explicit presence checks such as
+          has(entity.field) or entity.field != null.'
+        with_on_complete: 'ALLOWED. on_complete conditions evaluate according to the handler dependency graph. They may rely on
+          schema initial values and earlier step outputs, but not on same-handler top-level data_accumulation writes.'
+        with_rules: 'ALLOWED. rule conditions evaluate according to the handler dependency graph. They may rely on schema initial
+          values and earlier step outputs, but not on same-handler top-level data_accumulation writes.'
         with_advances_to: ALLOWED. Advances the new entity from initial_state to the target state.
       note_on_static_flows: 'For static flows (scoring, validation), create_entity is the mechanism for entity creation.
         Without it, the first event arriving from outside the flow has no entity to write to unless the runtime creates one
@@ -360,13 +379,19 @@ handler_specification:
   expression_context:
     description: 'Defines the namespaces available in CEL expressions used in guard.check, on_complete.condition,
       rules.condition, data_accumulation.expression, and filter.condition. Each namespace resolves to a specific
-      data source. Referencing a field that does not exist in the resolved data source is a runtime error.'
+      data source. Referencing an entity field that does not exist in entity_state.fields is a runtime error unless
+      the reference appears in an explicit presence-check position.'
     namespaces:
       entity:
         resolves_to: 'entity_state row for the current entity. entity.X reads entity_state.fields->>X.
           entity.current_state reads entity_state.current_state. entity.gates.X reads entity_state.gates->>X.'
         populated_by: 'data_accumulation writes, compute.store_as, sets_gate, advances_to, save_entity_field
           (agent tool), and create_entity (initial field population).'
+        read_model:
+          sparse_field: A field with no declared initial value remains absent from entity_state.fields until first explicit write.
+          missing_field_as_value: Reading a missing entity field as a value is a runtime error (no such key).
+          presence_check_positions: 'Missing fields are allowed only inside has(entity.X) or == null / != null comparisons.
+            These positions test presence instead of requiring a value.'
         does_NOT_include: 'Accumulated items. Dimension scores, fan-out results, and other per-item data
           collected by the accumulate handler step are NOT promoted to entity fields automatically. They exist
           only in the accumulator. To reference them, use the accumulated namespace.'
@@ -397,17 +422,31 @@ handler_specification:
         resolves_to: 'The merged policy context. policy.X reads the X key from the flow''s policy.yaml
           (or root policy.yaml if not overridden at flow level).'
     boot_validation:
-      description: 'The platform SHOULD validate expression field references at boot. For every entity.X
-        reference in a condition or expression, verify that at least one handler in the same flow writes X
-        to entity state (via data_accumulation, compute.store_as, or create_entity field population). If no
-        upstream writer exists, emit a boot warning. This catches the class of bug where a condition references
-        entity.field_name but the field is only available in the accumulator or was never written.'
-      severity: warning (not error — agents may write fields via save_entity_field that are not statically
-        visible in the contract)
-      example_violation: 'on_complete condition references entity.build_complexity, but no handler in the flow
-        has data_accumulation writing build_complexity or compute storing to build_complexity. The field only
-        exists as a dimension name in accumulated items. Correct usage would be
-        accumulated.filter(d, d.dimension == "build_complexity" && d.score >= threshold).size() == 1.'
+      description: 'The platform MUST validate entity field references at boot using only statically provable
+        initializers. Every entity.X used as a VALUE (not in a presence-check position) must be guaranteed initialized
+        at that position in the handler dependency graph.'
+      statically_provable_initializers:
+        schema_initial_value:
+          form: 'entity_schema mapping form with initial: ...'
+          valid_for: All reference positions, including guards on create_entity handlers.
+        create_entity_unconditional_data_accumulation:
+          form: The handler containing create_entity writes X unconditionally in top-level data_accumulation.
+          valid_for: Only positions that run strictly after same-handler top-level data_accumulation in the dependency graph
+            (payload_transform, emits, action, clear), plus downstream handlers after commit.
+          not_valid_for: guard.check, filter, reduce, count, compute inputs, on_complete.condition, rules.condition,
+            and same-handler data_accumulation.expression.
+      presence_positions:
+      - has(entity.X)
+      - entity.X == null
+      - entity.X != null
+      rule: 'For every entity.X used as a value, at least one of the following must be true: (1) X has a declared
+        schema initial value, or (2) the current create_entity handler writes X unconditionally in top-level
+        data_accumulation and the reference position runs strictly after that step, or (3) the reference is in a
+        presence-check position. Dynamic agent writes and conditional reachability do not count as static proof.'
+      severity: error (boot fails)
+      example_violation: 'A create_entity guard references entity.build_complexity as a value, but build_complexity is sparse
+        and only later written by data_accumulation or a downstream handler. Correct usage would be to declare an initial value
+        in entity_schema or use a presence check such as has(entity.build_complexity).'
     advances_to:
       field: advances_to
       type: string
@@ -1410,6 +1449,13 @@ engine:
     - 'Membership: in, contains'
     - 'String: startsWith, endsWith, matches'
     - 'List: size, exists, all, filter, map'
+    presence_semantics:
+      has_function:
+        signature: has(entity.X) -> boolean
+        meaning: Returns true if entity.X exists in entity_state.fields, false otherwise. Does not raise an error for missing fields.
+      null_comparison:
+        meaning: 'entity.X == null and entity.X != null are presence-check positions. They do not raise an error when X is missing.'
+      missing_field_rule: Missing entity fields are never implicitly coerced to a default value or to null outside explicit presence checks.
     examples:
     - entity.retry_count <= policy.max_retries
     - payload.category == "billing"
@@ -1418,6 +1464,8 @@ engine:
     - payload.decision == "approve"
     - entity.revision_count < policy.max_revisions
     - entity.total_amount >= policy.approval_threshold
+    - has(entity.kill_reason) ? entity.kill_reason : "active"
+    - entity.kill_reason != null
   error_model:
     description: How the platform handles failures at each layer.
     event_validation_failure:

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -474,6 +474,7 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 		if flowID == "" {
 			continue
 		}
+		schemaInitials := runtimepipeline.WorkflowEntitySchemaInitialValueFields(c.source)
 		writers := flowEntityFieldWriters(flow.Nodes)
 		for _, transition := range c.source.DerivedHandlerTransitions() {
 			if strings.TrimSpace(transition.FlowID) != flowID {
@@ -500,6 +501,9 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := guarded[field]; ok {
 							continue
 						}
+						if _, ok := schemaInitials[field]; ok {
+							continue
+						}
 						key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, field}, "|")
 						if _, ok := seen[key]; ok {
 							continue
@@ -507,11 +511,11 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := available[field]; ok {
 							continue
 						}
-						if expr.SelfTargetField == field {
+						if expr.SelfTargetField == field && !handler.CreateEntity {
 							continue
 						}
 						if runtimepipeline.WorkflowEntityReadsPersistedStateBeforeHandlerWrites(expr.Phase) {
-							if _, ok := handlerWriters[field]; ok {
+							if _, ok := handlerWriters[field]; ok && !handler.CreateEntity {
 								continue
 							}
 						}
@@ -2901,6 +2905,13 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			out = append(out, expressionReference{Kind: "count condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleCount})
 		}
 	}
+	if handler.PayloadTransform != nil {
+		for _, entry := range handler.PayloadTransform.TransformEntries() {
+			if expr := strings.TrimSpace(entry.Value.CEL); expr != "" {
+				out = append(out, expressionReference{Kind: "payload_transform value", Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecyclePayloadTransform})
+			}
+		}
+	}
 	if handler.Query != nil {
 		appendQueryExpressions(&out, *handler.Query)
 	}
@@ -2950,6 +2961,8 @@ func availableEntityFieldsForExpression(handler runtimecontracts.SystemNodeEvent
 		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextRule)
 	case runtimepipeline.WorkflowEntityFieldLifecycleReduce:
 		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
+	case runtimepipeline.WorkflowEntityFieldLifecyclePayloadTransform:
+		return runtimepipeline.WorkflowEntityFieldsAvailableBeforePayloadTransform(handler)
 	default:
 		return map[string]struct{}{}
 	}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -780,7 +780,7 @@ func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	}
 }
 
-func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenSameHandlerWritesFieldLater(t *testing.T) {
+func TestRun_RejectsGuardReferenceToSparseFieldEvenWhenSameHandlerWritesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.missing_score >= 70"}
@@ -792,15 +792,12 @@ func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenSameHandlerWritesFieldL
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_score") {
-		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
-	}
-	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.missing_score") {
-		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_score") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
 	}
 }
 
-func TestRun_AllowsFilterReferenceToPersistedFieldEvenWhenSameHandlerComputesFieldLater(t *testing.T) {
+func TestRun_RejectsFilterReferenceToSparseFieldEvenWhenSameHandlerComputesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.Filter = &runtimecontracts.FilterSpec{
@@ -817,11 +814,8 @@ func TestRun_AllowsFilterReferenceToPersistedFieldEvenWhenSameHandlerComputesFie
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.filtered_score") {
-		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
-	}
-	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.filtered_score") {
-		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.filtered_score") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
 	}
 }
 
@@ -863,6 +857,7 @@ func TestRun_AllowsExpressionFieldReferenceForSelfTargetEntityUpdate(t *testing.
 func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenHandlerWritesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = false
 	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.retry_count < 3"}
 	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
 		TargetField: "retry_count",
@@ -882,7 +877,16 @@ func TestRun_AllowsGuardReferenceToPersistedFieldEvenWhenHandlerWritesFieldLater
 
 func TestRun_AllowsOnCompleteReferenceToPersistedFieldEvenWhenHandlerWritesFieldLater(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "validation_phase",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer", Initial: 0},
+			},
+		}},
+	}
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
 	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
 		TargetField: "revision_count",
 		Value:       runtimecontracts.CELExpression("entity.revision_count + 1"),
@@ -900,6 +904,98 @@ func TestRun_AllowsOnCompleteReferenceToPersistedFieldEvenWhenHandlerWritesField
 	}
 	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.revision_count") {
 		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_AllowsCreateEntityGuardReferenceToSchemaInitializedField(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "validation_phase",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer", Initial: 0},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.revision_count == 0"}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsSparsePresenceChecksWithoutInitializer(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "validation_phase",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "kill_reason", Type: "text"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "has(entity.kill_reason) || entity.kill_reason == null"}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.kill_reason") {
+		t.Fatalf("unexpected sparse-field validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsHasGuardedTernaryReadWithoutInitializer(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "validation_phase",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "kill_reason", Type: "text"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Guard = &runtimecontracts.GuardSpec{Check: `has(entity.kill_reason) ? entity.kill_reason == "manual" : true`}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.kill_reason") {
+		t.Fatalf("unexpected guarded ternary sparse-field validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsCreateEntityGuardReferenceToFieldInitializedOnlyBySameHandlerDataAccumulation(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "validation_phase",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.revision_count == 0"}
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
+		TargetField: "revision_count",
+		Value:       runtimecontracts.LiteralExpression(0),
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
 	}
 }
 
@@ -925,7 +1021,7 @@ func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t
 	}
 }
 
-func TestRun_PreservesSiblingWriteErrorWhenGuardAlsoReadsPersistedField(t *testing.T) {
+func TestRun_PreservesSiblingWriteErrorWhenGuardAlsoReadsSparseField(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.Guard = &runtimecontracts.GuardSpec{Check: "entity.retry_count < 3"}
@@ -947,12 +1043,8 @@ func TestRun_PreservesSiblingWriteErrorWhenGuardAlsoReadsPersistedField(t *testi
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	for _, item := range report.Errors() {
-		if item.CheckID == "expression_field_reference_validation" &&
-			strings.Contains(item.Message, "entity.retry_count") &&
-			strings.Contains(item.Message, "in guard") {
-			t.Fatalf("unexpected guard expression_field_reference_validation error, got %#v", report.Errors())
-		}
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.retry_count") {
+		t.Fatalf("expected sparse-field guard error, got %#v", report.Errors())
 	}
 	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.base_score") {
 		t.Fatalf("expected sibling-write dependency error, got %#v", report.Errors())

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -355,11 +355,13 @@ type EntitySchemaGroup struct {
 	Fields []EntitySchemaField `yaml:"fields"`
 }
 type EntitySchemaField struct {
-	Name     string `yaml:"name"`
-	Type     string `yaml:"type"`
-	Primary  bool   `yaml:"primary"`
-	Indexed  bool   `yaml:"indexed"`
-	Nullable bool   `yaml:"nullable"`
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Initial     any    `yaml:"initial"`
+	Primary     bool   `yaml:"primary"`
+	Indexed     bool   `yaml:"indexed"`
+	Nullable    bool   `yaml:"nullable"`
+	Description string `yaml:"description"`
 }
 type NodeStateSchema struct {
 	Description string           `yaml:"description"`

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -340,6 +340,9 @@ func decodeEntitySchemaField(name string, node *yaml.Node) (EntitySchemaField, e
 	field := EntitySchemaField{Name: strings.TrimSpace(name)}
 	switch node.Kind {
 	case yaml.ScalarNode:
+		if strings.Contains(strings.ToLower(node.Value), " initial ") {
+			return EntitySchemaField{}, fmt.Errorf("entity schema field %s: scalar form cannot declare initial values; use mapping form with type and initial", field.Name)
+		}
 		parsed := parseTypedFieldString(node.Value)
 		field.Type = parsed.Type
 		field.Primary = parsed.Primary
@@ -353,9 +356,14 @@ func decodeEntitySchemaField(name string, node *yaml.Node) (EntitySchemaField, e
 			return EntitySchemaField{}, err
 		}
 		field.Type = aux.Type
+		field.Initial = aux.Initial
 		field.Primary = aux.Primary
 		field.Indexed = aux.Indexed
 		field.Nullable = aux.Nullable
+		field.Description = aux.Description
+		if strings.TrimSpace(field.Type) == "" {
+			return EntitySchemaField{}, fmt.Errorf("entity schema field %s: type is required", field.Name)
+		}
 		return field, nil
 	default:
 		return EntitySchemaField{}, fmt.Errorf("unsupported entity schema field yaml node kind %d", node.Kind)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -163,6 +163,66 @@ pins:
 	}
 }
 
+func TestEntitySchemaDecode_AcceptsMappingInitialValue(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: test
+version: 1.0.0
+entity_schema:
+  scoring_phase:
+    revision_count:
+      type: integer
+      initial: 0
+    is_duplicate:
+      type: boolean
+      initial: false
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := len(doc.EntitySchema.Groups); got != 1 {
+		t.Fatalf("len(EntitySchema.Groups) = %d", got)
+	}
+	fields := doc.EntitySchema.Groups[0].Fields
+	if got := fields[0].Name; got != "revision_count" {
+		t.Fatalf("Fields[0].Name = %q", got)
+	}
+	if got := fields[0].Initial; got != 0 {
+		t.Fatalf("Fields[0].Initial = %#v", got)
+	}
+	if got := fields[1].Initial; got != false {
+		t.Fatalf("Fields[1].Initial = %#v", got)
+	}
+}
+
+func TestEntitySchemaDecode_RejectsScalarInitialSuffix(t *testing.T) {
+	var doc ProjectPackageDocument
+	err := yaml.Unmarshal([]byte(`
+name: test
+version: 1.0.0
+entity_schema:
+  scoring_phase:
+    revision_count: integer initial 0
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "scalar form cannot declare initial values") {
+		t.Fatalf("yaml.Unmarshal error = %v, want scalar initial rejection", err)
+	}
+}
+
+func TestEntitySchemaDecode_RejectsMappingWithoutType(t *testing.T) {
+	var doc ProjectPackageDocument
+	err := yaml.Unmarshal([]byte(`
+name: test
+version: 1.0.0
+entity_schema:
+  scoring_phase:
+    revision_count:
+      initial: 0
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "type is required") {
+		t.Fatalf("yaml.Unmarshal error = %v, want missing-type rejection", err)
+	}
+}
+
 func TestFanOutSpecDecode_PreservesStructuredEmitMapping(t *testing.T) {
 	var spec FanOutSpec
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -45,11 +45,13 @@ type handlerExecutionOutcome struct {
 }
 
 type contractHandlerExecutionResult struct {
-	Transition      WorkflowTransition
-	Plan            handlerExecutionPlan
-	Outcome         *handlerExecutionOutcome
-	GuardsEvaluated []string
-	Handled         bool
+	Transition                WorkflowTransition
+	Plan                      handlerExecutionPlan
+	Outcome                   *handlerExecutionOutcome
+	GuardsEvaluated           []string
+	PreviewMetadata           map[string]any
+	InitialValuesMaterialized map[string]any
+	Handled                   bool
 }
 
 func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Context, evt events.Event, triggerCtx workflowTriggerContext) (contractHandlerExecutionResult, error) {
@@ -173,6 +175,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 			Plan:            plan,
 			Outcome:         outcome,
 			GuardsEvaluated: append([]string{}, outcome.GuardsEvaluated...),
+			PreviewMetadata: cloneStringAnyMap(triggerCtx.State.Metadata),
 			Handled:         true,
 		}, nil
 	}
@@ -185,6 +188,9 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	ctx = withPipelineFlowScope(ctx, flowID)
 	ctx = runtimecorrelation.WithInboundEvent(ctx, triggerCtx.Event)
 	ctx = runtimecorrelation.WithHandlerID(ctx, strings.TrimSpace(nodeID)+":"+strings.TrimSpace(string(triggerCtx.Event.Type)))
+	if handler.CreateEntity {
+		ctx = withWorkflowCreateEntityInitialValues(ctx, workflowEntitySchemaInitialValues(source))
+	}
 	deps := coordinatorEngineDependencies(pc)
 	if collectLocally {
 		deps.Outbox = noOpEngineOutbox{}
@@ -210,6 +216,14 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
 	}
+	if handler.CreateEntity && result.StateMutation.StateCarrier.Metadata == nil {
+		result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(stateSnapshot.StateCarrier.Metadata)
+	}
+	previewMetadata := previewMetadataAfterExecution(stateSnapshot, result.StateMutation)
+	initialValuesMaterialized := map[string]any(nil)
+	if handler.CreateEntity {
+		initialValuesMaterialized = workflowEntitySchemaInitialValues(source)
+	}
 	if !preview {
 		pc.recordInterceptedEmitDeadLetters(ctx, triggerCtx.Event, nodeID, handlerOutcomeFromExecutionResult(result))
 	}
@@ -234,11 +248,13 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	}
 	plan.DataAccumulation = outcome.DataAccumulation
 	return contractHandlerExecutionResult{
-		Transition:      workflowTransitionFromHandlerOutcome(triggerCtx.State, nodeID, strings.TrimSpace(string(triggerCtx.Event.Type)), outcome),
-		Plan:            plan,
-		Outcome:         outcome,
-		GuardsEvaluated: append([]string{}, outcome.GuardsEvaluated...),
-		Handled:         true,
+		Transition:                workflowTransitionFromHandlerOutcome(triggerCtx.State, nodeID, strings.TrimSpace(string(triggerCtx.Event.Type)), outcome),
+		Plan:                      plan,
+		Outcome:                   outcome,
+		GuardsEvaluated:           append([]string{}, outcome.GuardsEvaluated...),
+		PreviewMetadata:           previewMetadata,
+		InitialValuesMaterialized: initialValuesMaterialized,
+		Handled:                   true,
 	}, nil
 }
 
@@ -268,17 +284,9 @@ func resolveHandlerEntityIDForFlow(
 		entityID = instance.EntityID
 		if state != nil {
 			state.EntityID = entityID
-			state.Stage = ""
+			state.Stage = NormalizeWorkflowStateID(workflowInitialStateForFlow(source, flowID))
 			state.Status = ""
-			state.Metadata = map[string]any{"subject_id": instance.SubjectID}
-			if instance.InstancePath != "" {
-				state.Metadata["flow_path"] = instance.InstancePath
-				state.Metadata["storage_ref"] = instance.InstancePath
-			}
-			state.Metadata["instance_id"] = instance.InstanceID
-			if instance.ParentEntityID != "" {
-				state.Metadata["parent_entity_id"] = instance.ParentEntityID
-			}
+			state.Metadata = workflowCreateEntityMetadata(source, flowID, instance)
 		}
 		return entityID, evt
 	}
@@ -304,6 +312,41 @@ func resolveHandlerEntityIDForFlow(
 		state.EntityID = entityID
 	}
 	return entityID, evt
+}
+
+func workflowCreateEntityMetadata(source semanticview.Source, flowID string, instance FlowInstanceIdentity) map[string]any {
+	metadata := workflowEntitySchemaInitialValues(source)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if instance.SubjectID != "" {
+		metadata["subject_id"] = instance.SubjectID
+	}
+	if instance.InstancePath != "" {
+		metadata["flow_path"] = instance.InstancePath
+		metadata["storage_ref"] = instance.InstancePath
+	}
+	if instance.InstanceID != "" {
+		metadata["instance_id"] = instance.InstanceID
+	}
+	if instance.ParentEntityID != "" {
+		metadata["parent_entity_id"] = instance.ParentEntityID
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func previewMetadataAfterExecution(snapshot runtimeengine.StateSnapshot, mutation runtimeengine.StateMutation) map[string]any {
+	carrier := snapshot.StateCarrier
+	if mutation.StateCarrier.Metadata != nil {
+		carrier.Metadata = cloneStringAnyMap(mutation.StateCarrier.Metadata)
+	}
+	if len(mutation.StateCarrier.Gates) > 0 {
+		carrier.Gates = workflowCloneBoolMap(mutation.StateCarrier.Gates)
+	}
+	return carrier.PersistedMetadata()
 }
 
 func handlerOutcomeFromExecutionResult(result runtimeengine.ExecutionResult) *handlerExecutionOutcome {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -717,7 +717,22 @@ func TestResolveHandlerEntityIDForFlowDoesNotRetargetSameFlowInstancePath(t *tes
 	}
 }
 
-func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClearsState(t *testing.T) {
+func TestResolveHandlerEntityIDForFlowCreateEntitySeedsInitialStateAndSchemaDefaults(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "queued",
+			FlowInitial:  map[string]string{"scoring": "queued"},
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "scoring_phase",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "revision_count", Type: "integer", Initial: 0},
+						{Name: "is_duplicate", Type: "boolean", Initial: false},
+					},
+				}},
+			},
+		},
+	})
 	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
 	const inboundEntityID = "ent-parent"
 	state := WorkflowState{
@@ -731,7 +746,7 @@ func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClears
 		Payload: mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}),
 	}.WithEnvelope(events.EventEnvelope{EntityID: inboundEntityID})
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "scoring", handler, inboundEntityID, inbound, &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, inboundEntityID, inbound, &state)
 
 	if gotID == "" || gotID == inboundEntityID {
 		t.Fatalf("entityID = %q, want fresh id", gotID)
@@ -742,8 +757,8 @@ func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClears
 	if state.EntityID != gotID {
 		t.Fatalf("state entity_id = %q, want %q", state.EntityID, gotID)
 	}
-	if state.Stage != "" {
-		t.Fatalf("state stage = %q, want cleared", state.Stage)
+	if state.Stage != "queued" {
+		t.Fatalf("state stage = %q, want queued", state.Stage)
 	}
 	if state.Status != "" {
 		t.Fatalf("state status = %q, want cleared", state.Status)
@@ -767,16 +782,26 @@ func TestResolveHandlerEntityIDForFlowCreateEntityKeepsInboundReferenceAndClears
 	if got := strings.TrimSpace(asString(state.Metadata["storage_ref"])); got != "scoring/"+instanceID {
 		t.Fatalf("state storage_ref = %q, want %q", got, "scoring/"+instanceID)
 	}
+	if got := state.Metadata["revision_count"]; got != 0 {
+		t.Fatalf("state revision_count = %#v, want 0", got)
+	}
+	if got := state.Metadata["is_duplicate"]; got != false {
+		t.Fatalf("state is_duplicate = %#v, want false", got)
+	}
 	if wantEntityID := FlowInstanceEntityID("scoring/" + instanceID); gotID != wantEntityID {
 		t.Fatalf("entityID = %q, want persisted flow entity id %q", gotID, wantEntityID)
 	}
 }
 
-func TestHandlerExecutionStateSnapshotCreateEntityStartsClean(t *testing.T) {
+func TestHandlerExecutionStateSnapshotCreateEntityIncludesInitialStateAndDefaults(t *testing.T) {
 	snapshot, err := handlerExecutionStateSnapshot(runtimecontracts.SystemNodeEventHandler{CreateEntity: true}, "ent-child", WorkflowState{
 		EntityID: "ent-parent",
 		Stage:    WorkflowStateID("queued"),
-		Metadata: map[string]any{"subject_id": "ent-parent"},
+		Metadata: map[string]any{
+			"subject_id":     "ent-parent",
+			"revision_count": 0,
+			"is_duplicate":   false,
+		},
 	})
 	if err != nil {
 		t.Fatalf("handlerExecutionStateSnapshot: %v", err)
@@ -785,14 +810,20 @@ func TestHandlerExecutionStateSnapshotCreateEntityStartsClean(t *testing.T) {
 	if got := snapshot.EntityID.String(); got != "ent-child" {
 		t.Fatalf("snapshot entity_id = %q, want ent-child", got)
 	}
-	if snapshot.CurrentState != "" {
-		t.Fatalf("snapshot current_state = %q, want empty", snapshot.CurrentState)
+	if snapshot.CurrentState != "queued" {
+		t.Fatalf("snapshot current_state = %q, want queued", snapshot.CurrentState)
 	}
 	if snapshot.Metadata == nil {
 		t.Fatal("snapshot metadata = nil, want subject metadata")
 	}
 	if got := strings.TrimSpace(asString(snapshot.Metadata["subject_id"])); got != "ent-parent" {
 		t.Fatalf("snapshot subject_id = %q, want ent-parent", got)
+	}
+	if got := snapshot.Metadata["revision_count"]; got != 0 {
+		t.Fatalf("snapshot revision_count = %#v, want 0", got)
+	}
+	if got := snapshot.Metadata["is_duplicate"]; got != false {
+		t.Fatalf("snapshot is_duplicate = %#v, want false", got)
 	}
 }
 
@@ -834,6 +865,169 @@ func TestResolveHandlerEntityIDForFlowCreateEntitySeedsFirstFlowSubjectID(t *tes
 	}
 	if got := strings.TrimSpace(asString(state.Metadata["subject_id"])); got != gotID {
 		t.Fatalf("state subject_id = %q, want %q", got, gotID)
+	}
+}
+
+func TestExecuteNodeContractHandlerCreateEntityPersistsSchemaInitialValuesBeforeGuardReads(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bus := &recordingPipelineBus{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "validation",
+			Version:      "v-test",
+			InitialStage: "queued",
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "validation_phase",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "revision_count", Type: "integer", Initial: 0},
+						{Name: "kill_reason", Type: "text"},
+					},
+				}},
+			},
+		},
+	}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("validation", []WorkflowStage{
+				{Name: "queued"},
+			}, nil),
+		},
+	}
+
+	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		Guard:        &runtimecontracts.GuardSpec{Check: "entity.revision_count == 0 && !has(entity.kill_reason)"},
+		Emits:        runtimecontracts.EventEmission{Single: "entity.created"},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("candidate.discovered")},
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	emitted := bus.publishedEvent(0)
+	entityID := emitted.EntityID()
+	if entityID == "" {
+		t.Fatal("expected emitted event to carry created entity id")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(emitted.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal emitted payload: %v", err)
+	}
+	if got := payload["revision_count"]; got != float64(0) && got != 0 {
+		t.Fatalf("emitted payload revision_count = %#v, want 0", got)
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected created entity to persist")
+	}
+	if got := instance.Metadata["revision_count"]; got != float64(0) && got != 0 {
+		t.Fatalf("persisted revision_count = %#v, want 0", got)
+	}
+
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT field, COALESCE(writer_type, ''), COALESCE(writer_id, ''), COALESCE(handler_step, '')
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid
+		ORDER BY field, created_at
+	`, entityID)
+	if err != nil {
+		t.Fatalf("query entity_mutations: %v", err)
+	}
+	defer rows.Close()
+
+	initialMutations := map[string][3]string{}
+	for rows.Next() {
+		var field, writerType, writerID, handlerStep string
+		if err := rows.Scan(&field, &writerType, &writerID, &handlerStep); err != nil {
+			t.Fatalf("scan entity_mutations: %v", err)
+		}
+		if writerType == "platform" && writerID == "entity_initial_value" {
+			initialMutations[field] = [3]string{writerType, writerID, handlerStep}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if got, ok := initialMutations["revision_count"]; !ok {
+		t.Fatalf("expected initial-value mutation for revision_count, got %#v", initialMutations)
+	} else if got[2] != "create_entity" {
+		t.Fatalf("revision_count initial mutation metadata = %#v, want handler_step create_entity", got)
+	}
+}
+
+func TestPreviewContractHandlerExecutionShowsInitialValuesMaterialized(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {
+				ID: "node-a",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"candidate.discovered": {
+						CreateEntity: true,
+						Guard:        &runtimecontracts.GuardSpec{Check: "entity.revision_count == 0"},
+						Emits:        runtimecontracts.EventEmission{Single: "entity.created"},
+					},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "validation",
+			Version:      "v-test",
+			InitialStage: "queued",
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"node-a": {
+					"candidate.discovered": {
+						CreateEntity: true,
+						Guard:        &runtimecontracts.GuardSpec{Check: "entity.revision_count == 0"},
+						Emits:        runtimecontracts.EventEmission{Single: "entity.created"},
+					},
+				},
+			},
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "validation_phase",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "revision_count", Type: "integer", Initial: 0},
+						{Name: "is_duplicate", Type: "boolean", Initial: false},
+					},
+				}},
+			},
+		},
+	}
+
+	preview, err := PreviewContractHandlerExecution(context.Background(), bundle, "node-a", events.Event{
+		Type: events.EventType("candidate.discovered"),
+	}, WorkflowState{}, nil)
+	if err != nil {
+		t.Fatalf("PreviewContractHandlerExecution: %v", err)
+	}
+	if got := preview.Metadata["revision_count"]; got != 0 {
+		t.Fatalf("preview revision_count = %#v, want 0", got)
+	}
+	if got := preview.InitialValues["revision_count"]; got != 0 {
+		t.Fatalf("preview initial revision_count = %#v, want 0", got)
+	}
+	if got := preview.InitialValues["is_duplicate"]; got != false {
+		t.Fatalf("preview initial is_duplicate = %#v, want false", got)
 	}
 }
 
@@ -1053,7 +1247,7 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "branch_target", Value: runtimecontracts.LiteralExpression("handler")},
@@ -1068,17 +1262,11 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 		}.WithEntityID("ent-1"),
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
-	if err != nil {
-		t.Fatalf("executeNodeContractHandler: %v", err)
+	if err == nil {
+		t.Fatal("expected missing early entity field to fail closed at runtime")
 	}
-	if !result.Handled {
-		t.Fatal("expected handled result")
-	}
-	if got := strings.TrimSpace(result.Outcome.RuleID); got != "" {
-		t.Fatalf("rule_id = %q, want empty when on_complete cannot see current-handler top-level writes", got)
-	}
-	if got := bus.publishedCount(); got != 0 {
-		t.Fatalf("published count = %d, want 0 when branch selection cannot see early top-level writes", got)
+	if !strings.Contains(err.Error(), "entity.branch_target") {
+		t.Fatalf("error = %v, want missing entity.branch_target context", err)
 	}
 }
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -975,6 +975,102 @@ func TestExecuteNodeContractHandlerCreateEntityPersistsSchemaInitialValuesBefore
 	}
 }
 
+func TestExecuteNodeContractHandlerCreateEntityAllowsLaterClearOfSchemaInitialValue(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bus := &recordingPipelineBus{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "validation",
+			Version:      "v-test",
+			InitialStage: "queued",
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "validation_phase",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "revision_count", Type: "integer", Initial: 0},
+					},
+				}},
+			},
+		},
+	}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("validation", []WorkflowStage{
+				{Name: "queued"},
+			}, nil),
+		},
+	}
+
+	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		Clear:        &runtimecontracts.ClearSpec{Target: "entity.revision_count"},
+		Emits:        runtimecontracts.EventEmission{Single: "entity.created"},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("candidate.discovered")},
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	entityID := bus.publishedEvent(0).EntityID()
+	if entityID == "" {
+		t.Fatal("expected emitted event to carry created entity id")
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected created entity to persist")
+	}
+	if _, ok := instance.Metadata["revision_count"]; ok {
+		t.Fatalf("persisted revision_count = %#v, want field cleared", instance.Metadata["revision_count"])
+	}
+
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT field, COALESCE(writer_type, ''), COALESCE(writer_id, ''), COALESCE(handler_step, '')
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid AND field = 'revision_count'
+		ORDER BY created_at
+	`, entityID)
+	if err != nil {
+		t.Fatalf("query entity_mutations: %v", err)
+	}
+	defer rows.Close()
+
+	var sawInitial bool
+	for rows.Next() {
+		var field, writerType, writerID, handlerStep string
+		if err := rows.Scan(&field, &writerType, &writerID, &handlerStep); err != nil {
+			t.Fatalf("scan entity_mutations: %v", err)
+		}
+		if writerType == "platform" && writerID == "entity_initial_value" && handlerStep == "create_entity" {
+			sawInitial = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if !sawInitial {
+		t.Fatal("expected initial-value mutation for revision_count before later clear")
+	}
+}
+
 func TestPreviewContractHandlerExecutionShowsInitialValuesMaterialized(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -403,10 +403,13 @@ func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID stri
 		),
 	}
 	if handler.CreateEntity {
-		snapshot.StateCarrier.Metadata = cloneStringAnyMap(state.Metadata)
-		if snapshot.StateCarrier.Metadata == nil {
-			snapshot.StateCarrier.Metadata = map[string]any{}
+		snapshot.CurrentState = strings.TrimSpace(string(state.Stage))
+		carrier, err := runtimeengine.StateCarrierFromPersisted(cloneStringAnyMap(state.Metadata), nil)
+		if err != nil {
+			return runtimeengine.StateSnapshot{}, fmt.Errorf("workflow state metadata.gates: %w", err)
 		}
+		snapshot.StateCarrier.Metadata = carrier.Metadata
+		snapshot.StateCarrier.Gates = carrier.Gates
 		return snapshot, nil
 	}
 	snapshot.CurrentState = strings.TrimSpace(string(state.Stage))

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -21,10 +21,16 @@ const (
 	WorkflowEntityFieldLifecycleOnComplete       WorkflowEntityFieldLifecyclePhase = "on_complete"
 	WorkflowEntityFieldLifecycleRule             WorkflowEntityFieldLifecyclePhase = "rule"
 	WorkflowEntityFieldLifecycleDataAccumulation WorkflowEntityFieldLifecyclePhase = "data_accumulation"
+	WorkflowEntityFieldLifecyclePayloadTransform WorkflowEntityFieldLifecyclePhase = "payload_transform"
 )
 
 var workflowExpressionEntityReferencePattern = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 var workflowExpressionEntityPresencePattern = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
+var workflowExpressionEntityHasPattern = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
+var workflowExpressionEntityHasTernaryTruePattern = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+var workflowExpressionEntityHasTernaryFalsePattern = regexp.MustCompile(`!\s*has\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*[^:]+:\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+var workflowExpressionEntityNullCompareLeftPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=)\s*null\b`)
+var workflowExpressionEntityNullCompareRightPattern = regexp.MustCompile(`\bnull\s*(==|!=)\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
 
 func WorkflowEntityReferences(expression string) []string {
 	expression = strings.TrimSpace(stripWorkflowExpressionStringLiterals(expression))
@@ -120,24 +126,49 @@ func WorkflowBuiltinEntityField(field string) bool {
 }
 
 func WorkflowPresenceGuardedEntityFields(expression string) map[string]struct{} {
-	expression = strings.TrimSpace(expression)
+	expression = strings.TrimSpace(stripWorkflowExpressionStringLiterals(expression))
 	if expression == "" {
 		return nil
 	}
-	matches := workflowExpressionEntityPresencePattern.FindAllStringSubmatch(expression, -1)
-	if len(matches) == 0 {
-		return nil
+	out := map[string]struct{}{}
+	addField := func(field string) {
+		field = WorkflowEntityReferenceField(field)
+		if field != "" {
+			out[field] = struct{}{}
+		}
 	}
-	out := make(map[string]struct{}, len(matches))
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
+	for _, match := range workflowExpressionEntityPresencePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
 		}
-		field := strings.TrimSpace(match[1])
-		if field == "" {
-			continue
+	}
+	for _, match := range workflowExpressionEntityHasPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
 		}
-		out[field] = struct{}{}
+	}
+	for _, match := range workflowExpressionEntityHasTernaryTruePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 && WorkflowEntityReferenceField(match[1]) == WorkflowEntityReferenceField(match[2]) {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityHasTernaryFalsePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 && WorkflowEntityReferenceField(match[1]) == WorkflowEntityReferenceField(match[2]) {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityNullCompareLeftPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityNullCompareRightPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 {
+			addField(match[2])
+		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -161,6 +192,10 @@ func WorkflowEntityFieldsAvailableBeforeCondition(handler runtimecontracts.Syste
 
 func WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
 	return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleDataAccumulation)
+}
+
+func WorkflowEntityFieldsAvailableBeforePayloadTransform(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
+	return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecyclePayloadTransform)
 }
 
 func WorkflowEntityReadsPersistedStateBeforeHandlerWrites(phase WorkflowEntityFieldLifecyclePhase) bool {
@@ -324,6 +359,8 @@ func workflowEntityFieldLifecycleOrder(phase WorkflowEntityFieldLifecyclePhase) 
 		return 10
 	case WorkflowEntityFieldLifecycleDataAccumulation:
 		return 11
+	case WorkflowEntityFieldLifecyclePayloadTransform:
+		return 12
 	default:
 		return 0
 	}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -207,11 +207,13 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 }
 
 func rewriteWorkflowExpressionEntityNullPresenceChecks(expression string) string {
-	expression = workflowExpressionEntityNullNotEqualPattern.ReplaceAllString(expression, `has(entity.$1) && entity.$1 != null`)
-	expression = workflowExpressionNullEntityNotEqualPattern.ReplaceAllString(expression, `has(entity.$1) && entity.$1 != null`)
-	expression = workflowExpressionEntityNullEqualPattern.ReplaceAllString(expression, `!has(entity.$1) || entity.$1 == null`)
-	expression = workflowExpressionNullEntityEqualPattern.ReplaceAllString(expression, `!has(entity.$1) || entity.$1 == null`)
-	return expression
+	return rewriteWorkflowExpressionOutsideStringLiterals(expression, func(segment string) string {
+		segment = workflowExpressionEntityNullNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
+		segment = workflowExpressionNullEntityNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
+		segment = workflowExpressionEntityNullEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
+		segment = workflowExpressionNullEntityEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
+		return segment
+	})
 }
 
 func rewriteWorkflowExpressionQueryEntityCounts(expression string, ctx workflowExpressionContext) (string, error) {
@@ -378,6 +380,62 @@ func normalizeWorkflowExpressionStringLiterals(expression string) string {
 			continue
 		}
 		out.WriteByte(ch)
+	}
+	return out.String()
+}
+
+func rewriteWorkflowExpressionOutsideStringLiterals(expression string, rewrite func(string) string) string {
+	if expression == "" || rewrite == nil {
+		return expression
+	}
+	var out strings.Builder
+	segmentStart := 0
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if ch == '\\' && i+1 < len(expression) {
+			i++
+			continue
+		}
+		if ch == '"' && !inSingle {
+			if !inDouble {
+				out.WriteString(rewrite(expression[segmentStart:i]))
+				segmentStart = i
+				inDouble = true
+				continue
+			}
+			inDouble = false
+			i++
+			out.WriteString(expression[segmentStart:i])
+			segmentStart = i
+			i--
+			continue
+		}
+		if ch == '\'' && !inDouble {
+			if !inSingle {
+				out.WriteString(rewrite(expression[segmentStart:i]))
+				segmentStart = i
+				inSingle = true
+				continue
+			}
+			inSingle = false
+			i++
+			out.WriteString(expression[segmentStart:i])
+			segmentStart = i
+			i--
+			continue
+		}
+	}
+	if segmentStart < len(expression) {
+		if inSingle || inDouble {
+			out.WriteString(expression[segmentStart:])
+		} else {
+			out.WriteString(rewrite(expression[segmentStart:]))
+		}
+	}
+	if segmentStart == 0 && out.Len() == 0 {
+		return rewrite(expression)
 	}
 	return out.String()
 }

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -19,6 +19,10 @@ var workflowExpressionCountGEPattern = regexp.MustCompile(`count\(\s*([a-zA-Z_][
 var workflowExpressionStageRangeCountPattern = regexp.MustCompile(`count\(\s*entities\s+in\s+\[([a-zA-Z_][a-zA-Z0-9_]*)\.\.([a-zA-Z_][a-zA-Z0-9_]*)\]\s*\)`)
 var workflowExpressionQueryEntitiesCountPattern = regexp.MustCompile(`query_entities\(\s*([^()]+?)\s*\)\.count`)
 var workflowExpressionQueryPredicatePattern = regexp.MustCompile(`^\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=|>=|<=|>|<)\s*(.+?)\s*$`)
+var workflowExpressionEntityNullNotEqualPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*!=\s*null\b`)
+var workflowExpressionEntityNullEqualPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*==\s*null\b`)
+var workflowExpressionNullEntityNotEqualPattern = regexp.MustCompile(`\bnull\s*!=\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+var workflowExpressionNullEntityEqualPattern = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
 
 type workflowExpressionContext struct {
 	Entity           map[string]any
@@ -170,6 +174,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 		}
 	})
 	normalized = normalizeWorkflowExpressionStringLiterals(normalized)
+	normalized = rewriteWorkflowExpressionEntityNullPresenceChecks(normalized)
 	normalizedCtx := workflowExpressionContext{
 		Entity:           cloneStringAnyMap(ctx.Entity),
 		Payload:          cloneStringAnyMap(ctx.Payload),
@@ -199,6 +204,14 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 		return "", workflowExpressionContext{}, err
 	}
 	return normalized, normalizedCtx, nil
+}
+
+func rewriteWorkflowExpressionEntityNullPresenceChecks(expression string) string {
+	expression = workflowExpressionEntityNullNotEqualPattern.ReplaceAllString(expression, `has(entity.$1) && entity.$1 != null`)
+	expression = workflowExpressionNullEntityNotEqualPattern.ReplaceAllString(expression, `has(entity.$1) && entity.$1 != null`)
+	expression = workflowExpressionEntityNullEqualPattern.ReplaceAllString(expression, `!has(entity.$1) || entity.$1 == null`)
+	expression = workflowExpressionNullEntityEqualPattern.ReplaceAllString(expression, `!has(entity.$1) || entity.$1 == null`)
+	return expression
 }
 
 func rewriteWorkflowExpressionQueryEntityCounts(expression string, ctx workflowExpressionContext) (string, error) {

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -140,6 +140,29 @@ func TestWorkflowExpressionEvaluator_EvalBoolIgnoresEntityRefsInsideStringLitera
 	}
 }
 
+func TestWorkflowExpressionEvaluator_EvalBoolIgnoresNullPresencePatternsInsideStringLiterals(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	for _, tc := range []struct {
+		expression string
+		label      string
+	}{
+		{expression: `payload.label == "entity.kill_reason == null"`, label: "entity.kill_reason == null"},
+		{expression: `payload.label == "entity.kill_reason != null"`, label: "entity.kill_reason != null"},
+	} {
+		ok, err := eval.EvalBool(tc.expression, workflowExpressionContext{
+			Entity:  map[string]any{},
+			Payload: map[string]any{"label": tc.label},
+			Policy:  map[string]any{},
+		})
+		if err != nil {
+			t.Fatalf("EvalBool(%q) error = %v", tc.expression, err)
+		}
+		if !ok {
+			t.Fatalf("expected quoted null-presence text to stay literal for %q", tc.expression)
+		}
+	}
+}
+
 func TestParseWorkflowEntityQueryPredicate_ResolvesPayloadReference(t *testing.T) {
 	predicate, err := parseWorkflowEntityQueryPredicate(
 		`name == payload.name`,

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -68,6 +68,63 @@ func TestWorkflowExpressionEvaluator_EvalBoolFailsClosedOnMissingEntityField(t *
 	}
 }
 
+func TestWorkflowExpressionEvaluator_EvalBoolAllowsHasPresenceCheckOnSparseField(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`has(entity.kill_reason)`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{},
+		Policy:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool error = %v", err)
+	}
+	if ok {
+		t.Fatal("expected has(entity.kill_reason) to be false for sparse field")
+	}
+}
+
+func TestWorkflowExpressionEvaluator_EvalBoolAllowsNullPresenceChecksOnSparseField(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`entity.kill_reason == null`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{},
+		Policy:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool == null error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected sparse field == null to be true")
+	}
+
+	ok, err = eval.EvalBool(`entity.kill_reason != null`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{},
+		Policy:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool != null error = %v", err)
+	}
+	if ok {
+		t.Fatal("expected sparse field != null to be false")
+	}
+}
+
+func TestWorkflowExpressionEvaluator_EvalBoolAllowsHasGuardedTernaryReadOnSparseField(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`has(entity.kill_reason) ? entity.kill_reason == "manual" : true`, workflowExpressionContext{
+		Entity:  map[string]any{},
+		Payload: map[string]any{},
+		Policy:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool ternary error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected guarded ternary read to take fallback branch for sparse field")
+	}
+}
+
 func TestWorkflowExpressionEvaluator_EvalBoolIgnoresEntityRefsInsideStringLiterals(t *testing.T) {
 	eval := newWorkflowExpressionEvaluator()
 	ok, err := eval.EvalBool(`payload.label == "entity.score"`, workflowExpressionContext{

--- a/internal/runtime/pipeline/workflow_handler_preview.go
+++ b/internal/runtime/pipeline/workflow_handler_preview.go
@@ -17,6 +17,7 @@ type HandlerPreview struct {
 	Stage           WorkflowStateID
 	StatusText      string
 	Metadata        map[string]any
+	InitialValues   map[string]any
 	Emits           []string
 	ActionsExecuted []string
 	GuardsEvaluated []string
@@ -152,7 +153,8 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 		Status:          status,
 		Stage:           stage,
 		StatusText:      state.Status,
-		Metadata:        cloneStringAnyMap(state.Metadata),
+		Metadata:        cloneStringAnyMap(result.PreviewMetadata),
+		InitialValues:   cloneStringAnyMap(result.InitialValuesMaterialized),
 		Emits:           emits,
 		ActionsExecuted: actions,
 		GuardsEvaluated: guards,

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -95,8 +95,35 @@ type WorkflowInstanceStore struct {
 
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
+type workflowCreateEntityInitialValuesContextKey struct{}
+
+type workflowCreateEntityInitialValues struct {
+	Fields map[string]any
+}
+
 func NewWorkflowInstanceStore(db *sql.DB) *WorkflowInstanceStore {
 	return &WorkflowInstanceStore{db: db}
+}
+
+func withWorkflowCreateEntityInitialValues(ctx context.Context, fields map[string]any) context.Context {
+	if len(fields) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, workflowCreateEntityInitialValuesContextKey{}, workflowCreateEntityInitialValues{
+		Fields: cloneStringAnyMap(fields),
+	})
+}
+
+func workflowCreateEntityInitialValuesFromContext(ctx context.Context) (workflowCreateEntityInitialValues, bool) {
+	if ctx == nil {
+		return workflowCreateEntityInitialValues{}, false
+	}
+	raw := ctx.Value(workflowCreateEntityInitialValuesContextKey{})
+	info, ok := raw.(workflowCreateEntityInitialValues)
+	if !ok || len(info.Fields) == 0 {
+		return workflowCreateEntityInitialValues{}, false
+	}
+	return workflowCreateEntityInitialValues{Fields: cloneStringAnyMap(info.Fields)}, true
 }
 
 func (s *WorkflowInstanceStore) Enabled() bool {
@@ -584,12 +611,21 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	); err != nil {
 		return err
 	}
-	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rowID, previous, runtimemutationlog.EntityStateProjection{
+	afterProjection := runtimemutationlog.EntityStateProjection{
 		CurrentState: strings.TrimSpace(instance.CurrentState),
 		Fields:       projection.Fields,
 		Gates:        projection.GatesAny(),
 		Accumulator:  projection.Accumulator,
-	}, runtimemutationlog.Writer{
+	}
+	previousForDiff := previous
+	if createInfo, ok := workflowCreateEntityInitialValuesFromContext(ctx); ok {
+		nextPrevious, err := insertWorkflowCreateEntityInitialValueMutations(ctx, tx, rowID, previous, afterProjection, createInfo.Fields)
+		if err != nil {
+			return err
+		}
+		previousForDiff = nextPrevious
+	}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rowID, previousForDiff, afterProjection, runtimemutationlog.Writer{
 		Type:        "platform",
 		ID:          "workflow_instance_store",
 		HandlerStep: "upsert",
@@ -664,6 +700,65 @@ func lockWorkflowInstanceMutation(ctx context.Context, tx *sql.Tx, instanceID st
 		return fmt.Errorf("lock workflow instance mutation: %w", err)
 	}
 	return nil
+}
+
+func insertWorkflowCreateEntityInitialValueMutations(
+	ctx context.Context,
+	tx *sql.Tx,
+	entityID string,
+	before, after runtimemutationlog.EntityStateProjection,
+	initialValues map[string]any,
+) (runtimemutationlog.EntityStateProjection, error) {
+	if len(initialValues) == 0 {
+		return before, nil
+	}
+	adjusted := runtimemutationlog.EntityStateProjection{
+		CurrentState: before.CurrentState,
+		Fields:       cloneStringAnyMap(before.Fields),
+		Gates:        cloneStringAnyMap(before.Gates),
+		Accumulator:  cloneStringAnyMap(before.Accumulator),
+	}
+	if adjusted.Fields == nil {
+		adjusted.Fields = map[string]any{}
+	}
+	for field, declared := range initialValues {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		finalValue, ok := after.Fields[field]
+		if !ok {
+			return runtimemutationlog.EntityStateProjection{}, fmt.Errorf("create_entity initial value %s missing from persisted entity projection", field)
+		}
+		oldValue, hadOld := adjusted.Fields[field]
+		if hadOld && workflowJSONValuesEqual(oldValue, declared) {
+			continue
+		}
+		if err := runtimemutationlog.Insert(ctx, tx, runtimemutationlog.Record{
+			EntityID:    entityID,
+			Field:       field,
+			OldValue:    oldValueOrNil(oldValue, hadOld),
+			NewValue:    declared,
+			WriterType:  "platform",
+			WriterID:    "entity_initial_value",
+			HandlerStep: "create_entity",
+		}); err != nil {
+			return runtimemutationlog.EntityStateProjection{}, err
+		}
+		if workflowJSONValuesEqual(finalValue, declared) {
+			adjusted.Fields[field] = declared
+			continue
+		}
+		adjusted.Fields[field] = declared
+	}
+	return adjusted, nil
+}
+
+func oldValueOrNil(value any, ok bool) any {
+	if !ok {
+		return nil
+	}
+	return value
 }
 
 func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, entityID string) (runtimemutationlog.EntityStateProjection, error) {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -727,9 +727,6 @@ func insertWorkflowCreateEntityInitialValueMutations(
 			continue
 		}
 		finalValue, ok := after.Fields[field]
-		if !ok {
-			return runtimemutationlog.EntityStateProjection{}, fmt.Errorf("create_entity initial value %s missing from persisted entity projection", field)
-		}
 		oldValue, hadOld := adjusted.Fields[field]
 		if hadOld && workflowJSONValuesEqual(oldValue, declared) {
 			continue
@@ -745,7 +742,7 @@ func insertWorkflowCreateEntityInitialValueMutations(
 		}); err != nil {
 			return runtimemutationlog.EntityStateProjection{}, err
 		}
-		if workflowJSONValuesEqual(finalValue, declared) {
+		if ok && workflowJSONValuesEqual(finalValue, declared) {
 			adjusted.Fields[field] = declared
 			continue
 		}

--- a/internal/runtime/pipeline/workflow_validation_helpers.go
+++ b/internal/runtime/pipeline/workflow_validation_helpers.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -16,36 +17,92 @@ func stringValue(v any) string {
 	return ""
 }
 
+func asBool(v any) bool {
+	typed, ok := v.(bool)
+	return ok && typed
+}
+
 func workflowEntitySchemaFields(source semanticview.Source) map[string]struct{} {
-	out := map[string]struct{}{}
 	if source == nil {
-		return out
+		return map[string]struct{}{}
 	}
-	collectEntitySchemaFields(source.WorkflowEntitySchema(), out)
+	return workflowEntitySchemaFieldNames(source.WorkflowEntitySchema())
+}
+
+func workflowEntitySchemaFieldNames(raw any) map[string]struct{} {
+	out := map[string]struct{}{}
+	collectEntitySchemaFields(raw, out)
 	return out
 }
 
 func collectEntitySchemaFields(raw any, out map[string]struct{}) {
+	for name := range workflowEntitySchemaFieldDefinitions(raw) {
+		out[name] = struct{}{}
+	}
+}
+
+func workflowEntitySchemaInitialValues(source semanticview.Source) map[string]any {
+	if source == nil {
+		return nil
+	}
+	return workflowEntitySchemaInitialValuesFromRaw(source.WorkflowEntitySchema())
+}
+
+func WorkflowEntitySchemaInitialValueFields(source semanticview.Source) map[string]struct{} {
+	if source == nil {
+		return nil
+	}
+	out := map[string]struct{}{}
+	for field := range workflowEntitySchemaInitialValuesFromRaw(source.WorkflowEntitySchema()) {
+		out[field] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func workflowEntitySchemaInitialValuesFromRaw(raw any) map[string]any {
+	fields := workflowEntitySchemaFieldDefinitions(raw)
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(fields))
+	for name, field := range fields {
+		if field.Initial == nil {
+			continue
+		}
+		out[name] = cloneWorkflowSchemaValue(field.Initial)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func workflowEntitySchemaFieldDefinitions(raw any) map[string]runtimecontracts.EntitySchemaField {
+	out := map[string]runtimecontracts.EntitySchemaField{}
 	switch typed := raw.(type) {
 	case runtimecontracts.EntitySchema:
 		for _, group := range typed.Groups {
 			for _, field := range group.Fields {
 				name := strings.TrimSpace(field.Name)
 				if name != "" {
-					out[name] = struct{}{}
+					field.Name = name
+					out[name] = field
 				}
 			}
 		}
-		return
+		return out
 	case *runtimecontracts.EntitySchema:
 		if typed != nil {
-			collectEntitySchemaFields(*typed, out)
+			return workflowEntitySchemaFieldDefinitions(*typed)
 		}
-		return
+		return out
 	}
 	obj, ok := asObject(raw)
 	if !ok {
-		return
+		return out
 	}
 	if groups, ok := obj["groups"]; ok {
 		switch typed := groups.(type) {
@@ -59,13 +116,17 @@ func collectEntitySchemaFields(raw any, out map[string]struct{}) {
 				if !ok {
 					continue
 				}
-				collectEntitySchemaFields(fields, out)
+				for name, field := range workflowEntitySchemaFieldDefinitions(fields) {
+					out[name] = field
+				}
 			}
 		}
 	}
 	if fields, ok := obj["fields"]; ok {
-		collectEntitySchemaFields(fields, out)
-		return
+		for name, field := range workflowEntitySchemaFieldDefinitions(fields) {
+			out[name] = field
+		}
+		return out
 	}
 	if items, ok := raw.([]any); ok {
 		for _, item := range items {
@@ -75,9 +136,39 @@ func collectEntitySchemaFields(raw any, out map[string]struct{}) {
 			}
 			name := strings.TrimSpace(asString(field["name"]))
 			if name != "" {
-				out[name] = struct{}{}
+				out[name] = runtimecontracts.EntitySchemaField{
+					Name:        name,
+					Type:        strings.TrimSpace(asString(field["type"])),
+					Initial:     cloneWorkflowSchemaValue(field["initial"]),
+					Nullable:    asBool(field["nullable"]),
+					Description: strings.TrimSpace(asString(field["description"])),
+				}
 			}
 		}
+	}
+	return out
+}
+
+func cloneWorkflowSchemaValue(value any) any {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = cloneWorkflowSchemaValue(item)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, cloneWorkflowSchemaValue(item))
+		}
+		return out
+	case json.RawMessage:
+		return append(json.RawMessage(nil), typed...)
+	default:
+		return typed
 	}
 }
 


### PR DESCRIPTION
Closes #180

## Human Summary

This makes flow-entity schema initial values real at the create-time owner instead of leaving them implicit or reconstructing them later. The touched `create_entity` path now materializes approved `entity_schema` initial values before first handler reads, boot validation understands the approved sparse-field rules, and the touched preview/diagnostic slice shows which initial values were materialized.

## What Changed

- integrated the approved entity-schema initial-values draft into the authoritative `platform-spec.yaml` as a replacement, not an additive duplicate
- extended `entity_schema` contracts to preserve mapping-form `initial` and `description` metadata while rejecting unsupported scalar `initial` syntax and mapping forms without `type`
- seeded schema initial values into the create-entity state snapshot and persisted workflow instance metadata before first handler reads
- aligned handler preview diagnostics so the touched create-entity preview exposes `initial_values_materialized`
- aligned lifecycle-aware expression validation with the approved sparse-field rules:
  - `has(entity.X)`
  - `entity.X == null`
  - `entity.X != null`
  - `has(entity.X) ? entity.X : fallback`
- tightened boot validation so create-entity guards cannot claim same-handler top-level `data_accumulation` as an initializer, while schema initial values and presence checks remain valid
- recorded create-time initial value materialization in the touched mutation trail with `writer_type = platform` and `writer_id = entity_initial_value`

## Why This Is Needed

Before this change, flow-entity defaults were still implicit in the touched create path. That let first reads fail later as missing-field expression errors, and the touched diagnostics path could not clearly show what was actually materialized at creation time. This change makes initialization explicit at the canonical creation owner and keeps boot/runtime/diagnostic behavior aligned with the approved contract.

## Scope Boundaries

- scoped to the flow-managed `create_entity` pipeline path and the adjacent boot/runtime/preview behavior needed to make that path spec-compliant
- does not claim total system-wide default-materialization compliance for every entity-creation seam
- does not redesign storage/read models beyond the touched engine/pipeline carrier boundary
- does not widen into agent tool `create_entity` semantics or unrelated diagnostics surfaces

## Spec references

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: contract_formats.entity_schema`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: handler_fields.create_entity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_context`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_language`

## Tests Run

- `go test ./internal/runtime/contracts ./internal/runtime/pipeline ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`

## Residual Risk

- this only makes the touched flow-entity create path compliant; if another entity-creation owner outside this seam still reconstructs defaults later, that remains separate work
- the stricter boot-validation interpretation now rejects some previously tolerated sparse-field reads unless they use schema initials or explicit presence checks, which is intentional under the approved spec

## Follow-Up

- no spec escalation was needed after the approved draft was integrated
- if review wants broader coverage, the next separate seam would be non-pipeline entity creation paths rather than further widening this PR
