### PR TITLE
[agent-b][issue #126] Extract event-cardinality bootverify checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -237,7 +237,6 @@ func checkAgentPermissionValidation(c *checkerContext) []Finding {
 	return uniqueFindings(append(c.permissions(), c.permissionWarnings()...))
 }
 func checkPhantomProduces(c *checkerContext) []Finding            { return c.phantomProduces() }
-func checkSingleNodePerEvent(c *checkerContext) []Finding         { return c.singleNodePerEvent() }
 func checkPlatformMetadataValidation(c *checkerContext) []Finding { return c.platformMetadata() }
 func checkGateSchemaValidation(c *checkerContext) []Finding       { return c.gateSchemaValidation() }
 func checkDeprecatedContractAlias(c *checkerContext) []Finding    { return c.deprecatedAliases() }
@@ -1718,66 +1717,6 @@ func (c *checkerContext) phantomProduces() []Finding {
 		}
 	}
 	return c.phantomFindings
-}
-
-func (c *checkerContext) singleNodePerEvent() []Finding {
-	if c.singleNodeLoaded {
-		return c.singleNodeFindings
-	}
-	c.singleNodeLoaded = true
-	eventNames := map[string]struct{}{}
-	type subscriptionOwner struct {
-		NodeID string
-		FlowID string
-		Event  string
-	}
-	subscriptions := make([]subscriptionOwner, 0)
-	for eventType := range c.source.ResolvedEventCatalog() {
-		eventType = strings.TrimSpace(eventType)
-		if eventType != "" && !strings.Contains(eventType, "*") {
-			eventNames[eventType] = struct{}{}
-		}
-	}
-	for nodeID := range c.source.NodeEntries() {
-		sourceRef, _ := c.source.NodeContractSource(nodeID)
-		flowID := strings.TrimSpace(sourceRef.FlowID)
-		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" || strings.Contains(eventType, "*") {
-				continue
-			}
-			proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
-			eventKey := proof.EventKey()
-			if eventKey == "" {
-				continue
-			}
-			subscriptions = append(subscriptions, subscriptionOwner{
-				NodeID: strings.TrimSpace(nodeID),
-				FlowID: flowID,
-				Event:  eventKey,
-			})
-			eventNames[eventKey] = struct{}{}
-		}
-	}
-	for _, eventType := range sortedSetKeysLocal(eventNames) {
-		nodeIDs := make([]string, 0)
-		for _, subscription := range subscriptions {
-			if subscription.Event == eventType {
-				nodeIDs = append(nodeIDs, subscription.NodeID)
-			}
-		}
-		if len(nodeIDs) <= 1 {
-			continue
-		}
-		sort.Strings(nodeIDs)
-		c.singleNodeFindings = append(c.singleNodeFindings, Finding{
-			CheckID:  "single_node_per_event",
-			Severity: "error",
-			Message:  fmt.Sprintf("event %s has multiple owning nodes: %s", eventType, strings.Join(nodeIDs, ", ")),
-			Location: eventType,
-		})
-	}
-	return c.singleNodeFindings
 }
 
 func promptFindingsForDir(promptsDir, scopeLabel string, agents map[string]runtimecontracts.AgentRegistryEntry) []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1683,6 +1683,29 @@ func TestRun_UsesCompiledOwnersForEquivalentSingleNodePerEventRoutes(t *testing.
 	}
 }
 
