### PR TITLE
[agent-d][issue #177] Add structured emit tool outcome diagnostics

### DIFF
--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -221,6 +221,9 @@ func (e *Executor) Execute(ctx context.Context, name string, input any) (any, er
 	input = normalizeRuntimeToolInput(name, input)
 	start := time.Now()
 	out, err := e.dispatchTool(ctx, actor, name, input)
+	if isEmitToolName(name) {
+		return out, err
+	}
 	e.emitToolExecutionEvent(ctx, actor, name, input, out, err, time.Since(start), "dispatch")
 	return out, err
 }
@@ -502,6 +505,17 @@ func decodeToolInput(input any, out any) error {
 		return fmt.Errorf("decode input: %w", err)
 	}
 	return nil
+}
+
+func diagnosticPayloadMap(input any) map[string]any {
+	payload := map[string]any{}
+	if err := decodeToolInput(input, &payload); err != nil {
+		return nil
+	}
+	if payload == nil {
+		return map[string]any{}
+	}
+	return payload
 }
 
 func (e *Executor) mailboxStoreDependency() (MailboxPersistence, error) {

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -10,13 +10,12 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
 func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig, toolName string, input any) (any, error) {
 	eventType, ok := e.emitRegistry.EventTypeFromToolName(toolName)
 	if !ok {
-		return nil, NewRuntimeError(
+		err := NewRuntimeError(
 			"invalid_emit_tool_name",
 			"tool-executor",
 			"handle_emit_tool.resolve_event_type",
@@ -24,6 +23,8 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 			"invalid emit tool name: %s",
 			toolName,
 		)
+		e.logEmitToolOutcome(ctx, actor, toolName, "", "", nil, nil, events.Event{}, "invalid_emit_tool_name", "payload_shape", "resolve_event_type", err)
+		return nil, err
 	}
 	if e.bus == nil {
 		return nil, NewRuntimeError(
@@ -37,7 +38,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 
 	payloadMap := map[string]any{}
 	if err := decodeToolInput(input, &payloadMap); err != nil {
-		return nil, WrapRuntimeError(
+		wrapped := WrapRuntimeError(
 			"invalid_tool_input",
 			"tool-executor",
 			"handle_emit_tool.decode_input",
@@ -45,18 +46,22 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 			err,
 			"invalid emit tool input",
 		)
+		e.logEmitToolOutcome(ctx, actor, toolName, eventType, eventType, diagnosticPayloadMap(input), nil, events.Event{}, "payload_shape_failed", "payload_shape", "decode_input", wrapped)
+		return nil, wrapped
 	}
 	if payloadMap == nil {
 		payloadMap = map[string]any{}
 	}
+	preValidationPayload := diagnosticPayloadMap(payloadMap)
 	schemaEventType := eventType
 	eventType = e.resolveAgentScopedEmitEventType(actor, eventType)
 
 	inbound, _ := runtimebus.InboundEventFromContext(ctx)
 	payloadMap = e.enrichEmitPayloadContext(actor, inbound, schemaEventType, payloadMap)
 	payloadMap = e.trimEmitPayloadToSchema(schemaEventType, payloadMap)
+	postEnrichmentPayload := diagnosticPayloadMap(payloadMap)
 	if err := e.emitRegistry.ValidateEventPayloadAgainstSchema(schemaEventType, payloadMap); err != nil {
-		return nil, WrapRuntimeError(
+		wrapped := WrapRuntimeError(
 			"schema_validation_failed",
 			"tool-executor",
 			"handle_emit_tool.validate_schema",
@@ -64,27 +69,10 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 			err,
 			"emit payload schema validation failed",
 		)
+		e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, events.Event{}, "schema_validation_failed", "validation", "validate_schema", wrapped)
+		return nil, wrapped
 	}
 
-	entityIDSource := "payload"
-	if strings.TrimSpace(asString(payloadMap["entity_id"])) == "" {
-		switch {
-		case strings.TrimSpace(actor.EffectiveEntityID()) != "":
-			entityIDSource = "actor"
-		case strings.TrimSpace(inbound.EntityID()) != "":
-			entityIDSource = "inbound_event"
-		default:
-			entityIDSource = "none"
-		}
-	}
-	taskIDSource := "payload"
-	if strings.TrimSpace(asString(payloadMap["task_id"])) == "" {
-		if strings.TrimSpace(inbound.TaskID) != "" {
-			taskIDSource = "inbound_event"
-		} else {
-			taskIDSource = "none"
-		}
-	}
 	emitted := (events.Event{
 		ID:          uuid.NewString(),
 		Type:        events.EventType(eventType),
@@ -111,9 +99,8 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		}
 		emitted.Payload = mustJSON(payloadMap)
 	}
-	e.logEmitTargetResolution(ctx, actor, toolName, schemaEventType, eventType, emitted, entityIDSource, taskIDSource)
 	if err := e.bus.Publish(ctx, emitted); err != nil {
-		return nil, WrapRuntimeError(
+		wrapped := WrapRuntimeError(
 			"event_publish_failed",
 			"tool-executor",
 			"handle_emit_tool.publish",
@@ -123,7 +110,10 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 			eventType,
 			emitted.ID,
 		)
+		e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "event_publish_failed", "publish", "publish", wrapped)
+		return nil, wrapped
 	}
+	e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "published", "", "", nil)
 
 	if rec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && rec != nil {
 		rec.Append(emitted)
@@ -133,38 +123,6 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		"event_id":   emitted.ID,
 		"event_type": eventType,
 	}, nil
-}
-
-func (e *Executor) logEmitTargetResolution(ctx context.Context, actor models.AgentConfig, toolName, requestedEventType, resolvedEventType string, emitted events.Event, entityIDSource, taskIDSource string) {
-	if e == nil || e.bus == nil {
-		return
-	}
-	logger, ok := e.bus.(runtimeToolLogSink)
-	if !ok || logger == nil {
-		return
-	}
-	logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
-		Level:     "info",
-		Message:   "Emit tool target was resolved",
-		Component: "tool-executor",
-		Action:    "emit_target_resolved",
-		AgentID:   strings.TrimSpace(actor.ID),
-		EntityID:  strings.TrimSpace(actor.EffectiveEntityID()),
-		Detail: map[string]any{
-			"tool_name":             strings.TrimSpace(toolName),
-			"requested_event_type":  strings.TrimSpace(requestedEventType),
-			"resolved_event_type":   strings.TrimSpace(resolvedEventType),
-			"emitted_event_id":      strings.TrimSpace(emitted.ID),
-			"emitted_event_type":    strings.TrimSpace(string(emitted.Type)),
-			"emitted_entity_id":     strings.TrimSpace(emitted.EntityID()),
-			"emitted_task_id":       strings.TrimSpace(emitted.TaskID),
-			"entity_id_source":      strings.TrimSpace(entityIDSource),
-			"task_id_source":        strings.TrimSpace(taskIDSource),
-			"actor_entity_id":       strings.TrimSpace(actor.EffectiveEntityID()),
-			"inbound_parent_event":  strings.TrimSpace(emitted.ParentEventID),
-			"context_entity_target": strings.TrimSpace(emitted.EntityID()),
-		},
-	})
 }
 
 func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eventType string) string {

--- a/internal/runtime/tools/executor_emit_diagnostics.go
+++ b/internal/runtime/tools/executor_emit_diagnostics.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/events"
+	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/diaglog"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+const emitToolOutcomeAction = "emit_tool_outcome"
+
+func (e *Executor) logEmitToolOutcome(
+	ctx context.Context,
+	actor models.AgentConfig,
+	toolName string,
+	requestedEventType string,
+	resolvedEventType string,
+	preValidationPayload map[string]any,
+	postEnrichmentPayload map[string]any,
+	emitted events.Event,
+	outcome string,
+	failureClass string,
+	failureStage string,
+	execErr error,
+) {
+	logger := e.runtimeLogSink()
+	if logger == nil {
+		return
+	}
+	toolName = normalizeNativeToolName(toolName)
+	requestedEventType = strings.TrimSpace(requestedEventType)
+	resolvedEventType = strings.TrimSpace(resolvedEventType)
+	level := "info"
+	if execErr != nil {
+		level = "warn"
+	}
+	detail := map[string]any{
+		"tool_family":          "emit",
+		"tool_name":            toolName,
+		"requested_event_type": requestedEventType,
+		"resolved_event_type":  resolvedEventType,
+		"outcome":              strings.TrimSpace(outcome),
+		"ok":                   execErr == nil,
+	}
+	if v := strings.TrimSpace(failureClass); v != "" {
+		detail["failure_class"] = v
+	}
+	if v := strings.TrimSpace(failureStage); v != "" {
+		detail["failure_stage"] = v
+	}
+	if pre := safeTelemetryPayloadSnapshot(preValidationPayload); pre != nil {
+		detail["pre_validation_payload"] = pre
+	}
+	if post := safeTelemetryPayloadSnapshot(postEnrichmentPayload); post != nil {
+		detail["post_enrichment_payload"] = post
+	}
+	if v := strings.TrimSpace(emitted.ID); v != "" {
+		detail["emitted_event_id"] = v
+	}
+	if v := strings.TrimSpace(string(emitted.Type)); v != "" {
+		detail["emitted_event_type"] = v
+	}
+	if v := strings.TrimSpace(emitted.EntityID()); v != "" {
+		detail["emitted_entity_id"] = v
+	}
+	if v := strings.TrimSpace(emitted.TaskID); v != "" {
+		detail["emitted_task_id"] = v
+	}
+	if v := strings.TrimSpace(actor.EffectiveEntityID()); v != "" {
+		detail["actor_entity_id"] = v
+	}
+	if runtimeErr, ok := AsRuntimeError(execErr); ok {
+		if v := strings.TrimSpace(runtimeErr.Code); v != "" {
+			detail["runtime_error_code"] = v
+		}
+		if v := strings.TrimSpace(runtimeErr.Operation); v != "" {
+			detail["runtime_error_operation"] = v
+		}
+		if v := strings.TrimSpace(runtimeErr.Component); v != "" {
+			detail["runtime_error_component"] = v
+		}
+		detail["retryable"] = runtimeErr.Retryable
+	}
+	logger.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+		Level:     diaglog.NormalizeLevel(level),
+		Message:   emitToolOutcomeMessage(toolName, outcome, execErr),
+		Component: "tool-executor",
+		Action:    emitToolOutcomeAction,
+		AgentID:   strings.TrimSpace(actor.ID),
+		EntityID:  strings.TrimSpace(actor.EffectiveEntityID()),
+		Detail:    detail,
+		Error:     toolExecErrorText(execErr),
+	})
+}
+
+func emitToolOutcomeMessage(toolName, outcome string, execErr error) string {
+	toolName = strings.TrimSpace(toolName)
+	outcome = strings.TrimSpace(outcome)
+	switch outcome {
+	case "published":
+		if toolName == "" {
+			return "Emit tool published event successfully"
+		}
+		return fmt.Sprintf("Emit tool %s published event successfully", toolName)
+	case "payload_shape_failed":
+		if toolName == "" {
+			return "Emit tool payload shape failed before validation"
+		}
+		return fmt.Sprintf("Emit tool %s payload shape failed before validation", toolName)
+	case "schema_validation_failed":
+		if toolName == "" {
+			return "Emit tool schema validation failed"
+		}
+		return fmt.Sprintf("Emit tool %s schema validation failed", toolName)
+	case "event_publish_failed":
+		if toolName == "" {
+			return "Emit tool publish failed"
+		}
+		return fmt.Sprintf("Emit tool %s publish failed", toolName)
+	case "invalid_emit_tool_name":
+		if toolName == "" {
+			return "Emit tool name was invalid"
+		}
+		return fmt.Sprintf("Emit tool %s was invalid", toolName)
+	default:
+		if execErr == nil {
+			if toolName == "" {
+				return "Emit tool outcome recorded"
+			}
+			return fmt.Sprintf("Emit tool %s outcome recorded", toolName)
+		}
+		if toolName == "" {
+			return "Emit tool failed"
+		}
+		return fmt.Sprintf("Emit tool %s failed", toolName)
+	}
+}
+
+func safeTelemetryPayloadSnapshot(payload map[string]any) any {
+	if len(payload) == 0 {
+		return nil
+	}
+	return RedactTelemetryValue(payload)
+}
+
+func isEmitToolName(toolName string) bool {
+	return strings.HasPrefix(normalizeNativeToolName(toolName), "emit_")
+}

