### PR TITLE
[agent-c][issue #175] Canonicalize stalled run status

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -696,7 +696,7 @@ func projectRunOperationalStatus(report runStatusReport) runOperationalProjectio
 			activeDeliveries += item.Count
 		}
 	}
-	terminalScoring := eventCounts["scoring/vertical.marginal"] + eventCounts["scoring/vertical.rejected"] + eventCounts["vertical.shortlisted"]
+	terminalScoring := eventCounts["scoring/vertical.marginal"] + eventCounts["scoring/vertical.rejected"] + eventCounts["scoring/vertical.shortlisted"]
 	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
 		return runOperationalProjection{
 			State:          "stalled",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -236,6 +236,9 @@ func runVerifyCommand(ctx context.Context, repo string, args []string, out io.Wr
 type runStatusReport struct {
 	RunID             string                    `json:"run_id"`
 	RunTableStatus    string                    `json:"run_table_status,omitempty"`
+	OperationalState  string                    `json:"operational_state,omitempty"`
+	BlockingLayer     string                    `json:"blocking_layer,omitempty"`
+	BlockingReason    string                    `json:"blocking_reason,omitempty"`
 	RootEventID       string                    `json:"root_event_id,omitempty"`
 	RootEventType     string                    `json:"root_event_type,omitempty"`
 	StartedAt         time.Time                 `json:"started_at,omitempty"`
@@ -251,6 +254,12 @@ type runStatusReport struct {
 	Heuristics        []string                  `json:"heuristics,omitempty"`
 	RuntimeLogSummary []runStatusRuntimeSummary `json:"runtime_log_summary,omitempty"`
 	RuntimeLogs       []runStatusRuntimeLog     `json:"runtime_logs,omitempty"`
+}
+
+type runOperationalProjection struct {
+	State          string
+	BlockingLayer  string
+	BlockingReason string
 }
 
 type runStatusEventCount struct {
@@ -560,6 +569,10 @@ func loadRunStatusReport(ctx context.Context, db *sql.DB, runID string, opts run
 			return runStatusReport{}, err
 		}
 	}
+	operational := projectRunOperationalStatus(report)
+	report.OperationalState = operational.State
+	report.BlockingLayer = operational.BlockingLayer
+	report.BlockingReason = operational.BlockingReason
 	report.Heuristics = deriveRunStatusHeuristics(report)
 
 	return report, nil
@@ -656,6 +669,22 @@ func logLimitForStatus(opts runStatusOptions) int {
 }
 
 func deriveRunStatusHeuristics(report runStatusReport) []string {
+	heuristics := make([]string, 0, 4)
+	if len(report.DeadLetters) > 0 {
+		heuristics = append(heuristics, "dead letters exist for this run")
+	}
+	return heuristics
+}
+
+func projectRunOperationalStatus(report runStatusReport) runOperationalProjection {
+	status := strings.ToLower(strings.TrimSpace(report.RunTableStatus))
+	if status == "" {
+		return runOperationalProjection{}
+	}
+	if status != "running" {
+		return runOperationalProjection{State: status}
+	}
+
 	eventCounts := map[string]int{}
 	for _, item := range report.EventCounts {
 		eventCounts[strings.TrimSpace(item.EventName)] = item.Count
@@ -667,18 +696,22 @@ func deriveRunStatusHeuristics(report runStatusReport) []string {
 			activeDeliveries += item.Count
 		}
 	}
-	heuristics := make([]string, 0, 4)
 	terminalScoring := eventCounts["scoring/vertical.marginal"] + eventCounts["scoring/vertical.rejected"] + eventCounts["vertical.shortlisted"]
 	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
-		heuristics = append(heuristics, "run appears settled after scoring started but no terminal scoring outcome was emitted")
+		return runOperationalProjection{
+			State:          "stalled",
+			BlockingLayer:  "scoring_terminal_outcome",
+			BlockingReason: "terminal_scoring_outcome_missing",
+		}
 	}
-	if strings.EqualFold(strings.TrimSpace(report.RunTableStatus), "running") && activeDeliveries == 0 && !report.LastEventAt.IsZero() {
-		heuristics = append(heuristics, "runs table still says running, but there are no pending or in-progress deliveries")
+	if activeDeliveries == 0 && !report.LastEventAt.IsZero() {
+		return runOperationalProjection{
+			State:          "stalled",
+			BlockingLayer:  "delivery_lifecycle",
+			BlockingReason: "no_active_deliveries",
+		}
 	}
-	if len(report.DeadLetters) > 0 {
-		heuristics = append(heuristics, "dead letters exist for this run")
-	}
-	return heuristics
+	return runOperationalProjection{State: "running"}
 }
 
 func printRunStatusReport(w io.Writer, report runStatusReport) {
@@ -690,7 +723,16 @@ func printRunStatusReport(w io.Writer, report runStatusReport) {
 		fmt.Fprintf(w, "Root: %s (%s)\n", report.RootEventType, report.RootEventID)
 	}
 	if strings.TrimSpace(report.RunTableStatus) != "" {
-		fmt.Fprintf(w, "Run Status: %s\n", report.RunTableStatus)
+		fmt.Fprintf(w, "Run Table Status: %s\n", report.RunTableStatus)
+	}
+	if strings.TrimSpace(report.OperationalState) != "" {
+		fmt.Fprintf(w, "Operational State: %s\n", report.OperationalState)
+	}
+	if strings.TrimSpace(report.BlockingLayer) != "" {
+		fmt.Fprintf(w, "Blocking Layer: %s\n", report.BlockingLayer)
+	}
+	if strings.TrimSpace(report.BlockingReason) != "" {
+		fmt.Fprintf(w, "Blocking Reason: %s\n", report.BlockingReason)
 	}
 	fmt.Fprintf(w, "Started: %s\n", report.StartedAt.Format(time.RFC3339))
 	if !report.LastEventAt.IsZero() {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -137,6 +137,31 @@ func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.
 	}
 }
 
+func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutcome(t *testing.T) {
+	report := runStatusReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []runStatusEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+			{EventName: "scoring/vertical.shortlisted", Count: 1},
+		},
+		Deliveries: []runStatusDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := projectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
 func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
 	report := runStatusReport{
 		RunTableStatus: "running",

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -31,6 +31,9 @@ func TestPrintRunStatusReport(t *testing.T) {
 	report := runStatusReport{
 		RunID:             "run-123",
 		RunTableStatus:    "running",
+		OperationalState:  "stalled",
+		BlockingLayer:     "scoring_terminal_outcome",
+		BlockingReason:    "terminal_scoring_outcome_missing",
 		RootEventID:       "evt-1",
 		RootEventType:     "scan.requested",
 		StartedAt:         started,
@@ -66,7 +69,10 @@ func TestPrintRunStatusReport(t *testing.T) {
 	for _, want := range []string{
 		"Run run-123",
 		"Root: scan.requested (evt-1)",
-		"Run Status: running",
+		"Run Table Status: running",
+		"Operational State: stalled",
+		"Blocking Layer: scoring_terminal_outcome",
+		"Blocking Reason: terminal_scoring_outcome_missing",
 		"Summary: events=7 deliveries=1 dead_letters=0 agent_turns=1 runtime_warn_errors=1",
 		"Heuristics:",
 		"run appears settled after scoring started but no terminal scoring outcome was emitted",
@@ -82,6 +88,71 @@ func TestPrintRunStatusReport(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationallyStalled(t *testing.T) {
+	report := runStatusReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []runStatusDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 2},
+			{SubscriberID: "agent-2", Status: "failed", Count: 1},
+		},
+	}
+
+	got := projectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.T) {
+	report := runStatusReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []runStatusEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+		},
+		Deliveries: []runStatusDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := projectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "scoring_terminal_outcome" {
+		t.Fatalf("blocking_layer = %q, want scoring_terminal_outcome", got.BlockingLayer)
+	}
+	if got.BlockingReason != "terminal_scoring_outcome_missing" {
+		t.Fatalf("blocking_reason = %q, want terminal_scoring_outcome_missing", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
+	report := runStatusReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []runStatusDeliveryCount{
+			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
+			{SubscriberID: "agent-2", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := projectRunOperationalStatus(report)
+	if got.State != "running" {
+		t.Fatalf("state = %q, want running", got.State)
+	}
+	if got.BlockingLayer != "" || got.BlockingReason != "" {
+		t.Fatalf("unexpected blocking projection: %#v", got)
 	}
 }
 
@@ -309,6 +380,106 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	for _, heuristic := range report.Heuristics {
 		if strings.Contains(heuristic, "runs table still says running") {
 			t.Fatalf("unexpected running heuristic after durable completion: %#v", report.Heuristics)
+		}
+	}
+}
+
+func TestLoadRunStatusReport_ProjectsExplicitStalledRunState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	rootEventID := uuid.NewString()
+	deliveredEventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', now() - interval '10 minutes')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	for _, eventID := range []string{rootEventID, deliveredEventID} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'runtime', 'agent', now() - interval '5 minutes'
+			)
+		`, runID, eventID); err != nil {
+			t.Fatalf("seed event %s: %v", eventID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, delivered_at, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-1', 'delivered', now() - interval '2 minutes', now() - interval '4 minutes'
+		)
+	`, runID, deliveredEventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	if err != nil {
+		t.Fatalf("loadRunStatusReport: %v", err)
+	}
+	if report.RunTableStatus != "running" {
+		t.Fatalf("run_table_status = %q, want running", report.RunTableStatus)
+	}
+	if report.OperationalState != "stalled" {
+		t.Fatalf("operational_state = %q, want stalled", report.OperationalState)
+	}
+	if report.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", report.BlockingLayer)
+	}
+	if report.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", report.BlockingReason)
+	}
+	for _, heuristic := range report.Heuristics {
+		if strings.Contains(heuristic, "runs table still says running") {
+			t.Fatalf("unexpected stalled heuristic fallback: %#v", report.Heuristics)
+		}
+	}
+}
+
+func TestLoadRunStatusReport_ProjectsScoringOutcomeStall(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	rootEventID := uuid.NewString()
+	scoringEventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', now() - interval '10 minutes')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES
+			($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'runtime', 'agent', now() - interval '9 minutes'),
+			($1::uuid, $3::uuid, 'scoring/scoring.requested', 'global', '{}'::jsonb, 'runtime', 'agent', now() - interval '2 minutes')
+	`, runID, rootEventID, scoringEventID); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	if err != nil {
+		t.Fatalf("loadRunStatusReport: %v", err)
+	}
+	if report.OperationalState != "stalled" {
+		t.Fatalf("operational_state = %q, want stalled", report.OperationalState)
+	}
+	if report.BlockingLayer != "scoring_terminal_outcome" {
+		t.Fatalf("blocking_layer = %q, want scoring_terminal_outcome", report.BlockingLayer)
+	}
+	if report.BlockingReason != "terminal_scoring_outcome_missing" {
+		t.Fatalf("blocking_reason = %q, want terminal_scoring_outcome_missing", report.BlockingReason)
+	}
+	for _, heuristic := range report.Heuristics {
+		if strings.Contains(heuristic, "run appears settled after scoring started") {
+			t.Fatalf("unexpected scoring heuristic fallback: %#v", report.Heuristics)
 		}
 	}
 }


### PR DESCRIPTION
Part of #175

## Human Summary

This PR removes the local stalled-run heuristic from `swarm status` as the semantic owner of run state.

The touched CLI status surface now keeps raw `run_table_status` as durable run metadata, but adds one explicit run-level operational projection that can say a run is operationally `stalled` and name the real `blocking_layer` / `blocking_reason` instead of leaving the run generically `running` with only prose heuristics.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: turn_budget`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_sessions`
- governing rule from `#175`: session launch, long-running activity, and termination visibility should align to the canonical live-session model instead of ad hoc watchdog-only heuristics

## What Changed

- added one explicit run-level operational projection in `cmd/swarm/main.go`
- `loadRunStatusReport(...)` now computes `operational_state`, `blocking_layer`, and `blocking_reason`
- `printRunStatusReport(...)` now prints raw `Run Table Status` separately from the operational state
- the old stalled-state heuristic strings are no longer the owner for:
  - running with no active deliveries
  - scoring requested with no terminal scoring outcome
- added focused CLI tests for:
  - healthy running with active deliveries
  - stalled run with no active deliveries
  - stalled scoring path with missing terminal outcome
  - text output showing explicit operational state / blocking layer

## Why This Is Needed

Before this change, `swarm status` could still show `Run Status: running` even when the run had no active deliveries and was operationally stalled. The real blocking layer was only implied by free-form heuristic text.

That left the touched status surface semantically ambiguous. This PR makes the stalled-state meaning explicit and typed in the report model used by the CLI surface.

## Scope Boundaries

In scope:
- CLI run-status stalled-state projection
- explicit blocking-layer visibility for the touched run-status surface
- text/JSON output that consumes that same report path

Out of scope:
- long-running / no-output watchdog visibility
- broad observability redesign
- reopening umbrella `#131`

## Tests Run

- `go test ./cmd/swarm -run 'Test(PrintRunStatusReport|ProjectRunOperationalStatus_|LoadRunStatusReport_(ProjectsExplicitStalledRunState|ProjectsScoringOutcomeStall|UsesDurableCompletedRunState))$' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR closes the chosen CLI stalled-run child class only.

The broader runtime-lifecycle observability parent under `#175` remains open for the long-running / no-output watchdog slice.

## Follow-Up

- keep issue `#175` open for the remaining long-running / no-output watchdog visibility slice
- longer-term, a shared typed runtime lifecycle projection across CLI and future operator surfaces would still be better than separate local report structs
