### PR TITLE
[agent-a][issue #277] Resolve flow-local event warnings against owning flow schema and outputs

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -18,6 +18,7 @@ import (
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -340,6 +341,18 @@ func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
 	return bundle
 }
 
+func loadWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	fixtureRoot := filepath.Join(repoRoot, relativeRoot)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", fixtureRoot, err)
+	}
+	return bundle
+}
+
 func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t *testing.T) {
 	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
@@ -414,5 +427,32 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				t.Fatalf("BootReport warnings = %#v, want tool_resolution warning", warnings)
 			}
 		})
+	}
+}
+
+func TestVerifyBundle_DoesNotWarnForFlowLocalEmittedEventsWithOwningFlowSchemas(t *testing.T) {
+	source := semanticview.Wrap(loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-local-events")))
+
+	err := verifyBundle(context.Background(), source)
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from unrelated fixture warnings")
+	}
+	if strings.Contains(err.Error(), "'child/child.internal' emitted but no schema in events.yaml") {
+		t.Fatalf("unexpected flow-local no-schema warning: %v", err)
+	}
+	if strings.Contains(err.Error(), "'child/child.done' emitted but no schema in events.yaml") {
+		t.Fatalf("unexpected flow-local no-schema warning: %v", err)
+	}
+}
+
+func TestVerifyBundle_DoesNotWarnForFlowOwnedAgentOutputEvents(t *testing.T) {
+	source := semanticview.Wrap(loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-required-agents-child")))
+
+	err := verifyBundle(context.Background(), source)
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from unrelated fixture warnings")
+	}
+	if strings.Contains(err.Error(), "'analysis.done' emitted but nobody subscribes") {
+		t.Fatalf("unexpected flow-owned agent output warning: %v", err)
 	}
 }

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1957,13 +1957,16 @@ func (c *checkerContext) eventCycleDetection() []Finding {
 			if eventType == "" {
 				continue
 			}
-			trigger := c.source.ResolveFlowEventReference(flowID, eventType)
+			trigger := semanticview.ResolveFlowEventProof(c.source, flowID, eventType).EventKey()
+			if trigger == "" {
+				continue
+			}
 			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
 			if !ok {
 				continue
 			}
 			for _, emitted := range handlerEmits(handler) {
-				emitted = strings.TrimSpace(emitted)
+				emitted = semanticview.ResolveFlowEventProof(c.source, flowID, emitted).EventKey()
 				if emitted == "" || emitted != trigger {
 					continue
 				}
@@ -2514,18 +2517,23 @@ func (c *checkerContext) singleNodePerEvent() []Finding {
 			if eventType == "" || strings.Contains(eventType, "*") {
 				continue
 			}
+			proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
+			eventKey := proof.EventKey()
+			if eventKey == "" {
+				continue
+			}
 			subscriptions = append(subscriptions, subscriptionOwner{
 				NodeID: strings.TrimSpace(nodeID),
 				FlowID: flowID,
-				Event:  eventType,
+				Event:  eventKey,
 			})
-			eventNames[c.source.ResolveFlowEventReference(flowID, eventType)] = struct{}{}
+			eventNames[eventKey] = struct{}{}
 		}
 	}
 	for _, eventType := range sortedSetKeysLocal(eventNames) {
 		nodeIDs := make([]string, 0)
 		for _, subscription := range subscriptions {
-			if c.source.FlowEventMatches(subscription.FlowID, subscription.Event, eventType) {
+			if subscription.Event == eventType {
 				nodeIDs = append(nodeIDs, subscription.NodeID)
 			}
 		}
@@ -3841,13 +3849,16 @@ func detectEventCyclesSemanticModel(source semanticview.Source) error {
 			if eventType == "" || strings.Contains(eventType, "*") {
 				continue
 			}
-			trigger := source.ResolveFlowEventReference(flowID, eventType)
+			trigger := semanticview.ResolveFlowEventProof(source, flowID, eventType).EventKey()
+			if trigger == "" {
+				continue
+			}
 			handler, ok := source.NodeEventHandler(nodeID, eventType)
 			if !ok {
 				continue
 			}
 			for _, emitted := range handlerEmits(handler) {
-				emitted = strings.TrimSpace(emitted)
+				emitted = semanticview.ResolveFlowEventProof(source, flowID, emitted).EventKey()
 				if emitted == "" || strings.Contains(emitted, "*") || emitted == trigger {
 					continue
 				}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1174,12 +1174,12 @@ func (c *checkerContext) eventWarnings() []Finding {
 		return c.eventWarningFindings
 	}
 	c.eventWarningLoaded = true
-	emittedRefs := map[string]eventRefLocal{}
-	subscribedRefs := map[string]eventRefLocal{}
-	subscriptionPatterns := map[string]eventRefLocal{}
+	emittedRefs := map[string]semanticview.FlowEventProof{}
+	subscribedRefs := map[string]semanticview.FlowEventProof{}
+	subscriptionPatterns := map[string]eventPatternLocal{}
 	for _, scope := range c.source.FlowScopes() {
 		if eventType := strings.TrimSpace(scope.AutoEmitEvent); eventType != "" {
-			addEventRefLocal(emittedRefs, scope.ID, eventType)
+			addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
 		}
 		for _, eventType := range scope.InputEvents {
 			eventType = strings.TrimSpace(eventType)
@@ -1187,14 +1187,14 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventRefLocal(subscriptionPatterns, scope.ID, eventType)
+				addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
 			} else {
-				addEventRefLocal(subscribedRefs, scope.ID, eventType)
+				addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
 			}
 		}
 		for _, required := range c.source.FlowRequiredAgents(scope.ID) {
 			for _, eventType := range required.Emits {
-				addEventRefLocal(emittedRefs, scope.ID, eventType)
+				addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
 			}
 			for _, eventType := range required.SubscribesTo {
 				eventType = strings.TrimSpace(eventType)
@@ -1202,16 +1202,16 @@ func (c *checkerContext) eventWarnings() []Finding {
 					continue
 				}
 				if strings.Contains(eventType, "*") {
-					addEventRefLocal(subscriptionPatterns, scope.ID, eventType)
+					addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
 				} else {
-					addEventRefLocal(subscribedRefs, scope.ID, eventType)
+					addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
 				}
 			}
 		}
 	}
 	for _, required := range c.source.RequiredAgents() {
 		for _, eventType := range required.Emits {
-			addEventRefLocal(emittedRefs, "", eventType)
+			addEventProofLocal(emittedRefs, c.source, "", eventType)
 		}
 		for _, eventType := range required.SubscribesTo {
 			eventType = strings.TrimSpace(eventType)
@@ -1219,9 +1219,9 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventRefLocal(subscriptionPatterns, "", eventType)
+				addEventPatternLocal(subscriptionPatterns, "", eventType)
 			} else {
-				addEventRefLocal(subscribedRefs, "", eventType)
+				addEventProofLocal(subscribedRefs, c.source, "", eventType)
 			}
 		}
 	}
@@ -1234,9 +1234,9 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventRefLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
 			} else {
-				addEventRefLocal(subscribedRefs, flowID, eventType)
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
 		}
 		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
@@ -1245,27 +1245,27 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventRefLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
 			} else {
-				addEventRefLocal(subscribedRefs, flowID, eventType)
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
 			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
 			if !ok {
 				continue
 			}
 			for _, emitted := range handlerEmits(handler) {
-				addEventRefLocal(emittedRefs, flowID, emitted)
+				addEventProofLocal(emittedRefs, c.source, flowID, emitted)
 			}
 		}
 		for _, timer := range node.Timers {
-			addEventRefLocal(emittedRefs, flowID, strings.TrimSpace(timer.Event))
+			addEventProofLocal(emittedRefs, c.source, flowID, strings.TrimSpace(timer.Event))
 		}
 	}
 	for agentID, agent := range c.source.AgentEntries() {
 		agentSource, _ := c.source.AgentContractSource(agentID)
 		flowID := strings.TrimSpace(agentSource.FlowID)
 		for _, eventType := range agent.EmitEvents {
-			addEventRefLocal(emittedRefs, flowID, eventType)
+			addEventProofLocal(emittedRefs, c.source, flowID, eventType)
 		}
 		for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
 			eventType = strings.TrimSpace(eventType)
@@ -1273,83 +1273,84 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventRefLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
 			} else {
-				addEventRefLocal(subscribedRefs, flowID, eventType)
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
 		}
 	}
