### PR TITLE
[agent-a][issue #286] Move remaining shutdown-admission bypass entrypaths onto the runtime-owned gate

### DIFF
--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 
+	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -83,5 +87,42 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShut
 	}
 	if status.ProjectDir != "/tmp/new-project" {
 		t.Fatalf("status.ProjectDir = %q, want /tmp/new-project", status.ProjectDir)
+	}
+}
+
+type builderControlTestAgent struct{ id string }
+
+func (a builderControlTestAgent) ID() string                      { return a.id }
+func (builderControlTestAgent) Type() string                      { return "stub" }
+func (builderControlTestAgent) Subscriptions() []events.EventType { return nil }
+func (builderControlTestAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	return nil, nil
+}
+func (builderControlTestAgent) BoardStep(context.Context, string) (string, error) { return "ok", nil }
+
+func TestDashboardDynamicAgentControl_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	agent := builderControlTestAgent{id: "agent-1"}
+	manager := runtimemanager.NewAgentManagerWithOptions(nil, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return agent, nil
+	}, runtimemanager.AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: func() bool { return true },
+	})
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+
+	supervisor := &runtimeProjectSupervisor{
+		currentRT: &runtimepkg.Runtime{Manager: manager},
+	}
+	control := dashboardDynamicAgentControl{supervisor: supervisor}
+
+	if err := control.RestartAgent(agent.id); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
+		t.Fatalf("RestartAgent err = %v, want runtime shutting down", err)
+	}
+	if err := control.ReplayAgentBacklog(context.Background(), agent.id); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
+		t.Fatalf("ReplayAgentBacklog err = %v, want runtime shutting down", err)
+	}
+	if _, err := control.ChatWithAgent(context.Background(), agent.id, "run corpus", false); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
+		t.Fatalf("ChatWithAgent err = %v, want runtime shutting down", err)
 	}
 }

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -27,7 +27,12 @@ type runCanceller interface {
 	CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]runtimedelivery.Transition, error)
 }
 
+var errRuntimeShuttingDown = errors.New("runtime shutting down")
+
 func (am *AgentManager) RestartAgent(agentID string) error {
+	if am.shutdownAdmissionClosed() {
+		return errRuntimeShuttingDown
+	}
 	am.mu.RLock()
 	agent, ok := am.agents[agentID]
 	am.mu.RUnlock()
@@ -307,6 +312,9 @@ func (am *AgentManager) safeProcessEvent(ctx context.Context, agent Agent, evt e
 }
 
 func (am *AgentManager) ChatWithAgent(ctx context.Context, agentID, directive string, killPrevious bool) (string, error) {
+	if am.shutdownAdmissionClosed() {
+		return "", errRuntimeShuttingDown
+	}
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return "", errors.New("agent id is required")
@@ -564,6 +572,9 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 			return nil
 		}
 		if err := am.ReplayAgentBacklog(ctx, id); err != nil {
+			if errors.Is(err, errRuntimeShuttingDown) {
+				return nil
+			}
 			if am.bus != nil {
 				am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 					Level:     "error",
@@ -580,7 +591,7 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 
 func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) error {
 	if am.shutdownAdmissionClosed() {
-		return nil
+		return errRuntimeShuttingDown
 	}
 	if am.store == nil {
 		return fmt.Errorf("manager store unavailable")

--- a/internal/runtime/manager/runtime_chat_test.go
+++ b/internal/runtime/manager/runtime_chat_test.go
@@ -129,3 +129,18 @@ func TestAgentManager_ChatWithAgent_KillPreviousLogsForcedTerminalLifecycle(t *t
 		t.Fatalf("terminal detail = %#v", detail)
 	}
 }
+
+func TestAgentManager_ChatWithAgent_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	agent := &chatTestAgent{id: "campaign-coordinator"}
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: func() bool { return true },
+	})
+	am.agents[agent.id] = agent
+
+	if _, err := am.ChatWithAgent(context.Background(), agent.id, "run corpus", false); err == nil || err.Error() != "runtime shutting down" {
+		t.Fatalf("ChatWithAgent err = %v, want runtime shutting down", err)
+	}
+	if agent.calls != 0 {
+		t.Fatalf("board step calls = %d, want 0", agent.calls)
+	}
+}

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -78,11 +78,31 @@ func TestReplayAgentBacklog_UsesRuntimeShutdownAdmissionOwnerBeforeStoreAccess(t
 		RuntimeShutdownAdmissionClosed: closed.Load,
 	}, store)
 
