### PR TITLE
[agent-c][issue #292] Add runtime-log turn-block completeness invariants

### DIFF
--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
 )
 
@@ -482,6 +483,9 @@ func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
 		return ConversationTurn{}, fmt.Errorf("decode turn response_payload: %w", err)
 	}
 	if len(turnBlocksRaw) > 0 {
+		if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocksJSON(turnBlocksRaw); err != nil {
+			return ConversationTurn{}, fmt.Errorf("decode canonical runtime_log turn_blocks: %w", err)
+		}
 		if item.TurnBlocks, err = decodeJSONArray[ConversationTurnBlock](turnBlocksRaw); err != nil {
 			return ConversationTurn{}, fmt.Errorf("decode turn turn_blocks: %w", err)
 		}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1610,6 +1610,51 @@ func TestSQLConversationReader_GetFailsOnMalformedCanonicalTurnSummary(t *testin
 	}
 }
 
+func TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeLogTurnBlock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"brief"}`
+	messagePayload := `[{"role":"assistant","content":"hello"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "sess-1", "task", "global", "entity-1", "evt-1", "task.run", "",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{"message":{"content":"dispatch"}}`), []byte(`{"result":"done"}`), []byte(`[{"kind":"runtime_log","title":"runtime log","data":{"log_level":"warn","message":"runtime log","details":{"action":"tool_execution_denied"}}}]`), true, 25, 0, "", now,
+		))
+
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil || !strings.Contains(err.Error(), "canonical runtime_log block details.component is required") {
+		t.Fatalf("expected malformed canonical runtime_log turn block to fail, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetUsesSessionIDNotAgentID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -323,6 +323,85 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 	}
 }
 
+func TestCanonicalRuntimeLogTurnBlockSurface_RoundTripsThroughConversationReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "agent-1",
+		Mode:      "task",
+		Messages: []runtimellm.Message{
+			{Role: "assistant", Content: "done"},
+		},
+		Summary:   "done",
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:     "agent-1",
+		RuntimeMode: "task",
+		SessionID:   sessionID,
+		TurnBlocks: []runtimellm.TurnBlock{
+			{
+				Kind:  "runtime_log",
+				Title: "Tool execution was denied for save_entity_field",
+				Data: json.RawMessage(`{
+					"log_level":"warn",
+					"message":"Tool execution was denied for save_entity_field",
+					"details":{
+						"component":"tool-executor",
+						"action":"tool_execution_denied",
+						"tool_name":"save_entity_field"
+					}
+				}`),
+			},
+		},
+		ParseOK: true,
+		Latency: 5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task runtime_log block): %v", err)
+	}
+
+	reader := dashboardserver.NewSQLConversationReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLConversationReader returned nil")
+	}
+	item, ok, err := reader.Get(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Get conversation: %v", err)
+	}
+	if !ok {
+		t.Fatalf("conversation %s not found", sessionID)
+	}
+	if len(item.Turns) != 1 {
+		t.Fatalf("conversation turns = %d, want 1", len(item.Turns))
+	}
+	blocks := item.Turns[0].TurnBlocks
+	if len(blocks) != 1 || blocks[0].Kind != "runtime_log" {
+		t.Fatalf("runtime_log turn blocks = %#v", blocks)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(blocks[0].Data, &data); err != nil {
+		t.Fatalf("decode runtime_log turn block data: %v", err)
+	}
+	if readString(data["log_level"]) != "warn" || readString(data["message"]) != "Tool execution was denied for save_entity_field" {
+		t.Fatalf("runtime_log turn block data = %#v", data)
+	}
+	details, _ := data["details"].(map[string]any)
+	if readString(details["component"]) != "tool-executor" || readString(details["action"]) != "tool_execution_denied" {
+		t.Fatalf("runtime_log turn block details = %#v", details)
+	}
+}
+
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrites(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/runtime/llm/turn_blocks.go
+++ b/internal/runtime/llm/turn_blocks.go
@@ -331,14 +331,28 @@ func normalizeCanonicalRuntimeLogTurnBlockData(data TurnBlockRuntimeLogData) (Tu
 	if details == nil {
 		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details are required")
 	}
-	component := strings.TrimSpace(asString(details["component"]))
-	if component == "" {
-		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details.component is required")
+	if _, err := requireCanonicalRuntimeLogDetailString(details, "component"); err != nil {
+		return TurnBlockRuntimeLogData{}, err
 	}
-	action := strings.TrimSpace(asString(details["action"]))
-	if action == "" {
-		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details.action is required")
+	if _, err := requireCanonicalRuntimeLogDetailString(details, "action"); err != nil {
+		return TurnBlockRuntimeLogData{}, err
 	}
 	data.Details = append(json.RawMessage(nil), raw...)
 	return data, nil
+}
+
+func requireCanonicalRuntimeLogDetailString(details map[string]any, key string) (string, error) {
+	value, ok := details[key]
+	if !ok {
+		return "", fmt.Errorf("canonical runtime_log block details.%s is required", key)
+	}
+	s, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("canonical runtime_log block details.%s must be a string", key)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("canonical runtime_log block details.%s is required", key)
+	}
+	return s, nil
 }

--- a/internal/runtime/llm/turn_blocks.go
+++ b/internal/runtime/llm/turn_blocks.go
@@ -171,6 +171,43 @@ func (b TurnBlock) ToolLinkData() (TurnBlockToolLinkData, bool, error) {
 	return data, ok, err
 }
 
+func DecodeCanonicalRuntimeLogTurnBlocks(blocks []TurnBlock) ([]TurnBlockRuntimeLogData, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	out := make([]TurnBlockRuntimeLogData, 0)
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Kind) != "runtime_log" {
+			continue
+		}
+		data, ok, err := block.RuntimeLogData()
+		if err != nil {
+			return nil, fmt.Errorf("decode canonical runtime_log block: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("canonical runtime_log block is empty")
+		}
+		normalized, err := normalizeCanonicalRuntimeLogTurnBlockData(data)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func DecodeCanonicalRuntimeLogTurnBlocksJSON(raw []byte) ([]TurnBlockRuntimeLogData, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil, nil
+	}
+	var blocks []TurnBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, err
+	}
+	return DecodeCanonicalRuntimeLogTurnBlocks(blocks)
+}
+
 func DecodeCanonicalTurnSummaryBlocks(blocks []TurnBlock) (TurnSummaryTurnBlockData, bool, error) {
 	var (
 		summary      TurnSummaryTurnBlockData
@@ -270,4 +307,38 @@ func trimSummaryStringSlice(in []string) []string {
 		return nil
 	}
 	return out
+}
+
+func normalizeCanonicalRuntimeLogTurnBlockData(data TurnBlockRuntimeLogData) (TurnBlockRuntimeLogData, error) {
+	data.LogLevel = strings.TrimSpace(data.LogLevel)
+	if data.LogLevel == "" {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block log_level is required")
+	}
+	data.Message = strings.TrimSpace(data.Message)
+	if data.Message == "" {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block message is required")
+	}
+	data.StackTrace = strings.TrimSpace(data.StackTrace)
+
+	raw := bytes.TrimSpace(data.Details)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details are required")
+	}
+	var details map[string]any
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details must be an object: %w", err)
+	}
+	if details == nil {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details are required")
+	}
+	component := strings.TrimSpace(asString(details["component"]))
+	if component == "" {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details.component is required")
+	}
+	action := strings.TrimSpace(asString(details["action"]))
+	if action == "" {
+		return TurnBlockRuntimeLogData{}, fmt.Errorf("canonical runtime_log block details.action is required")
+	}
+	data.Details = append(json.RawMessage(nil), raw...)
+	return data, nil
 }

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -204,3 +204,16 @@ func TestDecodeCanonicalTurnSummaryBlocks_FailsOnDuplicateCanonicalSummary(t *te
 		t.Fatal("expected duplicate canonical summary not to decode successfully")
 	}
 }
+
+func TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnMissingCanonicalDetailsComponent(t *testing.T) {
+	_, err := DecodeCanonicalRuntimeLogTurnBlocks([]TurnBlock{
+		newRuntimeLogTurnBlock("runtime log", TurnBlockRuntimeLogData{
+			LogLevel: "warn",
+			Message:  "runtime log",
+			Details:  json.RawMessage(`{"action":"tool_execution_denied"}`),
+		}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical runtime_log block details.component is required") {
+		t.Fatalf("DecodeCanonicalRuntimeLogTurnBlocks error = %v", err)
+	}
+}

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -217,3 +217,16 @@ func TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnMissingCanonicalDetailsCompo
 		t.Fatalf("DecodeCanonicalRuntimeLogTurnBlocks error = %v", err)
 	}
 }
+
+func TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnNonStringCanonicalDetailsComponent(t *testing.T) {
+	_, err := DecodeCanonicalRuntimeLogTurnBlocks([]TurnBlock{
+		newRuntimeLogTurnBlock("runtime log", TurnBlockRuntimeLogData{
+			LogLevel: "warn",
+			Message:  "runtime log",
+			Details:  json.RawMessage(`{"component":123,"action":"tool_execution_denied"}`),
+		}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical runtime_log block details.component must be a string") {
+		t.Fatalf("DecodeCanonicalRuntimeLogTurnBlocks error = %v", err)
+	}
+}

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -207,6 +207,9 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	turnBlocksPayload := ""
 	if hasTurnBlocks {
 		rec = runtimellm.CanonicalizeTurnForPersistence(rec)
+		if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocks(rec.TurnBlocks); err != nil {
+			return fmt.Errorf("validate canonical runtime_log turn_blocks: %w", err)
+		}
 		turnBlocksPayload = normalizeJSONArray(rec.TurnBlocks)
 	}
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3539,6 +3539,46 @@ func TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlo
 	}
 }
 
+func TestManagerStore_AppendAgentTurn_FailsOnNonStringCanonicalRuntimeLogTurnBlockField(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "assistant", Content: "done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:     "a1",
+		RuntimeMode: "task",
+		SessionID:   sessionID,
+		TurnBlocks: []runtimellm.TurnBlock{
+			{
+				Kind:  "runtime_log",
+				Title: "runtime log",
+				Data:  json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":123,"action":"tool_execution_denied"}}`),
+			},
+		},
+		ParseOK: true,
+		Latency: 5 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical runtime_log block details.component must be a string") {
+		t.Fatalf("AppendAgentTurn error = %v, want canonical runtime_log string-type failure", err)
+	}
+}
+
 func TestManagerStore_AppendAgentTurn_TaskReactivatesExistingInactiveAuditRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3499,6 +3499,46 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	}
 }
 
