### PR TITLE
[agent-b][issue #284] Allow payload_transform to read statically provable create_entity writes

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1160,6 +1160,78 @@ func TestRun_RejectsCreateEntityPayloadTransformReadOfRuleOnlyWrite(t *testing.T
 	}
 }
 
+func TestRun_RejectsCreateEntityPayloadTransformReadOfRuleOnlyComputeOutput(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.entity_id != null",
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.revision_count",
+		},
+	}}
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"revision_count": "entity.revision_count",
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsCreateEntityPayloadTransformReadWhenRuleAlsoWritesUnconditionallyAvailableField(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.revision_count",
+	}
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.entity_id != null",
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				TargetField: "revision_count",
+				Value:       runtimecontracts.LiteralExpression(0),
+			}},
+		},
+	}}
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"revision_count": "entity.revision_count",
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1095,6 +1095,71 @@ func TestRun_RejectsCreateEntityGuardReferenceToFieldInitializedOnlyBySameHandle
 	}
 }
 
+func TestRun_AllowsCreateEntityPayloadTransformReadOfSameHandlerTopLevelWrite(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.DataAccumulation.Writes = []runtimecontracts.WorkflowDataWrite{{
+		TargetField: "revision_count",
+		Value:       runtimecontracts.LiteralExpression(0),
+	}}
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"revision_count": "entity.revision_count",
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsCreateEntityPayloadTransformReadOfRuleOnlyWrite(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "revision_count", Type: "integer"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.entity_id != null",
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				TargetField: "revision_count",
+				Value:       runtimecontracts.LiteralExpression(0),
+			}},
+		},
+	}}
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"revision_count": "entity.revision_count",
+		},
+	}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("expected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesSiblingWriteErrorWhenSelfTargetUpdateExistsInSameHandler(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -71,34 +71,44 @@ func WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler runtimecontract
 }
 
 func WorkflowEntityFieldsAvailableBeforePayloadTransform(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
-	available := workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecyclePayloadTransform)
-	removeRuleWriters := func(rule runtimecontracts.HandlerRuleEntry) {
-		for _, write := range rule.DataAccumulation.Writes {
-			if field, ok := workflowEntityFieldNameFromTarget(write.Target()); ok {
-				delete(available, field)
-			}
+	available := workflowBuiltinEntityFields()
+	addWriter := func(target string) {
+		if field, ok := workflowEntityFieldNameFromTarget(target); ok {
+			available[field] = struct{}{}
 		}
 	}
-	for _, rule := range handler.Rules {
-		removeRuleWriters(rule)
-	}
-	for _, rule := range handler.OnComplete {
-		removeRuleWriters(rule)
-	}
-	if handler.Accumulate != nil {
-		for _, rule := range handler.Accumulate.OnComplete {
-			removeRuleWriters(rule)
+	var addQueryWriter func(query *runtimecontracts.QuerySpec)
+	addQueryWriter = func(query *runtimecontracts.QuerySpec) {
+		if query == nil {
+			return
 		}
-		if handler.Accumulate.OnTimeout != nil {
-			removeRuleWriters(*handler.Accumulate.OnTimeout)
+		addWriter(query.StoreAs)
+		for i := range query.Queries {
+			addQueryWriter(&query.Queries[i])
 		}
 	}
-	for _, branch := range handler.Branch {
-		if branch.Then != nil {
-			removeRuleWriters(*branch.Then)
-		}
-		if branch.Else != nil {
-			removeRuleWriters(*branch.Else)
+	addQueryWriter(handler.Query)
+	if handler.Filter != nil {
+		addWriter(handler.Filter.StoreAs)
+	}
+	if handler.GroupBy != nil {
+		addWriter(handler.GroupBy.StoreAs)
+	}
+	if handler.Reduce != nil {
+		addWriter(handler.Reduce.StoreAs)
+	}
+	if handler.Count != nil {
+		addWriter(handler.Count.StoreAs)
+	}
+	if handler.Compute != nil {
+		addWriter(handler.Compute.StoreAs)
+	}
+	if handler.FanOut != nil {
+		available["fan_out_count"] = struct{}{}
+	}
+	if handler.CreateEntity {
+		for _, write := range handler.DataAccumulation.Writes {
+			addWriter(write.Target())
 		}
 	}
 	return available

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -71,7 +71,37 @@ func WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler runtimecontract
 }
 
 func WorkflowEntityFieldsAvailableBeforePayloadTransform(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
-	return workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecyclePayloadTransform)
+	available := workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecyclePayloadTransform)
+	removeRuleWriters := func(rule runtimecontracts.HandlerRuleEntry) {
+		for _, write := range rule.DataAccumulation.Writes {
+			if field, ok := workflowEntityFieldNameFromTarget(write.Target()); ok {
+				delete(available, field)
+			}
+		}
+	}
+	for _, rule := range handler.Rules {
+		removeRuleWriters(rule)
+	}
+	for _, rule := range handler.OnComplete {
+		removeRuleWriters(rule)
+	}
+	if handler.Accumulate != nil {
+		for _, rule := range handler.Accumulate.OnComplete {
+			removeRuleWriters(rule)
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			removeRuleWriters(*handler.Accumulate.OnTimeout)
+		}
+	}
+	for _, branch := range handler.Branch {
+		if branch.Then != nil {
+			removeRuleWriters(*branch.Then)
+		}
+		if branch.Else != nil {
+			removeRuleWriters(*branch.Else)
+		}
+	}
+	return available
 }
 
 func WorkflowEntityReadsPersistedStateBeforeHandlerWrites(phase WorkflowEntityFieldLifecyclePhase) bool {
@@ -169,6 +199,11 @@ func workflowEntityFieldsAvailableBeforePhase(handler runtimecontracts.SystemNod
 			if branch.Else != nil {
 				addRuleWriters(*branch.Else)
 			}
+		}
+	}
+	if handler.CreateEntity && phaseAfter(phase, WorkflowEntityFieldLifecycleDataAccumulation) {
+		for _, write := range handler.DataAccumulation.Writes {
+			addWriter(write.Target())
 		}
 	}
 	return available

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -57,6 +57,56 @@ func TestWorkflowEntityFieldsAvailableBeforeDataAccumulation_IncludesEarlierComp
 	}
 }
 
+func TestWorkflowEntityFieldsAvailableBeforePayloadTransform_IncludesCreateEntityTopLevelWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
+			},
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforePayloadTransform(handler)
+	if _, ok := available["revision_count"]; !ok {
+		t.Fatalf("revision_count missing from payload_transform availability: %#v", available)
+	}
+}
+
+func TestWorkflowEntityFieldsAvailableBeforePayloadTransform_ExcludesRuleOnlyWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			Condition: "entity.entity_id != null",
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{
+					{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
+				},
+			},
+		}},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforePayloadTransform(handler)
+	if _, ok := available["revision_count"]; ok {
+		t.Fatalf("revision_count unexpectedly available before payload_transform: %#v", available)
+	}
+}
+
+func TestWorkflowEntityFieldsAvailableBeforeCondition_StillExcludesCreateEntityTopLevelWrites(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
+			},
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforeCondition(handler, WorkflowConditionContextRule)
+	if _, ok := available["revision_count"]; ok {
+		t.Fatalf("revision_count unexpectedly available before rule selection: %#v", available)
+	}
+}
+
 func TestWorkflowEntityReadsPersistedStateBeforeHandlerWrites(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -91,6 +91,46 @@ func TestWorkflowEntityFieldsAvailableBeforePayloadTransform_ExcludesRuleOnlyWri
 	}
 }
 
