### PR TITLE
[agent-e][issue #318] Preserve internal-subscriber visibility across replay recovery

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -89,6 +89,14 @@ active_issues:
     title: Expose recovery and restart decisions through canonical diagnostics
     maps_to:
       - recovery_restart_diagnostics
+  - id: 313
+    title: Canonicalize subscriber visibility ownership across delivery planning and publish
+    maps_to:
+      - delivery_and_replay_ownership
+  - id: 318
+    title: Preserve internal-subscriber visibility across undispatched-event recovery
+    maps_to:
+      - delivery_and_replay_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -123,10 +131,13 @@ nodes:
     known_manifestations:
       - direct-recipient delivery as a shadow semantic path
       - descriptor-aware recipient policy can silently exclude non-agent in-memory subscribers such as startup control-plane checks, workflow-runtime, and system-node subscribers when publish planning treats all recipients as active-agent descriptors
+      - committed-but-undispatched replay can reconstruct only persisted agent recipients and drop internal subscribers such as workflow-runtime or system-node listeners after restart
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
     representative_issues:
       - 112
+      - 313
+      - 318
       - 144
       - 145
     common_framing_mistakes:

--- a/internal/runtime/bus/committed_recipients.go
+++ b/internal/runtime/bus/committed_recipients.go
@@ -1,0 +1,47 @@
+package bus
+
+import (
+	"context"
+	"strings"
+
+	"swarm/internal/events"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+)
+
+func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, eventID string) ([]string, error) {
+	if !runtimereplayclaim.SupportsPersistedReplay(eb.store) {
+		return nil, runtimereplayclaim.ErrAuthoritativeRecipientManifestUnavailable
+	}
+	recipients, err := eb.store.ListEventDeliveryRecipients(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range recipients {
+		recipients[i] = strings.TrimSpace(recipients[i])
+	}
+	if recipients == nil {
+		return []string{}, nil
+	}
+	return uniqueStrings(recipients), nil
+}
+
+func (eb *EventBus) currentInternalRecipientsForCommittedEvent(ctx context.Context, evt events.Event) ([]string, error) {
+	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	if err != nil {
+		return nil, err
+	}
+	return filterOutAgentIDs(plan.Recipients, plan.PersistedRecipients), nil
+}
+
+func (eb *EventBus) committedLiveRecipients(ctx context.Context, evt events.Event, persisted []string, includeInternal bool) ([]string, []string, error) {
+	persisted = uniqueStrings(persisted)
+	if !includeInternal {
+		return persisted, nil, nil
+	}
+	internal, err := eb.currentInternalRecipientsForCommittedEvent(ctx, evt)
+	if err != nil {
+		return nil, nil, err
+	}
+	live := uniqueStrings(append(append([]string(nil), persisted...), internal...))
+	return live, internal, nil
+}

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -29,7 +29,6 @@ type EventBus struct {
 	agentChans          map[string]chan events.Event
 	subscriptions       map[string][]events.EventType
 	subscriptionKinds   map[string]inMemorySubscriberKind
-	pendingInternalByID map[string][]string
 	routeTable          *RouteTable
 	deliveryPlanner     deliveryPlanner
 	interceptors        []EventInterceptor
@@ -102,7 +101,6 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		agentChans:          make(map[string]chan events.Event),
 		subscriptions:       make(map[string][]events.EventType),
 		subscriptionKinds:   make(map[string]inMemorySubscriberKind),
-		pendingInternalByID: make(map[string][]string),
 		routeTable:          routeTable,
 		store:               store,
 		logger:              opts.Logger,
@@ -242,7 +240,6 @@ func (eb *EventBus) ResetInMemoryState() error {
 	eb.agentChans = make(map[string]chan events.Event)
 	eb.subscriptions = make(map[string][]events.EventType)
 	eb.subscriptionKinds = make(map[string]inMemorySubscriberKind)
-	eb.pendingInternalByID = make(map[string][]string)
 	routeTable, err := eb.deriveBootRouteTableLocked()
 	if err != nil {
 		return err

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -638,17 +638,14 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	return nil
 }
 
-// PublishPersistedRecipients delivers an already-persisted authoritative
-// recipient manifest without re-running direct recipient planning.
+// PublishPersistedRecipients delivers an already-committed event using the
+// authoritative persisted agent manifest plus current internal subscribers.
 func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
 	recipients = uniqueStrings(recipients)
-	if len(recipients) == 0 {
-		return errors.New("persisted recipients are required")
-	}
 	if evt.Type == "" {
 		return errors.New("event type is required")
 	}
@@ -661,16 +658,29 @@ func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.E
 	if evt.CreatedAt.IsZero() {
 		evt.CreatedAt = time.Now()
 	}
-	if err := eb.deliverToAgents(ctx, evt, recipients); err != nil {
+	liveRecipients, internalRecipients, err := eb.committedLiveRecipients(ctx, evt, recipients, true)
+	if err != nil {
 		return err
+	}
+	if len(liveRecipients) == 0 {
+		return nil
+	}
+	if err := eb.deliverToAgents(ctx, evt, liveRecipients); err != nil {
+		return err
+	}
+	owner := "event_deliveries"
+	if len(internalRecipients) > 0 {
+		owner = "event_deliveries+current_internal_subscribers"
 	}
 	eb.logRuntime(ctx, "debug", "Persisted event was delivered to authoritative recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
 		"direct":                     true,
-		"delivery_manifest_owner":    "event_deliveries",
-		"recipients_count":           len(recipients),
+		"delivery_manifest_owner":    owner,
+		"recipients_count":           len(liveRecipients),
 		"parent_event_id":            strings.TrimSpace(evt.ParentEventID),
-		"requested_recipients":       append([]string(nil), recipients...),
-		"requested_recipients_count": len(recipients),
+		"requested_recipients":       append([]string(nil), liveRecipients...),
+		"requested_recipients_count": len(liveRecipients),
+		"persisted_recipients":       append([]string(nil), recipients...),
+		"internal_recipients":        append([]string(nil), internalRecipients...),
 	}, "", 0)
 	return nil
 }

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -54,7 +54,7 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if strings.TrimSpace(string(intent.Event.Type)) == "" {
 			continue
 		}
-		recipients, internalRecipients, err := o.deliveryRecipientsForIntent(ctx, *intent)
+		recipients, err := o.deliveryRecipientsForIntent(ctx, *intent)
 		if err != nil {
 			return err
 		}
@@ -64,25 +64,24 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if err := txStore.InsertEventDeliveriesTx(ctx, tx, intent.Event.ID, recipients); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
-		o.bus.setPendingInternalRecipients(intent.Event.ID, internalRecipients)
 	}
 	return nil
 }
 
