### PR TITLE
[agent-c][issue #199] Add canonical session termination metadata

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1129,6 +1129,51 @@ engine:
       runtime_state.provider_session_id — in agent_sessions for session/session_per_entity modes, in
       agent_conversation_audits for task mode. NOT in session_id or audit_id. Those are platform-owned
       UUID primary keys. The provider ID is an implementation detail that may change if the provider is swapped.'
+    session_termination_metadata:
+      description: 'Structured termination metadata for live reusable sessions. Stale live-session meanings
+        such as orphaned, contaminated, and superseded are NOT status values. status remains one of
+        active, suspended, terminated. termination_reason explains why the session was terminated.
+        successor_session_id links a terminated session to its replacement when one exists.'
+      uniqueness_model:
+        description: 'The database uniqueness model for agent_sessions applies only to non-terminated rows.
+          Terminated rows are historical lineage and may coexist for the same scope.'
+        old_constraint: UNIQUE (agent_id, scope_key)
+        new_constraint: 'UNIQUE INDEX agent_sessions_nonterminated_unique ON agent_sessions(agent_id, scope_key)
+          WHERE status <> ''terminated'''
+        live_owner_query: 'Live runtime ownership queries MUST filter status = ''active''.'
+        resumable_owner_query: 'Resumable-owner queries MUST filter status IN (''active'', ''suspended'').'
+      fields:
+        termination_reason:
+          values:
+          - normal
+          - cancelled
+          - failed
+          - orphaned
+          - contaminated
+          - legacy
+          semantics: 'legacy is reserved for migration backfill only. The runtime MUST NOT set legacy on new terminations.'
+        termination_detail: Optional human-readable detail for diagnostics/operator UI.
+        successor_session_id: 'UUID link to the successor session in the same agent/scope/scope_key lineage. A session is
+          superseded iff successor_session_id IS NOT NULL.'
+        terminated_at: Timestamp set when status transitions to terminated.
+      invariants:
+      - 'status IN (active, suspended) → termination_reason, termination_detail, successor_session_id, terminated_at are NULL.'
+      - 'status = terminated → termination_reason and terminated_at are required.'
+      - 'successor_session_id IS NOT NULL → status = terminated.'
+      - 'successor_session_id must reference a different session_id with the same agent_id, scope, and scope_key.'
+      - 'successor_session_id lineage must be acyclic.'
+      - 'terminated sessions are never resurrected to active or suspended.'
+      transitions:
+      - 'active → suspended'
+      - 'suspended → active'
+      - 'active → terminated'
+      - 'suspended → terminated'
+      - 'terminated rows may receive successor_session_id later, but status and termination_reason do not change.'
+      migration:
+      - 'Add nullable termination_reason, termination_detail, successor_session_id, terminated_at columns.'
+      - 'Replace old UNIQUE (agent_id, scope_key) with the partial non-terminated unique index.'
+      - 'Backfill legacy terminated rows to termination_reason = legacy and terminated_at = COALESCE(updated_at, created_at).'
+      - 'Enable invariant enforcement only after the legacy backfill.'
     conversation_mode_values:
       task: 'Stateless between invocations. No agent_sessions row. Audit snapshot persisted to
         agent_conversation_audits (write-only). Per-turn history in agent_turns. Never reloaded.
@@ -2465,7 +2510,9 @@ platform_tables:
         agent_conversation_audits instead. Supports three scopes: entity (one session per agent × entity),
         flow (one session per agent × flow instance), global (one session per agent, shared across all
         entities). scope directly reflects the declared session_scope. scope_key is the lookup key.
-        lease_holder/lease_expires_at for distributed session locking.'
+        lease_holder/lease_expires_at for distributed session locking. Termination metadata captures WHY
+        a row is terminated and WHETHER it was replaced; stale session meanings are not encoded as extra
+        status values.'
       ddl: "CREATE TABLE agent_sessions (\n    session_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \            UUID REFERENCES runs(run_id),\n    agent_id          TEXT NOT NULL REFERENCES agents(agent_id),\n\
         \    entity_id         UUID,\n    flow_instance     TEXT,\n    scope_key         TEXT NOT NULL,\n    scope         \
@@ -2473,20 +2520,27 @@ platform_tables:
         \ NULL DEFAULT '[]',\n    turn_count        INTEGER NOT NULL DEFAULT 0,\n    runtime_mode      TEXT NOT NULL\
         \ CHECK (runtime_mode IN ('session', 'session_per_entity')),\n    runtime_state     JSONB NOT NULL\
         \ DEFAULT '{}',\n    lease_holder      TEXT,\n    lease_expires_at  TIMESTAMPTZ,\n    status            TEXT NOT\
-        \ NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'terminated')),\n    created_at        TIMESTAMPTZ\
-        \ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (agent_id, scope_key),\n\
-        \    INDEX idx_sessions_run (run_id) WHERE run_id IS NOT NULL,\n    INDEX idx_sessions_agent (agent_id, status),\n\
+        \ NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'terminated')),\n    termination_reason TEXT\
+        \ CHECK (termination_reason IS NULL OR termination_reason IN ('normal', 'cancelled', 'failed', 'orphaned', 'contaminated', 'legacy')),\n\
+        \    termination_detail TEXT,\n    successor_session_id UUID REFERENCES agent_sessions(session_id),\n    terminated_at TIMESTAMPTZ,\n    created_at        TIMESTAMPTZ\
+        \ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((status IN ('active', 'suspended') AND termination_reason IS NULL AND termination_detail IS NULL AND successor_session_id IS NULL AND terminated_at IS NULL) OR (status = 'terminated' AND termination_reason IS NOT NULL AND terminated_at IS NOT NULL)),\n    CHECK (termination_detail IS NULL OR termination_reason IS NOT NULL),\n    CHECK (successor_session_id IS NULL OR status = 'terminated'),\n    CHECK (successor_session_id IS NULL OR successor_session_id <> session_id),\n\
+        \    UNIQUE INDEX agent_sessions_nonterminated_unique (agent_id, scope_key) WHERE status <> 'terminated',\n    INDEX idx_sessions_run (run_id) WHERE run_id IS NOT NULL,\n    INDEX idx_sessions_agent (agent_id, status),\n\
         \    INDEX idx_sessions_entity (entity_id) WHERE entity_id IS NOT NULL,\n    INDEX idx_sessions_scope (scope, status),\n\
-        \    INDEX idx_sessions_lease (lease_expires_at) WHERE lease_holder IS NOT NULL\n);"
+        \    INDEX idx_sessions_lease (lease_expires_at) WHERE lease_holder IS NOT NULL,\n    INDEX idx_sessions_terminated_reason (termination_reason, terminated_at) WHERE status = 'terminated'\n);"
       scope_rules:
         entity: entity_id NOT NULL, flow_instance NOT NULL, scope_key = entity_id. One session per agent per entity.
         flow: entity_id NULL, flow_instance NOT NULL, scope_key = flow_instance. One session per agent per flow instance.
         global: entity_id NULL, flow_instance NULL, scope_key = "global". One session per agent across the entire system.
-      lookup_pattern: 'Runtime acquires sessions via (agent_id, scope_key). The scope_key is derived from
-        conversation_mode: task → no session lookup, no agent_sessions row (audit goes to
-        agent_conversation_audits). session_per_entity + session_scope entity → scope_key = entity_id.
-        session + session_scope flow → scope_key = flow_instance. session + session_scope global →
-        scope_key = "global". No actor-shape inference.'
+      lookup_pattern: 'Runtime acquires sessions via (agent_id, scope_key) with explicit status filtering.
+        The scope_key is derived from conversation_mode: task → no session lookup, no agent_sessions row
+        (audit goes to agent_conversation_audits). session_per_entity + session_scope entity → scope_key =
+        entity_id. session + session_scope flow → scope_key = flow_instance. session + session_scope global
+        → scope_key = "global". No actor-shape inference.'
+      live_owner_query: 'Live session ownership MUST query status = ''active'' only.'
+      resumable_owner_query: 'Resume/supersession ownership MUST query status IN (''active'', ''suspended'').'
+      status_lifecycle: 'status remains active, suspended, terminated. orphaned and contaminated are
+        termination reasons. superseded is represented by successor_session_id IS NOT NULL. Terminated
+        rows are historical lineage and are never resurrected into live ownership.'
     agent_turns:
       description: 'Append-only per-turn agent execution audit log. Records the triggering event context, visible tools,
         attempted tool calls, emitted event names, canonical per-turn turn_blocks, and sanitized request/response payloads.

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -76,7 +76,8 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 		WHERE agent_id = $1
 		  AND scope_key = $2
 		  AND runtime_mode = $3
-		ORDER BY created_at DESC
+		  AND status IN ('active', 'suspended')
+		ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END, created_at DESC
 		LIMIT 1
 		FOR UPDATE
 	`, agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(
@@ -129,44 +130,8 @@ func (sr *PostgresRegistry) Acquire(ctx context.Context, agentID string, runtime
 		}, nil
 	}
 
-	if strings.TrimSpace(r.status) != "active" {
-		sessionID := uuid.NewString()
-		var expires time.Time
-		if err := tx.QueryRowContext(ctx, `
-			UPDATE agent_sessions
-			SET session_id = $1::uuid,
-			    entity_id = NULLIF($2,'')::uuid,
-			    flow_instance = NULLIF($3,''),
-			    scope = $4,
-			    conversation = '[]'::jsonb,
-			    turn_count = 0,
-			    runtime_mode = $5,
-			    runtime_state = '{}'::jsonb,
-			    lease_holder = $6,
-			    lease_expires_at = $7,
-			    status = 'active',
-			    updated_at = now()
-			WHERE agent_id = $8
-			  AND scope_key = $9
-			  AND runtime_mode = $10
-			RETURNING session_id::text, scope_key, lease_expires_at
-		`, sessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, lockOwner, now.Add(sr.lockTTL), agentID, resolved.ScopeKey, resolved.RuntimeMode).Scan(&r.sessionID, &r.scopeKey, &expires); err != nil {
-			return nil, fmt.Errorf("reactivate session row: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return nil, fmt.Errorf("commit acquire recycled: %w", err)
-		}
-		return &Lease{
-			SessionID:            r.sessionID,
-			AgentID:              agentID,
-			RuntimeMode:          resolved.RuntimeMode,
-			SessionScope:         resolved.Scope,
-			RetryReason:          "",
-			RetriesFromSessionID: "",
-			LockOwner:            lockOwner,
-			ScopeKey:             r.scopeKey,
-			ExpiresAt:            expires,
-		}, nil
+	if strings.TrimSpace(r.status) == "suspended" {
+		return nil, ErrSessionSuspended
 	}
 
 	if r.leaseHolder.Valid && r.leaseExpires.Valid && r.leaseExpires.Time.After(now) && r.leaseHolder.String != lockOwner {
@@ -282,33 +247,65 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 
 	newSessionID := uuid.NewString()
 	retryReason := strings.TrimSpace(rotation.RetryReason)
-	retriesFromSessionID := ""
-	if retryReason != "" {
-		retriesFromSessionID = currentSessionID
+	terminationReason := rotation.TerminationReason
+	if terminationReason == "" {
+		mappedReason, _, err := rotationTermination(retryReason)
+		if err != nil {
+			return nil, err
+		}
+		terminationReason = mappedReason
+	}
+	if err := validateRuntimeTerminationReason(terminationReason); err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET status = 'terminated',
+		    termination_reason = $1,
+		    termination_detail = NULLIF($2, ''),
+		    terminated_at = COALESCE(terminated_at, $3),
+		    successor_session_id = NULL,
+		    lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = now()
+		WHERE session_id = $4::uuid
+		  AND status = 'active'
+	`, terminationReason, retryReason, now, currentSessionID); err != nil {
+		return nil, fmt.Errorf("terminate rotated session row: %w", err)
 	}
 	var expiresAt time.Time
 	if err := tx.QueryRowContext(ctx, `
-		UPDATE agent_sessions
-		SET session_id = $1::uuid,
-		    entity_id = NULLIF($2,'')::uuid,
-		    flow_instance = NULLIF($3,''),
-		    scope = $4,
-		    conversation = '[]'::jsonb,
-		    turn_count = 0,
-		    runtime_mode = $5,
-		    runtime_state = jsonb_strip_nulls(jsonb_build_object(
-		    	'checkpoint_summary', NULLIF($6,''),
-		    	'retry_reason', NULLIF($7,''),
-		    	'retries_from_session_id', NULLIF($8,'')
-		    )),
-		    lease_holder = $9,
-		    lease_expires_at = $10,
-		    status = 'active',
-		    updated_at = now()
-		WHERE session_id = $11::uuid
+		INSERT INTO agent_sessions (
+			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status,
+			termination_reason, termination_detail, successor_session_id, terminated_at,
+			created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2, NULLIF($3,'')::uuid, NULLIF($4,''), $5, $6,
+			'[]'::jsonb, 0, $7,
+			jsonb_strip_nulls(jsonb_build_object(
+				'summary', NULLIF($8,''),
+				'retry_reason', NULLIF($9,''),
+				'retries_from_session_id', NULLIF($10,'')
+			)),
+			$11, $12, 'active',
+			NULL, NULL, NULL, NULL,
+			now(), now()
+		)
 		RETURNING lease_expires_at
-	`, newSessionID, resolved.EntityID, resolved.FlowInstance, resolved.Scope, resolved.RuntimeMode, strings.TrimSpace(rotation.CheckpointSummary), retryReason, retriesFromSessionID, lockOwner, now.Add(sr.lockTTL), currentSessionID).Scan(&expiresAt); err != nil {
-		return nil, fmt.Errorf("rotate session row: %w", err)
+	`, newSessionID, agentID, resolved.EntityID, resolved.FlowInstance, resolved.ScopeKey, resolved.Scope, resolved.RuntimeMode, strings.TrimSpace(rotation.CheckpointSummary), retryReason, currentSessionID, lockOwner, now.Add(sr.lockTTL)).Scan(&expiresAt); err != nil {
+		return nil, fmt.Errorf("insert rotated successor session row: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET successor_session_id = $1::uuid,
+		    updated_at = now()
+		WHERE session_id = $2::uuid
+		  AND status = 'terminated'
+	`, newSessionID, currentSessionID); err != nil {
+		return nil, fmt.Errorf("link rotated successor session row: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -321,7 +318,7 @@ func (sr *PostgresRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 		RuntimeMode:          resolved.RuntimeMode,
 		SessionScope:         resolved.Scope,
 		RetryReason:          retryReason,
-		RetriesFromSessionID: retriesFromSessionID,
+		RetriesFromSessionID: currentSessionID,
 		LockOwner:            lockOwner,
 		ScopeKey:             resolved.ScopeKey,
 		ExpiresAt:            expiresAt,
@@ -441,14 +438,16 @@ func (sr *PostgresRegistry) ScopeKeyEnabledForTest() bool {
 func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode) error {
 	if runtimeMode == "" {
 		_, err := sr.db.Exec(`
-			UPDATE agent_sessions
-			SET status = 'terminated',
-			    lease_holder = NULL,
-			    lease_expires_at = NULL,
-			    updated_at = now()
-			WHERE status = 'active'
-			  AND runtime_mode IN ('session', 'session_per_entity')
-		`)
+		UPDATE agent_sessions
+		SET status = 'terminated',
+		    termination_reason = 'orphaned',
+		    terminated_at = COALESCE(terminated_at, now()),
+		    lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = now()
+		WHERE status IN ('active', 'suspended')
+		  AND runtime_mode IN ('session', 'session_per_entity')
+	`)
 		if err != nil {
 			return fmt.Errorf("reset all sessions: %w", err)
 		}
@@ -460,10 +459,12 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode) error {
 	_, err := sr.db.Exec(`
 		UPDATE agent_sessions
 		SET status = 'terminated',
+		    termination_reason = 'orphaned',
+		    terminated_at = COALESCE(terminated_at, now()),
 		    lease_holder = NULL,
 		    lease_expires_at = NULL,
 		    updated_at = now()
-		WHERE status = 'active' AND runtime_mode = $1
+		WHERE status IN ('active', 'suspended') AND runtime_mode = $1
 	`, runtimeMode)
 	if err != nil {
 		return fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode.String(), err)

--- a/internal/runtime/sessions/postgres_test.go
+++ b/internal/runtime/sessions/postgres_test.go
@@ -103,6 +103,33 @@ func TestPostgresSessionRegistry_AcquireLeasedByOtherReturnsErrLeased(t *testing
 	}
 }
 
+func TestPostgresSessionRegistry_AcquireSuspendedReturnsErrSessionSuspended(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sr := NewPostgresRegistry(db, 30*time.Second)
+	fixedNow := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	sr.SetNowFnForTest(func() time.Time { return fixedNow })
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT\\s+session_id::text,\\s+scope_key,\\s+status,\\s+NULLIF\\(runtime_state->>'provider_session_id'").
+		WithArgs("a1", "global", RuntimeModeSession).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "scope_key", "status", "provider_session_id", "retry_reason", "retries_from_session_id", "lease_holder", "lease_expires_at"}).
+			AddRow("sess-suspended", "global", "suspended", nil, nil, nil, nil, nil))
+
+	_, err = sr.Acquire(context.Background(), "a1", RuntimeModeSession, SessionScopeGlobal, "owner-1", "global")
+	if err != ErrSessionSuspended {
+		t.Fatalf("expected ErrSessionSuspended, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -119,9 +146,15 @@ func TestPostgresSessionRegistry_Rotate_And_IncrementTurn(t *testing.T) {
 		WithArgs("a1", "global", RuntimeModeSession).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "lease_holder", "lease_expires_at"}).
 			AddRow("sess-1", "owner-1", fixedNow.Add(10*time.Second)))
-	mock.ExpectQuery("UPDATE agent_sessions\\s+SET session_id = \\$1::uuid,").
-		WithArgs(sqlmock.AnyArg(), "", "", "global", RuntimeModeSession, "sum", "session not found", "sess-1", "owner-1", fixedNow.Add(30*time.Second), "sess-1").
+	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated',").
+		WithArgs(TerminationReasonContaminated, "session not found", fixedNow, "sess-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("INSERT INTO agent_sessions").
+		WithArgs(sqlmock.AnyArg(), "a1", "", "", "global", "global", RuntimeModeSession, "sum", "session not found", "sess-1", "owner-1", fixedNow.Add(30*time.Second)).
 		WillReturnRows(sqlmock.NewRows([]string{"lease_expires_at"}).AddRow(fixedNow.Add(30 * time.Second)))
+	mock.ExpectExec("UPDATE agent_sessions\\s+SET successor_session_id = \\$1::uuid,").
+		WithArgs(sqlmock.AnyArg(), "sess-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
 	lease, err := sr.Rotate(context.Background(), "a1", RuntimeModeSession, SessionScopeGlobal, "owner-1", RotationMetadata{

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -38,6 +38,7 @@ type Lease struct {
 type RotationMetadata struct {
 	CheckpointSummary string
 	RetryReason       string
+	TerminationReason TerminationReason
 }
 
 type Record struct {
@@ -54,6 +55,10 @@ type Record struct {
 	LockOwner            string
 	LockExpiresAt        time.Time
 	LastUsedAt           time.Time
+	TerminationReason    string
+	TerminationDetail    string
+	SuccessorSessionID   string
+	TerminatedAt         time.Time
 }
 
 // InMemoryRegistry is the process-local bootstrap implementation.
@@ -61,6 +66,7 @@ type Record struct {
 type InMemoryRegistry struct {
 	mu      sync.Mutex
 	byKey   map[string]*Record
+	history map[string][]*Record
 	lockTTL time.Duration
 }
 
@@ -70,9 +76,12 @@ func NewInMemoryRegistry(lockTTL time.Duration) *InMemoryRegistry {
 	}
 	return &InMemoryRegistry{
 		byKey:   make(map[string]*Record),
+		history: make(map[string][]*Record),
 		lockTTL: lockTTL,
 	}
 }
+
+var ErrSessionSuspended = errors.New("session exists in suspended state and cannot own live execution")
 
 func NewRegistry(lockTTL time.Duration) Registry {
 	return NewInMemoryRegistry(lockTTL)
@@ -100,7 +109,10 @@ func (sr *InMemoryRegistry) Acquire(ctx context.Context, agentID string, runtime
 	now := time.Now()
 	key := registryKey(agentID, resolved.RuntimeMode, resolved.ScopeKey)
 	rec, ok := sr.byKey[key]
-	if !ok || rec.Status != "active" {
+	if ok && rec != nil && rec.Status == "suspended" {
+		return nil, ErrSessionSuspended
+	}
+	if !ok || rec.Status == "" {
 		rec = &Record{
 			SessionID:   uuid.NewString(),
 			AgentID:     agentID,
@@ -180,21 +192,43 @@ func (sr *InMemoryRegistry) Rotate(ctx context.Context, agentID string, runtimeM
 	}
 
 	retryReason := strings.TrimSpace(rotation.RetryReason)
-	retriesFromSessionID := ""
-	if retryReason != "" {
-		retriesFromSessionID = rec.SessionID
+	terminationReason := rotation.TerminationReason
+	if terminationReason == "" {
+		mappedReason, _, err := rotationTermination(retryReason)
+		if err != nil {
+			return nil, err
+		}
+		terminationReason = mappedReason
 	}
-	rec.Status = "rotating"
-	rec.CheckpointSummary = strings.TrimSpace(rotation.CheckpointSummary)
-	rec.RetryReason = retryReason
-	rec.RetriesFromSessionID = retriesFromSessionID
-	rec.SessionID = uuid.NewString()
+	if err := validateRuntimeTerminationReason(terminationReason); err != nil {
+		return nil, err
+	}
+	oldSessionID := rec.SessionID
+	terminated := *rec
+	terminated.Status = "terminated"
+	terminated.LockOwner = ""
+	terminated.LockExpiresAt = time.Time{}
+	terminated.TerminationReason = terminationReason.String()
+	terminated.TerminationDetail = retryReason
+	terminated.SuccessorSessionID = uuid.NewString()
+	terminated.TerminatedAt = now
+	terminated.LastUsedAt = now
+	sr.history[key] = append(sr.history[key], &terminated)
+
+	rec.SessionID = terminated.SuccessorSessionID
 	rec.ProviderSessionID = ""
 	rec.Status = "active"
+	rec.CheckpointSummary = strings.TrimSpace(rotation.CheckpointSummary)
+	rec.RetryReason = retryReason
+	rec.RetriesFromSessionID = oldSessionID
 	rec.TurnCount = 0
 	rec.LockOwner = lockOwner
 	rec.LockExpiresAt = now.Add(sr.lockTTL)
 	rec.LastUsedAt = now
+	rec.TerminationReason = ""
+	rec.TerminationDetail = ""
+	rec.SuccessorSessionID = ""
+	rec.TerminatedAt = time.Time{}
 
 	return &Lease{
 		SessionID:            rec.SessionID,
@@ -302,22 +336,60 @@ func (sr *InMemoryRegistry) Snapshot(agentID string) (*Record, bool) {
 	return nil, false
 }
 
+func (sr *InMemoryRegistry) History(agentID string) []Record {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	out := make([]Record, 0)
+	for _, entries := range sr.history {
+		for _, rec := range entries {
+			if rec == nil || rec.AgentID != agentID {
+				continue
+			}
+			out = append(out, *rec)
+		}
+	}
+	return out
+}
+
 func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode) error {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	if runtimeMode == "" {
+		now := time.Now()
+		for key, rec := range sr.byKey {
+			if rec == nil {
+				continue
+			}
+			terminated := *rec
+			terminated.Status = "terminated"
+			terminated.TerminationReason = TerminationReasonOrphaned.String()
+			terminated.TerminatedAt = now
+			terminated.LockOwner = ""
+			terminated.LockExpiresAt = time.Time{}
+			terminated.SuccessorSessionID = ""
+			sr.history[key] = append(sr.history[key], &terminated)
+		}
 		sr.byKey = make(map[string]*Record)
 		return nil
 	}
 	if runtimeMode == RuntimeModeTask {
 		return nil
 	}
+	now := time.Now()
 	for key, rec := range sr.byKey {
 		if rec == nil {
 			delete(sr.byKey, key)
 			continue
 		}
 		if rec.RuntimeMode == runtimeMode {
+			terminated := *rec
+			terminated.Status = "terminated"
+			terminated.TerminationReason = TerminationReasonOrphaned.String()
+			terminated.TerminatedAt = now
+			terminated.LockOwner = ""
+			terminated.LockExpiresAt = time.Time{}
+			terminated.SuccessorSessionID = ""
+			sr.history[key] = append(sr.history[key], &terminated)
 			delete(sr.byKey, key)
 		}
 	}

--- a/internal/runtime/sessions/registry_test.go
+++ b/internal/runtime/sessions/registry_test.go
@@ -62,6 +62,16 @@ func TestInMemorySessionRegistryRotate(t *testing.T) {
 	if rec.RetryReason != "session not found" || rec.RetriesFromSessionID != old {
 		t.Fatalf("unexpected retry lineage in record: %+v", rec)
 	}
+	history := sr.History("agent-a")
+	if len(history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(history))
+	}
+	if history[0].Status != "terminated" || history[0].TerminationReason != TerminationReasonContaminated.String() {
+		t.Fatalf("terminated history = %+v", history[0])
+	}
+	if history[0].SuccessorSessionID != rotated.SessionID {
+		t.Fatalf("SuccessorSessionID = %q, want %q", history[0].SuccessorSessionID, rotated.SessionID)
+	}
 }
 
 func TestInMemorySessionRegistryAdoptSessionID(t *testing.T) {
@@ -96,5 +106,19 @@ func TestInMemorySessionRegistry_SessionScopeRequiresExplicitDeclaration(t *test
 	sr := NewInMemoryRegistry(0)
 	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, "", "worker-a", ""); err == nil {
 		t.Fatal("expected session acquire without explicit scope to fail closed")
+	}
+}
+
+func TestInMemorySessionRegistry_AcquireSuspendedReturnsErrSessionSuspended(t *testing.T) {
+	sr := NewInMemoryRegistry(0)
+	sr.byKey[registryKey("agent-a", RuntimeModeSession, "global")] = &Record{
+		SessionID:   "sess-1",
+		AgentID:     "agent-a",
+		RuntimeMode: RuntimeModeSession,
+		ScopeKey:    "global",
+		Status:      "suspended",
+	}
+	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeSession, SessionScopeGlobal, "worker-a", "global"); err != ErrSessionSuspended {
+		t.Fatalf("expected ErrSessionSuspended, got %v", err)
 	}
 }

--- a/internal/runtime/sessions/termination.go
+++ b/internal/runtime/sessions/termination.go
@@ -1,0 +1,87 @@
+package sessions
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type TerminationReason string
+
+const (
+	TerminationReasonNormal       TerminationReason = "normal"
+	TerminationReasonCancelled    TerminationReason = "cancelled"
+	TerminationReasonFailed       TerminationReason = "failed"
+	TerminationReasonOrphaned     TerminationReason = "orphaned"
+	TerminationReasonContaminated TerminationReason = "contaminated"
+	TerminationReasonLegacy       TerminationReason = "legacy"
+)
+
+func (r TerminationReason) String() string { return string(r) }
+
+func normalizeTerminationReason(raw string) TerminationReason {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case TerminationReasonNormal.String():
+		return TerminationReasonNormal
+	case TerminationReasonCancelled.String():
+		return TerminationReasonCancelled
+	case TerminationReasonFailed.String():
+		return TerminationReasonFailed
+	case TerminationReasonOrphaned.String():
+		return TerminationReasonOrphaned
+	case TerminationReasonContaminated.String():
+		return TerminationReasonContaminated
+	case TerminationReasonLegacy.String():
+		return TerminationReasonLegacy
+	default:
+		return ""
+	}
+}
+
+func ParseTerminationReason(raw string) (TerminationReason, error) {
+	reason := normalizeTerminationReason(raw)
+	if reason == "" {
+		return "", fmt.Errorf("invalid termination reason %q", strings.TrimSpace(raw))
+	}
+	return reason, nil
+}
+
+func validateRuntimeTerminationReason(reason TerminationReason) error {
+	reason = normalizeTerminationReason(reason.String())
+	if reason == "" {
+		return fmt.Errorf("termination reason is required")
+	}
+	if reason == TerminationReasonLegacy {
+		return fmt.Errorf("termination reason legacy is reserved for migration backfill")
+	}
+	return nil
+}
+
+func rotationTermination(reason string) (TerminationReason, string, error) {
+	detail := strings.TrimSpace(reason)
+	switch detail {
+	case "":
+		return TerminationReasonNormal, "", nil
+	case "session in use", "session not found":
+		return TerminationReasonContaminated, detail, nil
+	default:
+		return TerminationReasonFailed, detail, nil
+	}
+}
+
+type TerminationMetadata struct {
+	Reason             TerminationReason
+	Detail             string
+	SuccessorSessionID string
+	TerminatedAt       time.Time
+}
+
+func (m TerminationMetadata) ValidateForWrite() error {
+	if err := validateRuntimeTerminationReason(m.Reason); err != nil {
+		return err
+	}
+	if m.TerminatedAt.IsZero() {
+		return fmt.Errorf("terminated_at is required")
+	}
+	return nil
+}

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -99,11 +99,13 @@ func (s *PostgresStore) MarkAgentTerminated(ctx context.Context, agentID string)
 	const qSessions = `
 		UPDATE agent_sessions
 		SET status = 'terminated',
+		    termination_reason = 'cancelled',
+		    terminated_at = COALESCE(terminated_at, now()),
 		    lease_holder = NULL,
 		    lease_expires_at = NULL,
 		    updated_at = now()
 		WHERE agent_id = $1
-		  AND status = 'active'
+		  AND status IN ('active', 'suspended')
 	`
 	if _, err := tx.ExecContext(ctx, qSessions, agentID); err != nil {
 		return fmt.Errorf("mark agent terminated sessions: %w", err)

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -129,6 +129,9 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if err := s.ensureConversationAuditTable(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureAgentSessionTerminationMetadata(ctx); err != nil {
+		return err
+	}
 ensureAgents:
 	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
 		return err
@@ -146,6 +149,199 @@ ensureAgents:
 	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *PostgresStore) ensureAgentSessionTerminationMetadata(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasTable("agent_sessions") {
+		return nil
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS termination_reason TEXT`,
+		`ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS termination_detail TEXT`,
+		`ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS successor_session_id UUID REFERENCES agent_sessions(session_id)`,
+		`ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS terminated_at TIMESTAMPTZ`,
+	} {
+		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure agent_sessions termination metadata columns: %w", err)
+		}
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET termination_reason = COALESCE(NULLIF(termination_reason, ''), 'legacy'),
+		    terminated_at = COALESCE(terminated_at, updated_at, created_at)
+		WHERE status = 'terminated'
+		  AND (NULLIF(termination_reason, '') IS NULL OR terminated_at IS NULL)
+	`); err != nil {
+		return fmt.Errorf("backfill agent_sessions termination metadata: %w", err)
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		DO $$
+		DECLARE rec RECORD;
+		BEGIN
+			FOR rec IN
+				SELECT c.conname
+				FROM pg_constraint c
+				WHERE c.conrelid = 'agent_sessions'::regclass
+				  AND c.contype = 'u'
+				  AND c.conkey = ARRAY[
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'agent_sessions'::regclass AND attname = 'agent_id'),
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'agent_sessions'::regclass AND attname = 'scope_key')
+				  ]
+			LOOP
+				EXECUTE format('ALTER TABLE agent_sessions DROP CONSTRAINT %I', rec.conname);
+			END LOOP;
+		END
+		$$;
+	`); err != nil {
+		return fmt.Errorf("drop legacy agent_sessions uniqueness constraint: %w", err)
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		CREATE UNIQUE INDEX IF NOT EXISTS agent_sessions_nonterminated_unique
+		ON agent_sessions (agent_id, scope_key)
+		WHERE status <> 'terminated'
+	`); err != nil {
+		return fmt.Errorf("ensure agent_sessions nonterminated unique index: %w", err)
+	}
+	for name, statement := range map[string]string{
+		"agent_sessions_termination_reason_enum_check": `
+			ALTER TABLE agent_sessions
+			ADD CONSTRAINT agent_sessions_termination_reason_enum_check
+			CHECK (
+				termination_reason IS NULL OR
+				termination_reason IN ('normal', 'cancelled', 'failed', 'orphaned', 'contaminated', 'legacy')
+			)
+		`,
+		"agent_sessions_status_termination_check": `
+			ALTER TABLE agent_sessions
+			ADD CONSTRAINT agent_sessions_status_termination_check
+			CHECK (
+				(status IN ('active', 'suspended') AND termination_reason IS NULL AND termination_detail IS NULL AND successor_session_id IS NULL AND terminated_at IS NULL)
+				OR
+				(status = 'terminated' AND termination_reason IS NOT NULL AND terminated_at IS NOT NULL)
+			)
+		`,
+		"agent_sessions_termination_detail_requires_reason_check": `
+			ALTER TABLE agent_sessions
+			ADD CONSTRAINT agent_sessions_termination_detail_requires_reason_check
+			CHECK (termination_detail IS NULL OR termination_reason IS NOT NULL)
+		`,
+		"agent_sessions_successor_requires_terminated_check": `
+			ALTER TABLE agent_sessions
+			ADD CONSTRAINT agent_sessions_successor_requires_terminated_check
+			CHECK (successor_session_id IS NULL OR status = 'terminated')
+		`,
+		"agent_sessions_successor_not_self_check": `
+			ALTER TABLE agent_sessions
+			ADD CONSTRAINT agent_sessions_successor_not_self_check
+			CHECK (successor_session_id IS NULL OR successor_session_id <> session_id)
+		`,
+	} {
+		exists, err := namedTableConstraintExists(ctx, s.DB, "agent_sessions", name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if _, err := s.DB.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure %s: %w", name, err)
+		}
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION enforce_agent_session_termination_invariants()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		DECLARE
+			succ_agent TEXT;
+			succ_scope TEXT;
+			succ_scope_key TEXT;
+			creates_cycle BOOLEAN;
+		BEGIN
+			IF TG_OP = 'UPDATE' THEN
+				IF NEW.agent_id IS DISTINCT FROM OLD.agent_id OR NEW.scope IS DISTINCT FROM OLD.scope OR NEW.scope_key IS DISTINCT FROM OLD.scope_key THEN
+					RAISE EXCEPTION 'agent_sessions identity fields are immutable';
+				END IF;
+				IF OLD.termination_reason IS NOT NULL AND NEW.termination_reason IS DISTINCT FROM OLD.termination_reason THEN
+					RAISE EXCEPTION 'agent_sessions termination_reason is immutable once set';
+				END IF;
+				IF OLD.terminated_at IS NOT NULL AND NEW.terminated_at IS DISTINCT FROM OLD.terminated_at THEN
+					RAISE EXCEPTION 'agent_sessions terminated_at is immutable once set';
+				END IF;
+			END IF;
+			IF NEW.termination_reason = 'legacy' AND (TG_OP = 'INSERT' OR COALESCE(OLD.termination_reason, '') <> 'legacy') THEN
+				RAISE EXCEPTION 'agent_sessions termination_reason legacy is reserved for migration backfill';
+			END IF;
+			IF NEW.successor_session_id IS NOT NULL THEN
+				SELECT agent_id, scope, scope_key
+				INTO succ_agent, succ_scope, succ_scope_key
+				FROM agent_sessions
+				WHERE session_id = NEW.successor_session_id;
+				IF NOT FOUND THEN
+					RAISE EXCEPTION 'agent_sessions successor_session_id must reference an existing session';
+				END IF;
+				IF succ_agent IS DISTINCT FROM NEW.agent_id OR succ_scope IS DISTINCT FROM NEW.scope OR succ_scope_key IS DISTINCT FROM NEW.scope_key THEN
+					RAISE EXCEPTION 'agent_sessions successor_session_id must reference the same agent/scope/scope_key lineage';
+				END IF;
+				WITH RECURSIVE lineage AS (
+					SELECT session_id, successor_session_id
+					FROM agent_sessions
+					WHERE session_id = NEW.successor_session_id
+					UNION ALL
+					SELECT s.session_id, s.successor_session_id
+					FROM agent_sessions s
+					JOIN lineage l ON s.session_id = l.successor_session_id
+					WHERE l.successor_session_id IS NOT NULL
+				)
+				SELECT EXISTS (
+					SELECT 1 FROM lineage WHERE session_id = NEW.session_id OR successor_session_id = NEW.session_id
+				)
+				INTO creates_cycle;
+				IF creates_cycle THEN
+					RAISE EXCEPTION 'agent_sessions successor_session_id must be acyclic';
+				END IF;
+			END IF;
+			RETURN NEW;
+		END
+		$$;
+	`); err != nil {
+		return fmt.Errorf("ensure agent_sessions invariant function: %w", err)
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		DROP TRIGGER IF EXISTS agent_sessions_invariant_write_guard ON agent_sessions;
+		CREATE TRIGGER agent_sessions_invariant_write_guard
+		BEFORE INSERT OR UPDATE ON agent_sessions
+		FOR EACH ROW
+		EXECUTE FUNCTION enforce_agent_session_termination_invariants();
+	`); err != nil {
+		return fmt.Errorf("ensure agent_sessions invariant trigger: %w", err)
+	}
+	return nil
+}
+
+func namedTableConstraintExists(ctx context.Context, db *sql.DB, tableName, constraintName string) (bool, error) {
+	if db == nil {
+		return false, nil
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conrelid = to_regclass($1)
+			  AND conname = $2
+		)
+	`, strings.TrimSpace(tableName), strings.TrimSpace(constraintName)).Scan(&exists); err != nil {
+		return false, fmt.Errorf("query constraint %s on %s: %w", strings.TrimSpace(constraintName), strings.TrimSpace(tableName), err)
+	}
+	return exists, nil
 }
 
 func (s *PostgresStore) ensureAgentRuntimeDescriptorColumn(ctx context.Context) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -118,21 +118,19 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if err != nil {
 		return err
 	}
-	if !catalog.hasTable("agent_turns") {
-		goto ensureAgents
-	}
-	if !catalog.hasColumns("agent_turns", "turn_blocks") {
-		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS turn_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`); err != nil {
-			return fmt.Errorf("ensure agent_turns.turn_blocks column: %w", err)
+	if catalog.hasTable("agent_turns") {
+		if !catalog.hasColumns("agent_turns", "turn_blocks") {
+			if _, err := s.DB.ExecContext(ctx, `ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS turn_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`); err != nil {
+				return fmt.Errorf("ensure agent_turns.turn_blocks column: %w", err)
+			}
 		}
-	}
-	if err := s.ensureConversationAuditTable(ctx); err != nil {
-		return err
+		if err := s.ensureConversationAuditTable(ctx); err != nil {
+			return err
+		}
 	}
 	if err := s.ensureAgentSessionTerminationMetadata(ctx); err != nil {
 		return err
 	}
-ensureAgents:
 	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
 		return err
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -65,6 +65,247 @@ func acquireLiveTestSession(t *testing.T, ctx context.Context, db *sql.DB, agent
 	return lease.SessionID
 }
 
+func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
+		t.Fatalf("drop agent_sessions: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agent_sessions (
+			session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			agent_id TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope_key TEXT NOT NULL,
+			scope TEXT NOT NULL DEFAULT 'entity',
+			conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			runtime_mode TEXT NOT NULL DEFAULT 'session',
+			runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+			lease_holder TEXT,
+			lease_expires_at TIMESTAMPTZ,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (agent_id, scope_key)
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agent_sessions: %v", err)
+	}
+	sessionID := uuid.NewString()
+	createdAt := time.Now().UTC().Add(-2 * time.Hour).Round(time.Second)
+	updatedAt := createdAt.Add(30 * time.Minute)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES ($1::uuid, 'a1', 'global', 'global', 'session', 'terminated', $2, $3)
+	`, sessionID, createdAt, updatedAt); err != nil {
+		t.Fatalf("insert legacy terminated session: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agent_sessions": {
+			DDL: "CREATE TABLE agent_sessions (\n    session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    agent_id TEXT NOT NULL,\n    entity_id UUID,\n    flow_instance TEXT,\n    scope_key TEXT NOT NULL,\n    scope TEXT NOT NULL DEFAULT 'entity',\n    conversation JSONB NOT NULL DEFAULT '[]',\n    turn_count INTEGER NOT NULL DEFAULT 0,\n    runtime_mode TEXT NOT NULL DEFAULT 'session',\n    runtime_state JSONB NOT NULL DEFAULT '{}',\n    lease_holder TEXT,\n    lease_expires_at TIMESTAMPTZ,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(agent_sessions): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(agent_sessions): %v", err)
+	}
+
+	var reason string
+	var terminatedAt time.Time
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(termination_reason, ''), terminated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&reason, &terminatedAt); err != nil {
+		t.Fatalf("load migrated terminated row: %v", err)
+	}
+	if reason != "legacy" {
+		t.Fatalf("termination_reason = %q, want legacy", reason)
+	}
+	if !terminatedAt.Equal(updatedAt) {
+		t.Fatalf("terminated_at = %s, want %s", terminatedAt, updatedAt)
+	}
+}
+
+func TestPostgresStore_AgentSessionsPartialUniquenessAllowsTerminatedHistoryButRejectsSecondLiveOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+
+	sessionA := uuid.NewString()
+	sessionB := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status,
+			termination_reason, terminated_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'terminated',
+			'failed', now(), now(), now()
+		)
+	`, sessionA); err != nil {
+		t.Fatalf("insert terminated row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'active', now(), now()
+		)
+	`, sessionB); err != nil {
+		t.Fatalf("insert active row after terminated history: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'suspended', now(), now()
+		)
+	`, uuid.NewString()); err == nil {
+		t.Fatal("expected second non-terminated owner insert to fail")
+	}
+}
+
+func TestPostgresRegistry_AcquireFailsClosedOnSuspendedResumableOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'suspended', now(), now()
+		)
+	`, uuid.NewString()); err != nil {
+		t.Fatalf("insert suspended session: %v", err)
+	}
+
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	if _, err := registry.Acquire(ctx, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "worker-1", "global"); err != runtimesessions.ErrSessionSuspended {
+		t.Fatalf("Acquire error = %v, want ErrSessionSuspended", err)
+	}
+}
+
+func TestPostgresRegistry_ResetAllMarksActiveSessionsOrphaned(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	if err := registry.ResetAll(runtimesessions.RuntimeModeSession); err != nil {
+		t.Fatalf("ResetAll: %v", err)
+	}
+
+	var (
+		status       string
+		reason       string
+		terminatedAt time.Time
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(termination_reason, ''), terminated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&status, &reason, &terminatedAt); err != nil {
+		t.Fatalf("load reset session row: %v", err)
+	}
+	if status != "terminated" {
+		t.Fatalf("status = %q, want terminated", status)
+	}
+	if reason != "orphaned" {
+		t.Fatalf("termination_reason = %q, want orphaned", reason)
+	}
+	if terminatedAt.IsZero() {
+		t.Fatal("terminated_at is zero")
+	}
+}
+
+func TestPostgresStore_AgentSessionSuccessorInvariantsRejectCrossScopeAndLegacyWrites(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+
+	oldID := uuid.NewString()
+	goodSuccessorID := uuid.NewString()
+	badSuccessorID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status,
+			termination_reason, terminated_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'terminated',
+			'failed', now(), now(), now()
+		)
+	`, oldID); err != nil {
+		t.Fatalf("insert terminated session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'active', now(), now()
+		)
+	`, goodSuccessorID); err != nil {
+		t.Fatalf("insert active successor candidate: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status,
+			termination_reason, terminated_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'flow-1', 'flow', 'session', 'terminated',
+			'failed', now(), now(), now()
+		)
+	`, badSuccessorID); err != nil {
+		t.Fatalf("insert terminated cross-scope candidate: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET successor_session_id = $2::uuid
+		WHERE session_id = $1::uuid
+	`, oldID, badSuccessorID); err == nil {
+		t.Fatal("expected cross-scope successor assignment to fail")
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status,
+			termination_reason, terminated_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'legacy-new', 'global', 'session', 'terminated',
+			'legacy', now(), now(), now()
+		)
+	`, uuid.NewString()); err == nil {
+		t.Fatal("expected new legacy termination write to fail")
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET successor_session_id = $2::uuid
+		WHERE session_id = $1::uuid
+	`, oldID, goodSuccessorID); err != nil {
+		t.Fatalf("set valid successor_session_id: %v", err)
+	}
+}
+
 func seedSpecEntityState(t *testing.T, ctx context.Context, db execer, entityID, flowInstance, slug, name, state string) {
 	t.Helper()
 	if strings.TrimSpace(flowInstance) == "" {
@@ -2535,6 +2776,53 @@ func TestManagerStore_LoadActiveConversationIncludesRetryLineage(t *testing.T) {
 	if gotReason != "session not found" || gotFrom != lease.SessionID {
 		t.Fatalf("unexpected runtime_state retry lineage: reason=%q from=%q", gotReason, gotFrom)
 	}
+
+	var (
+		oldStatus            string
+		oldTerminationReason string
+		oldSuccessorID       string
+		oldTerminatedAt      time.Time
+		sameAgent            bool
+		sameScope            bool
+		sameScopeKey         bool
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(status, ''),
+			COALESCE(termination_reason, ''),
+			COALESCE(successor_session_id::text, ''),
+			terminated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, lease.SessionID).Scan(&oldStatus, &oldTerminationReason, &oldSuccessorID, &oldTerminatedAt); err != nil {
+		t.Fatalf("load rotated predecessor metadata: %v", err)
+	}
+	if oldStatus != "terminated" {
+		t.Fatalf("predecessor status = %q, want terminated", oldStatus)
+	}
+	if oldTerminationReason != "contaminated" {
+		t.Fatalf("predecessor termination_reason = %q, want contaminated", oldTerminationReason)
+	}
+	if oldSuccessorID != rotated.SessionID {
+		t.Fatalf("predecessor successor_session_id = %q, want %q", oldSuccessorID, rotated.SessionID)
+	}
+	if oldTerminatedAt.IsZero() {
+		t.Fatal("predecessor terminated_at is zero")
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			old.agent_id = new.agent_id,
+			old.scope = new.scope,
+			old.scope_key = new.scope_key
+		FROM agent_sessions old
+		JOIN agent_sessions new ON new.session_id = $2::uuid
+		WHERE old.session_id = $1::uuid
+	`, lease.SessionID, rotated.SessionID).Scan(&sameAgent, &sameScope, &sameScopeKey); err != nil {
+		t.Fatalf("compare rotated lineage scope: %v", err)
+	}
+	if !sameAgent || !sameScope || !sameScopeKey {
+		t.Fatalf("rotated lineage mismatch: sameAgent=%v sameScope=%v sameScopeKey=%v", sameAgent, sameScope, sameScopeKey)
+	}
 }
 
 func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
@@ -3728,14 +4016,22 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	}
 
 	var (
-		agentStatus string
-		sessStatus  string
-		auditStatus string
+		agentStatus      string
+		sessStatus       string
+		sessReason       string
+		sessTerminatedAt time.Time
+		auditStatus      string
 	)
 	if err := db.QueryRowContext(ctx, `SELECT status FROM agents WHERE agent_id = $1`, "agent-cleanup-1").Scan(&agentStatus); err != nil {
 		t.Fatalf("read agent status: %v", err)
 	}
-	if err := db.QueryRowContext(ctx, `SELECT status FROM agent_sessions WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1`, "agent-cleanup-1").Scan(&sessStatus); err != nil {
+	if err := db.QueryRowContext(ctx, `
+		SELECT status, COALESCE(termination_reason, ''), terminated_at
+		FROM agent_sessions
+		WHERE agent_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, "agent-cleanup-1").Scan(&sessStatus, &sessReason, &sessTerminatedAt); err != nil {
 		t.Fatalf("read session status: %v", err)
 	}
 	if err := db.QueryRowContext(ctx, `SELECT status FROM agent_conversation_audits WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1`, "agent-cleanup-1").Scan(&auditStatus); err != nil {
@@ -3746,6 +4042,12 @@ func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
 	}
 	if sessStatus != "terminated" {
 		t.Fatalf("expected terminated session status, got %q", sessStatus)
+	}
+	if sessReason != "cancelled" {
+		t.Fatalf("expected cancelled session termination_reason, got %q", sessReason)
+	}
+	if sessTerminatedAt.IsZero() {
+		t.Fatal("expected non-zero session terminated_at")
 	}
 	if auditStatus != "terminated" {
 		t.Fatalf("expected terminated audit status, got %q", auditStatus)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -73,6 +73,9 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRo
 	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
 		t.Fatalf("drop agent_sessions: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_turns CASCADE`); err != nil {
+		t.Fatalf("drop agent_turns: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `
 		CREATE TABLE agent_sessions (
 			session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -137,6 +140,95 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRo
 	}
 	if !terminatedAt.Equal(updatedAt) {
 		t.Fatalf("terminated_at = %s, want %s", terminatedAt, updatedAt)
+	}
+}
+
+func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurnsSupportsResetAll(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
+		t.Fatalf("drop agent_sessions: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_turns CASCADE`); err != nil {
+		t.Fatalf("drop agent_turns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agent_sessions (
+			session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			agent_id TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope_key TEXT NOT NULL,
+			scope TEXT NOT NULL DEFAULT 'entity',
+			conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			runtime_mode TEXT NOT NULL DEFAULT 'session',
+			runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+			lease_holder TEXT,
+			lease_expires_at TIMESTAMPTZ,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (agent_id, scope_key)
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agent_sessions: %v", err)
+	}
+	sessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, 'a1', 'global', 'global', 'session', 'active', now(), now()
+		)
+	`, sessionID); err != nil {
+		t.Fatalf("insert legacy active session: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agent_sessions": {
+			DDL: "CREATE TABLE agent_sessions (\n    session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    agent_id TEXT NOT NULL,\n    entity_id UUID,\n    flow_instance TEXT,\n    scope_key TEXT NOT NULL,\n    scope TEXT NOT NULL DEFAULT 'entity',\n    conversation JSONB NOT NULL DEFAULT '[]',\n    turn_count INTEGER NOT NULL DEFAULT 0,\n    runtime_mode TEXT NOT NULL DEFAULT 'session',\n    runtime_state JSONB NOT NULL DEFAULT '{}',\n    lease_holder TEXT,\n    lease_expires_at TIMESTAMPTZ,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(agent_sessions): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(agent_sessions): %v", err)
+	}
+
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	if err := registry.ResetAll(runtimesessions.RuntimeModeSession); err != nil {
+		t.Fatalf("ResetAll after agent_sessions-only migration: %v", err)
+	}
+
+	var (
+		status       string
+		reason       string
+		terminatedAt time.Time
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(termination_reason, ''), terminated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&status, &reason, &terminatedAt); err != nil {
+		t.Fatalf("load reset legacy session row: %v", err)
+	}
+	if status != "terminated" {
+		t.Fatalf("status = %q, want terminated", status)
+	}
+	if reason != "orphaned" {
+		t.Fatalf("termination_reason = %q, want orphaned", reason)
+	}
+	if terminatedAt.IsZero() {
+		t.Fatal("terminated_at is zero")
 	}
 }
 

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -164,7 +164,8 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			[]string{
 				"session_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
 				"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
-				"lease_expires_at", "status", "created_at", "updated_at",
+				"lease_expires_at", "status", "termination_reason", "termination_detail",
+				"successor_session_id", "terminated_at", "created_at", "updated_at",
 			},
 			nil,
 		),

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -43,7 +43,8 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	addColumns("agent_sessions",
 		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
 		"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
-		"lease_expires_at", "status", "created_at", "updated_at",
+		"lease_expires_at", "status", "termination_reason", "termination_detail",
+		"successor_session_id", "terminated_at", "created_at", "updated_at",
 	)
 	addColumns("agent_conversation_audits",
 		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -20,7 +20,7 @@ var (
 	schemaDDLIdentifierPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 	schemaDDLNumericPattern    = regexp.MustCompile(`^numeric\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
 	schemaDDLCreateTableName   = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+"?([a-z_][a-z0-9_]*)"?`)
-	schemaDDLInlineIndexLine   = regexp.MustCompile(`(?i)^index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
+	schemaDDLInlineIndexLine   = regexp.MustCompile(`(?i)^(unique\s+)?index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
 )
 
 func SchemaFieldTypeToDDL(schemaType string) (string, error) {
@@ -350,6 +350,8 @@ func normalizePlatformDDLStatements(rawDDL string) ([]string, error) {
 			continue
 		case strings.HasPrefix(strings.ToUpper(statement), "CREATE INDEX "):
 			statement = schemaDDLEnsureIfNotExists(statement, "CREATE INDEX")
+		case strings.HasPrefix(strings.ToUpper(statement), "CREATE UNIQUE INDEX "):
+			statement = schemaDDLEnsureIfNotExists(statement, "CREATE UNIQUE INDEX")
 		default:
 			return nil, fmt.Errorf("unsupported platform DDL statement %q", statement)
 		}
@@ -382,13 +384,17 @@ func schemaDDLNormalizeCreateTable(statement string) (string, []string, error) {
 			continue
 		}
 		if matches := schemaDDLInlineIndexLine.FindStringSubmatch(trimmed); len(matches) >= 3 {
-			indexName := strings.TrimSpace(matches[1])
-			indexCols := strings.TrimSpace(matches[2])
+			uniquePrefix := strings.TrimSpace(matches[1])
+			indexName := strings.TrimSpace(matches[2])
+			indexCols := strings.TrimSpace(matches[3])
 			whereClause := ""
-			if len(matches) >= 4 {
-				whereClause = strings.TrimSpace(matches[3])
+			if len(matches) >= 5 {
+				whereClause = strings.TrimSpace(matches[4])
 			}
 			statement := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			if uniquePrefix != "" {
+				statement = fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			}
 			if whereClause != "" {
 				statement += " " + whereClause
 			}

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -88,6 +88,29 @@ func TestGeneratePlatformTableDDLs(t *testing.T) {
 	}
 }
 
+func TestGeneratePlatformTableDDLs_ExtractsInlineUniquePartialIndex(t *testing.T) {
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agent_sessions": {
+			DDL: "CREATE TABLE agent_sessions (\n    session_id UUID PRIMARY KEY,\n    agent_id TEXT NOT NULL,\n    scope_key TEXT NOT NULL,\n    status TEXT NOT NULL,\n    UNIQUE INDEX agent_sessions_nonterminated_unique (agent_id, scope_key) WHERE status <> 'terminated'\n);",
+		},
+	}
+
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Statements) != 2 {
+		t.Fatalf("plans = %#v", plans)
+	}
+	if got := plans[0].Statements[1]; !strings.Contains(got, `CREATE UNIQUE INDEX IF NOT EXISTS "agent_sessions_nonterminated_unique" ON "agent_sessions"(agent_id, scope_key) WHERE status <> 'terminated'`) {
+		t.Fatalf("unexpected unique partial index statement: %q", got)
+	}
+}
+
 func TestGeneratePlatformTableDDLs_OrdersRunsBeforeEvents(t *testing.T) {
 	var spec runtimecontracts.PlatformSpecDocument
 	spec.PlatformTables.Tables = map[string]struct {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -354,7 +354,7 @@ func platformSpecPath() (string, error) {
 
 var (
 	testutilCreateTableName = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+"?([a-z_][a-z0-9_]*)"?`)
-	testutilInlineIndexLine = regexp.MustCompile(`(?i)^index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
+	testutilInlineIndexLine = regexp.MustCompile(`(?i)^(unique\s+)?index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
 )
 
 func bootstrapPlatformTableStatements(spec runtimecontracts.PlatformSpecDocument) ([]string, error) {
@@ -412,6 +412,8 @@ func bootstrapNormalizePlatformDDL(rawDDL string) ([]string, error) {
 			statements = append(statements, indexStatements...)
 		case strings.HasPrefix(strings.ToUpper(statement), "CREATE INDEX "):
 			statements = append(statements, bootstrapEnsureIfNotExists(statement, "CREATE INDEX"))
+		case strings.HasPrefix(strings.ToUpper(statement), "CREATE UNIQUE INDEX "):
+			statements = append(statements, bootstrapEnsureIfNotExists(statement, "CREATE UNIQUE INDEX"))
 		default:
 			return nil, fmt.Errorf("unsupported platform ddl statement %q", statement)
 		}
@@ -443,13 +445,17 @@ func bootstrapNormalizeCreateTable(statement string) (string, []string, error) {
 			continue
 		}
 		if matches := testutilInlineIndexLine.FindStringSubmatch(trimmed); len(matches) >= 3 {
-			indexName := strings.TrimSpace(matches[1])
-			indexCols := strings.TrimSpace(matches[2])
+			uniquePrefix := strings.TrimSpace(matches[1])
+			indexName := strings.TrimSpace(matches[2])
+			indexCols := strings.TrimSpace(matches[3])
 			whereClause := ""
-			if len(matches) >= 4 {
-				whereClause = strings.TrimSpace(matches[3])
+			if len(matches) >= 5 {
+				whereClause = strings.TrimSpace(matches[4])
 			}
 			indexStmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			if uniquePrefix != "" {
+				indexStmt = fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			}
 			if whereClause != "" {
 				indexStmt += " " + whereClause
 			}


### PR DESCRIPTION
Closes #199

## Human Summary
This PR promotes the approved session-termination-metadata draft into the authoritative platform spec and implements that model in the live `agent_sessions` seam. Live sessions now keep `status` as `active | suspended | terminated`, while stale lifecycle meaning is carried explicitly by `termination_reason`, `termination_detail`, `successor_session_id`, and `terminated_at`.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_conversation_audits`
- promoted in this PR from approved draft: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.session-termination-metadata.yaml`

## What Changed
- promoted the approved session termination metadata draft into the authoritative `platform-spec.yaml`, including the `agent_sessions` DDL, lookup semantics, and partial non-terminated uniqueness model
- replaced the old `(agent_id, scope_key)` uniqueness model with canonical non-terminated uniqueness and explicit live-owner vs resumable-owner query semantics
- added store/runtime migration for `agent_sessions` termination metadata:
  - `termination_reason`
  - `termination_detail`
  - `successor_session_id`
  - `terminated_at`
- backfilled legacy terminated rows to `termination_reason = legacy` and `terminated_at = COALESCE(updated_at, created_at)`
- changed Postgres session rotation to terminate the old row and create a distinct successor row instead of rewriting `session_id` in place
- made live acquisition fail closed on suspended resumable owners instead of recycling non-active rows
- updated reset/termination paths to write canonical termination metadata (`orphaned` for runtime reset cleanup, `cancelled` for agent termination)
- added write-time invariant enforcement for reserved `legacy`, immutable termination fields, and successor lineage rules
- extended schema/testutil DDL normalization to support the new inline partial unique index from the authoritative spec

## Why This Is Needed
Before this change, stale live sessions were still represented by inference: rotation rewrote rows in place, terminated rows had no canonical reason/timestamp, and the old unique constraint prevented terminated lineage from coexisting with a successor for the same scope. That left live ownership and stale-session meaning ambiguous.

The approved model fixes that without inventing new status values. It keeps one canonical live-session owner in `agent_sessions`, makes stale state explicit, and keeps reader/runtime behavior aligned to the same stored semantics.

## Scope Boundaries
- scoped to live-session lifecycle semantics in `agent_sessions`
- task-mode `agent_conversation_audits` remains unchanged and out of scope
- no new status values were introduced
- no compatibility shim was kept beyond the required `legacy` migration backfill for pre-metadata terminated rows

## Tests Run
- `go test ./internal/runtime/sessions ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk
- the new invariant trigger is intentionally strict; any external/manual writes to `agent_sessions` that previously mutated identity or wrote fresh `legacy` values will now fail closed
- operator/dashboard surfaces do not yet expose the new termination metadata explicitly; the canonical persisted model is in place first

## Follow-Up
- if operator surfaces need first-class rendering of termination lineage, that should be a separate read-model issue sourced from the new canonical `agent_sessions` fields rather than local inference
