### PR TITLE
[agent-c][issue #171] Canonicalize turn persistence behind one adapter

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -294,7 +294,7 @@ func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjec
 		return fmt.Errorf("decode latest agent turn turn_summary: %w", err)
 	}
 	if ok {
-		projection.LastTool, err = summary.lastToolTransport(parseOK)
+		projection.LastTool, err = projectedTurnSummaryLastToolTransport(summary, parseOK)
 		if err != nil {
 			return fmt.Errorf("decode latest agent turn last_tool: %w", err)
 		}

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -484,7 +484,7 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 		}
 	}
 	if hasSummary {
-		item.AssistantVisibleOutput, item.Outcome, item.ReasoningBlocks, item.ProgressUpdates, item.ToolResults = summary.conversationFields()
+		item.AssistantVisibleOutput, item.Outcome, item.ReasoningBlocks, item.ProgressUpdates, item.ToolResults = projectedTurnSummaryConversationFields(summary)
 	}
 	return item, nil
 }
@@ -498,7 +498,7 @@ func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, st
 	if err != nil || !ok {
 		return "", "", nil, nil, nil
 	}
-	return summary.conversationFields()
+	return projectedTurnSummaryConversationFields(summary)
 }
 
 func readString(value any) string {

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
 )
 
@@ -33,55 +34,35 @@ func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor)
 	return state
 }
 
