### PR TITLE
[agent-a][issue #270] Align verify and boot warning parity

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -361,6 +361,18 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 			wantErr: false,
 		},
 		{
+			name: "missing emitted event schema warning",
+			bundle: func() *runtimecontracts.WorkflowContractBundle {
+				bundle := testWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
+				}
+				return bundle
+			}(),
+			errContains: "'missing.event' emitted but no schema in events.yaml",
+			wantErr:     true,
+		},
+		{
 			name: "tool implementation warning",
 			bundle: func() *runtimecontracts.WorkflowContractBundle {
 				bundle := testWorkflowValidationBundle()
@@ -372,18 +384,6 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				return bundle
 			}(),
 			errContains: "tool implementation warnings",
-			wantErr:     true,
-		},
-		{
-			name: "missing emit schema",
-			bundle: func() *runtimecontracts.WorkflowContractBundle {
-				bundle := testWorkflowValidationBundle()
-				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
-					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
-				}
-				return bundle
-			}(),
-			errContains: "emit schema strict mode enabled",
 			wantErr:     true,
 		},
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,7 +18,6 @@ import (
 	"swarm/internal/events"
 	runtimeagents "swarm/internal/runtime/agents"
 	runtimeauthority "swarm/internal/runtime/authority"
-	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -179,43 +178,12 @@ func ensureWorkflowBootWiring(opts RuntimeOptions) error {
 	if err != nil {
 		return err
 	}
-	if !bootWarningsFatal() {
-		return nil
-	}
-	warnings := bootWarningsExcludingCheckIDs(result.BootReport.Warnings(), "tool_resolution")
-	if len(warnings) == 0 {
-		return nil
-	}
-	lines := make([]string, 0, len(warnings))
-	for _, finding := range warnings {
-		lines = append(lines, strings.TrimSpace(finding.Message))
-	}
-	return fmt.Errorf(strings.Join(lines, "\n"))
+	_ = result
+	return nil
 }
 
 func bootWarningsFatal() bool {
 	return runtimeEnvBool("SWARM_BOOT_WARNINGS_FATAL", true)
-}
-
-func bootWarningsExcludingCheckIDs(findings []runtimebootverify.Finding, checkIDs ...string) []runtimebootverify.Finding {
-	if len(findings) == 0 {
-		return nil
-	}
-	skip := make(map[string]struct{}, len(checkIDs))
-	for _, checkID := range checkIDs {
-		checkID = strings.TrimSpace(checkID)
-		if checkID != "" {
-			skip[checkID] = struct{}{}
-		}
-	}
-	out := make([]runtimebootverify.Finding, 0, len(findings))
-	for _, finding := range findings {
-		if _, excluded := skip[strings.TrimSpace(finding.CheckID)]; excluded {
-			continue
-		}
-		out = append(out, finding)
-	}
-	return out
 }
 
 func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.PromptResolver, error) {

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -18,6 +18,8 @@ type WorkflowContractValidationOptions struct {
 	CheckMCPReachable              bool
 	StrictEmitSchemas              bool
 	FatalToolImplementationWarning bool
+	FatalBootWarnings              bool
+	ExcludedFatalBootWarningChecks []string
 }
 
 type WorkflowContractValidationResult struct {
@@ -32,6 +34,8 @@ func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Sto
 		CheckMCPReachable:              true,
 		StrictEmitSchemas:              runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true),
 		FatalToolImplementationWarning: bootWarningsFatal(),
+		FatalBootWarnings:              bootWarningsFatal(),
+		ExcludedFatalBootWarningChecks: []string{"tool_resolution"},
 	}
 }
 
@@ -54,6 +58,12 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	})
 	if result.BootReport.HasErrors() {
 		return result, fmt.Errorf("boot verification failed:\n%s", formatWorkflowValidationFindings(result.BootReport.Errors()))
+	}
+	if opts.FatalBootWarnings {
+		warnings := filterWorkflowValidationFindings(result.BootReport.Warnings(), opts.ExcludedFatalBootWarningChecks...)
+		if len(warnings) > 0 {
+			return result, fmt.Errorf("boot verification warnings:\n%s", formatWorkflowValidationFindings(warnings))
+		}
 	}
 
 	warnings, err := runtimetools.ValidateToolImplementations(source)
