### PR TITLE
[agent-a][issue #179] Canonicalize startup recovery diagnostics

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
 	runtimepkg "swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -322,6 +324,132 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 	detail, _ := log.Detail.(map[string]any)
 	if strings.TrimSpace(readString(detail["tool_name"])) != "save_entity_field" {
 		t.Fatalf("log detail.tool_name = %#v, want save_entity_field", detail["tool_name"])
+	}
+}
+
+type conformanceSemanticOnlyWorkflowRuntime struct {
+	source runtimesemanticview.Source
+}
+
+func (s conformanceSemanticOnlyWorkflowRuntime) SemanticSource() runtimesemanticview.Source {
+	return s.source
+}
+
+func (conformanceSemanticOnlyWorkflowRuntime) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return nil
+}
+
+func (conformanceSemanticOnlyWorkflowRuntime) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return nil
+}
+func (conformanceSemanticOnlyWorkflowRuntime) GuardRegistry() runtimepipeline.GuardRegistry {
+	return nil
+}
+func (conformanceSemanticOnlyWorkflowRuntime) ActionRegistry() runtimepipeline.ActionRegistry {
+	return nil
+}
+
+type conformanceNoopLLMRuntime struct{}
+
+func (conformanceNoopLLMRuntime) StartSession(context.Context, string, string, []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	return &runtimellm.Session{}, nil
+}
+
+func (conformanceNoopLLMRuntime) ContinueSession(context.Context, *runtimellm.Session, runtimellm.Message) (*runtimellm.Response, error) {
+	return &runtimellm.Response{}, nil
+}
+
+func loadConformanceRuntimeWorkflowModule(t *testing.T) conformanceSemanticOnlyWorkflowRuntime {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", "test-boot-success")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	return conformanceSemanticOnlyWorkflowRuntime{source: runtimesemanticview.Wrap(bundle)}
+}
+
+func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+
+	if err := pg.UpsertSchedule(ctx, runtimepipeline.Schedule{
+		AgentID:   "runtime",
+		EventType: "timer.check",
+		Mode:      "once",
+		At:        time.Now().Add(time.Minute),
+		TaskID:    "recover-me",
+	}); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+
+	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: false,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}, runtimepkg.Stores{
+		SQLDB:         db,
+		EventStore:    pg,
+		ManagerStore:  pg,
+		ScheduleStore: pg,
+	}, runtimepkg.RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
+		LLMRuntime:     conformanceNoopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	startErr := rt.Start(ctx)
+	if startErr == nil || !strings.Contains(startErr.Error(), "runtime.recovery_on_startup=false") {
+		t.Fatalf("Start error = %v, want explicit recovery denial", startErr)
+	}
+
+	reader := dashboardserver.NewSQLObservabilityReader(db)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "runtime",
+		Type:      "startup_recovery_decision",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("runtime log rows = %d, want 1: %#v", len(logs), logs)
+	}
+	log := logs[0]
+	if log.Level != "warn" {
+		t.Fatalf("log level = %q, want warn", log.Level)
+	}
+	if log.Action != "startup_recovery_decision" {
+		t.Fatalf("log action = %q, want startup_recovery_decision", log.Action)
+	}
+	if log.ErrorCode != "recovery_disabled_with_persisted_work" {
+		t.Fatalf("log error_code = %q, want recovery_disabled_with_persisted_work", log.ErrorCode)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := readString(detail["decision_outcome"]); got != "denied" {
+		t.Fatalf("detail.decision_outcome = %q, want denied", got)
+	}
+	if got := readString(detail["decision_reason_code"]); got != "recovery_disabled_with_persisted_work" {
+		t.Fatalf("detail.decision_reason_code = %q, want recovery_disabled_with_persisted_work", got)
+	}
+	if got, _ := detail["active_schedule_count"].(float64); int(got) != 1 {
+		t.Fatalf("detail.active_schedule_count = %v, want 1", detail["active_schedule_count"])
+	}
+	classes, _ := detail["recoverable_work_classes"].([]any)
+	if len(classes) != 1 || readString(classes[0]) != "active schedules" {
+		t.Fatalf("detail.recoverable_work_classes = %#v, want [active schedules]", detail["recoverable_work_classes"])
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -501,48 +501,74 @@ func (am *AgentManager) Recover(ctx context.Context) error {
 	return nil
 }
 
-func (am *AgentManager) RecoverableStateReasons(ctx context.Context) ([]string, error) {
-	reasons := make([]string, 0, 4)
+type RecoverableStateSnapshot struct {
+	PersistedAgentCount             int
+	PersistedFlowInstanceRouteCount int
+	ReplayEligibleEventPresent      bool
+}
+
+func (s RecoverableStateSnapshot) HasRecoverableWork() bool {
+	return s.PersistedAgentCount > 0 || s.PersistedFlowInstanceRouteCount > 0 || s.ReplayEligibleEventPresent
+}
+
+func (s RecoverableStateSnapshot) Classes() []string {
+	classes := make([]string, 0, 3)
+	if s.PersistedAgentCount > 0 {
+		classes = append(classes, "persisted agents")
+	}
+	if s.PersistedFlowInstanceRouteCount > 0 {
+		classes = append(classes, "persisted flow instance routes")
+	}
+	if s.ReplayEligibleEventPresent {
+		classes = append(classes, "events missing pipeline receipts")
+	}
+	sort.Strings(classes)
+	return classes
+}
+
+func (s RecoverableStateSnapshot) Detail() map[string]any {
+	return map[string]any{
+		"persisted_agent_count":               s.PersistedAgentCount,
+		"persisted_flow_instance_route_count": s.PersistedFlowInstanceRouteCount,
+		"replay_eligible_event_present":       s.ReplayEligibleEventPresent,
+	}
+}
+
+func (am *AgentManager) RecoverableStateSnapshot(ctx context.Context) (RecoverableStateSnapshot, error) {
+	snapshot := RecoverableStateSnapshot{}
 	if am == nil {
-		return reasons, nil
+		return snapshot, nil
 	}
 	if am.store != nil {
 		agents, err := am.store.LoadAgents(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("load persisted agents: %w", err)
+			return RecoverableStateSnapshot{}, fmt.Errorf("load persisted agents: %w", err)
 		}
-		if len(agents) > 0 {
-			reasons = append(reasons, "persisted agents")
-		}
+		snapshot.PersistedAgentCount = len(agents)
 	}
 	if am.bus == nil {
-		return reasons, nil
+		return snapshot, nil
 	}
 	store := am.bus.Store()
 	if store == nil {
-		return reasons, nil
+		return snapshot, nil
 	}
 	if routeStore, ok := store.(runtimebus.FlowInstanceRoutePersistence); ok && routeStore != nil {
 		routes, err := routeStore.ListFlowInstanceRoutes(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("list persisted flow instance routes: %w", err)
+			return RecoverableStateSnapshot{}, fmt.Errorf("list persisted flow instance routes: %w", err)
 		}
-		if len(routes) > 0 {
-			reasons = append(reasons, "persisted flow instance routes")
-		}
+		snapshot.PersistedFlowInstanceRouteCount = len(routes)
 	}
 	replayStore, ok := store.(runtimereplayclaim.Lister)
 	if ok && replayStore != nil {
 		eventsToReplay, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-30*24*time.Hour), 1)
 		if err != nil {
-			return nil, fmt.Errorf("list events missing pipeline receipts: %w", err)
+			return RecoverableStateSnapshot{}, fmt.Errorf("list events missing pipeline receipts: %w", err)
 		}
-		if len(eventsToReplay) > 0 {
-			reasons = append(reasons, "events missing pipeline receipts")
-		}
+		snapshot.ReplayEligibleEventPresent = len(eventsToReplay) > 0
 	}
-	sort.Strings(reasons)
-	return reasons, nil
+	return snapshot, nil
 }
 
 func (am *AgentManager) restoreFlowInstanceRoutes(ctx context.Context) error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -550,10 +550,16 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}()
 
 	startupRecoverySnapshot, err := rt.inspectStartupRecoverySnapshot(ctx)
