### PR TITLE
[agent-a][issue #314] Canonicalize reset orphan aftermath diagnostics

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -14,13 +14,16 @@ import (
 	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
 	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimediaglog "swarm/internal/runtime/diaglog"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimesemanticview "swarm/internal/runtime/semanticview"
+	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -413,7 +416,7 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("Start error = %v, want explicit recovery denial", startErr)
 	}
 
-	reader := dashboardserver.NewSQLObservabilityReader(db)
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
 	if reader == nil {
 		t.Fatal("NewSQLObservabilityReader returned nil")
 	}
@@ -450,6 +453,136 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 	classes, _ := detail["recoverable_work_classes"].([]any)
 	if len(classes) != 1 || readString(classes[0]) != "active schedules" {
 		t.Fatalf("detail.recoverable_work_classes = %#v, want [active schedules]", detail["recoverable_work_classes"])
+	}
+}
+
+type conformanceRuntimeLoggerHook struct {
+	logger *runtimepkg.RuntimeLogger
+}
+
+func (h conformanceRuntimeLoggerHook) Log(ctx context.Context, level runtimediaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {
+	if h.logger == nil {
+		return nil
+	}
+	return h.logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:       level,
+		Message:     message,
+		Component:   component,
+		Action:      action,
+		EventID:     eventID,
+		EventType:   eventType,
+		AgentID:     agentID,
+		EntityID:    entityID,
+		SessionID:   sessionID,
+		Correlation: correlation,
+		Detail:      detail,
+		Error:       errText,
+		DurationUS:  durationUS,
+	})
+}
+
+func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	logger := runtimepkg.NewRuntimeLogger(db, pg)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		Logger: conformanceRuntimeLoggerHook{logger: logger},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	lease, err := registry.Acquire(ctx, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "conformance", "global")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	am := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		RuntimeMode: runtimesessions.RuntimeModeSession.String(),
+		Sessions:    registry,
+	})
+	if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+		t.Fatalf("ResetRuntimeStateWithSource: %v", err)
+	}
+
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "runtime",
+		Type:      "reset_orphaned_sessions",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("runtime log rows = %d, want 1: %#v", len(logs), logs)
+	}
+	log := logs[0]
+	if log.Level != "warn" {
+		t.Fatalf("log level = %q, want warn", log.Level)
+	}
+	if log.Action != "reset_orphaned_sessions" {
+		t.Fatalf("log action = %q, want reset_orphaned_sessions", log.Action)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := readString(detail["source"]); got != "builder_api" {
+		t.Fatalf("detail.source = %q, want builder_api", got)
+	}
+	if got, _ := detail["orphaned_session_count"].(float64); int(got) != 1 {
+		t.Fatalf("detail.orphaned_session_count = %v, want 1", detail["orphaned_session_count"])
+	}
+	orphanedSessions, _ := detail["orphaned_sessions"].([]any)
+	if len(orphanedSessions) != 1 {
+		t.Fatalf("detail.orphaned_sessions = %#v, want one row", detail["orphaned_sessions"])
+	}
+	sessionRow, ok := orphanedSessions[0].(map[string]any)
+	if !ok {
+		t.Fatalf("detail.orphaned_sessions[0] = %#v, want object", orphanedSessions[0])
+	}
+	if got := readString(sessionRow["session_id"]); got != lease.SessionID {
+		t.Fatalf("detail.orphaned_sessions[0].session_id = %q, want %q", got, lease.SessionID)
+	}
+	if got := readString(sessionRow["agent_id"]); got != "agent-1" {
+		t.Fatalf("detail.orphaned_sessions[0].agent_id = %q, want agent-1", got)
+	}
+	if got := readString(sessionRow["termination_reason"]); got != "orphaned" {
+		t.Fatalf("detail.orphaned_sessions[0].termination_reason = %q, want orphaned", got)
+	}
+	if got := readString(sessionRow["termination_detail"]); got != "builder_api" {
+		t.Fatalf("detail.orphaned_sessions[0].termination_detail = %q, want builder_api", got)
+	}
+
+	var (
+		status            string
+		terminationReason string
+		terminationDetail string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(status, ''),
+			COALESCE(termination_reason, ''),
+			COALESCE(termination_detail, '')
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, lease.SessionID).Scan(&status, &terminationReason, &terminationDetail); err != nil {
+		t.Fatalf("load reset session row: %v", err)
+	}
+	if status != "terminated" {
+		t.Fatalf("status = %q, want terminated", status)
+	}
+	if terminationReason != "orphaned" {
+		t.Fatalf("termination_reason = %q, want orphaned", terminationReason)
+	}
+	if terminationDetail != "builder_api" {
+		t.Fatalf("termination_detail = %q, want builder_api", terminationDetail)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -775,7 +775,10 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 		am.resetRuntimeOwnedState()
 	}
 	if resetter, ok := am.sessions.(sessions.Resetter); ok && resetter != nil {
-		if err := resetter.ResetAll(sessions.NormalizeConversationRuntimeMode(am.runtimeMode)); err != nil {
+		summary, err := resetter.ResetAll(sessions.NormalizeConversationRuntimeMode(am.runtimeMode), sessions.ResetMetadata{
+			Source: source,
+		})
+		if err != nil {
 			if am.bus != nil {
 				am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
 					Level:     "error",
@@ -784,6 +787,14 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 					Error:     strings.TrimSpace(err.Error()),
 				})
 			}
+		} else if summary.OrphanedCount() > 0 && am.bus != nil {
+			am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
+				Level:     "warn",
+				Component: "runtime",
+				Action:    "reset_orphaned_sessions",
+				Message:   "Runtime reset orphaned live sessions",
+				Detail:    resetOrphanedSessionsDetail(summary, source, sessions.NormalizeConversationRuntimeMode(am.runtimeMode)),
+			})
 		}
 	}
 	if am.bus != nil {
@@ -833,6 +844,36 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 		}
 	}
 	return nil
