### PR TITLE
[agent-c][issue #300] Add mutation-surface completeness invariants

### DIFF
--- a/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
+++ b/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
@@ -1063,13 +1063,6 @@ Improvement items:
 
 Current extracted slices:
 
-- `#300` first slice: canonical mutation-proof completeness for reconstructable tracked `entity_state` from persisted `entity_mutations`
-  - closure target: touched seam canonicalized
-  - current same-concept consumers in that slice:
-    - conformance tracked-state reconstruction
-    - pipeline mutation-log tracked-state reconstruction
-  - remaining broader family work stays separate unless later sweeps find another live same-concept reconstruction consumer
-
 ### Entity state changes occur but `entity_mutations` stays empty
 
 Symptoms:

--- a/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
+++ b/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
@@ -1061,6 +1061,15 @@ Improvement items:
 - add a drift-detection command or test path that reconstructs entity state from `entity_mutations` and compares it to `entity_state`
 - treat any write path that bypasses mutation logging as a correctness bug, not observability debt
 
+Current extracted slices:
+
+- `#300` first slice: canonical mutation-proof completeness for reconstructable tracked `entity_state` from persisted `entity_mutations`
+  - closure target: touched seam canonicalized
+  - current same-concept consumers in that slice:
+    - conformance tracked-state reconstruction
+    - pipeline mutation-log tracked-state reconstruction
+  - remaining broader family work stays separate unless later sweeps find another live same-concept reconstruction consumer
+
 ### Entity state changes occur but `entity_mutations` stays empty
 
 Symptoms:

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -87,6 +87,7 @@ nodes:
     known_manifestations:
       - conversation and turn APIs widen typed persisted data
       - summary/runtime-log/mutation completeness may be inferred or silently omitted
+      - mutation-surface reconstruction can silently tolerate malformed persisted `entity_mutations` proof in touched conformance/read-model seams
     representative_issues:
       - 134
       - 224

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimesemanticview "swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
@@ -448,7 +450,9 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrite
 		t.Fatalf("update workflow instance: %v", err)
 	}
 
-	assertTrackedMutationStateMatchesEntityState(t, db, entityID)
+	if err := trackedMutationStateMatchesEntityState(db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(workflow): %v", err)
+	}
 }
 
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t *testing.T) {
@@ -476,7 +480,46 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t 
 		t.Fatalf("save_entity_field: %v", err)
 	}
 
-	assertTrackedMutationStateMatchesEntityState(t, db, entityID)
+	if err := trackedMutationStateMatchesEntityState(db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(tool): %v", err)
+	}
+}
+
+func TestCanonicalMutationSurface_FailsOnMalformedCanonicalMutationField(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+
+	requireMutationSurface(t, db)
+
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			entity_id, flow_instance, entity_type, current_state, gates, fields, accumulator
+		)
+		VALUES (
+			$1::uuid, 'mutation-flow/inst-1', 'default', 'queued', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb
+		)
+	`, entityID); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id) VALUES ($1::uuid)`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, writer_type, writer_id, handler_step
+		) VALUES (
+			$1::uuid, $2::uuid, 'gates.', 'null'::jsonb, 'true'::jsonb, 'platform', 'test', 'seed'
+		)
+	`, runID, entityID); err != nil {
+		t.Fatalf("seed malformed mutation: %v", err)
+	}
+
+	err := trackedMutationStateMatchesEntityState(db, entityID)
+	if err == nil || !strings.Contains(err.Error(), "gates mutation key is required") {
+		t.Fatalf("trackedMutationStateMatchesEntityState error = %v, want malformed gates failure", err)
+	}
 }
 
 func requireCanonicalConversationSurface(t *testing.T, ctx context.Context, pg *store.PostgresStore) {
@@ -563,15 +606,7 @@ func countTurnSummaryBlocks(blocks []dashboardserver.ConversationTurnBlock) int 
 	return count
 }
 
-type trackedMutationState struct {
-	CurrentState string         `json:"current_state"`
-	Fields       map[string]any `json:"fields"`
-	Gates        map[string]any `json:"gates"`
-	Accumulator  map[string]any `json:"accumulator"`
-}
-
-func assertTrackedMutationStateMatchesEntityState(t *testing.T, db *sql.DB, entityID string) {
-	t.Helper()
+func trackedMutationStateMatchesEntityState(db *sql.DB, entityID string) error {
 	var (
 		currentState string
 		fieldsRaw    []byte
@@ -587,20 +622,26 @@ func assertTrackedMutationStateMatchesEntityState(t *testing.T, db *sql.DB, enti
 		FROM entity_state
 		WHERE entity_id = $1::uuid
 	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw); err != nil {
-		t.Fatalf("load entity_state projection: %v", err)
+		return fmt.Errorf("load entity_state projection: %w", err)
 	}
 
-	want := trackedMutationState{
+	want := runtimemutationlog.EntityStateProjection{
 		CurrentState: strings.TrimSpace(currentState),
-		Fields:       decodeJSONMap(t, fieldsRaw),
-		Gates:        decodeJSONMap(t, gatesRaw),
-		Accumulator:  decodeJSONMap(t, accRaw),
+		Fields:       map[string]any{},
+		Gates:        map[string]any{},
+		Accumulator:  map[string]any{},
 	}
-	got := trackedMutationState{
-		Fields:      map[string]any{},
-		Gates:       map[string]any{},
-		Accumulator: map[string]any{},
+	var err error
+	if want.Fields, err = decodeJSONMapErr(fieldsRaw); err != nil {
+		return fmt.Errorf("decode entity_state fields: %w", err)
 	}
+	if want.Gates, err = decodeJSONMapErr(gatesRaw); err != nil {
+		return fmt.Errorf("decode entity_state gates: %w", err)
+	}
+	if want.Accumulator, err = decodeJSONMapErr(accRaw); err != nil {
+		return fmt.Errorf("decode entity_state accumulator: %w", err)
+	}
+	records := make([]runtimemutationlog.ProjectionMutation, 0, 8)
 
 	rows, err := db.QueryContext(context.Background(), `
 		SELECT field, new_value
