### PR TITLE
[agent-b][issue #126] Extract transition/runtime-event bootverify checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -237,15 +237,12 @@ func checkMCPServerReachable(c *checkerContext) []Finding         { return c.mcp
 func checkAgentPermissionValidation(c *checkerContext) []Finding {
 	return uniqueFindings(append(c.permissions(), c.permissionWarnings()...))
 }
-func checkPhantomProduces(c *checkerContext) []Finding               { return c.phantomProduces() }
-func checkSingleNodePerEvent(c *checkerContext) []Finding            { return c.singleNodePerEvent() }
-func checkPlatformMetadataValidation(c *checkerContext) []Finding    { return c.platformMetadata() }
-func checkTransitionReferenceValidation(c *checkerContext) []Finding { return c.transitionReferences() }
-func checkTransitionOwnershipValidation(c *checkerContext) []Finding { return c.transitionOwnership() }
-func checkEventRuntimeWiringValidation(c *checkerContext) []Finding  { return c.eventRuntimeWiring() }
-func checkTimerValidation(c *checkerContext) []Finding               { return c.timerValidation() }
-func checkGateSchemaValidation(c *checkerContext) []Finding          { return c.gateSchemaValidation() }
-func checkDeprecatedContractAlias(c *checkerContext) []Finding       { return c.deprecatedAliases() }
+func checkPhantomProduces(c *checkerContext) []Finding            { return c.phantomProduces() }
+func checkSingleNodePerEvent(c *checkerContext) []Finding         { return c.singleNodePerEvent() }
+func checkPlatformMetadataValidation(c *checkerContext) []Finding { return c.platformMetadata() }
+func checkTimerValidation(c *checkerContext) []Finding            { return c.timerValidation() }
+func checkGateSchemaValidation(c *checkerContext) []Finding       { return c.gateSchemaValidation() }
+func checkDeprecatedContractAlias(c *checkerContext) []Finding    { return c.deprecatedAliases() }
 
 func (c *checkerContext) eventWarningsByCheck(checkID string) []Finding {
 	items := c.eventWarnings()
@@ -314,205 +311,6 @@ func (c *checkerContext) platformMetadata() []Finding {
 		})
 	}
 	return c.platformMetaFindings
