### PR TITLE
[agent-a][issue #296] Fix platform-table DDL ordering for legacy compatibility prerequisites

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -140,6 +140,8 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 				return fmt.Errorf("ensure agent_turns.turn_blocks column: %w", err)
 			}
 		}
+	}
+	if catalog.hasTable("agent_conversation_audits") || catalog.hasTable("agent_turns") {
 		if err := s.ensureConversationAuditTable(ctx); err != nil {
 			return err
 		}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -79,6 +79,11 @@ func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTa
 	if _, err := s.DB.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
 		return fmt.Errorf("ensure pgcrypto extension: %w", err)
 	}
+	if schemaDDLIncludesPlatformTables(plans) {
+		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+			return fmt.Errorf("ensure platform-table compatibility prerequisites: %w", err)
+		}
+	}
 	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin schema ddl tx: %w", err)
@@ -104,10 +109,21 @@ func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTa
 		return fmt.Errorf("commit schema ddl tx: %w", err)
 	}
 	committed = true
-	if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
-		return err
+	if schemaDDLIncludesPlatformTables(plans) {
+		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+			return fmt.Errorf("ensure platform-table compatibility aftermath: %w", err)
+		}
 	}
 	return nil
+}
+
+func schemaDDLIncludesPlatformTables(plans []SchemaTableDDL) bool {
+	for _, plan := range plans {
+		if strings.TrimSpace(plan.SchemaKind) == "platform_spec" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) error {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -295,6 +295,139 @@ func TestPostgresStore_EnsureSchemaTables_PhasesAgentRuntimeDescriptorCompatibil
 	}
 }
 
