### PR TITLE
[agent-b][issue #163] Unify computed data_accumulation expression semantics

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -21,6 +21,7 @@ import (
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 type Check struct {
@@ -119,6 +120,9 @@ type checkerContext struct {
 	conditionExprLoaded   bool
 	conditionExprFindings []Finding
 
+	dataAccumulationExprLoaded   bool
+	dataAccumulationExprFindings []Finding
+
 	entityRefLoaded   bool
 	entityRefFindings []Finding
 
@@ -178,6 +182,7 @@ var bootCheckRegistry = []Check{
 	{ID: "agent_permission_validation", Severity: "error", Run: checkAgentPermissionValidation},
 	{ID: "transition_reference_validation", Severity: "error", Run: checkTransitionReferenceValidation},
 	{ID: "condition_expression_validation", Severity: "error", Run: checkConditionExpressionValidation},
+	{ID: "data_accumulation_expression_validation", Severity: "error", Run: checkDataAccumulationExpressionValidation},
 	{ID: "expression_field_reference_validation", Severity: "warning", Run: checkExpressionFieldReferenceValidation},
 	{ID: "transition_ownership_validation", Severity: "error", Run: checkTransitionOwnershipValidation},
 	{ID: "event_runtime_wiring_validation", Severity: "error", Run: checkEventRuntimeWiringValidation},
@@ -242,6 +247,9 @@ func checkSingleNodePerEvent(c *checkerContext) []Finding            { return c.
 func checkPlatformMetadataValidation(c *checkerContext) []Finding    { return c.platformMetadata() }
 func checkTransitionReferenceValidation(c *checkerContext) []Finding { return c.transitionReferences() }
 func checkConditionExpressionValidation(c *checkerContext) []Finding { return c.conditionExpressions() }
+func checkDataAccumulationExpressionValidation(c *checkerContext) []Finding {
+	return c.dataAccumulationExpressions()
+}
 func checkExpressionFieldReferenceValidation(c *checkerContext) []Finding {
 	return c.expressionFieldReferences()
 }
@@ -460,6 +468,33 @@ func (c *checkerContext) conditionExpressions() []Finding {
 		}
 	}
 	return c.conditionExprFindings
+}
+
+func (c *checkerContext) dataAccumulationExpressions() []Finding {
+	if c.dataAccumulationExprLoaded {
+		return c.dataAccumulationExprFindings
+	}
+	c.dataAccumulationExprLoaded = true
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			for _, expr := range handlerEntityExpressions(handler) {
+				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
+					continue
+				}
+				if err := workflowexpr.ValidateDataExpression(expr.Expression); err != nil {
+					c.dataAccumulationExprFindings = append(c.dataAccumulationExprFindings, Finding{
+						CheckID:  "data_accumulation_expression_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s handler %s %s %q is invalid for data_accumulation.expression: %v", nodeID, eventType, expr.Kind, expr.Expression, err),
+						Location: nodeID,
+					})
+				}
+			}
+		}
+	}
+	return c.dataAccumulationExprFindings
 }
 
 func (c *checkerContext) expressionFieldReferences() []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -671,6 +671,41 @@ func TestRun_RejectsItemNamespaceOutsideFilterConditions(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsAccumulatedNamespaceInDataAccumulationExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "tracking",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "expected_count", Type: "integer"},