-	catalog := c.source.ResolvedEventCatalog()
 	for _, key := range sortedSetKeysLocal(emittedRefs) {
 		ref := emittedRefs[key]
-		entry, eventKey, ok := resolvedEventEntryForRefLocal(c.source, catalog, ref)
-		if !ok {
-			if strings.HasPrefix(ref.Base, "timer.") || strings.HasPrefix(ref.Base, "platform.") {
+		if !ref.HasSchema {
+			if strings.HasPrefix(ref.DisplayName(), "timer.") || strings.HasPrefix(ref.DisplayName(), "platform.") {
 				continue
 			}
 			c.eventWarningFindings = append(c.eventWarningFindings, Finding{
 				CheckID:  "event_chain_integrity",
 				Severity: "warning",
-				Message:  fmt.Sprintf("'%s' emitted but no schema in events.yaml", ref.Base),
-				Location: ref.Base,
+				Message:  fmt.Sprintf("'%s' emitted but no schema in events.yaml", ref.DisplayName()),
+				Location: ref.DisplayName(),
 			})
 			continue
 		}
-		if eventRefConsumedLocal(c.source, eventKey, subscribedRefs, subscriptionPatterns) || len(c.source.RuntimeEventOwners(eventKey)) > 0 || eventHasExternalConsumerLocal(entry) || flowOutputBoundaryLocal(c.source, ref.FlowID, ref.Base) {
+		if eventRefConsumedLocal(c.source, ref.Canonical, subscribedRefs, subscriptionPatterns) || len(c.source.RuntimeEventOwners(ref.Canonical)) > 0 || eventHasExternalConsumerLocal(ref.Entry) || ref.CrossesDeclaredOutputBoundary(c.source) {
 			continue
 		}
 		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
 			CheckID:  "event_consumer_exists",
 			Severity: "warning",
-			Message:  fmt.Sprintf("'%s' emitted but nobody subscribes", eventKey),
-			Location: eventKey,
+			Message:  fmt.Sprintf("'%s' emitted but nobody subscribes", ref.Canonical),
+			Location: ref.Canonical,
 		})
 	}
 	for _, key := range sortedSetKeysLocal(subscribedRefs) {
 		ref := subscribedRefs[key]
-		entry, eventKey, ok := resolvedEventEntryForRefLocal(c.source, catalog, ref)
-		if !ok {
+		if !ref.HasSchema {
 			continue
 		}
 		if eventRefProducedLocal(c.source, ref, emittedRefs) {
 			continue
 		}
-		if eventProducedExternallyLocal(entry) || strings.EqualFold(strings.TrimSpace(entry.Status), "planned") {
+		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.Status), "planned") {
 			continue
 		}
 		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
 			CheckID:  "event_producer_exists",
 			Severity: "warning",
-			Message:  fmt.Sprintf("'%s' subscribed but nobody emits", eventKey),
-			Location: eventKey,
+			Message:  fmt.Sprintf("'%s' subscribed but nobody emits", ref.Canonical),
+			Location: ref.Canonical,
 		})
 	}
 	return c.eventWarningFindings
 }
 