-func (o engineOutbox) deliveryRecipientsForIntent(ctx context.Context, intent runtimeengine.EmitIntent) ([]string, []string, error) {
+func (o engineOutbox) deliveryRecipientsForIntent(ctx context.Context, intent runtimeengine.EmitIntent) ([]string, error) {
 	if len(intent.Recipients) > 0 {
 		plan, err := o.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		return plan.PersistedRecipients, nil, nil
+		return plan.PersistedRecipients, nil
 	}
 	plan, err := o.bus.deliveryPlanner.Plan(ctx, intent.Event)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	o.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
-	return plan.PersistedRecipients, filterOutAgentIDs(plan.Recipients, plan.PersistedRecipients), nil
+	return plan.PersistedRecipients, nil
 }
 
 func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runtimeengine.EmitIntent) error {
@@ -129,19 +128,23 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		}
 		return err
 	}
-	internalRecipients := d.bus.pendingInternalRecipients(intent.Event.ID)
-	liveRecipients := uniqueStrings(append(append([]string(nil), recipients...), internalRecipients...))
+	liveRecipients, internalRecipients, err := d.bus.committedLiveRecipients(ctx, intent.Event, recipients, len(intent.Recipients) == 0)
+	if err != nil {
+		return err
+	}
 	if len(liveRecipients) == 0 {
-		d.bus.clearPendingInternalRecipients(intent.Event.ID)
 		return nil
 	}
 	if err := d.bus.deliverToAgents(ctx, intent.Event, liveRecipients); err != nil {
 		return err
 	}
