### PR TITLE
[agent-d][issue #112] Make direct-recipient delivery an explicit semantic path under one owner

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 
 	"swarm/internal/events"
 )
@@ -97,6 +98,51 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.SubscribedRecipients = routing.SubscribedRecipients
 	plan.ExtraDetail = routing.ExtraDetail
 	return plan, nil
+}
+
+func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recipients []string) (eventDeliveryPlan, error) {
+	plan := eventDeliveryPlan{Event: evt}
+	if evt.Type == events.EventType("platform.runtime_log") {
+		return plan, nil
+	}
+	requested := uniqueStrings(recipients)
+	if len(requested) == 0 {
+		return eventDeliveryPlan{}, errors.New("direct delivery recipients are required")
+	}
+	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, requested)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	plan.Recipients = manifest.Recipients
+	plan.PersistedRecipients = manifest.PersistedRecipients
+	plan.ExtraDetail = map[string]any{
+		"direct":                     true,
+		"requested_recipients":       append([]string(nil), requested...),
+		"requested_recipients_count": len(requested),
+	}
+	if filtered := filteredRecipients(requested, manifest.Recipients); len(filtered) > 0 {
+		plan.ExtraDetail["filtered_out_recipients"] = filtered
+		plan.ExtraDetail["filtered_out_recipients_count"] = len(filtered)
+	}
+	return plan, nil
+}
+
+func filteredRecipients(requested, allowed []string) []string {
+	if len(requested) == 0 {
+		return nil
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, recipient := range allowed {
+		allowedSet[recipient] = struct{}{}
+	}
+	out := make([]string, 0, len(requested))
+	for _, recipient := range requested {
+		if _, ok := allowedSet[recipient]; ok {
+			continue
+		}
+		out = append(out, recipient)
+	}
+	return out
 }
 
 func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -579,9 +579,9 @@ func (eb *EventBus) recordPublishDiagnostic(ctx context.Context, evt events.Even
 	})
 }
 
-// PublishDirect persists an event and delivers it to the specified recipients
-// regardless of routing tables or subscription patterns. This is the "message"
-// primitive: explicit, point-to-point delivery.
+// PublishDirect persists an event and delivers it to an explicit caller-supplied
+// recipient set. The recipient manifest still routes through the canonical
+// delivery policy so explicit delivery cannot bypass scoped-recipient rules.
 func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipients []string) (err error) {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
@@ -596,10 +596,6 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		status, errText := pipelineReceiptStatus(ctx, err)
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
-	recipients = uniqueStrings(recipients)
-	if len(recipients) == 0 {
-		return errors.New("direct publish recipients are required")
-	}
 	if evt.Type == "" {
 		return errors.New("event type is required")
 	}
@@ -618,18 +614,63 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		evt.CreatedAt = time.Now()
 	}
 	ctx, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
-	if err := eb.persistEventRecord(ctx, evt, recipients); err != nil {
+	plan, err := eb.deliveryPlanner.PlanDirect(ctx, evt, recipients)
+	if err != nil {
+		return err
+	}
+	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
 		return err
 	}
 	persisted = true
