### PR TITLE
[agent-a][issue #253] Preserve flow-owned session_scope proof across startup surfaces

### DIFF
--- a/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
+++ b/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
@@ -306,6 +306,36 @@ Improvement items:
 - make invalid event payloads fail closed before persistence in canonical runtime paths
 - align delivery receipts and restart recovery semantics with the spec
 
+### Flow-owned session-scope proof drifts across supported consumers
+
+Symptoms:
+
+- package-backed flow-owned agents verify cleanly on one surface but fail on another
+- `session_scope flow/entity` is accepted in boot verification but later rejected during runtime startup/static bootstrap
+- supported consumers disagree about whether an agent is flow-owned or root-level
+
+Likely causes:
+
+- loader/tree ownership proof is preserved in one carrier but not another
+- semantic view, boot verification, and static bootstrap consume different flow-ownership carriers
+- runtime startup derives scope from contract-source locality while boot verification uses a stronger owning-flow proof
+
+Current mitigations:
+
+- package-backed project scopes now carry `OwningFlowID` in semantic view
+- boot verification consumes that owning-flow proof for `session_scope` validation
+
+Still brittle because:
+
+- runtime startup/static bootstrap can still bypass that proof model and classify the same agent through weaker local metadata
+
+Improvement items:
+
+- define one canonical agent-level owning-flow/session-scope proof model
+- make boot verification and static bootstrap consume the same proof owner
+- keep targeted verify and supported startup smoke as closure gates for this class
+- tracked in: `#253`
+
 ### Host/container path or network split causes environment confusion
 
 Symptoms:

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1446,7 +1446,10 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: agentLabel,
 				})
 			}
-			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, scope.OwningFlowID, agentID, agent)
+			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, semanticview.ResolveAgentSessionScopeProof(c.source, semanticview.AgentSessionScopeLocator{
+				AgentID:         agentID,
+				ProjectScopeKey: scope.Key,
+			}), agentID, agent)
 			if len(agent.Subscriptions) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
@@ -1557,7 +1560,10 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 					Location: agentLabel,
 				})
 			}
-			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, scope.OwningFlowID, agentID, agent)
+			c.invalidFindings = appendAgentSessionScopeFindings(c.invalidFindings, c.source, scopeLabel, semanticview.ResolveAgentSessionScopeProof(c.source, semanticview.AgentSessionScopeLocator{
+				AgentID: agentID,
+				FlowID:  scope.ID,
+			}), agentID, agent)
 			if len(agent.Subscriptions) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
@@ -1571,7 +1577,7 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 	return c.invalidFindings
 }
 