-}
-
-func (c *checkerContext) transitionReferences() []Finding {
-	if c.transitionRefLoaded {
-		return c.transitionRefFindings
-	}
-	c.transitionRefLoaded = true
-	for _, transition := range c.source.WorkflowTransitions() {
-		id := strings.TrimSpace(transition.ID)
-		if id == "" {
-			continue
-		}
-		if strings.TrimSpace(transition.Trigger) == "" {
-			c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-				CheckID:  "transition_reference_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("transition %s missing trigger", id),
-				Location: id,
-			})
-		} else if !eventExists(c.source, strings.TrimSpace(transition.Trigger)) {
-			c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-				CheckID:  "transition_reference_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("transition %s trigger %s missing from event catalog", id, transition.Trigger),
-				Location: id,
-			})
-		}
-		for _, actionID := range transition.Actions {
-			actionID = strings.TrimSpace(actionID)
-			if actionID == "" {
-				continue
-			}
-			action, ok := c.source.ActionInstructionByID(actionID)
-			if !ok {
-				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-					CheckID:  "transition_reference_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("transition %s references unknown action %s", id, actionID),
-					Location: id,
-				})
-				continue
-			}
-			if emits := strings.TrimSpace(action.Emits); emits != "" && !eventExists(c.source, emits) {
-				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-					CheckID:  "transition_reference_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("transition %s action %s emits missing event %s", id, actionID, emits),
-					Location: id,
-				})
-			}
-		}
-		for _, guardID := range transition.Guards {
-			guardID = strings.TrimSpace(guardID)
-			if guardID == "" {
-				continue
-			}
-			if _, ok := c.source.GuardInstructionByID(guardID); !ok {
-				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-					CheckID:  "transition_reference_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("transition %s references unknown guard %s", id, guardID),
-					Location: id,
-				})
-			}
-		}
-	}
-	for flowID := range c.source.FlowSchemaEntries() {
-		for _, eventType := range c.source.FlowInputEvents(flowID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType != "" && !eventExists(c.source, eventType) {
-				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-					CheckID:  "transition_reference_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s input event %s missing from event catalog", flowID, eventType),
-					Location: strings.TrimSpace(flowID),
-				})
-			}
-		}
-		for _, eventType := range c.source.FlowOutputEvents(flowID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType != "" && !eventExists(c.source, eventType) {
-				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
-					CheckID:  "transition_reference_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s output event %s missing from event catalog", flowID, eventType),
-					Location: strings.TrimSpace(flowID),
-				})
-			}
-		}
-	}
-	return c.transitionRefFindings
-}
-
-func (c *checkerContext) transitionOwnership() []Finding {
-	if c.transitionOwnerLoaded {
-		return c.transitionOwnerFindings
-	}
-	c.transitionOwnerLoaded = true
-	transitions := c.source.WorkflowTransitions()
-	transitionByID := make(map[string]runtimecontracts.WorkflowTransitionContract, len(transitions))
-	for _, transition := range transitions {
-		id := strings.TrimSpace(transition.ID)
-		if id != "" {
-			transitionByID[id] = transition
-		}
-	}
-	usesOwningNodeModel := contractBundleUsesOwningNodeModel(c.source)
-	for nodeID, node := range c.source.NodeEntries() {
-		nodeID = strings.TrimSpace(nodeID)
-		if nodeID == "" {
-			continue
-		}
-		subs := stringSet(c.source.NodeRuntimeSubscriptions(nodeID))
-		produces := stringSet(node.Produces)
-		for _, transitionID := range node.OwnedTransitions {
-			transitionID = strings.TrimSpace(transitionID)
-			if transitionID == "" {
-				continue
-			}
-			transition, ok := transitionByID[transitionID]
-			if !ok {
-				c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
-					CheckID:  "transition_ownership_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("node %s owns unknown transition %s", nodeID, transitionID),
-					Location: nodeID,
-				})
-				continue
-			}
-			if owner := strings.TrimSpace(transition.Node); owner != nodeID {
-				c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
-					CheckID:  "transition_ownership_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("node %s owns transition %s but workflow owner is %s", nodeID, transitionID, owner),
-					Location: nodeID,
-				})
-			}
-			trigger := strings.TrimSpace(transition.Trigger)
-			if trigger != "" && !usesOwningNodeModel {
-				if _, ok := subs[trigger]; !ok {
-					if _, emitted := produces[trigger]; !emitted {
-						c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
-							CheckID:  "transition_ownership_validation",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s cannot see trigger %s for owned transition %s", nodeID, trigger, transitionID),
-							Location: nodeID,
-						})
-					}
-				}
-			}
-		}
-	}
-	return c.transitionOwnerFindings
-}
-
-func (c *checkerContext) eventRuntimeWiring() []Finding {
-	if c.eventRuntimeLoaded {
-		return c.eventRuntimeFindings
-	}
-	c.eventRuntimeLoaded = true
-	nodes := c.source.NodeEntries()
-	usesOwningNodeModel := contractBundleUsesOwningNodeModel(c.source)
-	for eventType, entry := range c.source.EventEntries() {
-		eventType = strings.TrimSpace(eventType)
-		handling := strings.TrimSpace(entry.RuntimeHandling)
-		owner := strings.TrimSpace(entry.OwningNode)
-		if !requiresOwningNode(handling) || !usesOwningNodeModel {
-			continue
-		}
-		if owner == "" {
-			c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
-				CheckID:  "event_runtime_wiring_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("event %s with runtime_handling=%s missing owning_node", eventType, handling),
-				Location: eventType,
-			})
-			continue
-		}
-		if _, ok := nodes[owner]; !ok {
-			c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
-				CheckID:  "event_runtime_wiring_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("event %s owning_node %s missing from system nodes", eventType, owner),
-				Location: eventType,
-			})
-			continue
-		}
-		if handlers := c.source.NodeEventHandlers(owner); len(handlers) > 0 {
-			if _, ok := c.source.NodeEventHandler(owner, eventType); !ok {
-				c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
-					CheckID:  "event_runtime_wiring_validation",
-					Severity: "error",
-					Message:  fmt.Sprintf("event %s owning_node %s missing semantic event_handler", eventType, owner),
-					Location: eventType,
-				})
-			}
-		}
-	}
-	return c.eventRuntimeFindings
 }
 
 func (c *checkerContext) timerValidation() []Finding {
@@ -1395,7 +1193,6 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 		return c.handlerFindings
 	}
 	c.handlerLoaded = true
