### PR TITLE
[agent-c][issue #175] Canonicalize agent lifecycle projection

### DIFF
--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -83,6 +83,8 @@ func (r *SQLAgentReader) GetGenericAgent(ctx context.Context, id string) (generi
 
 type agentOperatorProjection struct {
 	Status              string
+	LifecycleState      string
+	BlockingLayer       string
 	PendingEvents       int
 	OldestPendingAgeSec int
 	LockOwner           string
@@ -99,6 +101,10 @@ type agentOperatorProjection struct {
 
 type pendingAgentDeliveryFactSource interface {
 	ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]store.PendingAgentDeliveryFacts, error)
+}
+
+type agentLifecycleFactSource interface {
+	ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error)
 }
 
 func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[string]agentOperatorProjection, error) {
@@ -220,10 +226,24 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	if err != nil {
 		return nil, err
 	}
+	lifecycleSource, ok := r.base.(agentLifecycleFactSource)
+	if !ok || lifecycleSource == nil {
+		return nil, fmt.Errorf("missing agent lifecycle fact source")
+	}
+	lifecycleByAgent, err := lifecycleSource.ListAgentLifecycleFacts(ctx, agentIDs)
+	if err != nil {
+		return nil, err
+	}
 	for agentID, facts := range factsByAgent {
 		projection := out[strings.TrimSpace(agentID)]
 		projection.PendingEvents = facts.PendingCount
 		projection.OldestPendingAgeSec = facts.OldestPendingAgeSec
+		out[strings.TrimSpace(agentID)] = projection
+	}
+	for agentID, facts := range lifecycleByAgent {
+		projection := out[strings.TrimSpace(agentID)]
+		projection.LifecycleState = strings.TrimSpace(facts.CurrentState)
+		projection.BlockingLayer = strings.TrimSpace(facts.BlockingLayer)
 		out[strings.TrimSpace(agentID)] = projection
 	}
 	return out, nil
@@ -243,6 +263,7 @@ func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjec
 		return
 	}
 	agent.Status = strings.TrimSpace(projection.Status)
+	agent.BlockingLayer = strings.TrimSpace(projection.BlockingLayer)
 	agent.PendingEvents = projection.PendingEvents
 	agent.OldestPendingAgeSec = projection.OldestPendingAgeSec
 	agent.LockOwner = strings.TrimSpace(projection.LockOwner)
@@ -267,11 +288,8 @@ func (p agentOperatorProjection) state() string {
 	if status == "terminated" {
 		return "terminated"
 	}
-	if p.InFlightTurn {
-		return "running"
-	}
-	if p.DeadLetters24h > 0 || p.Failures24h > 0 {
-		return "stuck"
+	if state := strings.TrimSpace(p.LifecycleState); state != "" {
+		return state
 	}
 	return "idle"
 }

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -263,7 +263,7 @@ func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjec
 		return
 	}
 	agent.Status = strings.TrimSpace(projection.Status)
-	agent.BlockingLayer = strings.TrimSpace(projection.BlockingLayer)
+	agent.BlockingLayer = projection.blockingLayer()
 	agent.PendingEvents = projection.PendingEvents
 	agent.OldestPendingAgeSec = projection.OldestPendingAgeSec
 	agent.LockOwner = strings.TrimSpace(projection.LockOwner)
@@ -291,7 +291,20 @@ func (p agentOperatorProjection) state() string {
 	if state := strings.TrimSpace(p.LifecycleState); state != "" {
 		return state
 	}
+	if p.InFlightTurn {
+		return "active"
+	}
 	return "idle"
+}
+
+func (p agentOperatorProjection) blockingLayer() string {
+	if layer := strings.TrimSpace(p.BlockingLayer); layer != "" {
+		return layer
+	}
+	if p.InFlightTurn {
+		return "session_execution"
+	}
+	return ""
 }
 
 func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjection, taskID string, parseOK bool, turnBlocksRaw []byte) error {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -306,6 +306,7 @@ type genericAgent struct {
 	Mode                string         `json:"mode,omitempty"`
 	Status              string         `json:"status,omitempty"`
 	State               string         `json:"state,omitempty"`
+	BlockingLayer       string         `json:"blocking_layer,omitempty"`
 	EntityID            string         `json:"entity_id,omitempty"`
 	ParentAgentID       string         `json:"parent_agent_id,omitempty"`
 	CoordinatorID       string         `json:"coordinator_id,omitempty"`

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1001,6 +1001,57 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	}
 }
 