+					},
+				}},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+							Writes: []runtimecontracts.WorkflowDataWrite{
+								{TargetField: "expected_count", Value: runtimecontracts.CELExpression("accumulated.size()")},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "data_accumulation_expression_validation", "accumulated.size()") {
+		t.Fatalf("expected accumulated namespace in data_accumulation expression to fail validation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesPermissionMismatchWarningsDuringMigration(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-permission-tool-mismatch")
 
@@ -1270,8 +1305,8 @@ func TestRun_UsesCompiledOwnersForEquivalentSingleNodePerEventRoutes(t *testing.
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 36 {
-		t.Fatalf("bootCheckRegistry count = %d, want 36", got)
+	if got := len(bootCheckRegistry); got != 37 {
+		t.Fatalf("bootCheckRegistry count = %d, want 37", got)
 	}
 	if got := len(supplementalChecks); got != 2 {
 		t.Fatalf("supplementalChecks count = %d, want 2", got)

--- a/internal/runtime/contracts/phase1_foundation_test.go
+++ b/internal/runtime/contracts/phase1_foundation_test.go
@@ -39,7 +39,6 @@ func TestPhase1SemanticModelUsesTypedContracts(t *testing.T) {
 
 	expectFieldType(t, reflect.TypeOf(ReduceSpec{}), "Params", reflect.TypeOf(map[string]ExpressionValue{}))
 	expectFieldType(t, reflect.TypeOf(WorkflowTransitionContract{}), "From", reflect.TypeOf([]string{}))
-	expectFieldType(t, reflect.TypeOf(WorkflowDataAccumulation{}), "Value", reflect.TypeOf(ExpressionValue{}))
 	expectFieldType(t, reflect.TypeOf(WorkflowDataWrite{}), "Value", reflect.TypeOf(ExpressionValue{}))
 	expectFieldType(t, reflect.TypeOf(FlowInstanceVariables{}), "Variables", reflect.TypeOf(map[string]FlowVariable{}))
 	expectFieldType(t, reflect.TypeOf(ToolSchemaEntry{}), "InputSchema", reflect.TypeOf(ToolInputSchema{}))

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -636,7 +636,6 @@ type WorkflowTransitionContract struct {
 type WorkflowDataAccumulation struct {
 	Writes      []WorkflowDataWrite `yaml:"writes"`
 	SourceEvent string              `yaml:"source_event"`
-	Value       ExpressionValue     `yaml:"value,omitempty"`
 }
 type WorkflowDataWrite struct {
 	Field       string          `yaml:"-" json:"field,omitempty"`

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -392,7 +392,7 @@ func decodeHandlerRuleEntryNode(node *yaml.Node) (*HandlerRuleEntry, error) {
 	if err := node.Decode(&rule); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emits.Empty() && !rule.DataAccumulation.HasWrites() && rule.DataAccumulation.Value.IsZero() && rule.Compute == nil && rule.FanOut == nil {
+	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emits.Empty() && !rule.DataAccumulation.HasWrites() && rule.Compute == nil && rule.FanOut == nil {
 		return nil, nil
 	}
 	return &rule, nil

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -319,22 +319,6 @@ func (a *WorkflowDataAccumulation) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func decodeWorkflowDataAccumulationShorthandWrite(target string, node *yaml.Node) (WorkflowDataWrite, error) {
-	write := WorkflowDataWrite{TargetField: strings.TrimSpace(target)}
-	if node == nil || node.Kind == 0 {
-		write.TargetPath = paths.Parse(write.Target())
-		return write, nil
-	}
-	switch node.Kind {
-	case yaml.ScalarNode:
-		return WorkflowDataWrite{}, fmt.Errorf("workflow data accumulation shorthand writes are not supported; use writes list")
-	case yaml.MappingNode:
-		return WorkflowDataWrite{}, fmt.Errorf("workflow data accumulation shorthand writes are not supported; use writes list")
-	default:
-		return WorkflowDataWrite{}, fmt.Errorf("workflow data accumulation shorthand writes are not supported; use writes list")
-	}
-}
-
 func (s *FilterSpec) UnmarshalYAML(node *yaml.Node) error {
 	if s == nil {
 		return nil

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -10,22 +10,18 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types/ref"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/core/values"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 const handlerAccumulatorBucketKey = "handler_accumulators"
 
 var (
-	dataExpressionEnvOnce sync.Once
-	dataExpressionEnv     *cel.Env
-	dataExpressionEnvErr  error
-
 	executionConditionEnvOnce sync.Once
 	executionConditionEnvRef  *cel.Env
 	executionConditionEnvErr  error
@@ -219,81 +215,20 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 }
 
 func evalDataAccumulationExpression(base BaseContext, state ExecutionState, expression string) (any, error) {
-	env, err := dataAccumulationEnv()
-	if err != nil {
-		return nil, err
-	}
-	ast, issues := env.Compile(strings.TrimSpace(expression))
-	if issues != nil && issues.Err() != nil {
-		return nil, issues.Err()
-	}
-	program, err := env.Program(ast)
-	if err != nil {
-		return nil, err
-	}
-	out, _, err := program.Eval(map[string]any{
-		"entity":  normalizedCELInputMap(base.Entity.Raw()),
-		"payload": normalizedCELInputMap(base.Payload.Raw()),
-		"policy":  normalizedCELInputMap(base.Policy.Raw()),
-		"fan_out": normalizedCELInputMap(state.FanOut),
+	return workflowexpr.EvalDataExpression(expression, workflowexpr.DataContext{
+		Entity:  base.Entity.Raw(),
+		Payload: base.Payload.Raw(),
+		Policy:  base.Policy.Raw(),
+		FanOut:  state.FanOut,
 	})
-	if err != nil {
-		return nil, err
-	}
-	return normalizeCELValue(out), nil
-}
-
-func dataAccumulationEnv() (*cel.Env, error) {
-	dataExpressionEnvOnce.Do(func() {
-		dataExpressionEnv, dataExpressionEnvErr = cel.NewEnv(
-			cel.Variable("entity", cel.DynType),
-			cel.Variable("payload", cel.DynType),
-			cel.Variable("policy", cel.DynType),
-			cel.Variable("fan_out", cel.DynType),
-		)
-	})
-	return dataExpressionEnv, dataExpressionEnvErr
 }
 
 func normalizeCELValue(value any) any {
-	switch typed := value.(type) {
-	case nil:
-		return nil
-	case ref.Val:
-		return normalizeCELValue(typed.Value())
-	case []any:
-		out := make([]any, 0, len(typed))
-		for _, item := range typed {
-			out = append(out, normalizeCELValue(item))
-		}
-		return out
-	case map[string]any:
-		out := make(map[string]any, len(typed))
-		for key, item := range typed {
-			out[key] = normalizeCELValue(item)
-		}
-		return out
-	case float64:
-		if math.Trunc(typed) == typed && typed <= math.MaxInt && typed >= math.MinInt {
-			return int(typed)
-		}
-		return typed
-	case int64:
-		return int(typed)
-	default:
-		return typed
-	}
+	return workflowexpr.NormalizeCELValue(value)
 }
 
 func normalizedCELInputMap(source map[string]any) map[string]any {
-	if len(source) == 0 {
-		return map[string]any{}
-	}
-	normalized, _ := normalizeCELValue(cloneStringAnyMap(source)).(map[string]any)
-	if normalized == nil {
-		return map[string]any{}
-	}
-	return normalized
+	return workflowexpr.NormalizeCELInputMap(source)
 }
 
 func payloadTransform(base BaseContext, state ExecutionState, spec *runtimecontracts.PayloadTransformSpec) (map[string]any, error) {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -505,6 +505,69 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 	}
 }
 
+func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpression(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: &runtimecontracts.WorkflowContractBundle{
+			Semantics: runtimecontracts.WorkflowSemanticView{
+				Name:    "validation",
+				Version: "v-test",
+				EntitySchema: runtimecontracts.EntitySchema{
+					Groups: []runtimecontracts.EntitySchemaGroup{
+						{
+							Name: "tracking",
+							Fields: []runtimecontracts.EntitySchemaField{
+								{Name: "kill_reason", Type: "text"},
+								{Name: "kill_reason_missing", Type: "boolean"},
+							},
+						},
+					},
+				},
+			},
+		}},
+	})
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"subject_id": entityID,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "kill_reason_missing", Value: runtimecontracts.CELExpression("entity.kill_reason == null")},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
+		State: pc.currentWorkflowState(context.Background(), entityID),
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("workflow instance missing after declarative write")
+	}
+	if got := instance.Metadata["kill_reason_missing"]; got != true {
+		t.Fatalf("kill_reason_missing = %#v, want true", got)
+	}
+}
+
 func TestResolveHandlerEntityIDForFlowKeepsSameFlowEntity(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -1,10 +1,10 @@
 package pipeline
 
 import (
-	"regexp"
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 type WorkflowEntityFieldLifecyclePhase string
@@ -24,96 +24,16 @@ const (
 	WorkflowEntityFieldLifecyclePayloadTransform WorkflowEntityFieldLifecyclePhase = "payload_transform"
 )
 
-var workflowExpressionEntityReferencePattern = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-var workflowExpressionEntityPresencePattern = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
-var workflowExpressionEntityHasPattern = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
-var workflowExpressionEntityHasTernaryTruePattern = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-var workflowExpressionEntityHasTernaryFalsePattern = regexp.MustCompile(`!\s*has\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*[^:]+:\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-var workflowExpressionEntityNullCompareLeftPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=)\s*null\b`)
-var workflowExpressionEntityNullCompareRightPattern = regexp.MustCompile(`\bnull\s*(==|!=)\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
-
 func WorkflowEntityReferences(expression string) []string {
-	expression = strings.TrimSpace(stripWorkflowExpressionStringLiterals(expression))
-	if expression == "" {
-		return nil
-	}
-	matches := workflowExpressionEntityReferencePattern.FindAllStringSubmatch(expression, -1)
-	out := make([]string, 0, len(matches))
-	seen := map[string]struct{}{}
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		ref := strings.TrimSpace(match[1])
-		if ref == "" {
-			continue
-		}
-		if _, ok := seen[ref]; ok {
-			continue
-		}
-		seen[ref] = struct{}{}
-		out = append(out, ref)
-	}
-	return out
+	return workflowexpr.EntityReferences(expression)
 }
 
 func stripWorkflowExpressionStringLiterals(expression string) string {
-	if expression == "" {
-		return ""
-	}
-	var out strings.Builder
-	out.Grow(len(expression))
-	inSingle := false
-	inDouble := false
-	escaped := false
-	for i := 0; i < len(expression); i++ {
-		ch := expression[i]
-		if escaped {
-			if inSingle || inDouble {
-				out.WriteByte(' ')
-			} else {
-				out.WriteByte(ch)
-			}
-			escaped = false
-			continue
-		}
-		if ch == '\\' {
-			escaped = true
-			if inSingle || inDouble {
-				out.WriteByte(' ')
-			} else {
-				out.WriteByte(ch)
-			}
-			continue
-		}
-		if ch == '"' && !inSingle {
-			inDouble = !inDouble
-			out.WriteByte(' ')
-			continue
-		}
-		if ch == '\'' && !inDouble {
-			inSingle = !inSingle
-			out.WriteByte(' ')
-			continue
-		}
-		if inSingle || inDouble {
-			out.WriteByte(' ')
-			continue
-		}
-		out.WriteByte(ch)
-	}
-	return out.String()
+	return workflowexpr.StripStringLiterals(expression)
 }
 
 func WorkflowEntityReferenceField(ref string) string {
-	ref = strings.TrimSpace(ref)
-	if ref == "" {
-		return ""
-	}
-	if idx := strings.IndexByte(ref, '.'); idx >= 0 {
-		ref = ref[:idx]
-	}
-	return strings.TrimSpace(ref)
+	return workflowexpr.EntityReferenceField(ref)
 }
 
 func WorkflowBuiltinEntityField(field string) bool {
@@ -126,51 +46,7 @@ func WorkflowBuiltinEntityField(field string) bool {
 }
 
 func WorkflowPresenceGuardedEntityFields(expression string) map[string]struct{} {
-	expression = strings.TrimSpace(stripWorkflowExpressionStringLiterals(expression))
-	if expression == "" {
-		return nil
-	}
-	out := map[string]struct{}{}
-	addField := func(field string) {
-		field = WorkflowEntityReferenceField(field)
-		if field != "" {
-			out[field] = struct{}{}
-		}
-	}
-	for _, match := range workflowExpressionEntityPresencePattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 2 {
-			addField(match[1])
-		}
-	}
-	for _, match := range workflowExpressionEntityHasPattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 2 {
-			addField(match[1])
-		}
-	}
-	for _, match := range workflowExpressionEntityHasTernaryTruePattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 3 && WorkflowEntityReferenceField(match[1]) == WorkflowEntityReferenceField(match[2]) {
-			addField(match[1])
-		}
-	}
-	for _, match := range workflowExpressionEntityHasTernaryFalsePattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 3 && WorkflowEntityReferenceField(match[1]) == WorkflowEntityReferenceField(match[2]) {
-			addField(match[1])
-		}
-	}
-	for _, match := range workflowExpressionEntityNullCompareLeftPattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 2 {
-			addField(match[1])
-		}
-	}
-	for _, match := range workflowExpressionEntityNullCompareRightPattern.FindAllStringSubmatch(expression, -1) {
-		if len(match) >= 3 {
-			addField(match[2])
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return workflowexpr.PresenceGuardedEntityFields(expression)
 }
 
 func WorkflowEntityFieldsAvailableBeforeCondition(handler runtimecontracts.SystemNodeEventHandler, context WorkflowConditionContext) map[string]struct{} {

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 var workflowExpressionKeywordReplacer = regexp.MustCompile(`\b(AND|OR|NOT|TRUE|FALSE)\b`)
@@ -19,10 +20,6 @@ var workflowExpressionCountGEPattern = regexp.MustCompile(`count\(\s*([a-zA-Z_][
 var workflowExpressionStageRangeCountPattern = regexp.MustCompile(`count\(\s*entities\s+in\s+\[([a-zA-Z_][a-zA-Z0-9_]*)\.\.([a-zA-Z_][a-zA-Z0-9_]*)\]\s*\)`)
 var workflowExpressionQueryEntitiesCountPattern = regexp.MustCompile(`query_entities\(\s*([^()]+?)\s*\)\.count`)
 var workflowExpressionQueryPredicatePattern = regexp.MustCompile(`^\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=|>=|<=|>|<)\s*(.+?)\s*$`)
-var workflowExpressionEntityNullNotEqualPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*!=\s*null\b`)
-var workflowExpressionEntityNullEqualPattern = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*==\s*null\b`)
-var workflowExpressionNullEntityNotEqualPattern = regexp.MustCompile(`\bnull\s*!=\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
-var workflowExpressionNullEntityEqualPattern = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
 
 type workflowExpressionContext struct {
 	Entity           map[string]any
@@ -207,13 +204,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 }
 
 func rewriteWorkflowExpressionEntityNullPresenceChecks(expression string) string {
-	return rewriteWorkflowExpressionOutsideStringLiterals(expression, func(segment string) string {
-		segment = workflowExpressionEntityNullNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
-		segment = workflowExpressionNullEntityNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
-		segment = workflowExpressionEntityNullEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
-		segment = workflowExpressionNullEntityEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
-		return segment
-	})
+	return workflowexpr.RewriteEntityNullPresenceChecks(expression)
 }
 
 func rewriteWorkflowExpressionQueryEntityCounts(expression string, ctx workflowExpressionContext) (string, error) {
@@ -380,62 +371,6 @@ func normalizeWorkflowExpressionStringLiterals(expression string) string {
 			continue
 		}
 		out.WriteByte(ch)
-	}
-	return out.String()
-}
-
-func rewriteWorkflowExpressionOutsideStringLiterals(expression string, rewrite func(string) string) string {
-	if expression == "" || rewrite == nil {
-		return expression
-	}
-	var out strings.Builder
-	segmentStart := 0
-	inSingle := false
-	inDouble := false
-	for i := 0; i < len(expression); i++ {
-		ch := expression[i]
-		if ch == '\\' && i+1 < len(expression) {
-			i++
-			continue
-		}
-		if ch == '"' && !inSingle {
-			if !inDouble {
-				out.WriteString(rewrite(expression[segmentStart:i]))
-				segmentStart = i
-				inDouble = true
-				continue
-			}
-			inDouble = false
-			i++
-			out.WriteString(expression[segmentStart:i])
-			segmentStart = i
-			i--
-			continue
-		}
-		if ch == '\'' && !inDouble {
-			if !inSingle {
-				out.WriteString(rewrite(expression[segmentStart:i]))
-				segmentStart = i
-				inSingle = true
-				continue
-			}
-			inSingle = false
-			i++
-			out.WriteString(expression[segmentStart:i])
-			segmentStart = i
-			i--
-			continue
-		}
-	}
-	if segmentStart < len(expression) {
-		if inSingle || inDouble {
-			out.WriteString(expression[segmentStart:])
-		} else {
-			out.WriteString(rewrite(expression[segmentStart:]))
-		}
-	}
-	if segmentStart == 0 && out.Len() == 0 {
-		return rewrite(expression)
 	}
 	return out.String()
 }

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -1,0 +1,420 @@
+package workflowexpr
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+var (
+	dataExpressionEnvOnce sync.Once
+	dataExpressionEnv     *cel.Env
+	dataExpressionEnvErr  error
+
+	workflowExpressionEntityReferencePattern        = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityPresencePattern         = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
+	workflowExpressionEntityHasPattern              = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
+	workflowExpressionEntityHasTernaryTruePattern   = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityHasTernaryFalsePattern  = regexp.MustCompile(`!\s*has\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*[^:]+:\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityNullCompareLeftPattern  = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=)\s*null\b`)
+	workflowExpressionEntityNullCompareRightPattern = regexp.MustCompile(`\bnull\s*(==|!=)\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+	workflowExpressionEntityNullNotEqualPattern     = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*!=\s*null\b`)
+	workflowExpressionEntityNullEqualPattern        = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*==\s*null\b`)
+	workflowExpressionNullEntityNotEqualPattern     = regexp.MustCompile(`\bnull\s*!=\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+	workflowExpressionNullEntityEqualPattern        = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+)
+
+type DataContext struct {
+	Entity  map[string]any
+	Payload map[string]any
+	Policy  map[string]any
+	FanOut  map[string]any
+}
+
+func ValidateDataExpression(expression string) error {
+	env, err := dataExpressionEnvForContext()
+	if err != nil {
+		return err
+	}
+	expression = strings.TrimSpace(RewriteEntityNullPresenceChecks(expression))
+	if expression == "" {
+		return fmt.Errorf("workflow data expression is empty")
+	}
+	_, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return issues.Err()
+	}
+	return nil
+}
+
+func EvalDataExpression(expression string, ctx DataContext) (any, error) {
+	env, err := dataExpressionEnvForContext()
+	if err != nil {
+		return nil, err
+	}
+	normalized := strings.TrimSpace(RewriteEntityNullPresenceChecks(expression))
+	if normalized == "" {
+		return nil, fmt.Errorf("workflow data expression is empty")
+	}
+	if missing := MissingEntityReferences(normalized, ctx.Entity); len(missing) > 0 {
+		return nil, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
+	}
+	ast, issues := env.Compile(normalized)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	program, err := env.Program(ast)
+	if err != nil {
+		return nil, err
+	}
+	out, _, err := program.Eval(map[string]any{
+		"entity":  NormalizeCELInputMap(ctx.Entity),
+		"payload": NormalizeCELInputMap(ctx.Payload),
+		"policy":  NormalizeCELInputMap(ctx.Policy),
+		"fan_out": NormalizeCELInputMap(ctx.FanOut),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return NormalizeCELValue(out), nil
+}
+
+func RewriteEntityNullPresenceChecks(expression string) string {
+	return rewriteOutsideStringLiterals(expression, func(segment string) string {
+		segment = workflowExpressionEntityNullNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
+		segment = workflowExpressionNullEntityNotEqualPattern.ReplaceAllString(segment, `has(entity.$1) && entity.$1 != null`)
+		segment = workflowExpressionEntityNullEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
+		segment = workflowExpressionNullEntityEqualPattern.ReplaceAllString(segment, `!has(entity.$1) || entity.$1 == null`)
+		return segment
+	})
+}
+
+func StripStringLiterals(expression string) string {
+	if expression == "" {
+		return ""
+	}
+	var out strings.Builder
+	out.Grow(len(expression))
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if escaped {
+			if inSingle || inDouble {
+				out.WriteByte(' ')
+			} else {
+				out.WriteByte(ch)
+			}
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			if inSingle || inDouble {
+				out.WriteByte(' ')
+			} else {
+				out.WriteByte(ch)
+			}
+			continue
+		}
+		if ch == '"' && !inSingle {
+			inDouble = !inDouble
+			out.WriteByte(' ')
+			continue
+		}
+		if ch == '\'' && !inDouble {
+			inSingle = !inSingle
+			out.WriteByte(' ')
+			continue
+		}
+		if inSingle || inDouble {
+			out.WriteByte(' ')
+			continue
+		}
+		out.WriteByte(ch)
+	}
+	return out.String()
+}
+
+func EntityReferences(expression string) []string {
+	expression = strings.TrimSpace(StripStringLiterals(expression))
+	if expression == "" {
+		return nil
+	}
+	matches := workflowExpressionEntityReferencePattern.FindAllStringSubmatch(expression, -1)
+	out := make([]string, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		ref := strings.TrimSpace(match[1])
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func EntityReferenceField(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(ref, '.'); idx >= 0 {
+		ref = ref[:idx]
+	}
+	return strings.TrimSpace(ref)
+}
+
+func PresenceGuardedEntityFields(expression string) map[string]struct{} {
+	expression = strings.TrimSpace(StripStringLiterals(expression))
+	if expression == "" {
+		return nil
+	}
+	out := map[string]struct{}{}
+	addField := func(field string) {
+		field = EntityReferenceField(field)
+		if field != "" {
+			out[field] = struct{}{}
+		}
+	}
+	for _, match := range workflowExpressionEntityPresencePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityHasPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityHasTernaryTruePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 && EntityReferenceField(match[1]) == EntityReferenceField(match[2]) {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityHasTernaryFalsePattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 && EntityReferenceField(match[1]) == EntityReferenceField(match[2]) {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityNullCompareLeftPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 2 {
+			addField(match[1])
+		}
+	}
+	for _, match := range workflowExpressionEntityNullCompareRightPattern.FindAllStringSubmatch(expression, -1) {
+		if len(match) >= 3 {
+			addField(match[2])
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func MissingEntityReferences(expression string, entity map[string]any) []string {
+	refs := EntityReferences(expression)
+	if len(refs) == 0 {
+		return nil
+	}
+	guarded := PresenceGuardedEntityFields(expression)
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		field := EntityReferenceField(ref)
+		if field == "" {
+			continue
+		}
+		if _, ok := guarded[field]; ok {
+			continue
+		}
+		if _, ok := lookupPath(entity, ref); ok {
+			continue
+		}
+		out = append(out, "entity."+ref)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
+	return out
+}
+
+func NormalizeCELValue(value any) any {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case ref.Val:
+		return NormalizeCELValue(typed.Value())
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, NormalizeCELValue(item))
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = NormalizeCELValue(item)
+		}
+		return out
+	case float64:
+		if math.Trunc(typed) == typed && typed <= math.MaxInt && typed >= math.MinInt {
+			return int(typed)
+		}
+		return typed
+	case int64:
+		return int(typed)
+	default:
+		return typed
+	}
+}
+
+func NormalizeCELInputMap(source map[string]any) map[string]any {
+	if len(source) == 0 {
+		return map[string]any{}
+	}
+	normalized, _ := NormalizeCELValue(cloneStringAnyMap(source)).(map[string]any)
+	if normalized == nil {
+		return map[string]any{}
+	}
+	return normalized
+}
+
+func dataExpressionEnvForContext() (*cel.Env, error) {
+	dataExpressionEnvOnce.Do(func() {
+		dataExpressionEnv, dataExpressionEnvErr = cel.NewEnv(
+			cel.Variable("entity", cel.DynType),
+			cel.Variable("payload", cel.DynType),
+			cel.Variable("policy", cel.DynType),
+			cel.Variable("fan_out", cel.DynType),
+		)
+	})
+	return dataExpressionEnv, dataExpressionEnvErr
+}
+
+func rewriteOutsideStringLiterals(expression string, rewrite func(string) string) string {
+	if expression == "" || rewrite == nil {
+		return expression
+	}
+	var out strings.Builder
+	segmentStart := 0
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if ch == '\\' && i+1 < len(expression) {
+			i++
+			continue
+		}
+		if ch == '"' && !inSingle {
+			if !inDouble {
+				out.WriteString(rewrite(expression[segmentStart:i]))
+				segmentStart = i
+				inDouble = true
+				continue
+			}
+			inDouble = false
+			i++
+			out.WriteString(expression[segmentStart:i])
+			segmentStart = i
+			i--
+			continue
+		}
+		if ch == '\'' && !inDouble {
+			if !inSingle {
+				out.WriteString(rewrite(expression[segmentStart:i]))
+				segmentStart = i
+				inSingle = true
+				continue
+			}
+			inSingle = false
+			i++
+			out.WriteString(expression[segmentStart:i])
+			segmentStart = i
+			i--
+			continue
+		}
+	}
+	if segmentStart < len(expression) {
+		if inSingle || inDouble {
+			out.WriteString(expression[segmentStart:])
+		} else {
+			out.WriteString(rewrite(expression[segmentStart:]))
+		}
+	}
+	if segmentStart == 0 && out.Len() == 0 {
+		return rewrite(expression)
+	}
+	return out.String()
+}
+
+func lookupPath(source map[string]any, path string) (any, bool) {
+	path = strings.TrimSpace(path)
+	if len(source) == 0 || path == "" {
+		return nil, false
+	}
+	current := any(cloneStringAnyMap(source))
+	for _, segment := range strings.Split(path, ".") {
+		segment = strings.TrimSpace(segment)
+		object, ok := current.(map[string]any)
+		if !ok || segment == "" {
+			return nil, false
+		}
+		current, ok = object[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, current != nil
+}
+
+func cloneStringAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneValue(value)
+	}
+	return out
+}
+
+func cloneValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = cloneValue(item)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, cloneValue(item))
+		}
+		return out
+	case []string:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, item)
+		}
+		return out
+	default:
+		return typed
+	}
+}

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -1,0 +1,38 @@
+package workflowexpr
+
+import "testing"
+
+func TestEvalDataExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T) {
+	value, err := EvalDataExpression(`entity.kill_reason == null`, DataContext{
+		Entity: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("EvalDataExpression error = %v", err)
+	}
+	got, ok := value.(bool)
+	if !ok {
+		t.Fatalf("EvalDataExpression value = %#v (%T), want bool", value, value)
+	}
+	if !got {
+		t.Fatal("expected sparse field == null presence check to evaluate true")
+	}
+}
+
+func TestEvalDataExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
+	_, err := EvalDataExpression(`entity.revision_count + 1`, DataContext{
+		Entity: map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected missing entity field read to fail closed")
+	}
+	if got := err.Error(); got == "" || got == "no such key: revision_count" {
+		t.Fatalf("expected explicit missing-field error, got %q", got)
+	}
+}
+
+func TestValidateDataExpression_RejectsAccumulatedNamespace(t *testing.T) {
+	err := ValidateDataExpression(`accumulated.size()`)
+	if err == nil {
+		t.Fatal("expected accumulated namespace to be rejected for data expressions")
+	}
+}


### PR DESCRIPTION
Part of #163

## Human Summary

This PR closes one explicit first slice of the broader `#163` watchpoint: computed declarative `data_accumulation.writes[].expression` now uses one explicit boot/runtime semantic model for the touched seam.

It does not claim closure of the full broader declarative `data_accumulation` model work tracked by `#163`.

## What Changed

- introduced a shared `internal/runtime/workflowexpr` owner for computed declarative write expressions
- moved `data_accumulation` runtime evaluation onto that owner from the old engine-local raw CEL path
- made sparse-field presence checks like `entity.kill_reason == null` work through the real declarative handler path instead of failing at runtime
- added boot-time validation for `data_accumulation.writes[].expression` so invalid contexts such as `accumulated.size()` fail before runtime
- aligned pipeline expression/lifecycle helpers to the shared reference/presence parsing helpers used by the new owner
- removed the dead `WorkflowDataAccumulation.Value` field and unused shorthand helper from the touched contracts slice

## Why This Is Needed

The remaining bug in this seam was no longer the old arithmetic symptom from `#243`. The real defect was split semantic ownership: boot already treated explicit entity presence checks as valid in `data_accumulation.expression`, but runtime still used a separate raw CEL path that could reject those same spec-valid expressions, while boot still missed invalid computed-write namespaces until runtime.

This PR closes that parity gap for the touched declarative computed-write slice.

## Scope Boundaries

In scope:
- `data_accumulation.writes[].expression` runtime interpretation
- boot validation for the same computed-write contract field
- lifecycle/reference helpers directly consumed by that slice
- removal of dead non-canonical `data_accumulation` contract vestiges in the touched path

Out of scope:
- general condition-expression redesign
- payload_transform semantic redesign
- broader declarative accumulation redesign beyond the computed-write slice
- closure of the broader `#163` umbrella/watchpoint

## Spec references

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_context`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: data_accumulation`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_language`
- governing rule: declarative `data_accumulation` computed writes must use one explicit CEL-capable model, with `entity` sparse-field reads failing closed except in explicit presence-check positions, and boot/runtime must agree on the allowed computed-write context.

## Tests Run

- `go test ./internal/runtime/workflowexpr ./internal/runtime/engine ./internal/runtime/pipeline ./internal/runtime/bootverify ./internal/runtime/contracts -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR intentionally closes the computed-write `data_accumulation` slice only. `payload_transform` still remains a separate contract-field seam even though it consumes some adjacent CEL machinery, and any broader cross-field expression-model consolidation should be tracked separately rather than claimed here.

## Follow-Up

- keep `#163` open for the broader declarative `data_accumulation` watchpoint beyond this first slice
- if we want one broader cross-field workflow expression model across `data_accumulation`, `payload_transform`, and condition evaluation, that should be handled as explicit follow-up work rather than assumed from this slice
