### PR TITLE
[agent-a][issue #147] Make operational config surfaces fail closed and remove inert controls

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -807,6 +807,9 @@ func loadRuntimeConfig(path string) (*config.Config, error) {
 }
 
 func defaultRuntimeConfig() (*config.Config, error) {
+	if err := rejectUnsupportedRuntimeControlEnv(); err != nil {
+		return nil, err
+	}
 	mode := strings.TrimSpace(os.Getenv("SWARM_LLM_RUNTIME_MODE"))
 	if mode == "" {
 		if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" && strings.TrimSpace(os.Getenv("SWARM_CLAUDE_DEFAULT_MODEL")) != "" {
@@ -817,9 +820,7 @@ func defaultRuntimeConfig() (*config.Config, error) {
 	}
 	cfg := &config.Config{
 		Runtime: config.RuntimeConfig{
-			MaxConcurrentAgents: envInt("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", 10),
-			EventPollInterval:   envDuration("SWARM_RUNTIME_EVENT_POLL_INTERVAL", time.Second),
-			RecoveryOnStartup:   envBool("SWARM_RUNTIME_RECOVERY_ON_STARTUP", false),
+			RecoveryOnStartup: envBool("SWARM_RUNTIME_RECOVERY_ON_STARTUP", false),
 		},
 		Database: config.DatabaseConfig{
 			Host:     envOrDefault("SWARM_DB_HOST", envOrDefault("PGHOST", "127.0.0.1")),
@@ -857,6 +858,21 @@ func defaultRuntimeConfig() (*config.Config, error) {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+func rejectUnsupportedRuntimeControlEnv() error {
+	unsupported := make([]string, 0, 2)
+	if _, ok := os.LookupEnv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS"); ok {
+		unsupported = append(unsupported, "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS")
+	}
+	if _, ok := os.LookupEnv("SWARM_RUNTIME_EVENT_POLL_INTERVAL"); ok {
+		unsupported = append(unsupported, "SWARM_RUNTIME_EVENT_POLL_INTERVAL")
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	sort.Strings(unsupported)
+	return fmt.Errorf("unsupported inert runtime controls configured: %s", strings.Join(unsupported, ", "))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -205,6 +205,39 @@ func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
 	}
 }
 
+func TestDefaultRuntimeConfig_RejectsUnsupportedRuntimeControlEnv(t *testing.T) {
+	t.Setenv("SWARM_LLM_RUNTIME_MODE", "api")
+	t.Setenv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "4")
+	t.Setenv("SWARM_CLAUDE_DEFAULT_MODEL", "test-model")
+	cfg, err := defaultRuntimeConfig()
+	if err == nil || !strings.Contains(err.Error(), "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS") {
+		t.Fatalf("defaultRuntimeConfig error = %v, want unsupported env rejection", err)
+	}
+	if cfg != nil {
+		t.Fatalf("defaultRuntimeConfig cfg = %#v, want nil on unsupported env", cfg)
+	}
+}
+
+func TestLoadRuntimeConfig_RejectsUnsupportedRuntimeControlsFromFile(t *testing.T) {
+	cfgText := strings.Join([]string{
+		"runtime:",
+		"  max_concurrent_agents: 4",
+		"llm:",
+		"  runtime_mode: api",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	p := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(p, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := loadRuntimeConfig(p); err == nil || !strings.Contains(err.Error(), "runtime.max_concurrent_agents") {
+		t.Fatalf("loadRuntimeConfig error = %v, want unsupported runtime control rejection", err)
+	}
+}
+
 func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	Database   DatabaseConfig `yaml:"database"`
 	LLM        LLMConfig      `yaml:"llm"`
 	Extensions map[string]any `yaml:",inline"`
+
+	typedExtensions ExtensionsConfig `yaml:"-"`
+	extensionsReady bool             `yaml:"-"`
 }
 
 type RuntimeConfig struct {
@@ -83,6 +86,12 @@ func (c *Config) Validate() error {
 	if c.LLM.RuntimeMode != "api" && c.LLM.RuntimeMode != "cli_test" {
 		return fmt.Errorf("invalid llm.runtime_mode: %q", c.LLM.RuntimeMode)
 	}
+	if c.Runtime.MaxConcurrentAgents != 0 {
+		return errors.New("runtime.max_concurrent_agents is unsupported: no runtime path enforces it")
+	}
+	if c.Runtime.EventPollInterval != 0 {
+		return errors.New("runtime.event_poll_interval is unsupported: no runtime path enforces it")
+	}
 	if c.LLM.RuntimeMode == "cli_test" {
 		if c.LLM.ClaudeCLI.Command == "" {
 			return errors.New("llm.claude_cli.command is required in cli_test mode")
@@ -105,32 +114,28 @@ func (c *Config) Validate() error {
 	if c.LLM.Session.RotateOnParseFailures <= 0 {
 		return errors.New("llm.session.rotate_on_parse_failures must be > 0")
 	}
+	if err := c.prepareTypedExtensions(); err != nil {
+		return err
+	}
 	return nil
 }
 
 // Sharding returns the sharding extension config, or zero value if not configured.
 func (c *Config) Sharding() runtimesharding.Config {
-	if c == nil || len(c.Extensions) == 0 {
+	if c == nil {
 		return runtimesharding.Config{}
 	}
-	var ext struct {
-		Sharding runtimesharding.Config `yaml:"sharding"`
-	}
-	_ = c.DecodeExtensions(&ext)
-	ext.Sharding.ApplyDefaults()
-	return ext.Sharding
+	c.mustPrepareTypedExtensions()
+	return c.typedExtensions.Sharding
 }
 
 // Budget returns the budget extension config, or zero value if not configured.
 func (c *Config) Budget() BudgetConfig {
-	if c == nil || len(c.Extensions) == 0 {
+	if c == nil {
 		return BudgetConfig{}
 	}
-	var ext struct {
-		Budget BudgetConfig `yaml:"budget"`
-	}
-	_ = c.DecodeExtensions(&ext)
-	return ext.Budget
+	c.mustPrepareTypedExtensions()
+	return c.typedExtensions.Budget
 }
 
 func (c *Config) DecodeExtensions(out any) error {
@@ -148,4 +153,27 @@ func (c *Config) DecodeExtensions(out any) error {
 		return fmt.Errorf("decode extensions: %w", err)
 	}
 	return nil
+}
+
+func (c *Config) prepareTypedExtensions() error {
+	if c == nil || c.extensionsReady {
+		return nil
+	}
+	var ext ExtensionsConfig
+	if err := c.DecodeExtensions(&ext); err != nil {
+		return err
+	}
+	if _, ok := c.Extensions["sharding"]; ok {
+		return errors.New("sharding extension is unsupported: no runtime path consumes it")
+	}
+	ext.ApplyDefaults()
+	c.typedExtensions = ext
+	c.extensionsReady = true
+	return nil
+}
+
+func (c *Config) mustPrepareTypedExtensions() {
+	if err := c.prepareTypedExtensions(); err != nil {
+		panic(fmt.Sprintf("invalid runtime config extensions: %v", err))
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	typedExtensions ExtensionsConfig `yaml:"-"`
 	extensionsReady bool             `yaml:"-"`
+	extensionsErr   error            `yaml:"-"`
 }
 
 type RuntimeConfig struct {
@@ -83,14 +84,11 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) Validate() error {
+	if err := c.ValidateOperationalControls(); err != nil {
+		return err
+	}
 	if c.LLM.RuntimeMode != "api" && c.LLM.RuntimeMode != "cli_test" {
 		return fmt.Errorf("invalid llm.runtime_mode: %q", c.LLM.RuntimeMode)
-	}
-	if c.Runtime.MaxConcurrentAgents != 0 {
-		return errors.New("runtime.max_concurrent_agents is unsupported: no runtime path enforces it")
-	}
-	if c.Runtime.EventPollInterval != 0 {
-		return errors.New("runtime.event_poll_interval is unsupported: no runtime path enforces it")
 	}
 	if c.LLM.RuntimeMode == "cli_test" {
 		if c.LLM.ClaudeCLI.Command == "" {
@@ -114,6 +112,20 @@ func (c *Config) Validate() error {
 	if c.LLM.Session.RotateOnParseFailures <= 0 {
 		return errors.New("llm.session.rotate_on_parse_failures must be > 0")
 	}
+	return nil
+}
+
+func (c *Config) ValidateOperationalControls() error {
+	if c.Runtime.MaxConcurrentAgents != 0 {
+		return errors.New("runtime.max_concurrent_agents is unsupported: no runtime path enforces it")
+	}
+	if c.Runtime.EventPollInterval != 0 {
+		return errors.New("runtime.event_poll_interval is unsupported: no runtime path enforces it")
+	}
+	return c.ValidateExtensions()
+}
+
+func (c *Config) ValidateExtensions() error {
 	if err := c.prepareTypedExtensions(); err != nil {
 		return err
 	}
@@ -125,7 +137,9 @@ func (c *Config) Sharding() runtimesharding.Config {
 	if c == nil {
 		return runtimesharding.Config{}
 	}
-	c.mustPrepareTypedExtensions()
+	if err := c.prepareTypedExtensions(); err != nil {
+		return runtimesharding.Config{}
+	}
 	return c.typedExtensions.Sharding
 }
 
@@ -134,7 +148,9 @@ func (c *Config) Budget() BudgetConfig {
 	if c == nil {
 		return BudgetConfig{}
 	}
-	c.mustPrepareTypedExtensions()
+	if err := c.prepareTypedExtensions(); err != nil {
+		return BudgetConfig{}
+	}
 	return c.typedExtensions.Budget
 }
 
@@ -156,24 +172,26 @@ func (c *Config) DecodeExtensions(out any) error {
 }
 
 func (c *Config) prepareTypedExtensions() error {
-	if c == nil || c.extensionsReady {
+	if c == nil {
 		return nil
+	}
+	if c.extensionsReady {
+		return nil
+	}
+	if c.extensionsErr != nil {
+		return c.extensionsErr
 	}
 	var ext ExtensionsConfig
 	if err := c.DecodeExtensions(&ext); err != nil {
+		c.extensionsErr = err
 		return err
 	}
 	if _, ok := c.Extensions["sharding"]; ok {
-		return errors.New("sharding extension is unsupported: no runtime path consumes it")
+		c.extensionsErr = errors.New("sharding extension is unsupported: no runtime path consumes it")
+		return c.extensionsErr
 	}
 	ext.ApplyDefaults()
 	c.typedExtensions = ext
 	c.extensionsReady = true
 	return nil
-}
-
-func (c *Config) mustPrepareTypedExtensions() {
-	if err := c.prepareTypedExtensions(); err != nil {
-		panic(fmt.Sprintf("invalid runtime config extensions: %v", err))
-	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,8 +13,6 @@ import (
 func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	cfgText := strings.Join([]string{
 		"runtime:",
-		"  max_concurrent_agents: 10",
-		"  event_poll_interval: 1s",
 		"  recovery_on_startup: false",
 		"database:",
 		"  host: 127.0.0.1",
@@ -103,6 +101,64 @@ func TestValidate_CLI_TestRequiresCommandAndJson(t *testing.T) {
 	c.LLM.ClaudeCLI.NoSessionPersistence = true
 	if err := c.Validate(); err == nil {
 		t.Fatal("expected error for missing command")
+	}
+}
+
+func TestLoad_FailsClosedOnMalformedBudgetExtension(t *testing.T) {
+	cfgText := strings.Join([]string{
+		"llm:",
+		"  runtime_mode: api",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+		"budget:",
+		"  human_tasks: oops",
+	}, "\n") + "\n"
+	p := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(p, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(p); err == nil || !strings.Contains(err.Error(), "decode extensions") {
+		t.Fatalf("Load error = %v, want decode extensions failure", err)
+	}
+}
+
+func TestValidate_RejectsUnsupportedRuntimeControls(t *testing.T) {
+	c := &Config{}
+	c.LLM.RuntimeMode = "api"
+	c.LLM.Session.LockTTL = 1 * time.Second
+	c.LLM.Session.RotateAfterTurns = 1
+	c.LLM.Session.RotateOnParseFailures = 1
+	c.Runtime.MaxConcurrentAgents = 2
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "runtime.max_concurrent_agents") {
+		t.Fatalf("Validate error = %v, want unsupported max_concurrent_agents", err)
+	}
+
+	c.Runtime.MaxConcurrentAgents = 0
+	c.Runtime.EventPollInterval = time.Second
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "runtime.event_poll_interval") {
+		t.Fatalf("Validate error = %v, want unsupported event_poll_interval", err)
+	}
+}
+
+func TestLoad_RejectsUnsupportedShardingExtension(t *testing.T) {
+	cfgText := strings.Join([]string{
+		"llm:",
+		"  runtime_mode: api",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+		"sharding:",
+		"  max_shards_per_job: 4",
+	}, "\n") + "\n"
+	p := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(p, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(p); err == nil || !strings.Contains(err.Error(), "sharding extension is unsupported") {
+		t.Fatalf("Load error = %v, want unsupported sharding extension", err)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -18,6 +18,7 @@ import (
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	workspace "swarm/internal/runtime/workspace"
@@ -498,6 +499,53 @@ func (am *AgentManager) Recover(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (am *AgentManager) RecoverableStateReasons(ctx context.Context) ([]string, error) {
+	reasons := make([]string, 0, 4)
+	if am == nil {
+		return reasons, nil
+	}
+	if am.store != nil {
+		agents, err := am.store.LoadAgents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load persisted agents: %w", err)
+		}
+		if len(agents) > 0 {
+			reasons = append(reasons, "persisted agents")
+		}
+	}
+	if am.bus == nil {
+		return reasons, nil
+	}
+	store := am.bus.Store()
+	if store == nil {
+		return reasons, nil
+	}
+	if routeStore, ok := store.(runtimebus.FlowInstanceRoutePersistence); ok && routeStore != nil {
+		routes, err := routeStore.ListFlowInstanceRoutes(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list persisted flow instance routes: %w", err)
+		}
+		if len(routes) > 0 {
+			reasons = append(reasons, "persisted flow instance routes")
+		}
+	}
+	replayStore, supported, err := runtimereplayclaim.RequireStore(store)
+	if err != nil {
+		return nil, fmt.Errorf("inspect persisted replay state: %w", err)
+	}
+	if supported {
+		eventsToReplay, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-30*24*time.Hour), 1)
+		if err != nil {
+			return nil, fmt.Errorf("list events missing pipeline receipts: %w", err)
+		}
+		if len(eventsToReplay) > 0 {
+			reasons = append(reasons, "events missing pipeline receipts")
+		}
+	}
+	sort.Strings(reasons)
+	return reasons, nil
 }
 
 func (am *AgentManager) restoreFlowInstanceRoutes(ctx context.Context) error {

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -531,11 +531,8 @@ func (am *AgentManager) RecoverableStateReasons(ctx context.Context) ([]string, 
 			reasons = append(reasons, "persisted flow instance routes")
 		}
 	}
-	replayStore, supported, err := runtimereplayclaim.RequireStore(store)
-	if err != nil {
-		return nil, fmt.Errorf("inspect persisted replay state: %w", err)
-	}
-	if supported {
+	replayStore, ok := store.(runtimereplayclaim.Lister)
+	if ok && replayStore != nil {
 		eventsToReplay, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-30*24*time.Hour), 1)
 		if err != nil {
 			return nil, fmt.Errorf("list events missing pipeline receipts: %w", err)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -205,6 +205,34 @@ func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.Prom
 	return runtimecontracts.NewBundlePromptResolver(bundle), nil
 }
 
+func (rt *Runtime) ensureRecoveryStartupExplicit(ctx context.Context) error {
+	if rt == nil || rt.Config == nil || rt.Config.Runtime.RecoveryOnStartup {
+		return nil
+	}
+	reasons := make([]string, 0, 4)
+	if rt.Stores.ScheduleStore != nil {
+		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
+		if err != nil {
+			return fmt.Errorf("inspect active schedules: %w", err)
+		}
+		if len(schedules) > 0 {
+			reasons = append(reasons, "active schedules")
+		}
+	}
+	if rt.Manager != nil {
+		managerReasons, err := rt.Manager.RecoverableStateReasons(ctx)
+		if err != nil {
+			return fmt.Errorf("inspect recoverable manager state: %w", err)
+		}
+		reasons = append(reasons, managerReasons...)
+	}
+	if len(reasons) == 0 {
+		return nil
+	}
+	sort.Strings(reasons)
+	return fmt.Errorf("runtime.recovery_on_startup=false but persisted runtime-owned work exists: %s", strings.Join(reasons, ", "))
+}
+
 func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts RuntimeOptions) (*Runtime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
@@ -545,6 +573,10 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		}
 		rt.cleanupStartFailure()
 	}()
+
+	if err := rt.ensureRecoveryStartupExplicit(ctx); err != nil {
+		return err
+	}
 
 	if rt.Pipeline != nil {
 		go rt.Pipeline.RunMaintenance(startCtx)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -237,6 +237,9 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
 	}
+	if err := cfg.ValidateExtensions(); err != nil {
+		return nil, fmt.Errorf("runtime config validation failed: %w", err)
+	}
 	if err := validateClaudeStartupConfig(cfg, opts); err != nil {
 		return nil, fmt.Errorf("claude runtime startup validation failed: %w", err)
 	}

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"swarm/internal/config"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -53,6 +54,16 @@ func (s *recoveryGuardEventStore) ListEventsMissingPipelineReceipt(context.Conte
 }
 func (*recoveryGuardEventStore) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
 	return nil, true, nil
+}
+
+type minimalRuntimeEventStore struct{}
+
+func (*minimalRuntimeEventStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (*minimalRuntimeEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*minimalRuntimeEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
 }
 
 func testOperationalRuntimeConfig() *config.Config {
@@ -137,5 +148,52 @@ func TestRuntimeStart_AllowsRecoveryDisabledWhenNoRecoverableWorkExists(t *testi
 	}
 	if err := rt.Shutdown(); err != nil {
 		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestRuntimeStart_AllowsRecoveryDisabledWithNonReplayEventStore(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		EventStore:    &minimalRuntimeEventStore{},
+		ScheduleStore: &recordingRuntimeScheduleStore{},
+		ManagerStore:  &recoveryGuardManagerStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestNewRuntime_FailsClosedOnMalformedExtensionConfig(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	rt, err := NewRuntime(context.Background(), &config.Config{
+		Runtime: config.RuntimeConfig{RecoveryOnStartup: false},
+		LLM:     config.LLMConfig{RuntimeMode: "api"},
+		Extensions: map[string]any{
+			"budget": map[string]any{
+				"human_tasks": "oops",
+			},
+		},
+	}, Stores{
+		EventStore: runtimebus.InMemoryEventStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime config validation failed") || !strings.Contains(err.Error(), "decode extensions") {
+		t.Fatalf("NewRuntime error = %v, want explicit extension validation failure", err)
+	}
+	if rt != nil {
+		t.Fatalf("NewRuntime returned %#v, want nil runtime on malformed config", rt)
 	}
 }

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -1,0 +1,141 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+type recoveryGuardManagerStore struct {
+	agents []runtimemanager.PersistedAgent
+}
+
+func (s *recoveryGuardManagerStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (s *recoveryGuardManagerStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return append([]runtimemanager.PersistedAgent(nil), s.agents...), nil
+}
+
+func (*recoveryGuardManagerStore) MarkAgentTerminated(context.Context, string) error { return nil }
+func (*recoveryGuardManagerStore) EnsureEntitySchema(context.Context, string) error  { return nil }
+func (*recoveryGuardManagerStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
+	return nil
+}
+func (*recoveryGuardManagerStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (*recoveryGuardManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+
+type recoveryGuardEventStore struct {
+	missing []events.PersistedReplayEvent
+}
+
+func (*recoveryGuardEventStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (*recoveryGuardEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*recoveryGuardEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (s *recoveryGuardEventStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.missing...), nil
+}
+func (*recoveryGuardEventStore) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	return nil, true, nil
+}
+
+func testOperationalRuntimeConfig() *config.Config {
+	return &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: false,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}
+}
+
+func TestRuntimeStart_FailsWhenRecoveryDisabledAndActiveSchedulesExist(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	store := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{{
+			AgentID:   "runtime",
+			EventType: "timer.check",
+			Mode:      "once",
+			At:        time.Now().Add(time.Minute),
+			TaskID:    "recover-me",
+		}},
+	}
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{ScheduleStore: store}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	err = rt.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "runtime.recovery_on_startup=false") || !strings.Contains(err.Error(), "active schedules") {
+		t.Fatalf("Start error = %v, want explicit active schedule denial", err)
+	}
+}
+
+func TestRuntimeStart_FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	eventStore := &recoveryGuardEventStore{
+		missing: []events.PersistedReplayEvent{{
+			Event: events.Event{
+				ID:   "evt-1",
+				Type: "support.item_created",
+			},
+		}},
+	}
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		EventStore:   eventStore,
+		ManagerStore: &recoveryGuardManagerStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	err = rt.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "runtime.recovery_on_startup=false") || !strings.Contains(err.Error(), "events missing pipeline receipts") {
+		t.Fatalf("Start error = %v, want explicit pipeline recovery denial", err)
+	}
+}
+
+func TestRuntimeStart_AllowsRecoveryDisabledWhenNoRecoverableWorkExists(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		ScheduleStore: &recordingRuntimeScheduleStore{},
+		EventStore:    &recoveryGuardEventStore{},
+		ManagerStore:  &recoveryGuardManagerStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -244,7 +244,10 @@ func TestNewRuntime_SchedulerMarksSchedulesFiredThroughCanonicalTerminalHelper(t
 		t.Fatalf("load bundle: %v", err)
 	}
 	store := &recordingRuntimeScheduleStore{fired: make(chan runtimepipeline.Schedule, 1)}
-	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{ScheduleStore: store}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), &config.Config{
+		Runtime: config.RuntimeConfig{RecoveryOnStartup: true},
+		LLM:     config.LLMConfig{RuntimeMode: "api"},
+	}, Stores{ScheduleStore: store}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
 		LLMRuntime:     noopLLMRuntime{},
@@ -315,7 +318,10 @@ func TestRuntime_StartRestoresExactSchedulesDistinctByFlowInstance(t *testing.T)
 		},
 		fired: make(chan runtimepipeline.Schedule, 2),
 	}
-	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{ScheduleStore: store}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), &config.Config{
+		Runtime: config.RuntimeConfig{RecoveryOnStartup: true},
+		LLM:     config.LLMConfig{RuntimeMode: "api"},
+	}, Stores{ScheduleStore: store}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
 		LLMRuntime:     noopLLMRuntime{},


### PR DESCRIPTION
Closes #147

## Human Summary

This first slice makes the live runtime config/startup seam fail closed instead of silently degrading. Malformed extension config now fails during config validation, inert runtime controls are rejected explicitly instead of pretending to protect anything, and startup now refuses to proceed with `recovery_on_startup=false` when persisted runtime-owned work already exists.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_sequence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_verification`
- governing rule from the issue: invalid or ambiguous operational configuration should fail closed at boot/runtime rather than degrade silently behind inert or misleading controls

## What Changed

- made `Config.Validate()` the typed validation owner for the touched runtime config / extension config slice
- stopped silently swallowing extension decode failures for the touched `budget` / `sharding` config path
- rejected unsupported inert controls in the touched runtime config seam:
  - `runtime.max_concurrent_agents`
  - `runtime.event_poll_interval`
  - `SWARM_RUNTIME_MAX_CONCURRENT_AGENTS`
  - `SWARM_RUNTIME_EVENT_POLL_INTERVAL`
  - configured `sharding` extension
- added a startup admission preflight in `Runtime.Start()` so `recovery_on_startup=false` now fails explicitly if persisted runtime-owned work already exists
- added focused config and runtime-start regressions

## Why This Is Needed

The previous behavior mixed three unsafe outcomes in one live seam:
- malformed extension config silently defaulted instead of failing
- inert runtime knobs stayed operator-visible even though no runtime path enforced them
- disabling recovery did not make startup explicit when persisted runtime-owned work still existed

That leaves operators with misleading controls and ambiguous startup behavior, which is the opposite of fail-closed runtime operations.

## Scope Boundaries

In scope:
- live runtime config ingestion in `cmd/swarm/main.go`
- typed validation / extension decode in `internal/config/config.go`
- startup admission for `recovery_on_startup` in `internal/runtime/runtime.go`

Out of scope:
- every operational config surface in the repo
- broader env parsing cleanup beyond the touched inert controls
- unrelated runtime recovery redesign

## Tests Run

- `go test ./internal/config -run 'Test(LoadAndValidate_CLI_TestMode|Load_FailsClosedOnMalformedBudgetExtension|Validate_RejectsUnsupportedRuntimeControls|Load_RejectsUnsupportedShardingExtension)$' -count=1`
- `go test ./cmd/swarm -run 'Test(DefaultRuntimeConfig_RejectsUnsupportedRuntimeControlEnv|LoadRuntimeConfig_RejectsUnsupportedRuntimeControlsFromFile)$' -count=1`
- `go test ./internal/runtime -run 'TestRuntimeStart_(FailsWhenRecoveryDisabledAndActiveSchedulesExist|FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists|AllowsRecoveryDisabledWhenNoRecoverableWorkExists|RestoresExactSchedulesDistinctByFlowInstance)$' -count=1`
- `go test ./internal/config ./cmd/swarm ./internal/runtime ./internal/runtime/manager -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR intentionally canonicalizes the first live runtime-config/startup seam, not the entire broader operational-config class. Other config surfaces can still need the same treatment if they are later proven to be fail-open or inert.

## Follow-Up

- no immediate same-seam follow-up is required for the touched runtime config/startup slice
- broader operational-config surfaces should stay on `#147` only if review identifies another same-class consumer or inert control in this seam