-type projectedTurnSummary struct {
-	AssistantVisibleOutput string                         `json:"assistant_visible_output,omitempty"`
-	Outcome                string                         `json:"outcome,omitempty"`
-	ReasoningBlocks        []string                       `json:"reasoning_blocks,omitempty"`
-	ProgressUpdates        []string                       `json:"progress_updates,omitempty"`
-	ToolResults            []projectedTurnSummaryToolItem `json:"tool_results,omitempty"`
-}
-
-type projectedTurnSummaryToolItem struct {
-	ToolName  string          `json:"tool_name,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Output    json.RawMessage `json:"output,omitempty"`
-}
-
-type projectedTurnBlockEnvelope struct {
-	Kind string          `json:"kind"`
-	Data json.RawMessage `json:"data,omitempty"`
-}
-
-func decodeTurnSummaryProjection(raw []byte) (projectedTurnSummary, bool, error) {
+func decodeTurnSummaryProjection(raw []byte) (runtimellm.TurnSummaryTurnBlockData, bool, error) {
 	if len(raw) == 0 {
-		return projectedTurnSummary{}, false, nil
+		return runtimellm.TurnSummaryTurnBlockData{}, false, nil
 	}
-	var blocks []projectedTurnBlockEnvelope
-	if err := json.Unmarshal(raw, &blocks); err != nil {
-		return projectedTurnSummary{}, false, err
+	var blocks []runtimellm.TurnBlock
+	if err := decodeJSONArrayInto(raw, &blocks); err != nil {
+		return runtimellm.TurnSummaryTurnBlockData{}, false, err
 	}
 	for _, block := range blocks {
 		if strings.TrimSpace(block.Kind) != "turn_summary" {
 			continue
 		}
-		data := bytes.TrimSpace(block.Data)
-		if len(data) == 0 || bytes.Equal(data, []byte("null")) || bytes.Equal(data, []byte("{}")) {
-			return projectedTurnSummary{}, false, nil
+		summary, ok, err := block.TurnSummaryData()
+		if err != nil {
+			return runtimellm.TurnSummaryTurnBlockData{}, false, fmt.Errorf("decode canonical turn_summary: %w", err)
 		}
-		var summary projectedTurnSummary
-		if err := json.Unmarshal(data, &summary); err != nil {
-			return projectedTurnSummary{}, false, fmt.Errorf("decode canonical turn_summary: %w", err)
+		if !ok {
+			return runtimellm.TurnSummaryTurnBlockData{}, false, nil
 		}
 		summary = normalizeProjectedTurnSummary(summary)
-		if summary.isZero() {
-			return projectedTurnSummary{}, false, nil
+		if projectedTurnSummaryIsZero(summary) {
+			return runtimellm.TurnSummaryTurnBlockData{}, false, nil
 		}
 		return summary, true, nil
 	}
-	return projectedTurnSummary{}, false, nil
+	return runtimellm.TurnSummaryTurnBlockData{}, false, nil
 }
 
-func normalizeProjectedTurnSummary(summary projectedTurnSummary) projectedTurnSummary {
+func normalizeProjectedTurnSummary(summary runtimellm.TurnSummaryTurnBlockData) runtimellm.TurnSummaryTurnBlockData {
 	summary.AssistantVisibleOutput = strings.TrimSpace(summary.AssistantVisibleOutput)
 	summary.Outcome = strings.TrimSpace(summary.Outcome)
 	summary.ReasoningBlocks = trimStringSlice(summary.ReasoningBlocks)
@@ -89,7 +70,7 @@ func normalizeProjectedTurnSummary(summary projectedTurnSummary) projectedTurnSu
 	if len(summary.ToolResults) == 0 {
 		summary.ToolResults = nil
 	} else {
-		out := make([]projectedTurnSummaryToolItem, 0, len(summary.ToolResults))
+		out := make([]runtimellm.TurnSummaryToolResult, 0, len(summary.ToolResults))
 		for _, item := range summary.ToolResults {
 			item.ToolName = strings.TrimSpace(item.ToolName)
 			item.ToolUseID = strings.TrimSpace(item.ToolUseID)
@@ -100,7 +81,7 @@ func normalizeProjectedTurnSummary(summary projectedTurnSummary) projectedTurnSu
 	return summary
 }
 
-func (p projectedTurnSummary) isZero() bool {
+func projectedTurnSummaryIsZero(p runtimellm.TurnSummaryTurnBlockData) bool {
 	return p.AssistantVisibleOutput == "" &&
 		p.Outcome == "" &&
 		len(p.ReasoningBlocks) == 0 &&
@@ -108,11 +89,11 @@ func (p projectedTurnSummary) isZero() bool {
 		len(p.ToolResults) == 0
 }
 
-func (p projectedTurnSummary) conversationFields() (string, string, []string, []string, []ConversationToolResult) {
-	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), p.toolResultsTransport()
+func projectedTurnSummaryConversationFields(p runtimellm.TurnSummaryTurnBlockData) (string, string, []string, []string, []ConversationToolResult) {
+	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), projectedTurnSummaryToolResultsTransport(p)
 }
 
-func (p projectedTurnSummary) toolResultsTransport() []ConversationToolResult {
+func projectedTurnSummaryToolResultsTransport(p runtimellm.TurnSummaryTurnBlockData) []ConversationToolResult {
 	if len(p.ToolResults) == 0 {
 		return nil
 	}
@@ -132,7 +113,7 @@ func (p projectedTurnSummary) toolResultsTransport() []ConversationToolResult {
 	return out
 }
 
-func (p projectedTurnSummary) lastToolTransport(parseOK bool) (*AgentLastTool, error) {
+func projectedTurnSummaryLastToolTransport(p runtimellm.TurnSummaryTurnBlockData, parseOK bool) (*AgentLastTool, error) {
 	if len(p.ToolResults) == 0 {
 		return nil, nil
 	}
@@ -158,6 +139,15 @@ func (p projectedTurnSummary) lastToolTransport(parseOK bool) (*AgentLastTool, e
 		out.Result = append(json.RawMessage(nil), trimmed...)
 	}
 	return out, nil
+}
+
+func decodeJSONArrayInto[T any](raw []byte, target *[]T) error {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*target = nil
+		return nil
+	}
+	return json.Unmarshal(data, target)
 }
 
 func trimStringSlice(in []string) []string {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -53,8 +53,8 @@ func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *test
 		ScopeKey:    "global",
 		TurnBlocks: []runtimellm.TurnBlock{
 			{Kind: "dispatch", Title: "task.run"},
-			{Kind: "tool_use", ToolName: "schedule", Input: map[string]any{"delay_seconds": 1209600}, Data: map[string]any{"tool_use_id": "toolu_1"}},
-			{Kind: "tool_result", Output: map[string]any{"status": "scheduled"}, Data: map[string]any{"tool_use_id": "toolu_1"}},
+			{Kind: "tool_use", ToolName: "schedule", Input: json.RawMessage(`{"delay_seconds":1209600}`), Data: json.RawMessage(`{"tool_use_id":"toolu_1"}`)},
+			{Kind: "tool_result", Output: json.RawMessage(`{"status":"scheduled"}`), Data: json.RawMessage(`{"tool_use_id":"toolu_1"}`)},
 			{Kind: "assistant_text", Text: "Parking for manual review."},
 			{Kind: "outcome", Text: "14-day review scheduled."},
 		},

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -339,7 +339,6 @@ func (r *AnthropicAPIRuntime) persistTurn(ctx context.Context, turn AgentTurnRec
 	if r.turns == nil {
 		return
 	}
-	turn.TurnBlocks = BuildTurnBlocks(turn)
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
 		// Turn telemetry should not break runtime path.
 		logPublisherRuntime(ctx, r.events, "error", "persist_api_turn_failed", "Persisting the API agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -20,7 +20,6 @@ func (r *ClaudeCLIRuntime) persistTurn(ctx context.Context, turn AgentTurnRecord
 	if r.turns == nil {
 		return
 	}
-	turn.TurnBlocks = BuildTurnBlocks(turn)
 	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
 		logPublisherRuntime(ctx, r.events, "error", "persist_cli_turn_failed", "Persisting the CLI agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
 	}

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -328,6 +328,26 @@ func TestAnthropicAPIRuntime_PersistTurnIncludesTaskMode(t *testing.T) {
 	}
 }
 
+func TestAnthropicAPIRuntime_PersistTurnDefersTurnBlockCanonicalizationToStore(t *testing.T) {
+	turns := &turnCapture{}
+	runtime := NewAnthropicAPIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", turns, nil, nil, nil)
+
+	runtime.persistTurn(context.Background(), AgentTurnRecord{
+		AgentID:        "agent-1",
+		RuntimeMode:    sessions.RuntimeModeTask.String(),
+		SessionID:      "session-1",
+		ResponseRaw:    []byte(`{"result":"done"}`),
+		TriggerEventID: "evt-1",
+	})
+
+	if len(turns.records) != 1 {
+		t.Fatalf("persisted turn count = %d, want 1", len(turns.records))
+	}
+	if len(turns.records[0].TurnBlocks) != 0 {
+		t.Fatalf("persisted turn blocks = %#v, want store-side canonicalization", turns.records[0].TurnBlocks)
+	}
+}
+
 func TestClaudeCLIRuntime_PersistTurnIncludesTaskMode(t *testing.T) {
 	turns := &turnCapture{}
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", turns, nil, nil, nil, nil)
@@ -343,6 +363,26 @@ func TestClaudeCLIRuntime_PersistTurnIncludesTaskMode(t *testing.T) {
 	}
 	if turns.records[0].RuntimeMode != sessions.RuntimeModeTask.String() {
 		t.Fatalf("runtime_mode = %q, want task", turns.records[0].RuntimeMode)
+	}
+}
+
+func TestClaudeCLIRuntime_PersistTurnDefersTurnBlockCanonicalizationToStore(t *testing.T) {
+	turns := &turnCapture{}
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", turns, nil, nil, nil, nil)
+
+	runtime.persistTurn(context.Background(), AgentTurnRecord{
+		AgentID:        "agent-2",
+		RuntimeMode:    sessions.RuntimeModeTask.String(),
+		SessionID:      "session-2",
+		ResponseRaw:    []byte(`{"result":"done"}`),
+		TriggerEventID: "evt-2",
+	})
+
+	if len(turns.records) != 1 {
+		t.Fatalf("persisted turn count = %d, want 1", len(turns.records))
+	}
+	if len(turns.records[0].TurnBlocks) != 0 {
+		t.Fatalf("persisted turn blocks = %#v, want store-side canonicalization", turns.records[0].TurnBlocks)
 	}
 }
 

--- a/internal/runtime/llm/turn_blocks.go
+++ b/internal/runtime/llm/turn_blocks.go
@@ -1,0 +1,171 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+type TurnBlock struct {
+	Kind     string          `json:"kind"`
+	Title    string          `json:"title,omitempty"`
+	Text     string          `json:"text,omitempty"`
+	ToolName string          `json:"tool_name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+	Output   json.RawMessage `json:"output,omitempty"`
+	Data     json.RawMessage `json:"data,omitempty"`
+}
+
+type TurnBlockDispatchData struct {
+	TriggerEventID   string `json:"trigger_event_id,omitempty"`
+	TriggerEventType string `json:"trigger_event_type,omitempty"`
+	EntityID         string `json:"entity_id,omitempty"`
+	TaskID           string `json:"task_id,omitempty"`
+}
+
+type TurnBlockPublishData struct {
+	EventID                     string                                  `json:"event_id,omitempty"`
+	EntityID                    string                                  `json:"entity_id,omitempty"`
+	ParentEventID               string                                  `json:"parent_event_id,omitempty"`
+	RoutedRecipients            []runtimebus.PublishDiagnosticRecipient `json:"routed_recipients,omitempty"`
+	RoutedRecipientsCount       int                                     `json:"routed_recipients_count,omitempty"`
+	SubscriptionRecipients      []string                                `json:"subscription_recipients,omitempty"`
+	SubscriptionRecipientsCount int                                     `json:"subscription_recipients_count,omitempty"`
+}
+
+type TurnBlockRuntimeLogData struct {
+	LogLevel   string          `json:"log_level,omitempty"`
+	Message    string          `json:"message,omitempty"`
+	Details    json.RawMessage `json:"details,omitempty"`
+	StackTrace string          `json:"stack_trace,omitempty"`
+}
+
+type TurnBlockToolLinkData struct {
+	ToolUseID string `json:"tool_use_id,omitempty"`
+}
+
+type TurnSummaryToolResult struct {
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
+}
+
+type TurnSummaryTurnBlockData struct {
+	AssistantVisibleOutput string                  `json:"assistant_visible_output,omitempty"`
+	Outcome                string                  `json:"outcome,omitempty"`
+	ReasoningBlocks        []string                `json:"reasoning_blocks,omitempty"`
+	ProgressUpdates        []string                `json:"progress_updates,omitempty"`
+	ToolResults            []TurnSummaryToolResult `json:"tool_results,omitempty"`
+}
+
+func CanonicalizeTurnForPersistence(rec AgentTurnRecord) AgentTurnRecord {
+	rec.TurnBlocks = BuildTurnBlocks(rec)
+	return rec
+}
+
+func rawTurnBlockValue(value any) json.RawMessage {
+	if value == nil {
+		return nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func newDispatchTurnBlock(title string, data TurnBlockDispatchData) TurnBlock {
+	return TurnBlock{
+		Kind:  "dispatch",
+		Title: strings.TrimSpace(title),
+		Data:  rawTurnBlockValue(data),
+	}
+}
+
+func newPublishTurnBlock(title string, data TurnBlockPublishData) TurnBlock {
+	return TurnBlock{
+		Kind:  "publish",
+		Title: strings.TrimSpace(title),
+		Data:  rawTurnBlockValue(data),
+	}
+}
+
+func newRuntimeLogTurnBlock(title string, data TurnBlockRuntimeLogData) TurnBlock {
+	return TurnBlock{
+		Kind:  "runtime_log",
+		Title: strings.TrimSpace(title),
+		Data:  rawTurnBlockValue(data),
+	}
+}
+
+func newToolUseTurnBlock(name string, input any, toolUseID string) TurnBlock {
+	return TurnBlock{
+		Kind:     "tool_use",
+		ToolName: strings.TrimSpace(name),
+		Input:    rawTurnBlockValue(input),
+		Data:     rawTurnBlockValue(TurnBlockToolLinkData{ToolUseID: strings.TrimSpace(toolUseID)}),
+	}
+}
+
+func newToolResultTurnBlock(name string, output any, toolUseID string) TurnBlock {
+	return TurnBlock{
+		Kind:     "tool_result",
+		ToolName: strings.TrimSpace(name),
+		Output:   rawTurnBlockValue(output),
+		Data:     rawTurnBlockValue(TurnBlockToolLinkData{ToolUseID: strings.TrimSpace(toolUseID)}),
+	}
+}
+
+func newTurnSummaryTurnBlock(data TurnSummaryTurnBlockData) TurnBlock {
+	return TurnBlock{
+		Kind: turnSummaryBlockKind,
+		Data: rawTurnBlockValue(data),
+	}
+}
+
+func (b TurnBlock) decodeData(target any) (bool, error) {
+	raw := bytes.TrimSpace(b.Data)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) || bytes.Equal(raw, []byte("{}")) {
+		return false, nil
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (b TurnBlock) DispatchData() (TurnBlockDispatchData, bool, error) {
+	var data TurnBlockDispatchData
+	ok, err := b.decodeData(&data)
+	return data, ok, err
+}
+
+func (b TurnBlock) PublishData() (TurnBlockPublishData, bool, error) {
+	var data TurnBlockPublishData
+	ok, err := b.decodeData(&data)
+	return data, ok, err
+}
+
+func (b TurnBlock) RuntimeLogData() (TurnBlockRuntimeLogData, bool, error) {
+	var data TurnBlockRuntimeLogData
+	ok, err := b.decodeData(&data)
+	return data, ok, err
+}
+
+func (b TurnBlock) TurnSummaryData() (TurnSummaryTurnBlockData, bool, error) {
+	var data TurnSummaryTurnBlockData
+	ok, err := b.decodeData(&data)
+	return data, ok, err
+}
+
+func (b TurnBlock) ToolLinkData() (TurnBlockToolLinkData, bool, error) {
+	var data TurnBlockToolLinkData
+	ok, err := b.decodeData(&data)
+	return data, ok, err
+}

--- a/internal/runtime/llm/turn_transcript.go
+++ b/internal/runtime/llm/turn_transcript.go
@@ -7,16 +7,6 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 )
 
-type TurnBlock struct {
-	Kind     string         `json:"kind"`
-	Title    string         `json:"title,omitempty"`
-	Text     string         `json:"text,omitempty"`
-	ToolName string         `json:"tool_name,omitempty"`
-	Input    any            `json:"input,omitempty"`
-	Output   any            `json:"output,omitempty"`
-	Data     map[string]any `json:"data,omitempty"`
-}
-
 const turnSummaryBlockKind = "turn_summary"
 
 func BuildTurnBlocks(rec AgentTurnRecord) []TurnBlock {
@@ -41,24 +31,12 @@ func buildDispatchBlock(rec AgentTurnRecord) TurnBlock {
 		strings.TrimSpace(rec.TaskID) == "" {
 		return TurnBlock{}
 	}
-	data := map[string]any{}
-	if v := strings.TrimSpace(rec.TriggerEventID); v != "" {
-		data["trigger_event_id"] = v
-	}
-	if v := strings.TrimSpace(rec.TriggerEventType); v != "" {
-		data["trigger_event_type"] = v
-	}
-	if v := strings.TrimSpace(rec.EntityID); v != "" {
-		data["entity_id"] = v
-	}
-	if v := strings.TrimSpace(rec.TaskID); v != "" {
-		data["task_id"] = v
-	}
-	return TurnBlock{
-		Kind:  "dispatch",
-		Title: strings.TrimSpace(rec.TriggerEventType),
-		Data:  data,
-	}
+	return newDispatchTurnBlock(strings.TrimSpace(rec.TriggerEventType), TurnBlockDispatchData{
+		TriggerEventID:   strings.TrimSpace(rec.TriggerEventID),
+		TriggerEventType: strings.TrimSpace(rec.TriggerEventType),
+		EntityID:         strings.TrimSpace(rec.EntityID),
+		TaskID:           strings.TrimSpace(rec.TaskID),
+	})
 }
 
 func buildFlightRecorderBlocks(rec AgentTurnRecord) []TurnBlock {
@@ -86,59 +64,33 @@ func buildPublishBlock(entry runtimebus.FlightRecorderEntry) (TurnBlock, bool) {
 	if eventType == "" {
 		return TurnBlock{}, false
 	}
-	data := map[string]any{}
-	if v := strings.TrimSpace(entry.EventID); v != "" {
-		data["event_id"] = v
-	}
-	if v := strings.TrimSpace(entry.EntityID); v != "" {
-		data["entity_id"] = v
-	}
-	if v := strings.TrimSpace(entry.ParentEventID); v != "" {
-		data["parent_event_id"] = v
-	}
-	if len(entry.RoutedRecipients) > 0 {
-		data["routed_recipients"] = entry.RoutedRecipients
-		data["routed_recipients_count"] = len(entry.RoutedRecipients)
-	}
-	if len(entry.SubscriptionRecipients) > 0 {
-		data["subscription_recipients"] = entry.SubscriptionRecipients
-		data["subscription_recipients_count"] = len(entry.SubscriptionRecipients)
-	}
-	return TurnBlock{
-		Kind:  "publish",
-		Title: eventType,
-		Data:  data,
-	}, true
+	return newPublishTurnBlock(eventType, TurnBlockPublishData{
+		EventID:                     strings.TrimSpace(entry.EventID),
+		EntityID:                    strings.TrimSpace(entry.EntityID),
+		ParentEventID:               strings.TrimSpace(entry.ParentEventID),
+		RoutedRecipients:            append([]runtimebus.PublishDiagnosticRecipient(nil), entry.RoutedRecipients...),
+		RoutedRecipientsCount:       len(entry.RoutedRecipients),
+		SubscriptionRecipients:      append([]string(nil), entry.SubscriptionRecipients...),
+		SubscriptionRecipientsCount: len(entry.SubscriptionRecipients),
+	}), true
 }
 
 func buildRuntimeLogBlock(entry runtimebus.FlightRecorderEntry) (TurnBlock, bool) {
 	message := strings.TrimSpace(entry.Message)
-	details, _ := entry.Details.(map[string]any)
-	if message == "" && len(details) == 0 {
+	detailsRaw := rawTurnBlockValue(entry.Details)
+	if message == "" && len(detailsRaw) == 0 {
 		return TurnBlock{}, false
-	}
-	data := map[string]any{}
-	if v := strings.TrimSpace(entry.LogLevel); v != "" {
-		data["log_level"] = v
-	}
-	if message != "" {
-		data["message"] = message
-	}
-	if entry.Details != nil {
-		data["details"] = entry.Details
-	}
-	if v := strings.TrimSpace(entry.StackTrace); v != "" {
-		data["stack_trace"] = v
 	}
 	title := message
 	if title == "" {
 		title = "runtime log"
 	}
-	return TurnBlock{
-		Kind:  "runtime_log",
-		Title: title,
-		Data:  data,
-	}, true
+	return newRuntimeLogTurnBlock(title, TurnBlockRuntimeLogData{
+		LogLevel:   strings.TrimSpace(entry.LogLevel),
+		Message:    message,
+		Details:    detailsRaw,
+		StackTrace: strings.TrimSpace(entry.StackTrace),
+	}), true
 }
 
 func parseTurnBlocksFromRaw(raw []byte) []TurnBlock {
@@ -266,14 +218,7 @@ func parseBlocksFromContent(content []any) []TurnBlock {
 			if input == nil {
 				input = entry["arguments"]
 			}
-			blocks = append(blocks, TurnBlock{
-				Kind:     "tool_use",
-				ToolName: name,
-				Input:    input,
-				Data: map[string]any{
-					"tool_use_id": strings.TrimSpace(asString(entry["id"])),
-				},
-			})
+			blocks = append(blocks, newToolUseTurnBlock(name, input, strings.TrimSpace(asString(entry["id"]))))
 		}
 	}
 	return blocks
@@ -290,20 +235,15 @@ func blocksFromUserObject(obj map[string]any) []TurnBlock {
 		if strings.TrimSpace(strings.ToLower(asString(entry["type"]))) != "tool_result" {
 			continue
 		}
-		block := TurnBlock{
-			Kind: "tool_result",
-			Data: map[string]any{
-				"tool_use_id": strings.TrimSpace(asString(entry["tool_use_id"])),
-			},
-		}
+		block := newToolResultTurnBlock("", nil, strings.TrimSpace(asString(entry["tool_use_id"])))
 		if content, ok := entry["content"].([]any); ok && len(content) > 0 {
 			if first, ok := content[0].(map[string]any); ok {
 				if text := strings.TrimSpace(asString(first["text"])); text != "" {
 					var decoded any
 					if json.Unmarshal([]byte(text), &decoded) == nil {
-						block.Output = decoded
+						block.Output = rawTurnBlockValue(decoded)
 					} else {
-						block.Output = text
+						block.Output = rawTurnBlockValue(text)
 					}
 				}
 			}
@@ -361,14 +301,7 @@ func blocksFromStreamEvent(obj map[string]any, pending map[int]*cliPendingToolCa
 			}
 		}
 		if strings.TrimSpace(call.Name) != "" {
-			return []TurnBlock{{
-				Kind:     "tool_use",
-				ToolName: call.Name,
-				Input:    args,
-				Data: map[string]any{
-					"tool_use_id": strings.TrimSpace(call.ID),
-				},
-			}}
+			return []TurnBlock{newToolUseTurnBlock(call.Name, args, strings.TrimSpace(call.ID))}
 		}
 	}
 	return nil
@@ -446,7 +379,7 @@ func buildTurnSummaryBlock(blocks []TurnBlock) (TurnBlock, bool) {
 	outcome := ""
 	reasoning := []string{}
 	progress := []string{}
-	toolResults := []any{}
+	toolResults := []TurnSummaryToolResult{}
 	reasoningSeen := map[string]struct{}{}
 	progressSeen := map[string]struct{}{}
 	for _, block := range blocks {
@@ -487,50 +420,45 @@ func buildTurnSummaryBlock(blocks []TurnBlock) (TurnBlock, bool) {
 	if outcome == "" {
 		outcome = assistantVisibleOutput
 	}
-	data := map[string]any{}
-	if assistantVisibleOutput != "" {
-		data["assistant_visible_output"] = assistantVisibleOutput
+	data := TurnSummaryTurnBlockData{
+		AssistantVisibleOutput: assistantVisibleOutput,
+		Outcome:                outcome,
+		ReasoningBlocks:        reasoning,
+		ProgressUpdates:        progress,
+		ToolResults:            toolResults,
 	}
-	if outcome != "" {
-		data["outcome"] = outcome
-	}
-	if len(reasoning) > 0 {
-		data["reasoning_blocks"] = reasoning
-	}
-	if len(progress) > 0 {
-		data["progress_updates"] = progress
-	}
-	if len(toolResults) > 0 {
-		data["tool_results"] = toolResults
-	}
-	if len(data) == 0 {
+	if data.AssistantVisibleOutput == "" &&
+		data.Outcome == "" &&
+		len(data.ReasoningBlocks) == 0 &&
+		len(data.ProgressUpdates) == 0 &&
+		len(data.ToolResults) == 0 {
 		return TurnBlock{}, false
 	}
-	return TurnBlock{Kind: turnSummaryBlockKind, Data: data}, true
+	return newTurnSummaryTurnBlock(data), true
 }
 
-func buildTurnSummaryToolResult(block TurnBlock) (map[string]any, bool) {
-	result := map[string]any{}
-	if name := strings.TrimSpace(block.ToolName); name != "" {
-		result["tool_name"] = name
+func buildTurnSummaryToolResult(block TurnBlock) (TurnSummaryToolResult, bool) {
+	result := TurnSummaryToolResult{
+		ToolName: strings.TrimSpace(block.ToolName),
 	}
 	if toolUseID := strings.TrimSpace(blockToolUseID(block)); toolUseID != "" {
-		result["tool_use_id"] = toolUseID
+		result.ToolUseID = toolUseID
 	}
-	if block.Output != nil {
-		result["output"] = block.Output
+	if len(block.Output) > 0 {
+		result.Output = append(json.RawMessage(nil), block.Output...)
 	}
-	if len(result) == 0 {
-		return nil, false
+	if result.ToolName == "" && result.ToolUseID == "" && len(result.Output) == 0 {
+		return TurnSummaryToolResult{}, false
 	}
 	return result, true
 }
 
 func blockToolUseID(block TurnBlock) string {
-	if len(block.Data) == 0 {
+	link, ok, err := block.ToolLinkData()
+	if err != nil || !ok {
 		return ""
 	}
-	return asString(block.Data["tool_use_id"])
+	return strings.TrimSpace(link.ToolUseID)
 }
 
 func firstReadableString(values ...string) string {

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"testing"
 
 	runtimebus "swarm/internal/runtime/bus"
@@ -79,9 +80,12 @@ func TestBuildTurnBlocks_IncludesPublishEntriesFromFlightRecorder(t *testing.T) 
 	if blocks[1].Title != "scoring/vertical.shortlisted" {
 		t.Fatalf("blocks[1].title = %q", blocks[1].Title)
 	}
-	routed, ok := blocks[1].Data["routed_recipients"].([]runtimebus.PublishDiagnosticRecipient)
-	if !ok || len(routed) != 1 || routed[0].LocalizedEvent != "vertical.shortlisted" {
-		t.Fatalf("publish block routed_recipients = %#v", blocks[1].Data["routed_recipients"])
+	data, ok, err := blocks[1].PublishData()
+	if err != nil {
+		t.Fatalf("PublishData: %v", err)
+	}
+	if !ok || len(data.RoutedRecipients) != 1 || data.RoutedRecipients[0].LocalizedEvent != "vertical.shortlisted" {
+		t.Fatalf("publish block routed_recipients = %#v", data.RoutedRecipients)
 	}
 }
 
@@ -113,12 +117,19 @@ func TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries(t *te
 	if blocks[0].Title != "Tool execution was denied for save_entity_field" {
 		t.Fatalf("title = %q", blocks[0].Title)
 	}
-	if got := asString(blocks[0].Data["log_level"]); got != "warn" {
-		t.Fatalf("log_level = %q", got)
+	data, ok, err := blocks[0].RuntimeLogData()
+	if err != nil {
+		t.Fatalf("RuntimeLogData: %v", err)
 	}
-	details, ok := blocks[0].Data["details"].(map[string]any)
 	if !ok {
-		t.Fatalf("details = %#v", blocks[0].Data["details"])
+		t.Fatal("expected runtime_log data")
+	}
+	if data.LogLevel != "warn" {
+		t.Fatalf("log_level = %q", data.LogLevel)
+	}
+	var details map[string]any
+	if err := json.Unmarshal(data.Details, &details); err != nil {
+		t.Fatalf("decode details: %v", err)
 	}
 	if details["denial_layer"] != "executor" {
 		t.Fatalf("details.denial_layer = %#v", details["denial_layer"])
@@ -129,38 +140,40 @@ func TestBuildTurnBlocks_AppendsCanonicalSummaryForExplicitBlocks(t *testing.T) 
 	blocks := BuildTurnBlocks(AgentTurnRecord{
 		TurnBlocks: []TurnBlock{
 			{Kind: "progress", Text: "Scheduling the follow-up review."},
-			{Kind: "tool_result", ToolName: "schedule", Output: map[string]any{"status": "scheduled"}, Data: map[string]any{"tool_use_id": "toolu_1"}},
+			newToolResultTurnBlock("schedule", map[string]any{"status": "scheduled"}, "toolu_1"),
 			{Kind: "assistant_text", Text: "Parking for manual review."},
 			{Kind: "outcome", Text: "14-day review scheduled."},
 		},
 	})
 
-	var summary map[string]any
+	var summary TurnSummaryTurnBlockData
+	var ok bool
 	for _, block := range blocks {
 		if block.Kind == turnSummaryBlockKind {
-			summary = block.Data
+			var err error
+			summary, ok, err = block.TurnSummaryData()
+			if err != nil {
+				t.Fatalf("TurnSummaryData: %v", err)
+			}
 			break
 		}
 	}
-	if len(summary) == 0 {
+	if !ok {
 		t.Fatalf("expected turn summary block, got %#v", blocks)
 	}
-	if got := asString(summary["assistant_visible_output"]); got != "Parking for manual review." {
+	if got := summary.AssistantVisibleOutput; got != "Parking for manual review." {
 		t.Fatalf("assistant_visible_output = %q", got)
 	}
-	if got := asString(summary["outcome"]); got != "14-day review scheduled." {
+	if got := summary.Outcome; got != "14-day review scheduled." {
 		t.Fatalf("outcome = %q", got)
 	}
-	progress, _ := summary["progress_updates"].([]string)
-	if len(progress) != 1 || progress[0] != "Scheduling the follow-up review." {
-		t.Fatalf("progress_updates = %#v", summary["progress_updates"])
+	if len(summary.ProgressUpdates) != 1 || summary.ProgressUpdates[0] != "Scheduling the follow-up review." {
+		t.Fatalf("progress_updates = %#v", summary.ProgressUpdates)
 	}
-	results, _ := summary["tool_results"].([]any)
-	if len(results) != 1 {
-		t.Fatalf("tool_results = %#v", summary["tool_results"])
+	if len(summary.ToolResults) != 1 {
+		t.Fatalf("tool_results = %#v", summary.ToolResults)
 	}
-	result, _ := results[0].(map[string]any)
-	if result["tool_name"] != "schedule" {
-		t.Fatalf("tool_result = %#v", result)
+	if summary.ToolResults[0].ToolName != "schedule" {
+		t.Fatalf("tool_result = %#v", summary.ToolResults[0])
 	}
 }

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -206,7 +206,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	hasTurnBlocks := caps.Conversations.TurnBlocks
 	turnBlocksPayload := ""
 	if hasTurnBlocks {
-		rec.TurnBlocks = runtimellm.BuildTurnBlocks(rec)
+		rec = runtimellm.CanonicalizeTurnForPersistence(rec)
 		turnBlocksPayload = normalizeJSONArray(rec.TurnBlocks)
 	}
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3048,7 +3048,7 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 		SessionID:   sessionID,
 		TurnBlocks: []runtimellm.TurnBlock{
 			{Kind: "dispatch", Title: "scoring/vertical.marginal"},
-			{Kind: "tool_use", ToolName: "schedule", Input: map[string]any{"delay_seconds": 1209600}},
+			{Kind: "tool_use", ToolName: "schedule", Input: json.RawMessage(`{"delay_seconds":1209600}`)},
 			{Kind: "outcome", Text: "14-day review scheduled."},
 		},
 		RequestPayload: []byte(`{"kind":"task"}`),
@@ -3064,6 +3064,53 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 		t.Fatalf("load turn_blocks: %v", err)
 	}
 	if !strings.Contains(got, `"dispatch"`) || !strings.Contains(got, `"schedule"`) || !strings.Contains(got, `"14-day review scheduled."`) || !strings.Contains(got, `"turn_summary"`) {
+		t.Fatalf("turn_blocks = %s", got)
+	}
+}
+
+func TestManagerStore_AppendAgentTurn_CanonicalizesTurnBlocksThroughSingleStoreAdapter(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS turn_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`); err != nil {
+		t.Fatalf("add turn_blocks column: %v", err)
+	}
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		ScopeKey:  "global",
+		Mode:      "task",
+		Messages:  []llm.Message{{Role: "assistant", Content: "done"}},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation: %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:          "a1",
+		RuntimeMode:      "task",
+		SessionID:        sessionID,
+		TriggerEventType: "task.run",
+		ResponseRaw:      []byte(`{"result":"14-day review scheduled."}`),
+		ParseOK:          true,
+		Latency:          5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn: %v", err)
+	}
+
+	var got string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(turn_blocks::text, '[]') FROM agent_turns WHERE session_id = $1::uuid ORDER BY created_at DESC LIMIT 1`, sessionID).Scan(&got); err != nil {
+		t.Fatalf("load turn_blocks: %v", err)
+	}
+	if strings.Count(got, `"turn_summary"`) != 1 {
+		t.Fatalf("turn_blocks = %s, want exactly one turn_summary", got)
+	}
+	if !strings.Contains(got, `"dispatch"`) || !strings.Contains(got, `"task.run"`) || !strings.Contains(got, `"14-day review scheduled."`) {
 		t.Fatalf("turn_blocks = %s", got)
 	}
 }


### PR DESCRIPTION
Closes #171

Spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_conversation_audits`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.agent_turns`
- governing rule: `agent_turns.turn_blocks` is the canonical per-turn persisted flight-recorder surface, populated from canonical runtime log plus turn-local publish/tool transcript context, and it must contain exactly one canonical `turn_summary` block when summary-bearing material is present.

## Human Summary

This PR closes the first turn-persistence semantic gap instead of only patching one call site. The store append path is now the single production owner for persisted `turn_blocks` materialization, the first stable block families in that same slice now use typed payload structs, and dashboard `turn_summary` readers no longer keep a second semantic model.

## What Changed

- added `internal/runtime/llm.CanonicalizeTurnForPersistence(...)` as the single production owner for persisted `turn_blocks` materialization
- made `AppendAgentTurn(...)` consume that owner and removed API/CLI runtime pre-builds of persisted `turn_blocks`
- replaced loose `map[string]any` / `[]any` assembly with typed payload structs for the first stable block families in scope:
  - `dispatch`
  - `publish`
  - `runtime_log`
  - `turn_summary`
- moved dashboard `turn_summary` decoding/projection to the shared `TurnSummaryTurnBlockData` owner instead of local duplicate structs and summary-field picking
- added focused runtime/store/dashboard/conformance regressions for the unified write owner and shared typed summary model

## Why This Is Needed

- persisted `turn_blocks` materialization was duplicated across runtime and store in the same write seam
- stable payload families in that same seam still used loose carriers even though their shape is already canonical enough to type
- dashboard still had a second live `turn_summary` interpreter, which left the broader semantic concept duplicated even after the write path improved
- this PR reduces semantic drift for the touched concept across runtime, store, and dashboard instead of only tightening one local helper

## Scope Boundaries

In scope:
- single-owner canonicalization for persisted `turn_blocks` writes
- typed payloads for the first stable `turn_blocks` families listed above
- shared typed `turn_summary` consumption in dashboard readers
- fail-closed handling for malformed canonical `turn_summary` payloads in the touched read path

Not in scope:
- broad redesign of every turn block family
- typing provider-derived/open transcript families whose payload shape remains intentionally open in this slice
- replacing the generic full-turn dashboard transport envelope for all block kinds

Why those remaining generic surfaces are not hidden duplicate ownership in this PR:
- provider-derived/open families (`tool_use`, `tool_result`, `assistant_text`, `reasoning`, `progress`, `outcome`) remain a different, intentionally open transcript concept rather than a second owner of the first stable typed slice covered here
- the dashboard `ConversationTurnBlock` list remains an opaque transport envelope for persisted blocks and no longer carries a second `turn_summary` semantic model

## Tests Run

- `go test ./internal/runtime/llm ./internal/store ./internal/runtime/conformance ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

- provider-derived/open block families still use the generic persisted envelope because this PR intentionally stops at the first stable typed family slice
- dashboard still exposes the full `turn_blocks` list generically; this PR removes the duplicated `turn_summary` semantic model, not the broader full-turn transport openness

## Follow-Up

- if we want full typed turn-block parity beyond the first stable families, that should be a broader turn-transcript workstream covering the intentionally open provider-derived families as a separate concept, not a fallback seam left inside this PR
