### PR TITLE
[agent-e][issue #313] Canonicalize non-agent subscriber delivery visibility

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -122,6 +122,7 @@ nodes:
     why_this_node_exists: runtime delivery drifts when publish, recovery, retry, and replay ownership are split across local paths
     known_manifestations:
       - direct-recipient delivery as a shadow semantic path
+      - descriptor-aware recipient policy can silently exclude non-agent in-memory subscribers such as startup control-plane checks, workflow-runtime, and system-node subscribers when publish planning treats all recipients as active-agent descriptors
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
     representative_issues:

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -3,31 +3,37 @@ package bus
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"swarm/internal/events"
 )
 
 type deliveryRoutingResult struct {
-	Recipients           []string
+	Recipients           []deliveryRecipientCandidate
 	RoutedRecipients     []Subscriber
 	SubscribedRecipients []string
 	ExtraDetail          map[string]any
 }
 
+type deliveryRecipientCandidate struct {
+	ID                string
+	PersistAsDelivery bool
+}
+
 type deliveryRouteResolver struct {
 	resolveRoutedSubscribers    func(string) []Subscriber
-	resolveSubscribedRecipients func(string) []string
+	resolveSubscribedRecipients func(string) []deliveryRecipientCandidate
 	describeSubscribersForEvent func(string, []Subscriber) []PublishDiagnosticRecipient
 }
 
 func (r deliveryRouteResolver) Resolve(evt events.Event) deliveryRoutingResult {
 	routedRecipients := r.resolveRoutedSubscribers(string(evt.Type))
 	subscribedRecipients := r.resolveSubscribedRecipients(string(evt.Type))
-	recipients := uniqueStrings(append(subscriberIDs(routedRecipients), subscribedRecipients...))
+	recipients := normalizeDeliveryRecipientCandidates(append(routedSubscriberCandidates(routedRecipients), subscribedRecipients...))
 	result := deliveryRoutingResult{
 		Recipients:           recipients,
 		RoutedRecipients:     routedRecipients,
-		SubscribedRecipients: subscribedRecipients,
+		SubscribedRecipients: deliveryRecipientIDs(subscribedRecipients),
 		ExtraDetail: map[string]any{
 			"routed_recipients_count":       len(routedRecipients),
 			"subscription_recipients_count": len(subscribedRecipients),
@@ -36,7 +42,7 @@ func (r deliveryRouteResolver) Resolve(evt events.Event) deliveryRoutingResult {
 	if described := publishDiagnosticRecipientMaps(r.describeSubscribersForEvent(string(evt.Type), routedRecipients)); len(described) > 0 {
 		result.ExtraDetail["routed_recipients"] = described
 	}
-	if direct := uniqueStrings(subscribedRecipients); len(direct) > 0 {
+	if direct := deliveryRecipientIDs(subscribedRecipients); len(direct) > 0 {
 		result.ExtraDetail["subscription_recipients"] = direct
 	}
 	return result
@@ -51,23 +57,18 @@ type deliveryRecipientPolicy struct {
 	loadActiveAgentDescriptors func(context.Context) (map[string]ActiveAgentDescriptor, bool, error)
 }
 
-func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event, recipients []string) (deliveryRecipientManifest, error) {
+func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event, recipients []deliveryRecipientCandidate) (deliveryRecipientManifest, error) {
 	descriptors, ok, err := p.loadActiveAgentDescriptors(ctx)
 	if err != nil {
 		return deliveryRecipientManifest{}, err
 	}
 	if !ok {
-		recipients = uniqueStrings(recipients)
 		return deliveryRecipientManifest{
-			Recipients:          recipients,
-			PersistedRecipients: recipients,
+			Recipients:          deliveryRecipientIDs(recipients),
+			PersistedRecipients: persistedDeliveryRecipientIDs(recipients),
 		}, nil
 	}
-	recipients = filterRecipientsForExplicitAgentScope(evt, recipients, descriptors)
-	return deliveryRecipientManifest{
-		Recipients:          recipients,
-		PersistedRecipients: append([]string(nil), recipients...),
-	}, nil
+	return filterDeliveryRecipientCandidates(evt, recipients, descriptors), nil
 }
 
 type deliveryPlanner struct {
@@ -109,7 +110,7 @@ func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recip
 	if len(requested) == 0 {
 		return eventDeliveryPlan{}, errors.New("direct delivery recipients are required")
 	}
-	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, requested)
+	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, agentDeliveryRecipientCandidates(requested))
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
@@ -149,11 +150,126 @@ func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
 			resolveRoutedSubscribers:    eb.resolveRoutedSubscribers,
-			resolveSubscribedRecipients: eb.resolveSubscribedRecipients,
+			resolveSubscribedRecipients: eb.resolveSubscribedRecipientsForPlanning,
 			describeSubscribersForEvent: eb.describeSubscribersForEvent,
 		},
 		deliveryRecipientPolicy{
 			loadActiveAgentDescriptors: eb.activeAgentDescriptors,
 		},
 	)
+}
+
+func normalizeDeliveryRecipientCandidates(in []deliveryRecipientCandidate) []deliveryRecipientCandidate {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]deliveryRecipientCandidate, 0, len(in))
+	indexByID := make(map[string]int, len(in))
+	for _, candidate := range in {
+		candidate.ID = strings.TrimSpace(candidate.ID)
+		if candidate.ID == "" {
+			continue
+		}
+		if idx, ok := indexByID[candidate.ID]; ok {
+			out[idx].PersistAsDelivery = out[idx].PersistAsDelivery || candidate.PersistAsDelivery
+			continue
+		}
+		indexByID[candidate.ID] = len(out)
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func routedSubscriberCandidates(in []Subscriber) []deliveryRecipientCandidate {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]deliveryRecipientCandidate, 0, len(in))
+	for _, subscriber := range in {
+		id := strings.TrimSpace(subscriber.ID)
+		if id == "" {
+			continue
+		}
+		if strings.TrimSpace(subscriber.Type) != "agent" {
+			continue
+		}
+		out = append(out, deliveryRecipientCandidate{
+			ID:                id,
+			PersistAsDelivery: true,
+		})
+	}
+	return out
+}
+
+func agentDeliveryRecipientCandidates(in []string) []deliveryRecipientCandidate {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]deliveryRecipientCandidate, 0, len(in))
+	for _, recipient := range in {
+		if recipient = strings.TrimSpace(recipient); recipient != "" {
+			out = append(out, deliveryRecipientCandidate{ID: recipient, PersistAsDelivery: true})
+		}
+	}
+	return normalizeDeliveryRecipientCandidates(out)
+}
+
+func deliveryRecipientIDs(in []deliveryRecipientCandidate) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, candidate := range in {
+		if candidate.ID = strings.TrimSpace(candidate.ID); candidate.ID != "" {
+			out = append(out, candidate.ID)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func persistedDeliveryRecipientIDs(in []deliveryRecipientCandidate) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, candidate := range in {
+		if !candidate.PersistAsDelivery {
+			continue
+		}
+		if candidate.ID = strings.TrimSpace(candidate.ID); candidate.ID != "" {
+			out = append(out, candidate.ID)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func filterDeliveryRecipientCandidates(evt events.Event, recipients []deliveryRecipientCandidate, descriptors map[string]ActiveAgentDescriptor) deliveryRecipientManifest {
+	recipients = normalizeDeliveryRecipientCandidates(recipients)
+	if len(recipients) == 0 {
+		return deliveryRecipientManifest{}
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	allowed := make([]string, 0, len(recipients))
+	persisted := make([]string, 0, len(recipients))
+	for _, recipient := range recipients {
+		if !recipient.PersistAsDelivery {
+			allowed = append(allowed, recipient.ID)
+			continue
+		}
+		descriptor, ok := descriptors[recipient.ID]
+		if !ok {
+			continue
+		}
+		if descriptor.EntityID != "" {
+			if eventEntityID == "" || descriptor.EntityID != eventEntityID {
+				continue
+			}
+		}
+		allowed = append(allowed, recipient.ID)
+		persisted = append(persisted, recipient.ID)
+	}
+	return deliveryRecipientManifest{
+		Recipients:          uniqueStrings(allowed),
+		PersistedRecipients: uniqueStrings(persisted),
+	}
 }

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -19,8 +19,12 @@ func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing
 				RouteSource:  "pin_auto_wire",
 			}}
 		},
-		resolveSubscribedRecipients: func(string) []string {
-			return []string{"direct-agent", "scan-orchestrator", "direct-agent"}
+		resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+			return []deliveryRecipientCandidate{
+				{ID: "direct-agent", PersistAsDelivery: true},
+				{ID: "scan-orchestrator", PersistAsDelivery: false},
+				{ID: "direct-agent", PersistAsDelivery: true},
+			}
 		},
 		describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
 			return []PublishDiagnosticRecipient{{
@@ -38,17 +42,17 @@ func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing
 	if got, want := len(result.RoutedRecipients), 1; got != want {
 		t.Fatalf("routed recipients = %d, want %d", got, want)
 	}
-	if got, want := len(result.SubscribedRecipients), 3; got != want {
+	if got, want := len(result.SubscribedRecipients), 2; got != want {
 		t.Fatalf("subscription recipients = %d, want %d", got, want)
 	}
 	if got, want := len(result.Recipients), 2; got != want {
 		t.Fatalf("candidate recipients = %d, want %d", got, want)
 	}
-	if got := result.Recipients[0]; got != "scan-orchestrator" {
-		t.Fatalf("first candidate recipient = %q, want scan-orchestrator", got)
+	if got := result.Recipients[0].ID; got != "direct-agent" {
+		t.Fatalf("first candidate recipient = %q, want direct-agent", got)
 	}
-	if got := result.Recipients[1]; got != "direct-agent" {
-		t.Fatalf("second candidate recipient = %q, want direct-agent", got)
+	if got := result.Recipients[1].ID; got != "scan-orchestrator" {
+		t.Fatalf("second candidate recipient = %q, want scan-orchestrator", got)
 	}
 	if got := result.ExtraDetail["routed_recipients_count"]; got != 1 {
 		t.Fatalf("routed_recipients_count = %#v, want 1", got)
@@ -75,7 +79,7 @@ func TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest(t *testin
 
 	manifest, err := policy.Evaluate(context.Background(), (events.Event{
 		Type: "task.completed",
-	}).WithEntityID("ent-1"), []string{"entity-agent", "other-agent", "shared-agent"})
+	}).WithEntityID("ent-1"), agentDeliveryRecipientCandidates([]string{"entity-agent", "other-agent", "shared-agent"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -90,14 +94,43 @@ func TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest(t *testin
 	}
 }
 
+func TestDeliveryRecipientPolicy_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning(t *testing.T) {
+	policy := deliveryRecipientPolicy{
+		loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+			return map[string]ActiveAgentDescriptor{
+				"agent-a": {AgentID: "agent-a"},
+			}, true, nil
+		},
+	}
+
+	manifest, err := policy.Evaluate(context.Background(), events.Event{Type: "task.completed"}, []deliveryRecipientCandidate{
+		{ID: "workflow-runtime", PersistAsDelivery: false},
+		{ID: "node:scan-orchestrator", PersistAsDelivery: false},
+		{ID: "agent-a", PersistAsDelivery: true},
+		{ID: "missing-agent", PersistAsDelivery: true},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(manifest.Recipients) != 3 || manifest.Recipients[0] != "workflow-runtime" || manifest.Recipients[1] != "node:scan-orchestrator" || manifest.Recipients[2] != "agent-a" {
+		t.Fatalf("recipients = %#v, want [workflow-runtime node:scan-orchestrator agent-a]", manifest.Recipients)
+	}
+	if len(manifest.PersistedRecipients) != 1 || manifest.PersistedRecipients[0] != "agent-a" {
+		t.Fatalf("persisted recipients = %#v, want [agent-a]", manifest.PersistedRecipients)
+	}
+}
+
 func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
 			resolveRoutedSubscribers: func(string) []Subscriber {
 				return []Subscriber{{ID: "worker", Type: "node"}}
 			},
-			resolveSubscribedRecipients: func(string) []string {
-				return []string{"worker", "observer"}
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{
+					{ID: "worker", PersistAsDelivery: false},
+					{ID: "observer", PersistAsDelivery: true},
+				}
 			},
 			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
 				return []PublishDiagnosticRecipient{{ID: "worker", Type: "node"}}
@@ -117,8 +150,11 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	if got, want := len(plan.Recipients), 2; got != want {
 		t.Fatalf("plan recipients = %d, want %d", got, want)
 	}
-	if got, want := len(plan.PersistedRecipients), 2; got != want {
+	if got, want := len(plan.PersistedRecipients), 1; got != want {
 		t.Fatalf("persisted recipients = %d, want %d", got, want)
+	}
+	if got := plan.PersistedRecipients[0]; got != "observer" {
+		t.Fatalf("persisted recipient = %q, want observer", got)
 	}
 	if got := plan.ExtraDetail["routed_recipients_count"]; got != 1 {
 		t.Fatalf("routed_recipients_count = %#v, want 1", got)
@@ -128,8 +164,10 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers:    func(string) []Subscriber { return nil },
-			resolveSubscribedRecipients: func(string) []string { return []string{"worker"} },
+			resolveRoutedSubscribers: func(string) []Subscriber { return nil },
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "worker", PersistAsDelivery: true}}
+			},
 			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient { return nil },
 		},
 		deliveryRecipientPolicy{

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -29,6 +29,7 @@ type EventBus struct {
 	agentChans          map[string]chan events.Event
 	subscriptions       map[string][]events.EventType
 	subscriptionKinds   map[string]inMemorySubscriberKind
+	pendingInternalByID map[string][]string
 	routeTable          *RouteTable
 	deliveryPlanner     deliveryPlanner
 	interceptors        []EventInterceptor
@@ -101,6 +102,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		agentChans:          make(map[string]chan events.Event),
 		subscriptions:       make(map[string][]events.EventType),
 		subscriptionKinds:   make(map[string]inMemorySubscriberKind),
+		pendingInternalByID: make(map[string][]string),
 		routeTable:          routeTable,
 		store:               store,
 		logger:              opts.Logger,
@@ -240,6 +242,7 @@ func (eb *EventBus) ResetInMemoryState() error {
 	eb.agentChans = make(map[string]chan events.Event)
 	eb.subscriptions = make(map[string][]events.EventType)
 	eb.subscriptionKinds = make(map[string]inMemorySubscriberKind)
+	eb.pendingInternalByID = make(map[string][]string)
 	routeTable, err := eb.deriveBootRouteTableLocked()
 	if err != nil {
 		return err

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -28,6 +28,7 @@ type EventBus struct {
 	channels            map[events.EventType]map[string]chan events.Event
 	agentChans          map[string]chan events.Event
 	subscriptions       map[string][]events.EventType
+	subscriptionKinds   map[string]inMemorySubscriberKind
 	routeTable          *RouteTable
 	deliveryPlanner     deliveryPlanner
 	interceptors        []EventInterceptor
@@ -65,6 +66,13 @@ type eventDeliveryPlan struct {
 	CycleEscalation      *events.Event
 }
 
+type inMemorySubscriberKind string
+
+const (
+	inMemorySubscriberAgent    inMemorySubscriberKind = "agent"
+	inMemorySubscriberInternal inMemorySubscriberKind = "internal"
+)
+
 func NewEventBus(store EventStore) (*EventBus, error) {
 	return NewEventBusWithOptions(store, EventBusOptions{})
 }
@@ -92,6 +100,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		channels:            make(map[events.EventType]map[string]chan events.Event),
 		agentChans:          make(map[string]chan events.Event),
 		subscriptions:       make(map[string][]events.EventType),
+		subscriptionKinds:   make(map[string]inMemorySubscriberKind),
 		routeTable:          routeTable,
 		store:               store,
 		logger:              opts.Logger,
@@ -230,6 +239,7 @@ func (eb *EventBus) ResetInMemoryState() error {
 	eb.channels = make(map[events.EventType]map[string]chan events.Event)
 	eb.agentChans = make(map[string]chan events.Event)
 	eb.subscriptions = make(map[string][]events.EventType)
+	eb.subscriptionKinds = make(map[string]inMemorySubscriberKind)
 	routeTable, err := eb.deriveBootRouteTableLocked()
 	if err != nil {
 		return err
@@ -271,22 +281,31 @@ func (eb *EventBus) PendingAgentDeliveries() int {
 }
 
 func (eb *EventBus) Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event {
+	return eb.subscribe(agentID, inMemorySubscriberAgent, eventTypes...)
+}
+
+func (eb *EventBus) SubscribeInternal(subscriberID string, eventTypes ...events.EventType) <-chan events.Event {
+	return eb.subscribe(subscriberID, inMemorySubscriberInternal, eventTypes...)
+}
+
+func (eb *EventBus) subscribe(subscriberID string, kind inMemorySubscriberKind, eventTypes ...events.EventType) <-chan events.Event {
 	ch := make(chan events.Event, 128)
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
-	if existing, ok := eb.agentChans[agentID]; ok {
+	if existing, ok := eb.agentChans[subscriberID]; ok {
 		ch = existing
 	} else {
-		eb.agentChans[agentID] = ch
+		eb.agentChans[subscriberID] = ch
 	}
+	eb.subscriptionKinds[subscriberID] = kind
 
 	for _, et := range eventTypes {
-		eb.subscriptions[agentID] = AppendUniqueEventType(eb.subscriptions[agentID], et)
+		eb.subscriptions[subscriberID] = AppendUniqueEventType(eb.subscriptions[subscriberID], et)
 		if eb.channels[et] == nil {
 			eb.channels[et] = make(map[string]chan events.Event)
 		}
-		eb.channels[et][agentID] = ch
+		eb.channels[et][subscriberID] = ch
 	}
 	return ch
 }
@@ -304,6 +323,7 @@ func (eb *EventBus) Unsubscribe(agentID string) {
 		close(ch)
 	}
 	delete(eb.subscriptions, agentID)
+	delete(eb.subscriptionKinds, agentID)
 	for et := range eb.channels {
 		delete(eb.channels[et], agentID)
 		if len(eb.channels[et]) == 0 {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -184,7 +184,7 @@ func (eb *EventBus) publishTransactional(
 	if passthrough {
 		if len(inboundPlan.Recipients) > 0 {
 			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
-			if err := eb.deliverToAgents(ctx, evt, inboundPlan.PersistedRecipients); err != nil {
+			if err := eb.deliverToAgents(ctx, evt, inboundPlan.Recipients); err != nil {
 				return err
 			}
 			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
@@ -310,7 +310,7 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 	}
 	if passthrough {
 		if len(plan.Recipients) > 0 {
-			if err := eb.deliverToAgents(ctx, evt, plan.PersistedRecipients); err != nil {
+			if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
 				return err
 			}
 			eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
@@ -392,7 +392,7 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 	}
 	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
 	if len(plan.Recipients) > 0 {
-		if err := eb.deliverToAgents(ctx, evt, plan.PersistedRecipients); err != nil {
+		if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
 			return err
 		}
 		eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -510,6 +510,58 @@ func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane"})
 }
 
+func TestEventBusPublish_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "agent-a"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	workflowCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.trigger"))
+	nodeCh := eb.SubscribeInternal("scan-orchestrator", events.EventType("custom.trigger"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.trigger"))
+	missingCh := eb.Subscribe("agent-missing", events.EventType("custom.trigger"))
+
+	if err := eb.Publish(context.Background(), events.Event{
+		Type:      events.EventType("custom.trigger"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case evt := <-workflowCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("workflow-runtime did not receive event")
+	}
+	select {
+	case evt := <-nodeCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("system node event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("system node did not receive event")
+	}
+	select {
+	case evt := <-agentCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("agent event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("agent did not receive event")
+	}
+	waitForNoEvent(t, missingCh)
+
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
+}
+
 func TestEventBusPublish_FailsClosedWhenDescriptorLookupFails(t *testing.T) {
 	store := &descriptorAwareEventStore{
 		listErr: errors.New("descriptor lookup failed"),

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -192,18 +192,25 @@ func (eb *EventBus) deliverByType(evt events.Event) {
 }
 
 func (eb *EventBus) resolveSubscribedRecipients(eventType string) []string {
+	return deliveryRecipientIDs(eb.resolveSubscribedRecipientsForPlanning(eventType))
+}
+
+func (eb *EventBus) resolveSubscribedRecipientsForPlanning(eventType string) []deliveryRecipientCandidate {
 	eb.mu.RLock()
 	defer eb.mu.RUnlock()
-	recipients := make([]string, 0, len(eb.subscriptions))
+	recipients := make([]deliveryRecipientCandidate, 0, len(eb.subscriptions))
 	for agentID, pats := range eb.subscriptions {
 		for _, pat := range pats {
 			if routeMatches(string(pat), eventType) {
-				recipients = append(recipients, agentID)
+				recipients = append(recipients, deliveryRecipientCandidate{
+					ID:                agentID,
+					PersistAsDelivery: eb.subscriptionKinds[agentID] != inMemorySubscriberInternal,
+				})
 				break
 			}
 		}
 	}
-	return recipients
+	return normalizeDeliveryRecipientCandidates(recipients)
 }
 
 func (eb *EventBus) ResolveSubscribedRecipients(eventType string) []string {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -54,7 +54,7 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if strings.TrimSpace(string(intent.Event.Type)) == "" {
 			continue
 		}
-		recipients, err := o.persistedRecipientsForIntent(ctx, *intent)
+		recipients, internalRecipients, err := o.deliveryRecipientsForIntent(ctx, *intent)
 		if err != nil {
 			return err
 		}
@@ -64,24 +64,25 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if err := txStore.InsertEventDeliveriesTx(ctx, tx, intent.Event.ID, recipients); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
+		o.bus.setPendingInternalRecipients(intent.Event.ID, internalRecipients)
 	}
 	return nil
 }
 
-func (o engineOutbox) persistedRecipientsForIntent(ctx context.Context, intent runtimeengine.EmitIntent) ([]string, error) {
+func (o engineOutbox) deliveryRecipientsForIntent(ctx context.Context, intent runtimeengine.EmitIntent) ([]string, []string, error) {
 	if len(intent.Recipients) > 0 {
 		plan, err := o.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return plan.PersistedRecipients, nil
+		return plan.PersistedRecipients, nil, nil
 	}
 	plan, err := o.bus.deliveryPlanner.Plan(ctx, intent.Event)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	o.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
-	return plan.PersistedRecipients, nil
+	return plan.PersistedRecipients, filterOutAgentIDs(plan.Recipients, plan.PersistedRecipients), nil
 }
 
 func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runtimeengine.EmitIntent) error {
@@ -128,11 +129,26 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		}
 		return err
 	}
-	if len(recipients) > 0 {
-		if err := d.bus.PublishPersistedRecipients(ctx, intent.Event, recipients); err != nil {
-			return err
-		}
+	internalRecipients := d.bus.pendingInternalRecipients(intent.Event.ID)
+	liveRecipients := uniqueStrings(append(append([]string(nil), recipients...), internalRecipients...))
+	if len(liveRecipients) == 0 {
+		d.bus.clearPendingInternalRecipients(intent.Event.ID)
+		return nil
 	}
+	if err := d.bus.deliverToAgents(ctx, intent.Event, liveRecipients); err != nil {
+		return err
+	}
+	d.bus.clearPendingInternalRecipients(intent.Event.ID)
+	d.bus.logRuntime(ctx, "debug", "Persisted event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
+		"direct":                     true,
+		"delivery_manifest_owner":    "event_deliveries+in_memory_internal",
+		"recipients_count":           len(liveRecipients),
+		"parent_event_id":            strings.TrimSpace(intent.Event.ParentEventID),
+		"requested_recipients":       append([]string(nil), liveRecipients...),
+		"requested_recipients_count": len(liveRecipients),
+		"persisted_recipients":       append([]string(nil), recipients...),
+		"internal_recipients":        append([]string(nil), internalRecipients...),
+	}, "", 0)
 	return nil
 }
 
@@ -164,4 +180,45 @@ func normalizeOutboxEvent(evt events.Event) events.Event {
 		evt.CreatedAt = time.Now().UTC()
 	}
 	return evt
+}
+
+func (eb *EventBus) setPendingInternalRecipients(eventID string, recipients []string) {
+	if eb == nil {
+		return
+	}
+	eventID = strings.TrimSpace(eventID)
+	recipients = uniqueStrings(recipients)
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	if eventID == "" || len(recipients) == 0 {
+		delete(eb.pendingInternalByID, eventID)
+		return
+	}
+	eb.pendingInternalByID[eventID] = append([]string(nil), recipients...)
+}
+
+func (eb *EventBus) pendingInternalRecipients(eventID string) []string {
+	if eb == nil {
+		return nil
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	return append([]string(nil), eb.pendingInternalByID[eventID]...)
+}
+
+func (eb *EventBus) clearPendingInternalRecipients(eventID string) {
+	if eb == nil {
+		return
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return
+	}
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	delete(eb.pendingInternalByID, eventID)
 }

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -273,6 +273,81 @@ func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testin
 	}
 }
 
+func TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedManifest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "agent-a"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.emitted"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.emitted"))
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-internal-live",
+			Type:      events.EventType("custom.emitted"),
+			Payload:   []byte(`{"entity_id":"ent-1"}`),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	gotPersisted, err := store.ListEventDeliveryRecipients(context.Background(), intent.Event.ID)
+	if err != nil {
+		t.Fatalf("ListEventDeliveryRecipients: %v", err)
+	}
+	if strings.Join(gotPersisted, ",") != "agent-a" {
+		t.Fatalf("persisted recipients = %v, want [agent-a]", gotPersisted)
+	}
+
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	select {
+	case evt := <-internalCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("internal event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected internal subscriber to receive outbox event")
+	}
+	select {
+	case evt := <-agentCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("agent event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected agent subscriber to receive outbox event")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestEngineDispatcherRunsInterceptorsForPersistedEmitIntents(t *testing.T) {
 	store := &recordingEventStore{}
 	eb, err := runtimebus.NewEventBus(store)

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -413,7 +413,7 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("Start error = %v, want explicit recovery denial", startErr)
 	}
 
-	reader := dashboardserver.NewSQLObservabilityReader(db)
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
 	if reader == nil {
 		t.Fatal("NewSQLObservabilityReader returned nil")
 	}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -185,7 +185,13 @@ func (pc *PipelineCoordinator) interceptPolicy(eventType string, evt events.Even
 }
 
 func (pc *PipelineCoordinator) subscribe() <-chan events.Event {
-	return pc.bus.Subscribe(runtimeWorkflowID, workflowSubscriptions(pc.WorkflowNodes())...)
+	subscriptions := workflowSubscriptions(pc.WorkflowNodes())
+	if internalBus, ok := any(pc.bus).(interface {
+		SubscribeInternal(string, ...events.EventType) <-chan events.Event
+	}); ok {
+		return internalBus.SubscribeInternal(runtimeWorkflowID, subscriptions...)
+	}
+	return pc.bus.Subscribe(runtimeWorkflowID, subscriptions...)
 }
 
 func (pc *PipelineCoordinator) handleEvent(ctx context.Context, evt events.Event) bool {

--- a/internal/runtime/pipeline/internal_subscription_test.go
+++ b/internal/runtime/pipeline/internal_subscription_test.go
@@ -1,0 +1,84 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"swarm/internal/events"
+	runtimeengine "swarm/internal/runtime/engine"
+)
+
+type recordingInternalSubscriptionBus struct {
+	mode       string
+	subscriber string
+	eventTypes []events.EventType
+}
+
+func (b *recordingInternalSubscriptionBus) Subscribe(subscriber string, eventTypes ...events.EventType) <-chan events.Event {
+	b.mode = "subscribe"
+	b.subscriber = subscriber
+	b.eventTypes = append([]events.EventType(nil), eventTypes...)
+	return make(chan events.Event, 1)
+}
+
+func (b *recordingInternalSubscriptionBus) SubscribeInternal(subscriber string, eventTypes ...events.EventType) <-chan events.Event {
+	b.mode = "internal"
+	b.subscriber = subscriber
+	b.eventTypes = append([]events.EventType(nil), eventTypes...)
+	return make(chan events.Event, 1)
+}
+
+func (*recordingInternalSubscriptionBus) Publish(context.Context, events.Event) error { return nil }
+func (*recordingInternalSubscriptionBus) PublishDirect(context.Context, events.Event, []string) error {
+	return nil
+}
+func (*recordingInternalSubscriptionBus) ResolveSubscribedRecipients(string) []string { return nil }
+func (*recordingInternalSubscriptionBus) LogRuntime(context.Context, RuntimeLogEntry) error {
+	return nil
+}
+func (*recordingInternalSubscriptionBus) EngineOutbox() runtimeengine.OutboxWriter {
+	return noOpEngineOutbox{}
+}
+func (*recordingInternalSubscriptionBus) EngineDispatcher() runtimeengine.PostCommitDispatcher {
+	return noOpEngineDispatcher{}
+}
+
+func TestPipelineCoordinatorSubscribe_UsesInternalSubscribers(t *testing.T) {
+	bus := &recordingInternalSubscriptionBus{}
+	pc := &PipelineCoordinator{bus: bus}
+
+	ch := pc.subscribe()
+	if ch == nil {
+		t.Fatal("subscribe returned nil channel")
+	}
+	if bus.mode != "internal" {
+		t.Fatalf("subscription mode = %q, want internal", bus.mode)
+	}
+	if bus.subscriber != runtimeWorkflowID {
+		t.Fatalf("subscriber = %q, want %q", bus.subscriber, runtimeWorkflowID)
+	}
+}
+
+func TestSystemNodeRunnerSubscribe_UsesInternalSubscribers(t *testing.T) {
+	bus := &recordingInternalSubscriptionBus{}
+	runner := newSystemNodeRunner("scan-orchestrator", bus, nil, func() []events.EventType {
+		return []events.EventType{"custom.trigger"}
+	}, func(context.Context, events.Event) error { return nil })
+	if runner == nil {
+		t.Fatal("newSystemNodeRunner returned nil")
+	}
+
+	ch := runner.subscribe()
+	if ch == nil {
+		t.Fatal("subscribe returned nil channel")
+	}
+	if bus.mode != "internal" {
+		t.Fatalf("subscription mode = %q, want internal", bus.mode)
+	}
+	if bus.subscriber != "scan-orchestrator" {
+		t.Fatalf("subscriber = %q, want scan-orchestrator", bus.subscriber)
+	}
+	if len(bus.eventTypes) != 1 || bus.eventTypes[0] != "custom.trigger" {
+		t.Fatalf("event types = %#v, want [custom.trigger]", bus.eventTypes)
+	}
+}

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -174,6 +174,11 @@ func (n *systemNodeRunner) subscribe() <-chan events.Event {
 	if n.subscriptionsFn != nil {
 		subscriptions = n.subscriptionsFn()
 	}
+	if internalBus, ok := any(n.bus).(interface {
+		SubscribeInternal(string, ...events.EventType) <-chan events.Event
+	}); ok {
+		return internalBus.SubscribeInternal(n.nodeID, subscriptions...)
+	}
 	return n.bus.Subscribe(n.nodeID, subscriptions...)
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -689,7 +689,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	var bootCheck <-chan events.Event
 	if rt.Options.SelfCheck && rt.Bus != nil {
-		bootCheck = rt.Bus.Subscribe("bootstrap-self-check", events.EventType("platform.boot"))
+		bootCheck = rt.Bus.SubscribeInternal("bootstrap-self-check", events.EventType("platform.boot"))
 	}
 	if err := rt.publishBootCompleted(context.Background()); err != nil {
 		return fmt.Errorf("publish platform.boot: %w", err)

--- a/internal/runtime/runtime_boot_selfcheck_test.go
+++ b/internal/runtime/runtime_boot_selfcheck_test.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+type bootSelfCheckDescriptorStore struct {
+	mu          sync.Mutex
+	descriptors []runtimebus.ActiveAgentDescriptor
+	deliveries  []string
+}
+
+func (*bootSelfCheckDescriptorStore) AppendEvent(context.Context, events.Event) error { return nil }
+
+func (s *bootSelfCheckDescriptorStore) InsertEventDeliveries(_ context.Context, _ string, recipients []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveries = append([]string(nil), recipients...)
+	return nil
+}
+
+func (s *bootSelfCheckDescriptorStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deliveries...), nil
+}
+
+func (s *bootSelfCheckDescriptorStore) ListActiveAgentDescriptors(context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {
+	return append([]runtimebus.ActiveAgentDescriptor(nil), s.descriptors...), nil
+}
+
+func (s *bootSelfCheckDescriptorStore) persistedDeliveries() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deliveries...)
+}
+
+func TestRuntimeStart_SelfCheckUsesInternalSubscriberVisibility(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	store := &bootSelfCheckDescriptorStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{{AgentID: "agent-a"}},
+	}
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		EventStore: store,
+	}, RuntimeOptions{
+		SelfCheck:      true,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	})
+	if got := store.persistedDeliveries(); len(got) != 0 {
+		t.Fatalf("persisted deliveries = %#v, want none for bootstrap self-check", got)
+	}
+}


### PR DESCRIPTION
## Summary
This PR canonicalizes non-agent in-memory subscriber visibility for live runtime publish and same-process post-commit dispatch. Control-plane, workflow-runtime, and system-node subscribers now stay live recipients without being treated as persisted agent deliveries, while agent recipients remain descriptor-filtered.

Part of #313
Related to #318

## Why
Startup self-check was timing out on `platform.boot` because descriptor-aware planning treated every subscriber as an active-agent descriptor candidate, then publish delivered only `PersistedRecipients`. The same drift also affected same-process outbox dispatch.

This PR fixes those live/same-process seams. It does not close the crash/restart recovery seam for committed-but-undispatched events; that remaining manifestation is tracked at #318.

## What Changed
- added typed in-memory subscription ownership in `EventBus` via `SubscribeInternal(...)`
- split delivery planning between live recipients and persisted agent deliveries
- stopped promoting non-agent route-table declarations into authoritative live recipients unless there is an in-memory internal subscription
- wired runtime boot self-check, pipeline coordinator, and system node runner onto the internal subscription path
- preserved internal subscribers during same-process outbox post-commit dispatch
- added focused regressions for planner, publish, outbox, runtime, and pipeline seams
- refined the `delivery_and_replay_ownership` watchlist node with this manifestation
- updated one stale conformance test callsite to the current observability reader constructor so repo-wide tests stay green

## Spec Refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 4 resolve_subscribers`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 5 node_handling`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 6 agent_delivery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform.boot`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `routing_rules.routable_events`

## Tests
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./internal/runtime/conformance -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
Crash/restart recovery of committed-but-undispatched events still reconstructs only persisted agent recipients. That remaining same-parent visibility seam is tracked at #318, so this PR should not be treated as full failure-class closure for #313.
