### PR TITLE
[agent-d][issue #218] Establish an explicit startup probe outcome contract

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -81,6 +81,10 @@ active_issues:
     title: Add structured tool-call diagnostics for payload validation, enrichment, and publish outcomes
     maps_to:
       - tool_execution_outcome_diagnostics
+  - id: 218
+    title: Eliminate string-based startup tool probe classification with an explicit validation/probe contract
+    maps_to:
+      - transport_policy_and_surface_parity
   - id: 179
     title: Expose recovery and restart decisions through canonical diagnostics
     maps_to:
@@ -96,11 +100,13 @@ nodes:
       - context-token policy differs across transport surfaces
       - startup validation does not prove the real filtered transport path
       - startup reachability probe conflates tool-call transport proof with tool-specific required-input validity
+      - startup callable proof lacks an explicit typed probe outcome contract
       - agent-visible tool availability differs between prompt and transport
     representative_issues:
       - 111
       - 136
       - 137
+      - 218
       - 305
     common_framing_mistakes:
       too_broad:

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -229,6 +229,16 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 			g.writeToolCallErrorResult(w, req.ID, err)
 			return
 		}
+		startupProbe, err := DecodeStartupProbeRequest(req.Params[startupProbeParamKey])
+		if err != nil {
+			err = g.newRuntimeError(ErrCodeInvalidRequest, "mcp.tools.call.startup_probe", false, err, "invalid startup probe request")
+			g.logMCP(r, "warn", "mcp.tools.call.invalid_probe", err, map[string]any{
+				"method":    "tools/call",
+				"tool_name": toolName,
+			})
+			g.writeToolCallErrorResult(w, req.ID, err)
+			return
+		}
 		ctx, err := g.mcpExecutionContext(r, toolName)
 		if err != nil {
 			g.logMCP(r, "warn", "mcp.tools.call.context_error", err, map[string]any{
@@ -277,7 +287,23 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 				"method":    "tools/call",
 				"tool_name": toolName,
 			})
-			g.writeToolCallErrorResult(w, req.ID, err)
+			payload := map[string]any{
+				"content": []map[string]any{{"type": "text", "text": g.formatError(err)}},
+				"isError": true,
+			}
+			if runtimeErr := RuntimeErrorPayloadFromError(err); runtimeErr != nil {
+				payload["runtimeError"] = runtimeErr
+				if startupProbe != nil {
+					outcome, outcomeErr := StartupProbeResultForRuntimeError(startupProbe.Contract, toolName, runtimeErr)
+					if outcomeErr != nil {
+						err = g.newRuntimeError(ErrCodeInvalidRequest, "mcp.tools.call.startup_probe", false, outcomeErr, "invalid startup probe request")
+						g.writeToolCallErrorResult(w, req.ID, err)
+						return
+					}
+					payload[startupProbeResultKey] = outcome
+				}
+			}
+			WriteRPCResult(w, req.ID, payload)
 			return
 		}
 		g.logMCP(r, "debug", "mcp.tools.call.success", nil, map[string]any{
@@ -287,10 +313,14 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 		if g.hooks.AfterToolSuccess != nil {
 			g.hooks.AfterToolSuccess(ctx, r, toolName)
 		}
-		WriteRPCResult(w, req.ID, map[string]any{
+		result := map[string]any{
 			"content": []map[string]any{{"type": "text", "text": ToolResultText(out)}},
 			"isError": false,
-		})
+		}
+		if startupProbe != nil {
+			result[startupProbeResultKey] = StartupProbeSuccessResult(startupProbe.Contract, toolName)
+		}
+		WriteRPCResult(w, req.ID, result)
 		return
 	case "ping":
 		WriteRPCResult(w, req.ID, map[string]any{})

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -830,6 +830,109 @@ func TestGatewayHandleMCP_ToolsCallIncludesStructuredRuntimeErrorPayload(t *test
 	}
 }
 
+func TestGatewayHandleMCP_ToolsCallIncludesExplicitStartupProbeSuccessOutcome(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	g := NewGateway(testToolExecutor(func(_ context.Context, _ string, _ any) (any, error) {
+		return map[string]any{"ok": true}, nil
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-startup-probe-success", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{},
+			"swarmProbe": map[string]any{
+				"contract": StartupProbeContractManagedAgentCallable,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-startup-probe-success")
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	resp := mustRPCResponse(t, rec)
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	probeResult, err := DecodeStartupProbeResult(result["swarmStartupProbe"])
+	if err != nil {
+		t.Fatalf("DecodeStartupProbeResult: %v", err)
+	}
+	if probeResult.Outcome != StartupProbeOutcomeSuccess {
+		t.Fatalf("startup probe outcome = %q, want success", probeResult.Outcome)
+	}
+}
+
+func TestGatewayHandleMCP_ToolsCallIncludesExplicitStartupProbeValidationOnlyOutcome(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	g := NewGateway(testToolExecutor(func(_ context.Context, _ string, _ any) (any, error) {
+		return nil, runtimerterr.WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required")
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-startup-probe-validation", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{},
+			"swarmProbe": map[string]any{
+				"contract": StartupProbeContractManagedAgentCallable,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-startup-probe-validation")
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	resp := mustRPCResponse(t, rec)
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	probeResult, err := DecodeStartupProbeResult(result["swarmStartupProbe"])
+	if err != nil {
+		t.Fatalf("DecodeStartupProbeResult: %v", err)
+	}
+	if probeResult.Outcome != StartupProbeOutcomeValidationOnly {
+		t.Fatalf("startup probe outcome = %q, want validation_only", probeResult.Outcome)
+	}
+	if probeResult.CauseCode != "invalid_tool_input" {
+		t.Fatalf("startup probe cause_code = %q, want invalid_tool_input", probeResult.CauseCode)
+	}
+}
+
 func TestGatewayHandleMCP_RejectsToolWhenContextTokenMisses(t *testing.T) {
 	callCount := 0
 	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {

--- a/internal/runtime/mcp/startup_probe_contract.go
+++ b/internal/runtime/mcp/startup_probe_contract.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	StartupProbeContractManagedAgentCallable = "managed_agent_callable_proof_v1"
+	startupProbeParamKey                     = "swarmProbe"
+	startupProbeResultKey                    = "swarmStartupProbe"
+)
+
+type StartupProbeRequest struct {
+	Contract string `json:"contract"`
+}
+
+type StartupProbeOutcome string
+
+const (
+	StartupProbeOutcomeSuccess          StartupProbeOutcome = "success"
+	StartupProbeOutcomeValidationOnly   StartupProbeOutcome = "validation_only"
+	StartupProbeOutcomeExecutionFailure StartupProbeOutcome = "execution_failure"
+)
+
+type StartupProbeResult struct {
+	Contract         string              `json:"contract"`
+	Outcome          StartupProbeOutcome `json:"outcome"`
+	ToolName         string              `json:"tool_name,omitempty"`
+	RuntimeErrorCode string              `json:"runtime_error_code,omitempty"`
+	CauseCode        string              `json:"cause_code,omitempty"`
+	Message          string              `json:"message,omitempty"`
+}
+
+func DecodeStartupProbeRequest(raw any) (*StartupProbeRequest, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encode startup probe request: %w", err)
+	}
+	var req StartupProbeRequest
+	if err := json.Unmarshal(encoded, &req); err != nil {
+		return nil, fmt.Errorf("decode startup probe request: %w", err)
+	}
+	req.Contract = strings.TrimSpace(req.Contract)
+	if req.Contract == "" {
+		return nil, fmt.Errorf("startup probe contract is required")
+	}
+	if req.Contract != StartupProbeContractManagedAgentCallable {
+		return nil, fmt.Errorf("unsupported startup probe contract %q", req.Contract)
+	}
+	return &req, nil
+}
+
+func DecodeStartupProbeResult(raw any) (*StartupProbeResult, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("startup probe result is required")
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encode startup probe result: %w", err)
+	}
+	var result StartupProbeResult
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		return nil, fmt.Errorf("decode startup probe result: %w", err)
+	}
+	result.Contract = strings.TrimSpace(result.Contract)
+	result.ToolName = strings.TrimSpace(result.ToolName)
+	result.RuntimeErrorCode = strings.TrimSpace(result.RuntimeErrorCode)
+	result.CauseCode = strings.TrimSpace(result.CauseCode)
+	result.Message = strings.TrimSpace(result.Message)
+	if result.Contract != StartupProbeContractManagedAgentCallable {
+		return nil, fmt.Errorf("unsupported startup probe result contract %q", result.Contract)
+	}
+	switch result.Outcome {
+	case StartupProbeOutcomeSuccess, StartupProbeOutcomeValidationOnly, StartupProbeOutcomeExecutionFailure:
+	default:
+		return nil, fmt.Errorf("startup probe outcome is required")
+	}
+	return &result, nil
+}
+
+func StartupProbeSuccessResult(contract, toolName string) *StartupProbeResult {
+	return &StartupProbeResult{
+		Contract: strings.TrimSpace(contract),
+		Outcome:  StartupProbeOutcomeSuccess,
+		ToolName: strings.TrimSpace(toolName),
+	}
+}
+
+func StartupProbeResultForRuntimeError(contract, toolName string, runtimeErr *RuntimeErrorPayload) (*StartupProbeResult, error) {
+	contract = strings.TrimSpace(contract)
+	if contract != StartupProbeContractManagedAgentCallable {
+		return nil, fmt.Errorf("unsupported startup probe contract %q", contract)
+	}
+	if runtimeErr == nil {
+		return nil, fmt.Errorf("runtime error payload is required")
+	}
+	result := &StartupProbeResult{
+		Contract:         contract,
+		Outcome:          StartupProbeOutcomeExecutionFailure,
+		ToolName:         strings.TrimSpace(toolName),
+		RuntimeErrorCode: strings.TrimSpace(runtimeErr.Code),
+		Message:          strings.TrimSpace(runtimeErr.Message),
+	}
+	if runtimeErr.Cause != nil {
+		result.CauseCode = strings.TrimSpace(runtimeErr.Cause.Code)
+	}
+	if result.CauseCode == "invalid_tool_input" {
+		result.Outcome = StartupProbeOutcomeValidationOnly
+	}
+	return result, nil
+}

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -331,6 +331,9 @@ func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding 
 		Params: map[string]any{
 			"name":      strings.TrimSpace(name),
 			"arguments": map[string]any{},
+			"swarmProbe": map[string]any{
+				"contract": runtimemcp.StartupProbeContractManagedAgentCallable,
+			},
 		},
 		ID: "startup-tools-call",
 	})
@@ -341,21 +344,44 @@ func startupProbeMCPToolsCall(ctx context.Context, client *http.Client, binding 
 	if !ok {
 		return fmt.Errorf("tools/call returned invalid result payload")
 	}
-	if isError, _ := result["isError"].(bool); !isError {
-		return nil
-	}
-	runtimeErr, err := runtimemcp.DecodeRuntimeErrorPayload(result["runtimeError"])
+	probeResult, err := runtimemcp.DecodeStartupProbeResult(result["swarmStartupProbe"])
 	if err != nil {
-		return fmt.Errorf("tools/call returned invalid runtimeError payload: %w", err)
+		return fmt.Errorf("tools/call returned invalid startup probe result: %w", err)
 	}
-	message := strings.TrimSpace(startupMCPErrorText(result))
-	if message != "" {
-		return fmt.Errorf(message)
+	if probeResult.ToolName != strings.TrimSpace(name) {
+		return fmt.Errorf("tools/call returned startup probe result for unexpected tool %q", probeResult.ToolName)
 	}
-	if runtimeErr != nil && strings.TrimSpace(runtimeErr.Message) != "" {
-		return fmt.Errorf("%s", strings.TrimSpace(runtimeErr.Message))
+	isError, _ := result["isError"].(bool)
+	switch probeResult.Outcome {
+	case runtimemcp.StartupProbeOutcomeSuccess, runtimemcp.StartupProbeOutcomeValidationOnly:
+		if probeResult.Outcome == runtimemcp.StartupProbeOutcomeSuccess && isError {
+			return fmt.Errorf("tools/call returned inconsistent startup probe success result")
+		}
+		if probeResult.Outcome == runtimemcp.StartupProbeOutcomeValidationOnly && !isError {
+			return fmt.Errorf("tools/call returned inconsistent startup probe validation-only result")
+		}
+		return nil
+	case runtimemcp.StartupProbeOutcomeExecutionFailure:
+		if !isError {
+			return fmt.Errorf("tools/call returned inconsistent startup probe execution-failure result")
+		}
+		if message := strings.TrimSpace(startupMCPErrorText(result)); message != "" {
+			return fmt.Errorf(message)
+		}
+		runtimeErr, err := runtimemcp.DecodeRuntimeErrorPayload(result["runtimeError"])
+		if err == nil && runtimeErr != nil {
+			if strings.TrimSpace(runtimeErr.Message) != "" {
+				return fmt.Errorf("%s", strings.TrimSpace(runtimeErr.Message))
+			}
+			return fmt.Errorf("tools/call returned runtime error code=%s", strings.TrimSpace(runtimeErr.Code))
+		}
+		if code := strings.TrimSpace(probeResult.RuntimeErrorCode); code != "" {
+			return fmt.Errorf("tools/call returned runtime error code=%s", code)
+		}
+		return fmt.Errorf("tools/call returned startup probe execution failure")
+	default:
+		return fmt.Errorf("tools/call returned unsupported startup probe outcome %q", probeResult.Outcome)
 	}
-	return fmt.Errorf("tools/call returned runtime error code=%s", strings.TrimSpace(runtimeErr.Code))
 }
 
 func startupMCPErrorText(result map[string]any) string {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -229,6 +229,34 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 	}
 }
 
+func TestValidateClaudeMCPToolsForManagedAgents_AcceptsExplicitValidationOnlyProbeOutcome(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "campaign-coordinator",
+		Role:   "campaign_coordinator",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+		execErrs: map[string]error{
+			"health_check": WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_health_check.input", false, nil, "probe input is invalid"),
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(exec.executed, []string{"health_check"}) {
+		t.Fatalf("executed = %#v, want health_check tools/call smoke", exec.executed)
+	}
+}
+
 func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTokenMismatch(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"


### PR DESCRIPTION
Closes #218

## Spec references

No exact `platform-spec.yaml` section governs the managed-agent Claude startup probe contract at this level of detail. The binding authority for this PR is issue `#218`, its approved pre-audit, and the recorded gate decision.

Closest surrounding spec context re-read before implementation:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_sequence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: implementation_classes.mcp`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: mcp_client`

## Human Summary

This PR makes the managed-agent Claude startup callable proof use one explicit typed probe-outcome contract instead of inferring meaning from generic `tools/call` success/error shape. Startup now asks the MCP gateway for a specific startup probe contract, and the gateway returns a structured probe outcome that explicitly says whether the callable seam was proven by success, proven by validation-only rejection, or failed by real execution/runtime error.

## What Changed

- added a typed startup probe contract in `internal/runtime/mcp/startup_probe_contract.go`
- updated the MCP gateway `tools/call` path to emit explicit startup probe outcomes when that contract is requested
- updated Claude startup validation to consume only that explicit probe outcome instead of deriving startup meaning from free-form result/error interpretation
- kept the schema-safe probe selection from `#305` / `#308`
- added startup and gateway tests for:
  - explicit success outcome
  - explicit validation-only outcome
  - real execution failure remaining fail-closed
- refined the `transport_policy_and_surface_parity` watchlist node to record this manifestation and map `#218`

## Why This Is Needed

After `#305` / `#308`, the startup seam no longer relied on string heuristics for the required-input false-failure slice, but it still lacked a dedicated canonical owner for startup probe meaning. Startup was still interpreting generic `tools/call` envelopes rather than consuming one typed producer-owned probe contract. This PR closes that remaining drift in the managed-agent Claude startup callable-proof seam.

## Scope Boundaries

- in scope:
  - managed-agent Claude startup callable-proof contract semantics
  - the MCP gateway/startup boundary directly required to make that contract explicit
  - focused startup and gateway proof tests
- out of scope:
  - broad MCP redesign outside this startup seam
  - unrelated tool catalog or operator-surface cleanup
  - broader watchlist parent closure for all `transport_policy_and_surface_parity` work

Chosen working failure class closure target:
- `failure class eliminated`

Broader parent state:
- the broader watchlist parent `transport_policy_and_surface_parity` remains open
- this PR claims closure only of the chosen working failure class for `#218`, not the broader parent

## Tests Run

- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents_(UsesRealFilteredTransport|AcceptsExplicitValidationOnlyProbeOutcome|FailsClosedOnConfiguredGatewayTokenMismatch|FailsOnEmptyVisibleToolSurface|SkipsCallableProbeWhenVisibleToolsRequireInput|FailsClosedOnUnexpectedCallableProbeError|FailsClosedOnGenericPhraseNonValidationProbeError)' -count=1`
- `go test ./internal/runtime/mcp -run 'TestGatewayHandleMCP_ToolsCallIncludes(StructuredRuntimeErrorPayload|ExplicitStartupProbeSuccessOutcome|ExplicitStartupProbeValidationOnlyOutcome)' -count=1`
- `go test ./internal/runtime ./internal/runtime/mcp ./internal/runtime/llm -count=1`
- `go test ./... -count=1`

## Residual Risk

- this PR closes the explicit startup probe outcome-contract class only in the managed-agent Claude startup callable-proof seam
- startup probeability is still inferred from tool shape and the selected startup contract rather than being a first-class tool capability in the wider runtime model

## Follow-Up

- no new concrete same-class follow-up is created here because the chosen working failure class is intended to be fully closed by this PR
- the broader watchlist parent `transport_policy_and_surface_parity` remains open for other tracked classes outside this seam