-	d.bus.clearPendingInternalRecipients(intent.Event.ID)
+	owner := "event_deliveries"
+	if len(internalRecipients) > 0 {
+		owner = "event_deliveries+current_internal_subscribers"
+	}
 	d.bus.logRuntime(ctx, "debug", "Persisted event intent was delivered", "eventbus", "delivered", intent.Event.ID, string(intent.Event.Type), "", intent.Event.EntityID(), "", nil, map[string]any{
 		"direct":                     true,
-		"delivery_manifest_owner":    "event_deliveries+in_memory_internal",
+		"delivery_manifest_owner":    owner,
 		"recipients_count":           len(liveRecipients),
 		"parent_event_id":            strings.TrimSpace(intent.Event.ParentEventID),
 		"requested_recipients":       append([]string(nil), liveRecipients...),
@@ -180,45 +183,4 @@ func normalizeOutboxEvent(evt events.Event) events.Event {
 		evt.CreatedAt = time.Now().UTC()
 	}
 	return evt
-}
-
-func (eb *EventBus) setPendingInternalRecipients(eventID string, recipients []string) {
-	if eb == nil {
-		return
-	}
-	eventID = strings.TrimSpace(eventID)
-	recipients = uniqueStrings(recipients)
-	eb.mu.Lock()
-	defer eb.mu.Unlock()
-	if eventID == "" || len(recipients) == 0 {
-		delete(eb.pendingInternalByID, eventID)
-		return
-	}
-	eb.pendingInternalByID[eventID] = append([]string(nil), recipients...)
-}
-
-func (eb *EventBus) pendingInternalRecipients(eventID string) []string {
-	if eb == nil {
-		return nil
-	}
-	eventID = strings.TrimSpace(eventID)
-	if eventID == "" {
-		return nil
-	}
-	eb.mu.RLock()
-	defer eb.mu.RUnlock()
-	return append([]string(nil), eb.pendingInternalByID[eventID]...)
-}
-
-func (eb *EventBus) clearPendingInternalRecipients(eventID string) {
-	if eb == nil {
-		return
-	}
-	eventID = strings.TrimSpace(eventID)
-	if eventID == "" {
-		return
-	}
-	eb.mu.Lock()
-	defer eb.mu.Unlock()
-	delete(eb.pendingInternalByID, eventID)
 }

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	runtimeengine "swarm/internal/runtime/engine"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
@@ -93,7 +92,6 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if err != nil {
 		return 0, err
 	}
-	dispatcher := engineDispatcher{bus: eb}
 	redelivered := 0
 	for _, record := range events {
 		evt := record.Event
@@ -115,8 +113,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			_ = lease.Release(ctx)
 			return redelivered, err
 		}
-		intent := runtimeengine.EmitIntent{Event: evt, Recipients: recipients}
-		if err := dispatcher.dispatchIntent(ctx, intent); err != nil {
+		if err := eb.PublishPersistedRecipients(ctx, evt, recipients); err != nil {
 			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
 				eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
 			}
@@ -128,21 +125,4 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 		redelivered++
 	}
 	return redelivered, nil
-}
-
-func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, eventID string) ([]string, error) {
-	if !runtimereplayclaim.SupportsPersistedReplay(eb.store) {
-		return nil, runtimereplayclaim.ErrAuthoritativeRecipientManifestUnavailable
-	}
-	recipients, err := eb.store.ListEventDeliveryRecipients(ctx, eventID)
-	if err != nil {
-		return nil, err
-	}
-	for i := range recipients {
-		recipients[i] = strings.TrimSpace(recipients[i])
-	}
-	if recipients == nil {
-		return []string{}, nil
-	}
-	return uniqueStrings(recipients), nil
 }

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -134,6 +134,88 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	}
 }
 