-	eb.logQueuedDeliveries(ctx, evt, recipients, "direct_publish", map[string]any{"direct": true})
+	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "direct_publish", plan.ExtraDetail)
+	if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
+		return err
+	}
+	detail := map[string]any{
+		"direct":           true,
+		"recipients_count": len(plan.Recipients),
+		"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
+	}
+	for k, v := range plan.ExtraDetail {
+		detail[k] = v
+	}
+	eb.logRuntime(ctx, "debug", "Event was delivered directly to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, detail, "", int(time.Since(start)/time.Microsecond))
+	return nil
+}
+
+// PublishPersistedRecipients delivers an already-persisted authoritative
+// recipient manifest without re-running direct recipient planning.
+func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error {
+	ctx = WithCurrentRuntimeEpoch(ctx)
+	if err := ensurePublishEpoch(ctx); err != nil {
+		return err
+	}
+	recipients = uniqueStrings(recipients)
+	if len(recipients) == 0 {
+		return errors.New("persisted recipients are required")
+	}
+	if evt.Type == "" {
+		return errors.New("event type is required")
+	}
+	if !isValidEventTypeName(string(evt.Type)) {
+		return fmt.Errorf("invalid event type: %s", strings.TrimSpace(string(evt.Type)))
+	}
+	if evt.ID == "" {
+		evt.ID = uuid.NewString()
+	}
+	if evt.CreatedAt.IsZero() {
+		evt.CreatedAt = time.Now()
+	}
 	if err := eb.deliverToAgents(ctx, evt, recipients); err != nil {
 		return err
 	}
-	eb.logRuntime(ctx, "debug", "Event was delivered directly to recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
-		"direct":           true,
-		"recipients_count": len(recipients),
-		"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
-	}, "", int(time.Since(start)/time.Microsecond))
+	eb.logRuntime(ctx, "debug", "Persisted event was delivered to authoritative recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
+		"direct":                     true,
+		"delivery_manifest_owner":    "event_deliveries",
+		"recipients_count":           len(recipients),
+		"parent_event_id":            strings.TrimSpace(evt.ParentEventID),
+		"requested_recipients":       append([]string(nil), recipients...),
+		"requested_recipients_count": len(recipients),
+	}, "", 0)
 	return nil
 }

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -331,50 +331,72 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 }
 
 func TestEventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut(t *testing.T) {
-	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-
-	pg := &store.PostgresStore{DB: db}
-	eb, err := runtimebus.NewEventBus(pg)
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "agent-a"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 
-	eventID := uuid.NewString()
-	entityID := uuid.NewString()
-	err = eb.PublishDirect(ctx, (events.Event{
-		ID:        eventID,
+	err = eb.PublishDirect(context.Background(), (events.Event{
+		ID:        uuid.NewString(),
 		Type:      events.EventType("custom.direct"),
-		Payload:   []byte(`{"entity_id":"` + entityID + `"}`),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
 		CreatedAt: time.Now().UTC(),
-	}).WithEntityID(entityID), []string{"agent-a"})
+	}).WithEntityID("ent-1"), []string{"agent-a"})
 	if err == nil || !strings.Contains(err.Error(), "authoritative delivery incomplete") {
 		t.Fatalf("PublishDirect missing recipient error = %v, want authoritative delivery incomplete", err)
 	}
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
+}
 
