### PR TITLE
[agent-c][issue #224] Remove implicit canonical schema defaults from dashboard readers

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -86,6 +86,7 @@ nodes:
     why_this_node_exists: operator APIs drift when they widen typed persisted data into loose carriers and inference-heavy summaries
     known_manifestations:
       - conversation and turn APIs widen typed persisted data
+      - dashboard readers synthesize canonical schema capabilities when no explicit capability owner is provided
       - summary/runtime-log/mutation completeness may be inferred or silently omitted
       - mutation-surface reconstruction can silently tolerate malformed persisted `entity_mutations` proof in touched conformance/read-model seams
     representative_issues:

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -106,7 +106,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	if err := store.RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+	if err := requireAgentOperatorProjectionCapabilities(caps); err != nil {
 		return nil, err
 	}
 	latestTurnBlocksExpr := `'[]'::jsonb`
@@ -231,23 +231,11 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 
 func (r *SQLAgentReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
 	if r != nil {
-		if source, ok := r.base.(conversationCapabilitySource); ok && source != nil {
+		if source, ok := r.base.(schemaCapabilitySource); ok && source != nil {
 			return source.ResolveSchemaCapabilities(ctx)
 		}
 	}
-	return store.StoreSchemaCapabilities{
-		Events: store.EventSchemaCapabilities{
-			Log:        store.SchemaFlavorCanonical,
-			Deliveries: store.SchemaFlavorCanonical,
-			Receipts:   store.SchemaFlavorCanonical,
-		},
-		Conversations: store.ConversationSchemaCapabilities{
-			Sessions:   store.SchemaFlavorCanonical,
-			Audits:     store.SchemaFlavorCanonical,
-			Turns:      store.SchemaFlavorCanonical,
-			TurnBlocks: true,
-		},
-	}, nil
+	return store.StoreSchemaCapabilities{}, missingDashboardCapabilityOwner("agent reader")
 }
 
 func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjection, turnLimit int) {

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -19,14 +19,10 @@ const (
 
 type SQLConversationReader struct {
 	db        *sql.DB
-	capSource conversationCapabilitySource
+	capSource schemaCapabilitySource
 }
 
-type conversationCapabilitySource interface {
-	ResolveSchemaCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error)
-}
-
-func NewSQLConversationReader(db *sql.DB, capSource conversationCapabilitySource) *SQLConversationReader {
+func NewSQLConversationReader(db *sql.DB, capSource schemaCapabilitySource) *SQLConversationReader {
 	if db == nil {
 		return nil
 	}
@@ -44,10 +40,10 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 	if err != nil {
 		return nil, err
 	}
-	sources := conversationQuerySources(caps)
-	if len(sources) == 0 {
-		return []ConversationSummary{}, nil
+	if err := requireConversationSurfaceCapabilities(caps); err != nil {
+		return nil, err
 	}
+	sources := conversationQuerySources(caps)
 	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			session_id,
@@ -97,10 +93,10 @@ func (r *SQLConversationReader) Get(ctx context.Context, sessionID string) (Conv
 	if err != nil {
 		return ConversationDetail{}, false, err
 	}
-	sources := conversationQuerySources(caps)
-	if len(sources) == 0 {
-		return ConversationDetail{}, false, nil
+	if err := requireConversationSurfaceCapabilities(caps); err != nil {
+		return ConversationDetail{}, false, err
 	}
+	sources := conversationQuerySources(caps)
 
 	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT
@@ -262,8 +258,8 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 	if err != nil {
 		return nil, err
 	}
-	if caps.Conversations.Turns != store.SchemaFlavorCanonical {
-		return []ConversationTurn{}, nil
+	if err := requireConversationTurnCapabilities(caps, "conversation turn reader capability surface"); err != nil {
+		return nil, err
 	}
 	query := `
 		SELECT
@@ -358,14 +354,7 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 
 func (r *SQLConversationReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
 	if r == nil || r.capSource == nil {
-		return store.StoreSchemaCapabilities{
-			Conversations: store.ConversationSchemaCapabilities{
-				Sessions:   store.SchemaFlavorCanonical,
-				Audits:     store.SchemaFlavorCanonical,
-				Turns:      store.SchemaFlavorCanonical,
-				TurnBlocks: true,
-			},
-		}, nil
+		return store.StoreSchemaCapabilities{}, missingDashboardCapabilityOwner("conversation reader")
 	}
 	return r.capSource.ResolveSchemaCapabilities(ctx)
 }

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -258,7 +258,7 @@ func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agent
 	if err != nil {
 		return nil, err
 	}
-	if err := requireConversationTurnCapabilities(caps, "conversation turn reader capability surface"); err != nil {
+	if err := requireConversationTurnCapabilities(caps); err != nil {
 		return nil, err
 	}
 	query := `

--- a/internal/dashboard/server/schema_capabilities.go
+++ b/internal/dashboard/server/schema_capabilities.go
@@ -32,27 +32,21 @@ func requireConversationSurfaceCapabilities(caps store.StoreSchemaCapabilities) 
 	if caps.Conversations.Sessions == store.SchemaFlavorCanonical || caps.Conversations.Audits == store.SchemaFlavorCanonical {
 		return nil
 	}
-	if caps.Conversations.Sessions == store.SchemaFlavorUnavailable && caps.Conversations.Audits == store.SchemaFlavorUnavailable {
-		return missingDashboardCapabilityOwner("conversation reader capability surface")
-	}
 	if caps.Conversations.Audits != store.SchemaFlavorUnavailable {
 		return unsupportedDashboardSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 	}
 	return unsupportedDashboardSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 }
 
-func requireConversationTurnCapabilities(caps store.StoreSchemaCapabilities, surface string) error {
+func requireConversationTurnCapabilities(caps store.StoreSchemaCapabilities) error {
 	if caps.Conversations.Turns == store.SchemaFlavorCanonical {
 		return nil
-	}
-	if caps.Conversations.Turns == store.SchemaFlavorUnavailable {
-		return missingDashboardCapabilityOwner(surface)
 	}
 	return unsupportedDashboardSchemaCapability("agent_turns", caps.Conversations.Turns)
 }
 
 func requireAgentOperatorProjectionCapabilities(caps store.StoreSchemaCapabilities) error {
-	if err := requireConversationTurnCapabilities(caps, "agent operator projection capability surface"); err != nil {
+	if err := requireConversationTurnCapabilities(caps); err != nil {
 		return err
 	}
 	return store.RequireCanonicalPendingAgentDeliveryCapabilities(caps)

--- a/internal/dashboard/server/schema_capabilities.go
+++ b/internal/dashboard/server/schema_capabilities.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type schemaCapabilitySource interface {
+	ResolveSchemaCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error)
+}
+
+func missingDashboardCapabilityOwner(surface string) error {
+	return fmt.Errorf("dashboard: %s requires explicit schema capability owner", strings.TrimSpace(surface))
+}
+
+func unsupportedDashboardSchemaCapability(subject string, flavor store.SchemaFlavor) error {
+	subject = strings.TrimSpace(subject)
+	switch flavor {
+	case store.SchemaFlavorUnavailable:
+		return fmt.Errorf("dashboard: %s schema is unavailable at the explicit capability boundary", subject)
+	case store.SchemaFlavorUnsupported, store.SchemaFlavorLegacy:
+		return fmt.Errorf("dashboard: %s schema is unsupported by the explicit capability boundary", subject)
+	default:
+		return fmt.Errorf("dashboard: %s schema capability is invalid (%s)", subject, strings.TrimSpace(string(flavor)))
+	}
+}
+
+func requireConversationSurfaceCapabilities(caps store.StoreSchemaCapabilities) error {
+	if caps.Conversations.Sessions == store.SchemaFlavorCanonical || caps.Conversations.Audits == store.SchemaFlavorCanonical {
+		return nil
+	}
+	if caps.Conversations.Sessions == store.SchemaFlavorUnavailable && caps.Conversations.Audits == store.SchemaFlavorUnavailable {
+		return missingDashboardCapabilityOwner("conversation reader capability surface")
+	}
+	if caps.Conversations.Audits != store.SchemaFlavorUnavailable {
+		return unsupportedDashboardSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
+	}
+	return unsupportedDashboardSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+}
+
+func requireConversationTurnCapabilities(caps store.StoreSchemaCapabilities, surface string) error {
+	if caps.Conversations.Turns == store.SchemaFlavorCanonical {
+		return nil
+	}
+	if caps.Conversations.Turns == store.SchemaFlavorUnavailable {
+		return missingDashboardCapabilityOwner(surface)
+	}
+	return unsupportedDashboardSchemaCapability("agent_turns", caps.Conversations.Turns)
+}
+
+func requireAgentOperatorProjectionCapabilities(caps store.StoreSchemaCapabilities) error {
+	if err := requireConversationTurnCapabilities(caps, "agent operator projection capability surface"); err != nil {
+		return err
+	}
+	return store.RequireCanonicalPendingAgentDeliveryCapabilities(caps)
+}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -976,6 +976,56 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalReceiptCapa
 	}
 }
 
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubAgents{rows: []runtimemanager.PersistedAgent{{
+		Config: runtimeactors.AgentConfig{
+			ID:   "agent-1",
+			Role: "researcher",
+			Mode: "global",
+			Type: "managed",
+		},
+		Status: "active",
+	}}}, 12)
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "agent reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnCapability(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	caps := canonicalEventAndConversationCaps()
+	caps.Conversations.Turns = store.SchemaFlavorLegacy
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: caps,
+	}, 12)
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "agent_turns schema is unsupported") {
+		t.Fatalf("expected explicit unsupported turn capability error, got %v", err)
+	}
+}
+
 func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelector(t *testing.T) {
 	dsn, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -1737,7 +1787,51 @@ func TestSQLConversationReader_GetMissing(t *testing.T) {
 	}
 }
 
-func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
+func TestSQLConversationReader_ListFailsClosedWithoutCapabilityOwner(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, nil)
+	if _, err := reader.List(context.Background(), 10); err == nil || !strings.Contains(err.Error(), "conversation reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLConversationReader_ListFailsClosedWithoutCanonicalConversationSurface(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorLegacy,
+			Audits:   store.SchemaFlavorLegacy,
+		},
+	}})
+	if _, err := reader.List(context.Background(), 10); err == nil || !strings.Contains(err.Error(), "schema is unsupported by the explicit capability boundary") {
+		t.Fatalf("expected unsupported conversation surface capability error, got %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetFailsClosedWithoutCapabilityOwner(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, nil)
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil || !strings.Contains(err.Error(), "conversation reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetFailsClosedWithoutTurnCapability(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -1747,6 +1841,7 @@ func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorLegacy,
 		},
 	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
@@ -1760,14 +1855,8 @@ func TestSQLConversationReader_GetSkipsTurnsWithoutCapability(t *testing.T) {
 		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
 
 	item, ok, err := reader.Get(context.Background(), "sess-1")
-	if err != nil {
-		t.Fatalf("get conversation: %v", err)
-	}
-	if !ok {
-		t.Fatalf("expected conversation to exist")
-	}
-	if len(item.Turns) != 0 {
-		t.Fatalf("turns = %#v", item.Turns)
+	if err == nil || !strings.Contains(err.Error(), "agent_turns schema is unsupported") {
+		t.Fatalf("expected unsupported turn capability error, got item=%+v ok=%v err=%v", item, ok, err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1818,6 +1818,24 @@ func TestSQLConversationReader_ListFailsClosedWithoutCanonicalConversationSurfac
 	}
 }
 
+func TestSQLConversationReader_ListFailsClosedWhenCapabilityOwnerReportsUnavailableConversationSurface(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorUnavailable,
+			Audits:   store.SchemaFlavorUnavailable,
+		},
+	}})
+	if _, err := reader.List(context.Background(), 10); err == nil || !strings.Contains(err.Error(), "schema is unavailable at the explicit capability boundary") {
+		t.Fatalf("expected unavailable conversation surface capability error, got %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetFailsClosedWithoutCapabilityOwner(t *testing.T) {
 	db, _, err := sqlmock.New()
 	if err != nil {
@@ -1857,6 +1875,38 @@ func TestSQLConversationReader_GetFailsClosedWithoutTurnCapability(t *testing.T)
 	item, ok, err := reader.Get(context.Background(), "sess-1")
 	if err == nil || !strings.Contains(err.Error(), "agent_turns schema is unsupported") {
 		t.Fatalf("expected unsupported turn capability error, got item=%+v ok=%v err=%v", item, ok, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetFailsClosedWhenCapabilityOwnerReportsUnavailableTurnCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorUnavailable,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	summaryState := `{"summary":"brief"}`
+	messagePayload := `[{"role":"assistant","content":"hello"}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(summaryState), []byte(messagePayload), now))
+
+	item, ok, err := reader.Get(context.Background(), "sess-1")
+	if err == nil || !strings.Contains(err.Error(), "agent_turns schema is unavailable at the explicit capability boundary") {
+		t.Fatalf("expected unavailable turn capability error, got item=%+v ok=%v err=%v", item, ok, err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
Part of #224

## Human Summary
This removes the remaining reader-local canonical schema defaults from the first dashboard reader family that still synthesized them. `SQLConversationReader` and `SQLAgentReader` now require an explicit store-backed capability owner and fail closed when the required capability boundary is missing or non-canonical.

## Spec References
- none; this is runtime/read-model architecture hardening
- justification: no exact platform spec section governs dashboard reader capability-source defaults. The governing rule for this PR is operator-surface canonical ownership: schema-dependent dashboard reads must bind to one explicit store capability owner instead of synthesizing canonical capability assumptions locally.

## What Changed
- added one shared dashboard reader capability contract in `internal/dashboard/server/schema_capabilities.go`
- removed local hardcoded canonical `StoreSchemaCapabilities` defaults from:
  - `internal/dashboard/server/conversations_sql.go`
  - `internal/dashboard/server/agents_sql.go`
- made the touched readers require an explicit capability owner or fail closed
- tightened conversation detail loading so unsupported `agent_turns` capability now fails explicitly instead of silently omitting turns
- added focused regressions for:
  - missing capability owner in conversation list/detail readers
  - non-canonical conversation source capability
  - missing capability owner in agent operator projection
  - non-canonical turn capability in agent/conversation readers
- refined the operator-surfaces watchlist node for this manifestation in `docs/watchlists/operator-surfaces.yaml`

## Why This Is Needed
The touched readers still made local schema decisions by manufacturing canonical capabilities when no explicit owner was provided. That kept schema ownership implicit in operator-facing read paths and let tests or future call sites get canonical behavior without a real capability boundary. This PR removes that drift for the first bounded reader family.

## Scope Boundaries
In scope:
- dashboard reader-local capability default synthesis in `SQLConversationReader` and `SQLAgentReader`
- explicit fail-closed behavior when those touched readers lack a real capability owner or required canonical capability
- focused regression coverage for the touched reader family

Not in scope:
- observability readers that currently have no capability-owner seam at all
- broad dashboard redesign
- unrelated operator-surface cleanup
- store/schema redesign beyond what is needed to make the touched reader family explicit

## Tests Run
- `go test ./internal/dashboard/server -run 'TestSQL(ConversationReader_(ListFailsClosedWithoutCapabilityOwner|ListFailsClosedWithoutCanonicalConversationSurface|GetFailsClosedWithoutCapabilityOwner|GetFailsClosedWithoutTurnCapability)|AgentReader_ListGenericAgents_(FailsClosedWithoutCapabilityOwner|FailsClosedWithoutCanonicalTurnCapability|FailsClosedWithoutCanonicalReceiptCapability))$' -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
This closes the first same-concept default-synthesis family, not the full dashboard capability-ownership class. `SQLObservabilityReader` still bypasses explicit capability ownership entirely, but that is a different class than local canonical default synthesis and remains outside this first slice.

## Follow-Up
No same-concept local default-synthesis seam remains live in the touched reader family after this PR. A separate follow-up may still be warranted for reader families that currently have no capability-owner seam at all, especially observability/event readers.