-	runtimeExecutors := supportedWorkflowRuntimeExecutorIDs(c.source)
 	nodes := c.source.NodeEntries()
 	for _, transition := range c.source.WorkflowTransitions() {
 		id := strings.TrimSpace(transition.ID)
@@ -1480,30 +1277,7 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 			}
 		}
 	}
-	usesOwningNodeModel := contractBundleUsesOwningNodeModel(c.source)
-	for eventType, entry := range c.source.EventEntries() {
-		eventType = strings.TrimSpace(eventType)
-		handling := strings.TrimSpace(entry.RuntimeHandling)
-		owner := strings.TrimSpace(entry.OwningNode)
-		if !requiresOwningNode(handling) || !usesOwningNodeModel {
-			continue
-		}
-		if owner == "" {
-			continue
-		}
-		if _, ok := nodes[owner]; !ok {
-			continue
-		}
-		if _, ok := runtimeExecutors[owner]; ok {
-			continue
-		}
-		c.handlerFindings = append(c.handlerFindings, Finding{
-			CheckID:  "handler_field_compliance",
-			Severity: "error",
-			Message:  fmt.Sprintf("event %s owning_node %s has no runtime executor", eventType, owner),
-			Location: eventType,
-		})
-	}
+	c.handlerFindings = append(c.handlerFindings, runtimeHandledEventsMissingExecutors(c.source)...)
 	return c.handlerFindings
 }
 
@@ -2899,32 +2673,6 @@ func handlerActionExecutable(source semanticview.Source, actionID string) bool {
 	}
 	entry, ok := source.ActionInstructionByID(actionID)
 	return ok && entry.Executable()
