### PR TITLE
[agent-c][issue #168] Add canonical turn summary completeness invariants

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -338,7 +338,10 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 		if err != nil {
 			return nil, err
 		}
-		assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(item.TurnBlocks)
+		assistantText, outcome, reasoning, progress, toolResults, err := summarizeConversationTurnBlocks(item.TurnBlocks)
+		if err != nil {
+			return nil, fmt.Errorf("summarize conversation turn blocks: %w", err)
+		}
 		item.AssistantVisibleOutput = assistantText
 		item.Outcome = outcome
 		item.ReasoningBlocks = reasoning
@@ -489,16 +492,20 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 	return item, nil
 }
 
-func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, string, []string, []string, []ConversationToolResult) {
+func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, string, []string, []string, []ConversationToolResult, error) {
 	raw, err := json.Marshal(blocks)
 	if err != nil {
-		return "", "", nil, nil, nil
+		return "", "", nil, nil, nil, err
 	}
 	summary, ok, err := decodeTurnSummaryProjection(raw)
-	if err != nil || !ok {
-		return "", "", nil, nil, nil
+	if err != nil {
+		return "", "", nil, nil, nil, err
 	}
-	return projectedTurnSummaryConversationFields(summary)
+	if !ok {
+		return "", "", nil, nil, nil, nil
+	}
+	assistant, outcome, reasoning, progress, toolResults := projectedTurnSummaryConversationFields(summary)
+	return assistant, outcome, reasoning, progress, toolResults, nil
 }
 
 func readString(value any) string {

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
@@ -35,58 +34,11 @@ func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor)
 }
 
 func decodeTurnSummaryProjection(raw []byte) (runtimellm.TurnSummaryTurnBlockData, bool, error) {
-	if len(raw) == 0 {
-		return runtimellm.TurnSummaryTurnBlockData{}, false, nil
-	}
-	var blocks []runtimellm.TurnBlock
-	if err := decodeJSONArrayInto(raw, &blocks); err != nil {
+	summary, ok, err := runtimellm.DecodeCanonicalTurnSummaryJSON(raw)
+	if err != nil {
 		return runtimellm.TurnSummaryTurnBlockData{}, false, err
 	}
-	for _, block := range blocks {
-		if strings.TrimSpace(block.Kind) != "turn_summary" {
-			continue
-		}
-		summary, ok, err := block.TurnSummaryData()
-		if err != nil {
-			return runtimellm.TurnSummaryTurnBlockData{}, false, fmt.Errorf("decode canonical turn_summary: %w", err)
-		}
-		if !ok {
-			return runtimellm.TurnSummaryTurnBlockData{}, false, nil
-		}
-		summary = normalizeProjectedTurnSummary(summary)
-		if projectedTurnSummaryIsZero(summary) {
-			return runtimellm.TurnSummaryTurnBlockData{}, false, nil
-		}
-		return summary, true, nil
-	}
-	return runtimellm.TurnSummaryTurnBlockData{}, false, nil
-}
-
-func normalizeProjectedTurnSummary(summary runtimellm.TurnSummaryTurnBlockData) runtimellm.TurnSummaryTurnBlockData {
-	summary.AssistantVisibleOutput = strings.TrimSpace(summary.AssistantVisibleOutput)
-	summary.Outcome = strings.TrimSpace(summary.Outcome)
-	summary.ReasoningBlocks = trimStringSlice(summary.ReasoningBlocks)
-	summary.ProgressUpdates = trimStringSlice(summary.ProgressUpdates)
-	if len(summary.ToolResults) == 0 {
-		summary.ToolResults = nil
-	} else {
-		out := make([]runtimellm.TurnSummaryToolResult, 0, len(summary.ToolResults))
-		for _, item := range summary.ToolResults {
-			item.ToolName = strings.TrimSpace(item.ToolName)
-			item.ToolUseID = strings.TrimSpace(item.ToolUseID)
-			out = append(out, item)
-		}
-		summary.ToolResults = out
-	}
-	return summary
-}
-
-func projectedTurnSummaryIsZero(p runtimellm.TurnSummaryTurnBlockData) bool {
-	return p.AssistantVisibleOutput == "" &&
-		p.Outcome == "" &&
-		len(p.ReasoningBlocks) == 0 &&
-		len(p.ProgressUpdates) == 0 &&
-		len(p.ToolResults) == 0
+	return summary, ok, nil
 }
 
 func projectedTurnSummaryConversationFields(p runtimellm.TurnSummaryTurnBlockData) (string, string, []string, []string, []ConversationToolResult) {
@@ -148,24 +100,6 @@ func decodeJSONArrayInto[T any](raw []byte, target *[]T) error {
 		return nil
 	}
 	return json.Unmarshal(data, target)
-}
-
-func trimStringSlice(in []string) []string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(in))
-	for _, item := range in {
-		trimmed := strings.TrimSpace(item)
-		if trimmed == "" {
-			continue
-		}
-		out = append(out, trimmed)
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 func cloneStringSlice(in []string) []string {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -666,30 +666,11 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 		}).AddRow(
 			"turn-1", "agent-1", "sess-1", "task", "global", "entity-1", "evt-1", "scoring/vertical.marginal", "",
 			[]byte(`["schedule"]`), []byte(toolCallsPayload), []byte(`["vertical.marginal_review_due"]`), []byte(`{"runtime-tools":"ok"}`), []byte(`["mcp__runtime-tools__schedule"]`), []byte(`["mcp__runtime-tools__schedule"]`),
-			[]byte(`{"message":{"content":"dispatch"}}`), []byte(responsePayload), []byte(`[]`), true, 92282, 0, "", now,
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(responsePayload), []byte(`[{"kind":"assistant_text","text":"stale fallback text"},{"kind":"outcome","text":"stale raw outcome"}]`), true, 92282, 0, "", now,
 		))
 