-	if err != nil {
+	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
+	if err != nil && !startupRecoverySnapshot.RecoveryOnStartup {
 		return err
 	}
-	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
+	if err != nil {
+		startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
+		startupRecoveryDecision.ReasonCode = startupRecoveryReasonInspectFailed
+		startupRecoveryDecision.ErrorText = err.Error()
+		startupRecoveryDecision.InspectionError = err.Error()
+	}
 	if denyErr := startupRecoveryDecision.denialError(); denyErr != nil {
 		startupRecoveryDecision.ErrorText = denyErr.Error()
 		rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -205,34 +205,6 @@ func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.Prom
 	return runtimecontracts.NewBundlePromptResolver(bundle), nil
 }
 
-func (rt *Runtime) ensureRecoveryStartupExplicit(ctx context.Context) error {
-	if rt == nil || rt.Config == nil || rt.Config.Runtime.RecoveryOnStartup {
-		return nil
-	}
-	reasons := make([]string, 0, 4)
-	if rt.Stores.ScheduleStore != nil {
-		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
-		if err != nil {
-			return fmt.Errorf("inspect active schedules: %w", err)
-		}
-		if len(schedules) > 0 {
-			reasons = append(reasons, "active schedules")
-		}
-	}
-	if rt.Manager != nil {
-		managerReasons, err := rt.Manager.RecoverableStateReasons(ctx)
-		if err != nil {
-			return fmt.Errorf("inspect recoverable manager state: %w", err)
-		}
-		reasons = append(reasons, managerReasons...)
-	}
-	if len(reasons) == 0 {
-		return nil
-	}
-	sort.Strings(reasons)
-	return fmt.Errorf("runtime.recovery_on_startup=false but persisted runtime-owned work exists: %s", strings.Join(reasons, ", "))
-}
-
 func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts RuntimeOptions) (*Runtime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
@@ -577,8 +549,15 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		rt.cleanupStartFailure()
 	}()
 