@@ -609,7 +650,7 @@ func assertTrackedMutationStateMatchesEntityState(t *testing.T, db *sql.DB, enti
 		ORDER BY created_at ASC, mutation_id ASC
 	`, entityID)
 	if err != nil {
-		t.Fatalf("query mutations: %v", err)
+		return fmt.Errorf("query mutations: %w", err)
 	}
 	defer rows.Close()
 
@@ -621,87 +662,75 @@ func assertTrackedMutationStateMatchesEntityState(t *testing.T, db *sql.DB, enti
 			newValue []byte
 		)
 		if err := rows.Scan(&field, &newValue); err != nil {
-			t.Fatalf("scan mutation: %v", err)
+			return fmt.Errorf("scan mutation: %w", err)
 		}
-		applyTrackedMutation(&got, strings.TrimSpace(field), decodeJSONValue(t, newValue))
+		value, err := decodeJSONValueErr(newValue)
+		if err != nil {
+			return fmt.Errorf("decode mutation value: %w", err)
+		}
+		records = append(records, runtimemutationlog.ProjectionMutation{
+			Field:    strings.TrimSpace(field),
+			NewValue: value,
+		})
 	}
 	if err := rows.Err(); err != nil {
-		t.Fatalf("read mutations: %v", err)
+		return fmt.Errorf("read mutations: %w", err)
 	}
 	if rowCount == 0 {
-		t.Fatal("entity_mutations is empty; canonical mutation surface is missing")
+		return fmt.Errorf("entity_mutations is empty; canonical mutation surface is missing")
+	}
+	got, err := runtimemutationlog.ReconstructEntityStateProjection(records)
+	if err != nil {
+		return fmt.Errorf("reconstruct mutation state: %w", err)
 	}
 	if !trackedStatesEqual(got, want) {
-		t.Fatalf("mutation reconstruction mismatch:\n got=%s\nwant=%s", mustCanonicalJSON(t, got), mustCanonicalJSON(t, want))
+		return fmt.Errorf("mutation reconstruction mismatch:\n got=%s\nwant=%s", mustCanonicalJSON(nil, got), mustCanonicalJSON(nil, want))
 	}
+	return nil
 }
 
-func applyTrackedMutation(state *trackedMutationState, field string, value any) {
-	if state == nil {
-		return
-	}
-	switch {
-	case field == "current_state":
-		state.CurrentState = strings.TrimSpace(readString(value))
-	case strings.HasPrefix(field, "gates."):
-		key := strings.TrimSpace(strings.TrimPrefix(field, "gates."))
-		if key == "" {
-			return
-		}
-		if value == nil {
-			delete(state.Gates, key)
-			return
-		}
-		state.Gates[key] = value
-	case strings.HasPrefix(field, "accumulator."):
-		key := strings.TrimSpace(strings.TrimPrefix(field, "accumulator."))
-		if key == "" {
-			return
-		}
-		if value == nil {
-			delete(state.Accumulator, key)
-			return
-		}
-		state.Accumulator[key] = value
-	default:
-		key := strings.TrimSpace(field)
-		if key == "" {
-			return
-		}
-		if value == nil {
-			delete(state.Fields, key)
-			return
-		}
-		state.Fields[key] = value
-	}
-}
-
-func trackedStatesEqual(left, right trackedMutationState) bool {
+func trackedStatesEqual(left, right runtimemutationlog.EntityStateProjection) bool {
 	return mustCanonicalJSON(nil, left) == mustCanonicalJSON(nil, right)
 }
 
 func decodeJSONMap(t *testing.T, raw []byte) map[string]any {
 	t.Helper()
-	if len(raw) == 0 {
-		return map[string]any{}
-	}
-	out := map[string]any{}
-	if err := json.Unmarshal(raw, &out); err != nil {
+	out, err := decodeJSONMapErr(raw)
+	if err != nil {
 		t.Fatalf("json.Unmarshal map: %v", err)
 	}
 	return out
 }
 
+func decodeJSONMapErr(raw []byte) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func decodeJSONValue(t *testing.T, raw []byte) any {
 	t.Helper()
-	if len(raw) == 0 {
-		return nil
-	}
-	var out any
-	if err := json.Unmarshal(raw, &out); err != nil {
+	out, err := decodeJSONValueErr(raw)
+	if err != nil {
 		t.Fatalf("json.Unmarshal value: %v", err)
 	}
 	return out
+}
+
+func decodeJSONValueErr(raw []byte) (any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func mustCanonicalJSON(t *testing.T, value any) string {

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -45,6 +45,11 @@ type EntityStateProjection struct {
 	Accumulator  map[string]any
 }
 
+type ProjectionMutation struct {
+	Field    string
+	NewValue any
+}
+
 func Insert(ctx context.Context, db DBTX, rec Record) error {
 	if db == nil {
 		return ErrInvalidMutationLogWriter("mutation log DB is required")
@@ -149,6 +154,45 @@ func InsertEntityStateDiff(ctx context.Context, db DBTX, entityID string, before
 	return nil
 }
 
+func ReconstructEntityStateProjection(records []ProjectionMutation) (EntityStateProjection, error) {
+	state := EntityStateProjection{
+		Fields:      map[string]any{},
+		Gates:       map[string]any{},
+		Accumulator: map[string]any{},
+	}
+	for _, rec := range records {
+		if err := ApplyEntityStateProjectionMutation(&state, rec.Field, rec.NewValue); err != nil {
+			return EntityStateProjection{}, err
+		}
+	}
+	return state, nil
+}
+
+func ApplyEntityStateProjectionMutation(state *EntityStateProjection, field string, value any) error {
+	if state == nil {
+		return ErrInvalidMutationLogWriter("projection state is required")
+	}
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return ErrInvalidMutationLogWriter("mutation field is required")
+	}
+	switch {
+	case field == "current_state":
+		next, ok := value.(string)
+		if !ok {
+			return ErrInvalidMutationLogWriter("current_state mutation value must be a string")
+		}
+		state.CurrentState = strings.TrimSpace(next)
+		return nil
+	case strings.HasPrefix(field, "gates."):
+		return applyProjectionMapValue(state.ensureGates(), strings.TrimPrefix(field, "gates."), value, "gates")
+	case strings.HasPrefix(field, "accumulator."):
+		return applyProjectionMapValue(state.ensureAccumulator(), strings.TrimPrefix(field, "accumulator."), value, "accumulator")
+	default:
+		return applyProjectionMapValue(state.ensureFields(), field, value, "fields")
+	}
+}
+
 func diffMapRecords(entityID, prefix string, before, after map[string]any, writerType, writerID, handlerStep string) ([]Record, error) {
 	keys := make([]string, 0, len(before)+len(after))
 	seen := map[string]struct{}{}
@@ -223,6 +267,43 @@ func stringOrNil(raw string) any {
 		return nil
 	}
 	return raw
+}
+
+func (p *EntityStateProjection) ensureFields() map[string]any {
+	if p.Fields == nil {
+		p.Fields = map[string]any{}
+	}
+	return p.Fields
+}
+
+func (p *EntityStateProjection) ensureGates() map[string]any {
+	if p.Gates == nil {
+		p.Gates = map[string]any{}
+	}
+	return p.Gates
+}
+
+func (p *EntityStateProjection) ensureAccumulator() map[string]any {
+	if p.Accumulator == nil {
+		p.Accumulator = map[string]any{}
+	}
+	return p.Accumulator
+}
+
+func applyProjectionMapValue(target map[string]any, key string, value any, bucket string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		if bucket == "" {
+			return ErrInvalidMutationLogWriter("mutation field is required")
+		}
+		return ErrInvalidMutationLogWriter(fmt.Sprintf("%s mutation key is required", strings.TrimSpace(bucket)))
+	}
+	if value == nil {
+		delete(target, key)
+		return nil
+	}
+	target[key] = value
+	return nil
 }
 
 func normalizeRunID(runID string) string {

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -1,0 +1,51 @@
+package mutationlog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReconstructEntityStateProjection_FailsOnMalformedGateKey(t *testing.T) {
+	_, err := ReconstructEntityStateProjection([]ProjectionMutation{{
+		Field:    "gates.",
+		NewValue: true,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "gates mutation key is required") {
+		t.Fatalf("ReconstructEntityStateProjection error = %v", err)
+	}
+}
+
+func TestReconstructEntityStateProjection_FailsOnMalformedAccumulatorKey(t *testing.T) {
+	_, err := ReconstructEntityStateProjection([]ProjectionMutation{{
+		Field:    "accumulator.",
+		NewValue: map[string]any{"bad": true},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "accumulator mutation key is required") {
+		t.Fatalf("ReconstructEntityStateProjection error = %v", err)
+	}
+}
+
+func TestReconstructEntityStateProjection_RoundTripsTrackedEntityState(t *testing.T) {
+	got, err := ReconstructEntityStateProjection([]ProjectionMutation{
+		{Field: "current_state", NewValue: "done"},
+		{Field: "status", NewValue: "closed"},
+		{Field: "gates.g_done", NewValue: true},
+		{Field: "accumulator.evidence", NewValue: map[string]any{"score": float64(2)}},
+	})
+	if err != nil {
+		t.Fatalf("ReconstructEntityStateProjection: %v", err)
+	}
+	if got.CurrentState != "done" {
+		t.Fatalf("CurrentState = %q", got.CurrentState)
+	}
+	if got.Fields["status"] != "closed" {
+		t.Fatalf("Fields = %#v", got.Fields)
+	}
+	if got.Gates["g_done"] != true {
+		t.Fatalf("Gates = %#v", got.Gates)
+	}
+	acc, _ := got.Accumulator["evidence"].(map[string]any)
+	if acc["score"] != float64(2) {
+		t.Fatalf("Accumulator = %#v", got.Accumulator)
+	}
+}

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	"swarm/internal/testutil"
 )
 
@@ -137,7 +139,9 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		}
 	}
 
-	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(upsert): %v", err)
+	}
 }
 
 func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
@@ -154,7 +158,9 @@ func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
 	if !containsMutationField(fields, "gates.g_ready") {
 		t.Fatalf("mutation fields missing gates.g_ready: %v", fields)
 	}
-	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(gate): %v", err)
+	}
 }
 
 func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
@@ -171,7 +177,35 @@ func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
 	if !containsMutationField(fields, "accumulator.evidence") {
 		t.Fatalf("mutation fields missing accumulator.evidence: %v", fields)
 	}
-	assertMutationLogMatchesTrackedEntityState(t, db, entityID)
+	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(evidence): %v", err)
+	}
+}
+
+func TestMutationLogTrackedStateFailsOnMalformedCanonicalMutationField(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	entityID := uuid.NewString()
+	pc := testMutationLoggingCoordinator(db)
+	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
+
+	var runID string
+	if err := db.QueryRowContext(context.Background(), `SELECT run_id::text FROM runs ORDER BY started_at DESC LIMIT 1`).Scan(&runID); err != nil {
+		t.Fatalf("load run_id: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, writer_type, writer_id, handler_step
+		) VALUES (
+			$1::uuid, $2::uuid, 'accumulator.', 'null'::jsonb, '{"bad":true}'::jsonb, 'platform', 'test', 'seed'
+		)
+	`, runID, entityID); err != nil {
+		t.Fatalf("seed malformed mutation: %v", err)
+	}
+
+	err := trackedMutationStateMatchesEntityState(t, db, entityID)
+	if err == nil || !strings.Contains(err.Error(), "accumulator mutation key is required") {
+		t.Fatalf("trackedMutationStateMatchesEntityState error = %v, want malformed accumulator failure", err)
+	}
 }
 
 func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *testing.T) {
@@ -325,7 +359,7 @@ func mutationFieldsForEntity(t *testing.T, db *sql.DB, entityID string) []string
 	return out
 }
 
