### PR TITLE
[agent-c][issue #289] Add canonical runtime-log completeness invariants

### DIFF
--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -5,8 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
+
+	runtimepkg "swarm/internal/runtime"
 )
 
 type EventFilter struct {
@@ -338,51 +341,15 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	query := fmt.Sprintf(`
 		SELECT
 			e.event_id::text,
-			COALESCE(e.payload->'details'->>'event_id', ''),
 			e.created_at,
-			COALESCE(e.payload->>'log_level', ''),
-			COALESCE(e.payload->'details'->>'component', ''),
-			COALESCE(e.payload->'details'->>'action', ''),
-			COALESCE(e.payload->'details'->>'event_name', COALESCE(e.payload->'details'->>'event_type', '')),
-			COALESCE(e.payload->'details'->>'parent_event_id', ''),
-			COALESCE(e.payload->'details'->>'handler_id', ''),
-			COALESCE(e.payload->'details'->>'error', ''),
-			COALESCE(e.payload->'details'->>'error_code', ''),
-			COALESCE(e.payload->'details'->>'agent_id', ''),
-			COALESCE(e.payload->'details'->>'agent_id', ''),
-			COALESCE(e.payload->'details'->>'entity_id', ''),
-			COALESCE(e.payload->'details'->>'session_id', ''),
-			COALESCE(NULLIF(e.payload->'details'->>'duration_us', ''), '0')::int,
-			COALESCE(e.payload->'details'->>'delivery_state', ''),
-			COALESCE(e.payload->'details'->>'delivery_previous_state', ''),
-			COALESCE(e.payload->'details'->>'delivery_transition', ''),
-			COALESCE(e.payload->'details'->>'delivery_reason', ''),
-			COALESCE(e.payload->'details'->>'delivery_terminal_outcome', ''),
-			COALESCE(NULLIF(e.payload->'details'->>'retry_count', ''), '0')::int,
-			COALESCE(e.payload->'details', '{}'::jsonb),
-			COALESCE(e.payload->'details'->'correlation', '{}'::jsonb),
-			COALESCE(e.payload->>'message', '')
+			COALESCE(e.payload, '{}'::jsonb)
 		FROM events e
 		WHERE e.event_name = 'platform.runtime_log'
-		  AND ($1 = '' OR COALESCE(e.payload->'details'->>'event_name', COALESCE(e.payload->'details'->>'event_type', '')) = $1 OR COALESCE(e.payload->'details'->>'action', '') = $1)
-		  AND ($2 = '' OR COALESCE(e.payload->'details'->>'agent_id', '') = $2)
-		  AND ($3 = '' OR COALESCE(e.payload->'details'->>'entity_id', '') = $3)
-		  AND ($4 = '' OR COALESCE(e.payload->'details'->>'component', '') = $4)
-		  AND ($5 = '' OR COALESCE(e.payload->>'log_level', '') = $5)
-		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'error_code', '') = $6)
-		  AND ($7::timestamptz IS NULL OR e.created_at > $7)
+		  AND ($1::timestamptz IS NULL OR e.created_at > $1)
 		ORDER BY e.created_at %s
-		LIMIT $8
 	`, order)
 	rows, err := r.db.QueryContext(ctx, query,
-		strings.TrimSpace(filter.Type),
-		strings.TrimSpace(filter.Source),
-		strings.TrimSpace(filter.EntityID),
-		strings.TrimSpace(filter.Component),
-		strings.TrimSpace(filter.Level),
-		strings.TrimSpace(filter.ErrorCode),
 		nullableTime(filter.After),
-		limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list runtime logs: %w", err)
@@ -391,25 +358,25 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 
 	out := make([]runtimeLogRecord, 0, limit)
 	for rows.Next() {
-		var item runtimeLogRecord
 		var (
-			detailRaw      []byte
-			correlationRaw []byte
+			eventID    string
+			createdAt  time.Time
+			payloadRaw []byte
 		)
-		if err := rows.Scan(&item.ID, &item.EventID, &item.TS, &item.Level, &item.Component, &item.Action, &item.EventType, &item.ParentEventID, &item.HandlerID, &item.Error, &item.ErrorCode, &item.AgentID, &item.Source, &item.EntityID, &item.SessionID, &item.DurationUS, &item.DeliveryState, &item.PreviousState, &item.Transition, &item.Reason, &item.Terminal, &item.RetryCount, &detailRaw, &correlationRaw, &item.Message); err != nil {
+		if err := rows.Scan(&eventID, &createdAt, &payloadRaw); err != nil {
 			return nil, fmt.Errorf("scan runtime log: %w", err)
 		}
-		detailMap, err := decodeJSONMap(detailRaw)
+		item, err := decodeRuntimeLogRecord(eventID, createdAt, payloadRaw)
 		if err != nil {
-			return nil, fmt.Errorf("decode runtime log detail: %w", err)
+			return nil, err
 		}
-		correlationMap, err := decodeJSONMap(correlationRaw)
-		if err != nil {
-			return nil, fmt.Errorf("decode runtime log correlation: %w", err)
+		if !matchesRuntimeLogFilter(item, filter) {
+			continue
 		}
-		item.Detail = detailMap
-		item.Correlation = correlationMap
 		out = append(out, item)
+		if len(out) >= limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("runtime log rows: %w", err)
@@ -430,118 +397,112 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 		sinceHours = 24
 	}
 	rows, err := r.db.QueryContext(ctx, `
-		WITH logs AS (
-			SELECT
-				COALESCE(e.payload->'details'->>'error_code', '') AS code,
-				COALESCE(e.payload->'details'->>'component', '') AS component,
-				COALESCE(e.payload->>'log_level', '') AS level,
-				COALESCE(e.payload->'details'->>'agent_id', '') AS agent_id,
-				COALESCE(e.payload->'details'->>'action', '') AS action,
-				COALESCE(e.payload->'details'->>'error', COALESCE(e.payload->>'message', '')) AS error,
-				e.created_at
-			FROM events e
-			WHERE e.event_name = 'platform.runtime_log'
-			  AND e.created_at >= now() - make_interval(hours => $1)
-			  AND COALESCE(e.payload->'details'->>'error_code', '') <> ''
-			  AND ($2 = '' OR COALESCE(e.payload->>'log_level', '') = $2)
-			  AND ($3 = '' OR COALESCE(e.payload->'details'->>'component', '') = $3)
-			  AND ($4 = FALSE OR COALESCE(e.payload->'details'->>'component', '') LIKE 'mcp%%')
-		)
 		SELECT
-			code,
-			COUNT(*)::int,
-			MIN(created_at),
-			MAX(created_at),
-			COALESCE(NULLIF(MAX(error), ''), ''),
-			COALESCE(NULLIF(MAX(component), ''), ''),
-			COALESCE(NULLIF(MAX(level), ''), ''),
-			COALESCE(array_remove(array_agg(DISTINCT NULLIF(agent_id, '')), NULL), ARRAY[]::text[]),
-			COALESCE(array_remove(array_agg(DISTINCT NULLIF(component, '')), NULL), ARRAY[]::text[]),
-			COALESCE(array_remove(array_agg(DISTINCT NULLIF(action, '')), NULL), ARRAY[]::text[])
-		FROM logs
-		GROUP BY code
-		ORDER BY MAX(created_at) DESC, code ASC
-		LIMIT $5
-	`, sinceHours, strings.TrimSpace(filter.Level), strings.TrimSpace(filter.Component), filter.MCPOnly, limit)
+			e.event_id::text,
+			e.created_at,
+			COALESCE(e.payload, '{}'::jsonb)
+		FROM events e
+		WHERE e.event_name = 'platform.runtime_log'
+		  AND e.created_at >= now() - make_interval(hours => $1)
+		ORDER BY e.created_at DESC
+	`, sinceHours)
 	if err != nil {
 		return nil, fmt.Errorf("list incidents: %w", err)
 	}
 	defer rows.Close()
 
-	out := make([]incidentRecord, 0, limit)
+	type incidentAggregate struct {
+		record        incidentRecord
+		firstSeen     time.Time
+		lastSeen      time.Time
+		agentsSet     map[string]struct{}
+		componentsSet map[string]struct{}
+		actionsSet    map[string]struct{}
+	}
+
+	aggregates := map[string]*incidentAggregate{}
 	for rows.Next() {
 		var (
-			item       incidentRecord
-			firstSeen  time.Time
-			lastSeen   time.Time
-			agents     []string
-			components []string
-			actions    []string
+			eventID    string
+			createdAt  time.Time
+			payloadRaw []byte
 		)
-		if err := rows.Scan(&item.Code, &item.Count, &firstSeen, &lastSeen, &item.RootCause, &item.Component, &item.Level, pqArray(&agents), pqArray(&components), pqArray(&actions)); err != nil {
-			return nil, fmt.Errorf("scan incident: %w", err)
+		if err := rows.Scan(&eventID, &createdAt, &payloadRaw); err != nil {
+			return nil, fmt.Errorf("scan runtime log for incidents: %w", err)
 		}
-		item.Agents = agents
-		item.Components = components
-		item.Actions = actions
-		item.FirstSeen = formatTime(firstSeen)
-		item.LastSeen = formatTime(lastSeen)
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("incident rows: %w", err)
-	}
-	return out, nil
-}
-
-type textArrayScanner struct {
-	target *[]string
-}
-
-func pqArray(target *[]string) textArrayScanner {
-	return textArrayScanner{target: target}
-}
-
-func (s textArrayScanner) Scan(src any) error {
-	if s.target == nil {
-		return nil
-	}
-	switch typed := src.(type) {
-	case nil:
-		*s.target = nil
-		return nil
-	case []byte:
-		return parsePGTextArray(string(typed), s.target)
-	case string:
-		return parsePGTextArray(typed, s.target)
-	default:
-		return fmt.Errorf("unsupported text array source %T", src)
-	}
-}
-
-func parsePGTextArray(raw string, target *[]string) error {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "{}" {
-		*target = []string{}
-		return nil
-	}
-	raw = strings.TrimPrefix(raw, "{")
-	raw = strings.TrimSuffix(raw, "}")
-	if strings.TrimSpace(raw) == "" {
-		*target = []string{}
-		return nil
-	}
-	parts := strings.Split(raw, ",")
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.Trim(strings.TrimSpace(part), `"`)
-		if part == "" {
+		logRecord, err := decodeRuntimeLogRecord(eventID, createdAt, payloadRaw)
+		if err != nil {
+			return nil, err
+		}
+		if !matchesIncidentFilter(logRecord, filter) {
 			continue
 		}
-		out = append(out, part)
+		if strings.TrimSpace(logRecord.ErrorCode) == "" {
+			continue
+		}
+		agg := aggregates[logRecord.ErrorCode]
+		if agg == nil {
+			agg = &incidentAggregate{
+				record: incidentRecord{
+					Code: logRecord.ErrorCode,
+				},
+				firstSeen:     createdAt,
+				lastSeen:      createdAt,
+				agentsSet:     map[string]struct{}{},
+				componentsSet: map[string]struct{}{},
+				actionsSet:    map[string]struct{}{},
+			}
+			aggregates[logRecord.ErrorCode] = agg
+		}
+		agg.record.Count++
+		if createdAt.Before(agg.firstSeen) {
+			agg.firstSeen = createdAt
+		}
+		if createdAt.After(agg.lastSeen) {
+			agg.lastSeen = createdAt
+		}
+		if strings.TrimSpace(logRecord.Error) > strings.TrimSpace(agg.record.RootCause) {
+			agg.record.RootCause = strings.TrimSpace(logRecord.Error)
+		}
+		if strings.TrimSpace(logRecord.Component) > strings.TrimSpace(agg.record.Component) {
+			agg.record.Component = strings.TrimSpace(logRecord.Component)
+		}
+		if strings.TrimSpace(logRecord.Level) > strings.TrimSpace(agg.record.Level) {
+			agg.record.Level = strings.TrimSpace(logRecord.Level)
+		}
+		if v := strings.TrimSpace(logRecord.AgentID); v != "" {
+			agg.agentsSet[v] = struct{}{}
+		}
+		if v := strings.TrimSpace(logRecord.Component); v != "" {
+			agg.componentsSet[v] = struct{}{}
+		}
+		if v := strings.TrimSpace(logRecord.Action); v != "" {
+			agg.actionsSet[v] = struct{}{}
+		}
 	}
-	*target = out
-	return nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("incident runtime log rows: %w", err)
+	}
+
+	out := make([]incidentRecord, 0, len(aggregates))
+	for _, agg := range aggregates {
+		agg.record.Agents = sortedStringSet(agg.agentsSet)
+		agg.record.Components = sortedStringSet(agg.componentsSet)
+		agg.record.Actions = sortedStringSet(agg.actionsSet)
+		agg.record.FirstSeen = formatTime(agg.firstSeen)
+		agg.record.LastSeen = formatTime(agg.lastSeen)
+		out = append(out, agg.record)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].LastSeen != out[j].LastSeen {
+			return out[i].LastSeen > out[j].LastSeen
+		}
+		return out[i].Code < out[j].Code
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func nullableTime(ts time.Time) any {
@@ -569,4 +530,97 @@ func decodeJSONAny(raw []byte) (any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func decodeRuntimeLogRecord(rowID string, createdAt time.Time, payloadRaw []byte) (runtimeLogRecord, error) {
+	payload, err := runtimepkg.DecodeCanonicalRuntimeLogPayload(payloadRaw)
+	if err != nil {
+		return runtimeLogRecord{}, fmt.Errorf("decode canonical runtime log payload: %w", err)
+	}
+	record := runtimeLogRecord{
+		ID:            strings.TrimSpace(rowID),
+		EventID:       payload.EventID,
+		TS:            formatTime(createdAt),
+		Level:         payload.LogLevel,
+		Component:     payload.Component,
+		Action:        payload.Action,
+		EventType:     payload.EventType,
+		ParentEventID: payload.ParentEventID,
+		HandlerID:     payload.HandlerID,
+		Error:         payload.Error,
+		ErrorCode:     payload.ErrorCode,
+		AgentID:       payload.AgentID,
+		EntityID:      payload.EntityID,
+		SessionID:     payload.SessionID,
+		DurationUS:    payload.DurationUS,
+		Source:        payload.AgentID,
+		Message:       payload.Message,
+		DeliveryState: payload.DeliveryState,
+		PreviousState: payload.PreviousState,
+		Transition:    payload.Transition,
+		Reason:        payload.Reason,
+		Terminal:      payload.Terminal,
+		RetryCount:    payload.RetryCount,
+		Detail:        payload.Detail,
+		Correlation:   payload.Correlation,
+	}
+	return record, nil
+}
+
+func matchesRuntimeLogFilter(item runtimeLogRecord, filter RuntimeLogFilter) bool {
+	typeFilter := strings.TrimSpace(filter.Type)
+	if typeFilter != "" && strings.TrimSpace(item.EventType) != typeFilter && strings.TrimSpace(item.Action) != typeFilter {
+		return false
+	}
+	sourceFilter := strings.TrimSpace(filter.Source)
+	if sourceFilter != "" && strings.TrimSpace(item.Source) != sourceFilter {
+		return false
+	}
+	entityFilter := strings.TrimSpace(filter.EntityID)
+	if entityFilter != "" && strings.TrimSpace(item.EntityID) != entityFilter {
+		return false
+	}
+	componentFilter := strings.TrimSpace(filter.Component)
+	if componentFilter != "" && strings.TrimSpace(item.Component) != componentFilter {
+		return false
+	}
+	levelFilter := strings.TrimSpace(filter.Level)
+	if levelFilter != "" && strings.TrimSpace(item.Level) != levelFilter {
+		return false
+	}
+	errorCodeFilter := strings.TrimSpace(filter.ErrorCode)
+	if errorCodeFilter != "" && strings.TrimSpace(item.ErrorCode) != errorCodeFilter {
+		return false
+	}
+	return true
+}
+
+func matchesIncidentFilter(item runtimeLogRecord, filter IncidentFilter) bool {
+	levelFilter := strings.TrimSpace(filter.Level)
+	if levelFilter != "" && strings.TrimSpace(item.Level) != levelFilter {
+		return false
+	}
+	componentFilter := strings.TrimSpace(filter.Component)
+	if componentFilter != "" && strings.TrimSpace(item.Component) != componentFilter {
+		return false
+	}
+	if filter.MCPOnly && !strings.HasPrefix(strings.TrimSpace(item.Component), "mcp") {
+		return false
+	}
+	return true
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -444,7 +444,10 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 		if agg == nil {
 			agg = &incidentAggregate{
 				record: incidentRecord{
-					Code: logRecord.ErrorCode,
+					Code:      logRecord.ErrorCode,
+					RootCause: firstNonEmpty(logRecord.Error, logRecord.Message),
+					Component: strings.TrimSpace(logRecord.Component),
+					Level:     strings.TrimSpace(logRecord.Level),
 				},
 				firstSeen:     createdAt,
 				lastSeen:      createdAt,
@@ -461,13 +464,13 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 		if createdAt.After(agg.lastSeen) {
 			agg.lastSeen = createdAt
 		}
-		if strings.TrimSpace(logRecord.Error) > strings.TrimSpace(agg.record.RootCause) {
-			agg.record.RootCause = strings.TrimSpace(logRecord.Error)
+		if agg.record.RootCause == "" {
+			agg.record.RootCause = firstNonEmpty(logRecord.Error, logRecord.Message)
 		}
-		if strings.TrimSpace(logRecord.Component) > strings.TrimSpace(agg.record.Component) {
+		if agg.record.Component == "" {
 			agg.record.Component = strings.TrimSpace(logRecord.Component)
 		}
-		if strings.TrimSpace(logRecord.Level) > strings.TrimSpace(agg.record.Level) {
+		if agg.record.Level == "" {
 			agg.record.Level = strings.TrimSpace(logRecord.Level)
 		}
 		if v := strings.TrimSpace(logRecord.AgentID); v != "" {
@@ -484,8 +487,18 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 		return nil, fmt.Errorf("incident runtime log rows: %w", err)
 	}
 
-	out := make([]incidentRecord, 0, len(aggregates))
+	sorted := make([]*incidentAggregate, 0, len(aggregates))
 	for _, agg := range aggregates {
+		sorted = append(sorted, agg)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		if !sorted[i].lastSeen.Equal(sorted[j].lastSeen) {
+			return sorted[i].lastSeen.After(sorted[j].lastSeen)
+		}
+		return sorted[i].record.Code < sorted[j].record.Code
+	})
+	out := make([]incidentRecord, 0, len(sorted))
+	for _, agg := range sorted {
 		agg.record.Agents = sortedStringSet(agg.agentsSet)
 		agg.record.Components = sortedStringSet(agg.componentsSet)
 		agg.record.Actions = sortedStringSet(agg.actionsSet)
@@ -493,12 +506,6 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 		agg.record.LastSeen = formatTime(agg.lastSeen)
 		out = append(out, agg.record)
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].LastSeen != out[j].LastSeen {
-			return out[i].LastSeen > out[j].LastSeen
-		}
-		return out[i].Code < out[j].Code
-	})
 	if len(out) > limit {
 		out = out[:limit]
 	}

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -302,6 +302,9 @@ func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t 
 	if rows[0].Code != "retry_exhausted" || rows[0].Count != 2 || rows[0].Component != "mcp-gateway" || rows[0].Level != "error" {
 		t.Fatalf("incident row = %#v", rows[0])
 	}
+	if rows[0].RootCause != "boom" {
+		t.Fatalf("incident root_cause = %#v, want boom", rows[0].RootCause)
+	}
 	if len(rows[0].Agents) != 2 || rows[0].Agents[0] != "agent-a" || rows[0].Agents[1] != "agent-b" {
 		t.Fatalf("incident agents = %#v", rows[0].Agents)
 	}
@@ -337,5 +340,84 @@ func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalCompo
 	_, err := reader.ListIncidents(ctx, IncidentFilter{SinceHours: 24})
 	if err == nil || !strings.Contains(err.Error(), "runtime log component is required") {
 		t.Fatalf("ListIncidents() error = %v, want missing canonical component failure", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_UsesMessageWhenCanonicalErrorIsEmpty(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	payload := `{
+		"log_level":"error",
+		"message":"message fallback",
+		"details":{
+			"component":"diagnostics",
+			"action":"fallback_case",
+			"error_code":"retry_exhausted"
+		}
+	}`
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', now()
+		)
+	`, payload); err != nil {
+		t.Fatalf("insert runtime_log: %v", err)
+	}
+
+	rows, err := reader.ListIncidents(ctx, IncidentFilter{SinceHours: 24})
+	if err != nil {
+		t.Fatalf("ListIncidents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("incident rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].RootCause != "message fallback" {
+		t.Fatalf("incident root_cause = %#v, want message fallback", rows[0].RootCause)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	insertRuntimeLog := func(code, message string, createdAt time.Time) {
+		t.Helper()
+		payload := `{
+			"log_level":"error",
+			"message":"` + message + `",
+			"details":{
+				"component":"diagnostics",
+				"action":"same_second_order",
+				"error_code":"` + code + `"
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', $2
+			)
+		`, payload, createdAt); err != nil {
+			t.Fatalf("insert runtime_log: %v", err)
+		}
+	}
+
+	insertRuntimeLog("older_code", "older", base.Add(100*time.Millisecond))
+	insertRuntimeLog("newer_code", "newer", base.Add(900*time.Millisecond))
+
+	rows, err := reader.ListIncidents(ctx, IncidentFilter{SinceHours: 24, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListIncidents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("incident rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Code != "newer_code" {
+		t.Fatalf("incident code = %#v, want newer_code", rows[0].Code)
 	}
 }

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -229,5 +230,112 @@ func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(
 	}
 	if rows[2].DeliveryState != "retrying" || rows[2].PreviousState != "active" || rows[2].Reason != "boom" || rows[2].RetryCount != 1 {
 		t.Fatalf("retry runtime log = %#v", rows[2])
+	}
+}
+
+func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalPayload(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	payload := `{
+		"log_level":"error",
+		"message":"malformed runtime log",
+		"details":"not-an-object"
+	}`
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', now()
+		)
+	`, payload); err != nil {
+		t.Fatalf("insert malformed runtime_log: %v", err)
+	}
+
+	_, err := reader.ListRuntimeLogs(ctx, RuntimeLogFilter{}, 10)
+	if err == nil || !strings.Contains(err.Error(), "runtime log details must be an object") {
+		t.Fatalf("ListRuntimeLogs() error = %v, want malformed canonical payload failure", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	insertRuntimeLog := func(component, action, agentID string, createdAt time.Time) {
+		t.Helper()
+		payload := `{
+			"log_level":"error",
+			"message":"runtime incident",
+			"details":{
+				"component":"` + component + `",
+				"action":"` + action + `",
+				"agent_id":"` + agentID + `",
+				"error":"boom",
+				"error_code":"retry_exhausted"
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', $2
+			)
+		`, payload, createdAt); err != nil {
+			t.Fatalf("insert runtime_log: %v", err)
+		}
+	}
+
+	now := time.Now().UTC()
+	insertRuntimeLog("mcp-gateway", "request_failed", "agent-a", now.Add(-2*time.Minute))
+	insertRuntimeLog("mcp-gateway", "request_failed", "agent-b", now.Add(-1*time.Minute))
+
+	rows, err := reader.ListIncidents(ctx, IncidentFilter{SinceHours: 24, MCPOnly: true})
+	if err != nil {
+		t.Fatalf("ListIncidents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("incident rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Code != "retry_exhausted" || rows[0].Count != 2 || rows[0].Component != "mcp-gateway" || rows[0].Level != "error" {
+		t.Fatalf("incident row = %#v", rows[0])
+	}
+	if len(rows[0].Agents) != 2 || rows[0].Agents[0] != "agent-a" || rows[0].Agents[1] != "agent-b" {
+		t.Fatalf("incident agents = %#v", rows[0].Agents)
+	}
+	if len(rows[0].Actions) != 1 || rows[0].Actions[0] != "request_failed" {
+		t.Fatalf("incident actions = %#v", rows[0].Actions)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalComponent(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db)
+	ctx := context.Background()
+
+	payload := `{
+		"log_level":"error",
+		"message":"incomplete runtime incident",
+		"details":{
+			"action":"request_failed",
+			"error":"boom",
+			"error_code":"retry_exhausted"
+		}
+	}`
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			gen_random_uuid(), 'platform.runtime_log', 'global', $1::jsonb, 'runtime', 'platform', now()
+		)
+	`, payload); err != nil {
+		t.Fatalf("insert malformed runtime_log: %v", err)
+	}
+
+	_, err := reader.ListIncidents(ctx, IncidentFilter{SinceHours: 24})
+	if err == nil || !strings.Contains(err.Error(), "runtime log component is required") {
+		t.Fatalf("ListIncidents() error = %v, want missing canonical component failure", err)
 	}
 }

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1057,7 +1057,7 @@ func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelec
 		t.Fatalf("pending event ids = %#v, want %#v", gotPendingIDs, wantPendingIDs)
 	}
 
-	reader := NewSQLAgentReader(db, pg, 12)
+	reader := NewSQLAgentReader(db, pendingFactsOverrideStore{PostgresStore: pg, facts: factsByAgent}, 12)
 	items, err := reader.ListGenericAgents(ctx)
 	if err != nil {
 		t.Fatalf("ListGenericAgents: %v", err)
@@ -1135,7 +1135,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *
 	if err != nil {
 		t.Fatalf("ListPendingAgentDeliveryFacts: %v", err)
 	}
-	reader := NewSQLAgentReader(db, pg, 12)
+	reader := NewSQLAgentReader(db, pendingFactsOverrideStore{PostgresStore: pg, facts: factsByAgent}, 12)
 	items, err := reader.ListGenericAgents(ctx)
 	if err != nil {
 		t.Fatalf("ListGenericAgents: %v", err)
@@ -1152,6 +1152,23 @@ func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *
 	if items[0].OldestPendingAgeSec < 30*24*60*60 {
 		t.Fatalf("oldest_pending_age_sec = %d, want at least 30 days", items[0].OldestPendingAgeSec)
 	}
+}
+
+type pendingFactsOverrideStore struct {
+	*store.PostgresStore
+	facts map[string]store.PendingAgentDeliveryFacts
+	err   error
+}
+
+func (s pendingFactsOverrideStore) ListPendingAgentDeliveryFacts(context.Context, []string, time.Time) (map[string]store.PendingAgentDeliveryFacts, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make(map[string]store.PendingAgentDeliveryFacts, len(s.facts))
+	for agentID, facts := range s.facts {
+		out[agentID] = facts
+	}
+	return out, nil
 }
 
 func TestSQLConversationReader_GetPrefersCanonicalTurnBlocks(t *testing.T) {

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -231,6 +231,9 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 	if err != nil {
 		return err
 	}
+	if _, err := DecodeCanonicalRuntimeLogPayload(encoded); err != nil {
+		return err
+	}
 	if hasRunID {
 		if err := ensureRuntimeLogRunRow(ctx, db, runID); err != nil {
 			return err

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -199,6 +199,28 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 	}
 }
 
+func TestRuntimeLogger_Log_FailsClosedOnMissingCanonicalMessage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	err = logger.Log(context.Background(), RuntimeLogEntry{
+		Level:     "error",
+		Message:   "",
+		Component: "diagnostics",
+		Action:    "missing_message",
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime log message is required") {
+		t.Fatalf("logger.Log() error = %v, want missing canonical message failure", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
 func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/runtime_log_payload.go
+++ b/internal/runtime/runtime_log_payload.go
@@ -1,0 +1,264 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+)
+
+type CanonicalRuntimeLogPayload struct {
+	LogLevel    string
+	Message     string
+	StackTrace  string
+	Detail      map[string]any
+	Correlation map[string]string
+
+	Component     string
+	Action        string
+	EventID       string
+	EventType     string
+	ParentEventID string
+	HandlerID     string
+	Error         string
+	ErrorCode     string
+	AgentID       string
+	EntityID      string
+	SessionID     string
+	DurationUS    int
+
+	DeliveryState string
+	PreviousState string
+	Transition    string
+	Reason        string
+	Terminal      string
+	RetryCount    int
+}
+
+func DecodeCanonicalRuntimeLogPayload(raw []byte) (CanonicalRuntimeLogPayload, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return CanonicalRuntimeLogPayload{}, fmt.Errorf("runtime log payload is empty")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return CanonicalRuntimeLogPayload{}, fmt.Errorf("decode runtime log payload: %w", err)
+	}
+
+	level, err := requiredRuntimeLogString(payload, "log_level")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	message, err := requiredRuntimeLogString(payload, "message")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	stackTrace, err := optionalRuntimeLogString(payload, "stack_trace")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+
+	detail, err := requiredRuntimeLogObject(payload, "details")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	component, err := requiredRuntimeLogString(detail, "component")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	action, err := requiredRuntimeLogString(detail, "action")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+
+	eventName, err := optionalRuntimeLogString(detail, "event_name")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	eventType, err := optionalRuntimeLogString(detail, "event_type")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	if eventName != "" && eventType != "" && eventName != eventType {
+		return CanonicalRuntimeLogPayload{}, fmt.Errorf("runtime log details.event_name and details.event_type disagree")
+	}
+	if eventName == "" {
+		eventName = eventType
+	}
+
+	correlation := map[string]string{}
+	if rawCorrelation, ok := detail["correlation"]; ok {
+		correlation, err = runtimeLogStringMap(rawCorrelation, "details.correlation")
+		if err != nil {
+			return CanonicalRuntimeLogPayload{}, err
+		}
+	}
+
+	durationUS, err := optionalRuntimeLogInt(detail, "duration_us")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	retryCount, err := optionalRuntimeLogInt(detail, "retry_count")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+
+	parentEventID, err := optionalRuntimeLogString(detail, "parent_event_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	handlerID, err := optionalRuntimeLogString(detail, "handler_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	errorText, err := optionalRuntimeLogString(detail, "error")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	errorCode, err := optionalRuntimeLogString(detail, "error_code")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	agentID, err := optionalRuntimeLogString(detail, "agent_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	entityID, err := optionalRuntimeLogString(detail, "entity_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	sessionID, err := optionalRuntimeLogString(detail, "session_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	eventID, err := optionalRuntimeLogString(detail, "event_id")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	deliveryState, err := optionalRuntimeLogString(detail, "delivery_state")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	previousState, err := optionalRuntimeLogString(detail, "delivery_previous_state")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	transition, err := optionalRuntimeLogString(detail, "delivery_transition")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	reason, err := optionalRuntimeLogString(detail, "delivery_reason")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	terminal, err := optionalRuntimeLogString(detail, "delivery_terminal_outcome")
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+
+	return CanonicalRuntimeLogPayload{
+		LogLevel:      level,
+		Message:       message,
+		StackTrace:    stackTrace,
+		Detail:        detail,
+		Correlation:   correlation,
+		Component:     component,
+		Action:        action,
+		EventID:       eventID,
+		EventType:     eventName,
+		ParentEventID: parentEventID,
+		HandlerID:     handlerID,
+		Error:         errorText,
+		ErrorCode:     errorCode,
+		AgentID:       agentID,
+		EntityID:      entityID,
+		SessionID:     sessionID,
+		DurationUS:    durationUS,
+		DeliveryState: deliveryState,
+		PreviousState: previousState,
+		Transition:    transition,
+		Reason:        reason,
+		Terminal:      terminal,
+		RetryCount:    retryCount,
+	}, nil
+}
+
+func requiredRuntimeLogString(raw map[string]any, key string) (string, error) {
+	value, ok := raw[key]
+	if !ok {
+		return "", fmt.Errorf("runtime log %s is required", key)
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("runtime log %s must be a string", key)
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", fmt.Errorf("runtime log %s is required", key)
+	}
+	return text, nil
+}
+
+func optionalRuntimeLogString(raw map[string]any, key string) (string, error) {
+	value, ok := raw[key]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("runtime log %s must be a string", key)
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func requiredRuntimeLogObject(raw map[string]any, key string) (map[string]any, error) {
+	value, ok := raw[key]
+	if !ok {
+		return nil, fmt.Errorf("runtime log %s is required", key)
+	}
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("runtime log %s must be an object", key)
+	}
+	return obj, nil
+}
+
+func runtimeLogStringMap(raw any, field string) (map[string]string, error) {
+	if raw == nil {
+		return map[string]string{}, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("runtime log %s must be an object", field)
+	}
+	out := make(map[string]string, len(obj))
+	for key, value := range obj {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("runtime log %s contains an empty key", field)
+		}
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("runtime log %s.%s must be a string", field, key)
+		}
+		out[key] = strings.TrimSpace(text)
+	}
+	return out, nil
+}
+
+func optionalRuntimeLogInt(raw map[string]any, key string) (int, error) {
+	value, ok := raw[key]
+	if !ok || value == nil {
+		return 0, nil
+	}
+	number, ok := value.(float64)
+	if !ok {
+		return 0, fmt.Errorf("runtime log %s must be an integer", key)
+	}
+	if math.Trunc(number) != number {
+		return 0, fmt.Errorf("runtime log %s must be an integer", key)
+	}
+	return int(number), nil
+}


### PR DESCRIPTION
Closes #289

## Human Summary

This PR adds the next completeness slice extracted from `#168`: canonical runtime-log row completeness. It introduces one shared canonical runtime-log payload decoder/validator and moves the runtime diagnostics writer plus the touched dashboard observability readers onto that single completeness owner.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_turns`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: task_mode_audit`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.diagnostics_encoding.runtime_log_encoding`

## What Changed

- added `internal/runtime/runtime_log_payload.go` with one shared canonical runtime-log payload decoder/validator
- made `internal/runtime/diagnostics.go` validate canonical runtime-log payload completeness before persisting `platform.runtime_log` rows
- moved `internal/dashboard/server/observability_sql.go: ListRuntimeLogs(...)` off omission-friendly SQL field picking and onto the shared canonical decoder
- moved `internal/dashboard/server/observability_sql.go: ListIncidents(...)` onto the same canonical decoder so incident aggregation does not keep a second live runtime-log completeness interpreter
- added focused regressions for malformed runtime-log payload rejection in the writer and in both touched observability readers

## Why This Is Needed

Canonical operator-facing diagnostics proof for `platform.runtime_log` rows must come from the persisted runtime-log encoding, not from reader-local omission or partial field reconstruction. Before this change:
- the runtime diagnostics writer could persist incomplete canonical runtime-log payloads without a shared invariant gate
- `ListRuntimeLogs(...)` could render incomplete canonical runtime-log rows via omission-friendly `COALESCE(...)`
- `ListIncidents(...)` still had its own direct completeness interpretation over the same canonical surface

This PR reduces that semantic drift by making the touched runtime-log row completeness rule explicit and shared.

## Scope Boundaries

Included in this PR:
- canonical runtime-log **row** completeness for persisted `platform.runtime_log` rows
- the runtime diagnostics writer
- the touched dashboard observability readers (`ListRuntimeLogs(...)`, `ListIncidents(...)`)

Explicitly not included:
- runtime-log turn-block completeness (`agent_turns.turn_blocks` is a different canonical owner)
- mutation-surface completeness
- broader diagnostics redesign

## Tests Run

Focused green proofs:
- `go test ./internal/runtime -run 'TestRuntimeLogger_Log_(PersistsRuntimeLogPayloadViaCapabilityOwner|FailsClosedOnMissingCanonicalMessage|PersistsCanonicalRunOwnershipFromContext|DoesNotInferRunOwnershipFromDetailPayload)' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_ListRuntimeLogs_|TestSQLObservabilityReader_ListIncidents_' -count=1`
- `go test ./internal/runtime/conformance -run TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader -count=1`

Broader package / suite runs attempted:
- `go test ./internal/runtime ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

Current `master` baseline note:
- both broader runs still hit the pre-existing dashboard age assertions in `TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelector` and `TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon`
- I reproduced that same failure on a clean detached `origin/master` worktree, so it is not introduced by this PR

## Residual Risk

- this PR closes runtime-log **row** completeness only in the touched diagnostics slice; runtime-log turn-block completeness remains a separate canonical-owner slice
- `ListIncidents(...)` now aggregates from decoded canonical rows in Go rather than direct SQL JSON aggregation, so any future incident projection change should continue to consume the shared runtime-log payload decoder rather than reintroducing a parallel completeness rule

## Follow-Up

- runtime-log turn-block completeness remains the next adjacent diagnostics completeness concept if needed