+func TestWorkflowEntityFieldsAvailableBeforePayloadTransform_ExcludesRuleOnlyComputeOutputs(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			Condition: "entity.entity_id != null",
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpCount,
+				StoreAs:   "entity.revision_count",
+			},
+		}},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforePayloadTransform(handler)
+	if _, ok := available["revision_count"]; ok {
+		t.Fatalf("revision_count unexpectedly available before payload_transform: %#v", available)
+	}
+}
+
+func TestWorkflowEntityFieldsAvailableBeforePayloadTransform_PreservesUnconditionalWriterWhenRuleAlsoWritesField(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.revision_count",
+		},
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			Condition: "entity.entity_id != null",
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{
+					{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
+				},
+			},
+		}},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforePayloadTransform(handler)
+	if _, ok := available["revision_count"]; !ok {
+		t.Fatalf("revision_count missing from payload_transform availability: %#v", available)
+	}
+}
+
 func TestWorkflowEntityFieldsAvailableBeforeCondition_StillExcludesCreateEntityTopLevelWrites(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		CreateEntity: true,


### PR DESCRIPTION
Closes #284

## Human Summary
Boot verification now accepts the spec-valid `create_entity` pattern where a handler writes entity fields unconditionally in top-level `data_accumulation` and then reads those fields in later same-handler `payload_transform` expressions.

## What Changed
- extended the canonical lifecycle-availability owner in `internal/runtime/pipeline/workflow_entity_field_lifecycle.go` so `create_entity` handlers expose top-level unconditional `data_accumulation` writes to later phases that run strictly after `data_accumulation`
- narrowed `payload_transform` availability so it does not inherit conditional rule/on_complete/branch-produced writes as statically provable fields
- added focused lifecycle regressions for:
  - allowed create-entity top-level writes before `payload_transform`
  - still-forbidden rule-only writes before `payload_transform`
  - still-forbidden create-entity top-level writes before `rules`
- added focused bootverify regressions proving the valid `payload_transform` case passes and the rule-only case still fails with `expression_field_reference_validation`

## Why This Is Needed
The authoritative spec says that in a `create_entity` handler, top-level unconditional `data_accumulation` writes are statically provable for later positions that run strictly after that step, including `payload_transform`. The previous lifecycle helper was narrower than the spec for that valid case, while also being too broad for conditional rule-produced writes in the same `payload_transform` position.

## Scope Boundaries
- this PR is limited to same-handler statically provable entity-field availability for `payload_transform` in the `create_entity` seam
- it does not broaden availability for `guard`, `rules`, `on_complete`, or same-handler `data_accumulation.expression`
- it does not claim any separate `emits` or `action` expression-validation seam because those are not consumers of this exact bootverify availability helper

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: handler_execution_order.graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: create_entity.interactions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_validation.statically_provable_initializers`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_validation.rule`

## Tests Run
- `go test ./internal/runtime/pipeline ./internal/runtime/bootverify -run 'Test(WorkflowEntityFieldsAvailableBeforePayloadTransform_IncludesCreateEntityTopLevelWrites|WorkflowEntityFieldsAvailableBeforePayloadTransform_ExcludesRuleOnlyWrites|WorkflowEntityFieldsAvailableBeforeCondition_StillExcludesCreateEntityTopLevelWrites|Run_AllowsCreateEntityPayloadTransformReadOfSameHandlerTopLevelWrite|Run_RejectsCreateEntityPayloadTransformReadOfRuleOnlyWrite)$' -count=1`
- `go test ./internal/runtime/pipeline ./internal/runtime/bootverify -count=1`
- `go test ./... -count=1` (fails in unrelated `internal/dashboard/server` pending-age assertions: `TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelector` / `...UsesFullPendingDeliveryFactHorizon`)

## Residual Risk
The most likely hidden interaction is any future bootverify consumer that reuses the generic phase helper expecting conditional rule-produced fields to be statically provable for late phases. In the current repo sweep, `payload_transform` is the only consumer of this exact late-phase statically-provable entity-field helper.

## Follow-Up
None required from this seam if review agrees with the current spec interpretation.