+func TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlock(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "assistant", Content: "done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+
+	err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:     "a1",
+		RuntimeMode: "task",
+		SessionID:   sessionID,
+		TurnBlocks: []runtimellm.TurnBlock{
+			{
+				Kind:  "runtime_log",
+				Title: "runtime log",
+				Data:  json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"action":"tool_execution_denied"}}`),
+			},
+		},
+		ParseOK: true,
+		Latency: 5 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical runtime_log block details.component is required") {
+		t.Fatalf("AppendAgentTurn error = %v, want canonical runtime_log turn-block failure", err)
+	}
+}
+
 func TestManagerStore_AppendAgentTurn_TaskReactivatesExistingInactiveAuditRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #292

## Human Summary
This PR closes the canonical runtime-log turn-block completeness slice extracted from `#168`. It makes persisted `agent_turns.turn_blocks` the explicit owner for canonical runtime-log turn-block completeness in the touched seam, and moves the first same-concept consumers onto one shared invariant.

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_turns`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: task_mode_audit`

## What Changed
- added one shared canonical runtime-log turn-block decoder/validator in `internal/runtime/llm/turn_blocks.go`
- made `AppendAgentTurn(...)` fail closed before persistence when canonical `runtime_log` turn blocks are malformed
- made the dashboard conversation turn reader fail closed when persisted canonical `runtime_log` turn blocks are malformed
- added focused proofs for:
  - decoder rejection of malformed canonical runtime-log blocks
  - store append rejection of malformed canonical runtime-log blocks
  - dashboard conversation readback rejection of malformed canonical runtime-log blocks
  - valid persisted round-trip through the canonical conversation reader

## Why This Is Needed
After `#285` and `#291`, runtime-log turn-block completeness was still drifting in one bounded slice: persisted `agent_turns.turn_blocks` could carry malformed canonical `runtime_log` blocks while the append path and conversation readback path treated the surface as healthy. That left reader-side omission/tolerance alive for the same canonical persisted owner.

## Scope Boundaries
- in scope:
  - canonical runtime-log turn-block completeness on persisted `agent_turns.turn_blocks`
  - the append/persist path and conversation readback path that consume that same canonical owner
- out of scope:
  - runtime-log row completeness (`#291`)
  - turn-summary completeness (`#285`)
  - mutation-surface completeness
  - broader dashboard transcript redesign

## Tests Run
- `go test ./internal/runtime/llm -run 'TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnMissingCanonicalDetailsComponent' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeLogTurnBlock' -count=1`
- `go test ./internal/store -run 'TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlock' -count=1`
- `go test ./internal/runtime/conformance -run 'TestCanonicalRuntimeLogTurnBlockSurface_RoundTripsThroughConversationReader' -count=1`
- `go test ./internal/runtime/llm ./internal/store ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR only moves the bounded same-concept consumers identified in the coverage audit. Other transcript surfaces that display full turn blocks remain separate transport concerns and should not reinterpret canonical runtime-log completeness locally.

## Follow-Up
No immediate same-concept follow-up remains in this bounded slice. Any future work should stay separate unless it consumes canonical runtime-log turn-block completeness from the same persisted owner.