-	var eventCount, deliveryCount, receiptCount int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = $1::uuid`, eventID).Scan(&eventCount); err != nil {
-		t.Fatalf("count events: %v", err)
+func TestEventBusPublishDirect_FiltersEntityScopedRecipientsByExplicitMetadata(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "control-plane"},
+			{AgentID: "reviewer-ent-1", EntityID: "ent-1"},
+			{AgentID: "reviewer-ent-2", EntityID: "ent-2"},
+		},
 	}
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid`, eventID).Scan(&deliveryCount); err != nil {
-		t.Fatalf("count deliveries: %v", err)
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM event_receipts
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'platform'
-		  AND subscriber_id = 'pipeline'
-	`, eventID).Scan(&receiptCount); err != nil {
-		t.Fatalf("count pipeline receipts: %v", err)
+	controlCh := eb.Subscribe("control-plane")
+	matchCh := eb.Subscribe("reviewer-ent-1")
+	otherCh := eb.Subscribe("reviewer-ent-2")
+
+	err = eb.PublishDirect(context.Background(), events.Event{
+		Type:      events.EventType("custom.direct"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1"), []string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"})
+	if err != nil {
+		t.Fatalf("PublishDirect: %v", err)
 	}
-	if eventCount != 1 || deliveryCount != 1 {
-		t.Fatalf("persisted rows = events:%d deliveries:%d, want 1 each", eventCount, deliveryCount)
+
+	select {
+	case evt := <-controlCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("control event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("control-plane did not receive direct event")
 	}
-	if receiptCount != 0 {
-		t.Fatalf("pipeline receipt count = %d, want 0 before real fan-out", receiptCount)
+	select {
+	case evt := <-matchCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("matched event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("matching entity-scoped reviewer did not receive direct event")
 	}
+	waitForNoEvent(t, otherCh)
+
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane", "reviewer-ent-1"})
 }
 
 func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *testing.T) {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -128,9 +128,6 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		}
 		return err
 	}
-	if len(intent.Recipients) > 0 && len(recipients) == 0 {
-		return d.dispatchExplicitDirectIntent(ctx, intent)
-	}
 	if len(recipients) > 0 {
 		if err := d.bus.PublishPersistedRecipients(ctx, intent.Event, recipients); err != nil {
 			return err

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimeengine "swarm/internal/runtime/engine"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type engineOutbox struct {
@@ -122,13 +123,39 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 	}
 	recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, intent.Event.ID)
 	if err != nil {
+		if len(intent.Recipients) > 0 && errors.Is(err, runtimereplayclaim.ErrAuthoritativeRecipientManifestUnavailable) {
+			return d.dispatchExplicitDirectIntent(ctx, intent)
+		}
 		return err
+	}
+	if len(intent.Recipients) > 0 && len(recipients) == 0 {
+		return d.dispatchExplicitDirectIntent(ctx, intent)
 	}
 	if len(recipients) > 0 {
 		if err := d.bus.PublishPersistedRecipients(ctx, intent.Event, recipients); err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+func (d engineDispatcher) dispatchExplicitDirectIntent(ctx context.Context, intent runtimeengine.EmitIntent) error {
+	plan, err := d.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
+	if err != nil {
+		return err
+	}
+	if err := d.bus.deliverToAgents(ctx, intent.Event, plan.Recipients); err != nil {
+		return err
+	}
+	detail := map[string]any{
+		"direct":           true,
+		"recipients_count": len(plan.Recipients),
+		"parent_event_id":  strings.TrimSpace(intent.Event.ParentEventID),
+	}
+	for k, v := range plan.ExtraDetail {
+		detail[k] = v
+	}
+	d.bus.logRuntime(ctx, "debug", "Deferred direct event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, detail, "", 0)
 	return nil
 }
 

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -69,7 +69,11 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 
 func (o engineOutbox) persistedRecipientsForIntent(ctx context.Context, intent runtimeengine.EmitIntent) ([]string, error) {
 	if len(intent.Recipients) > 0 {
-		return uniqueStrings(intent.Recipients), nil
+		plan, err := o.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
+		if err != nil {
+			return nil, err
+		}
+		return plan.PersistedRecipients, nil
 	}
 	plan, err := o.bus.deliveryPlanner.Plan(ctx, intent.Event)
 	if err != nil {
@@ -115,21 +119,15 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		if !passthrough {
 			return nil
 		}
-		recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, intent.Event.ID)
-		if err != nil {
-			return err
-		}
-		intent.Recipients = recipients
 	}
-	recipients := uniqueStrings(intent.Recipients)
+	recipients, err := d.bus.authoritativeRecipientsForEvent(ctx, intent.Event.ID)
+	if err != nil {
+		return err
+	}
 	if len(recipients) > 0 {
-		if err := d.bus.deliverToAgents(ctx, intent.Event, recipients); err != nil {
+		if err := d.bus.PublishPersistedRecipients(ctx, intent.Event, recipients); err != nil {
 			return err
 		}
-		d.bus.logRuntime(ctx, "debug", "Deferred event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
-			"direct":           true,
-			"recipients_count": len(recipients),
-		}, "", 0)
 	}
 	return nil
 }

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -2,6 +2,7 @@ package bus_test
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"testing"
@@ -13,12 +14,18 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeengine "swarm/internal/runtime/engine"
 	runtimepipeline "swarm/internal/runtime/pipeline"
-	"swarm/internal/store"
 )
 
 type recordingEventStore struct {
 	mu     sync.Mutex
 	events []events.Event
+}
+
+type directRecipientTransactionalStore struct {
+	mu          sync.Mutex
+	descriptors []runtimebus.ActiveAgentDescriptor
+	events      []events.Event
+	deliveries  map[string][]string
 }
 
 func (s *recordingEventStore) AppendEvent(_ context.Context, evt events.Event) error {
@@ -44,6 +51,49 @@ func (s *recordingEventStore) eventTypes() []string {
 		out = append(out, string(evt.Type))
 	}
 	return out
+}
+
+func (s *directRecipientTransactionalStore) AppendEvent(context.Context, events.Event) error {
+	return nil
+}
+
+func (s *directRecipientTransactionalStore) InsertEventDeliveries(_ context.Context, eventID string, agentIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deliveries == nil {
+		s.deliveries = map[string][]string{}
+	}
+	s.deliveries[eventID] = append([]string(nil), agentIDs...)
+	return nil
+}
+
+func (s *directRecipientTransactionalStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deliveries[eventID]...), nil
+}
+
+func (s *directRecipientTransactionalStore) ListActiveAgentDescriptors(context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {
+	return append([]runtimebus.ActiveAgentDescriptor(nil), s.descriptors...), nil
+}
+
+func (*directRecipientTransactionalStore) BeginEventTx(context.Context) (*sql.Tx, error) {
+	return nil, nil
+}
+
+func (s *directRecipientTransactionalStore) AppendEventTx(_ context.Context, _ *sql.Tx, evt events.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+	return nil
+}
+
+func (s *directRecipientTransactionalStore) InsertEventDeliveriesTx(ctx context.Context, _ *sql.Tx, eventID string, agentIDs []string) error {
+	return s.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (*directRecipientTransactionalStore) UpsertPipelineReceiptTx(context.Context, *sql.Tx, string, string, string) error {
+	return nil
 }
 
 type interceptingTestHandler struct{}
@@ -95,44 +145,18 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 
 	entityID := uuid.NewString()
 	mock.ExpectBegin()
-	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(
-		sqlmock.NewRows([]string{"table_name", "column_name"}).
-			AddRow("events", "event_id").
-			AddRow("events", "event_name").
-			AddRow("events", "entity_id").
-			AddRow("events", "flow_instance").
-			AddRow("events", "scope").
-			AddRow("events", "payload").
-			AddRow("events", "chain_depth").
-			AddRow("events", "produced_by").
-			AddRow("events", "produced_by_type").
-			AddRow("events", "source_event_id").
-			AddRow("events", "created_at").
-			AddRow("event_deliveries", "event_id").
-			AddRow("event_deliveries", "subscriber_type").
-			AddRow("event_deliveries", "subscriber_id").
-			AddRow("event_deliveries", "status").
-			AddRow("event_deliveries", "retry_count").
-			AddRow("event_deliveries", "reason_code").
-			AddRow("event_deliveries", "last_error").
-			AddRow("event_deliveries", "active_session_id").
-			AddRow("event_deliveries", "started_at").
-			AddRow("event_deliveries", "delivered_at").
-			AddRow("event_deliveries", "created_at"),
-	)
-	mock.ExpectExec("INSERT INTO events").
-		WithArgs("evt-1", "custom.emitted", entityID, "", "entity", sqlmock.AnyArg(), 0, "", "platform", "", sqlmock.AnyArg()).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO event_deliveries").
-		WithArgs("evt-1", "reviewer").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
 	tx, err := db.Begin()
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
-	eb, err := runtimebus.NewEventBus(&store.PostgresStore{DB: db})
+	recordingStore := &directRecipientTransactionalStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "reviewer", EntityID: entityID},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(recordingStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
@@ -152,6 +176,98 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("Commit: %v", err)
 	}
+	if got := len(recordingStore.events); got != 1 {
+		t.Fatalf("persisted events = %d, want 1", got)
+	}
+	gotPersisted, err := recordingStore.ListEventDeliveryRecipients(context.Background(), "evt-1")
+	if err != nil {
+		t.Fatalf("ListEventDeliveryRecipients: %v", err)
+	}
+	if strings.Join(gotPersisted, ",") != "reviewer" {
+		t.Fatalf("persisted recipients = %v, want [reviewer]", gotPersisted)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "control-plane"},
+			{AgentID: "reviewer-ent-1", EntityID: "ent-1"},
+			{AgentID: "reviewer-ent-2", EntityID: "ent-2"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controlCh := eb.Subscribe("control-plane")
+	matchCh := eb.Subscribe("reviewer-ent-1")
+	otherCh := eb.Subscribe("reviewer-ent-2")
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-direct-intent",
+			Type:      events.EventType("custom.direct"),
+			Payload:   []byte(`{"entity_id":"ent-1"}`),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+		Recipients: []string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"},
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	gotPersisted, err := store.ListEventDeliveryRecipients(context.Background(), intent.Event.ID)
+	if err != nil {
+		t.Fatalf("ListEventDeliveryRecipients: %v", err)
+	}
+	wantPersisted := []string{"control-plane", "reviewer-ent-1"}
+	if strings.Join(gotPersisted, ",") != strings.Join(wantPersisted, ",") {
+		t.Fatalf("persisted recipients = %v, want %v", gotPersisted, wantPersisted)
+	}
+
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	select {
+	case <-controlCh:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("control-plane did not receive direct intent")
+	}
+	select {
+	case evt := <-matchCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("matched event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("matching entity-scoped agent did not receive direct intent")
+	}
+	select {
+	case evt := <-otherCh:
+		t.Fatalf("unexpected event delivered to filtered recipient: %#v", evt)
+	case <-time.After(25 * time.Millisecond):
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
 	}

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -352,3 +352,67 @@ func TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPe
 		t.Fatal("expected explicit direct recipient to receive event")
 	}
 }
+
+func TestEngineDispatcher_TransactionalDirectIntentHonorsEmptyPersistedManifest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "reviewer-ent-2", EntityID: "ent-2"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	filteredCh := eb.Subscribe("reviewer-ent-2")
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-empty-direct-manifest",
+			Type:      events.EventType("custom.direct"),
+			Payload:   []byte(`{"entity_id":"ent-1"}`),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+		Recipients: []string{"reviewer-ent-2"},
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	gotPersisted, err := store.ListEventDeliveryRecipients(context.Background(), intent.Event.ID)
+	if err != nil {
+		t.Fatalf("ListEventDeliveryRecipients: %v", err)
+	}
+	if len(gotPersisted) != 0 {
+		t.Fatalf("persisted recipients = %v, want empty authoritative manifest", gotPersisted)
+	}
+
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	select {
+	case evt := <-filteredCh:
+		t.Fatalf("unexpected event delivered from empty authoritative manifest: %#v", evt)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -321,3 +321,34 @@ func TestEngineDispatcher_FailsClosedWithoutAuthoritativeRecipientManifestOnInMe
 		t.Fatalf("DispatchPostCommit error = %q, want missing authoritative manifest failure", got)
 	}
 }
+
+func TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPersisted(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	recipientCh := eb.Subscribe("agent-a")
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-direct-no-tx",
+			Type:      events.EventType("custom.emitted"),
+			Payload:   []byte(`{"entity_id":"ent-1"}`),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+		Recipients: []string{"agent-a"},
+	}
+
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+
+	select {
+	case evt := <-recipientCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("delivered event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected explicit direct recipient to receive event")
+	}
+}

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -425,6 +425,9 @@ func (*conformanceRecoveryBus) Publish(context.Context, events.Event) error { re
 func (*conformanceRecoveryBus) PublishDirect(context.Context, events.Event, []string) error {
 	return nil
 }
+func (*conformanceRecoveryBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
 func (*conformanceRecoveryBus) Subscribe(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -127,6 +127,9 @@ func (b *flowActivationTestBus) Publish(_ context.Context, evt events.Event) err
 func (*flowActivationTestBus) PublishDirect(context.Context, events.Event, []string) error {
 	return nil
 }
+func (*flowActivationTestBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
 func (*flowActivationTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -27,6 +27,9 @@ func (b *recordingReceiptBus) Publish(_ context.Context, evt events.Event) error
 func (*recordingReceiptBus) PublishDirect(context.Context, events.Event, []string) error {
 	return nil
 }
+func (*recordingReceiptBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
 func (*recordingReceiptBus) Subscribe(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -23,6 +23,9 @@ type recoveryTestBus struct {
 
 func (*recoveryTestBus) Publish(context.Context, events.Event) error                 { return nil }
 func (*recoveryTestBus) PublishDirect(context.Context, events.Event, []string) error { return nil }
+func (*recoveryTestBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
 func (*recoveryTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -32,6 +32,7 @@ type AgentFactory func(cfg models.AgentConfig) (Agent, error)
 type Bus interface {
 	Publish(ctx context.Context, evt events.Event) error
 	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
+	PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error
 	Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event
 	Unsubscribe(agentID string)
 	Store() runtimebus.EventStore

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -22,7 +22,7 @@ type EventStore interface {
 
 type Publisher interface {
 	Publish(ctx context.Context, evt events.Event) error
-	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
+	PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error
 }
 
 type RecoveryManager struct {
@@ -129,7 +129,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			_ = lease.Release(ctx)
 			continue
 		}
-		if err := r.bus.PublishDirect(ctx, evt, persistedRecipients); err != nil {
+		if err := r.bus.PublishPersistedRecipients(ctx, evt, persistedRecipients); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("replay event %s: %w", evt.ID, err)
 			}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -32,9 +32,9 @@ func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event
 	return p.inner.Publish(ctx, evt)
 }
 
-func (p *recoveryCapturePublisher) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error {
+func (p *recoveryCapturePublisher) PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error {
 	p.direct = append(p.direct, evt)
-	return p.inner.PublishDirect(ctx, evt, recipients)
+	return p.inner.PublishPersistedRecipients(ctx, evt, recipients)
 }
 
 func (s *recoveryMissingClaimStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -64,7 +64,7 @@ type blockingRecoveryPublisher struct {
 
 func (*blockingRecoveryPublisher) Publish(context.Context, events.Event) error { return nil }
 
-func (p *blockingRecoveryPublisher) PublishDirect(context.Context, events.Event, []string) error {
+func (p *blockingRecoveryPublisher) PublishPersistedRecipients(context.Context, events.Event, []string) error {
 	if p.count.Add(1) == 1 {
 		close(p.started)
 		<-p.release


### PR DESCRIPTION
Closes #112

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: event_schema.routing_derivation.delivery_rules`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.dead_letter_schema`

## Human Summary
This PR removes direct-recipient delivery as an accidental alternate semantic path. Explicit direct recipients now go through the canonical delivery planner and recipient policy once, while recovery and post-commit dispatch use a distinct persisted-recipient publish path for already-authoritative `event_deliveries` manifests.

## What Changed
- added `deliveryPlanner.PlanDirect(...)` so explicit recipient delivery uses the same canonical recipient policy and filtered persisted manifest as routed delivery
- updated `EventBus.PublishDirect(...)` and outbox persistence to use that planner-owned direct manifest instead of ad hoc recipient handling
- added `EventBus.PublishPersistedRecipients(...)` and moved recovery/post-commit dispatch onto it so persisted authoritative recipients are delivered without re-planning
- updated recovery/manager test buses to require the persisted-recipient publish contract explicitly
- added focused tests proving explicit direct recipients are filtered/persisted canonically and that deferred outbox delivery dispatches the canonical persisted manifest

## Why This Is Needed
Before this change, direct-recipient delivery was a live alternate interpreter of delivery semantics. It could bypass planner-owned recipient filtering and diverge from planned delivery persistence, while recovery reused the same API for a different semantic concept: delivering already-authoritative persisted recipients. This PR closes that semantic split.

## Scope Boundaries
In scope:
- explicit direct-recipient runtime bus/outbox delivery semantics
- persisted authoritative recipient dispatch for recovery/post-commit dispatch
- focused proofs for recipient filtering and persistence invariants in the touched seam

Out of scope:
- broader delivery lifecycle redesign
- unrelated store cleanup
- spec changes

## Tests Run
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/manager ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR keeps the semantic split explicit between caller-supplied direct recipients and persisted authoritative recipients. Any future bus entrypoint that tries to deliver explicit recipients without `PlanDirect(...)`, or replay persisted recipients without `PublishPersistedRecipients(...)`, would reintroduce drift and should be treated as off-contract.

## Follow-Up
No follow-up issue is required from this seam if review agrees that explicit direct-recipient planning and persisted recipient dispatch are the only two distinct concepts here.