-type eventRefLocal struct {
-	Base   string
+type eventPatternLocal struct {
 	FlowID string
+	Base   string
 }
 
-func addEventRefLocal(refs map[string]eventRefLocal, flowID, eventType string) {
+func addEventProofLocal(refs map[string]semanticview.FlowEventProof, source semanticview.Source, flowID, eventType string) {
+	ref := semanticview.ResolveFlowEventProof(source, flowID, eventType)
+	if strings.TrimSpace(ref.DisplayName()) == "" {
+		return
+	}
+	key := strings.TrimSpace(ref.FlowID) + "::" + ref.DisplayName()
+	refs[key] = ref
+}
+
+func addEventPatternLocal(refs map[string]eventPatternLocal, flowID, eventType string) {
 	eventType = strings.TrimSpace(eventType)
 	if eventType == "" {
 		return
 	}
-	ref := eventRefLocal{Base: eventType, FlowID: strings.TrimSpace(flowID)}
+	ref := eventPatternLocal{Base: eventType, FlowID: strings.TrimSpace(flowID)}
 	key := ref.FlowID + "::" + ref.Base
 	refs[key] = ref
 }
 
-func resolvedEventEntryForRefLocal(source semanticview.Source, catalog map[string]runtimecontracts.EventCatalogEntry, ref eventRefLocal) (runtimecontracts.EventCatalogEntry, string, bool) {
-	_ = catalog
-	return source.ResolveFlowEventCatalogEntry(ref.FlowID, ref.Base)
-}
-
-func eventRefConsumedLocal(source semanticview.Source, eventType string, subscribedRefs, patterns map[string]eventRefLocal) bool {
+func eventRefConsumedLocal(source semanticview.Source, eventType string, subscribedRefs map[string]semanticview.FlowEventProof, patterns map[string]eventPatternLocal) bool {
 	for _, subscribed := range subscribedRefs {
-		if source.FlowEventMatches(subscribed.FlowID, subscribed.Base, eventType) {
+		if source.FlowEventMatches(subscribed.FlowID, subscribed.Authored, eventType) {
 			return true
 		}
 	}
@@ -1361,32 +1362,9 @@ func eventRefConsumedLocal(source semanticview.Source, eventType string, subscri
 	return false
 }
 
-func eventRefProducedLocal(source semanticview.Source, ref eventRefLocal, emittedRefs map[string]eventRefLocal) bool {
+func eventRefProducedLocal(source semanticview.Source, ref semanticview.FlowEventProof, emittedRefs map[string]semanticview.FlowEventProof) bool {
 	for _, emitted := range emittedRefs {
-		if source.FlowEventMatches(ref.FlowID, ref.Base, source.ResolveFlowEventReference(emitted.FlowID, emitted.Base)) {
-			return true
-		}
-	}
-	return false
-}
-
-func flowOutputBoundaryLocal(source semanticview.Source, flowID, eventType string) bool {
-	eventType = strings.TrimSpace(eventType)
-	if eventType == "" {
-		return false
-	}
-	flowID = strings.TrimSpace(flowID)
-	if flowID == "" {
-		if bundle, ok := semanticview.Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
-			for _, output := range bundle.RootSchema.Pins.Outputs.Events {
-				if source.ResolveFlowEventReference("", output) == eventType {
-					return true
-				}
-			}
-		}
-	}
-	for _, output := range source.FlowOutputEvents(flowID) {
-		if source.ResolveFlowEventReference(flowID, output) == eventType {
+		if source.FlowEventMatches(ref.FlowID, ref.Authored, emitted.Canonical) {
 			return true
 		}
 	}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -764,6 +764,29 @@ func TestRun_DoesNotWarnForLocalizedCrossFlowEventRouting(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnForFlowLocalEmittedEventsWithOwningFlowSchemas(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-local-events"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "event_chain_integrity", "child/child.internal") {
+		t.Fatalf("unexpected event_chain_integrity warning for child/child.internal, got %#v", report.Warnings())
+	}
+	if reportContains(report.Warnings(), "event_chain_integrity", "child/child.done") {
+		t.Fatalf("unexpected event_chain_integrity warning for child/child.done, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForFlowOwnedAgentEmissionsDeclaredAsFlowOutputs(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-required-agents-child"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "event_consumer_exists", "analysis.done") {
+		t.Fatalf("unexpected event_consumer_exists warning for analysis.done flow output, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -614,6 +614,19 @@ func TestRun_MapsSelfEmitToEventCycleDetection(t *testing.T) {
 	}
 }
 
+func TestRun_MapsSelfEmitToEventCycleDetectionForFlowLocalHandlers(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-local-events"))
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.Emits = runtimecontracts.EventEmission{Single: eventType}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "event_cycle_detection", "emits its own trigger event") {
+		t.Fatalf("expected event_cycle_detection error for flow-local handler, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsBareConditionToConditionExpressionValidation(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-bare-condition")
 
@@ -1819,6 +1832,13 @@ func writeFlowHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBun
 		bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{}
 	}
 	bundle.Nodes[nodeID] = node
+	if bundle.Semantics.NodeHandlers == nil {
+		bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	if bundle.Semantics.NodeHandlers[nodeID] == nil {
+		bundle.Semantics.NodeHandlers[nodeID] = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	bundle.Semantics.NodeHandlers[nodeID][eventType] = handler
 }
 
 func renameFlowHandlerEvent(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, nodeID, oldEventType, newEventType string, handler runtimecontracts.SystemNodeEventHandler) {
@@ -1835,6 +1855,14 @@ func renameFlowHandlerEvent(t *testing.T, bundle *runtimecontracts.WorkflowContr
 		bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{}
 	}
 	bundle.Nodes[nodeID] = node
+	if bundle.Semantics.NodeHandlers == nil {
+		bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	if bundle.Semantics.NodeHandlers[nodeID] == nil {
+		bundle.Semantics.NodeHandlers[nodeID] = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	delete(bundle.Semantics.NodeHandlers[nodeID], oldEventType)
+	bundle.Semantics.NodeHandlers[nodeID][newEventType] = handler
 	if len(bundle.Semantics.FlowInputs[flowID]) > 0 {
 		inputs := append([]string{}, bundle.Semantics.FlowInputs[flowID]...)
 		for idx, eventType := range inputs {

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -10,7 +10,6 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
-	runtimeeventidentity "swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
@@ -719,45 +718,15 @@ func pipelineEmitPayloadProperties(source semanticview.Source, flowID, eventType
 	if source == nil {
 		return nil
 	}
-	candidates := make([]string, 0, 4)
-	eventType = strings.TrimSpace(eventType)
-	flowID = strings.TrimSpace(flowID)
-	if eventType != "" {
-		candidates = append(candidates, eventType)
+	proof := semanticview.ResolveFlowEventProof(source, strings.TrimSpace(flowID), strings.TrimSpace(eventType))
+	if !proof.HasSchema {
+		return nil
 	}
-	if flowID != "" && eventType != "" {
-		candidates = append(candidates, source.ResolveFlowEventReference(flowID, eventType))
+	allowed := eventPayloadProperties(proof.Entry)
+	if len(allowed) > 0 {
+		return allowed
 	}
-	if leaf := runtimeeventidentity.LeafName(eventType); leaf != "" && leaf != eventType {
-		candidates = append(candidates, leaf)
-		if flowID != "" {
-			candidates = append(candidates, source.ResolveFlowEventReference(flowID, leaf))
-		}
-	}
-	seen := map[string]struct{}{}
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		entry, ok := source.EventEntry(candidate)
-		if !ok {
-			entry, _, ok = source.ResolveFlowEventCatalogEntry(flowID, candidate)
-		}
-		if !ok {
-			continue
-		}
-		allowed := eventPayloadProperties(entry)
-		if len(allowed) > 0 {
-			return allowed
-		}
-		return map[string]struct{}{}
-	}
-	return nil
+	return map[string]struct{}{}
 }
 
 func eventPayloadProperties(entry runtimecontracts.EventCatalogEntry) map[string]struct{} {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1008,6 +1009,29 @@ func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputR
 	}
 	if _, ok := output["result"]; ok {
 		t.Fatalf("output emit result should be trimmed to the target event schema: %#v", output["result"])
+	}
+}
+
+func TestPipelineEmitPayloadProperties_UsesCanonicalFlowEventProofForLocalAndCanonicalRefs(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
+
+	canonical := pipelineEmitPayloadProperties(source, "child", "child/child.internal")
+	local := pipelineEmitPayloadProperties(source, "child", "child.internal")
+
+	if len(canonical) == 0 {
+		t.Fatalf("expected canonical child event schema properties, got %#v", canonical)
+	}
+	if len(local) == 0 {
+		t.Fatalf("expected local child event schema properties, got %#v", local)
+	}
+	if !reflect.DeepEqual(canonical, local) {
+		t.Fatalf("local/canonical payload properties drifted: canonical=%#v local=%#v", canonical, local)
+	}
+	if _, ok := canonical["entity_id"]; !ok {
+		t.Fatalf("expected entity_id in canonical payload properties: %#v", canonical)
+	}
+	if _, ok := canonical["step"]; !ok {
+		t.Fatalf("expected step in canonical payload properties: %#v", canonical)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -205,7 +205,7 @@ func workflowEmitTargetsParentEntity(source semanticview.Source, flowID, eventTy
 	if source == nil || flowID == "" {
 		return false
 	}
-	return source.FlowHasOutputEvent(flowID, eventType)
+	return semanticview.ResolveFlowEventProof(source, flowID, eventType).CrossesDeclaredOutputBoundary(source)
 }
 
 func workflowEntityMetadataPayload(source semanticview.Source, metadata map[string]any) map[string]any {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -87,13 +87,22 @@ func TestWorkflowEmitTargetsParentEntity_OutputPin(t *testing.T) {
 	if !workflowEmitTargetsParentEntity(source, "child", "child/child.done") {
 		t.Fatal("expected child/child.done to target the parent entity")
 	}
+	if !workflowEmitTargetsParentEntity(source, "child", "child.done") {
+		t.Fatal("expected local child.done to target the parent entity through the same canonical proof")
+	}
 	if workflowEmitTargetsParentEntity(source, "child", "child/child.internal") {
 		t.Fatal("did not expect child/child.internal to target the parent entity")
+	}
+	if workflowEmitTargetsParentEntity(source, "child", "child.internal") {
+		t.Fatal("did not expect local child.internal to target the parent entity")
 	}
 
 	pinSource := loadWorkflowFixtureSource(t, "test-child-flow-pin-wiring")
 	if !workflowEmitTargetsParentEntity(pinSource, "child", "child/work.completed") {
 		t.Fatal("expected child/work.completed to target the parent entity")
+	}
+	if !workflowEmitTargetsParentEntity(pinSource, "child", "work.completed") {
+		t.Fatal("expected local work.completed to target the parent entity through the same canonical proof")
 	}
 }
 

--- a/internal/runtime/semanticview/event_proof.go
+++ b/internal/runtime/semanticview/event_proof.go
@@ -1,0 +1,138 @@
+package semanticview
+
+import (
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeeventidentity "swarm/internal/runtime/core/eventidentity"
+)
+
+type FlowEventProof struct {
+	FlowID     string
+	Authored   string
+	Local      string
+	Canonical  string
+	CatalogKey string
+	Entry      runtimecontracts.EventCatalogEntry
+	HasSchema  bool
+}
+
+func ResolveFlowEventProof(source Source, flowID, eventType string) FlowEventProof {
+	flowID = strings.TrimSpace(flowID)
+	authored := runtimeeventidentity.Normalize(eventType)
+	proof := FlowEventProof{
+		FlowID:    flowID,
+		Authored:  authored,
+		Local:     authored,
+		Canonical: authored,
+	}
+	if source == nil || authored == "" {
+		return proof
+	}
+
+	if canonical := runtimeeventidentity.Normalize(source.ResolveFlowEventReference(flowID, authored)); canonical != "" {
+		proof.Canonical = canonical
+	}
+
+	if local := localizeFlowEventForProof(source, flowID, proof.Canonical); local != "" {
+		proof.Local = local
+	}
+
+	candidates := uniqueNormalizedProofCandidates(proof.Local, proof.Authored, proof.Canonical)
+	for _, candidate := range candidates {
+		entry, key, ok := source.ResolveFlowEventCatalogEntry(flowID, candidate)
+		if !ok {
+			continue
+		}
+		proof.Entry = entry
+		proof.CatalogKey = strings.TrimSpace(key)
+		proof.HasSchema = true
+		if proof.Local == "" {
+			proof.Local = proof.CatalogKey
+		}
+		break
+	}
+	return proof
+}
+
+func (p FlowEventProof) DisplayName() string {
+	switch {
+	case strings.TrimSpace(p.Canonical) != "":
+		return strings.TrimSpace(p.Canonical)
+	case strings.TrimSpace(p.Authored) != "":
+		return strings.TrimSpace(p.Authored)
+	default:
+		return strings.TrimSpace(p.Local)
+	}
+}
+
+func (p FlowEventProof) CrossesDeclaredOutputBoundary(source Source) bool {
+	if source == nil {
+		return false
+	}
+	canonical := strings.TrimSpace(p.Canonical)
+	if canonical == "" {
+		return false
+	}
+	flowID := strings.TrimSpace(p.FlowID)
+	if flowID == "" {
+		if bundle, ok := Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
+			for _, output := range bundle.RootSchema.Pins.Outputs.Events {
+				if source.ResolveFlowEventReference("", output) == canonical {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, output := range source.FlowOutputEvents(flowID) {
+		if source.ResolveFlowEventReference(flowID, output) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+func localizeFlowEventForProof(source Source, flowID, canonical string) string {
+	if source == nil {
+		return ""
+	}
+	canonical = runtimeeventidentity.Normalize(canonical)
+	if canonical == "" {
+		return ""
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return canonical
+	}
+	scope, ok := FlowScopeByID(source, flowID)
+	if !ok {
+		return canonical
+	}
+	localNames := make([]string, 0, len(scope.Events))
+	for name := range scope.Events {
+		name = runtimeeventidentity.Normalize(name)
+		if name == "" {
+			continue
+		}
+		localNames = append(localNames, name)
+	}
+	return runtimeeventidentity.LocalizeForFlow(scope.Path, localNames, canonical)
+}
+
+func uniqueNormalizedProofCandidates(values ...string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = runtimeeventidentity.Normalize(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/runtime/semanticview/event_proof.go
+++ b/internal/runtime/semanticview/event_proof.go
@@ -66,6 +66,13 @@ func (p FlowEventProof) DisplayName() string {
 	}
 }
 
+func (p FlowEventProof) EventKey() string {
+	if canonical := strings.TrimSpace(p.Canonical); canonical != "" {
+		return canonical
+	}
+	return p.DisplayName()
+}
+
 func (p FlowEventProof) CrossesDeclaredOutputBoundary(source Source) bool {
 	if source == nil {
 		return false

--- a/internal/runtime/swarmflowtest/catalog_runner_event_warning_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_event_warning_test.go
@@ -1,0 +1,34 @@
+package swarmflowtest
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCatalogCollectBootIssues_DoesNotReintroduceFlowLocalEventWarningDrift(t *testing.T) {
+	repoRoot := repoRootForTest(t)
+	bundle := catalogLoadBootBundle(t, filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-child-flow-local-events"))
+
+	issues := catalogCollectBootIssues(bundle)
+	for _, issue := range issues {
+		if issue.Category != "EVENT-NO-SCHEMA" {
+			continue
+		}
+		if strings.Contains(issue.Message, "child/child.internal") || strings.Contains(issue.Message, "child/child.done") {
+			t.Fatalf("unexpected flow-local event warning drift: %#v", issues)
+		}
+	}
+}
+
+func TestCatalogCollectBootIssues_DoesNotReintroduceFlowOutputConsumerWarningDrift(t *testing.T) {
+	repoRoot := repoRootForTest(t)
+	bundle := catalogLoadBootBundle(t, filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-required-agents-child"))
+
+	issues := catalogCollectBootIssues(bundle)
+	for _, issue := range issues {
+		if issue.Category == "EVENT-NO-CONSUMER" && strings.Contains(issue.Message, "analysis.done") {
+			t.Fatalf("unexpected flow-owned output consumer warning drift: %#v", issues)
+		}
+	}
+}

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1,6 +1,7 @@
 package swarmflowtest
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,9 +15,12 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/timeridentity"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
 )
 
 type catalogTriggerStep struct {
@@ -129,6 +133,7 @@ type catalogBootBundle struct {
 	AllAgents map[string]any
 	AllPolicy map[string]any
 	AllTools  map[string]any
+	Source    semanticview.Source
 }
 
 type catalogNodeContract struct {
@@ -1075,6 +1080,27 @@ func catalogLoadBootBundle(t testing.TB, dir string) catalogBootBundle {
 		AllPolicy: cloneStringAnyMapCatalog(root.Policy),
 		AllTools:  cloneStringAnyMapCatalog(root.Tools),
 	}
+	if bundle.AllNodes == nil {
+		bundle.AllNodes = map[string]any{}
+	}
+	if bundle.AllEvents == nil {
+		bundle.AllEvents = map[string]any{}
+	}
+	if bundle.AllAgents == nil {
+		bundle.AllAgents = map[string]any{}
+	}
+	if bundle.AllPolicy == nil {
+		bundle.AllPolicy = map[string]any{}
+	}
+	if bundle.AllTools == nil {
+		bundle.AllTools = map[string]any{}
+	}
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	semanticBundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, dir, platformSpec)
+	if err == nil {
+		bundle.Source = semanticview.Wrap(semanticBundle)
+	}
 	entries, err := os.ReadDir(filepath.Join(dir, "flows"))
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("read boot flow fixtures: %v", err)
@@ -1121,79 +1147,27 @@ func catalogLoadBootBundle(t testing.TB, dir string) catalogBootBundle {
 
 func catalogCollectBootIssues(bundle catalogBootBundle) []catalogBootIssue {
 	issues := make([]catalogBootIssue, 0, 16)
-	eventDefined := map[string]struct{}{}
-	for _, key := range catalogSortedKeys(bundle.AllEvents) {
-		if len(catalogMap(bundle.AllEvents[key])) > 0 {
-			eventDefined[key] = struct{}{}
-		}
-	}
-	eventsEmitted := map[string]struct{}{}
-	eventsSubscribed := map[string]struct{}{}
-	fanOutEvents := map[string]struct{}{}
 	eventGraph := map[string]map[string]struct{}{}
 	allScopes := append([]catalogBootScope{bundle.Root}, bundle.Flows...)
 	for _, scope := range allScopes {
-		if eventName := catalogAutoEmitEvent(scope.Schema); eventName != "" {
-			eventsEmitted[eventName] = struct{}{}
-		}
 		for _, nodeID := range catalogSortedKeys(scope.Nodes) {
 			node := catalogMap(scope.Nodes[nodeID])
-			for _, ev := range catalogStringSlice(node["subscribes_to"]) {
-				evClean := catalogNormalizeSubscribedEvent(ev)
-				if evClean != "" && !strings.Contains(evClean, "*") {
-					eventsSubscribed[evClean] = struct{}{}
-				}
-			}
 			for _, eventType := range catalogSortedKeys(catalogMap(node["event_handlers"])) {
-				eventsSubscribed[eventType] = struct{}{}
 				handler := catalogMap(catalogMap(node["event_handlers"])[eventType])
 				emits := catalogCollectHandlerEmits(handler)
 				for _, emitted := range emits {
 					if emitted == "" {
 						continue
 					}
-					eventsEmitted[emitted] = struct{}{}
 					if eventGraph[eventType] == nil {
 						eventGraph[eventType] = map[string]struct{}{}
 					}
 					eventGraph[eventType][emitted] = struct{}{}
 				}
-				fanOut := catalogMap(handler["fan_out"])
-				if emit := catalogBootText(fanOut["emit_per_item"]); emit != "" {
-					fanOutEvents[emit] = struct{}{}
-				}
-			}
-		}
-		for _, agentID := range catalogSortedKeys(scope.Agents) {
-			agent := catalogMap(scope.Agents[agentID])
-			for _, ev := range catalogStringSlice(agent["emit_events"]) {
-				if ev != "" {
-					eventsEmitted[ev] = struct{}{}
-				}
-			}
-			for _, ev := range append(catalogStringSlice(agent["subscriptions"]), catalogStringSlice(agent["subscribes_to"])...) {
-				evClean := catalogNormalizeSubscribedEvent(ev)
-				if evClean != "" && !strings.Contains(evClean, "*") {
-					eventsSubscribed[evClean] = struct{}{}
-				}
 			}
 		}
 	}
-	for _, ev := range catalogSortedSetKeys(eventsEmitted) {
-		if _, ok := eventDefined[ev]; !ok && !strings.HasPrefix(ev, "timer.") && !strings.HasPrefix(ev, "*.") {
-			issues = append(issues, catalogBootIssue{Severity: "warning", Category: "EVENT-NO-SCHEMA", Message: fmt.Sprintf("'%s' emitted but no schema in events.yaml", ev)})
-		}
-	}
-	for _, ev := range catalogSortedSetKeys(eventsEmitted) {
-		if _, ok := eventDefined[ev]; ok && !catalogSetHas(eventsSubscribed, ev) && !strings.HasPrefix(ev, "pipeline.") && !catalogIsSuppressedEvent(bundle.AllEvents, ev) {
-			issues = append(issues, catalogBootIssue{Severity: "warning", Category: "EVENT-NO-CONSUMER", Message: fmt.Sprintf("'%s' emitted but nobody subscribes", ev)})
-		}
-	}
-	for _, ev := range catalogSortedSetKeys(eventsSubscribed) {
-		if _, ok := eventDefined[ev]; ok && !catalogSetHas(eventsEmitted, ev) && !catalogSetHas(fanOutEvents, ev) && !strings.HasPrefix(ev, "timer.") && !catalogIsSuppressedEvent(bundle.AllEvents, ev) {
-			issues = append(issues, catalogBootIssue{Severity: "warning", Category: "EVENT-NO-PRODUCER", Message: fmt.Sprintf("'%s' subscribed but nobody emits", ev)})
-		}
-	}
+	issues = append(issues, catalogSemanticEventWarningIssues(bundle.Source)...)
 	for _, scope := range allScopes {
 		scopeLabel := catalogBootScopeLabel(scope)
 		mergedPolicy := cloneStringAnyMapCatalog(bundle.AllPolicy)
@@ -1437,6 +1411,33 @@ func catalogCollectBootIssues(bundle catalogBootBundle) []catalogBootIssue {
 	}
 	for _, cycle := range catalogFindEventCycles(eventGraph) {
 		issues = append(issues, catalogBootIssue{Severity: "error", Category: "EVENT-CYCLE", Message: fmt.Sprintf("Node handler emit cycle: %s", strings.Join(cycle, " -> "))})
+	}
+	return issues
+}
+
+func catalogSemanticEventWarningIssues(source semanticview.Source) []catalogBootIssue {
+	if source == nil {
+		return nil
+	}
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	issues := make([]catalogBootIssue, 0, len(report.Warnings()))
+	for _, warning := range report.Warnings() {
+		category := ""
+		switch strings.TrimSpace(warning.CheckID) {
+		case "event_chain_integrity":
+			category = "EVENT-NO-SCHEMA"
+		case "event_consumer_exists":
+			category = "EVENT-NO-CONSUMER"
+		case "event_producer_exists":
+			category = "EVENT-NO-PRODUCER"
+		default:
+			continue
+		}
+		issues = append(issues, catalogBootIssue{
+			Severity: strings.TrimSpace(warning.Severity),
+			Category: category,
+			Message:  strings.TrimSpace(warning.Message),
+		})
 	}
 	return issues
 }


### PR DESCRIPTION
Closes #277

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: contract_formats.event_schema`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: local_name`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: flow_directory.events_yaml`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: node_coherence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_coherence`

## Human Summary
This PR removes the false boot-verification warnings for flow-local emitted events and flow-owned agent output events by moving the touched warning path onto one typed flow-event proof model. The same local/canonical event meaning is now used for schema lookup, consumer checks, and flow-output boundary proof.

## What Changed
- added `semanticview.FlowEventProof` as the typed owner for the touched event-reference / owning-flow proof seam
- moved `bootverify.eventWarnings()` to consume that typed proof instead of ad hoc `eventRefLocal` + separate schema/output checks
- moved the `swarmflowtest` boot warning oracle onto the same semantic warning path for the affected event warning categories
- added focused regressions for:
  - flow-local node emissions with owning-flow schemas
  - flow-owned agent emissions declared as flow outputs
  - supported-surface `verifyBundle` parity on the same fixtures
  - conformance-harness drift guard on the same warning classes

## Why This Is Needed
The platform spec requires flow `events.yaml` declarations to use local names, while runtime-facing event identity can be canonicalized by flow path. The previous warning path mixed those interpretations and produced false `EVENT-NO-SCHEMA` / `EVENT-NO-CONSUMER` results. This PR closes that semantic gap instead of preserving dual ownership.

## Scope Boundaries
- in scope: flow-local emitted-event warning semantics, owning-flow output-boundary proof, and the conformance-harness duplicate for those warning classes
- out of scope: broader event-existence / wildcard validation (`eventExists`) and unrelated event validation seams

## Tests Run
- `go test ./internal/runtime/bootverify ./cmd/swarm ./internal/runtime/swarmflowtest -count=1`
- `go run ./cmd/swarm verify -contracts tests/tier11-flow-composition/test-child-flow-local-events`
- `go run ./cmd/swarm verify -contracts tests/tier11-flow-composition/test-required-agents-child`
- `go test ./... -count=1`

## Residual Risk
No known residual risk remains in the touched warning seam. The remaining warnings in the two issue fixtures are unrelated pre-existing warnings (`event_producer_exists`, `input_pin_wiring`, `prompt_exists`) and were not changed here.

## Follow-Up
None currently identified for this semantic concept. The only currently known adjacent bypass is `bootverify.eventExists`, which is a separate event-existence/wildcard class and was explicitly left out of `#277`.