-func appendAgentSessionScopeFindings(findings []Finding, source semanticview.Source, scopeLabel, flowID, agentID string, agent runtimecontracts.AgentRegistryEntry) []Finding {
+func appendAgentSessionScopeFindings(findings []Finding, source semanticview.Source, scopeLabel string, proof semanticview.AgentSessionScopeProof, agentID string, agent runtimecontracts.AgentRegistryEntry) []Finding {
 	agentLabel := scopedObjectLabel(scopeLabel, agentID)
 	mode, err := sessions.ParseConversationRuntimeMode(agent.ConversationMode)
 	if err != nil {
@@ -1588,7 +1594,7 @@ func appendAgentSessionScopeFindings(findings []Finding, source semanticview.Sou
 	}
 	switch sessionScope {
 	case sessions.SessionScopeFlow:
-		if strings.TrimSpace(flowID) == "" {
+		if strings.TrimSpace(proof.OwningFlowID) == "" {
 			return append(findings, Finding{
 				CheckID:  "invalid_field_detection",
 				Severity: "error",
@@ -1597,7 +1603,7 @@ func appendAgentSessionScopeFindings(findings []Finding, source semanticview.Sou
 			})
 		}
 	case sessions.SessionScopeEntity:
-		if strings.TrimSpace(flowID) == "" {
+		if strings.TrimSpace(proof.OwningFlowID) == "" {
 			return append(findings, Finding{
 				CheckID:  "invalid_field_detection",
 				Severity: "error",
@@ -1605,11 +1611,11 @@ func appendAgentSessionScopeFindings(findings []Finding, source semanticview.Sou
 				Location: agentLabel,
 			})
 		}
-		if flowIsStateless(source, flowID) {
+		if flowIsStateless(source, proof.OwningFlowID) {
 			return append(findings, Finding{
 				CheckID:  "invalid_field_detection",
 				Severity: "error",
-				Message:  fmt.Sprintf("agent %s session_scope entity requires stateful flow %s", agentLabel, validationFlowLabel(flowID)),
+				Message:  fmt.Sprintf("agent %s session_scope entity requires stateful flow %s", agentLabel, validationFlowLabel(proof.OwningFlowID)),
 				Location: agentLabel,
 			})
 		}

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -206,11 +206,11 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 	for _, scope := range source.ProjectScopes() {
 		projectAgents := make(map[string]runtimecontracts.AgentRegistryEntry, len(scope.Agents))
 		for logicalID, entry := range scope.Agents {
-			agentID := strings.TrimSpace(entry.ID)
-			if agentID == "" {
-				agentID = strings.TrimSpace(logicalID)
-			}
-			if sourceInfo, ok := source.AgentContractSource(agentID); ok && strings.TrimSpace(sourceInfo.FlowID) != "" {
+			proof := semanticview.ResolveAgentSessionScopeProof(source, semanticview.AgentSessionScopeLocator{
+				AgentID:         logicalID,
+				ProjectScopeKey: scope.Key,
+			})
+			if strings.TrimSpace(proof.OwningFlowID) != "" {
 				continue
 			}
 			projectAgents[strings.TrimSpace(logicalID)] = entry
@@ -224,7 +224,10 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 		if flowID == "" || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
 			continue
 		}
-		if err := am.ensureStaticAgentsForScope(ctx, source, flowID, strings.Trim(scope.Path, "/"), scope.Agents); err != nil {
+		proof := semanticview.ResolveAgentSessionScopeProof(source, semanticview.AgentSessionScopeLocator{
+			FlowID: flowID,
+		})
+		if err := am.ensureStaticAgentsForScope(ctx, source, proof.OwningFlowID, proof.FlowPath, scope.Agents); err != nil {
 			return err
 		}
 	}

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -205,18 +205,42 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 	}
 	for _, scope := range source.ProjectScopes() {
 		projectAgents := make(map[string]runtimecontracts.AgentRegistryEntry, len(scope.Agents))
+		packageFlowAgents := map[string]staticAgentFlowGroup{}
 		for logicalID, entry := range scope.Agents {
 			proof := semanticview.ResolveAgentSessionScopeProof(source, semanticview.AgentSessionScopeLocator{
 				AgentID:         logicalID,
 				ProjectScopeKey: scope.Key,
 			})
 			if strings.TrimSpace(proof.OwningFlowID) != "" {
+				if flowScopeContainsStaticAgent(source, proof.OwningFlowID, logicalID, entry) {
+					continue
+				}
+				groupKey := staticAgentFlowGroupKey(proof.OwningFlowID, proof.FlowPath)
+				group := packageFlowAgents[groupKey]
+				group.FlowID = strings.TrimSpace(proof.OwningFlowID)
+				group.FlowPath = strings.Trim(strings.TrimSpace(proof.FlowPath), "/")
+				if group.Agents == nil {
+					group.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+				}
+				group.Agents[strings.TrimSpace(logicalID)] = entry
+				packageFlowAgents[groupKey] = group
 				continue
 			}
 			projectAgents[strings.TrimSpace(logicalID)] = entry
 		}
 		if err := am.ensureStaticAgentsForScope(ctx, source, "", "", projectAgents); err != nil {
 			return err
+		}
+		groupKeys := make([]string, 0, len(packageFlowAgents))
+		for key := range packageFlowAgents {
+			groupKeys = append(groupKeys, key)
+		}
+		sort.Strings(groupKeys)
+		for _, key := range groupKeys {
+			group := packageFlowAgents[key]
+			if err := am.ensureStaticAgentsForScope(ctx, source, group.FlowID, group.FlowPath, group.Agents); err != nil {
+				return err
+			}
 		}
 	}
 	for _, scope := range source.FlowScopes() {
@@ -232,6 +256,41 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 		}
 	}
 	return nil
+}
+
+type staticAgentFlowGroup struct {
+	FlowID   string
+	FlowPath string
+	Agents   map[string]runtimecontracts.AgentRegistryEntry
+}
+
+func staticAgentFlowGroupKey(flowID, flowPath string) string {
+	return strings.TrimSpace(flowID) + "\x00" + strings.Trim(strings.TrimSpace(flowPath), "/")
+}
+
+func flowScopeContainsStaticAgent(source semanticview.Source, flowID, logicalID string, entry runtimecontracts.AgentRegistryEntry) bool {
+	flowID = strings.TrimSpace(flowID)
+	logicalID = strings.TrimSpace(logicalID)
+	if source == nil || flowID == "" || logicalID == "" {
+		return false
+	}
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return false
+	}
+	if scopedEntry, ok := scope.Agents[logicalID]; ok {
+		return scopedEntry.ID == entry.ID
+	}
+	entryID := strings.TrimSpace(entry.ID)
+	if entryID == "" {
+		return false
+	}
+	for scopedLogicalID, scopedEntry := range scope.Agents {
+		if strings.TrimSpace(scopedLogicalID) == logicalID || strings.TrimSpace(scopedEntry.ID) == entryID {
+			return true
+		}
+	}
+	return false
 }
 
 func (am *AgentManager) DeactivateFlowInstance(ctx context.Context, templateID, instanceID, flowPath, entityID string) error {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/runtime/sessions"
 	"swarm/internal/testutil"
 )
 
@@ -726,6 +729,39 @@ func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.
 	}
 }
 
+func TestEnsureStaticAgents_PackageBackedFlowOwnedAgentsCarryCanonicalFlowPath(t *testing.T) {
+	source := loadPackageBackedStaticAgentSource(t)
+	bus := &flowActivationTestBus{}
+	store := &flowActivationTestStore{}
+	var captured []models.AgentConfig
+	am := NewAgentManagerWithOptions(bus, func(cfg models.AgentConfig) (Agent, error) {
+		if _, err := sessions.ValidateAgentSessionScopeConfig(cfg); err != nil {
+			return nil, err
+		}
+		captured = append(captured, cfg)
+		return flowActivationStubAgent{id: cfg.ID}, nil
+	}, AgentManagerOptions{}, store)
+
+	if err := am.EnsureStaticAgents(context.Background(), source); err != nil {
+		t.Fatalf("EnsureStaticAgents: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured agents = %#v, want 1", captured)
+	}
+	if captured[0].FlowPath != "support" {
+		t.Fatalf("FlowPath = %q, want support", captured[0].FlowPath)
+	}
+	if captured[0].Mode != "support" {
+		t.Fatalf("Mode = %q, want support", captured[0].Mode)
+	}
+	if captured[0].ID != "backend-{vertical_id}" {
+		t.Fatalf("ID = %q, want backend-{vertical_id}", captured[0].ID)
+	}
+	if len(store.upserts) != 1 || store.upserts[0].Config.FlowPath != "support" {
+		t.Fatalf("persisted agents = %#v, want support flow path", store.upserts)
+	}
+}
+
 func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := NewAgentManager(bus, nil)
@@ -733,6 +769,87 @@ func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(testFlowBundle(""), "review", "inst-1", "ent-1", "review/inst-1"))
 	if err == nil || !strings.Contains(err.Error(), "workflow instance store is required") {
 		t.Fatalf("ActivateFlowInstance err = %v, want workflow instance store error", err)
+	}
+}
+
+func loadPackageBackedStaticAgentSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support/item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{vertical_id}
+  type: generic
+  role: backend
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeFlowActivationFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }
 

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -762,6 +762,36 @@ func TestEnsureStaticAgents_PackageBackedFlowOwnedAgentsCarryCanonicalFlowPath(t
 	}
 }
 
+func TestEnsureStaticAgents_SoleParentFlowPackageAgentsStartWithOwningFlowPath(t *testing.T) {
+	source := loadSoleParentFlowStaticAgentSource(t)
+	bus := &flowActivationTestBus{}
+	store := &flowActivationTestStore{}
+	var captured []models.AgentConfig
+	am := NewAgentManagerWithOptions(bus, func(cfg models.AgentConfig) (Agent, error) {
+		if _, err := sessions.ValidateAgentSessionScopeConfig(cfg); err != nil {
+			return nil, err
+		}
+		captured = append(captured, cfg)
+		return flowActivationStubAgent{id: cfg.ID}, nil
+	}, AgentManagerOptions{}, store)
+
+	if err := am.EnsureStaticAgents(context.Background(), source); err != nil {
+		t.Fatalf("EnsureStaticAgents: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured agents = %#v, want 1", captured)
+	}
+	if captured[0].FlowPath != "support" {
+		t.Fatalf("FlowPath = %q, want support", captured[0].FlowPath)
+	}
+	if captured[0].Mode != "support" {
+		t.Fatalf("Mode = %q, want support", captured[0].Mode)
+	}
+	if captured[0].ID != "backend-{vertical_id}" {
+		t.Fatalf("ID = %q, want backend-{vertical_id}", captured[0].ID)
+	}
+}
+
 func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := NewAgentManager(bus, nil)
@@ -825,6 +855,79 @@ support/item.created:
         type: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{vertical_id}
+  type: generic
+  role: backend
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func loadSoleParentFlowStaticAgentSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: extras
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support/item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
+name: extras
+version: "1.0.0"
+flows: []
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "agents.yaml"), `
 backend:
   id: backend-{vertical_id}
   type: generic

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -1,0 +1,129 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestRuntimeStart_PackageBackedFlowOwnedStaticAgentsCarryCanonicalFlowPath(t *testing.T) {
+	source := loadPackageBackedRuntimeSessionScopeSource(t)
+
+	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{}, RuntimeOptions{
+		SelfCheck:      false,
+		LLMRuntime:     noopLLMRuntime{},
+		WorkflowModule: semanticOnlyWorkflowRuntime{source: source},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = rt.Shutdown()
+	})
+
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cfg, ok := rt.Manager.GetAgentConfig("backend-{vertical_id}")
+	if !ok {
+		t.Fatal("expected package-backed static flow agent config")
+	}
+	if cfg.FlowPath != "support" {
+		t.Fatalf("FlowPath = %q, want support", cfg.FlowPath)
+	}
+	if cfg.Mode != "support" {
+		t.Fatalf("Mode = %q, want support", cfg.Mode)
+	}
+}
+
+func loadPackageBackedRuntimeSessionScopeSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "prompts", "backend.md"), "Handle support events.\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support/item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{vertical_id}
+  type: generic
+  role: backend
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+  emit_events:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeRuntimeSessionScopeFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -15,7 +15,16 @@ import (
 
 func TestRuntimeStart_PackageBackedFlowOwnedStaticAgentsCarryCanonicalFlowPath(t *testing.T) {
 	source := loadPackageBackedRuntimeSessionScopeSource(t)
+	assertRuntimeStartCarriesFlowPath(t, source)
+}
 
+func TestRuntimeStart_SoleParentFlowPackageAgentsCarryCanonicalFlowPath(t *testing.T) {
+	source := loadSoleParentFlowRuntimeSessionScopeSource(t)
+	assertRuntimeStartCarriesFlowPath(t, source)
+}
+
+func assertRuntimeStartCarriesFlowPath(t *testing.T, source semanticview.Source) {
+	t.Helper()
 	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{}, RuntimeOptions{
 		SelfCheck:      false,
 		LLMRuntime:     noopLLMRuntime{},
@@ -98,6 +107,82 @@ support/item.created:
         type: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{vertical_id}
+  type: generic
+  role: backend
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+  emit_events:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func loadSoleParentFlowRuntimeSessionScopeSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: extras
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support/item.created:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "extras", "prompts", "backend.md"), "Handle support events.\n")
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
+name: extras
+version: "1.0.0"
+flows: []
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "extras", "agents.yaml"), `
 backend:
   id: backend-{vertical_id}
   type: generic