-	item, ok, err := reader.Get(context.Background(), "sess-1")
-	if err != nil {
-		t.Fatalf("get conversation: %v", err)
-	}
-	if !ok {
-		t.Fatalf("expected conversation to exist")
-	}
-	if item.AgentID != "agent-1" || item.SessionID != "sess-1" || len(item.Messages) != 1 || len(item.Turns) != 1 {
-		t.Fatalf("unexpected detail: %+v", item)
-	}
-	if item.Kind != "live_session" {
-		t.Fatalf("expected live_session detail kind, got %+v", item)
-	}
-	if item.RuntimeState.LastTurn == nil || !item.RuntimeState.LastTurn.ParseOK {
-		t.Fatalf("expected runtime_state.last_turn parse_ok=true, got %+v", item.RuntimeState)
-	}
-	if item.RuntimeState.RetryReason != "session not found" || item.RuntimeState.RetriesFromSessionID != "sess-0" {
-		t.Fatalf("expected retry lineage in runtime_state, got %+v", item.RuntimeState)
-	}
-	if item.Turns[0].AssistantVisibleOutput != "" || item.Turns[0].Outcome != "" || len(item.Turns[0].ToolResults) != 0 {
-		t.Fatalf("expected missing canonical summary to fail closed, got %+v", item.Turns[0])
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
+		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -786,18 +767,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
 		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
-	items, err := reader.ListGenericAgents(context.Background())
-	if err != nil {
-		t.Fatalf("ListGenericAgents: %v", err)
-	}
-	if len(items) != 1 {
-		t.Fatalf("expected one agent, got %+v", items)
-	}
-	if items[0].CurrentTaskID != "task-1" {
-		t.Fatalf("current_task_id = %q", items[0].CurrentTaskID)
-	}
-	if items[0].LastTool != nil {
-		t.Fatalf("expected missing canonical summary to fail closed, got last_tool=%#v", items[0].LastTool)
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
+		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -1396,18 +1367,8 @@ func TestSummarizeConversationTurnBlocks_FailsClosedOnEmptyCanonicalSummary(t *t
 		{Kind: "turn_summary", Data: json.RawMessage(`{}`)},
 	}
 
-	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(blocks)
-	if assistantText != "" || outcome != "" {
-		t.Fatalf("expected empty canonical summary strings, got assistant=%q outcome=%q", assistantText, outcome)
-	}
-	if reasoning != nil {
-		t.Fatalf("expected nil reasoning blocks, got %#v", reasoning)
-	}
-	if progress != nil {
-		t.Fatalf("expected nil progress updates, got %#v", progress)
-	}
-	if toolResults != nil {
-		t.Fatalf("expected nil tool results, got %#v", toolResults)
+	if _, _, _, _, _, err := summarizeConversationTurnBlocks(blocks); err == nil || !strings.Contains(err.Error(), "canonical turn_summary block is empty") {
+		t.Fatalf("expected empty canonical summary to fail, got %v", err)
 	}
 }
 
@@ -1418,7 +1379,10 @@ func TestSummarizeConversationTurnBlocks_DoesNotInferOutcomeWithoutCanonicalFiel
 		{Kind: "turn_summary", Data: json.RawMessage(`{"assistant_visible_output":"Parking for manual review."}`)},
 	}
 
-	assistantText, outcome, reasoning, progress, toolResults := summarizeConversationTurnBlocks(blocks)
+	assistantText, outcome, reasoning, progress, toolResults, err := summarizeConversationTurnBlocks(blocks)
+	if err != nil {
+		t.Fatalf("summarizeConversationTurnBlocks: %v", err)
+	}
 	if assistantText != "Parking for manual review." {
 		t.Fatalf("assistant_visible_output = %q", assistantText)
 	}

--- a/internal/runtime/llm/turn_blocks.go
+++ b/internal/runtime/llm/turn_blocks.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	runtimebus "swarm/internal/runtime/bus"
@@ -168,4 +169,105 @@ func (b TurnBlock) ToolLinkData() (TurnBlockToolLinkData, bool, error) {
 	var data TurnBlockToolLinkData
 	ok, err := b.decodeData(&data)
 	return data, ok, err
+}
+
+func DecodeCanonicalTurnSummaryBlocks(blocks []TurnBlock) (TurnSummaryTurnBlockData, bool, error) {
+	var (
+		summary      TurnSummaryTurnBlockData
+		foundSummary bool
+	)
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Kind) != turnSummaryBlockKind {
+			continue
+		}
+		if foundSummary {
+			return TurnSummaryTurnBlockData{}, false, fmt.Errorf("multiple canonical turn_summary blocks")
+		}
+		decoded, ok, err := block.TurnSummaryData()
+		if err != nil {
+			return TurnSummaryTurnBlockData{}, false, fmt.Errorf("decode canonical turn_summary: %w", err)
+		}
+		if !ok {
+			return TurnSummaryTurnBlockData{}, false, fmt.Errorf("canonical turn_summary block is empty")
+		}
+		summary = normalizeTurnSummaryTurnBlockData(decoded)
+		if turnSummaryTurnBlockDataIsZero(summary) {
+			return TurnSummaryTurnBlockData{}, false, fmt.Errorf("canonical turn_summary block is empty")
+		}
+		foundSummary = true
+	}
+	if !foundSummary {
+		if turnBlocksRequireCanonicalSummary(blocks) {
+			return TurnSummaryTurnBlockData{}, false, fmt.Errorf("missing canonical turn_summary for summary-bearing turn blocks")
+		}
+		return TurnSummaryTurnBlockData{}, false, nil
+	}
+	return summary, true, nil
+}
+
+func DecodeCanonicalTurnSummaryJSON(raw []byte) (TurnSummaryTurnBlockData, bool, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return TurnSummaryTurnBlockData{}, false, nil
+	}
+	var blocks []TurnBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return TurnSummaryTurnBlockData{}, false, err
+	}
+	return DecodeCanonicalTurnSummaryBlocks(blocks)
+}
+
+func normalizeTurnSummaryTurnBlockData(summary TurnSummaryTurnBlockData) TurnSummaryTurnBlockData {
+	summary.AssistantVisibleOutput = strings.TrimSpace(summary.AssistantVisibleOutput)
+	summary.Outcome = strings.TrimSpace(summary.Outcome)
+	summary.ReasoningBlocks = trimSummaryStringSlice(summary.ReasoningBlocks)
+	summary.ProgressUpdates = trimSummaryStringSlice(summary.ProgressUpdates)
+	if len(summary.ToolResults) == 0 {
+		summary.ToolResults = nil
+	} else {
+		out := make([]TurnSummaryToolResult, 0, len(summary.ToolResults))
+		for _, item := range summary.ToolResults {
+			item.ToolName = strings.TrimSpace(item.ToolName)
+			item.ToolUseID = strings.TrimSpace(item.ToolUseID)
+			out = append(out, item)
+		}
+		summary.ToolResults = out
+	}
+	return summary
+}
+
+func turnSummaryTurnBlockDataIsZero(summary TurnSummaryTurnBlockData) bool {
+	return summary.AssistantVisibleOutput == "" &&
+		summary.Outcome == "" &&
+		len(summary.ReasoningBlocks) == 0 &&
+		len(summary.ProgressUpdates) == 0 &&
+		len(summary.ToolResults) == 0
+}
+
+func turnBlocksRequireCanonicalSummary(blocks []TurnBlock) bool {
+	for _, block := range blocks {
+		switch strings.TrimSpace(block.Kind) {
+		case "assistant_text", "outcome", "reasoning", "progress", "tool_result":
+			return true
+		}
+	}
+	return false
+}
+
+func trimSummaryStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	runtimebus "swarm/internal/runtime/bus"
@@ -175,5 +176,31 @@ func TestBuildTurnBlocks_AppendsCanonicalSummaryForExplicitBlocks(t *testing.T) 
 	}
 	if summary.ToolResults[0].ToolName != "schedule" {
 		t.Fatalf("tool_result = %#v", summary.ToolResults[0])
+	}
+}
+
+func TestDecodeCanonicalTurnSummaryBlocks_FailsWhenSummaryBearingBlocksLackCanonicalSummary(t *testing.T) {
+	_, ok, err := DecodeCanonicalTurnSummaryBlocks([]TurnBlock{
+		{Kind: "assistant_text", Text: "Parking for manual review."},
+		{Kind: "outcome", Text: "14-day review scheduled."},
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
+		t.Fatalf("DecodeCanonicalTurnSummaryBlocks error = %v", err)
+	}
+	if ok {
+		t.Fatal("expected missing canonical summary not to decode successfully")
+	}
+}
+
+func TestDecodeCanonicalTurnSummaryBlocks_FailsOnDuplicateCanonicalSummary(t *testing.T) {
+	_, ok, err := DecodeCanonicalTurnSummaryBlocks([]TurnBlock{
+		newTurnSummaryTurnBlock(TurnSummaryTurnBlockData{AssistantVisibleOutput: "one", Outcome: "one"}),
+		newTurnSummaryTurnBlock(TurnSummaryTurnBlockData{AssistantVisibleOutput: "two", Outcome: "two"}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple canonical turn_summary blocks") {
+		t.Fatalf("DecodeCanonicalTurnSummaryBlocks error = %v", err)
+	}
+	if ok {
+		t.Fatal("expected duplicate canonical summary not to decode successfully")
 	}
 }


### PR DESCRIPTION
Closes #168

Spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_turns`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_conversation_audits`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: task_mode_audit`
- governing rule: canonical operator-facing summary proof must come from the persisted turn/audit owners, not reader-local reconstruction or silent omission.

## Human Summary

This PR adds the first reusable completeness invariant bundle after `#171`: canonical `turn_summary` completeness for persisted turn blocks. Dashboard agent/conversation readers now fail closed when summary-bearing persisted turn blocks are missing the canonical `turn_summary` proof instead of silently degrading to empty summary fields or `last_tool=nil`.

## What Changed

- added one shared `turn_summary` completeness decoder/validator in `internal/runtime/llm`
- made the shared decoder reject:
  - missing canonical `turn_summary` for summary-bearing turn blocks
  - empty canonical `turn_summary`
  - duplicate canonical `turn_summary` blocks
- moved dashboard summary projection to that shared invariant owner
- made conversation turn summarization fail closed instead of silently returning empty summary fields when canonical completeness is broken
- made agent operator projection fail closed instead of silently treating incomplete latest-turn summary state as healthy
- added focused regressions for missing and duplicate canonical summary proof

## Why This Is Needed

- after `#171`, the canonical `turn_summary` shape was shared, but completeness interpretation still lived locally in dashboard readers
- that let persisted turns with summary-bearing canonical blocks still look healthy on operator surfaces even when the canonical `turn_summary` block was missing
- this PR removes that remaining reader-local completeness interpreter for the chosen slice and replaces it with one reusable invariant owner

## Scope Boundaries

In scope:
- canonical `turn_summary` completeness on persisted `agent_turns.turn_blocks`
- dashboard agent/conversation readers that consume that summary proof
- reusable invariant owner for the touched slice

Not in scope:
- canonical runtime-log row completeness
- canonical mutation-surface completeness
- broader redesign of all turn block families

Why those are not hidden same-concept drift in this PR:
- runtime-log completeness and mutation completeness have different canonical owners and different consumer seams; they were explicitly audited and classified as separate classes, not left ambiguous inside this patch

## Tests Run

- `go test ./internal/runtime/llm ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR intentionally stops at `turn_summary` completeness; runtime-log and mutation completeness remain separate follow-up classes
- dashboard full-turn transport is still intentionally generic; this PR only changes summary completeness interpretation, not the raw transport envelope

## Follow-Up

- add the next invariant bundle for canonical runtime-log completeness
- add the next invariant bundle for canonical mutation-surface completeness