-	if err := rt.ensureRecoveryStartupExplicit(ctx); err != nil {
+	startupRecoverySnapshot, err := rt.inspectStartupRecoverySnapshot(ctx)
+	if err != nil {
 		return err
+	}
+	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
+	if denyErr := startupRecoveryDecision.denialError(); denyErr != nil {
+		startupRecoveryDecision.ErrorText = denyErr.Error()
+		rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
+		return denyErr
 	}
 
 	if rt.Pipeline != nil {
@@ -594,8 +573,10 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("load schedules failed: %w", err)
 		}
+		startupRecoveryDecision.ScheduleRestoreAttempted = len(schedules) > 0
 		for _, sc := range schedules {
 			if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, rt.Stores.ScheduleStore, rt.Scheduler, sc); err != nil {
+				startupRecoveryDecision.ScheduleRestoreFailures++
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("scheduler", "restore_schedule_failed", rt.Logger.Error(ctx, "scheduler", "restore_schedule_failed", map[string]any{
 						"agent_id":   sc.AgentID,
@@ -603,7 +584,9 @@ func (rt *Runtime) Start(ctx context.Context) error {
 						"entity_id":  sc.EffectiveEntityID(),
 					}, err))
 				}
+				continue
 			}
+			startupRecoveryDecision.ScheduleRestoreSuccesses++
 		}
 		if err := ensureLifecycleWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
@@ -617,11 +600,17 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		}
 	}
 	if rt.Config.Runtime.RecoveryOnStartup && rt.Manager != nil {
+		startupRecoveryDecision.ManagerRecoveryAttempted = true
 		if err := rt.Manager.Recover(ctx); err != nil {
+			startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
+			startupRecoveryDecision.ReasonCode = startupRecoveryReasonRecoverFailed
+			startupRecoveryDecision.ErrorText = err.Error()
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("runtime", "recovery_failed", rt.Logger.Error(ctx, "runtime", "recovery_failed", nil, err))
 			}
+			startupRecoveryDecision.ManagerResetAttempted = true
 			if resetErr := rt.Manager.ResetRuntimeState(); resetErr != nil {
+				startupRecoveryDecision.ManagerResetError = resetErr.Error()
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("runtime", "recovery_reset_failed", rt.Logger.Error(ctx, "runtime", "recovery_reset_failed", nil, resetErr))
 				}
@@ -662,6 +651,12 @@ func (rt *Runtime) Start(ctx context.Context) error {
 			}
 		}
 	}