-}
-
-func requiresOwningNode(runtimeHandling string) bool {
-	switch strings.TrimSpace(runtimeHandling) {
-	case "consuming", "dual_delivery", "projection", "stage_projection":
-		return true
-	default:
-		return false
-	}
-}
-
-func contractBundleUsesOwningNodeModel(source semanticview.Source) bool {
-	if source == nil {
-		return false
-	}
-	for _, entry := range source.EventEntries() {
-		if strings.TrimSpace(entry.OwningNode) != "" {
-			return true
-		}
-	}
-	for _, node := range source.NodeEntries() {
-		if len(source.NodeEventHandlers(node.ID)) > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 func detectEventCyclesSemanticModel(source semanticview.Source) error {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1683,6 +1683,56 @@ func TestRun_UsesCompiledOwnersForEquivalentSingleNodePerEventRoutes(t *testing.
 	}
 }
 
+func TestRun_ReportsMissingTransitionTriggerEvent(t *testing.T) {
+	bundle := bootverifyTransitionRuntimeOwnershipBundle()
+	bundle.Semantics.Transitions[0].Trigger = "ticket.missing"
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "transition_reference_validation", "trigger ticket.missing missing from event catalog") {
+		t.Fatalf("expected transition_reference_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsTransitionOwnershipMismatch(t *testing.T) {
+	bundle := bootverifyTransitionRuntimeOwnershipBundle()
+	bundle.Semantics.Transitions[0].Node = "projector"
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "transition_ownership_validation", "workflow owner is projector") {
+		t.Fatalf("expected transition_ownership_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsMissingSemanticHandlerForOwnedRuntimeEvent(t *testing.T) {
+	bundle := bootverifyTransitionRuntimeOwnershipBundle()
+	event := bundle.Events["ticket.opened"]
+	event.OwningNode = "dispatcher"
+	bundle.Events["ticket.opened"] = event
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "event_runtime_wiring_validation", "owning_node dispatcher missing semantic event_handler") {
+		t.Fatalf("expected event_runtime_wiring_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
+	bundle := bootverifyTransitionRuntimeOwnershipBundle()
+	bundle.Nodes["idle-owner"] = runtimecontracts.SystemNodeContract{ID: "idle-owner"}
+	event := bundle.Events["ticket.audit"]
+	event.RuntimeHandling = "projection"
+	event.OwningNode = "idle-owner"
+	bundle.Events["ticket.audit"] = event
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "event ticket.audit owning_node idle-owner has no runtime executor") {
+		t.Fatalf("expected handler_field_compliance runtime executor error, got %#v", report.Errors())
+	}
+}
+
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
 	if got := len(bootCheckRegistry); got != 38 {
 		t.Fatalf("bootCheckRegistry count = %d, want 38", got)
@@ -2163,6 +2213,66 @@ func loadFixtureBundleAt(t *testing.T, repoRoot, fixtureRoot, platformSpec strin
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", fixtureRoot, err)
 	}
 	return bundle
+}
+
+func bootverifyTransitionRuntimeOwnershipBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Transitions: []runtimecontracts.WorkflowTransitionContract{{
+				ID:      "ticket-open",
+				Trigger: "ticket.created",
+				Node:    "dispatcher",
+				Actions: []string{"emit_opened"},
+				Guards:  []string{"allow_ticket"},
+			}},
+			ActionByID: map[string]runtimecontracts.GuardActionEntry{
+				"emit_opened": {
+					ID:    "emit_opened",
+					Emits: "ticket.opened",
+				},
+			},
+			GuardByID: map[string]runtimecontracts.GuardActionEntry{
+				"allow_ticket": {
+					ID:    "allow_ticket",
+					Check: "true",
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"dispatcher": {
+					"ticket.created": {},
+				},
+				"projector": {
+					"ticket.opened": {},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"dispatcher": {
+				ID:               "dispatcher",
+				OwnedTransitions: []string{"ticket-open"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"ticket.created": {},
+				},
+			},
+			"projector": {
+				ID: "projector",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"ticket.opened": {},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"ticket.created": {
+				RuntimeHandling: "consuming",
+				OwningNode:      "dispatcher",
+			},
+			"ticket.opened": {
+				RuntimeHandling: "projection",
+				OwningNode:      "projector",
+			},
+			"ticket.audit": {},
+		},
+	}
 }
 
 func reportContains(items []Finding, checkID, contains string) bool {

--- a/internal/runtime/bootverify/workflow_transition_runtime_checks.go
+++ b/internal/runtime/bootverify/workflow_transition_runtime_checks.go
@@ -1,0 +1,284 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkTransitionReferenceValidation(c *checkerContext) []Finding { return c.transitionReferences() }
+func checkTransitionOwnershipValidation(c *checkerContext) []Finding { return c.transitionOwnership() }
+func checkEventRuntimeWiringValidation(c *checkerContext) []Finding  { return c.eventRuntimeWiring() }
+
+func (c *checkerContext) transitionReferences() []Finding {
+	if c.transitionRefLoaded {
+		return c.transitionRefFindings
+	}
+	c.transitionRefLoaded = true
+	for _, transition := range c.source.WorkflowTransitions() {
+		id := strings.TrimSpace(transition.ID)
+		if id == "" {
+			continue
+		}
+		if strings.TrimSpace(transition.Trigger) == "" {
+			c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+				CheckID:  "transition_reference_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("transition %s missing trigger", id),
+				Location: id,
+			})
+		} else if !eventExists(c.source, strings.TrimSpace(transition.Trigger)) {
+			c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+				CheckID:  "transition_reference_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("transition %s trigger %s missing from event catalog", id, transition.Trigger),
+				Location: id,
+			})
+		}
+		for _, actionID := range transition.Actions {
+			actionID = strings.TrimSpace(actionID)
+			if actionID == "" {
+				continue
+			}
+			action, ok := c.source.ActionInstructionByID(actionID)
+			if !ok {
+				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+					CheckID:  "transition_reference_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("transition %s references unknown action %s", id, actionID),
+					Location: id,
+				})
+				continue
+			}
+			if emits := strings.TrimSpace(action.Emits); emits != "" && !eventExists(c.source, emits) {
+				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+					CheckID:  "transition_reference_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("transition %s action %s emits missing event %s", id, actionID, emits),
+					Location: id,
+				})
+			}
+		}
+		for _, guardID := range transition.Guards {
+			guardID = strings.TrimSpace(guardID)
+			if guardID == "" {
+				continue
+			}
+			if _, ok := c.source.GuardInstructionByID(guardID); !ok {
+				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+					CheckID:  "transition_reference_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("transition %s references unknown guard %s", id, guardID),
+					Location: id,
+				})
+			}
+		}
+	}
+	for flowID := range c.source.FlowSchemaEntries() {
+		for _, eventType := range c.source.FlowInputEvents(flowID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType != "" && !eventExists(c.source, eventType) {
+				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+					CheckID:  "transition_reference_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("flow %s input event %s missing from event catalog", flowID, eventType),
+					Location: strings.TrimSpace(flowID),
+				})
+			}
+		}
+		for _, eventType := range c.source.FlowOutputEvents(flowID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType != "" && !eventExists(c.source, eventType) {
+				c.transitionRefFindings = append(c.transitionRefFindings, Finding{
+					CheckID:  "transition_reference_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("flow %s output event %s missing from event catalog", flowID, eventType),
+					Location: strings.TrimSpace(flowID),
+				})
+			}
+		}
+	}
+	return c.transitionRefFindings
+}
+
+func (c *checkerContext) transitionOwnership() []Finding {
+	if c.transitionOwnerLoaded {
+		return c.transitionOwnerFindings
+	}
+	c.transitionOwnerLoaded = true
+	transitions := c.source.WorkflowTransitions()
+	transitionByID := make(map[string]runtimecontracts.WorkflowTransitionContract, len(transitions))
+	for _, transition := range transitions {
+		id := strings.TrimSpace(transition.ID)
+		if id != "" {
+			transitionByID[id] = transition
+		}
+	}
+	usesOwningNodeModel := contractBundleUsesOwningNodeModel(c.source)
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		if nodeID == "" {
+			continue
+		}
+		subs := stringSet(c.source.NodeRuntimeSubscriptions(nodeID))
+		produces := stringSet(node.Produces)
+		for _, transitionID := range node.OwnedTransitions {
+			transitionID = strings.TrimSpace(transitionID)
+			if transitionID == "" {
+				continue
+			}
+			transition, ok := transitionByID[transitionID]
+			if !ok {
+				c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
+					CheckID:  "transition_ownership_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s owns unknown transition %s", nodeID, transitionID),
+					Location: nodeID,
+				})
+				continue
+			}
+			if owner := strings.TrimSpace(transition.Node); owner != nodeID {
+				c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
+					CheckID:  "transition_ownership_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s owns transition %s but workflow owner is %s", nodeID, transitionID, owner),
+					Location: nodeID,
+				})
+			}
+			trigger := strings.TrimSpace(transition.Trigger)
+			if trigger != "" && !usesOwningNodeModel {
+				if _, ok := subs[trigger]; !ok {
+					if _, emitted := produces[trigger]; !emitted {
+						c.transitionOwnerFindings = append(c.transitionOwnerFindings, Finding{
+							CheckID:  "transition_ownership_validation",
+							Severity: "error",
+							Message:  fmt.Sprintf("node %s cannot see trigger %s for owned transition %s", nodeID, trigger, transitionID),
+							Location: nodeID,
+						})
+					}
+				}
+			}
+		}
+	}
+	return c.transitionOwnerFindings
+}
+
+func (c *checkerContext) eventRuntimeWiring() []Finding {
+	if c.eventRuntimeLoaded {
+		return c.eventRuntimeFindings
+	}
+	c.eventRuntimeLoaded = true
+	nodes := c.source.NodeEntries()
+	for _, requirement := range runtimeHandledEventRequirements(c.source) {
+		if requirement.owner == "" {
+			c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
+				CheckID:  "event_runtime_wiring_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("event %s with runtime_handling=%s missing owning_node", requirement.eventType, requirement.handling),
+				Location: requirement.eventType,
+			})
+			continue
+		}
+		if _, ok := nodes[requirement.owner]; !ok {
+			c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
+				CheckID:  "event_runtime_wiring_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("event %s owning_node %s missing from system nodes", requirement.eventType, requirement.owner),
+				Location: requirement.eventType,
+			})
+			continue
+		}
+		if handlers := c.source.NodeEventHandlers(requirement.owner); len(handlers) > 0 {
+			if _, ok := c.source.NodeEventHandler(requirement.owner, requirement.eventType); !ok {
+				c.eventRuntimeFindings = append(c.eventRuntimeFindings, Finding{
+					CheckID:  "event_runtime_wiring_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("event %s owning_node %s missing semantic event_handler", requirement.eventType, requirement.owner),
+					Location: requirement.eventType,
+				})
+			}
+		}
+	}
+	return c.eventRuntimeFindings
+}
+
+type runtimeHandledEventRequirement struct {
+	eventType string
+	handling  string
+	owner     string
+}
+
+func runtimeHandledEventRequirements(source semanticview.Source) []runtimeHandledEventRequirement {
+	if source == nil || !contractBundleUsesOwningNodeModel(source) {
+		return nil
+	}
+	out := make([]runtimeHandledEventRequirement, 0)
+	for eventType, entry := range source.EventEntries() {
+		eventType = strings.TrimSpace(eventType)
+		handling := strings.TrimSpace(entry.RuntimeHandling)
+		if eventType == "" || !requiresOwningNode(handling) {
+			continue
+		}
+		out = append(out, runtimeHandledEventRequirement{
+			eventType: eventType,
+			handling:  handling,
+			owner:     strings.TrimSpace(entry.OwningNode),
+		})
+	}
+	return out
+}
+
+func runtimeHandledEventsMissingExecutors(source semanticview.Source) []Finding {
+	if source == nil {
+		return nil
+	}
+	runtimeExecutors := supportedWorkflowRuntimeExecutorIDs(source)
+	nodes := source.NodeEntries()
+	out := make([]Finding, 0)
+	for _, requirement := range runtimeHandledEventRequirements(source) {
+		if requirement.owner == "" {
+			continue
+		}
+		if _, ok := nodes[requirement.owner]; !ok {
+			continue
+		}
+		if _, ok := runtimeExecutors[requirement.owner]; ok {
+			continue
+		}
+		out = append(out, Finding{
+			CheckID:  "handler_field_compliance",
+			Severity: "error",
+			Message:  fmt.Sprintf("event %s owning_node %s has no runtime executor", requirement.eventType, requirement.owner),
+			Location: requirement.eventType,
+		})
+	}
+	return out
+}
+
+func requiresOwningNode(runtimeHandling string) bool {
+	switch strings.TrimSpace(runtimeHandling) {
+	case "consuming", "dual_delivery", "projection", "stage_projection":
+		return true
+	default:
+		return false
+	}
+}
+
+func contractBundleUsesOwningNodeModel(source semanticview.Source) bool {
+	if source == nil {
+		return false
+	}
+	for _, entry := range source.EventEntries() {
+		if strings.TrimSpace(entry.OwningNode) != "" {
+			return true
+		}
+	}
+	for _, node := range source.NodeEntries() {
+		if len(source.NodeEventHandlers(node.ID)) > 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Part of #126

## Human Summary
This extracts the transition/runtime-event ownership bootverify cluster out of the monolithic `checks.go` file into one boundary-owned module, and adds direct report-surface proof for the weakest ownership/reference/runtime-wiring paths in that cluster.

## What Changed
- extracted `transition_reference_validation`, `transition_ownership_validation`, and `event_runtime_wiring_validation` into `internal/runtime/bootverify/workflow_transition_runtime_checks.go`
- moved the concept-local ownership helpers `requiresOwningNode(...)` and `contractBundleUsesOwningNodeModel(...)` with that module
- aligned the adjacent `handler_field_compliance` runtime-executor subpath to consume the same ownership helper instead of keeping a second local interpreter alive
- removed the extracted cluster implementation from `internal/runtime/bootverify/checks.go` while preserving the existing registry/report/startup surface
- added focused `Run(...)` report tests for:
  - missing transition trigger event
  - transition owner mismatch
  - missing semantic handler for an owned runtime-handled event
  - missing runtime executor for an owned runtime-handled event

## Why This Is Needed
`#126` remains the umbrella maintenance issue for bootverify decomposition. This slice closes another coherent cluster that was still embedded in `checks.go`, with no direct report-surface proof on current `master` for its main ownership/reference/runtime-wiring manifestations.

## Scope Boundaries
- this PR canonicalizes only the transition/runtime-event ownership bootverify slice
- it does not claim closure of all remaining `#126` bootverify decomposition work
- it does not absorb timer validation, single-node-per-event validation, or broader runtime ownership redesign

## Spec References
No direct platform-spec refs for this PR.
This is maintenance-only bootverify decomposition that preserves the existing startup verification semantics rather than redesigning them.

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(ReportsMissingTransitionTriggerEvent|ReportsTransitionOwnershipMismatch|ReportsMissingSemanticHandlerForOwnedRuntimeEvent|ReportsMissingRuntimeExecutorForOwnedRuntimeEvent)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
The main residual reviewer attention point is the shared generic `eventExists(...)` helper, which remains intentionally shared with adjacent concepts such as timer validation. This PR does not claim timer validation as closed.

## Follow-Up
- continue `#126` with the next remaining coherent bootverify cluster still embedded in `checks.go`
- if later work shows `eventExists(...)` is carrying concept-specific ownership semantics rather than a generic catalog-existence role, reopen the scope and split that helper accordingly
