### PR TITLE
[agent-a][issue #321] Canonicalize startup pipeline replay diagnostics

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
+	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -583,6 +584,161 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	}
 	if terminationDetail != "builder_api" {
 		t.Fatalf("termination_detail = %q, want builder_api", terminationDetail)
+	}
+}
+
+func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+
+	logger := runtimepkg.NewRuntimeLogger(db, pg)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		Logger: conformanceRuntimeLoggerHook{logger: logger},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	replayRecipient := "agent-replay"
+	_ = bus.Subscribe(replayRecipient)
+
+	replayRunID := uuid.NewString()
+	replayParentID := uuid.NewString()
+	replayChildID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          replayParentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       replayRunID,
+		CreatedAt:   time.Now().Add(-3 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(replay parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            replayChildID,
+		Type:          events.EventType("system.recover.replay"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         replayRunID,
+		ParentEventID: replayParentID,
+		CreatedAt:     time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(replay child): %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, replayChildID, []string{replayRecipient}); err != nil {
+		t.Fatalf("InsertEventDeliveries(replay child): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, replayParentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(replay parent): %v", err)
+	}
+
+	skipRunID := uuid.NewString()
+	skipParentID := uuid.NewString()
+	skipChildID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          skipParentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       skipRunID,
+		CreatedAt:   time.Now().Add(-3 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(skip parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            skipChildID,
+		Type:          events.EventType("system.recover.skip"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         skipRunID,
+		ParentEventID: skipParentID,
+		CreatedAt:     time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(skip child): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, skipParentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(skip parent): %v", err)
+	}
+
+	droppedEventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, 'system.recover.drop', 'global', '{}'::jsonb, 'runtime', 'platform', now()
+		)
+	`, droppedEventID); err != nil {
+		t.Fatalf("seed dropped replay event: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, bus)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "pipeline-recovery",
+		Type:      "startup_recovery_pipeline_replay_aftermath",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 3 {
+		t.Fatalf("runtime log rows = %d, want 3: %#v", len(logs), logs)
+	}
+	findLogIndex := func(eventID string) int {
+		t.Helper()
+		for idx, log := range logs {
+			if strings.TrimSpace(log.EventID) == strings.TrimSpace(eventID) {
+				return idx
+			}
+		}
+		t.Fatalf("missing runtime log for event %q in %#v", eventID, logs)
+		return -1
+	}
+
+	replayed := logs[findLogIndex(replayChildID)]
+	if replayed.Action != "startup_recovery_pipeline_replay_aftermath" {
+		t.Fatalf("replayed action = %q, want startup_recovery_pipeline_replay_aftermath", replayed.Action)
+	}
+	replayedDetail, _ := replayed.Detail.(map[string]any)
+	if got := readString(replayedDetail["decision_outcome"]); got != "replayed" {
+		t.Fatalf("replayed detail.decision_outcome = %q, want replayed", got)
+	}
+	if got := readString(replayedDetail["decision_reason_code"]); got != "persisted_recipients_replayed" {
+		t.Fatalf("replayed detail.decision_reason_code = %q, want persisted_recipients_replayed", got)
+	}
+
+	skipped := logs[findLogIndex(skipChildID)]
+	skippedDetail, _ := skipped.Detail.(map[string]any)
+	if got := readString(skippedDetail["decision_outcome"]); got != "skipped" {
+		t.Fatalf("skipped detail.decision_outcome = %q, want skipped", got)
+	}
+	if got := readString(skippedDetail["decision_reason_code"]); got != "no_persisted_recipients" {
+		t.Fatalf("skipped detail.decision_reason_code = %q, want no_persisted_recipients", got)
+	}
+
+	dropped := logs[findLogIndex(droppedEventID)]
+	droppedDetail, _ := dropped.Detail.(map[string]any)
+	if got := readString(droppedDetail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped detail.decision_outcome = %q, want dropped", got)
+	}
+	if got := readString(droppedDetail["decision_reason_code"]); got != "replay_quarantined" {
+		t.Fatalf("dropped detail.decision_reason_code = %q, want replay_quarantined", got)
+	}
+	if readString(droppedDetail["error_code"]) != "replay_quarantined" {
+		t.Fatalf("dropped detail.error_code = %q, want replay_quarantined", readString(droppedDetail["error_code"]))
+	}
+	if strings.TrimSpace(dropped.Error) == "" {
+		t.Fatal("dropped recovery aftermath log missing explicit error text")
 	}
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -19,11 +19,16 @@ import (
 type recoveryTestBus struct {
 	storedRoutes []runtimebus.FlowInstanceRouteRecord
 	restored     []string
+	replayable   []events.PersistedReplayEvent
+	deliveries   map[string][]string
+	runtimeLogs  []runtimepipeline.RuntimeLogEntry
+	direct       []events.Event
 }
 
 func (*recoveryTestBus) Publish(context.Context, events.Event) error                 { return nil }
 func (*recoveryTestBus) PublishDirect(context.Context, events.Event, []string) error { return nil }
-func (*recoveryTestBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+func (b *recoveryTestBus) PublishPersistedRecipients(_ context.Context, evt events.Event, _ []string) error {
+	b.direct = append(b.direct, evt)
 	return nil
 }
 func (*recoveryTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
@@ -31,20 +36,21 @@ func (*recoveryTestBus) Subscribe(string, ...events.EventType) <-chan events.Eve
 }
 func (*recoveryTestBus) Unsubscribe(string)        {}
 func (*recoveryTestBus) ResetInMemoryState() error { return nil }
-func (*recoveryTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
+func (b *recoveryTestBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.runtimeLogs = append(b.runtimeLogs, entry)
 	return nil
 }
 func (b *recoveryTestBus) Store() runtimebus.EventStore                                  { return b }
 func (b *recoveryTestBus) AppendEvent(context.Context, events.Event) error               { return nil }
 func (b *recoveryTestBus) InsertEventDeliveries(context.Context, string, []string) error { return nil }
-func (*recoveryTestBus) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
-	return []string{}, nil
+func (b *recoveryTestBus) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	return append([]string(nil), b.deliveries[eventID]...), nil
 }
 func (*recoveryTestBus) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
 	return recoveryTestReplayLease{}, true, nil
 }
 func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
-	return nil, nil
+	return append([]events.PersistedReplayEvent(nil), b.replayable...), nil
 }
 func (b *recoveryTestBus) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {
 	return nil
@@ -173,11 +179,68 @@ func TestRecover_UsesCanonicalLoadedAgentMetadata(t *testing.T) {
 	}
 }
 
+func TestRecover_UsesCanonicalPipelineReplayAftermathDiagnostics(t *testing.T) {
+	childID := "evt-replay"
+	parentID := "evt-parent"
+	bus := &recoveryTestBus{
+		replayable: []events.PersistedReplayEvent{{
+			Event: events.Event{
+				ID:            childID,
+				Type:          events.EventType("system.recover"),
+				RunID:         "run-1",
+				ParentEventID: parentID,
+				CreatedAt:     time.Now().UTC(),
+			},
+		}},
+		deliveries: map[string][]string{
+			childID: {"agent-a"},
+		},
+	}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, &recoveryTestStore{})
+
+	if err := am.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(bus.direct) != 1 || bus.direct[0].ID != childID {
+		t.Fatalf("direct replayed events = %#v, want [%s]", bus.direct, childID)
+	}
+	entry := findManagerRecoveryAftermathLog(t, bus.runtimeLogs, childID, "replayed", "persisted_recipients_replayed")
+	if strings.TrimSpace(entry.Component) != "pipeline-recovery" {
+		t.Fatalf("runtime log component = %q, want pipeline-recovery", entry.Component)
+	}
+}
+
 type recoveryTestAgent struct{ id string }
 
 type recoveryTestReplayLease struct{}
 
 func (recoveryTestReplayLease) Release(context.Context) error { return nil }
+
+func findManagerRecoveryAftermathLog(t *testing.T, logs []runtimepipeline.RuntimeLogEntry, eventID, outcome, reason string) runtimepipeline.RuntimeLogEntry {
+	t.Helper()
+	for _, entry := range logs {
+		if strings.TrimSpace(entry.Action) != "startup_recovery_pipeline_replay_aftermath" {
+			continue
+		}
+		if strings.TrimSpace(entry.EventID) != strings.TrimSpace(eventID) {
+			continue
+		}
+		detail, _ := entry.Detail.(map[string]any)
+		outcomeText, _ := detail["decision_outcome"].(string)
+		reasonText, _ := detail["decision_reason_code"].(string)
+		if strings.TrimSpace(outcomeText) != strings.TrimSpace(outcome) {
+			continue
+		}
+		if strings.TrimSpace(reasonText) != strings.TrimSpace(reason) {
+			continue
+		}
+		return entry
+	}
+	t.Fatalf("missing manager recovery aftermath log for event=%q outcome=%q reason=%q in %#v", eventID, outcome, reason, logs)
+	return runtimepipeline.RuntimeLogEntry{}
+}
 
 func (a recoveryTestAgent) ID() string                      { return a.id }
 func (recoveryTestAgent) Type() string                      { return "generic" }

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	"swarm/internal/runtime/diaglog"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
@@ -23,6 +24,10 @@ type EventStore interface {
 type Publisher interface {
 	Publish(ctx context.Context, evt events.Event) error
 	PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error
+}
+
+type recoveryRuntimeLogger interface {
+	LogRuntime(ctx context.Context, entry RuntimeLogEntry) error
 }
 
 type RecoveryManager struct {
@@ -46,6 +51,85 @@ func NewRecoveryManagerWith(store EventStore, bus Publisher) *RecoveryManager {
 	return rm
 }
 
+const (
+	startupRecoveryPipelineReplayAction = "startup_recovery_pipeline_replay_aftermath"
+
+	startupRecoveryPipelineReplayOutcomeReplayed = "replayed"
+	startupRecoveryPipelineReplayOutcomeSkipped  = "skipped"
+	startupRecoveryPipelineReplayOutcomeDropped  = "dropped"
+
+	startupRecoveryPipelineReplayReasonReplayed              = "persisted_recipients_replayed"
+	startupRecoveryPipelineReplayReasonClaimNotAcquired      = "replay_claim_not_acquired"
+	startupRecoveryPipelineReplayReasonNoPersistedRecipients = "no_persisted_recipients"
+	startupRecoveryPipelineReplayReasonQuarantined           = "replay_quarantined"
+)
+
+func startupRecoveryPipelineReplayDetail(evt events.Event, outcome, reason string, recipients []string) map[string]any {
+	detail := map[string]any{
+		"decision_family":           "startup_pipeline_replay",
+		"decision_outcome":          strings.TrimSpace(outcome),
+		"decision_reason_code":      strings.TrimSpace(reason),
+		"event_id":                  strings.TrimSpace(evt.ID),
+		"event_type":                strings.TrimSpace(string(evt.Type)),
+		"persisted_run_id":          strings.TrimSpace(evt.RunID),
+		"parent_event_id":           strings.TrimSpace(evt.ParentEventID),
+		"entity_id":                 evt.EntityID(),
+		"flow_instance":             evt.FlowInstance(),
+		"persisted_recipient_count": len(recipients),
+	}
+	if len(recipients) > 0 {
+		copied := make([]string, 0, len(recipients))
+		for _, recipient := range recipients {
+			if trimmed := strings.TrimSpace(recipient); trimmed != "" {
+				copied = append(copied, trimmed)
+			}
+		}
+		detail["persisted_recipients"] = copied
+		detail["persisted_recipient_count"] = len(copied)
+	}
+	if strings.TrimSpace(outcome) == startupRecoveryPipelineReplayOutcomeDropped {
+		detail["error_code"] = strings.TrimSpace(reason)
+	}
+	return detail
+}
+
+func startupRecoveryPipelineReplayMessage(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case startupRecoveryPipelineReplayOutcomeDropped:
+		return "Startup recovery dropped persisted pipeline replay"
+	case startupRecoveryPipelineReplayOutcomeSkipped:
+		return "Startup recovery skipped persisted pipeline replay"
+	default:
+		return "Startup recovery replayed persisted pipeline event"
+	}
+}
+
+func startupRecoveryPipelineReplayLevel(outcome string) diaglog.Level {
+	switch strings.TrimSpace(outcome) {
+	case startupRecoveryPipelineReplayOutcomeDropped:
+		return diaglog.LevelWarn
+	default:
+		return diaglog.LevelInfo
+	}
+}
+
+func logStartupRecoveryPipelineReplayAftermath(ctx context.Context, logger recoveryRuntimeLogger, evt events.Event, outcome, reason, errText string, recipients []string) {
+	if logger == nil {
+		return
+	}
+	_ = logger.LogRuntime(ctx, RuntimeLogEntry{
+		Level:     startupRecoveryPipelineReplayLevel(outcome),
+		Component: "pipeline-recovery",
+		Action:    startupRecoveryPipelineReplayAction,
+		Message:   startupRecoveryPipelineReplayMessage(outcome),
+		EventID:   strings.TrimSpace(evt.ID),
+		EventType: strings.TrimSpace(string(evt.Type)),
+		EntityID:  evt.EntityID(),
+		Detail:    startupRecoveryPipelineReplayDetail(evt, outcome, reason, recipients),
+		Error:     strings.TrimSpace(errText),
+	})
+}
+
 func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if r == nil || r.store == nil || r.bus == nil {
 		return nil
@@ -65,6 +149,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 	if limit <= 0 {
 		limit = 500
 	}
+	logger, _ := r.bus.(recoveryRuntimeLogger)
 	eventsToReplay, err := replayStore.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-window), limit)
 	if err != nil {
 		return err
@@ -87,6 +172,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			continue
 		}
 		if !claimed {
+			logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeSkipped, startupRecoveryPipelineReplayReasonClaimNotAcquired, "", nil)
 			continue
 		}
 		if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
@@ -102,6 +188,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 					firstErr = fmt.Errorf("mark replay event %s error receipt: %w", evt.ID, err)
 				}
 			}
+			logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeDropped, startupRecoveryPipelineReplayReasonQuarantined, replayErr, nil)
 			_ = lease.Release(ctx)
 			continue
 		}
@@ -126,6 +213,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 					firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
 				}
 			}
+			logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeSkipped, startupRecoveryPipelineReplayReasonNoPersistedRecipients, "", nil)
 			_ = lease.Release(ctx)
 			continue
 		}
@@ -141,6 +229,7 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 				firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
 			}
 		}
+		logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeReplayed, startupRecoveryPipelineReplayReasonReplayed, "", persistedRecipients)
 		_ = lease.Release(ctx)
 	}
 	return firstErr

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -117,6 +117,9 @@ func logStartupRecoveryPipelineReplayAftermath(ctx context.Context, logger recov
 	if logger == nil {
 		return
 	}
+	if evt.Type == events.EventType("platform.runtime_log") {
+		return
+	}
 	_ = logger.LogRuntime(ctx, RuntimeLogEntry{
 		Level:     startupRecoveryPipelineReplayLevel(outcome),
 		Component: "pipeline-recovery",

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -544,6 +544,54 @@ func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *test
 	findRecoveryAftermathLog(t, capture.logs, childID, "skipped", "no_persisted_recipients")
 }
 
+func TestRecoveryManager_DoesNotEmitAftermathLogForRuntimeLogReplayCandidate(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, 'platform.runtime_log', 'global', '{"message":"prior diagnostics"}'::jsonb, 'runtime', 'platform', now()
+		)
+	`, eventID); err != nil {
+		t.Fatalf("seed runtime log event: %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.logs) != 0 {
+		t.Fatalf("runtime log aftermath entries = %#v, want none", capture.logs)
+	}
+	var receiptStatus, receiptReason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&receiptStatus, &receiptReason); err != nil {
+		t.Fatalf("load runtime log receipt: %v", err)
+	}
+	if receiptStatus != "dead_letter" {
+		t.Fatalf("runtime log receipt outcome = %q, want dead_letter", receiptStatus)
+	}
+	if receiptReason != "pipeline_error" {
+		t.Fatalf("runtime log receipt reason = %q, want pipeline_error", receiptReason)
+	}
+}
+
 func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -2,6 +2,7 @@ package pipeline_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -19,6 +20,7 @@ type recoveryCapturePublisher struct {
 	inner     runtimepipeline.Publisher
 	published []events.Event
 	direct    []events.Event
+	logs      []runtimepipeline.RuntimeLogEntry
 }
 
 type recoveryMissingClaimStore struct {
@@ -35,6 +37,11 @@ func (p *recoveryCapturePublisher) Publish(ctx context.Context, evt events.Event
 func (p *recoveryCapturePublisher) PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error {
 	p.direct = append(p.direct, evt)
 	return p.inner.PublishPersistedRecipients(ctx, evt, recipients)
+}
+
+func (p *recoveryCapturePublisher) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	p.logs = append(p.logs, entry)
+	return nil
 }
 
 func (s *recoveryMissingClaimStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -60,6 +67,7 @@ type blockingRecoveryPublisher struct {
 	started chan struct{}
 	release chan struct{}
 	count   atomic.Int32
+	logs    []runtimepipeline.RuntimeLogEntry
 }
 
 func (*blockingRecoveryPublisher) Publish(context.Context, events.Event) error { return nil }
@@ -70,6 +78,42 @@ func (p *blockingRecoveryPublisher) PublishPersistedRecipients(context.Context, 
 		<-p.release
 	}
 	return nil
+}
+
+func (p *blockingRecoveryPublisher) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.logs = append(p.logs, entry)
+	return nil
+}
+
+func recoveryDetailString(v any) string {
+	if text, ok := v.(string); ok {
+		return strings.TrimSpace(text)
+	}
+	return strings.TrimSpace("")
+}
+
+func findRecoveryAftermathLog(t *testing.T, logs []runtimepipeline.RuntimeLogEntry, eventID, outcome, reason string) runtimepipeline.RuntimeLogEntry {
+	t.Helper()
+	for _, entry := range logs {
+		if strings.TrimSpace(entry.Action) != "startup_recovery_pipeline_replay_aftermath" {
+			continue
+		}
+		if strings.TrimSpace(entry.EventID) != strings.TrimSpace(eventID) {
+			continue
+		}
+		detail, _ := entry.Detail.(map[string]any)
+		if got := recoveryDetailString(detail["decision_outcome"]); got != strings.TrimSpace(outcome) {
+			continue
+		}
+		if got := recoveryDetailString(detail["decision_reason_code"]); got != strings.TrimSpace(reason) {
+			continue
+		}
+		return entry
+	}
+	t.Fatalf("missing recovery aftermath log for event=%q outcome=%q reason=%q in %#v", eventID, outcome, reason, logs)
+	return runtimepipeline.RuntimeLogEntry{}
 }
 
 func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
@@ -173,6 +217,18 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	if receiptStatus != "success" {
 		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
 	}
+	logEntry := findRecoveryAftermathLog(t, capture.logs, childID, "replayed", "persisted_recipients_replayed")
+	if logEntry.Level != "info" {
+		t.Fatalf("recovery aftermath level = %q, want info", logEntry.Level)
+	}
+	if logEntry.EventType != string(child.Type) {
+		t.Fatalf("recovery aftermath event_type = %q, want %q", logEntry.EventType, child.Type)
+	}
+	detail, _ := logEntry.Detail.(map[string]any)
+	recipients, _ := detail["persisted_recipients"].([]string)
+	if len(recipients) != 1 || recipients[0] != recipientID {
+		t.Fatalf("persisted_recipients = %#v, want [%q]", detail["persisted_recipients"], recipientID)
+	}
 }
 
 func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing.T) {
@@ -264,6 +320,13 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	}
 	if badReason != "pipeline_error" {
 		t.Fatalf("bad receipt reason = %q, want pipeline_error", badReason)
+	}
+	logEntry := findRecoveryAftermathLog(t, capture.logs, badEventID, "dropped", "replay_quarantined")
+	if logEntry.Level != "warn" {
+		t.Fatalf("recovery aftermath level = %q, want warn", logEntry.Level)
+	}
+	if got := strings.TrimSpace(logEntry.Error); got == "" {
+		t.Fatal("expected dropped recovery aftermath log to carry explicit error text")
 	}
 }
 