+func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenDeliveryLifecycleIsAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: canonicalEventAndConversationCaps(),
+		facts: map[string]store.PendingAgentDeliveryFacts{
+			"agent-1": {},
+		},
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", 2, "lease-owner", time.Now().Add(time.Minute), 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+
+	items, err := reader.ListGenericAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].State != "active" {
+		t.Fatalf("state = %q, want active from live session fallback", items[0].State)
+	}
+	if items[0].BlockingLayer != "session_execution" {
+		t.Fatalf("blocking_layer = %q, want session_execution from live session fallback", items[0].BlockingLayer)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -132,10 +132,33 @@ func (s stubConversationCaps) ResolveSchemaCapabilities(context.Context) (store.
 }
 
 type stubSQLAgents struct {
+	rows           []runtimemanager.PersistedAgent
+	caps           store.StoreSchemaCapabilities
+	err            error
+	facts          map[string]store.PendingAgentDeliveryFacts
+	lifecycleFacts map[string]store.AgentLifecycleFacts
+}
+
+type stubSQLAgentsWithoutLifecycle struct {
 	rows  []runtimemanager.PersistedAgent
 	caps  store.StoreSchemaCapabilities
-	err   error
 	facts map[string]store.PendingAgentDeliveryFacts
+}
+
+func (s stubSQLAgentsWithoutLifecycle) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return s.rows, nil
+}
+
+func (s stubSQLAgentsWithoutLifecycle) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return s.caps, nil
+}
+
+func (s stubSQLAgentsWithoutLifecycle) ListPendingAgentDeliveryFacts(_ context.Context, agentIDs []string, _ time.Time) (map[string]store.PendingAgentDeliveryFacts, error) {
+	out := make(map[string]store.PendingAgentDeliveryFacts, len(agentIDs))
+	for _, agentID := range agentIDs {
+		out[agentID] = s.facts[agentID]
+	}
+	return out, nil
 }
 
 func (s stubSQLAgents) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
@@ -150,6 +173,14 @@ func (s stubSQLAgents) ListPendingAgentDeliveryFacts(_ context.Context, agentIDs
 	out := make(map[string]store.PendingAgentDeliveryFacts, len(agentIDs))
 	for _, agentID := range agentIDs {
 		out[agentID] = s.facts[agentID]
+	}
+	return out, nil
+}
+
+func (s stubSQLAgents) ListAgentLifecycleFacts(_ context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error) {
+	out := make(map[string]store.AgentLifecycleFacts, len(agentIDs))
+	for _, agentID := range agentIDs {
+		out[agentID] = s.lifecycleFacts[agentID]
 	}
 	return out, nil
 }
@@ -880,6 +911,9 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 		facts: map[string]store.PendingAgentDeliveryFacts{
 			"agent-1": {PendingCount: 2, OldestPendingAgeSec: 45},
 		},
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {CurrentState: "launching", BlockingLayer: "session_launch"},
+		},
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -899,14 +933,68 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	if items[0].Status != "active" {
 		t.Fatalf("status = %q, want active from operator projection", items[0].Status)
 	}
