### PR TITLE
[agent-b][issue #126] Extract timer bootverify checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -13,7 +13,6 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
-	"swarm/internal/runtime/core/timeridentity"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -240,7 +239,6 @@ func checkAgentPermissionValidation(c *checkerContext) []Finding {
 func checkPhantomProduces(c *checkerContext) []Finding            { return c.phantomProduces() }
 func checkSingleNodePerEvent(c *checkerContext) []Finding         { return c.singleNodePerEvent() }
 func checkPlatformMetadataValidation(c *checkerContext) []Finding { return c.platformMetadata() }
-func checkTimerValidation(c *checkerContext) []Finding            { return c.timerValidation() }
 func checkGateSchemaValidation(c *checkerContext) []Finding       { return c.gateSchemaValidation() }
 func checkDeprecatedContractAlias(c *checkerContext) []Finding    { return c.deprecatedAliases() }
 
@@ -311,113 +309,6 @@ func (c *checkerContext) platformMetadata() []Finding {
 		})
 	}
 	return c.platformMetaFindings
-}
-
-func (c *checkerContext) timerValidation() []Finding {
-	if c.timerLoaded {
-		return c.timerFindings
-	}
-	c.timerLoaded = true
-	for _, timer := range c.source.WorkflowTimers() {
-		owner := strings.TrimSpace(timer.Owner)
-		if owner == "" {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s missing owner", timer.ID),
-				Location: strings.TrimSpace(timer.ID),
-			})
-			continue
-		}
-		if owner != "runtime" {
-			if _, systemNode := c.source.NodeEntries()[owner]; !systemNode {
-				if !participantExistsLocal(c.source, owner) {
-					c.timerFindings = append(c.timerFindings, Finding{
-						CheckID:  "timer_validation",
-						Severity: "error",
-						Message:  fmt.Sprintf("timer %s owner %s missing from participants", timer.ID, owner),
-						Location: strings.TrimSpace(timer.ID),
-					})
-				}
-			}
-		}
-		if !eventExists(c.source, strings.TrimSpace(timer.Event)) {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s event %s missing from event catalog", timer.ID, timer.Event),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		}
-		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
-		if err != nil {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s start_on %q is invalid: %v", timer.ID, timer.StartOn, err),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		} else {
-			c.validateTimerTrigger(timer, "start_on", startTrigger)
-		}
-		cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
-		if err != nil {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s cancel_on %q is invalid: %v", timer.ID, timer.CancelOn, err),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		} else {
-			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)
-		}
-	}
-	return c.timerFindings
-}
-
-func (c *checkerContext) validateTimerTrigger(timer runtimecontracts.WorkflowTimerContract, field string, trigger timeridentity.Trigger) {
-	if !trigger.Valid() {
-		return
-	}
-	switch trigger.Kind {
-	case timeridentity.TriggerKindState:
-		if !containsString(flowStatesForTimer(c.source, timer.FlowID), trigger.Name) {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s %s references unknown state %s", timer.ID, field, trigger.Name),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		}
-	case timeridentity.TriggerKindEvent:
-		if !eventExists(c.source, trigger.Name) {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "warning",
-				Message:  fmt.Sprintf("timer %s %s references unknown event %s", timer.ID, field, trigger.Name),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		}
-	}
-}
-
-func flowStatesForTimer(source semanticview.Source, flowID string) []string {
-	flowID = strings.TrimSpace(flowID)
-	if source == nil {
-		return nil
-	}
-	if flowID != "" {
-		return source.FlowStates(flowID)
-	}
-	stages := source.WorkflowStages()
-	out := make([]string, 0, len(stages))
-	for _, stage := range stages {
-		name := strings.TrimSpace(stage.ID)
-		if name != "" {
-			out = append(out, name)
-		}
-	}
-	return out
 }
 
 func (c *checkerContext) gateSchemaValidation() []Finding {
@@ -2538,25 +2429,6 @@ func eventExists(source semanticview.Source, eventType string) bool {
 	}
 	for candidate := range source.EventEntries() {
 		if routeMatchesLocal(eventType, strings.TrimSpace(candidate)) {
-			return true
-		}
-	}
-	return false
-}
-
-func participantExistsLocal(source semanticview.Source, participant string) bool {
-	participant = strings.TrimSpace(participant)
-	if participant == "" || source == nil {
-		return false
-	}
-	if participant == "runtime" || participant == "human" {
-		return true
-	}
-	if _, ok := source.NodeEntries()[participant]; ok {
-		return true
-	}
-	for _, agent := range source.AgentEntries() {
-		if strings.TrimSpace(agent.ID) == participant || strings.TrimSpace(agent.Role) == participant {
 			return true
 		}
 	}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1782,6 +1782,42 @@ func TestRun_ReportsWarningForUnknownTimerTriggerEvent(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsErrorForTimerMissingOwner(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle := loadFixtureBundleAt(t, repoRoot, root, platformSpec)
+	bundle.Semantics.Timers[0].Owner = ""
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "missing owner") {
+		t.Fatalf("expected timer_validation missing owner error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerOwnerMissingFromParticipants(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle := loadFixtureBundleAt(t, repoRoot, root, platformSpec)
+	bundle.Semantics.Timers[0].Owner = "missing-owner"
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "owner missing-owner missing from participants") {
+		t.Fatalf("expected timer_validation missing participant owner error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerEventMissingFromCatalog(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle := loadFixtureBundleAt(t, repoRoot, root, platformSpec)
+	bundle.Semantics.Timers[0].Event = "timer.missing"
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "event timer.missing missing from event catalog") {
+		t.Fatalf("expected timer_validation missing timer event error, got %#v", report.Errors())
+	}
+}
+
 func repoRootForBootverifyTest(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()
@@ -1912,9 +1948,30 @@ support/item.created:
 	return root
 }
 
+type timerValidationFixtureOptions struct {
+	startOn           string
+	cancelOn          string
+	owner             string
+	event             string
+	includeTimerEvent bool
+}
+
 func writeTimerValidationFixture(t *testing.T, startOn, cancelOn string) string {
+	return writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           startOn,
+		cancelOn:          cancelOn,
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+	})
+}
+
+func writeTimerValidationFixtureWithOptions(t *testing.T, opts timerValidationFixtureOptions) string {
 	t.Helper()
 	root := t.TempDir()
+	if strings.TrimSpace(opts.event) == "" {
+		opts.event = "timer.reminder"
+	}
 
 	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: timer-validation
@@ -1936,6 +1993,16 @@ flows:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	timerEventBlock := ""
+	if opts.includeTimerEvent {
+		timerEventBlock = strings.TrimSpace(`
+` + opts.event + `:
+  payload:
+    properties:
+      entity_id:
+        type: string
+`)
+	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
 name: support
 initial_state: waiting
@@ -1954,19 +2021,16 @@ ticket.closed:
     properties:
       entity_id:
         type: string
-timer.reminder:
-  payload:
-    properties:
-      entity_id:
-        type: string
+`+timerEventBlock+`
 `)
 	timerBlock := `
     - id: reminder
-      event: timer.reminder
+      owner: ` + opts.owner + `
+      event: ` + opts.event + `
       delay: 1m
-      start_on: ` + startOn + "\n"
-	if strings.TrimSpace(cancelOn) != "" {
-		timerBlock += "      cancel_on: " + cancelOn + "\n"
+      start_on: ` + opts.startOn + "\n"
+	if strings.TrimSpace(opts.cancelOn) != "" {
+		timerBlock += "      cancel_on: " + opts.cancelOn + "\n"
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
 support-node:

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -1,0 +1,138 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/timeridentity"
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkTimerValidation(c *checkerContext) []Finding { return c.timerValidation() }
+
+func (c *checkerContext) timerValidation() []Finding {
+	if c.timerLoaded {
+		return c.timerFindings
+	}
+	c.timerLoaded = true
+	for _, timer := range c.source.WorkflowTimers() {
+		owner := strings.TrimSpace(timer.Owner)
+		if owner == "" {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s missing owner", timer.ID),
+				Location: strings.TrimSpace(timer.ID),
+			})
+			continue
+		}
+		if owner != "runtime" {
+			if _, systemNode := c.source.NodeEntries()[owner]; !systemNode {
+				if !participantExistsLocal(c.source, owner) {
+					c.timerFindings = append(c.timerFindings, Finding{
+						CheckID:  "timer_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("timer %s owner %s missing from participants", timer.ID, owner),
+						Location: strings.TrimSpace(timer.ID),
+					})
+				}
+			}
+		}
+		if !eventExists(c.source, strings.TrimSpace(timer.Event)) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s event %s missing from event catalog", timer.ID, timer.Event),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		}
+		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
+		if err != nil {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s start_on %q is invalid: %v", timer.ID, timer.StartOn, err),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		} else {
+			c.validateTimerTrigger(timer, "start_on", startTrigger)
+		}
+		cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
+		if err != nil {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s cancel_on %q is invalid: %v", timer.ID, timer.CancelOn, err),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		} else {
+			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)
+		}
+	}
+	return c.timerFindings
+}
+
+func (c *checkerContext) validateTimerTrigger(timer runtimecontracts.WorkflowTimerContract, field string, trigger timeridentity.Trigger) {
+	if !trigger.Valid() {
+		return
+	}
+	switch trigger.Kind {
+	case timeridentity.TriggerKindState:
+		if !containsString(flowStatesForTimer(c.source, timer.FlowID), trigger.Name) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s %s references unknown state %s", timer.ID, field, trigger.Name),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		}
+	case timeridentity.TriggerKindEvent:
+		if !eventExists(c.source, trigger.Name) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "warning",
+				Message:  fmt.Sprintf("timer %s %s references unknown event %s", timer.ID, field, trigger.Name),
+				Location: strings.TrimSpace(timer.ID),
+			})
+		}
+	}
+}
+
+func flowStatesForTimer(source semanticview.Source, flowID string) []string {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil {
+		return nil
+	}
+	if flowID != "" {
+		return source.FlowStates(flowID)
+	}
+	stages := source.WorkflowStages()
+	out := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		name := strings.TrimSpace(stage.ID)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func participantExistsLocal(source semanticview.Source, participant string) bool {
+	participant = strings.TrimSpace(participant)
+	if participant == "" || source == nil {
+		return false
+	}
+	if participant == "runtime" || participant == "human" {
+		return true
+	}
+	if _, ok := source.NodeEntries()[participant]; ok {
+		return true
+	}
+	for _, agent := range source.AgentEntries() {
+		if strings.TrimSpace(agent.ID) == participant || strings.TrimSpace(agent.Role) == participant {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -413,7 +413,7 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("Start error = %v, want explicit recovery denial", startErr)
 	}
 
-	reader := dashboardserver.NewSQLObservabilityReader(db)
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
 	if reader == nil {
 		t.Fatal("NewSQLObservabilityReader returned nil")
 	}


### PR DESCRIPTION
Part of #126

## Human Summary
Extract the bootverify timer-validation concept cluster out of the monolithic checks file into its own boundary-owned module, and add direct report-surface proof for the weakest timer integrity paths.

## What Changed
- moved the timer-validation cluster out of `internal/runtime/bootverify/checks.go` into `internal/runtime/bootverify/workflow_timer_checks.go`
- kept the existing registry/report/startup surface unchanged
- moved the concept-local helpers with the cluster:
  - `timerValidation()`
  - `validateTimerTrigger(...)`
  - `flowStatesForTimer(...)`
  - `participantExistsLocal(...)`
- added direct report-surface coverage for:
  - missing timer owner
  - timer owner missing from participants
  - timer event missing from the event catalog
- preserved the existing proofs for invalid `start_on`, invalid `cancel_on`, unknown state, and unknown event

## Why This Is Needed
`#126` is decomposing bootverify by real concept boundaries rather than helper adjacency. Timer owner/trigger integrity is still a coherent startup-gate concept embedded in `checks.go`, and its direct report-surface coverage was weaker than the already-extracted slices.

## Scope Boundaries
- this PR closes the timer-validation child class only
- it does not close umbrella issue `#126`
- it does not absorb `single_node_per_event`, which remains a separate event-cardinality concept unless later evidence proves otherwise
- it does not redesign runtime timer semantics outside bootverify maintenance

## Spec References
- none; this is non-semantic maintenance
- justification: the change decomposes the startup verification boundary and adds direct regression proof without changing platform contract semantics

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(ReportsErrorForTimerMissingOwner|ReportsErrorForTimerOwnerMissingFromParticipants|ReportsErrorForTimerEventMissingFromCatalog|ReportsErrorForUnprefixedTimerStartOn|ReportsErrorForTimerCancelOnBoot|ReportsErrorForUnknownTimerTriggerState|ReportsWarningForUnknownTimerTriggerEvent)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
- the remaining `#126` tail still contains adjacent event-oriented bootverify clusters, so helper adjacency can still look like shared semantics unless each future slice is pressure-tested the same way

## Follow-Up
- continue `#126` with the remaining parent tail tracked on the umbrella issue
- likely next child classes remain:
  - event-cardinality uniqueness
  - entity-target/state-schema coverage
  - event-topology/event-catalog integrity