--- a/internal/runtime/semanticview/agent_session_scope_proof.go
+++ b/internal/runtime/semanticview/agent_session_scope_proof.go
@@ -1,0 +1,78 @@
+package semanticview
+
+import (
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+type AgentSessionScopeLocator struct {
+	AgentID         string
+	ProjectScopeKey string
+	FlowID          string
+}
+
+type AgentSessionScopeProof struct {
+	AgentID         string
+	ProjectScopeKey string
+	ContractSource  runtimecontracts.ContractItemSource
+	OwningFlowID    string
+	FlowPath        string
+}
+
+func ResolveAgentSessionScopeProof(source Source, locator AgentSessionScopeLocator) AgentSessionScopeProof {
+	proof := AgentSessionScopeProof{
+		AgentID:         strings.TrimSpace(locator.AgentID),
+		ProjectScopeKey: strings.TrimSpace(locator.ProjectScopeKey),
+	}
+	if source == nil {
+		return proof
+	}
+
+	if proof.AgentID != "" {
+		if contractSource, ok := source.AgentContractSource(proof.AgentID); ok {
+			proof.ContractSource = contractSource
+			if proof.ProjectScopeKey == "" {
+				proof.ProjectScopeKey = strings.TrimSpace(contractSource.PackageKey)
+			}
+		}
+	}
+
+	if proof.AgentID == "" && proof.ProjectScopeKey == "" && strings.TrimSpace(locator.FlowID) == "" {
+		return proof
+	}
+
+	if flowID := strings.TrimSpace(locator.FlowID); flowID != "" {
+		proof.OwningFlowID = flowID
+	} else if proof.ProjectScopeKey != "" {
+		if projectScope, ok := projectScopeByKey(source, proof.ProjectScopeKey); ok {
+			proof.ProjectScopeKey = projectScope.Key
+			proof.OwningFlowID = strings.TrimSpace(projectScope.OwningFlowID)
+		}
+	}
+
+	if proof.OwningFlowID == "" {
+		return proof
+	}
+
+	if flowScope, ok := source.FlowScopeByID(proof.OwningFlowID); ok {
+		proof.FlowPath = strings.Trim(strings.TrimSpace(flowScope.Path), "/")
+		return proof
+	}
+
+	proof.FlowPath = strings.Trim(strings.TrimSpace(source.FlowPath(proof.OwningFlowID)), "/")
+	return proof
+}
+
+func projectScopeByKey(source Source, key string) (ProjectScope, bool) {
+	key = strings.TrimSpace(key)
+	if source == nil || key == "" {
+		return ProjectScope{}, false
+	}
+	for _, scope := range source.ProjectScopes() {
+		if strings.TrimSpace(scope.Key) == key {
+			return scope, true
+		}
+	}
+	return ProjectScope{}, false
+}

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -164,6 +164,143 @@ flow-agent:
 	}
 }
 