+}
+
+func resetOrphanedSessionsDetail(summary sessions.ResetSummary, source string, runtimeMode sessions.RuntimeMode) map[string]any {
+	detail := map[string]any{
+		"orphaned_session_count": summary.OrphanedCount(),
+		"orphaned_sessions":      make([]map[string]any, 0, len(summary.OrphanedSessions)),
+	}
+	if runtimeMode != "" {
+		detail["runtime_mode"] = runtimeMode.String()
+	}
+	if source = strings.TrimSpace(source); source != "" {
+		detail["source"] = source
+	}
+	records := detail["orphaned_sessions"].([]map[string]any)
+	for _, item := range summary.OrphanedSessions {
+		record := map[string]any{
+			"session_id":         strings.TrimSpace(item.SessionID),
+			"agent_id":           strings.TrimSpace(item.AgentID),
+			"scope_key":          strings.TrimSpace(item.ScopeKey),
+			"runtime_mode":       item.RuntimeMode.String(),
+			"previous_status":    strings.TrimSpace(item.PreviousStatus),
+			"termination_reason": strings.TrimSpace(item.TerminationReason),
+		}
+		if terminationDetail := strings.TrimSpace(item.TerminationDetail); terminationDetail != "" {
+			record["termination_detail"] = terminationDetail
+		}
+		records = append(records, record)
+	}
+	detail["orphaned_sessions"] = records
+	return detail
 }
 
 func (am *AgentManager) startAgentLoop(parent context.Context, agent Agent) {

--- a/internal/runtime/manager/runtime_reset_test.go
+++ b/internal/runtime/manager/runtime_reset_test.go
@@ -1,12 +1,57 @@
 package manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemcp "swarm/internal/runtime/mcp"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/sessions"
 )
