### PR TITLE
[agent-a][issue #219] Make runtime shutdown own admission gating before drain begins

### DIFF
--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -53,22 +53,24 @@ func (t *InboundTarget) NormalizeEntity() {
 }
 
 type InboundGateway struct {
-	mux    *http.ServeMux
-	bus    *runtimebus.EventBus
-	store  InboundPersistence
-	logger *RuntimeLogger
+	mux                     *http.ServeMux
+	bus                     *runtimebus.EventBus
+	store                   InboundPersistence
+	logger                  *RuntimeLogger
+	shutdownAdmissionClosed func() bool
 }
 
-func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, stores ...InboundPersistence) *InboundGateway {
+func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
 	var store InboundPersistence
 	if len(stores) > 0 {
 		store = stores[0]
 	}
 	g := &InboundGateway{
-		mux:    http.NewServeMux(),
-		bus:    bus,
-		store:  store,
-		logger: logger,
+		mux:                     http.NewServeMux(),
+		bus:                     bus,
+		store:                   store,
+		logger:                  logger,
+		shutdownAdmissionClosed: shutdownAdmissionClosed,
 	}
 	g.mux.HandleFunc("/webhooks/", g.handleWebhook)
 	return g
@@ -79,6 +81,10 @@ func (g *InboundGateway) Handler() http.Handler {
 }
 
 func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if g.shutdownAdmissionClosed != nil && g.shutdownAdmissionClosed() {
+		http.Error(w, "runtime shutting down", http.StatusServiceUnavailable)
+		return
+	}
 	if runtimebus.RuntimeIngressPaused() {
 		http.Error(w, "runtime reset in progress", http.StatusServiceUnavailable)
 		return

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -52,7 +52,7 @@ func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	store := &rollbackTrackingInboundStore{}
-	g := NewInboundGateway(bus, nil, store)
+	g := NewInboundGateway(bus, nil, nil, store)
 
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
 	rec := httptest.NewRecorder()
@@ -66,5 +66,28 @@ func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.
 	}
 	if !store.rolled {
 		t.Fatal("expected inbound event marker rollback on publish failure")
+	}
+}
+
+func TestInboundGateway_Returns503WhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &rollbackTrackingInboundStore{}
+	g := NewInboundGateway(bus, nil, func() bool { return true }, store)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "runtime shutting down") {
+		t.Fatalf("body = %q, want runtime shutting down", rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("did not expect inbound event recording after shutdown admission closed")
 	}
 }

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -18,24 +18,25 @@ import (
 )
 
 type AgentManager struct {
-	mu                       sync.RWMutex
-	agents                   map[string]Agent
-	agentCfg                 map[string]models.AgentConfig
-	agentUpAt                map[string]time.Time
-	workspaces               workspace.Lifecycle
-	bus                      Bus
-	factory                  AgentFactory
-	store                    ManagerPersistence
-	sessions                 sessions.Registry
-	semanticSource           semanticview.Source
-	promptResolver           runtimecontracts.PromptResolver
-	budget                   BudgetGuard
-	resetRuntimeOwnedState   func()
-	runtimeMode              string
-	throttleSuppressPrefixes []string
-	inFlightMu               sync.Mutex
-	inFlight                 map[string]struct{}
-	workflowInstances        flowInstancePersistence
+	mu                             sync.RWMutex
+	agents                         map[string]Agent
+	agentCfg                       map[string]models.AgentConfig
+	agentUpAt                      map[string]time.Time
+	workspaces                     workspace.Lifecycle
+	bus                            Bus
+	factory                        AgentFactory
+	store                          ManagerPersistence
+	sessions                       sessions.Registry
+	semanticSource                 semanticview.Source
+	promptResolver                 runtimecontracts.PromptResolver
+	budget                         BudgetGuard
+	resetRuntimeOwnedState         func()
+	runtimeShutdownAdmissionClosed func() bool
+	runtimeMode                    string
+	throttleSuppressPrefixes       []string
+	inFlightMu                     sync.Mutex
+	inFlight                       map[string]struct{}
+	workflowInstances              flowInstancePersistence
 
 	runMu              sync.Mutex
 	running            bool
@@ -92,28 +93,29 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		}
 	}
 	return &AgentManager{
-		agents:                   make(map[string]Agent),
-		agentCfg:                 make(map[string]models.AgentConfig),
-		agentUpAt:                make(map[string]time.Time),
-		bus:                      bus,
-		factory:                  factory,
-		store:                    store,
-		workspaces:               opts.Workspaces,
-		sessions:                 opts.Sessions,
-		semanticSource:           opts.SemanticSource,
-		promptResolver:           opts.PromptResolver,
-		workflowInstances:        opts.WorkflowInstances,
-		runtimeMode:              strings.TrimSpace(opts.RuntimeMode),
-		budget:                   opts.Budget,
-		resetRuntimeOwnedState:   opts.ResetRuntimeOwnedState,
-		throttleSuppressPrefixes: throttleSuppressPrefixes,
-		inFlight:                 make(map[string]struct{}),
-		loopCancel:               make(map[string]context.CancelFunc),
-		poisonPanicCounts:        make(map[string]int),
-		poisonEventEntities:      make(map[string]map[string]struct{}),
-		poisonEventEmitted:       make(map[string]bool),
-		deadLetterWindows:        make(map[string][]deadLetterEscalationSample),
-		deadLetterLastRaised:     make(map[string]time.Time),
+		agents:                         make(map[string]Agent),
+		agentCfg:                       make(map[string]models.AgentConfig),
+		agentUpAt:                      make(map[string]time.Time),
+		bus:                            bus,
+		factory:                        factory,
+		store:                          store,
+		workspaces:                     opts.Workspaces,
+		sessions:                       opts.Sessions,
+		semanticSource:                 opts.SemanticSource,
+		promptResolver:                 opts.PromptResolver,
+		workflowInstances:              opts.WorkflowInstances,
+		runtimeMode:                    strings.TrimSpace(opts.RuntimeMode),
+		budget:                         opts.Budget,
+		resetRuntimeOwnedState:         opts.ResetRuntimeOwnedState,
+		runtimeShutdownAdmissionClosed: opts.RuntimeShutdownAdmissionClosed,
+		throttleSuppressPrefixes:       throttleSuppressPrefixes,
+		inFlight:                       make(map[string]struct{}),
+		loopCancel:                     make(map[string]context.CancelFunc),
+		poisonPanicCounts:              make(map[string]int),
+		poisonEventEntities:            make(map[string]map[string]struct{}),
+		poisonEventEmitted:             make(map[string]bool),
+		deadLetterWindows:              make(map[string][]deadLetterEscalationSample),
+		deadLetterLastRaised:           make(map[string]time.Time),
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -111,6 +111,25 @@ func (am *AgentManager) isShuttingDown() bool {
 	return am.shuttingDown
 }
 
+func (am *AgentManager) shutdownAdmissionClosed() bool {
+	if am == nil {
+		return false
+	}
+	am.runMu.Lock()
+	defer am.runMu.Unlock()
+	return am.shutdownAdmissionClosedLocked()
+}
+
+func (am *AgentManager) shutdownAdmissionClosedLocked() bool {
+	if am == nil {
+		return false
+	}
+	if am.runtimeShutdownAdmissionClosed != nil {
+		return am.runtimeShutdownAdmissionClosed()
+	}
+	return am.shuttingDown
+}
+
 func (am *AgentManager) waitForRunShutdown() error {
 	done := make(chan struct{})
 	go func() {
@@ -397,7 +416,7 @@ func (am *AgentManager) killPreviousRuns(ctx context.Context, producerID string)
 
 func (am *AgentManager) Run(ctx context.Context) {
 	am.runMu.Lock()
-	if am.running || am.shuttingDown {
+	if am.running || am.shutdownAdmissionClosedLocked() {
 		am.runMu.Unlock()
 		return
 	}
@@ -535,7 +554,7 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 	am.mu.RUnlock()
 
 	for _, id := range ids {
-		if am.isShuttingDown() {
+		if am.shutdownAdmissionClosed() {
 			return nil
 		}
 		if am.isAuthBreakerTripped() {
@@ -557,11 +576,11 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 }
 
 func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) error {
+	if am.shutdownAdmissionClosed() {
+		return nil
+	}
 	if am.store == nil {
 		return fmt.Errorf("manager store unavailable")
-	}
-	if am.isShuttingDown() {
-		return nil
 	}
 	if am.isAuthBreakerTripped() {
 		return nil
@@ -767,7 +786,7 @@ func (am *AgentManager) startAgentLoop(parent context.Context, agent Agent) {
 						if !ok {
 							return
 						}
-						if am.isShuttingDown() {
+						if am.shutdownAdmissionClosed() {
 							return
 						}
 						evtCtx := runtimecorrelation.WithInboundEvent(loopCtx, evt)

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -124,10 +124,13 @@ func (am *AgentManager) shutdownAdmissionClosedLocked() bool {
 	if am == nil {
 		return false
 	}
+	if am.shuttingDown {
+		return true
+	}
 	if am.runtimeShutdownAdmissionClosed != nil {
 		return am.runtimeShutdownAdmissionClosed()
 	}
-	return am.shuttingDown
+	return false
 }
 
 func (am *AgentManager) waitForRunShutdown() error {

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -1,0 +1,85 @@
+package manager
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+type shutdownAdmissionManagerStore struct {
+	listPendingCalled atomic.Bool
+}
+
+func (*shutdownAdmissionManagerStore) UpsertAgent(context.Context, PersistedAgent) error {
+	return nil
+}
+
+func (*shutdownAdmissionManagerStore) LoadAgents(context.Context) ([]PersistedAgent, error) {
+	return nil, nil
+}
+
+func (*shutdownAdmissionManagerStore) MarkAgentTerminated(context.Context, string) error {
+	return nil
+}
+
+func (*shutdownAdmissionManagerStore) EnsureEntitySchema(context.Context, string) error {
+	return nil
+}
+
+func (*shutdownAdmissionManagerStore) UpsertEventReceipt(context.Context, string, string, ReceiptStatus, string) error {
+	return nil
+}
+
+func (s *shutdownAdmissionManagerStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	s.listPendingCalled.Store(true)
+	return nil, nil
+}
+
+func (s *shutdownAdmissionManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	s.listPendingCalled.Store(true)
+	return nil, nil
+}
+
+func TestRun_UsesRuntimeShutdownAdmissionOwner(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	var closed atomic.Bool
+	closed.Store(true)
+
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: closed.Load,
+	})
+
+	am.Run(context.Background())
+
+	if am.IsRunning() {
+		t.Fatal("Run started manager even though runtime shutdown admission was already closed")
+	}
+}
+
+func TestReplayAgentBacklog_UsesRuntimeShutdownAdmissionOwnerBeforeStoreAccess(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	var closed atomic.Bool
+	closed.Store(true)
+	store := &shutdownAdmissionManagerStore{}
+
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: closed.Load,
+	}, store)
+
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("ReplayAgentBacklog: %v", err)
+	}
+	if store.listPendingCalled.Load() {
+		t.Fatal("ReplayAgentBacklog touched the store even though runtime shutdown admission was already closed")
+	}
+}

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -2,12 +2,14 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
 type shutdownAdmissionManagerStore struct {
@@ -82,4 +84,178 @@ func TestReplayAgentBacklog_UsesRuntimeShutdownAdmissionOwnerBeforeStoreAccess(t
 	if store.listPendingCalled.Load() {
 		t.Fatal("ReplayAgentBacklog touched the store even though runtime shutdown admission was already closed")
 	}
+}
+
+func TestResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &shutdownAdmissionManagerStore{}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, nil
+		},
+	}
+
+	am := NewAgentManagerWithOptions(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	}, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: func() bool { return false },
+	}, store)
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reset-path in-flight work to start")
+	}
+
+	resetErrCh := make(chan error, 1)
+	go func() {
+		resetErrCh <- am.ResetRuntimeState()
+	}()
+
+	waitForManagerShuttingDown(t, am)
+
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("ReplayAgentBacklog during reset shutdown: %v", err)
+	}
+	if store.listPendingCalled.Load() {
+		t.Fatal("ReplayAgentBacklog touched the store while reset-driven manager shutdown was in progress")
+	}
+
+	close(release)
+
+	select {
+	case err := <-resetErrCh:
+		if err != nil {
+			t.Fatalf("ResetRuntimeState: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ResetRuntimeState to finish")
+	}
+}
+
+func TestAuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdown(t *testing.T) {
+	runtimebus.ResumeRuntimeIngress()
+	defer runtimebus.ResumeRuntimeIngress()
+
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &shutdownAdmissionManagerStore{}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, nil
+		},
+	}
+
+	am := NewAgentManagerWithOptions(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	}, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: func() bool { return false },
+	}, store)
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for auth-breaker in-flight work to start")
+	}
+
+	breakerDone := make(chan struct{})
+	go func() {
+		am.maybeTripAuthCircuitBreaker(agent.id, "evt-in-1", errors.New("claude auth required"))
+		close(breakerDone)
+	}()
+
+	waitForManagerShuttingDown(t, am)
+
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("ReplayAgentBacklog during auth-breaker shutdown: %v", err)
+	}
+	if store.listPendingCalled.Load() {
+		t.Fatal("ReplayAgentBacklog touched the store while auth-breaker shutdown was in progress")
+	}
+
+	close(release)
+
+	select {
+	case <-breakerDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for auth-breaker shutdown to finish")
+	}
+}
+
+func waitForManagerShuttingDown(t *testing.T, am *AgentManager) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		am.runMu.Lock()
+		shuttingDown := am.shuttingDown
+		am.runMu.Unlock()
+		if shuttingDown {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for manager shutdown to start")
 }

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -124,15 +124,16 @@ type BudgetGuard interface {
 type StrategicContext = json.RawMessage
 
 type AgentManagerOptions struct {
-	Workspaces                workspace.Lifecycle
-	Sessions                  sessions.Registry
-	SemanticSource            semanticview.Source
-	PromptResolver            runtimecontracts.PromptResolver
-	WorkflowInstances         flowInstancePersistence
-	RuntimeMode               string
-	Budget                    BudgetGuard
-	ResetRuntimeOwnedState    func()
-	ThrottleSuppressPrefixes  []string
-	DisableSpinupControl      bool
-	EnableLegacySpinupControl bool
+	Workspaces                     workspace.Lifecycle
+	Sessions                       sessions.Registry
+	SemanticSource                 semanticview.Source
+	PromptResolver                 runtimecontracts.PromptResolver
+	WorkflowInstances              flowInstancePersistence
+	RuntimeMode                    string
+	Budget                         BudgetGuard
+	ResetRuntimeOwnedState         func()
+	RuntimeShutdownAdmissionClosed func() bool
+	ThrottleSuppressPrefixes       []string
+	DisableSpinupControl           bool
+	EnableLegacySpinupControl      bool
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -71,6 +71,7 @@ type Runtime struct {
 	cancelStart    context.CancelFunc
 	ownershipLease runtimestartupownership.Lease
 	ownerID        string
+	shutdownGate   shutdownAdmission
 
 	Config         *config.Config
 	Stores         Stores
@@ -92,6 +93,13 @@ type Runtime struct {
 	Authority      runtimeauthority.Provider
 	EmitRegistry   *runtimetools.EmitRegistry
 	PromptResolver runtimecontracts.PromptResolver
+}
+
+func (rt *Runtime) shutdownAdmissionClosed() bool {
+	if rt == nil {
+		return false
+	}
+	return rt.shutdownGate.Closed()
 }
 
 const runtimeQuiescenceStableChecks = 3
@@ -403,13 +411,14 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 				rt.MCPTurns.Reset()
 			}
 		},
-		ThrottleSuppressPrefixes: runtimeThrottleSuppressPrefixes(source),
-		DisableSpinupControl:     true,
+		RuntimeShutdownAdmissionClosed: rt.shutdownAdmissionClosed,
+		ThrottleSuppressPrefixes:       runtimeThrottleSuppressPrefixes(source),
+		DisableSpinupControl:           true,
 	}, stores.ManagerStore)
 	managerRef = rt.Manager
 
 	if stores.InboundStore != nil {
-		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, stores.InboundStore)
+		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed, stores.InboundStore)
 	}
 	if opts.EnableToolGateway {
 		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, strings.TrimSpace(opts.ToolGatewayToken), RuntimeMCPGatewayHooks(rt.Logger, func(agentID string) (runtimeactors.AgentConfig, bool) {
@@ -504,6 +513,9 @@ func scheduledEvent(sc runtimepipeline.Schedule) events.Event {
 func (rt *Runtime) Start(ctx context.Context) error {
 	if rt == nil {
 		return fmt.Errorf("runtime is nil")
+	}
+	if rt.shutdownAdmissionClosed() {
+		return fmt.Errorf("runtime shutdown already started")
 	}
 	rt.lifecycleMu.Lock()
 	if rt.cancelStart != nil || rt.ownershipLease != nil {
@@ -659,6 +671,7 @@ func (rt *Runtime) Shutdown() error {
 	if rt == nil {
 		return nil
 	}
+	rt.shutdownGate.Close()
 	var shutdownErr error
 	if rt.Manager != nil {
 		if err := rt.Manager.Shutdown(); err != nil && shutdownErr == nil {

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -1,0 +1,186 @@
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
+)
+
+type runtimeShutdownTestAgent struct {
+	id            string
+	subscriptions []events.EventType
+	onEvent       func(context.Context, events.Event) ([]events.Event, error)
+}
+
+func (a runtimeShutdownTestAgent) ID() string { return a.id }
+func (runtimeShutdownTestAgent) Type() string { return "test" }
+func (a runtimeShutdownTestAgent) Subscriptions() []events.EventType {
+	return append([]events.EventType(nil), a.subscriptions...)
+}
+func (a runtimeShutdownTestAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Event, error) {
+	return a.onEvent(ctx, evt)
+}
+
+type runtimeShutdownManagerStore struct {
+	listPendingCalled bool
+}
+
+func (*runtimeShutdownManagerStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (*runtimeShutdownManagerStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return nil, nil
+}
+
+func (*runtimeShutdownManagerStore) MarkAgentTerminated(context.Context, string) error {
+	return nil
+}
+
+func (*runtimeShutdownManagerStore) EnsureEntitySchema(context.Context, string) error {
+	return nil
+}
+
+func (*runtimeShutdownManagerStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
+	return nil
+}
+
+func (s *runtimeShutdownManagerStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	s.listPendingCalled = true
+	return nil, nil
+}
+
+func (s *runtimeShutdownManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	s.listPendingCalled = true
+	return nil, nil
+}
+
+type runtimeShutdownInboundStore struct {
+	recorded bool
+}
+
+func (s *runtimeShutdownInboundStore) RecordInboundEvent(context.Context, string, string, string) (bool, error) {
+	s.recorded = true
+	return true, nil
+}
+
+func (s *runtimeShutdownInboundStore) ResolveInboundTarget(context.Context, string, string) (InboundTarget, error) {
+	return InboundTarget{EntityID: "entity-1", EntitySlug: "entity-1"}, nil
+}
+
+func (*runtimeShutdownInboundStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
+	return 0, nil
+}
+
+func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	agent := runtimeShutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, nil
+		},
+	}
+
+	rt := &Runtime{}
+	managerStore := &runtimeShutdownManagerStore{}
+	am := runtimemanager.NewAgentManagerWithOptions(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		if cfg.ID != agent.id {
+			t.Fatalf("unexpected agent id: %q", cfg.ID)
+		}
+		return agent, nil
+	}, runtimemanager.AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: rt.shutdownAdmissionClosed,
+	}, managerStore)
+	rt.Manager = am
+
+	inboundStore := &runtimeShutdownInboundStore{}
+	rt.InboundGateway = NewInboundGateway(bus, nil, rt.shutdownAdmissionClosed, inboundStore)
+
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight work to start")
+	}
+
+	shutdownErrCh := make(chan error, 1)
+	go func() {
+		shutdownErrCh <- rt.Shutdown()
+	}()
+
+	select {
+	case err := <-shutdownErrCh:
+		t.Fatalf("Shutdown returned before in-flight work drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if !rt.shutdownAdmissionClosed() {
+		t.Fatal("runtime shutdown admission was not closed before manager drain")
+	}
+	if err := am.ReplayAgentBacklog(context.Background(), agent.id); err != nil {
+		t.Fatalf("ReplayAgentBacklog during shutdown: %v", err)
+	}
+	if managerStore.listPendingCalled {
+		t.Fatal("ReplayAgentBacklog touched manager persistence even though runtime shutdown admission was closed")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	rec := httptest.NewRecorder()
+	rt.InboundGateway.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("inbound status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "runtime shutting down") {
+		t.Fatalf("inbound body = %q, want runtime shutting down", rec.Body.String())
+	}
+	if inboundStore.recorded {
+		t.Fatal("inbound store was touched after runtime shutdown admission closed")
+	}
+
+	close(release)
+
+	select {
+	case err := <-shutdownErrCh:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown to finish")
+	}
+}

--- a/internal/runtime/shutdown_admission.go
+++ b/internal/runtime/shutdown_admission.go
@@ -1,0 +1,21 @@
+package runtime
+
+import "sync/atomic"
+
+type shutdownAdmission struct {
+	closed atomic.Bool
+}
+
+func (a *shutdownAdmission) Close() {
+	if a == nil {
+		return
+	}
+	a.closed.Store(true)
+}
+
+func (a *shutdownAdmission) Closed() bool {
+	if a == nil {
+		return false
+	}
+	return a.closed.Load()
+}


### PR DESCRIPTION
Closes #219

## Spec references
- none; issue #219 explicitly states there are no exact platform spec references for this runtime-hardening seam
- binding context: issue body and lead thread on #219

## Human Summary
This PR makes `Runtime.Shutdown()` the canonical owner of shutdown admission for the approved first slice. Shutdown now closes a runtime-owned admission gate before manager drain begins, the touched core-manager admission paths consume that owner instead of relying on `am.shuttingDown`, and inbound ingress denies new work through the same owner while reset ingress pause remains a separate concept.

## What Changed
- added a runtime-owned shutdown admission gate in `internal/runtime/shutdown_admission.go`
- made `Runtime.Shutdown()` close that gate before manager drain/teardown starts
- wired core manager admission checks to the runtime-owned gate in the touched slice:
  - `Run()`
  - `replayPendingEvents()`
  - `ReplayAgentBacklog()`
  - agent loop admission before processing queued events
- moved inbound ingress admission onto the same runtime-owned shutdown gate
- kept `runtimebus.RuntimeIngressPaused()` as the separate owner for reset-mode ingress pause
- added focused tests for runtime ordering, manager admission, and inbound denial
- opened follow-up issue #286 for the remaining out-of-slice bypasses (`mcp` gateway + dashboard/operator direct-control entrypaths)

## Why This Is Needed
Shutdown admission was split across runtime ordering, manager-local shutdown state, and separate ingress checks. That let “no new work after shutdown starts” drift across surfaces. This PR closes that gap for the approved first slice and makes the runtime-owned gate explicit.

## Scope Boundaries
- in scope: runtime-owned shutdown admission, touched core-manager admission checks, and one real non-manager ingress path (`inbound`)
- out of scope: reset-mode semantic redesign, MCP gateway shutdown admission, and dashboard/operator direct-control entrypaths
- those remaining bypass seams are tracked in #286

## Tests Run
- `go test ./internal/runtime/manager -run 'Test(Run_UsesRuntimeShutdownAdmissionOwner|ReplayAgentBacklog_UsesRuntimeShutdownAdmissionOwnerBeforeStoreAccess)$' -count=1`
- `go test ./internal/runtime -run 'Test(InboundGateway_Returns503WhenRuntimeShutdownAdmissionClosed|RuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager -count=1`
- `go test ./... -count=1`

## Residual Risk
No known residual risk remains in the covered runtime/core-manager/inbound slice. Remaining out-of-slice shutdown-admission bypasses are explicit and tracked in #286 rather than left implicit.

## Follow-Up
- #286