+func TestResolveAgentSessionScopeProof_PackageBackedAgentCarriesFlowPath(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{vertical_id}
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - support/item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	proof := ResolveAgentSessionScopeProof(source, AgentSessionScopeLocator{
+		AgentID:         "backend",
+		ProjectScopeKey: "flows/support",
+	})
+	if proof.OwningFlowID != "support" {
+		t.Fatalf("OwningFlowID = %q, want support", proof.OwningFlowID)
+	}
+	if proof.FlowPath != "support" {
+		t.Fatalf("FlowPath = %q, want support", proof.FlowPath)
+	}
+}
+
+func TestResolveAgentSessionScopeProof_FlowScopedAgentCarriesFlowPath(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: session-scope-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  groups:
+    - name: item
+      fields:
+        - name: item_id
+          type: string
+          primary: true
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+  - done
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+backend:
+  id: backend-{flow_id}
+  model_tier: sonnet
+  conversation_mode: session
+  session_scope: flow
+  subscriptions:
+    - item.created
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	proof := ResolveAgentSessionScopeProof(source, AgentSessionScopeLocator{
+		AgentID: "backend",
+		FlowID:  "support",
+	})
+	if proof.OwningFlowID != "support" {
+		t.Fatalf("OwningFlowID = %q, want support", proof.OwningFlowID)
+	}
+	if proof.FlowPath != "support" {
+		t.Fatalf("FlowPath = %q, want support", proof.FlowPath)
+	}
+}
+
 func writeSemanticviewFixtureFile(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
Closes #253

## Human Summary

Package-backed flow-owned agents were already validating cleanly on the targeted verify / boot path, but runtime startup was still losing that same flow-owned `session_scope` proof during static agent bootstrap. This PR introduces one semanticview-owned agent proof model and moves both supported consumers onto it so valid package-backed flow agents keep their canonical flow identity and flow path across both surfaces.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`

## What Changed

- added `semanticview.ResolveAgentSessionScopeProof(...)` as the canonical typed owner for agent-level flow-owned `session_scope` proof
- moved boot verification session-scope checks to consume that proof owner instead of reading scope-local carriers directly
- moved runtime static-agent bootstrap off raw `AgentContractSource(...).FlowID` and onto the same semanticview proof model
- added semanticview proof regressions, static-bootstrap manager coverage, and a focused `Runtime.Start(...)` regression for package-backed flow-owned agents
- mapped this reopened failure class into `docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md`

## Why This Is Needed

The reopened issue is a cross-surface correctness bug, not just a bootverify symptom. The platform was preserving enough flow ownership proof for one supported consumer and still reinterpreting or dropping it for another, which meant valid package-backed flow agents could verify green and then die during runtime startup with `session_scope flow requires flow path metadata`.

## Scope Boundaries

In scope:
- flow-owned `session_scope` proof production and consumption across loader/tree/semanticview, boot verification, and runtime static bootstrap
- fail-closed behavior for truly invalid root-level or stateless session-scope cases

Out of scope:
- broader session persistence redesign
- unrelated runtime startup failures after static bootstrap
- downstream runtime actor/session consumers that already validate materialized `FlowPath` fail-closed

## Tests Run

- `go test ./internal/runtime/semanticview -run 'Test(ProjectScopes_|ResolveAgentSessionScopeProof_)' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_(RejectsRootAgentFlowSessionScope|RejectsEntitySessionScopeInStatelessFlow|AcceptsPackageBackedFlowSessionScopeDeclarations|RejectsPackageBackedEntitySessionScopeInStatelessFlow)$' -count=1`
- `go test ./internal/runtime/manager -run 'Test(EnsureStaticAgents_PackageBackedFlowOwnedAgentsCarryCanonicalFlowPath|EnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions|EnsureStaticFlowRequiredAgentsRegistersStaticFlowSubscriptions)$' -count=1`
- `go test ./internal/runtime -run 'TestRuntimeStart_PackageBackedFlowOwnedStaticAgentsCarryCanonicalFlowPath$' -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `SWARM_BOOT_WARNINGS_FATAL=false SWARM_LLM_RUNTIME_MODE=api ANTHROPIC_API_KEY=dummy SWARM_CLAUDE_DEFAULT_MODEL=test-model go run ./cmd/swarm -contracts /Users/youmew/swarm/empire/contracts -health-addr 127.0.0.1:18081 -self-check=false`
- `go test ./cmd/swarm ./internal/runtime ./internal/runtime/bootverify ./internal/runtime/manager ./internal/runtime/semanticview -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR closes the currently known supported-consumer class listed in #253. The remaining risk is only that a not-yet-identified same-concept consumer outside the audited set could still bypass the semanticview proof owner; the pre-audit and proof audit account for the current repo-wide sweep explicitly.

## Follow-Up

- no follow-up issue is required if review agrees the audited supported-consumer set is complete
- if review identifies another same-concept consumer of flow-owned `session_scope` proof, it should stay on `#253` unless it is proven to be a separate semantic class
