### PR TITLE
[agent-b][issue #163] Canonicalize declarative workflow value expressions

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -123,6 +123,9 @@ type checkerContext struct {
 	dataAccumulationExprLoaded   bool
 	dataAccumulationExprFindings []Finding
 
+	payloadTransformExprLoaded   bool
+	payloadTransformExprFindings []Finding
+
 	entityRefLoaded   bool
 	entityRefFindings []Finding
 
@@ -183,6 +186,7 @@ var bootCheckRegistry = []Check{
 	{ID: "transition_reference_validation", Severity: "error", Run: checkTransitionReferenceValidation},
 	{ID: "condition_expression_validation", Severity: "error", Run: checkConditionExpressionValidation},
 	{ID: "data_accumulation_expression_validation", Severity: "error", Run: checkDataAccumulationExpressionValidation},
+	{ID: "payload_transform_expression_validation", Severity: "error", Run: checkPayloadTransformExpressionValidation},
 	{ID: "expression_field_reference_validation", Severity: "warning", Run: checkExpressionFieldReferenceValidation},
 	{ID: "transition_ownership_validation", Severity: "error", Run: checkTransitionOwnershipValidation},
 	{ID: "event_runtime_wiring_validation", Severity: "error", Run: checkEventRuntimeWiringValidation},
@@ -249,6 +253,9 @@ func checkTransitionReferenceValidation(c *checkerContext) []Finding { return c.
 func checkConditionExpressionValidation(c *checkerContext) []Finding { return c.conditionExpressions() }
 func checkDataAccumulationExpressionValidation(c *checkerContext) []Finding {
 	return c.dataAccumulationExpressions()
+}
+func checkPayloadTransformExpressionValidation(c *checkerContext) []Finding {
+	return c.payloadTransformExpressions()
 }
 func checkExpressionFieldReferenceValidation(c *checkerContext) []Finding {
 	return c.expressionFieldReferences()
@@ -483,7 +490,7 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
 					continue
 				}
-				if err := workflowexpr.ValidateDataExpression(expr.Expression); err != nil {
+				if err := workflowexpr.ValidateValueExpression(expr.Expression); err != nil {
 					c.dataAccumulationExprFindings = append(c.dataAccumulationExprFindings, Finding{
 						CheckID:  "data_accumulation_expression_validation",
 						Severity: "error",
@@ -495,6 +502,33 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 		}
 	}
 	return c.dataAccumulationExprFindings
+}
+
+func (c *checkerContext) payloadTransformExpressions() []Finding {
+	if c.payloadTransformExprLoaded {
+		return c.payloadTransformExprFindings
+	}
+	c.payloadTransformExprLoaded = true
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			for _, expr := range handlerEntityExpressions(handler) {
+				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecyclePayloadTransform {
+					continue
+				}
+				if err := workflowexpr.ValidateValueExpression(expr.Expression); err != nil {
+					c.payloadTransformExprFindings = append(c.payloadTransformExprFindings, Finding{
+						CheckID:  "payload_transform_expression_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s handler %s %s %q is invalid for payload_transform: %v", nodeID, eventType, expr.Kind, expr.Expression, err),
+						Location: nodeID,
+					})
+				}
+			}
+		}
+	}
+	return c.payloadTransformExprFindings
 }
 
 func (c *checkerContext) expressionFieldReferences() []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -719,6 +719,31 @@ func TestRun_RejectsAccumulatedNamespaceInDataAccumulationExpressions(t *testing
 	}
 }
 
+func TestRun_RejectsAccumulatedNamespaceInPayloadTransformExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						PayloadTransform: &runtimecontracts.PayloadTransformSpec{
+							Fields: map[string]string{
+								"bad": "accumulated.size()",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "payload_transform_expression_validation", "accumulated.size()") {
+		t.Fatalf("expected accumulated namespace in payload_transform expression to fail validation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesPermissionMismatchWarningsDuringMigration(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-permission-tool-mismatch")
 
@@ -1341,8 +1366,8 @@ func TestRun_UsesCompiledOwnersForEquivalentSingleNodePerEventRoutes(t *testing.
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 37 {
-		t.Fatalf("bootCheckRegistry count = %d, want 37", got)
+	if got := len(bootCheckRegistry); got != 38 {
+		t.Fatalf("bootCheckRegistry count = %d, want 38", got)
 	}
 	if got := len(supplementalChecks); got != 2 {
 		t.Fatalf("supplementalChecks count = %d, want 2", got)

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -150,7 +150,7 @@ func evalExpressionValue(base BaseContext, state ExecutionState, expr runtimecon
 		}
 		return nil, false, nil
 	case runtimecontracts.ExpressionKindCEL:
-		value, err := evalDataAccumulationExpression(base, state, expr.CEL)
+		value, err := evalWorkflowValueExpression(base, state, expr.CEL)
 		if err != nil {
 			return nil, false, err
 		}
@@ -193,7 +193,7 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 		case write.Value.HasLiteralValue():
 			snapshot.SetMetadata(target, write.Value.Literal)
 		case write.Value.HasCELValue():
-			value, err := evalDataAccumulationExpression(base, state, write.Value.CEL)
+			value, err := evalWorkflowValueExpression(base, state, write.Value.CEL)
 			if err != nil {
 				return fmt.Errorf("data_accumulation target %s: %w", strings.TrimSpace(write.Target()), err)
 			}
@@ -214,8 +214,8 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 	return nil
 }
 
-func evalDataAccumulationExpression(base BaseContext, state ExecutionState, expression string) (any, error) {
-	return workflowexpr.EvalDataExpression(expression, workflowexpr.DataContext{
+func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string) (any, error) {
+	return workflowexpr.EvalValueExpression(expression, workflowexpr.ValueContext{
 		Entity:  base.Entity.Raw(),
 		Payload: base.Payload.Raw(),
 		Policy:  base.Policy.Raw(),
@@ -244,7 +244,7 @@ func payloadTransform(base BaseContext, state ExecutionState, spec *runtimecontr
 		if !entry.Value.HasCELValue() {
 			continue
 		}
-		value, err := evalDataAccumulationExpression(base, state, entry.Value.CEL)
+		value, err := evalWorkflowValueExpression(base, state, entry.Value.CEL)
 		if err != nil {
 			return nil, fmt.Errorf("payload transform target %s: %w", entry.Target, err)
 		}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1268,6 +1268,100 @@ func TestExecuteNodeContractHandlerAppliesPayloadTransformToEmittedEvent(t *test
 	}
 }
 
+func TestExecuteNodeContractHandlerAppliesPayloadTransformSparseFieldPresenceCheck(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Emits: runtimecontracts.EventEmission{Single: "custom.emitted"},
+		PayloadTransform: &runtimecontracts.PayloadTransformSpec{
+			Fields: map[string]string{
+				"kill_reason_missing": "entity.kill_reason == null",
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("custom.trigger"),
+			Payload: mustJSON(map[string]any{"entity_id": "ent-1"}),
+		}.WithEntityID("ent-1"),
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got := payload["kill_reason_missing"]; got != true {
+		t.Fatalf("payload.kill_reason_missing = %#v, want true", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerPayloadTransformEntityPresenceCheckMintsEntityID(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: &runtimecontracts.WorkflowContractBundle{
+				Semantics: runtimecontracts.WorkflowSemanticView{
+					EntitySchema: runtimecontracts.EntitySchema{
+						Groups: []runtimecontracts.EntitySchemaGroup{
+							{
+								Name: "identity",
+								Fields: []runtimecontracts.EntitySchemaField{
+									{Name: "kill_reason", Type: "text"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Emits: runtimecontracts.EventEmission{Single: "custom.emitted"},
+		PayloadTransform: &runtimecontracts.PayloadTransformSpec{
+			Fields: map[string]string{
+				"label": `has(entity.kill_reason) ? entity.kill_reason : payload.reason`,
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("custom.trigger"),
+			Payload: mustJSON(map[string]any{"reason": "active"}),
+		},
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	emitted := bus.publishedEvent(0)
+	if got := emitted.EntityID(); got == "" {
+		t.Fatal("expected payload_transform entity reference to mint entity_id")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(emitted.Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got := payload["label"]; got != "active" {
+		t.Fatalf("payload.label = %#v, want active", got)
+	}
+}
+
 func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionAdvancesParentFlow(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
 	bundle, ok := semanticview.Bundle(source)

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -13,6 +13,7 @@ import (
 	"swarm/internal/runtime/core/timeridentity"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 type Event = events.Event
@@ -453,7 +454,7 @@ func payloadTransformReferencesEntity(spec *runtimecontracts.PayloadTransformSpe
 		return false
 	}
 	for _, entry := range spec.TransformEntries() {
-		if entry.Value.Kind == runtimecontracts.ExpressionKindCEL && strings.HasPrefix(strings.TrimSpace(entry.Value.CEL), "entity.") {
+		if entry.Value.Kind == runtimecontracts.ExpressionKindCEL && workflowexpr.ExpressionReferencesEntity(entry.Value.CEL) {
 			return true
 		}
 	}

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -30,14 +30,14 @@ var (
 	workflowExpressionNullEntityEqualPattern        = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
 )
 
-type DataContext struct {
+type ValueContext struct {
 	Entity  map[string]any
 	Payload map[string]any
 	Policy  map[string]any
 	FanOut  map[string]any
 }
 
-func ValidateDataExpression(expression string) error {
+func ValidateValueExpression(expression string) error {
 	env, err := dataExpressionEnvForContext()
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func ValidateDataExpression(expression string) error {
 	return nil
 }
 
-func EvalDataExpression(expression string, ctx DataContext) (any, error) {
+func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 	env, err := dataExpressionEnvForContext()
 	if err != nil {
 		return nil, err
@@ -83,6 +83,10 @@ func EvalDataExpression(expression string, ctx DataContext) (any, error) {
 		return nil, err
 	}
 	return NormalizeCELValue(out), nil
+}
+
+func ExpressionReferencesEntity(expression string) bool {
+	return len(EntityReferences(expression)) > 0
 }
 
 func RewriteEntityNullPresenceChecks(expression string) string {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -2,24 +2,24 @@ package workflowexpr
 
 import "testing"
 
-func TestEvalDataExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T) {
-	value, err := EvalDataExpression(`entity.kill_reason == null`, DataContext{
+func TestEvalValueExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T) {
+	value, err := EvalValueExpression(`entity.kill_reason == null`, ValueContext{
 		Entity: map[string]any{},
 	})
 	if err != nil {
-		t.Fatalf("EvalDataExpression error = %v", err)
+		t.Fatalf("EvalValueExpression error = %v", err)
 	}
 	got, ok := value.(bool)
 	if !ok {
-		t.Fatalf("EvalDataExpression value = %#v (%T), want bool", value, value)
+		t.Fatalf("EvalValueExpression value = %#v (%T), want bool", value, value)
 	}
 	if !got {
 		t.Fatal("expected sparse field == null presence check to evaluate true")
 	}
 }
 
-func TestEvalDataExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
-	_, err := EvalDataExpression(`entity.revision_count + 1`, DataContext{
+func TestEvalValueExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
+	_, err := EvalValueExpression(`entity.revision_count + 1`, ValueContext{
 		Entity: map[string]any{},
 	})
 	if err == nil {
@@ -30,9 +30,18 @@ func TestEvalDataExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
 	}
 }
 
-func TestValidateDataExpression_RejectsAccumulatedNamespace(t *testing.T) {
-	err := ValidateDataExpression(`accumulated.size()`)
+func TestValidateValueExpression_RejectsAccumulatedNamespace(t *testing.T) {
+	err := ValidateValueExpression(`accumulated.size()`)
 	if err == nil {
 		t.Fatal("expected accumulated namespace to be rejected for data expressions")
+	}
+}
+
+func TestExpressionReferencesEntity_IgnoresStringLiterals(t *testing.T) {
+	if ExpressionReferencesEntity(`payload.reason == "entity.kill_reason"`) {
+		t.Fatal("expected quoted entity reference text to be ignored")
+	}
+	if !ExpressionReferencesEntity(`has(entity.kill_reason) ? entity.kill_reason : payload.reason`) {
+		t.Fatal("expected real entity reference to be detected")
 	}
 }


### PR DESCRIPTION
Part of #163

## Human Summary

This PR closes the remaining live drift in the declarative workflow value-expression slice that stayed open after `#280`.

`data_accumulation.writes[].expression` and `payload_transform` value expressions now use one canonical value-expression owner across runtime, boot validation, and the touched pipeline reader path.

This does not claim closure of the full broader `#163` umbrella.

## What Changed

- generalized `internal/runtime/workflowexpr` from the first `data_accumulation` slice into the shared declarative workflow value-expression owner for the touched concept
- moved payload-transform boot compile/context validation onto that owner with a new `payload_transform_expression_validation` boot check
- replaced the raw `strings.HasPrefix("entity.")` payload-transform entity-reference heuristic in the pipeline with the canonical shared entity-reference parser
- kept runtime evaluation on the same owner for both `data_accumulation` and `payload_transform`
- added focused regressions for:
  - invalid payload-transform namespace rejection at boot
  - valid sparse-field presence checks in the real payload-transform runtime path
  - non-prefix entity-reference detection in payload-transform expressions

## Why This Is Needed

After `#280`, runtime already used the canonical workflow value-expression owner for both declarative computed writes and payload-transform values, but the surrounding seam still drifted:

- boot compile/context validation still bypassed that owner for `payload_transform`
- the pipeline still used a raw prefix heuristic to decide whether a payload-transform expression referenced `entity`

That left multiple live interpreters of the same semantic concept. This PR removes those remaining bypasses in the touched value-expression slice.

## Scope Boundaries

In scope:
- declarative workflow value-expression semantics for:
  - `data_accumulation.writes[].expression`
  - `payload_transform` value expressions
- boot/runtime/pipeline parity for that concept
- removal of touched bypass paths for the same concept

Out of scope:
- boolean condition-expression redesign (`guard`, `rules`, `on_complete`, `filter`, `count`)
- timer/policy placeholder semantics
- broader declarative accumulation semantics outside the value-expression concept
- full closure of the broader `#163` umbrella

## Spec references

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_context`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: data_accumulation`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: payload_transform`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: expression_language`
- governing rule: declarative workflow contract fields that evaluate CEL to a value must use one explicit semantic model, including sparse-field presence-check behavior and fail-closed invalid-namespace handling in the touched seam.

## Tests Run

- `go test ./internal/runtime/workflowexpr ./internal/runtime/bootverify ./internal/runtime/pipeline -run 'Test(ValidateValueExpression_RejectsAccumulatedNamespace|ExpressionReferencesEntity_IgnoresStringLiterals|Run_RejectsAccumulatedNamespaceInPayloadTransformExpressions|ExecuteNodeContractHandlerAppliesPayloadTransformSparseFieldPresenceCheck|ExecuteNodeContractHandlerPayloadTransformEntityPresenceCheckMintsEntityID|Run_RejectsAccumulatedNamespaceInDataAccumulationExpressions)$' -count=1`
- `go test ./internal/runtime/engine -run 'TestExecutor_(AppliesPayloadTransformToEmittedEvent|PayloadTransformCELFailureReturnsError)$' -count=1`
- `go test ./internal/runtime/workflowexpr ./internal/runtime/engine ./internal/runtime/pipeline ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR closes the declarative workflow value-expression slice only. If `#163` later grows to claim broader declarative accumulation closure beyond value expressions, that still needs separate proof for different semantic concepts rather than being implied by this PR.

## Follow-Up

- keep `#163` open unless/until the broader non-value-expression declarative accumulation work is proven closed
- if any additional declarative VALUE expression consumer is discovered later, it should be audited against `internal/runtime/workflowexpr` immediately rather than adding another local interpreter