-func assertMutationLogMatchesTrackedEntityState(t *testing.T, db *sql.DB, entityID string) {
+func trackedMutationStateMatchesEntityState(t *testing.T, db *sql.DB, entityID string) error {
 	t.Helper()
 	var (
 		currentState string
@@ -342,20 +376,16 @@ func assertMutationLogMatchesTrackedEntityState(t *testing.T, db *sql.DB, entity
 		FROM entity_state
 		WHERE entity_id = $1::uuid
 	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw); err != nil {
-		t.Fatalf("load entity_state projection: %v", err)
+		return fmt.Errorf("load entity_state projection: %w", err)
 	}
 
-	want := trackedMutationState{
+	want := runtimemutationlog.EntityStateProjection{
 		CurrentState: strings.TrimSpace(currentState),
 		Fields:       decodeJSONMap(t, fieldsRaw),
 		Gates:        decodeJSONMap(t, gatesRaw),
 		Accumulator:  decodeJSONMap(t, accRaw),
 	}
-	got := trackedMutationState{
-		Fields:      map[string]any{},
-		Gates:       map[string]any{},
-		Accumulator: map[string]any{},
-	}
+	records := make([]runtimemutationlog.ProjectionMutation, 0, 8)
 	rows, err := db.QueryContext(context.Background(), `
 		SELECT field, old_value, new_value
 		FROM entity_mutations
@@ -363,7 +393,7 @@ func assertMutationLogMatchesTrackedEntityState(t *testing.T, db *sql.DB, entity
 		ORDER BY created_at ASC, mutation_id ASC
 	`, entityID)
 	if err != nil {
-		t.Fatalf("query mutations: %v", err)
+		return fmt.Errorf("query mutations: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -373,52 +403,25 @@ func assertMutationLogMatchesTrackedEntityState(t *testing.T, db *sql.DB, entity
 			newValue []byte
 		)
 		if err := rows.Scan(&field, &oldValue, &newValue); err != nil {
-			t.Fatalf("scan mutation: %v", err)
+			return fmt.Errorf("scan mutation: %w", err)
 		}
-		applyTrackedMutation(&got, strings.TrimSpace(field), decodeJSONValue(t, newValue))
+		records = append(records, runtimemutationlog.ProjectionMutation{
+			Field:    strings.TrimSpace(field),
+			NewValue: decodeJSONValue(t, newValue),
+		})
 	}
 	if err := rows.Err(); err != nil {
-		t.Fatalf("read mutations: %v", err)
+		return fmt.Errorf("read mutations: %w", err)
+	}
+	got, err := runtimemutationlog.ReconstructEntityStateProjection(records)
+	if err != nil {
+		return fmt.Errorf("reconstruct mutation state: %w", err)
 	}
 
 	if !trackedStatesEqual(got, want) {
-		t.Fatalf("mutation reconstruction mismatch:\n got=%s\nwant=%s", mustCanonicalJSON(t, got), mustCanonicalJSON(t, want))
+		return fmt.Errorf("mutation reconstruction mismatch:\n got=%s\nwant=%s", mustCanonicalJSON(t, got), mustCanonicalJSON(t, want))
 	}
-}
-
-type trackedMutationState struct {
-	CurrentState string         `json:"current_state"`
-	Fields       map[string]any `json:"fields"`
-	Gates        map[string]any `json:"gates"`
-	Accumulator  map[string]any `json:"accumulator"`
-}
-
-func applyTrackedMutation(state *trackedMutationState, field string, value any) {
-	if state == nil {
-		return
-	}
-	switch {
-	case field == "current_state":
-		state.CurrentState = strings.TrimSpace(trackedAsString(value))
-	case strings.HasPrefix(field, "gates."):
-		applyTrackedMapValue(state.Gates, strings.TrimPrefix(field, "gates."), value)
-	case strings.HasPrefix(field, "accumulator."):
-		applyTrackedMapValue(state.Accumulator, strings.TrimPrefix(field, "accumulator."), value)
-	default:
-		applyTrackedMapValue(state.Fields, field, value)
-	}
-}
-
-func applyTrackedMapValue(target map[string]any, key string, value any) {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return
-	}
-	if value == nil {
-		delete(target, key)
-		return
-	}
-	target[key] = value
+	return nil
 }
 
 func decodeJSONMap(t *testing.T, raw []byte) map[string]any {
@@ -448,7 +451,7 @@ func decodeJSONValue(t *testing.T, raw []byte) any {
 	return out
 }
 
-func trackedStatesEqual(left, right trackedMutationState) bool {
+func trackedStatesEqual(left, right runtimemutationlog.EntityStateProjection) bool {
 	return mustCanonicalJSONForCompare(left) == mustCanonicalJSONForCompare(right)
 }
 
@@ -469,13 +472,4 @@ func containsMutationField(items []string, want string) bool {
 		}
 	}
 	return false
-}
-
-func trackedAsString(v any) string {
-	switch typed := v.(type) {
-	case string:
-		return typed
-	default:
-		return ""
-	}
 }


### PR DESCRIPTION
Closes #300

## Human Summary
This PR closes the first mutation-surface completeness slice extracted from `#168`. It introduces one shared canonical reconstruction/completeness owner for persisted `entity_mutations`, moves the two same-concept reconstruction consumers onto it, and makes malformed canonical mutation proof fail closed instead of being silently ignored.

## Spec refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_mutations`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: mutation_log`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_state`

## What Changed
- added a shared reconstruction/completeness owner in `internal/runtime/mutationlog/mutationlog.go` for tracked entity-state proof from persisted `entity_mutations`
- moved conformance mutation-surface reconstruction in `internal/runtime/conformance/persisted_surfaces_test.go` onto that shared owner
- moved pipeline mutation-log tracked-state verification in `internal/runtime/pipeline/mutation_logging_test.go` onto that same shared owner
- added fail-closed malformed-field-path regressions for canonical mutation proof
- added direct unit coverage for the new shared mutation reconstruction owner

## Why This Is Needed
Before this PR, the first same-concept mutation completeness consumers still used duplicated local reconstruction helpers. Those helpers could silently ignore malformed persisted mutation rows such as `gates.` or `accumulator.` and still report a healthy mutation surface. That left canonical mutation proof incomplete while conformance-style reconstruction looked fine.

## Scope Boundaries
In scope:
- canonical mutation-proof completeness for reconstructable tracked `entity_state` from persisted `entity_mutations`
- the first two same-concept reconstruction consumers found by repo sweep

Out of scope:
- turn-summary completeness (closed by `#285`)
- runtime-log row completeness (closed by `#291`)
- runtime-log turn-block completeness (closed by `#293`)
- broader mutation-log writer redesign
- broader operator/query APIs over mutation timelines

## Tests Run
- `go test ./internal/runtime/mutationlog -count=1`
- `go test ./internal/runtime/conformance -run 'TestCanonicalMutationSurface_(ReconstructsTrackedEntityStateForWorkflowWrites|ReconstructsTrackedEntityStateForToolWrites|FailsOnMalformedCanonicalMutationField)$' -count=1`
- `go test ./internal/runtime/pipeline -run 'Test(WorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLog|ApplyWorkflowGateMutation_LogsMutationRow|RecordWorkflowEvidence_LogsMutationRow|MutationLogTrackedStateFailsOnMalformedCanonicalMutationField|MutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable)$' -count=1`
- `go test ./internal/runtime/mutationlog ./internal/runtime/conformance ./internal/runtime/pipeline -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR canonicalizes the first bounded reconstruction/proof seam only. It does not claim that every mutation-log consumer or every write-path completeness manifestation in the broader watchlist family is now closed.

## Follow-Up
No immediate same-concept consumer remains live in this first slice after the repo sweep. Broader mutation-log family work should continue as separate extracted issues if new same-concept consumers or uncovered write-path manifestations are found.