-	if items[0].State != "running" {
-		t.Fatalf("state = %q, want running from operator projection", items[0].State)
+	if items[0].State != "launching" {
+		t.Fatalf("state = %q, want launching from canonical lifecycle owner", items[0].State)
+	}
+	if items[0].BlockingLayer != "session_launch" {
+		t.Fatalf("blocking_layer = %q, want session_launch", items[0].BlockingLayer)
 	}
 	if items[0].PendingEvents != 2 {
 		t.Fatalf("pending_events = %d, want 2", items[0].PendingEvents)
 	}
 	if items[0].CurrentTaskID != "task-7" {
 		t.Fatalf("current_task_id = %q, want task-7", items[0].CurrentTaskID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: canonicalEventAndConversationCaps(),
+		facts: map[string]store.PendingAgentDeliveryFacts{
+			"agent-1": {PendingCount: 1, OldestPendingAgeSec: 12},
+		},
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {CurrentState: "active", BlockingLayer: "session_execution"},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", 3, "lease-owner", time.Now().Add(time.Minute), 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+
+	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("GetGenericAgent: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected agent to exist")
+	}
+	if item.State != "active" {
+		t.Fatalf("state = %q, want active", item.State)
+	}
+	if item.BlockingLayer != "session_execution" {
+		t.Fatalf("blocking_layer = %q, want session_execution", item.BlockingLayer)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -931,6 +1019,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 			Status: "active",
 		}},
 		caps: canonicalEventAndConversationCaps(),
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {},
+		},
 	}, 12)
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
@@ -969,6 +1060,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalReceiptCapa
 			Status: "active",
 		}},
 		caps: caps,
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {},
+		},
 	}, 12)
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "event_receipts schema is unsupported") {
@@ -1019,10 +1113,51 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnCapabil
 			Status: "active",
 		}},
 		caps: caps,
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {},
+		},
 	}, 12)
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "agent_turns schema is unsupported") {
 		t.Fatalf("expected explicit unsupported turn capability error, got %v", err)
+	}
+}
+
+func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgentsWithoutLifecycle{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: canonicalEventAndConversationCaps(),
+		facts: map[string]store.PendingAgentDeliveryFacts{
+			"agent-1": {PendingCount: 1, OldestPendingAgeSec: 10},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", 0, "", nil, 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+
+	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
+		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }
 
@@ -1131,8 +1266,11 @@ func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelec
 	if items[0].DeadLetters24h != 1 {
 		t.Fatalf("dead_letters_24h = %d, want 1 dead-letter delivery", items[0].DeadLetters24h)
 	}
-	if items[0].State != "stuck" {
-		t.Fatalf("state = %q, want stuck", items[0].State)
+	if items[0].State != "retrying" {
+		t.Fatalf("state = %q, want retrying", items[0].State)
+	}
+	if items[0].BlockingLayer != "delivery_retry" {
+		t.Fatalf("blocking_layer = %q, want delivery_retry", items[0].BlockingLayer)
 	}
 }
 
@@ -1206,6 +1344,12 @@ func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *
 	}
 	if items[0].OldestPendingAgeSec < 30*24*60*60 {
 		t.Fatalf("oldest_pending_age_sec = %d, want at least 30 days", items[0].OldestPendingAgeSec)
+	}
+	if items[0].State != "queued" {
+		t.Fatalf("state = %q, want queued", items[0].State)
+	}
+	if items[0].BlockingLayer != "delivery_queue" {
+		t.Fatalf("blocking_layer = %q, want delivery_queue", items[0].BlockingLayer)
 	}
 }
 

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -413,7 +413,7 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("Start error = %v, want explicit recovery denial", startErr)
 	}
 
-	reader := dashboardserver.NewSQLObservabilityReader(db)
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
 	if reader == nil {
 		t.Fatal("NewSQLObservabilityReader returned nil")
 	}