+func TestPostgresStore_EnsureSchemaTables_PhasesConversationAuditRunIDCompatibilityBeforeDependentDDL(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_turns CASCADE`); err != nil {
+		t.Fatalf("drop agent_turns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_conversation_audits CASCADE`); err != nil {
+		t.Fatalf("drop agent_conversation_audits: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS runs CASCADE`); err != nil {
+		t.Fatalf("drop runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TABLE runs (run_id UUID PRIMARY KEY DEFAULT gen_random_uuid())`); err != nil {
+		t.Fatalf("create runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agent_conversation_audits (
+			session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			agent_id TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope_key TEXT,
+			scope TEXT NOT NULL DEFAULT 'global',
+			conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			runtime_mode TEXT NOT NULL DEFAULT 'task',
+			runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agent_conversation_audits: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agent_conversation_audits": {
+			DDL: "CREATE TABLE IF NOT EXISTS agent_conversation_audits (\n    session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    agent_id TEXT NOT NULL,\n    entity_id UUID,\n    flow_instance TEXT,\n    scope_key TEXT,\n    scope TEXT NOT NULL DEFAULT 'global',\n    conversation JSONB NOT NULL DEFAULT '[]',\n    turn_count INTEGER NOT NULL DEFAULT 0,\n    runtime_mode TEXT NOT NULL DEFAULT 'task',\n    runtime_state JSONB NOT NULL DEFAULT '{}',\n    run_id UUID REFERENCES runs(run_id),\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\nCREATE INDEX IF NOT EXISTS idx_audits_run ON agent_conversation_audits (run_id, created_at) WHERE run_id IS NOT NULL;",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(agent_conversation_audits dependent ddl): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(agent_conversation_audits dependent ddl): %v", err)
+	}
+
+	var (
+		hasRunID  bool
+		indexName string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_conversation_audits' AND column_name = 'run_id'
+		)
+	`).Scan(&hasRunID); err != nil {
+		t.Fatalf("check run_id column: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(to_regclass('idx_audits_run')::text, '')`).Scan(&indexName); err != nil {
+		t.Fatalf("check idx_audits_run: %v", err)
+	}
+	if !hasRunID {
+		t.Fatal("run_id column missing after EnsureSchemaTables")
+	}
+	if indexName != "idx_audits_run" {
+		t.Fatalf("idx_audits_run regclass = %q, want idx_audits_run", indexName)
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_PhasesEntitySubjectIDCompatibilityBeforeDependentDDL(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS entity_state CASCADE`); err != nil {
+		t.Fatalf("drop entity_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE entity_state (
+			entity_id UUID PRIMARY KEY
+		)
+	`); err != nil {
+		t.Fatalf("create legacy entity_state: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"entity_state": {
+			DDL: "CREATE TABLE IF NOT EXISTS entity_state (\n    entity_id UUID PRIMARY KEY,\n    subject_id UUID\n);\nCREATE INDEX IF NOT EXISTS idx_entity_subject ON entity_state(subject_id) WHERE subject_id IS NOT NULL;",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(entity_state dependent ddl): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(entity_state dependent ddl): %v", err)
+	}
+
+	var (
+		hasSubjectID bool
+		indexName    string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'entity_state' AND column_name = 'subject_id'
+		)
+	`).Scan(&hasSubjectID); err != nil {
+		t.Fatalf("check subject_id column: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(to_regclass('idx_entity_subject')::text, '')`).Scan(&indexName); err != nil {
+		t.Fatalf("check idx_entity_subject: %v", err)
+	}
+	if !hasSubjectID {
+		t.Fatal("subject_id column missing after EnsureSchemaTables")
+	}
+	if indexName != "idx_entity_subject" {
+		t.Fatalf("idx_entity_subject regclass = %q, want idx_entity_subject", indexName)
+	}
+}
+
 func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurnsSupportsResetAll(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -143,6 +143,158 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRo
 	}
 }
 
+func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeDependentDDL(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
+		t.Fatalf("drop agent_sessions: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agent_sessions (
+			session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			agent_id TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope_key TEXT NOT NULL,
+			scope TEXT NOT NULL DEFAULT 'entity',
+			conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			runtime_mode TEXT NOT NULL DEFAULT 'session',
+			runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+			lease_holder TEXT,
+			lease_expires_at TIMESTAMPTZ,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (agent_id, scope_key)
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agent_sessions: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agent_sessions": {
+			DDL: "CREATE TABLE IF NOT EXISTS agent_sessions (\n    session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    agent_id TEXT NOT NULL,\n    entity_id UUID,\n    flow_instance TEXT,\n    scope_key TEXT NOT NULL,\n    scope TEXT NOT NULL DEFAULT 'entity',\n    conversation JSONB NOT NULL DEFAULT '[]',\n    turn_count INTEGER NOT NULL DEFAULT 0,\n    runtime_mode TEXT NOT NULL DEFAULT 'session',\n    runtime_state JSONB NOT NULL DEFAULT '{}',\n    lease_holder TEXT,\n    lease_expires_at TIMESTAMPTZ,\n    status TEXT NOT NULL DEFAULT 'active',\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\nCREATE INDEX IF NOT EXISTS idx_sessions_terminated_reason ON agent_sessions (termination_reason, terminated_at) WHERE status = 'terminated';",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(agent_sessions dependent ddl): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(agent_sessions dependent ddl): %v", err)
+	}
+
+	var (
+		hasTerminationReason bool
+		hasTerminatedAt      bool
+		indexName            string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_sessions' AND column_name = 'termination_reason'
+		)
+	`).Scan(&hasTerminationReason); err != nil {
+		t.Fatalf("check termination_reason column: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_sessions' AND column_name = 'terminated_at'
+		)
+	`).Scan(&hasTerminatedAt); err != nil {
+		t.Fatalf("check terminated_at column: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(to_regclass('idx_sessions_terminated_reason')::text, '')`).Scan(&indexName); err != nil {
+		t.Fatalf("check idx_sessions_terminated_reason: %v", err)
+	}
+	if !hasTerminationReason || !hasTerminatedAt {
+		t.Fatalf("termination metadata columns missing: termination_reason=%v terminated_at=%v", hasTerminationReason, hasTerminatedAt)
+	}
+	if indexName != "idx_sessions_terminated_reason" {
+		t.Fatalf("idx_sessions_terminated_reason regclass = %q, want idx_sessions_terminated_reason", indexName)
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_PhasesAgentRuntimeDescriptorCompatibilityBeforeDependentDDL(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agents CASCADE`); err != nil {
+		t.Fatalf("drop agents: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agents (
+			agent_id TEXT PRIMARY KEY,
+			flow_instance TEXT,
+			role TEXT NOT NULL,
+			model_tier TEXT NOT NULL,
+			llm_backend TEXT NOT NULL DEFAULT 'api',
+			conversation_mode TEXT NOT NULL,
+			parent_agent_id TEXT,
+			entity_id UUID,
+			config JSONB NOT NULL DEFAULT '{}'::jsonb,
+			subscriptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+			emit_events JSONB NOT NULL DEFAULT '[]'::jsonb,
+			tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+			permissions JSONB NOT NULL DEFAULT '[]'::jsonb,
+			status TEXT NOT NULL DEFAULT 'active',
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			last_active_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agents: %v", err)
+	}
+
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"agents": {
+			DDL: "CREATE TABLE IF NOT EXISTS agents (\n    agent_id TEXT PRIMARY KEY,\n    flow_instance TEXT,\n    role TEXT NOT NULL,\n    model_tier TEXT NOT NULL,\n    llm_backend TEXT NOT NULL DEFAULT 'api',\n    conversation_mode TEXT NOT NULL,\n    parent_agent_id TEXT,\n    entity_id UUID,\n    config JSONB NOT NULL DEFAULT '{}',\n    subscriptions JSONB NOT NULL DEFAULT '[]',\n    emit_events JSONB NOT NULL DEFAULT '[]',\n    tools JSONB NOT NULL DEFAULT '[]',\n    permissions JSONB NOT NULL DEFAULT '[]',\n    runtime_descriptor JSONB NOT NULL DEFAULT '{}',\n    status TEXT NOT NULL DEFAULT 'active',\n    turn_count INTEGER NOT NULL DEFAULT 0,\n    last_active_at TIMESTAMPTZ,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\nCREATE INDEX IF NOT EXISTS idx_agents_runtime_descriptor ON agents USING GIN (runtime_descriptor);",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(agents dependent ddl): %v", err)
+	}
+	if err := pg.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(agents dependent ddl): %v", err)
+	}
+
+	var (
+		hasRuntimeDescriptor bool
+		indexName            string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agents' AND column_name = 'runtime_descriptor'
+		)
+	`).Scan(&hasRuntimeDescriptor); err != nil {
+		t.Fatalf("check runtime_descriptor column: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(to_regclass('idx_agents_runtime_descriptor')::text, '')`).Scan(&indexName); err != nil {
+		t.Fatalf("check idx_agents_runtime_descriptor: %v", err)
+	}
+	if !hasRuntimeDescriptor {
+		t.Fatal("runtime_descriptor column missing after EnsureSchemaTables")
+	}
+	if indexName != "idx_agents_runtime_descriptor" {
+		t.Fatalf("idx_agents_runtime_descriptor regclass = %q, want idx_agents_runtime_descriptor", indexName)
+	}
+}
+
 func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurnsSupportsResetAll(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #296

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_termination_metadata`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.tables.agent_sessions`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.tables.agents`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.notes.migrations`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: test_bootstrap.bootstrap_function`

## Human Summary
This PR fixes the platform-table DDL ordering bug in `EnsureSchemaTables()`. The scheduler now applies additive compatibility prerequisites before replaying spec-generated platform-table DDL for already-existing legacy-compatible tables, then reruns the compatibility upgrader afterward for newly created or residual additive work. That closes the reported `agent_sessions` startup failure and the broader ordering class in this seam.

## What Changed
- changed `PostgresStore.EnsureSchemaTables(...)` to phase platform-table compatibility prerequisites before executing spec-generated platform-table statements
- kept a post-DDL compatibility pass so newly created platform tables and residual additive compatibility work still converge to the canonical shape
- left entity/node-state DDL scheduling unchanged because this issue is specifically about authoritative platform-table ordering
- added deterministic regressions for:
  - legacy-shaped `agent_sessions` plus newer dependent spec DDL on `termination_reason` / `terminated_at`
  - legacy-shaped `agents` plus newer dependent spec DDL on `runtime_descriptor`

## Why This Is Needed
`CREATE TABLE IF NOT EXISTS` is a no-op on an existing legacy table. Before this PR, `EnsureSchemaTables()` could then run newer spec-generated dependent statements immediately, even if the columns they referenced only arrived later via additive compatibility migration. That ordering is unsafe for authoritative platform tables and can abort startup before readiness.

## Scope Boundaries
- in scope: platform-table DDL scheduling order in `EnsureSchemaTables()` and nearby compatibility prerequisite sequencing
- in scope: generic ordering-class regressions in the store seam
- out of scope: contract-specific allowances, destructive table recreation, or unrelated store/runtime cleanup

## Tests Run
- `go test ./internal/store -run 'TestPostgresStore_EnsureSchemaTables_Phases(AgentSessionCompatibilityBeforeDependentDDL|AgentRuntimeDescriptorCompatibilityBeforeDependentDDL)$' -count=1`
- `go test ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
No known residual risk remains in the touched platform-table DDL ordering seam. The scheduler now applies one durable prerequisite-before-dependent-DDL rule for platform-table plans instead of relying on the later compatibility pass to rescue existing legacy tables.

## Follow-Up
- none identified at current audit depth