+	if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleRestoreFailures > 0 {
+		startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
+		startupRecoveryDecision.ReasonCode = startupRecoveryReasonScheduleRestore
+		startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleRestoreFailures)
+	}
+	rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
 	if rt.Bus != nil {
 		rt.Bus.StartOutboxSweeper(startCtx, runtimebus.DefaultOutboxSweeperConfig())
 	}

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -1,0 +1,372 @@
+package runtime
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/testutil"
+)
+
+type startupRecoveryTestLease struct{}
+
+func (startupRecoveryTestLease) Release(context.Context) error { return nil }
+
+type startupRecoveryCapabilityEventStore struct{}
+
+func (startupRecoveryCapabilityEventStore) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (startupRecoveryCapabilityEventStore) AppendEvent(context.Context, events.Event) error {
+	return nil
+}
+
+func (startupRecoveryCapabilityEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (startupRecoveryCapabilityEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (startupRecoveryCapabilityEventStore) SupportsPersistedReplay() bool { return false }
+
+type startupRecoveryEventStore struct {
+	missing  []events.PersistedReplayEvent
+	claimErr error
+}
+
+func (startupRecoveryEventStore) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (startupRecoveryEventStore) AppendEvent(context.Context, events.Event) error { return nil }
+
+func (startupRecoveryEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (startupRecoveryEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (s startupRecoveryEventStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.missing...), nil
+}
+
+func (s startupRecoveryEventStore) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	if s.claimErr != nil {
+		return nil, false, s.claimErr
+	}
+	return startupRecoveryTestLease{}, true, nil
+}
+
+func (startupRecoveryEventStore) SupportsPersistedReplay() bool { return true }
+
+func testRecoveryDiagnosticsConfig(recoveryOnStartup bool) *config.Config {
+	return &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: recoveryOnStartup,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}
+}
+
+func latestStartupRecoveryDecisionLog(t *testing.T, db *sql.DB) (level, message, errorText string, detail map[string]any) {
+	t.Helper()
+	var payloadRaw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->'details'->>'component' = 'runtime'
+		  AND payload->'details'->>'action' = 'startup_recovery_decision'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&payloadRaw); err != nil {
+		t.Fatalf("load startup recovery decision runtime log: %v", err)
+	}
+	payload, err := DecodeCanonicalRuntimeLogPayload(payloadRaw)
+	if err != nil {
+		t.Fatalf("DecodeCanonicalRuntimeLogPayload: %v", err)
+	}
+	return payload.LogLevel, payload.Message, payload.Error, payload.Detail
+}
+
+func detailString(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(asString(v))
+	}
+}
+
+func detailBool(v any) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+func detailInt(v any) int {
+	switch typed := v.(type) {
+	case float64:
+		return int(typed)
+	case int:
+		return typed
+	default:
+		return 0
+	}
+}
+
+func detailClasses(v any) []string {
+	out := []string{}
+	switch typed := v.(type) {
+	case []string:
+		for _, item := range typed {
+			if text := detailString(item); text != "" {
+				out = append(out, text)
+			}
+		}
+	case []any:
+		for _, item := range typed {
+			if text := detailString(item); text != "" {
+				out = append(out, text)
+			}
+		}
+	}
+	return out
+}
+
+func assertContainsClass(t *testing.T, classes []string, want string) {
+	t.Helper()
+	for _, item := range classes {
+		if item == want {
+			return
+		}
+	}
+	t.Fatalf("recoverable_work_classes = %#v, want %q present", classes, want)
+}
+
+func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	scheduleStore := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{{
+			AgentID:   "runtime",
+			EventType: "timer.check",
+			Mode:      "once",
+			At:        time.Now().Add(time.Minute),
+			TaskID:    "recover-me",
+		}},
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(false), Stores{
+		SQLDB:         db,
+		EventStore:    startupRecoveryCapabilityEventStore{},
+		ManagerStore:  &recoveryGuardManagerStore{},
+		ScheduleStore: scheduleStore,
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	err = rt.Start(ctx)
+	if err == nil || !strings.Contains(err.Error(), "runtime.recovery_on_startup=false") {
+		t.Fatalf("Start error = %v, want explicit startup denial", err)
+	}
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "warn" {
+		t.Fatalf("log level = %q, want warn", level)
+	}
+	if errorText != err.Error() {
+		t.Fatalf("log error = %q, want %q", errorText, err.Error())
+	}
+	if got := detailString(detail["decision_outcome"]); got != "denied" {
+		t.Fatalf("decision_outcome = %q, want denied", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonDisabledWithWork) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonDisabledWithWork)
+	}
+	if got := detailInt(detail["active_schedule_count"]); got != 1 {
+		t.Fatalf("active_schedule_count = %d, want 1", got)
+	}
+	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "active schedules")
+}
+
+func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	eventStore := &startupRecoveryEventStore{
+		missing: []events.PersistedReplayEvent{{
+			Event: events.Event{ID: "evt-1", Type: "support.item_created"},
+		}},
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(false), Stores{
+		SQLDB:        db,
+		EventStore:   eventStore,
+		ManagerStore: &recoveryGuardManagerStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	err = rt.Start(ctx)
+	if err == nil || !strings.Contains(err.Error(), "events missing pipeline receipts") {
+		t.Fatalf("Start error = %v, want replay-eligible denial", err)
+	}
+
+	level, _, _, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "warn" {
+		t.Fatalf("log level = %q, want warn", level)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "denied" {
+		t.Fatalf("decision_outcome = %q, want denied", got)
+	}
+	if !detailBool(detail["replay_eligible_event_present"]) {
+		t.Fatalf("replay_eligible_event_present = %#v, want true", detail["replay_eligible_event_present"])
+	}
+	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "events missing pipeline receipts")
+}
+
+func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	scheduleStore := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{{
+			AgentID:   "runtime",
+			EventType: "timer.check",
+			Mode:      "once",
+			At:        time.Now().Add(time.Minute),
+			TaskID:    "recover-me",
+		}},
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:         db,
+		EventStore:    startupRecoveryCapabilityEventStore{},
+		ManagerStore:  &recoveryGuardManagerStore{},
+		ScheduleStore: scheduleStore,
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "info" {
+		t.Fatalf("log level = %q, want info", level)
+	}
+	if errorText != "" {
+		t.Fatalf("log error = %q, want empty", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "allowed" {
+		t.Fatalf("decision_outcome = %q, want allowed", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonEnabledWithWork) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonEnabledWithWork)
+	}
+	if !detailBool(detail["schedule_restore_attempted"]) {
+		t.Fatalf("schedule_restore_attempted = %#v, want true", detail["schedule_restore_attempted"])
+	}
+	if got := detailInt(detail["schedule_restore_success_count"]); got != 1 {
+		t.Fatalf("schedule_restore_success_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["schedule_restore_failure_count"]); got != 0 {
+		t.Fatalf("schedule_restore_failure_count = %d, want 0", got)
+	}
+	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "active schedules")
+}
+
+func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	eventStore := &startupRecoveryEventStore{
+		missing: []events.PersistedReplayEvent{{
+			Event: events.Event{ID: "evt-1", Type: "support.item_created"},
+		}},
+		claimErr: errors.New("claim failed"),
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:        db,
+		EventStore:   eventStore,
+		ManagerStore: &recoveryGuardManagerStore{},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "error" {
+		t.Fatalf("log level = %q, want error", level)
+	}
+	if !strings.Contains(errorText, "claim replay event evt-1: claim failed") {
+		t.Fatalf("log error = %q, want degraded recovery error", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "degraded" {
+		t.Fatalf("decision_outcome = %q, want degraded", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonRecoverFailed) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonRecoverFailed)
+	}
+	if !detailBool(detail["manager_recovery_attempted"]) {
+		t.Fatalf("manager_recovery_attempted = %#v, want true", detail["manager_recovery_attempted"])
+	}
+	if !detailBool(detail["manager_reset_attempted"]) {
+		t.Fatalf("manager_reset_attempted = %#v, want true", detail["manager_reset_attempted"])
+	}
+	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "events missing pipeline receipts")
+}

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/testutil"
 )