-	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
-		t.Fatalf("ReplayAgentBacklog: %v", err)
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err == nil || err.Error() != "runtime shutting down" {
+		t.Fatalf("ReplayAgentBacklog err = %v, want runtime shutting down", err)
 	}
 	if store.listPendingCalled.Load() {
 		t.Fatal("ReplayAgentBacklog touched the store even though runtime shutdown admission was already closed")
+	}
+}
+
+func TestRestartAgent_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	agent := shutdownTestAgent{id: "agent-1"}
+	am := NewAgentManagerWithOptions(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	}, AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: func() bool { return true },
+	})
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+
+	if err := am.RestartAgent(agent.id); err == nil || err.Error() != "runtime shutting down" {
+		t.Fatalf("RestartAgent err = %v, want runtime shutting down", err)
 	}
 }
 
@@ -146,8 +166,8 @@ func TestResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown
 
 	waitForManagerShuttingDown(t, am)
 
-	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
-		t.Fatalf("ReplayAgentBacklog during reset shutdown: %v", err)
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err == nil || err.Error() != "runtime shutting down" {
+		t.Fatalf("ReplayAgentBacklog during reset shutdown err = %v, want runtime shutting down", err)
 	}
 	if store.listPendingCalled.Load() {
 		t.Fatal("ReplayAgentBacklog touched the store while reset-driven manager shutdown was in progress")
@@ -229,8 +249,8 @@ func TestAuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdo
 
 	waitForManagerShuttingDown(t, am)
 
-	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err != nil {
-		t.Fatalf("ReplayAgentBacklog during auth-breaker shutdown: %v", err)
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-1"); err == nil || err.Error() != "runtime shutting down" {
+		t.Fatalf("ReplayAgentBacklog during auth-breaker shutdown err = %v, want runtime shutting down", err)
 	}
 	if store.listPendingCalled.Load() {
 		t.Fatal("ReplayAgentBacklog touched the store while auth-breaker shutdown was in progress")

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -20,23 +20,24 @@ import (
 )
 
 type GatewayHooks struct {
-	RuntimeIngressPaused      func() bool
-	FormatError               func(error) string
-	NewRuntimeError           func(code, operation string, retryable bool, cause error, format string, args ...any) error
-	RetryableFromError        func(error) (bool, bool)
-	WithActor                 func(context.Context, models.AgentConfig) context.Context
-	ActorFromContext          func(context.Context) (models.AgentConfig, bool)
-	ResolveActorConfig        func(string) (models.AgentConfig, bool)
-	WithCurrentRuntimeEpoch   func(context.Context) context.Context
-	WithInboundEvent          func(context.Context, events.Event) context.Context
-	WithEmittedEventsRecorder func(context.Context, *runtimebus.EmittedEventsRecorder) context.Context
-	ResolveTurnContext        func(string) (TurnContext, bool)
-	MarkEmitKeyUsed           func(string, string) bool
-	EmitToolsForActor         func(models.AgentConfig) []llm.ToolDefinition
-	EmitTools                 func(string) []llm.ToolDefinition
-	EmitSchemaForTool         func(string) (description string, schema any, ok bool)
-	Log                       func(context.Context, string, string, string, string, map[string]any, string)
-	AfterToolSuccess          func(context.Context, *http.Request, string)
+	RuntimeIngressPaused           func() bool
+	RuntimeShutdownAdmissionClosed func() bool
+	FormatError                    func(error) string
+	NewRuntimeError                func(code, operation string, retryable bool, cause error, format string, args ...any) error
+	RetryableFromError             func(error) (bool, bool)
+	WithActor                      func(context.Context, models.AgentConfig) context.Context
+	ActorFromContext               func(context.Context) (models.AgentConfig, bool)
+	ResolveActorConfig             func(string) (models.AgentConfig, bool)
+	WithCurrentRuntimeEpoch        func(context.Context) context.Context
+	WithInboundEvent               func(context.Context, events.Event) context.Context
+	WithEmittedEventsRecorder      func(context.Context, *runtimebus.EmittedEventsRecorder) context.Context
+	ResolveTurnContext             func(string) (TurnContext, bool)
+	MarkEmitKeyUsed                func(string, string) bool
+	EmitToolsForActor              func(models.AgentConfig) []llm.ToolDefinition
+	EmitTools                      func(string) []llm.ToolDefinition
+	EmitSchemaForTool              func(string) (description string, schema any, ok bool)
+	Log                            func(context.Context, string, string, string, string, map[string]any, string)
+	AfterToolSuccess               func(context.Context, *http.Request, string)
 }
 
 type Gateway struct {
@@ -89,12 +90,16 @@ func (g *Gateway) Handler() http.Handler {
 }
 
 func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
-	if g.runtimeIngressPaused() {
-		WriteJSON(w, http.StatusServiceUnavailable, ToolGatewayResponse{OK: false, Error: "runtime reset in progress"})
-		return
-	}
 	if r.Method != http.MethodPost {
 		WriteJSON(w, http.StatusMethodNotAllowed, ToolGatewayResponse{OK: false, Error: "method not allowed"})
+		return
+	}
+	if g.runtimeShutdownAdmissionClosed() {
+		WriteJSON(w, http.StatusServiceUnavailable, ToolGatewayResponse{OK: false, Error: "runtime shutting down"})
+		return
+	}
+	if g.runtimeIngressPaused() {
+		WriteJSON(w, http.StatusServiceUnavailable, ToolGatewayResponse{OK: false, Error: "runtime reset in progress"})
 		return
 	}
 	if err := g.authorize(r); err != nil {
@@ -147,10 +152,6 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
-	if g.runtimeIngressPaused() {
-		WriteRPCError(w, nil, -32002, "runtime reset in progress")
-		return
-	}
 	switch r.Method {
 	case http.MethodGet:
 		w.Header().Set("content-type", "text/plain")
@@ -159,6 +160,14 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 		return
 	case http.MethodPost:
+		if g.runtimeShutdownAdmissionClosed() {
+			WriteRPCError(w, nil, -32002, "runtime shutting down")
+			return
+		}
+		if g.runtimeIngressPaused() {
+			WriteRPCError(w, nil, -32002, "runtime reset in progress")
+			return
+		}
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -601,6 +610,13 @@ func (g *Gateway) runtimeIngressPaused() bool {
 		return false
 	}
 	return g.hooks.RuntimeIngressPaused()
+}
+
+func (g *Gateway) runtimeShutdownAdmissionClosed() bool {
+	if g == nil || g.hooks.RuntimeShutdownAdmissionClosed == nil {
+		return false
+	}
+	return g.hooks.RuntimeShutdownAdmissionClosed()
 }
 
 func (g *Gateway) formatError(err error) string {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -960,6 +960,77 @@ func TestGatewayAuthorize_DeniesInvalidBearer(t *testing.T) {
 	}
 }
 
+func TestGatewayHandleTool_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	callCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{
+		RuntimeShutdownAdmissionClosed: func() bool { return true },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(`{"input":{"query":"kind='vertical'"}}`))
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "runtime shutting down") {
+		t.Fatalf("body = %s, want runtime shutting down", rec.Body.String())
+	}
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+}
+
+func TestGatewayHandleMCP_DeniesToolCallWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	callCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{
+		RuntimeShutdownAdmissionClosed: func() bool { return true },
+		ResolveTurnContext:             registry.ResolveTurnContext,
+		WithActor:                      models.WithActor,
+		WithCurrentRuntimeEpoch:        runtimebus.WithCurrentRuntimeEpoch,
+	})
+	putTestTurnContext(t, registry, "ctx-shutdown", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"query": "kind = 'vertical'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-shutdown")
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	resp := mustRPCResponse(t, rec)
+	if resp.Error == nil || !strings.Contains(resp.Error.Message, "runtime shutting down") {
+		t.Fatalf("rpc error = %#v, want runtime shutting down", resp.Error)
+	}
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+}
+
 func TestGatewayHandleMCP_RejectsReadOnlyToolWhenContextTokenMisses(t *testing.T) {
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -30,21 +30,22 @@ func newMCPRuntimeError(code, operation string, retryable bool, cause error, for
 	return WrapRuntimeError(code, "mcp-gateway", operation, retryable, cause, format, args...)
 }
 
-func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
+func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), runtimeShutdownAdmissionClosed func() bool, emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
 	if emitRegistry == nil {
 		emitRegistry = runtimetools.NewEmitRegistry(nil, nil)
 	}
 	return runtimemcp.GatewayHooks{
-		RuntimeIngressPaused:      runtimebus.RuntimeIngressPaused,
-		FormatError:               FormatRuntimeError,
-		NewRuntimeError:           newMCPRuntimeError,
-		RetryableFromError:        retryableFromGatewayError,
-		WithActor:                 runtimeactors.WithActor,
-		ActorFromContext:          runtimeactors.ActorFromContext,
-		ResolveActorConfig:        resolveActorConfig,
-		WithCurrentRuntimeEpoch:   runtimebus.WithCurrentRuntimeEpoch,
-		WithInboundEvent:          runtimebus.WithInboundEvent,
-		WithEmittedEventsRecorder: runtimebus.WithEmittedEventsRecorder,
+		RuntimeIngressPaused:           runtimebus.RuntimeIngressPaused,
+		RuntimeShutdownAdmissionClosed: runtimeShutdownAdmissionClosed,
+		FormatError:                    FormatRuntimeError,
+		NewRuntimeError:                newMCPRuntimeError,
+		RetryableFromError:             retryableFromGatewayError,
+		WithActor:                      runtimeactors.WithActor,
+		ActorFromContext:               runtimeactors.ActorFromContext,
+		ResolveActorConfig:             resolveActorConfig,
+		WithCurrentRuntimeEpoch:        runtimebus.WithCurrentRuntimeEpoch,
+		WithInboundEvent:               runtimebus.WithInboundEvent,
+		WithEmittedEventsRecorder:      runtimebus.WithEmittedEventsRecorder,
 		ResolveTurnContext: func(token string) (runtimemcp.TurnContext, bool) {
 			if turnContexts == nil {
 				return runtimemcp.TurnContext{}, false

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -426,7 +426,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 				return runtimeactors.AgentConfig{}, false
 			}
 			return rt.Manager.GetAgentConfig(strings.TrimSpace(agentID))
-		}, rt.EmitRegistry, rt.MCPTurns))
+		}, rt.shutdownAdmissionClosed, rt.EmitRegistry, rt.MCPTurns))
 	}
 
 	return rt, nil

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -181,7 +181,7 @@ func startupProbeCaps() map[string]toolcapabilities.Capability {
 func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManager, exec *startupProbeToolExecutor, gatewayToken string) *runtimemcp.TurnContextRegistry {
 	t.Helper()
 	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
-	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, turns))
+	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil, turns))
 	server := httptest.NewServer(gateway.Handler())
 	t.Cleanup(server.Close)
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -153,8 +153,8 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 	if !rt.shutdownAdmissionClosed() {
 		t.Fatal("runtime shutdown admission was not closed before manager drain")
 	}