+func TestSweepUndispatched_ReconstructsInternalSubscribersForInternalOnlyReplay(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-internal-only",
+				Type:      events.EventType("custom.internal"),
+				Payload:   []byte(`{"entity_id":"ent-internal"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-internal")},
+		},
+		deliveries: map[string][]string{},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.internal"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	if got := store.receipts["evt-internal-only"]; got != "processed" {
+		t.Fatalf("receipt status = %q, want processed", got)
+	}
+	select {
+	case evt := <-internalCh:
+		if evt.ID != "evt-internal-only" {
+			t.Fatalf("delivered event id = %q, want evt-internal-only", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal replay delivery")
+	}
+}
+
+func TestSweepUndispatched_ReconstructsInternalSubscribersAlongsidePersistedAgents(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-mixed",
+				Type:      events.EventType("custom.mixed"),
+				Payload:   []byte(`{"entity_id":"ent-mixed"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-mixed")},
+		},
+		deliveries: map[string][]string{"evt-mixed": {"agent-a"}},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.mixed"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.mixed"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	select {
+	case evt := <-internalCh:
+		if evt.ID != "evt-mixed" {
+			t.Fatalf("internal delivered event id = %q, want evt-mixed", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal subscriber to receive replayed event")
+	}
+	select {
+	case evt := <-agentCh:
+		if evt.ID != "evt-mixed" {
+			t.Fatalf("agent delivered event id = %q, want evt-mixed", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected persisted agent recipient to receive replayed event")
+	}
+}
+
 func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -113,22 +113,6 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			_ = lease.Release(ctx)
 			continue
 		}
-		if len(persistedRecipients) == 0 {
-			if recorder == nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("mark replay event %s delivered receipt: missing pipeline receipt recorder", evt.ID)
-				}
-				_ = lease.Release(ctx)
-				continue
-			}
-			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
-				}
-			}
-			_ = lease.Release(ctx)
-			continue
-		}
 		if err := r.bus.PublishPersistedRecipients(ctx, evt, persistedRecipients); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("replay event %s: %w", evt.ID, err)

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -175,6 +175,66 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	}
 }
 
+func TestRecoveryManager_ReplaysInternalSubscribersWithEmptyPersistedManifest(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+	internalCh := bus.SubscribeInternal("workflow-runtime", events.EventType("system.recover.internal"))
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		Type:        events.EventType("system.recover.internal"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-time.Minute).UTC(),
+	}.WithEntityID(entityID)
+
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 1 {
+		t.Fatalf("direct replayed events = %#v, want one replayed event", capture.direct)
+	}
+	select {
+	case delivered := <-internalCh:
+		if delivered.ID != eventID {
+			t.Fatalf("delivered event id = %q, want %q", delivered.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal subscriber to receive replayed event")
+	}
+
+	var receiptStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&receiptStatus); err != nil {
+		t.Fatalf("load replay receipt: %v", err)
+	}
+	if receiptStatus != "success" {
+		t.Fatalf("replay receipt outcome = %q, want success", receiptStatus)
+	}
+}
+
 func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)


### PR DESCRIPTION
## Summary
This PR is an attempted closure of the committed-event replay visibility seam from #318, but the current head is blocked in review because replay still lacks a durable direct-vs-subscribed recipient discriminator across the crash boundary.

Part of #318
Related to #313
Related to #325

## Why
`#317` fixed live publish and same-process post-commit dispatch, but committed-but-undispatched recovery still replayed only persisted agent recipients. This branch attempted to reconstruct current internal subscribers during replay.

Review exposed the remaining blocker: the persisted recovery surface does not durably encode whether a replayed committed event was originally:
- subscription-scoped and therefore allowed to re-derive current internal subscribers
- or direct-scoped and therefore required to remain limited to its original explicit recipient set across restart

Because that discriminator is missing, the current head is not merge-ready.

## What Changed On This Branch
- added a shared committed-event recipient reconstruction owner in the runtime bus
- removed the temporary same-process `pendingInternalByID` cache
- made post-commit dispatch, `SweepUndispatched(...)`, and `PublishPersistedRecipients(...)` use the same persisted-agent plus current-internal reconstruction path
- changed startup pipeline recovery to replay empty persisted manifests through that same owner instead of auto-marking them processed
- added focused sweeper and pipeline recovery regressions for internal-only and mixed agent-plus-internal replay
- refined `docs/watchlists/runtime-operations.yaml` under `delivery_and_replay_ownership`

## Blocking Review Outcome
- the current implementation broadens direct-event semantics after crash/restart because replay cannot distinguish direct-scoped committed events from subscribed committed events
- that remaining seam is now tracked explicitly at #325
- this PR should not be merged in its current form

## Governing Spec Refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 3 persist_event`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 4 resolve_subscribers`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 6 agent_delivery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.lifecycle.step 8 mark_delivered`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_loop.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `routing_rules.routable_events`

## Scope Boundaries
- no direct-recipient redesign landed here
- no persisted-manifest schema change landed here
- no broader event-bus redesign outside committed subscribed-event recovery was attempted

## Tests Run On Current Head
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
- medium-high if merged as-is because direct-event replay scoping is still incorrect
- remaining concrete child seam is tracked at #325