@@ -410,6 +473,75 @@ func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 	if receiptStatus != "success" {
 		t.Fatalf("pipeline receipt outcome = %q, want success", receiptStatus)
 	}
+	findRecoveryAftermathLog(t, publisher.logs, childID, "skipped", "replay_claim_not_acquired")
+}
+
+func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	childID := uuid.NewString()
+
+	parent := events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}
+	child := events.Event{
+		ID:            childID,
+		Type:          events.EventType("system.recover.no_recipients"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-1 * time.Minute).UTC(),
+	}
+
+	if err := pg.AppendEvent(ctx, parent); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, child); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 0 {
+		t.Fatalf("direct replayed events = %#v, want none", capture.direct)
+	}
+
+	var receiptStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, childID).Scan(&receiptStatus); err != nil {
+		t.Fatalf("load child receipt: %v", err)
+	}
+	if receiptStatus != "success" {
+		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
+	}
+	findRecoveryAftermathLog(t, capture.logs, childID, "skipped", "no_persisted_recipients")
 }
 
 func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions(t *testing.T) {


### PR DESCRIPTION
Closes #321

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`

## Human Summary

This PR closes the chosen `#321` child class by making startup pipeline replay of persisted undelivered events emit one canonical runtime-owned aftermath record for replayed, skipped, and dropped outcomes. Operators can now read the same truth through the canonical runtime-log observability surface instead of inferring recovery meaning from partial receipts or aggregate startup summaries.

## What Changed

- Added one canonical recovery-aftermath runtime log in `RecoveryManager.Recover(...)` for the startup pipeline-replay family.
- Made the owner emit explicit replay/skip/drop diagnostics for:
  - replayed persisted recipients
  - skipped replay because replay ownership was already claimed elsewhere
  - skipped replay because no persisted recipients exist
  - dropped/quarantined replay because replay cannot proceed
- Added owner-path tests for replayed, skipped, dropped, and zero-recipient skip branches.
- Added startup consumer proof that `AgentManager.Recover(...)` consumes the same owner.
- Added supported-surface proof that `SQLObservabilityReader.ListRuntimeLogs(...)` round-trips the same replay/skip/drop truth.

## Why This Is Needed

Before this change, startup pipeline replay decisions were split across recovery execution, durable delivery facts, and partial startup summaries. That left operators without one canonical runtime-owned story for what restart recovery actually replayed, skipped, or dropped for persisted undelivered events.

## Scope Boundaries

In scope:
- startup pipeline replay of persisted undelivered events through `internal/runtime/pipeline/coordinator_recovery.go: RecoveryManager.Recover(...)`
- the runtime-owned replay/skip/drop aftermath owner for that child class
- the supported runtime-log observability reader surface for that child class

Out of scope:
- startup admission / execution-summary diagnostics already closed by `#179` / `#312`
- reset/restart orphan-aftermath diagnostics already closed by `#314` / `#316`
- timer replay/drop recovery aftermath
- manager backlog replay / in-flight recovery invariants
- broad observability redesign

## Tests Run

- `go test ./internal/runtime/pipeline -run 'TestRecoveryManager_(ReplaysPersistedCorrelationEnvelope|QuarantinesMissingPersistedRunIDAndContinues|ClaimsReplayOwnershipUnderOverlap|ExplicitlySkipsReplayWithoutPersistedRecipients)$' -count=1`
- `go test ./internal/runtime/manager -run 'TestRecover_(RestoresPersistedFlowInstanceRoutes|UsesCanonicalLoadedAgentMetadata|UsesCanonicalPipelineReplayAftermathDiagnostics)$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(StartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityReader|StartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader|ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime/conformance ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

This PR intentionally closes only the startup pipeline-replay replay/skip/drop child class. The broader `recovery_restart_diagnostics` parent still has remaining sibling work for timer replay/drop aftermath and manager backlog / in-flight recovery invariants.

## Follow-Up

- Parent watchlist node `recovery_restart_diagnostics` remains open.
- The remaining child-slice tail is still estimated at `1-2` slices:
  - timer replay/drop recovery aftermath diagnostics
  - manager backlog replay / in-flight recovery invariants
