### PR TITLE
[agent-d][issue #305] Narrow startup MCP reachability probe semantics

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -95,11 +95,13 @@ nodes:
     known_manifestations:
       - context-token policy differs across transport surfaces
       - startup validation does not prove the real filtered transport path
+      - startup reachability probe conflates tool-call transport proof with tool-specific required-input validity
       - agent-visible tool availability differs between prompt and transport
     representative_issues:
       - 111
       - 136
       - 137
+      - 305
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -231,7 +231,7 @@ func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapa
 		if !ok || !capability.Callable || capability.Kind == toolcapabilities.KindEmit {
 			continue
 		}
-		if !schemaRequiresObjectFields(tool.InputSchema) {
+		if !schemaAllowsEmptyObjectArguments(tool.InputSchema) {
 			continue
 		}
 		return name, true
@@ -239,19 +239,38 @@ func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapa
 	return "", false
 }
 
-func schemaRequiresObjectFields(schema any) bool {
+func schemaAllowsEmptyObjectArguments(schema any) bool {
 	typed, ok := schema.(map[string]any)
 	if !ok {
 		return false
 	}
-	if strings.TrimSpace(asString(typed["type"])) != "object" {
+	if schemaType := strings.TrimSpace(asString(typed["type"])); schemaType != "" && schemaType != "object" {
 		return false
 	}
-	required, ok := typed["required"].([]any)
-	if !ok || len(required) == 0 {
-		return false
+	return len(schemaRequiredFieldNames(typed["required"])) == 0
+}
+
+func schemaRequiredFieldNames(raw any) []string {
+	switch typed := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if name := strings.TrimSpace(asString(item)); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if name := strings.TrimSpace(item); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	default:
+		return nil
 	}
-	return true
 }
 
 func startupProbeMCPToolsList(ctx context.Context, client *http.Client, binding llm.MCPHTTPBinding) ([]runtimemcp.ToolDef, error) {
@@ -329,27 +348,14 @@ func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding 
 	if err != nil {
 		return fmt.Errorf("tools/call returned invalid runtimeError payload: %w", err)
 	}
-	if startupProbeAcceptsRuntimeValidation(runtimeErr) {
-		return nil
-	}
 	message := strings.TrimSpace(startupMCPErrorText(result))
 	if message != "" {
 		return fmt.Errorf(message)
 	}
+	if runtimeErr != nil && strings.TrimSpace(runtimeErr.Message) != "" {
+		return fmt.Errorf("%s", strings.TrimSpace(runtimeErr.Message))
+	}
 	return fmt.Errorf("tools/call returned runtime error code=%s", strings.TrimSpace(runtimeErr.Code))
-}
-
-func startupProbeAcceptsRuntimeValidation(runtimeErr *runtimemcp.RuntimeErrorPayload) bool {
-	if runtimeErr == nil {
-		return false
-	}
-	if strings.TrimSpace(runtimeErr.Code) != runtimemcp.ErrCodeToolExecFailed {
-		return false
-	}
-	if runtimeErr.Cause == nil {
-		return false
-	}
-	return strings.TrimSpace(runtimeErr.Cause.Code) == "invalid_tool_input"
 }
 
 func startupMCPErrorText(result map[string]any) string {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -158,6 +158,14 @@ func startupProbeDefs() []llm.ToolDefinition {
 				"required":   []any{"query"},
 			},
 		},
+		{
+			Name:        "health_check",
+			Description: "No-input reachability smoke",
+			Schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
 	}
 }
 
@@ -171,6 +179,12 @@ func startupProbeCaps() map[string]toolcapabilities.Capability {
 		},
 		"query_entities": {
 			Name:               "query_entities",
+			Visible:            true,
+			Callable:           true,
+			ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+		},
+		"health_check": {
+			Name:               "health_check",
 			Visible:            true,
 			Callable:           true,
 			ContextRequirement: toolcapabilities.ContextRequirementActorContext,
@@ -210,8 +224,8 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
-	if !slices.Equal(exec.executed, []string{"query_entities"}) {
-		t.Fatalf("executed = %#v, want query_entities tools/call smoke", exec.executed)
+	if !slices.Equal(exec.executed, []string{"health_check"}) {
+		t.Fatalf("executed = %#v, want health_check tools/call smoke", exec.executed)
 	}
 }
 
@@ -267,24 +281,53 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_ToleratesValidationStyleCallableProbeErrors(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_SkipsCallableProbeWhenVisibleToolsRequireInput(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
-	manager := runtimemanager.NewAgentManager(nil, nil)
-	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
-		t.Fatalf("SpawnAgent: %v", err)
-	}
-	exec := &startupProbeToolExecutor{
-		defs: startupProbeDefs(),
-		caps: startupProbeCaps(),
-		execErrs: map[string]error{
-			"query_entities": WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required"),
+	for _, tc := range []struct {
+		name    string
+		execErr error
+	}{
+		{
+			name:    "structured_invalid_tool_input",
+			execErr: WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required"),
 		},
-	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+		{
+			name:    "plain_required_field_message",
+			execErr: errors.New("bash.command is required"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := runtimemanager.NewAgentManager(nil, nil)
+			if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+				t.Fatalf("SpawnAgent: %v", err)
+			}
+			exec := &startupProbeToolExecutor{
+				defs: []llm.ToolDefinition{{
+					Name:   "query_entities",
+					Schema: map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}, "required": []any{"query"}},
+				}},
+				caps: map[string]toolcapabilities.Capability{
+					"query_entities": {
+						Name:               "query_entities",
+						Visible:            true,
+						Callable:           true,
+						ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+					},
+				},
+				execErrs: map[string]error{
+					"query_entities": tc.execErr,
+				},
+			}
+			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
-		t.Fatalf("expected validation-style probe error to be tolerated, got %v", err)
+			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
+				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+			}
+			if len(exec.executed) != 0 {
+				t.Fatalf("executed = %#v, want no tools/call smoke for required-input-only surface", exec.executed)
+			}
+		})
 	}
 }
 
@@ -299,7 +342,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableP
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 		execErrs: map[string]error{
-			"query_entities": errors.New("unexpected tool failure"),
+			"health_check": errors.New("unexpected tool failure"),
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
@@ -321,7 +364,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonVal
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 		execErrs: map[string]error{
-			"query_entities": errors.New("schema validation failed: execution path must be enabled before use"),
+			"health_check": errors.New("schema validation failed: execution path must be enabled before use"),
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")


### PR DESCRIPTION
Closes #305

## Spec references

No exact `platform-spec.yaml` section currently defines the Claude managed-agent startup probe success criterion at this level of detail, so the binding context for this slice is issue `#305` and its approved pre-audit.

Closest governing sections re-read before implementation:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_sequence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: implementation_classes.mcp`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: mcp_client`

## Human Summary

This first slice stops the Claude managed-agent startup MCP reachability probe from depending on whether the selected visible tool accepts empty input. Startup now proves filtered transport reachability with `tools/list`, then only performs a `tools/call` smoke probe when there is a visible callable non-emit tool whose schema safely accepts an empty object.

## What Changed

- narrowed startup probe target selection to visible callable non-emit tools whose schema allows empty object arguments
- removed the old validation-tolerance path that treated tool-specific input rejection as successful startup proof
- kept unexpected callable failures fail-closed when a startup-safe probe tool does exist
- added focused startup regressions for required-input-only visible tool surfaces and ordinary validation-error variants
- refined the runtime operations watchlist node for this manifestation

## Why This Is Needed

The bug class here is startup reachability semantics being conflated with tool-specific valid-input semantics. A required-input tool rejecting `{}` is not evidence that the MCP transport or capability surface is unavailable. Treating that rejection as startup failure was off-target; treating it as success via validation-error heuristics was also too loose.

## Scope Boundaries

- first slice only for the Claude managed-agent startup probe seam
- not a broad MCP/runtime redesign
- not generic tool diagnostics work
- not unrelated authorization or visibility cleanup
- honest closure target for this PR: `touched seam canonicalized`

## Tests Run

- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents_(UsesRealFilteredTransport|FailsClosedOnConfiguredGatewayTokenMismatch|FailsOnEmptyVisibleToolSurface|SkipsCallableProbeWhenVisibleToolsRequireInput|FailsClosedOnUnexpectedCallableProbeError|FailsClosedOnGenericPhraseNonValidationProbeError)' -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk

- this canonicalizes only the touched Claude startup probe seam; other startup or probe surfaces are intentionally out of scope
- the broader explicit startup probe contract cleanup discussed near `#218` remains separate unless later work fully closes that adjacent class

## Follow-Up

- if startup-probe semantics need exact normative spec language beyond the current issue-thread binding context, that should be drafted and promoted through the review-spec flow in a dedicated follow-up
- if adjacent startup surfaces still classify tool validation as reachability proof, they should be audited against the same watchlist node