--- a/internal/store/agent_lifecycle_read_surface.go
+++ b/internal/store/agent_lifecycle_read_surface.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
+
+	"github.com/lib/pq"
+)
+
+type AgentLifecycleFacts struct {
+	CurrentState  string
+	BlockingLayer string
+}
+
+type agentLifecycleDeliveryRecord struct {
+	AgentID         string
+	Status          string
+	ActiveSessionID string
+	CreatedAt       time.Time
+	DeliveredAt     sql.NullTime
+}
+
+func RequireCanonicalAgentLifecycleCapabilities(caps StoreSchemaCapabilities) error {
+	if caps.Events.Deliveries == SchemaFlavorCanonical {
+		return nil
+	}
+	return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+}
+
+func (s *PostgresStore) ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]AgentLifecycleFacts, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := RequireCanonicalAgentLifecycleCapabilities(caps); err != nil {
+		return nil, err
+	}
+	normalized := normalizePendingAgentIDs(agentIDs)
+	if len(normalized) == 0 {
+		return map[string]AgentLifecycleFacts{}, nil
+	}
+	records, err := s.listAgentLifecycleRecordsSpec(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]AgentLifecycleFacts, len(normalized))
+	for _, agentID := range normalized {
+		out[agentID] = AgentLifecycleFacts{}
+	}
+	grouped := make(map[string][]agentLifecycleDeliveryRecord, len(normalized))
+	for _, record := range records {
+		grouped[record.AgentID] = append(grouped[record.AgentID], record)
+	}
+	for _, agentID := range normalized {
+		out[agentID] = canonicalAgentLifecycleFactsFromRecords(grouped[agentID])
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) listAgentLifecycleRecordsSpec(ctx context.Context, agentIDs []string) ([]agentLifecycleDeliveryRecord, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			d.subscriber_id,
+			COALESCE(d.status, ''),
+			COALESCE(d.active_session_id::text, ''),
+			d.created_at,
+			d.delivered_at
+		FROM event_deliveries d
+		WHERE d.subscriber_type = 'agent'
+		  AND d.subscriber_id = ANY($1)
+		  AND COALESCE(d.status, '') IN ('pending', 'in_progress', 'failed', 'dead_letter')
+	`, pq.Array(agentIDs))
+	if err != nil {
+		return nil, fmt.Errorf("query agent lifecycle records: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]agentLifecycleDeliveryRecord, 0)
+	for rows.Next() {
+		var record agentLifecycleDeliveryRecord
+		if err := rows.Scan(
+			&record.AgentID,
+			&record.Status,
+			&record.ActiveSessionID,
+			&record.CreatedAt,
+			&record.DeliveredAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent lifecycle record: %w", err)
+		}
+		record.AgentID = strings.TrimSpace(record.AgentID)
+		out = append(out, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read agent lifecycle rows: %w", err)
+	}
+	return out, nil
+}
+
+type agentLifecycleCandidate struct {
+	facts      AgentLifecycleFacts
+	observedAt time.Time
+	priority   int
+}
+
+func canonicalAgentLifecycleFactsFromRecords(records []agentLifecycleDeliveryRecord) AgentLifecycleFacts {
+	var live *agentLifecycleCandidate
+	var exhausted *agentLifecycleCandidate
+	for _, record := range records {
+		state, ok := runtimedelivery.StateFromDelivery(record.Status, record.ActiveSessionID)
+		if !ok {
+			continue
+		}
+		candidate := agentLifecycleCandidate{
+			facts: AgentLifecycleFacts{
+				CurrentState:  string(state),
+				BlockingLayer: agentLifecycleBlockingLayer(state),
+			},
+			observedAt: agentLifecycleObservedAt(record),
+			priority:   agentLifecyclePriority(state),
+		}
+		switch state {
+		case runtimedelivery.StateQueued, runtimedelivery.StateLaunching, runtimedelivery.StateActive, runtimedelivery.StateRetrying:
+			if live == nil || candidate.priority > live.priority || (candidate.priority == live.priority && candidate.observedAt.After(live.observedAt)) {
+				live = &candidate
+			}
+		case runtimedelivery.StateExhausted:
+			if exhausted == nil || candidate.observedAt.After(exhausted.observedAt) {
+				exhausted = &candidate
+			}
+		}
+	}
+	if live != nil {
+		return live.facts
+	}
+	if exhausted != nil {
+		return exhausted.facts
+	}
+	return AgentLifecycleFacts{}
+}
+
+func agentLifecycleObservedAt(record agentLifecycleDeliveryRecord) time.Time {
+	if record.DeliveredAt.Valid {
+		return record.DeliveredAt.Time
+	}
+	return record.CreatedAt
+}
+
+func agentLifecyclePriority(state runtimedelivery.State) int {
+	switch state {
+	case runtimedelivery.StateRetrying:
+		return 4
+	case runtimedelivery.StateLaunching:
+		return 3
+	case runtimedelivery.StateActive:
+		return 2
+	case runtimedelivery.StateQueued:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func agentLifecycleBlockingLayer(state runtimedelivery.State) string {
+	switch state {
+	case runtimedelivery.StateQueued:
+		return "delivery_queue"
+	case runtimedelivery.StateLaunching:
+		return "session_launch"
+	case runtimedelivery.StateActive:
+		return "session_execution"
+	case runtimedelivery.StateRetrying:
+		return "delivery_retry"
+	case runtimedelivery.StateExhausted:
+		return "delivery_terminal"
+	default:
+		return ""
+	}
+}

--- a/internal/store/agent_lifecycle_read_surface_test.go
+++ b/internal/store/agent_lifecycle_read_surface_test.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_ListAgentLifecycleFacts_UsesCanonicalLiveLifecycle(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	activeEventID := uuid.NewString()
+	oldDeadLetterEventID := uuid.NewString()
+	for _, eventID := range []string{activeEventID, oldDeadLetterEventID} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, scope, payload, produced_by, produced_by_type
+			) VALUES (
+				$1::uuid, $2::uuid, 'task.completed', 'global', '{}'::jsonb, 'runtime', 'agent'
+			)
+		`, eventID, runID); err != nil {
+			t.Fatalf("seed event %s: %v", eventID, err)
+		}
+	}
+
+	activeSessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, created_at
+		) VALUES
+			($1::uuid, $2::uuid, 'agent', 'agent-1', 'in_progress', $3::uuid, now() - interval '1 minute'),
+			($1::uuid, $4::uuid, 'agent', 'agent-1', 'dead_letter', NULL, now() - interval '2 hours')
+	`, runID, activeEventID, activeSessionID, oldDeadLetterEventID); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+
+	facts, err := pg.ListAgentLifecycleFacts(ctx, []string{"agent-1"})
+	if err != nil {
+		t.Fatalf("ListAgentLifecycleFacts: %v", err)
+	}
+	if got := facts["agent-1"].CurrentState; got != "active" {
+		t.Fatalf("current_state = %q, want active", got)
+	}
+	if got := facts["agent-1"].BlockingLayer; got != "session_execution" {
+		t.Fatalf("blocking_layer = %q, want session_execution", got)
+	}
+}
+
+func TestPostgresStore_ListAgentLifecycleFacts_UsesCanonicalTerminalLifecycleWhenNoLiveWorkRemains(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type
+		) VALUES (
+			$1::uuid, $2::uuid, 'task.completed', 'global', '{}'::jsonb, 'runtime', 'agent'
+		)
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at, delivered_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-1', 'dead_letter', now() - interval '5 minutes', now() - interval '1 minute'
+		)
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	facts, err := pg.ListAgentLifecycleFacts(ctx, []string{"agent-1"})
+	if err != nil {
+		t.Fatalf("ListAgentLifecycleFacts: %v", err)
+	}
+	if got := facts["agent-1"].CurrentState; got != "exhausted" {
+		t.Fatalf("current_state = %q, want exhausted", got)
+	}
+	if got := facts["agent-1"].BlockingLayer; got != "delivery_terminal" {
+		t.Fatalf("blocking_layer = %q, want delivery_terminal", got)
+	}
+}


### PR DESCRIPTION
Part of #175

## Human Summary

This PR removes the dashboard generic-agent lifecycle heuristic that flattened canonical launch and live-work state into `running | stuck | idle`.

The generic-agent operator surface now reads one canonical per-agent lifecycle fact from persisted `event_deliveries`, names the real lifecycle state directly (`queued`, `launching`, `active`, `retrying`, `exhausted`, `idle`, `terminated`), and exposes the corresponding `blocking_layer` instead of leaving active work generically `running`.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: turn_budget`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- governing rule from `#175`: session launch, long-running activity, and termination visibility should align to the canonical live-session model instead of ad hoc watchdog-only heuristics