+
+type resetTestBus struct {
+	entries []runtimepipeline.RuntimeLogEntry
+}
+
+func (b *resetTestBus) Publish(context.Context, events.Event) error { return nil }
+func (b *resetTestBus) PublishDirect(context.Context, events.Event, []string) error {
+	return nil
+}
+func (b *resetTestBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
+func (b *resetTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+func (b *resetTestBus) Unsubscribe(string)           {}
+func (b *resetTestBus) Store() runtimebus.EventStore { return runtimebus.InMemoryEventStore{} }
+func (b *resetTestBus) ResetInMemoryState() error    { return nil }
+func (b *resetTestBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.entries = append(b.entries, entry)
+	return nil
+}
+
+type resetTestRegistry struct {
+	summary sessions.ResetSummary
+}
+
+func (*resetTestRegistry) Acquire(context.Context, string, sessions.RuntimeMode, sessions.SessionScope, string, string) (*sessions.Lease, error) {
+	return nil, nil
+}
+func (*resetTestRegistry) Release(context.Context, *sessions.Lease) error { return nil }
+func (*resetTestRegistry) Rotate(context.Context, string, sessions.RuntimeMode, sessions.SessionScope, string, sessions.RotationMetadata, string) (*sessions.Lease, error) {
+	return nil, nil
+}
+func (*resetTestRegistry) IncrementTurn(context.Context, string, sessions.RuntimeMode, sessions.SessionScope, string, string) error {
+	return nil
+}
+func (r *resetTestRegistry) ResetAll(sessions.RuntimeMode, sessions.ResetMetadata) (sessions.ResetSummary, error) {
+	return r.summary, nil
+}
 
 func TestResetRuntimeState_OnlyResetsOwnedTurnContextRegistry(t *testing.T) {
 	registryA := runtimemcp.NewTurnContextRegistry(nil)
@@ -39,5 +84,62 @@ func TestResetRuntimeState_OnlyResetsOwnedTurnContextRegistry(t *testing.T) {
 	}
 	if turn.Actor.ID != "agent-b" {
 		t.Fatalf("registryB actor id = %q, want agent-b", turn.Actor.ID)
+	}
+}
+
+func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
+	bus := &resetTestBus{}
+	registry := &resetTestRegistry{summary: sessions.ResetSummary{
+		OrphanedSessions: []sessions.ResetDisposition{{
+			SessionID:         "sess-1",
+			AgentID:           "agent-a",
+			RuntimeMode:       sessions.RuntimeModeSession,
+			ScopeKey:          "global",
+			PreviousStatus:    "active",
+			TerminationReason: sessions.TerminationReasonOrphaned.String(),
+			TerminationDetail: "builder_api",
+		}},
+	}}
+
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		RuntimeMode: "session",
+		Sessions:    registry,
+	})
+	if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+		t.Fatalf("ResetRuntimeStateWithSource: %v", err)
+	}
+
+	if len(bus.entries) != 1 {
+		t.Fatalf("runtime log entry count = %d, want 1", len(bus.entries))
+	}
+	entry := bus.entries[0]
+	if entry.Component != "runtime" {
+		t.Fatalf("runtime log component = %q, want runtime", entry.Component)
+	}
+	if entry.Action != "reset_orphaned_sessions" {
+		t.Fatalf("runtime log action = %q, want reset_orphaned_sessions", entry.Action)
+	}
+	if entry.Level != "warn" {
+		t.Fatalf("runtime log level = %q, want warn", entry.Level)
+	}
+	detail, ok := entry.Detail.(map[string]any)
+	if !ok {
+		t.Fatalf("runtime log detail = %#v, want map", entry.Detail)
+	}
+	if got := detail["source"]; got != "builder_api" {
+		t.Fatalf("detail.source = %#v, want builder_api", got)
+	}
+	if got := detail["orphaned_session_count"]; got != 1 {
+		t.Fatalf("detail.orphaned_session_count = %#v, want 1", got)
+	}
+	records, ok := detail["orphaned_sessions"].([]map[string]any)
+	if !ok || len(records) != 1 {
+		t.Fatalf("detail.orphaned_sessions = %#v, want one record", detail["orphaned_sessions"])
+	}
+	if got := records[0]["session_id"]; got != "sess-1" {
+		t.Fatalf("detail.orphaned_sessions[0].session_id = %#v, want sess-1", got)
+	}
+	if got := records[0]["termination_reason"]; got != "orphaned" {
+		t.Fatalf("detail.orphaned_sessions[0].termination_reason = %#v, want orphaned", got)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -615,7 +615,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				handleRuntimeLogPersistenceError("runtime", "recovery_failed", rt.Logger.Error(ctx, "runtime", "recovery_failed", nil, err))
 			}
 			startupRecoveryDecision.ManagerResetAttempted = true
-			if resetErr := rt.Manager.ResetRuntimeState(); resetErr != nil {
+			if resetErr := rt.Manager.ResetRuntimeStateWithSource("startup_recovery_failed"); resetErr != nil {
 				startupRecoveryDecision.ManagerResetError = resetErr.Error()
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("runtime", "recovery_reset_failed", rt.Logger.Error(ctx, "runtime", "recovery_reset_failed", nil, resetErr))

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -457,6 +457,8 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode, metadata ResetMeta
 			    updated_at = now()
 			FROM affected
 			WHERE s.session_id = affected.session_id
+			  AND s.status IN ('active', 'suspended')
+			  AND s.runtime_mode IN ('session', 'session_per_entity')
 			RETURNING affected.session_id::text, affected.agent_id, affected.scope_key, affected.runtime_mode, affected.status
 		)
 		SELECT session_id, agent_id, scope_key, runtime_mode, status
@@ -501,6 +503,8 @@ func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode, metadata ResetMeta
 			    updated_at = now()
 			FROM affected
 			WHERE s.session_id = affected.session_id
+			  AND s.status IN ('active', 'suspended')
+			  AND s.runtime_mode = $1
 			RETURNING affected.session_id::text, affected.agent_id, affected.scope_key, affected.runtime_mode, affected.status
 		)
 		SELECT session_id, agent_id, scope_key, runtime_mode, status