@@ -18,6 +19,33 @@ import (
 type startupRecoveryTestLease struct{}
 
 func (startupRecoveryTestLease) Release(context.Context) error { return nil }
+
+type startupRecoveryManagerStore struct {
+	loadErr error
+}
+
+func (s startupRecoveryManagerStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (s startupRecoveryManagerStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
+	return nil, nil
+}
+
+func (startupRecoveryManagerStore) MarkAgentTerminated(context.Context, string) error { return nil }
+func (startupRecoveryManagerStore) EnsureEntitySchema(context.Context, string) error  { return nil }
+func (startupRecoveryManagerStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
+	return nil
+}
+func (startupRecoveryManagerStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (startupRecoveryManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
 
 type startupRecoveryCapabilityEventStore struct{}
 
@@ -369,4 +397,55 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 		t.Fatalf("manager_reset_attempted = %#v, want true", detail["manager_reset_attempted"])
 	}
 	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "events missing pipeline receipts")
+}
+
+func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartup(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:        db,
+		EventStore:   startupRecoveryCapabilityEventStore{},
+		ManagerStore: startupRecoveryManagerStore{loadErr: errors.New("load agents failed")},
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "error" {
+		t.Fatalf("log level = %q, want error", level)
+	}
+	if !strings.Contains(errorText, "load agents: load agents failed") {
+		t.Fatalf("log error = %q, want manager recovery failure detail", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "degraded" {
+		t.Fatalf("decision_outcome = %q, want degraded", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonRecoverFailed) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonRecoverFailed)
+	}
+	if got := detailBool(detail["recovery_inspection_complete"]); got {
+		t.Fatalf("recovery_inspection_complete = %#v, want false", detail["recovery_inspection_complete"])
+	}
+	if got := detailString(detail["recovery_inspection_error"]); !strings.Contains(got, "inspect recoverable manager state: load persisted agents: load agents failed") {
+		t.Fatalf("recovery_inspection_error = %q, want startup inspection failure detail", got)
+	}
+	if !detailBool(detail["manager_recovery_attempted"]) {
+		t.Fatalf("manager_recovery_attempted = %#v, want true", detail["manager_recovery_attempted"])
+	}
 }

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -25,12 +25,14 @@ const (
 	startupRecoveryReasonDisabledWithWork startupRecoveryReasonCode = "recovery_disabled_with_persisted_work"
 	startupRecoveryReasonEnabledNoWork    startupRecoveryReasonCode = "recovery_enabled_no_persisted_work"
 	startupRecoveryReasonEnabledWithWork  startupRecoveryReasonCode = "recovery_enabled_with_persisted_work"
+	startupRecoveryReasonInspectFailed    startupRecoveryReasonCode = "startup_recovery_inspection_failed"
 	startupRecoveryReasonScheduleRestore  startupRecoveryReasonCode = "schedule_restore_failed"
 	startupRecoveryReasonRecoverFailed    startupRecoveryReasonCode = "startup_recovery_failed"
 )
 
 type startupRecoverySnapshot struct {
 	RecoveryOnStartup   bool
+	InspectionComplete  bool
 	ActiveScheduleCount int
 	Manager             runtimemanager.RecoverableStateSnapshot
 }
@@ -51,13 +53,16 @@ func (s startupRecoverySnapshot) WorkClasses() []string {
 
 func (s startupRecoverySnapshot) Detail() map[string]any {
 	detail := map[string]any{
-		"recovery_on_startup":      s.RecoveryOnStartup,
-		"active_schedule_count":    s.ActiveScheduleCount,
-		"recoverable_work_present": s.HasRecoverableWork(),
-		"recoverable_work_classes": s.WorkClasses(),
+		"recovery_on_startup":          s.RecoveryOnStartup,
+		"recovery_inspection_complete": s.InspectionComplete,
 	}
-	for key, value := range s.Manager.Detail() {
-		detail[key] = value
+	if s.InspectionComplete {
+		detail["active_schedule_count"] = s.ActiveScheduleCount
+		detail["recoverable_work_present"] = s.HasRecoverableWork()
+		detail["recoverable_work_classes"] = s.WorkClasses()
+		for key, value := range s.Manager.Detail() {
+			detail[key] = value
+		}
 	}
 	return detail
 }
@@ -74,6 +79,7 @@ type startupRecoveryDecisionReport struct {
 	ManagerRecoveryAttempted bool
 	ManagerResetAttempted    bool
 	ManagerResetError        string
+	InspectionError          string
 }
 
 func newStartupRecoveryDecisionReport(snapshot startupRecoverySnapshot) startupRecoveryDecisionReport {
@@ -136,6 +142,9 @@ func (r startupRecoveryDecisionReport) detail() map[string]any {
 	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
 		detail["error"] = errText
 	}
+	if inspectErr := strings.TrimSpace(r.InspectionError); inspectErr != "" {
+		detail["recovery_inspection_error"] = inspectErr
+	}
 	if resetErr := strings.TrimSpace(r.ManagerResetError); resetErr != "" {
 		detail["manager_reset_error"] = resetErr
 	}
@@ -144,7 +153,8 @@ func (r startupRecoveryDecisionReport) detail() map[string]any {
 
 func (rt *Runtime) inspectStartupRecoverySnapshot(ctx context.Context) (startupRecoverySnapshot, error) {
 	snapshot := startupRecoverySnapshot{
-		RecoveryOnStartup: rt != nil && rt.Config != nil && rt.Config.Runtime.RecoveryOnStartup,
+		RecoveryOnStartup:  rt != nil && rt.Config != nil && rt.Config.Runtime.RecoveryOnStartup,
+		InspectionComplete: true,
 	}
 	if rt == nil {
 		return snapshot, nil
@@ -152,14 +162,16 @@ func (rt *Runtime) inspectStartupRecoverySnapshot(ctx context.Context) (startupR
 	if rt.Stores.ScheduleStore != nil {
 		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
 		if err != nil {
-			return startupRecoverySnapshot{}, fmt.Errorf("inspect active schedules: %w", err)
+			snapshot.InspectionComplete = false
+			return snapshot, fmt.Errorf("inspect active schedules: %w", err)
 		}
 		snapshot.ActiveScheduleCount = len(schedules)
 	}
 	if rt.Manager != nil {
 		managerSnapshot, err := rt.Manager.RecoverableStateSnapshot(ctx)
 		if err != nil {
-			return startupRecoverySnapshot{}, fmt.Errorf("inspect recoverable manager state: %w", err)
+			snapshot.InspectionComplete = false
+			return snapshot, fmt.Errorf("inspect recoverable manager state: %w", err)
 		}
 		snapshot.Manager = managerSnapshot
 	}

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -1,0 +1,185 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"swarm/internal/runtime/diaglog"
+	runtimemanager "swarm/internal/runtime/manager"
+)
+
+type startupRecoveryOutcome string
+
+const (
+	startupRecoveryOutcomeAllowed  startupRecoveryOutcome = "allowed"
+	startupRecoveryOutcomeDenied   startupRecoveryOutcome = "denied"
+	startupRecoveryOutcomeDegraded startupRecoveryOutcome = "degraded"
+)
+
+type startupRecoveryReasonCode string
+
+const (
+	startupRecoveryReasonDisabledNoWork   startupRecoveryReasonCode = "recovery_disabled_no_persisted_work"
+	startupRecoveryReasonDisabledWithWork startupRecoveryReasonCode = "recovery_disabled_with_persisted_work"
+	startupRecoveryReasonEnabledNoWork    startupRecoveryReasonCode = "recovery_enabled_no_persisted_work"
+	startupRecoveryReasonEnabledWithWork  startupRecoveryReasonCode = "recovery_enabled_with_persisted_work"
+	startupRecoveryReasonScheduleRestore  startupRecoveryReasonCode = "schedule_restore_failed"
+	startupRecoveryReasonRecoverFailed    startupRecoveryReasonCode = "startup_recovery_failed"
+)
+
+type startupRecoverySnapshot struct {
+	RecoveryOnStartup   bool
+	ActiveScheduleCount int
+	Manager             runtimemanager.RecoverableStateSnapshot
+}
+
+func (s startupRecoverySnapshot) HasRecoverableWork() bool {
+	return s.ActiveScheduleCount > 0 || s.Manager.HasRecoverableWork()
+}
+
+func (s startupRecoverySnapshot) WorkClasses() []string {
+	classes := make([]string, 0, 1+len(s.Manager.Classes()))
+	if s.ActiveScheduleCount > 0 {
+		classes = append(classes, "active schedules")
+	}
+	classes = append(classes, s.Manager.Classes()...)
+	sort.Strings(classes)
+	return classes
+}
+
+func (s startupRecoverySnapshot) Detail() map[string]any {
+	detail := map[string]any{
+		"recovery_on_startup":      s.RecoveryOnStartup,
+		"active_schedule_count":    s.ActiveScheduleCount,
+		"recoverable_work_present": s.HasRecoverableWork(),
+		"recoverable_work_classes": s.WorkClasses(),
+	}
+	for key, value := range s.Manager.Detail() {
+		detail[key] = value
+	}
+	return detail
+}
+
+type startupRecoveryDecisionReport struct {
+	Snapshot startupRecoverySnapshot
+
+	Outcome                  startupRecoveryOutcome
+	ReasonCode               startupRecoveryReasonCode
+	ErrorText                string
+	ScheduleRestoreAttempted bool
+	ScheduleRestoreSuccesses int
+	ScheduleRestoreFailures  int
+	ManagerRecoveryAttempted bool
+	ManagerResetAttempted    bool
+	ManagerResetError        string
+}
+
+func newStartupRecoveryDecisionReport(snapshot startupRecoverySnapshot) startupRecoveryDecisionReport {
+	report := startupRecoveryDecisionReport{
+		Snapshot: snapshot,
+		Outcome:  startupRecoveryOutcomeAllowed,
+	}
+	switch {
+	case snapshot.RecoveryOnStartup && snapshot.HasRecoverableWork():
+		report.ReasonCode = startupRecoveryReasonEnabledWithWork
+	case snapshot.RecoveryOnStartup:
+		report.ReasonCode = startupRecoveryReasonEnabledNoWork
+	case snapshot.HasRecoverableWork():
+		report.Outcome = startupRecoveryOutcomeDenied
+		report.ReasonCode = startupRecoveryReasonDisabledWithWork
+	default:
+		report.ReasonCode = startupRecoveryReasonDisabledNoWork
+	}
+	return report
+}
+
+func (r startupRecoveryDecisionReport) denialError() error {
+	if r.Outcome != startupRecoveryOutcomeDenied {
+		return nil
+	}
+	return fmt.Errorf("runtime.recovery_on_startup=false but persisted runtime-owned work exists: %s", strings.Join(r.Snapshot.WorkClasses(), ", "))
+}
+
+func (r startupRecoveryDecisionReport) message() string {
+	switch r.Outcome {
+	case startupRecoveryOutcomeDenied:
+		return "Runtime startup denied by recovery admission"
+	case startupRecoveryOutcomeDegraded:
+		return "Runtime startup recovery completed in a degraded state"
+	default:
+		return "Runtime startup recovery decision recorded"
+	}
+}
+
+func (r startupRecoveryDecisionReport) level() string {
+	switch r.Outcome {
+	case startupRecoveryOutcomeDenied:
+		return "warn"
+	case startupRecoveryOutcomeDegraded:
+		return "error"
+	default:
+		return "info"
+	}
+}
+
+func (r startupRecoveryDecisionReport) detail() map[string]any {
+	detail := r.Snapshot.Detail()
+	detail["decision_outcome"] = string(r.Outcome)
+	detail["decision_reason_code"] = string(r.ReasonCode)
+	detail["schedule_restore_attempted"] = r.ScheduleRestoreAttempted
+	detail["schedule_restore_success_count"] = r.ScheduleRestoreSuccesses
+	detail["schedule_restore_failure_count"] = r.ScheduleRestoreFailures
+	detail["manager_recovery_attempted"] = r.ManagerRecoveryAttempted
+	detail["manager_reset_attempted"] = r.ManagerResetAttempted
+	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
+		detail["error"] = errText
+	}
+	if resetErr := strings.TrimSpace(r.ManagerResetError); resetErr != "" {
+		detail["manager_reset_error"] = resetErr
+	}
+	return detail
+}
+
+func (rt *Runtime) inspectStartupRecoverySnapshot(ctx context.Context) (startupRecoverySnapshot, error) {
+	snapshot := startupRecoverySnapshot{
+		RecoveryOnStartup: rt != nil && rt.Config != nil && rt.Config.Runtime.RecoveryOnStartup,
+	}
+	if rt == nil {
+		return snapshot, nil
+	}
+	if rt.Stores.ScheduleStore != nil {
+		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
+		if err != nil {
+			return startupRecoverySnapshot{}, fmt.Errorf("inspect active schedules: %w", err)
+		}
+		snapshot.ActiveScheduleCount = len(schedules)
+	}
+	if rt.Manager != nil {
+		managerSnapshot, err := rt.Manager.RecoverableStateSnapshot(ctx)
+		if err != nil {
+			return startupRecoverySnapshot{}, fmt.Errorf("inspect recoverable manager state: %w", err)
+		}
+		snapshot.Manager = managerSnapshot
+	}
+	return snapshot, nil
+}
+
+func (rt *Runtime) logStartupRecoveryDecision(ctx context.Context, report startupRecoveryDecisionReport) {
+	if rt == nil || rt.Logger == nil {
+		return
+	}
+	entry := RuntimeLogEntry{
+		Level:     diaglog.Level(report.level()),
+		Message:   report.message(),
+		Component: "runtime",
+		Action:    "startup_recovery_decision",
+		Error:     strings.TrimSpace(report.ErrorText),
+		Detail:    report.detail(),
+	}
+	if strings.TrimSpace(entry.Error) != "" {
+		entry.Detail.(map[string]any)["error_code"] = string(report.ReasonCode)
+	}
+	handleRuntimeLogPersistenceError("runtime", "startup_recovery_decision", rt.Logger.Log(ctx, entry))
+}


### PR DESCRIPTION
Closes #179

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`
- Governing rule used in this slice: startup recovery admission and recovery execution-summary diagnostics must reflect the same durable timer and replay semantics the runtime actually enforces.

## Human Summary
This first slice makes startup recovery decisions visible through one runtime-owned diagnostic record instead of leaving operator-visible meaning split across startup checks, config interpretation, and ad hoc recovery logs.

## What Changed
- Introduced one typed startup recovery snapshot and decision report for runtime startup admission and recovery-summary diagnostics.
- Replaced the old ad hoc `ensureRecoveryStartupExplicit(...)` path with canonical startup decision inspection and logging.
- Added manager-side recoverable-state snapshots so startup diagnostics report concrete persisted-work classes and counts.
- Logged canonical `runtime.startup_recovery_decision` records for allowed, denied, and degraded startup recovery outcomes.
- Added focused runtime tests and a persisted-surface proof through the observability reader.

## Why This Is Needed
Operators currently cannot reliably tell why startup recovery was allowed, denied, or degraded from one canonical surface. The old path could deny startup, restore schedules, or fail recovery with only partial or ad hoc logging. This slice closes that drift for startup recovery admission and execution-summary diagnostics.

## Scope Boundaries
- This PR is the approved first slice for the broader `recovery_restart_diagnostics` parent class.
- It closes the chosen working class: startup recovery admission and startup recovery execution-summary diagnostics.
- It does not claim closure for the full parent class of restart/recovery diagnostics across all later operator surfaces.
- Out of scope: broader observability redesign, dashboard/read-model cleanup beyond the touched persisted surface, and unrelated runtime operations logging.

## Tests Run
- `go test ./internal/runtime -run 'TestRuntimeStart_(RecoveryDisabledEmitsDeniedDecisionForActiveSchedules|RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork|RecoveryEnabledEmitsAllowedDecisionSummary|RecoveryFailureEmitsDegradedDecisionSummary|FailsWhenRecoveryDisabledAndActiveSchedulesExist|FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists|AllowsRecoveryDisabledWhenNoRecoverableWorkExists|AllowsRecoveryDisabledWithNonReplayEventStore|RestoresExactSchedulesDistinctByFlowInstance)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
- Closure level for this PR is `touched seam canonicalized`, not full parent-class elimination.
- Broader restart/recovery diagnostics still remain outside this first slice and stay tracked under the existing watchlist node.

## Follow-Up
- Parent class `recovery_restart_diagnostics` remains open in the watchlist for the remaining restart/recovery decision surfaces.
- The approved pre-audit estimated `2-3` additional child slices beyond this startup-admission/execution-summary slice.