--- a/internal/runtime/tools/executor_emit_diagnostics.go
+++ b/internal/runtime/tools/executor_emit_diagnostics.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -144,7 +145,15 @@ func safeTelemetryPayloadSnapshot(payload map[string]any) any {
 	if len(payload) == 0 {
 		return nil
 	}
-	return RedactTelemetryValue(payload)
+	redacted := RedactTelemetryValue(payload)
+	raw, err := json.Marshal(redacted)
+	if err == nil && len(raw) <= maxToolTelemetryChars {
+		return redacted
+	}
+	return map[string]any{
+		"truncated": true,
+		"summary":   SafeTelemetryText(payload),
+	}
 }
 
 func isEmitToolName(toolName string) bool {

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -401,6 +401,33 @@ func TestExecutorTelemetry_EmitToolLogsPayloadShapeFailureBeforeSchemaValidation
 	}
 }
 
+func TestExecutorTelemetry_EmitToolLogsInvalidEmitToolNameOutcome(t *testing.T) {
+	bus := &telemetryBusStub{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{})
+	actor := models.AgentConfig{ID: "agent-emit-5"}
+
+	if _, err := exec.handleEmitTool(context.Background(), actor, "emit_not_registered", map[string]any{}); err == nil {
+		t.Fatal("expected invalid emit tool name failure")
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	log := bus.logs[0]
+	if log.Action != emitToolOutcomeAction {
+		t.Fatalf("action = %q, want %q", log.Action, emitToolOutcomeAction)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "invalid_emit_tool_name" {
+		t.Fatalf("outcome = %#v, want invalid_emit_tool_name", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_class"])); got != "payload_shape" {
+		t.Fatalf("failure_class = %#v, want payload_shape", detail["failure_class"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "resolve_event_type" {
+		t.Fatalf("failure_stage = %#v, want resolve_event_type", detail["failure_stage"])
+	}
+}
+
 func testTime() time.Time {
 	return time.Unix(1700000000, 0).UTC()
 }

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -3,12 +3,15 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -16,10 +19,15 @@ import (
 )
 
 type telemetryBusStub struct {
-	logs []runtimepipeline.RuntimeLogEntry
+	logs       []runtimepipeline.RuntimeLogEntry
+	publishErr error
+	published  []events.Event
 }
 
-func (*telemetryBusStub) Publish(context.Context, events.Event) error { return nil }
+func (b *telemetryBusStub) Publish(_ context.Context, evt events.Event) error {
+	b.published = append(b.published, evt)
+	return b.publishErr
+}
 
 func (*telemetryBusStub) PublishDirect(context.Context, events.Event, []string) error { return nil }
 
@@ -182,4 +190,217 @@ func TestExecutorTelemetry_LogsExecutionFailure(t *testing.T) {
 	if strings.TrimSpace(log.Error) == "" {
 		t.Fatal("expected error text in runtime log")
 	}
+}
+
+func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) {
+	bus := &telemetryBusStub{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category":  {Type: "string"},
+						"entity_id": {Type: "string"},
+						"task_id":   {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:       "agent-emit-1",
+		EntityID: "entity-actor",
+		EmitEvents: []string{
+			"category.assessed",
+		},
+	})
+	ctx = runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:        "evt-inbound",
+		Type:      events.EventType("trigger.input"),
+		TaskID:    "task-inbound",
+		Payload:   []byte(`{"entity_id":"entity-inbound"}`),
+		CreatedAt: testTime(),
+	}.WithEntityID("entity-inbound"))
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "AP automation"}); err != nil {
+		t.Fatalf("Execute(emit): %v", err)
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	log := bus.logs[0]
+	if log.Action != emitToolOutcomeAction {
+		t.Fatalf("action = %q, want %q", log.Action, emitToolOutcomeAction)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "published" {
+		t.Fatalf("outcome = %#v, want published", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["requested_event_type"])); got != "category.assessed" {
+		t.Fatalf("requested_event_type = %#v, want category.assessed", detail["requested_event_type"])
+	}
+	if got := strings.TrimSpace(asString(detail["resolved_event_type"])); got != "category.assessed" {
+		t.Fatalf("resolved_event_type = %#v, want category.assessed", detail["resolved_event_type"])
+	}
+	pre, _ := detail["pre_validation_payload"].(map[string]any)
+	post, _ := detail["post_enrichment_payload"].(map[string]any)
+	if got := strings.TrimSpace(asString(pre["entity_id"])); got != "" {
+		t.Fatalf("pre_validation entity_id = %#v, want empty", pre["entity_id"])
+	}
+	if got := strings.TrimSpace(asString(post["entity_id"])); got != "entity-actor" {
+		t.Fatalf("post_enrichment entity_id = %#v, want entity-actor", post["entity_id"])
+	}
+	if got := strings.TrimSpace(asString(post["task_id"])); got != "task-inbound" {
+		t.Fatalf("post_enrichment task_id = %#v, want task-inbound", post["task_id"])
+	}
+	if got := strings.TrimSpace(asString(detail["emitted_event_id"])); got == "" {
+		t.Fatal("expected emitted_event_id")
+	}
+}
+
+func TestExecutorTelemetry_EmitToolLogsSchemaValidationFailureSeparatelyFromPublishFailure(t *testing.T) {
+	bus := &telemetryBusStub{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:         "agent-emit-2",
+		EmitEvents: []string{"category.assessed"},
+	})
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{}); err == nil {
+		t.Fatal("expected schema validation failure")
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	detail, _ := bus.logs[0].Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "schema_validation_failed" {
+		t.Fatalf("outcome = %#v, want schema_validation_failed", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_class"])); got != "validation" {
+		t.Fatalf("failure_class = %#v, want validation", detail["failure_class"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "validate_schema" {
+		t.Fatalf("failure_stage = %#v, want validate_schema", detail["failure_stage"])
+	}
+	if _, ok := detail["emitted_event_id"]; ok {
+		t.Fatalf("unexpected emitted_event_id on schema validation failure: %#v", detail["emitted_event_id"])
+	}
+}
+
+func TestExecutorTelemetry_EmitToolLogsPublishFailureWithCanonicalEventIdentity(t *testing.T) {
+	bus := &telemetryBusStub{publishErr: errors.New("publish down")}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:         "agent-emit-3",
+		EmitEvents: []string{"category.assessed"},
+	})
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "finops"}); err == nil {
+		t.Fatal("expected publish failure")
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	log := bus.logs[0]
+	detail, _ := log.Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "event_publish_failed" {
+		t.Fatalf("outcome = %#v, want event_publish_failed", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_class"])); got != "publish" {
+		t.Fatalf("failure_class = %#v, want publish", detail["failure_class"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "publish" {
+		t.Fatalf("failure_stage = %#v, want publish", detail["failure_stage"])
+	}
+	if got := strings.TrimSpace(asString(detail["emitted_event_id"])); got == "" {
+		t.Fatal("expected emitted_event_id on publish failure")
+	}
+	if got := strings.TrimSpace(asString(detail["emitted_event_type"])); got != "category.assessed" {
+		t.Fatalf("emitted_event_type = %#v, want category.assessed", detail["emitted_event_type"])
+	}
+	if strings.TrimSpace(log.Error) == "" {
+		t.Fatal("expected error text on publish failure")
+	}
+}
+
+func TestExecutorTelemetry_EmitToolLogsPayloadShapeFailureBeforeSchemaValidation(t *testing.T) {
+	bus := &telemetryBusStub{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:         "agent-emit-4",
+		EmitEvents: []string{"category.assessed"},
+	})
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", func() {}); err == nil {
+		t.Fatal("expected payload-shape failure")
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	log := bus.logs[0]
+	if log.Action != emitToolOutcomeAction {
+		t.Fatalf("action = %q, want %q", log.Action, emitToolOutcomeAction)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "payload_shape_failed" {
+		t.Fatalf("outcome = %#v, want payload_shape_failed", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_class"])); got != "payload_shape" {
+		t.Fatalf("failure_class = %#v, want payload_shape", detail["failure_class"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "decode_input" {
+		t.Fatalf("failure_stage = %#v, want decode_input", detail["failure_stage"])
+	}
+	if _, ok := detail["post_enrichment_payload"]; ok {
+		t.Fatalf("unexpected post_enrichment_payload on payload-shape failure: %#v", detail["post_enrichment_payload"])
+	}
+	if _, ok := detail["emitted_event_id"]; ok {
+		t.Fatalf("unexpected emitted_event_id on payload-shape failure: %#v", detail["emitted_event_id"])
+	}
+}
+
+func testTime() time.Time {
+	return time.Unix(1700000000, 0).UTC()
 }

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -425,6 +426,52 @@ func TestExecutorTelemetry_EmitToolLogsInvalidEmitToolNameOutcome(t *testing.T) 
 	}
 	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "resolve_event_type" {
 		t.Fatalf("failure_stage = %#v, want resolve_event_type", detail["failure_stage"])
+	}
+}
+
+func TestExecutorTelemetry_EmitToolCapsOversizedPayloadSnapshots(t *testing.T) {
+	bus := &telemetryBusStub{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "string"},
+						"notes":    {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:         "agent-emit-6",
+		EmitEvents: []string{"category.assessed"},
+	})
+	oversizedPayload := map[string]any{"category": "finops"}
+	for i := 0; i < 80; i++ {
+		oversizedPayload[fmt.Sprintf("extra_%02d", i)] = strings.Repeat("x", 40)
+	}
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", oversizedPayload); err != nil {
+		t.Fatalf("Execute(emit oversized): %v", err)
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	detail, _ := bus.logs[0].Detail.(map[string]any)
+	pre, _ := detail["pre_validation_payload"].(map[string]any)
+	if truncated, _ := pre["truncated"].(bool); !truncated {
+		t.Fatalf("pre_validation_payload.truncated = %#v, want true", pre["truncated"])
+	}
+	summary := strings.TrimSpace(asString(pre["summary"]))
+	if summary == "" {
+		t.Fatal("expected truncated payload summary")
+	}
+	if len(summary) > maxToolTelemetryChars+3 {
+		t.Fatalf("summary length = %d, want <= %d", len(summary), maxToolTelemetryChars+3)
 	}
 }
 


### PR DESCRIPTION
Closes #177

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_execution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: native_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: emit_tool_convention`

## Human Summary
This first slice adds one canonical structured diagnostics surface for emit-tool execution outcomes. Emit tools now record canonical tool/event identity, safe payload snapshots before and after enrichment, and explicit distinction between payload-shape, schema-validation, and downstream publish failures.

## What Changed
- added `emit_tool_outcome` runtime-log entries owned by `handleEmitTool(...)`
- logged canonical requested/resolved event type and emitted event identity on the emit path
- recorded safe pre-validation and post-enrichment payload snapshots for emit tools
- distinguished decode/input-shape failures, schema-validation failures, and publish failures
- added focused telemetry tests for published, payload-shape failure, schema-validation failure, and publish-failure cases
- removed the duplicate generic tool-execution log on successful emit dispatch so the emit path has one canonical diagnostics owner

## Why This Is Needed
Emit-tool failures were too hard to explain from the existing diagnostics because payload-shape problems, schema-validation failures, and publish failures were not surfaced as one structured outcome model. This slice makes the touched tool family observable through one canonical execution owner instead of loose layer-by-layer narration.

## Scope Boundaries
- first slice only: auto-generated emit tools (`emit_*`)
- does not redesign diagnostics for every tool family
- does not widen into unrelated authorization or visibility work
- keeps native tools and other runtime tools out of scope for this PR

## Tests Run
- `go test ./internal/runtime/tools -run 'TestExecutorTelemetry_(LogsSuccess|LogsDeniedExecution|LogsExecutionFailure|EmitToolLogsStructuredPublishedOutcome|EmitToolLogsSchemaValidationFailureSeparatelyFromPublishFailure|EmitToolLogsPublishFailureWithCanonicalEventIdentity|EmitToolLogsPayloadShapeFailureBeforeSchemaValidation)' -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR intentionally canonicalizes only the emit-tool family. Other tool families still rely on their existing diagnostics surfaces, so broader cross-family tool-outcome parity remains separate work.

## Follow-Up
If broader tool-family diagnostics parity is needed later, it should be handled as additional explicitly scoped slices with their own manifestation tables rather than generalized from this emit-tool-first slice.