### PR TITLE
[agent-c][issue #224] Require explicit capability ownership in observability readers

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1249,7 +1249,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		agents = dashboardserver.NewSQLAgentReader(stores.Postgres.DB, stores.Postgres, rotateAfterTurns)
 		mailbox = stores.Postgres
 		conversations = dashboardserver.NewSQLConversationReader(stores.Postgres.DB, stores.Postgres)
-		observability = dashboardserver.NewSQLObservabilityReader(stores.Postgres.DB)
+		observability = dashboardserver.NewSQLObservabilityReader(stores.Postgres.DB, stores.Postgres)
 	}
 	if supervisor != nil {
 		agentControl = dashboardDynamicAgentControl{supervisor: supervisor}

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -87,6 +87,7 @@ nodes:
     known_manifestations:
       - conversation and turn APIs widen typed persisted data
       - dashboard readers synthesize canonical schema capabilities when no explicit capability owner is provided
+      - observability readers bypass explicit schema capability ownership for event and runtime-log surfaces
       - summary/runtime-log/mutation completeness may be inferred or silently omitted
       - mutation-surface reconstruction can silently tolerate malformed persisted `entity_mutations` proof in touched conformance/read-model seams
     representative_issues:

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	runtimepkg "swarm/internal/runtime"
+	"swarm/internal/store"
 )
 
 type EventFilter struct {
@@ -131,14 +132,22 @@ type incidentRecord struct {
 }
 
 type SQLObservabilityReader struct {
-	db *sql.DB
+	db        *sql.DB
+	capSource schemaCapabilitySource
 }
 
-func NewSQLObservabilityReader(db *sql.DB) *SQLObservabilityReader {
+func NewSQLObservabilityReader(db *sql.DB, capSource schemaCapabilitySource) *SQLObservabilityReader {
 	if db == nil {
 		return nil
 	}
-	return &SQLObservabilityReader{db: db}
+	return &SQLObservabilityReader{db: db, capSource: capSource}
+}
+
+func (r *SQLObservabilityReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
+	if r == nil || r.capSource == nil {
+		return store.StoreSchemaCapabilities{}, missingDashboardCapabilityOwner("observability reader")
+	}
+	return r.capSource.ResolveSchemaCapabilities(ctx)
 }
 
 func applyDeliveryLifecycle(record *eventRecord, lifecycle deliveryLifecycleSummary) {
@@ -154,6 +163,13 @@ func applyDeliveryLifecycle(record *eventRecord, lifecycle deliveryLifecycleSumm
 func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFilter, limit int) ([]eventRecord, error) {
 	if r == nil || r.db == nil {
 		return []eventRecord{}, nil
+	}
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireObservabilityEventCapabilities(caps); err != nil {
+		return nil, err
 	}
 	if limit <= 0 {
 		limit = 200
@@ -249,6 +265,13 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 	if r == nil || r.db == nil {
 		return eventRecord{}, false, nil
 	}
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return eventRecord{}, false, err
+	}
+	if err := requireObservabilityEventCapabilities(caps); err != nil {
+		return eventRecord{}, false, err
+	}
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return eventRecord{}, false, nil
@@ -331,6 +354,13 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	if r == nil || r.db == nil {
 		return []runtimeLogRecord{}, nil
 	}
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 200
 	}
@@ -387,6 +417,13 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter IncidentFilter) ([]incidentRecord, error) {
 	if r == nil || r.db == nil {
 		return []incidentRecord{}, nil
+	}
+	caps, err := r.resolveCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
+		return nil, err
 	}
 	limit := filter.Limit
 	if limit <= 0 {

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -11,12 +11,31 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
 
+type stubObservabilityCaps struct {
+	caps store.StoreSchemaCapabilities
+}
+
+func (s stubObservabilityCaps) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return s.caps, nil
+}
+
+func canonicalObservabilityCaps() store.StoreSchemaCapabilities {
+	return store.StoreSchemaCapabilities{
+		Events: store.EventSchemaCapabilities{
+			Log:        store.SchemaFlavorCanonical,
+			Deliveries: store.SchemaFlavorCanonical,
+			Receipts:   store.SchemaFlavorCanonical,
+		},
+	}
+}
+
 func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	runID := uuid.NewString()
@@ -83,7 +102,7 @@ func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *tes
 
 func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	runID := uuid.NewString()
@@ -179,7 +198,7 @@ func TestHandler_EventDetailIncludesDeliveryLifecycle(t *testing.T) {
 
 func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	insertRuntimeLog := func(eventID, state, prev, reason, terminal string, retryCount int, createdAt time.Time) {
@@ -235,7 +254,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalPayload(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	payload := `{
@@ -261,7 +280,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalP
 
 func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	insertRuntimeLog := func(component, action, agentID string, createdAt time.Time) {
@@ -315,7 +334,7 @@ func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t 
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalComponent(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	payload := `{
@@ -345,7 +364,7 @@ func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalCompo
 
 func TestSQLObservabilityReader_ListIncidents_UsesMessageWhenCanonicalErrorIsEmpty(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	payload := `{
@@ -381,7 +400,7 @@ func TestSQLObservabilityReader_ListIncidents_UsesMessageWhenCanonicalErrorIsEmp
 
 func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	reader := NewSQLObservabilityReader(db)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
 	base := time.Now().UTC().Truncate(time.Second)
@@ -419,5 +438,85 @@ func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *t
 	}
 	if rows[0].Code != "newer_code" {
 		t.Fatalf("incident code = %#v, want newer_code", rows[0].Code)
+	}
+}
+
+func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, nil)
+
+	if _, err := reader.ListEvents(context.Background(), EventFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_GetEvent_FailsClosedWithoutCapabilityOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, nil)
+
+	if _, _, err := reader.GetEvent(context.Background(), "evt-1"); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, nil)
+
+	if _, err := reader.ListRuntimeLogs(context.Background(), RuntimeLogFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, nil)
+
+	if _, err := reader.ListIncidents(context.Background(), IncidentFilter{SinceHours: 24}); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
+		t.Fatalf("expected missing capability owner error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCanonicalEventSurface(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	caps := canonicalObservabilityCaps()
+	caps.Events.Deliveries = store.SchemaFlavorLegacy
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
+
+	if _, err := reader.ListEvents(context.Background(), EventFilter{}, 10); err == nil || !strings.Contains(err.Error(), "event_deliveries schema is unsupported") {
+		t.Fatalf("expected event_deliveries capability error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_GetEvent_FailsClosedWhenCapabilityOwnerReportsUnavailableEventSurface(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	caps := canonicalObservabilityCaps()
+	caps.Events.Deliveries = store.SchemaFlavorUnavailable
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
+
+	if _, _, err := reader.GetEvent(context.Background(), "evt-1"); err == nil || !strings.Contains(err.Error(), "event_deliveries schema is unavailable") {
+		t.Fatalf("expected unavailable event_deliveries capability error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRuntimeLogSurface(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	caps := canonicalObservabilityCaps()
+	caps.Events.Log = store.SchemaFlavorLegacy
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
+
+	if _, err := reader.ListRuntimeLogs(context.Background(), RuntimeLogFilter{}, 10); err == nil || !strings.Contains(err.Error(), "events schema is unsupported") {
+		t.Fatalf("expected events capability error, got %v", err)
+	}
+}
+
+func TestSQLObservabilityReader_ListIncidents_FailsClosedWhenCapabilityOwnerReportsUnavailableRuntimeLogSurface(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	caps := canonicalObservabilityCaps()
+	caps.Events.Log = store.SchemaFlavorUnavailable
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
+
+	if _, err := reader.ListIncidents(context.Background(), IncidentFilter{SinceHours: 24}); err == nil || !strings.Contains(err.Error(), "events schema is unavailable") {
+		t.Fatalf("expected unavailable events capability error, got %v", err)
 	}
 }

--- a/internal/dashboard/server/schema_capabilities.go
+++ b/internal/dashboard/server/schema_capabilities.go
@@ -51,3 +51,20 @@ func requireAgentOperatorProjectionCapabilities(caps store.StoreSchemaCapabiliti
 	}
 	return store.RequireCanonicalPendingAgentDeliveryCapabilities(caps)
 }
+
+func requireObservabilityEventCapabilities(caps store.StoreSchemaCapabilities) error {
+	if caps.Events.Log != store.SchemaFlavorCanonical {
+		return unsupportedDashboardSchemaCapability("events", caps.Events.Log)
+	}
+	if caps.Events.Deliveries != store.SchemaFlavorCanonical {
+		return unsupportedDashboardSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	}
+	return nil
+}
+
+func requireObservabilityRuntimeLogCapabilities(caps store.StoreSchemaCapabilities) error {
+	if caps.Events.Log != store.SchemaFlavorCanonical {
+		return unsupportedDashboardSchemaCapability("events", caps.Events.Log)
+	}
+	return nil
+}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -280,7 +280,7 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 		t.Fatalf("logger.Log() error = %v", err)
 	}
 
-	reader := dashboardserver.NewSQLObservabilityReader(db)
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
 	if reader == nil {
 		t.Fatal("NewSQLObservabilityReader returned nil")
 	}


### PR DESCRIPTION
Closes #224

## Human Summary
This closes the remaining dashboard reader capability-ownership drift tracked by `#224`. `SQLObservabilityReader` now requires one explicit store-backed schema capability owner, and all touched observability readers fail closed when canonical event or runtime-log surfaces are unavailable, unsupported, or missing at that boundary.

## Spec References
- none; this is runtime/read-model architecture hardening
- justification: no exact platform spec section governs dashboard reader capability-source ownership. The governing rule for this PR is operator-surface canonical ownership: schema-dependent dashboard readers must bind to one explicit store capability owner instead of bypassing capability ownership implicitly.

## What Changed
- added explicit capability-owner enforcement for `SQLObservabilityReader`
- introduced shared observability capability gates in `internal/dashboard/server/schema_capabilities.go` for:
  - event readers (`events` + `event_deliveries`)
  - runtime-log readers (`events`)
- updated `internal/dashboard/server/observability_sql.go` so:
  - `ListEvents(...)`
  - `GetEvent(...)`
  - `ListRuntimeLogs(...)`
  - `ListIncidents(...)`
  all resolve explicit store schema capabilities before querying and fail closed on non-canonical capability states
- updated production wiring in `cmd/swarm/main.go` to pass `stores.Postgres` as the observability capability owner
- updated runtime-log conformance and observability tests to use the explicit capability boundary
- refined the `typed_persisted_operator_reads` watchlist node to record the observability capability-bypass manifestation

## Why This Is Needed
After `#307`, the only currently known live dashboard reader family still bypassing capability ownership was `SQLObservabilityReader`. It queried canonical event/runtime-log surfaces directly from `*sql.DB` and therefore let schema-dependent observability behavior proceed without any explicit capability owner. That kept `#224` open: the broader dashboard capability-ownership class was not actually closed until observability moved onto the same explicit boundary.

## Scope Boundaries
In scope:
- explicit capability ownership for schema-dependent observability readers
- fail-closed handling for missing/non-canonical event and runtime-log schema capability states
- production wiring and focused proofs needed to close the `#224` parent class honestly

Out of scope:
- broad dashboard redesign
- unrelated operator-surface cleanup
- broader shared observability-contract work across CLI/builder/dashboard
- store/schema redesign beyond what is required to make the observability reader family explicit

## Tests Run
- `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_(ListEvents_(UsesCanonicalDeliveryLifecycle|FailsClosedWithoutCapabilityOwner|FailsClosedWithoutCanonicalEventSurface)|GetEvent_(UsesCanonicalDeliveryRows|FailsClosedWithoutCapabilityOwner|FailsClosedWhenCapabilityOwnerReportsUnavailableEventSurface)|ListRuntimeLogs_(ProjectsDeliveryLifecycleFields|FailsClosedOnMalformedCanonicalPayload|FailsClosedWithoutCapabilityOwner|FailsClosedWithoutCanonicalRuntimeLogSurface)|ListIncidents_(UsesCanonicalRuntimeLogPayloads|FailsClosedOnMissingCanonicalComponent|UsesMessageWhenCanonicalErrorIsEmpty|SortsByRawLastSeenBeforeLimit|FailsClosedWithoutCapabilityOwner|FailsClosedWhenCapabilityOwnerReportsUnavailableRuntimeLogSurface))$' -count=1`
- `go test ./internal/runtime/conformance -run TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/dashboard/server ./internal/runtime/conformance ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
Low in the touched class. The remaining broader observability architecture smell is not another live dashboard capability-ownership bypass in the current sweep; it is the longer-run type-model weakness that capability ownership is still injected per reader family rather than through one typed dashboard capability context.

## Follow-Up
No same-parent dashboard reader family still bypassing capability ownership is known after this PR. If a future SQL-backed reader is added without an explicit capability owner, that should be treated as a regression against the now-closed `#224` class, not as acceptable staged debt.