@@ -95,4 +105,25 @@ func formatValidationErrors(errs []error) string {
 		lines = append(lines, strings.TrimSpace(err.Error()))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func filterWorkflowValidationFindings(findings []runtimebootverify.Finding, excludedCheckIDs ...string) []runtimebootverify.Finding {
+	if len(findings) == 0 {
+		return nil
+	}
+	excluded := make(map[string]struct{}, len(excludedCheckIDs))
+	for _, checkID := range excludedCheckIDs {
+		checkID = strings.TrimSpace(checkID)
+		if checkID != "" {
+			excluded[checkID] = struct{}{}
+		}
+	}
+	out := make([]runtimebootverify.Finding, 0, len(findings))
+	for _, finding := range findings {
+		if _, skip := excluded[strings.TrimSpace(finding.CheckID)]; skip {
+			continue
+		}
+		out = append(out, finding)
+	}
+	return out
 }

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -37,6 +37,18 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 			wantErr: false,
 		},
 		{
+			name: "missing emitted event schema warning",
+			source: func() semanticview.Source {
+				bundle := testRuntimeWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
+				}
+				return semanticview.Wrap(bundle)
+			}(),
+			errContains: "'missing.event' emitted but no schema in events.yaml",
+			wantErr:     true,
+		},
+		{
 			name: "tool implementation warning",
 			source: func() semanticview.Source {
 				bundle := testRuntimeWorkflowValidationBundle()
@@ -48,18 +60,6 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 				return semanticview.Wrap(bundle)
 			}(),
 			errContains: "tool implementation warnings",
-			wantErr:     true,
-		},
-		{
-			name: "missing emit schema",
-			source: func() semanticview.Source {
-				bundle := testRuntimeWorkflowValidationBundle()
-				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
-					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
-				}
-				return semanticview.Wrap(bundle)
-			}(),
-			errContains: "emit schema strict mode enabled",
 			wantErr:     true,
 		},
 	}
@@ -82,9 +82,11 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 
 func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T) {
 	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 	bundle := testRuntimeWorkflowValidationBundle()
 	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 		"agent-1": {ID: "agent-1", EmitEvents: []string{"ready.event"}},
+		"agent-2": {ID: "agent-2", Subscriptions: []string{"ready.event"}},
 	}
 	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
 		"ready.event": {
@@ -103,6 +105,9 @@ func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T
 	}
 	if len(result.MissingEmitSchemaEventTypes) != 0 {
 		t.Fatalf("MissingEmitSchemaEventTypes = %#v, want none", result.MissingEmitSchemaEventTypes)
+	}
+	if len(result.BootReport.Warnings()) != 0 {
+		t.Fatalf("BootReport warnings = %#v, want none", result.BootReport.Warnings())
 	}
 }
 


### PR DESCRIPTION
Closes #270

Spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: contract_formats.event_schema`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.platform_builtin_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.agent_tool_filtering`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_verification`
- governing rule: contract validation, event-schema coverage, and tool availability must be derived from one canonical platform model; the runtime must not accept a contract set in targeted verification and then reject it during boot for the same semantic class.

## Human Summary

This finishes the reopened parity fix by moving boot-warning fatality into the shared verify/boot validation entrypoint. Targeted `verify` now fails on the same emitted-event boot warning class that runtime boot already rejected, while still keeping `tool_resolution` on the explicit warning-only path.

## What Changed

- moved boot-warning fatality into `ValidateWorkflowContractSurface(...)`
- made the shared validator own the exclusion list for warning classes that stay non-fatal in this seam (`tool_resolution`)
- removed the runtime-local warning fatalization branch from `ensureWorkflowBootWiring(...)`
- added focused parity regressions for emitted-event warning drift and retained tool warning parity coverage

## Why This Is Needed

`#270` was reopened because the first pass improved tool-validation parity but left the emitted-event-schema manifestation unresolved. The remaining drift was that targeted `verify` ignored boot warnings entirely while runtime boot promoted them to fatal under the current boot-warning policy. That left the supported surfaces contradicting each other on the same contract set.

## Scope Boundaries

In scope:
- verify-vs-boot warning fatality parity in the shared contract-validation seam
- emitted-event warning parity proof
- tool-validation parity regression guard in the same seam

Not in scope:
- authored Empire contract migration
- broader boot-verification redesign
- product-specific allowances for missing event schemas or topology warnings

## Tests Run

- `go test ./cmd/swarm ./internal/runtime -run 'Test(VerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses|EnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath|ValidateWorkflowContractSurface_AllowsExplicitEventSchemas|ValidateWorkflowContractSurface_FatalToolImplementationWarningsFollowSharedOptions)$' -count=1`
- `go test ./cmd/swarm ./internal/runtime ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`
- `go run ./cmd/swarm verify -contracts /Users/youmew/swarm/empire/contracts`
- `SWARM_LLM_RUNTIME_MODE=api ANTHROPIC_API_KEY=dummy SWARM_CLAUDE_DEFAULT_MODEL=test-model make run-clear CONTRACTS_ROOT=/Users/youmew/swarm/empire/contracts`

## Residual Risk

No known residual parity risk remains in the touched seam. The two supported surfaces now fail on the same emitted-event warning class, and `tool_resolution` remains explicitly non-fatal on both sides.

## Follow-Up

None in this seam. If the Empire contracts should eventually boot cleanly, that is authored-contract cleanup rather than remaining verify-vs-boot platform drift.