--- a/internal/runtime/sessions/postgres.go
+++ b/internal/runtime/sessions/postgres.go
@@ -435,39 +435,93 @@ func (sr *PostgresRegistry) ScopeKeyEnabledForTest() bool {
 	return true
 }
 
-func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode) error {
+func (sr *PostgresRegistry) ResetAll(runtimeMode RuntimeMode, metadata ResetMetadata) (ResetSummary, error) {
+	summary := ResetSummary{}
+	source := strings.TrimSpace(metadata.Source)
 	if runtimeMode == "" {
-		_, err := sr.db.Exec(`
-		UPDATE agent_sessions
-		SET status = 'terminated',
-		    termination_reason = 'orphaned',
-		    terminated_at = COALESCE(terminated_at, now()),
-		    lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = now()
-		WHERE status IN ('active', 'suspended')
-		  AND runtime_mode IN ('session', 'session_per_entity')
-	`)
+		rows, err := sr.db.Query(`
+		WITH affected AS (
+			SELECT session_id, agent_id, scope_key, runtime_mode, status
+			FROM agent_sessions
+			WHERE status IN ('active', 'suspended')
+			  AND runtime_mode IN ('session', 'session_per_entity')
+		),
+		updated AS (
+			UPDATE agent_sessions AS s
+			SET status = 'terminated',
+			    termination_reason = 'orphaned',
+			    termination_detail = NULLIF($1, ''),
+			    terminated_at = COALESCE(terminated_at, now()),
+			    lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = now()
+			FROM affected
+			WHERE s.session_id = affected.session_id
+			RETURNING affected.session_id::text, affected.agent_id, affected.scope_key, affected.runtime_mode, affected.status
+		)
+		SELECT session_id, agent_id, scope_key, runtime_mode, status
+		FROM updated
+		ORDER BY agent_id ASC, scope_key ASC, session_id ASC
+	`, source)
 		if err != nil {
-			return fmt.Errorf("reset all sessions: %w", err)
+			return ResetSummary{}, fmt.Errorf("reset all sessions: %w", err)
 		}
-		return nil
+		defer rows.Close()
+		for rows.Next() {
+			var disposition ResetDisposition
+			if err := rows.Scan(&disposition.SessionID, &disposition.AgentID, &disposition.ScopeKey, &disposition.RuntimeMode, &disposition.PreviousStatus); err != nil {
+				return ResetSummary{}, fmt.Errorf("scan reset all session summary: %w", err)
+			}
+			disposition.TerminationReason = TerminationReasonOrphaned.String()
+			disposition.TerminationDetail = source
+			summary.OrphanedSessions = append(summary.OrphanedSessions, disposition)
+		}
+		if err := rows.Err(); err != nil {
+			return ResetSummary{}, fmt.Errorf("reset all sessions rows: %w", err)
+		}
+		return summary, nil
 	}
 	if runtimeMode == RuntimeModeTask {
-		return nil
+		return summary, nil
 	}
-	_, err := sr.db.Exec(`
-		UPDATE agent_sessions
-		SET status = 'terminated',
-		    termination_reason = 'orphaned',
-		    terminated_at = COALESCE(terminated_at, now()),
-		    lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = now()
-		WHERE status IN ('active', 'suspended') AND runtime_mode = $1
-	`, runtimeMode)
+	rows, err := sr.db.Query(`
+		WITH affected AS (
+			SELECT session_id, agent_id, scope_key, runtime_mode, status
+			FROM agent_sessions
+			WHERE status IN ('active', 'suspended') AND runtime_mode = $1
+		),
+		updated AS (
+			UPDATE agent_sessions AS s
+			SET status = 'terminated',
+			    termination_reason = 'orphaned',
+			    termination_detail = NULLIF($2, ''),
+			    terminated_at = COALESCE(terminated_at, now()),
+			    lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = now()
+			FROM affected
+			WHERE s.session_id = affected.session_id
+			RETURNING affected.session_id::text, affected.agent_id, affected.scope_key, affected.runtime_mode, affected.status
+		)
+		SELECT session_id, agent_id, scope_key, runtime_mode, status
+		FROM updated
+		ORDER BY agent_id ASC, scope_key ASC, session_id ASC
+	`, runtimeMode, source)
 	if err != nil {
-		return fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode.String(), err)
+		return ResetSummary{}, fmt.Errorf("reset sessions runtime=%s: %w", runtimeMode.String(), err)
 	}
-	return nil
+	defer rows.Close()
+	for rows.Next() {
+		var disposition ResetDisposition
+		if err := rows.Scan(&disposition.SessionID, &disposition.AgentID, &disposition.ScopeKey, &disposition.RuntimeMode, &disposition.PreviousStatus); err != nil {
+			return ResetSummary{}, fmt.Errorf("scan reset sessions runtime=%s summary: %w", runtimeMode.String(), err)
+		}
+		disposition.TerminationReason = TerminationReasonOrphaned.String()
+		disposition.TerminationDetail = source
+		summary.OrphanedSessions = append(summary.OrphanedSessions, disposition)
+	}
+	if err := rows.Err(); err != nil {
+		return ResetSummary{}, fmt.Errorf("reset sessions runtime=%s rows: %w", runtimeMode.String(), err)
+	}
+	return summary, nil
 }