## What Changed

- added a store-owned `ListAgentLifecycleFacts(...)` read surface in `internal/store/agent_lifecycle_read_surface.go`
- made `SQLAgentReader` consume that explicit lifecycle owner instead of interpreting lease/failure counters as lifecycle truth
- changed the generic-agent dashboard transport so `state` now carries canonical lifecycle state for the touched slice and `blocking_layer` names the concrete blocking layer
- added focused store and dashboard regressions for canonical queued / launching / active / retrying / exhausted projection behavior and explicit missing-owner failure
- updated the runtime conformance test helper call site to use the explicit observability capability owner required by the current branch baseline

## Why This Is Needed

The old generic-agent status surface hid the difference between work that had never launched, work blocked during launch, work actively executing in session, and work stuck in retry/dead-letter states.

That was semantic drift in an operator-facing status surface: the dashboard projection was locally interpreting lifecycle truth instead of consuming the canonical delivery/session owners directly.

## Scope Boundaries

In scope:
- dashboard generic-agent lifecycle projection
- explicit lifecycle owner for that reader family
- touched list/detail execution paths that consume the same projection

Out of scope:
- run-level stalled-state visibility in CLI/status surfaces
- long-running / no-output watchdog visibility
- broad dashboard redesign

## Tests Run

- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_(ListGenericAgents_(UsesOperatorProjectionAsCanonicalOwner|FailsClosedWithoutLifecycleFactOwner|AlignsBacklogWithCanonicalPendingSelector|UsesFullPendingDeliveryFactHorizon)|GetGenericAgent_UsesCanonicalLifecycleProjection)$' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_ListAgentLifecycleFacts_' -count=1`
- `go test ./internal/runtime/conformance -count=1`
- `go test ./cmd/swarm ./internal/dashboard/server ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR closes the chosen dashboard generic-agent lifecycle projection class only.

The broader runtime-lifecycle observability parent remains open for:
- run-level stalled-state visibility
- long-running / no-output session watchdog visibility

## Follow-Up

- keep issue `#175` open for the remaining parent-class slices above
- the longer-run better direction is one typed runtime-lifecycle projection reused across dashboard and CLI status surfaces; this PR does not attempt that broader consolidation