-	if err := am.ReplayAgentBacklog(context.Background(), agent.id); err != nil {
-		t.Fatalf("ReplayAgentBacklog during shutdown: %v", err)
+	if err := am.ReplayAgentBacklog(context.Background(), agent.id); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
+		t.Fatalf("ReplayAgentBacklog during shutdown err = %v, want runtime shutting down", err)
 	}
 	if managerStore.listPendingCalled {
 		t.Fatal("ReplayAgentBacklog touched manager persistence even though runtime shutdown admission was closed")


### PR DESCRIPTION
Closes #286

## Spec references
- none; issue #286 explicitly states there are no exact platform spec references for this runtime-hardening seam
- binding context: issue body/thread and merged PR #287 scope boundaries

## Human Summary
This PR closes the remaining shutdown-admission bypasses left intentionally out of #287. MCP gateway work-bearing ingress and the builder/dashboard direct-control path now consume the same runtime-owned shutdown-admission owner, while reset ingress pause remains a separate concept.

## What Changed
- added runtime shutdown-admission gating to MCP gateway work-bearing ingress:
  - `/tools/*`
  - `/mcp` POST methods
- kept MCP reset ingress pause as a separate check and separate denial reason
- moved remaining manager-owned direct-control operations onto shutdown admission:
  - `RestartAgent()`
  - `ChatWithAgent()`
  - `ReplayAgentBacklog()` now returns an explicit shutdown denial instead of a silent no-op
- kept builder/dashboard direct-control entrypaths thin by consuming the same manager/runtime-owned owner instead of adding a separate local interpretation
- added focused tests for:
  - MCP `/tools/*` denial during shutdown
  - MCP `/mcp tools/call` denial during shutdown
  - manager restart/chat/replay denial during shutdown
  - builder/dashboard direct-control denial through the same owner

## Why This Is Needed
After #287, shutdown admission still drifted across the remaining MCP and dashboard/control entry surfaces. That meant "no new work after runtime shutdown starts" still depended on which surface was used. This PR removes those remaining bypasses for the approved follow-up slice.

## Scope Boundaries
- in scope: MCP gateway work-bearing ingress and builder/dashboard direct-control shutdown-admission parity
- in scope: manager direct-control methods that those builder/dashboard surfaces delegate to
- out of scope: reset-mode semantic redesign
- out of scope: unrelated runtime lifecycle cleanup

## Tests Run
- `go test ./internal/runtime/mcp ./internal/runtime/manager ./cmd/swarm -run 'Test(GatewayHandleTool_DeniesWhenRuntimeShutdownAdmissionClosed|GatewayHandleMCP_DeniesToolCallWhenRuntimeShutdownAdmissionClosed|Run_UsesRuntimeShutdownAdmissionOwner|ReplayAgentBacklog_UsesRuntimeShutdownAdmissionOwnerBeforeStoreAccess|RestartAgent_DeniesWhenRuntimeShutdownAdmissionClosed|ResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown|AuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdown|AgentManager_ChatWithAgent_DeniesWhenRuntimeShutdownAdmissionClosed|DashboardDynamicAgentControl_DeniesWhenRuntimeShutdownAdmissionClosed|RuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/mcp ./internal/runtime/manager ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
No known shutdown-admission bypass remains in the issue-defined MCP gateway and builder/dashboard direct-control slice.

## Follow-Up
- none identified at current audit depth