--- a/internal/runtime/sessions/postgres_test.go
+++ b/internal/runtime/sessions/postgres_test.go
@@ -254,17 +254,32 @@ func TestPostgresSessionRegistry_ResetAll_TerminatesActiveSessions(t *testing.T)
 	defer db.Close()
 
 	sr := NewPostgresRegistry(db, 30*time.Second)
-	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'.*runtime_mode IN \\('session', 'session_per_entity'\\)").
-		WillReturnResult(sqlmock.NewResult(0, 2))
-	if err := sr.ResetAll(""); err != nil {
+	mock.ExpectQuery("WITH affected AS \\(").
+		WithArgs("").
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "agent_id", "scope_key", "runtime_mode", "status"}).
+			AddRow("sess-1", "a1", "global", RuntimeModeSession, "active").
+			AddRow("sess-2", "a2", "entity-1", RuntimeModeSessionPerEntity, "suspended"))
+	summary, err := sr.ResetAll("", ResetMetadata{})
+	if err != nil {
 		t.Fatalf("ResetAll(all runtimes): %v", err)
 	}
+	if got := summary.OrphanedCount(); got != 2 {
+		t.Fatalf("ResetAll(all runtimes) orphaned_count = %d, want 2", got)
+	}
 
-	mock.ExpectExec("UPDATE agent_sessions\\s+SET status = 'terminated'.*runtime_mode = \\$1").
-		WithArgs(RuntimeModeSession).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	if err := sr.ResetAll(RuntimeModeSession); err != nil {
+	mock.ExpectQuery("WITH affected AS \\(").
+		WithArgs(RuntimeModeSession, "builder_api").
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "agent_id", "scope_key", "runtime_mode", "status"}).
+			AddRow("sess-3", "a3", "global", RuntimeModeSession, "active"))
+	summary, err = sr.ResetAll(RuntimeModeSession, ResetMetadata{Source: "builder_api"})
+	if err != nil {
 		t.Fatalf("ResetAll(session): %v", err)
+	}
+	if got := summary.OrphanedCount(); got != 1 {
+		t.Fatalf("ResetAll(session) orphaned_count = %d, want 1", got)
+	}
+	if got := summary.OrphanedSessions[0].TerminationDetail; got != "builder_api" {
+		t.Fatalf("ResetAll(session) termination_detail = %q, want builder_api", got)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/runtime/sessions/registry.go
+++ b/internal/runtime/sessions/registry.go
@@ -19,7 +19,29 @@ type Registry interface {
 }
 
 type Resetter interface {
-	ResetAll(runtimeMode RuntimeMode) error
+	ResetAll(runtimeMode RuntimeMode, metadata ResetMetadata) (ResetSummary, error)
+}
+
+type ResetMetadata struct {
+	Source string
+}
+
+type ResetDisposition struct {
+	SessionID         string
+	AgentID           string
+	RuntimeMode       RuntimeMode
+	ScopeKey          string
+	PreviousStatus    string
+	TerminationReason string
+	TerminationDetail string
+}
+
+type ResetSummary struct {
+	OrphanedSessions []ResetDisposition
+}
+
+func (s ResetSummary) OrphanedCount() int {
+	return len(s.OrphanedSessions)
 }
 
 type Lease struct {
@@ -351,9 +373,11 @@ func (sr *InMemoryRegistry) History(agentID string) []Record {
 	return out
 }
 
-func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode) error {
+func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode, metadata ResetMetadata) (ResetSummary, error) {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
+	summary := ResetSummary{}
+	source := strings.TrimSpace(metadata.Source)
 	if runtimeMode == "" {
 		now := time.Now()
 		for key, rec := range sr.byKey {
@@ -363,17 +387,27 @@ func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode) error {
 			terminated := *rec
 			terminated.Status = "terminated"
 			terminated.TerminationReason = TerminationReasonOrphaned.String()
+			terminated.TerminationDetail = source
 			terminated.TerminatedAt = now
 			terminated.LockOwner = ""
 			terminated.LockExpiresAt = time.Time{}
 			terminated.SuccessorSessionID = ""
 			sr.history[key] = append(sr.history[key], &terminated)
+			summary.OrphanedSessions = append(summary.OrphanedSessions, ResetDisposition{
+				SessionID:         terminated.SessionID,
+				AgentID:           terminated.AgentID,
+				RuntimeMode:       terminated.RuntimeMode,
+				ScopeKey:          terminated.ScopeKey,
+				PreviousStatus:    rec.Status,
+				TerminationReason: terminated.TerminationReason,
+				TerminationDetail: terminated.TerminationDetail,
+			})
 		}
 		sr.byKey = make(map[string]*Record)
-		return nil
+		return summary, nil
 	}
 	if runtimeMode == RuntimeModeTask {
-		return nil
+		return summary, nil
 	}
 	now := time.Now()
 	for key, rec := range sr.byKey {
@@ -385,13 +419,23 @@ func (sr *InMemoryRegistry) ResetAll(runtimeMode RuntimeMode) error {
 			terminated := *rec
 			terminated.Status = "terminated"
 			terminated.TerminationReason = TerminationReasonOrphaned.String()
+			terminated.TerminationDetail = source
 			terminated.TerminatedAt = now
 			terminated.LockOwner = ""
 			terminated.LockExpiresAt = time.Time{}
 			terminated.SuccessorSessionID = ""
 			sr.history[key] = append(sr.history[key], &terminated)
+			summary.OrphanedSessions = append(summary.OrphanedSessions, ResetDisposition{
+				SessionID:         terminated.SessionID,
+				AgentID:           terminated.AgentID,
+				RuntimeMode:       terminated.RuntimeMode,
+				ScopeKey:          terminated.ScopeKey,
+				PreviousStatus:    rec.Status,
+				TerminationReason: terminated.TerminationReason,
+				TerminationDetail: terminated.TerminationDetail,
+			})
 			delete(sr.byKey, key)
 		}
 	}
-	return nil
+	return summary, nil
 }

--- a/internal/runtime/sessions/registry_test.go
+++ b/internal/runtime/sessions/registry_test.go
@@ -97,7 +97,7 @@ func TestInMemorySessionRegistry_TaskModeIsStateless(t *testing.T) {
 	if _, err := sr.Acquire(context.Background(), "agent-a", RuntimeModeTask, "", "worker-a", ""); err == nil {
 		t.Fatal("expected task mode acquire to reject stateless sessions")
 	}
-	if err := sr.ResetAll(RuntimeModeTask); err != nil {
+	if _, err := sr.ResetAll(RuntimeModeTask, ResetMetadata{}); err != nil {
 		t.Fatalf("ResetAll(task): %v", err)
 	}
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -490,8 +490,12 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurns
 	}
 
 	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
-	if err := registry.ResetAll(runtimesessions.RuntimeModeSession); err != nil {
+	summary, err := registry.ResetAll(runtimesessions.RuntimeModeSession, runtimesessions.ResetMetadata{})
+	if err != nil {
 		t.Fatalf("ResetAll after agent_sessions-only migration: %v", err)
+	}
+	if got := summary.OrphanedCount(); got != 1 {
+		t.Fatalf("ResetAll orphaned_count = %d, want 1", got)
 	}
 
 	var (
@@ -588,20 +592,28 @@ func TestPostgresRegistry_ResetAllMarksActiveSessionsOrphaned(t *testing.T) {
 
 	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
 	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
-	if err := registry.ResetAll(runtimesessions.RuntimeModeSession); err != nil {
+	summary, err := registry.ResetAll(runtimesessions.RuntimeModeSession, runtimesessions.ResetMetadata{Source: "builder_api"})
+	if err != nil {
 		t.Fatalf("ResetAll: %v", err)
+	}
+	if got := summary.OrphanedCount(); got != 1 {
+		t.Fatalf("ResetAll orphaned_count = %d, want 1", got)
+	}
+	if got := summary.OrphanedSessions[0].TerminationDetail; got != "builder_api" {
+		t.Fatalf("ResetAll termination_detail = %q, want builder_api", got)
 	}
 
 	var (
 		status       string
 		reason       string
+		detail       string
 		terminatedAt time.Time
 	)
 	if err := db.QueryRowContext(ctx, `
-		SELECT COALESCE(status, ''), COALESCE(termination_reason, ''), terminated_at
+		SELECT COALESCE(status, ''), COALESCE(termination_reason, ''), COALESCE(termination_detail, ''), terminated_at
 		FROM agent_sessions
 		WHERE session_id = $1::uuid
-	`, sessionID).Scan(&status, &reason, &terminatedAt); err != nil {
+	`, sessionID).Scan(&status, &reason, &detail, &terminatedAt); err != nil {
 		t.Fatalf("load reset session row: %v", err)
 	}
 	if status != "terminated" {
@@ -609,6 +621,9 @@ func TestPostgresRegistry_ResetAllMarksActiveSessionsOrphaned(t *testing.T) {
 	}
 	if reason != "orphaned" {
 		t.Fatalf("termination_reason = %q, want orphaned", reason)
+	}
+	if detail != "builder_api" {
+		t.Fatalf("termination_detail = %q, want builder_api", detail)
 	}
 	if terminatedAt.IsZero() {
 		t.Fatal("terminated_at is zero")


### PR DESCRIPTION
Closes #314

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`

## Human Summary
This PR closes the approved child slice under `recovery_restart_diagnostics` by making reset/restart orphaned live-session aftermath explicit through one runtime-owned diagnostics path instead of leaving operators to reconstruct it from session row mutations and scattered local logs.

## What Changed
- extended session resetters to return typed orphaned-session aftermath facts and persist reset source metadata into `agent_sessions.termination_detail`
- made `AgentManager.resetRuntimeState(...)` emit one canonical `reset_orphaned_sessions` runtime log when reset/restart orphans live sessions
- tagged the startup-recovery reset path with `startup_recovery_failed` so restart-triggered resets carry an explicit source
- added focused manager, session-store, store migration, and conformance observability proofs for the canonical aftermath record

## Why This Is Needed
Before this change, the runtime orphaned live sessions during reset/restart but did not expose one canonical operator-visible aftermath record. Operators could inspect terminated session rows, but the runtime-owned reason and affected-session summary were still implicit and split across behavior and ad hoc logs.

## Scope Boundaries
In scope:
- reset/restart orphaned live-session aftermath diagnostics
- canonical persisted session-disposition facts for that class
- canonical runtime-owned diagnostics for that class
- supported observability proof for that class

Out of scope:
- superseded session-chain semantics from ordinary `Rotate(...)` / `session_rotated` paths
- delivery/timer replay-or-drop aftermath diagnostics
- broader observability redesign
- startup admission / execution-summary diagnostics already closed by `#179` / `#312`

## Tests Run
- `go test ./internal/runtime/manager -run 'Test(ResetRuntimeState_OnlyResetsOwnedTurnContextRegistry|ResetRuntimeState_LogsCanonicalOrphanedSessionAftermath)$' -count=1`
- `go test ./internal/runtime/sessions -run 'Test(InMemorySessionRegistry_TaskModeIsStateless|PostgresSessionRegistryResetAll)$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader|StartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager ./internal/runtime/sessions ./internal/runtime/conformance ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk
This PR closes the chosen child class only. The broader parent `recovery_restart_diagnostics` remains open for other restart/recovery aftermath siblings such as replay/drop decisions and any future restart-owned supersede semantics if later proven.

## Follow-Up
- parent watchlist node `recovery_restart_diagnostics` remains open
- remaining child-slice tail stays tracked in `docs/watchlists/runtime-operations.yaml`