+func TestRun_ReportsExactDuplicateSingleNodePerEventOwnership(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-success")
+	handler := bundle.Nodes["complete-task"].EventHandlers["task.requested"]
+	addProjectHandler(t, bundle, "shadow-complete-task", "task.requested", handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "single_node_per_event", "task.requested") {
+		t.Fatalf("expected single_node_per_event duplicate-owner error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_DoesNotReportSingleNodePerEventForWildcardOnlyOverlap(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	addProjectHandler(t, bundle, "dispatcher-shadow", "child/*", runtimecontracts.SystemNodeEventHandler{})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "single_node_per_event", "child/task.feedback") {
+		t.Fatalf("unexpected single_node_per_event wildcard collision, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsMissingTransitionTriggerEvent(t *testing.T) {
 	bundle := bootverifyTransitionRuntimeOwnershipBundle()
 	bundle.Semantics.Transitions[0].Trigger = "ticket.missing"
@@ -2424,4 +2447,26 @@ func renameFlowHandlerEvent(t *testing.T, bundle *runtimecontracts.WorkflowContr
 		}
 		bundle.Semantics.FlowInputs[flowID] = inputs
 	}
+}
+
+func addProjectHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) {
+	t.Helper()
+	if bundle.Nodes == nil {
+		bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{}
+	}
+	node := bundle.Nodes[nodeID]
+	node.ID = nodeID
+	node.ExecutionType = "system_node"
+	if node.EventHandlers == nil {
+		node.EventHandlers = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	node.EventHandlers[eventType] = handler
+	bundle.Nodes[nodeID] = node
+	if bundle.Semantics.NodeHandlers == nil {
+		bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	if bundle.Semantics.NodeHandlers[nodeID] == nil {
+		bundle.Semantics.NodeHandlers[nodeID] = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	bundle.Semantics.NodeHandlers[nodeID][eventType] = handler
 }

--- a/internal/runtime/bootverify/workflow_event_cardinality_checks.go
+++ b/internal/runtime/bootverify/workflow_event_cardinality_checks.go
@@ -1,0 +1,71 @@
+package bootverify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkSingleNodePerEvent(c *checkerContext) []Finding { return c.singleNodePerEvent() }
+
+func (c *checkerContext) singleNodePerEvent() []Finding {
+	if c.singleNodeLoaded {
+		return c.singleNodeFindings
+	}
+	c.singleNodeLoaded = true
+	eventNames := map[string]struct{}{}
+	type subscriptionOwner struct {
+		NodeID string
+		FlowID string
+		Event  string
+	}
+	subscriptions := make([]subscriptionOwner, 0)
+	for eventType := range c.source.ResolvedEventCatalog() {
+		eventType = strings.TrimSpace(eventType)
+		if eventType != "" && !strings.Contains(eventType, "*") {
+			eventNames[eventType] = struct{}{}
+		}
+	}
+	for nodeID := range c.source.NodeEntries() {
+		sourceRef, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(sourceRef.FlowID)
+		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" || strings.Contains(eventType, "*") {
+				continue
+			}
+			proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
+			eventKey := proof.EventKey()
+			if eventKey == "" {
+				continue
+			}
+			subscriptions = append(subscriptions, subscriptionOwner{
+				NodeID: strings.TrimSpace(nodeID),
+				FlowID: flowID,
+				Event:  eventKey,
+			})
+			eventNames[eventKey] = struct{}{}
+		}
+	}
+	for _, eventType := range sortedSetKeysLocal(eventNames) {
+		nodeIDs := make([]string, 0)
+		for _, subscription := range subscriptions {
+			if subscription.Event == eventType {
+				nodeIDs = append(nodeIDs, subscription.NodeID)
+			}
+		}
+		if len(nodeIDs) <= 1 {
+			continue
+		}
+		sort.Strings(nodeIDs)
+		c.singleNodeFindings = append(c.singleNodeFindings, Finding{
+			CheckID:  "single_node_per_event",
+			Severity: "error",
+			Message:  fmt.Sprintf("event %s has multiple owning nodes: %s", eventType, strings.Join(nodeIDs, ", ")),
+			Location: eventType,
+		})
+	}
+	return c.singleNodeFindings
+}


### PR DESCRIPTION
Part of #126

## Human Summary
Extract the bootverify event-cardinality uniqueness check into its own boundary-owned module and add direct report-surface proofs for exact duplicate canonical event ownership and the wildcard no-false-positive guardrail.

## What Changed
- moved the `single_node_per_event` bootverify class out of `internal/runtime/bootverify/checks.go` into `internal/runtime/bootverify/workflow_event_cardinality_checks.go`
- kept the registry/report/startup surface unchanged
- kept neighboring event-topology and event-catalog integrity checks in `checks.go` because the pre-audit showed they are a different child class
- added direct `Run(...)` proofs for:
  - exact duplicate canonical event ownership across two nodes
  - wildcard-only overlap not creating a false-positive uniqueness collision
- preserved the existing compiled-owner proof for equivalent localized routes

## Why This Is Needed
`#126` is still decomposing the bootverify startup gate by honest concept boundaries. Event-cardinality uniqueness is one coherent startup invariant that was still embedded in the monolith, and its direct report-surface proof was weaker than the already-extracted slices.

## Scope Boundaries
- this PR closes the event-cardinality uniqueness child class only
- it does not close umbrella issue `#126`
- it does not absorb the broader event-topology / event-catalog integrity cluster
- it does not redesign runtime event routing outside bootverify maintenance

## Spec References
- none; this is non-semantic maintenance
- justification: the change decomposes the startup verification boundary and adds direct regression proof without changing platform contract semantics

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(UsesCompiledOwnersForEquivalentSingleNodePerEventRoutes|ReportsExactDuplicateSingleNodePerEventOwnership|DoesNotReportSingleNodePerEventForWildcardOnlyOverlap)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
- the remaining `#126` tail still contains adjacent event-topology and event-catalog integrity checks that share some helpers, so future slices still need explicit sibling pressure-tests before extraction

## Follow-Up
- continue `#126` with the remaining parent tail tracked on the umbrella issue
- the most likely next child classes remain:
  - event-topology / event-catalog integrity
  - entity-target / state-schema coverage
  - handler/runtime contract compliance
