### PR TITLE
[agent-b][issue #126] Extract event topology bootverify checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -208,15 +208,6 @@ func newCheckerContext(ctx context.Context, source semanticview.Source, opts Opt
 	}
 }
 
-func checkEventChainIntegrity(c *checkerContext) []Finding {
-	return c.eventWarningsByCheck("event_chain_integrity")
-}
-func checkEventConsumerExists(c *checkerContext) []Finding {
-	return c.eventWarningsByCheck("event_consumer_exists")
-}
-func checkEventProducerExists(c *checkerContext) []Finding {
-	return c.eventWarningsByCheck("event_producer_exists")
-}
 func checkPayloadFieldCoverage(c *checkerContext) []Finding       { return c.payloadFieldCoverage() }
 func checkStateMachineCoherence(c *checkerContext) []Finding      { return c.stateMachineCoherence() }
 func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.requiredAgentsMatch() }
@@ -226,7 +217,6 @@ func checkPromptExists(c *checkerContext) []Finding               { return c.pro
 func checkProducesDrift(c *checkerContext) []Finding              { return c.producesDrift() }
 func checkInvalidFieldDetection(c *checkerContext) []Finding      { return c.invalidFieldDetection() }
 func checkPolicyConflictDetection(c *checkerContext) []Finding    { return c.policyConflicts() }
-func checkEventCycleDetection(c *checkerContext) []Finding        { return c.eventCycleDetection() }
 func checkDialectCompliance(c *checkerContext) []Finding          { return c.dialectCompliance() }
 func checkNativeToolsValid(c *checkerContext) []Finding           { return c.nativeTools() }
 func checkPlatformNamespaceViolation(c *checkerContext) []Finding { return c.platformNamespace() }
@@ -240,17 +230,6 @@ func checkPhantomProduces(c *checkerContext) []Finding            { return c.pha
 func checkPlatformMetadataValidation(c *checkerContext) []Finding { return c.platformMetadata() }
 func checkGateSchemaValidation(c *checkerContext) []Finding       { return c.gateSchemaValidation() }
 func checkDeprecatedContractAlias(c *checkerContext) []Finding    { return c.deprecatedAliases() }
-
-func (c *checkerContext) eventWarningsByCheck(checkID string) []Finding {
-	items := c.eventWarnings()
-	out := make([]Finding, 0)
-	for _, finding := range items {
-		if finding.CheckID == checkID {
-			out = append(out, finding)
-		}
-	}
-	return out
-}
 
 func (c *checkerContext) permissions() []Finding {
 	if c.permissionLoaded {
@@ -491,208 +470,6 @@ func (c *checkerContext) policyConflicts() []Finding {
 	return c.policyFindings
 }
 
-func (c *checkerContext) eventWarnings() []Finding {
-	if c.eventWarningLoaded {
-		return c.eventWarningFindings
-	}
-	c.eventWarningLoaded = true
-	emittedRefs := map[string]semanticview.FlowEventProof{}
-	subscribedRefs := map[string]semanticview.FlowEventProof{}
-	subscriptionPatterns := map[string]eventPatternLocal{}
-	for _, scope := range c.source.FlowScopes() {
-		if eventType := strings.TrimSpace(scope.AutoEmitEvent); eventType != "" {
-			addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
-		}
-		for _, eventType := range scope.InputEvents {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
-			}
-		}
-		for _, required := range c.source.FlowRequiredAgents(scope.ID) {
-			for _, eventType := range required.Emits {
-				addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
-			}
-			for _, eventType := range required.SubscribesTo {
-				eventType = strings.TrimSpace(eventType)
-				if eventType == "" {
-					continue
-				}
-				if strings.Contains(eventType, "*") {
-					addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
-				} else {
-					addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
-				}
-			}
-		}
-	}
-	for _, required := range c.source.RequiredAgents() {
-		for _, eventType := range required.Emits {
-			addEventProofLocal(emittedRefs, c.source, "", eventType)
-		}
-		for _, eventType := range required.SubscribesTo {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, "", eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, "", eventType)
-			}
-		}
-	}
-	for nodeID, node := range c.source.NodeEntries() {
-		nodeSource, _ := c.source.NodeContractSource(nodeID)
-		flowID := strings.TrimSpace(nodeSource.FlowID)
-		for _, eventType := range node.SubscribesTo {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
-			}
-		}
-		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
-			}
-			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
-			if !ok {
-				continue
-			}
-			for _, emitted := range handlerEmits(handler) {
-				addEventProofLocal(emittedRefs, c.source, flowID, emitted)
-			}
-		}
-		for _, timer := range node.Timers {
-			addEventProofLocal(emittedRefs, c.source, flowID, strings.TrimSpace(timer.Event))
-		}
-	}
-	for agentID, agent := range c.source.AgentEntries() {
-		agentSource, _ := c.source.AgentContractSource(agentID)
-		flowID := strings.TrimSpace(agentSource.FlowID)
-		for _, eventType := range agent.EmitEvents {
-			addEventProofLocal(emittedRefs, c.source, flowID, eventType)
-		}
-		for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
-			}
-		}
-	}
-	for _, key := range sortedSetKeysLocal(emittedRefs) {
-		ref := emittedRefs[key]
-		if !ref.HasSchema {
-			if strings.HasPrefix(ref.DisplayName(), "timer.") || strings.HasPrefix(ref.DisplayName(), "platform.") {
-				continue
-			}
-			c.eventWarningFindings = append(c.eventWarningFindings, Finding{
-				CheckID:  "event_chain_integrity",
-				Severity: "warning",
-				Message:  fmt.Sprintf("'%s' emitted but no schema in events.yaml", ref.DisplayName()),
-				Location: ref.DisplayName(),
-			})
-			continue
-		}
-		if eventRefConsumedLocal(c.source, ref.Canonical, subscribedRefs, subscriptionPatterns) || len(c.source.RuntimeEventOwners(ref.Canonical)) > 0 || eventHasExternalConsumerLocal(ref.Entry) || ref.CrossesDeclaredOutputBoundary(c.source) {
-			continue
-		}
-		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
-			CheckID:  "event_consumer_exists",
-			Severity: "warning",
-			Message:  fmt.Sprintf("'%s' emitted but nobody subscribes", ref.Canonical),
-			Location: ref.Canonical,
-		})
-	}
-	for _, key := range sortedSetKeysLocal(subscribedRefs) {
-		ref := subscribedRefs[key]
-		if !ref.HasSchema {
-			continue
-		}
-		if eventRefProducedLocal(c.source, ref, emittedRefs) {
-			continue
-		}
-		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.Status), "planned") {
-			continue
-		}
-		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
-			CheckID:  "event_producer_exists",
-			Severity: "warning",
-			Message:  fmt.Sprintf("'%s' subscribed but nobody emits", ref.Canonical),
-			Location: ref.Canonical,
-		})
-	}
-	return c.eventWarningFindings
-}
-
-type eventPatternLocal struct {
-	FlowID string
-	Base   string
-}
-
-func addEventProofLocal(refs map[string]semanticview.FlowEventProof, source semanticview.Source, flowID, eventType string) {
-	ref := semanticview.ResolveFlowEventProof(source, flowID, eventType)
-	if strings.TrimSpace(ref.DisplayName()) == "" {
-		return
-	}
-	key := strings.TrimSpace(ref.FlowID) + "::" + ref.DisplayName()
-	refs[key] = ref
-}
-
-func addEventPatternLocal(refs map[string]eventPatternLocal, flowID, eventType string) {
-	eventType = strings.TrimSpace(eventType)
-	if eventType == "" {
-		return
-	}
-	ref := eventPatternLocal{Base: eventType, FlowID: strings.TrimSpace(flowID)}
-	key := ref.FlowID + "::" + ref.Base
-	refs[key] = ref
-}
-
-func eventRefConsumedLocal(source semanticview.Source, eventType string, subscribedRefs map[string]semanticview.FlowEventProof, patterns map[string]eventPatternLocal) bool {
-	for _, subscribed := range subscribedRefs {
-		if source.FlowEventMatches(subscribed.FlowID, subscribed.Authored, eventType) {
-			return true
-		}
-	}
-	for _, pattern := range patterns {
-		if source.FlowEventMatches(pattern.FlowID, pattern.Base, eventType) {
-			return true
-		}
-	}
-	return false
-}
-
-func eventRefProducedLocal(source semanticview.Source, ref semanticview.FlowEventProof, emittedRefs map[string]semanticview.FlowEventProof) bool {
-	for _, emitted := range emittedRefs {
-		if source.FlowEventMatches(ref.FlowID, ref.Authored, emitted.Canonical) {
-			return true
-		}
-	}
-	return false
-}
-
 func sortedSetKeysLocal[T any](m map[string]T) []string {
 	if len(m) == 0 {
 		return nil
@@ -703,21 +480,6 @@ func sortedSetKeysLocal[T any](m map[string]T) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-func eventHasExternalConsumerLocal(entry runtimecontracts.EventCatalogEntry) bool {
-	if len(entry.Consumer) > 0 || len(entry.ConsumerType) > 0 {
-		return true
-	}
-	return false
-}
-
-func eventProducedExternallyLocal(entry runtimecontracts.EventCatalogEntry) bool {
-	if len(entry.Producer) > 0 {
-		return true
-	}
-	source := strings.ToLower(strings.TrimSpace(entry.Source))
-	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
 }
 
 func (c *checkerContext) payloadFieldCoverage() []Finding {
@@ -1169,53 +931,6 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 	}
 	c.handlerFindings = append(c.handlerFindings, runtimeHandledEventsMissingExecutors(c.source)...)
 	return c.handlerFindings
-}
-
-func (c *checkerContext) eventCycleDetection() []Finding {
-	if c.cycleLoaded {
-		return c.cycleFindings
-	}
-	c.cycleLoaded = true
-	for nodeID := range c.source.NodeEntries() {
-		nodeID = strings.TrimSpace(nodeID)
-		nodeSource, _ := c.source.NodeContractSource(nodeID)
-		flowID := strings.TrimSpace(nodeSource.FlowID)
-		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			trigger := semanticview.ResolveFlowEventProof(c.source, flowID, eventType).EventKey()
-			if trigger == "" {
-				continue
-			}
-			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
-			if !ok {
-				continue
-			}
-			for _, emitted := range handlerEmits(handler) {
-				emitted = semanticview.ResolveFlowEventProof(c.source, flowID, emitted).EventKey()
-				if emitted == "" || emitted != trigger {
-					continue
-				}
-				c.cycleFindings = append(c.cycleFindings, Finding{
-					CheckID:  "event_cycle_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("node %s handler %s emits its own trigger event", nodeID, trigger),
-					Location: nodeID,
-				})
-			}
-		}
-	}
-	if err := detectEventCyclesSemanticModel(c.source); err != nil {
-		c.cycleFindings = append(c.cycleFindings, Finding{
-			CheckID:  "event_cycle_detection",
-			Severity: "error",
-			Message:  err.Error(),
-			Location: "global",
-		})
-	}
-	return uniqueFindings(c.cycleFindings)
 }
 
 func (c *checkerContext) requiredAgentsMatch() []Finding {
@@ -2484,46 +2199,6 @@ func handlerActionExecutable(source semanticview.Source, actionID string) bool {
 	}
 	entry, ok := source.ActionInstructionByID(actionID)
 	return ok && entry.Executable()
-}
-
-func detectEventCyclesSemanticModel(source semanticview.Source) error {
-	if source == nil {
-		return nil
-	}
-	graph := map[string]map[string]struct{}{}
-	for nodeID := range source.NodeEntries() {
-		nodeSource, _ := source.NodeContractSource(nodeID)
-		flowID := strings.TrimSpace(nodeSource.FlowID)
-		for _, eventType := range source.NodeHandlerSubscriptions(nodeID) {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" || strings.Contains(eventType, "*") {
-				continue
-			}
-			trigger := semanticview.ResolveFlowEventProof(source, flowID, eventType).EventKey()
-			if trigger == "" {
-				continue
-			}
-			handler, ok := source.NodeEventHandler(nodeID, eventType)
-			if !ok {
-				continue
-			}
-			for _, emitted := range handlerEmits(handler) {
-				emitted = semanticview.ResolveFlowEventProof(source, flowID, emitted).EventKey()
-				if emitted == "" || strings.Contains(emitted, "*") || emitted == trigger {
-					continue
-				}
-				if graph[trigger] == nil {
-					graph[trigger] = map[string]struct{}{}
-				}
-				graph[trigger][emitted] = struct{}{}
-			}
-		}
-	}
-	cycles := workflowFindEventCyclesLocal(graph)
-	if len(cycles) == 0 {
-		return nil
-	}
-	return fmt.Errorf("EVENT-CYCLE: node handler emit cycle: %s", strings.Join(cycles[0], " -> "))
 }
 
 func workflowFindEventCyclesLocal(graph map[string]map[string]struct{}) [][]string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -193,6 +193,95 @@ func TestRun_MapsEventNoProducerToNamedWarning(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnForEventConsumerExistsWhenCatalogDeclaresConsumerMetadata(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Platform: runtimecontracts.PlatformSpecDocument{},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"producer": {
+					"task.start": {Emits: runtimecontracts.EventEmission{Single: "task.done"}},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"producer": {
+				SubscribesTo: []string{"task.start"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.start": {
+						Emits: runtimecontracts.EventEmission{Single: "task.done"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.start": {Source: "external"},
+			"task.done":  {ConsumerType: []string{"dashboard"}},
+		},
+	}
+	bundle.Platform.Platform.Name = "test"
+	bundle.Platform.Platform.Version = "1.0.0"
+	source := semanticview.Wrap(bundle)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Warnings(), "event_consumer_exists", "task.done") {
+		t.Fatalf("unexpected event_consumer_exists warning with consumer metadata, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForEventProducerExistsWhenCatalogDeclaresExternalOrPlannedSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		entry runtimecontracts.EventCatalogEntry
+	}{
+		{
+			name:  "external source",
+			entry: runtimecontracts.EventCatalogEntry{Source: "external system"},
+		},
+		{
+			name:  "planned status",
+			entry: runtimecontracts.EventCatalogEntry{Status: "planned"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &runtimecontracts.WorkflowContractBundle{
+				Platform: runtimecontracts.PlatformSpecDocument{},
+				Semantics: runtimecontracts.WorkflowSemanticView{
+					NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+						"consumer": {
+							"task.requested": {},
+						},
+					},
+				},
+				Nodes: map[string]runtimecontracts.SystemNodeContract{
+					"consumer": {
+						SubscribesTo: []string{"task.requested"},
+						EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+							"task.requested": {},
+						},
+					},
+				},
+				Events: map[string]runtimecontracts.EventCatalogEntry{
+					"task.requested": tc.entry,
+				},
+			}
+			bundle.Platform.Platform.Name = "test"
+			bundle.Platform.Platform.Version = "1.0.0"
+			source := semanticview.Wrap(bundle)
+
+			report := Run(context.Background(), source, Options{})
+
+			if reportContains(report.Warnings(), "event_producer_exists", "task.requested") {
+				t.Fatalf("unexpected event_producer_exists warning for %s, got %#v", tc.name, report.Warnings())
+			}
+		})
+	}
+}
+
 func TestRun_MapsMissingPromptToPromptExistsWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-prompt-missing")
 
@@ -689,6 +778,47 @@ func TestRun_MapsSelfEmitToEventCycleDetectionForFlowLocalHandlers(t *testing.T)
 
 	if !reportContains(report.Errors(), "event_cycle_detection", "emits its own trigger event") {
 		t.Fatalf("expected event_cycle_detection error for flow-local handler, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsSemanticModelMultiHopEventCycle(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-self-emit")
+	bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+		"node-a": {
+			"task.a": {Emits: runtimecontracts.EventEmission{Single: "task.b"}},
+		},
+		"node-b": {
+			"task.b": {Emits: runtimecontracts.EventEmission{Single: "task.a"}},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"node-a": {
+			ID:           "node-a",
+			SubscribesTo: []string{"task.a"},
+			Produces:     []string{"task.b"},
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"task.a": {Emits: runtimecontracts.EventEmission{Single: "task.b"}},
+			},
+		},
+		"node-b": {
+			ID:           "node-b",
+			SubscribesTo: []string{"task.b"},
+			Produces:     []string{"task.a"},
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"task.b": {Emits: runtimecontracts.EventEmission{Single: "task.a"}},
+			},
+		},
+	}
+	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
+		"task.a": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"entity_id": {Type: "string"}}}},
+		"task.b": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"entity_id": {Type: "string"}}}},
+	}
+	source := semanticview.Wrap(bundle)
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "event_cycle_detection", "EVENT-CYCLE") {
+		t.Fatalf("expected semantic-model event_cycle_detection error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -1,0 +1,335 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkEventChainIntegrity(c *checkerContext) []Finding {
+	return c.eventWarningsByCheck("event_chain_integrity")
+}
+
+func checkEventConsumerExists(c *checkerContext) []Finding {
+	return c.eventWarningsByCheck("event_consumer_exists")
+}
+
+func checkEventProducerExists(c *checkerContext) []Finding {
+	return c.eventWarningsByCheck("event_producer_exists")
+}
+
+func checkEventCycleDetection(c *checkerContext) []Finding { return c.eventCycleDetection() }
+
+func (c *checkerContext) eventWarningsByCheck(checkID string) []Finding {
+	items := c.eventWarnings()
+	out := make([]Finding, 0)
+	for _, finding := range items {
+		if finding.CheckID == checkID {
+			out = append(out, finding)
+		}
+	}
+	return out
+}
+
+func (c *checkerContext) eventWarnings() []Finding {
+	if c.eventWarningLoaded {
+		return c.eventWarningFindings
+	}
+	c.eventWarningLoaded = true
+	emittedRefs := map[string]semanticview.FlowEventProof{}
+	subscribedRefs := map[string]semanticview.FlowEventProof{}
+	subscriptionPatterns := map[string]eventPatternLocal{}
+	for _, scope := range c.source.FlowScopes() {
+		if eventType := strings.TrimSpace(scope.AutoEmitEvent); eventType != "" {
+			addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
+		}
+		for _, eventType := range scope.InputEvents {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if strings.Contains(eventType, "*") {
+				addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
+			} else {
+				addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
+			}
+		}
+		for _, required := range c.source.FlowRequiredAgents(scope.ID) {
+			for _, eventType := range required.Emits {
+				addEventProofLocal(emittedRefs, c.source, scope.ID, eventType)
+			}
+			for _, eventType := range required.SubscribesTo {
+				eventType = strings.TrimSpace(eventType)
+				if eventType == "" {
+					continue
+				}
+				if strings.Contains(eventType, "*") {
+					addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
+				} else {
+					addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
+				}
+			}
+		}
+	}
+	for _, required := range c.source.RequiredAgents() {
+		for _, eventType := range required.Emits {
+			addEventProofLocal(emittedRefs, c.source, "", eventType)
+		}
+		for _, eventType := range required.SubscribesTo {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if strings.Contains(eventType, "*") {
+				addEventPatternLocal(subscriptionPatterns, "", eventType)
+			} else {
+				addEventProofLocal(subscribedRefs, c.source, "", eventType)
+			}
+		}
+	}
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range node.SubscribesTo {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if strings.Contains(eventType, "*") {
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+			} else {
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
+			}
+		}
+		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if strings.Contains(eventType, "*") {
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+			} else {
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
+			}
+			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				continue
+			}
+			for _, emitted := range handlerEmits(handler) {
+				addEventProofLocal(emittedRefs, c.source, flowID, emitted)
+			}
+		}
+		for _, timer := range node.Timers {
+			addEventProofLocal(emittedRefs, c.source, flowID, strings.TrimSpace(timer.Event))
+		}
+	}
+	for agentID, agent := range c.source.AgentEntries() {
+		agentSource, _ := c.source.AgentContractSource(agentID)
+		flowID := strings.TrimSpace(agentSource.FlowID)
+		for _, eventType := range agent.EmitEvents {
+			addEventProofLocal(emittedRefs, c.source, flowID, eventType)
+		}
+		for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if strings.Contains(eventType, "*") {
+				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+			} else {
+				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
+			}
+		}
+	}
+	for _, key := range sortedSetKeysLocal(emittedRefs) {
+		ref := emittedRefs[key]
+		if !ref.HasSchema {
+			if strings.HasPrefix(ref.DisplayName(), "timer.") || strings.HasPrefix(ref.DisplayName(), "platform.") {
+				continue
+			}
+			c.eventWarningFindings = append(c.eventWarningFindings, Finding{
+				CheckID:  "event_chain_integrity",
+				Severity: "warning",
+				Message:  fmt.Sprintf("'%s' emitted but no schema in events.yaml", ref.DisplayName()),
+				Location: ref.DisplayName(),
+			})
+			continue
+		}
+		if eventRefConsumedLocal(c.source, ref.Canonical, subscribedRefs, subscriptionPatterns) || len(c.source.RuntimeEventOwners(ref.Canonical)) > 0 || eventHasExternalConsumerLocal(ref.Entry) || ref.CrossesDeclaredOutputBoundary(c.source) {
+			continue
+		}
+		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
+			CheckID:  "event_consumer_exists",
+			Severity: "warning",
+			Message:  fmt.Sprintf("'%s' emitted but nobody subscribes", ref.Canonical),
+			Location: ref.Canonical,
+		})
+	}
+	for _, key := range sortedSetKeysLocal(subscribedRefs) {
+		ref := subscribedRefs[key]
+		if !ref.HasSchema {
+			continue
+		}
+		if eventRefProducedLocal(c.source, ref, emittedRefs) {
+			continue
+		}
+		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.Status), "planned") {
+			continue
+		}
+		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
+			CheckID:  "event_producer_exists",
+			Severity: "warning",
+			Message:  fmt.Sprintf("'%s' subscribed but nobody emits", ref.Canonical),
+			Location: ref.Canonical,
+		})
+	}
+	return c.eventWarningFindings
+}
+
+type eventPatternLocal struct {
+	FlowID string
+	Base   string
+}
+
+func addEventProofLocal(refs map[string]semanticview.FlowEventProof, source semanticview.Source, flowID, eventType string) {
+	ref := semanticview.ResolveFlowEventProof(source, flowID, eventType)
+	if strings.TrimSpace(ref.DisplayName()) == "" {
+		return
+	}
+	key := strings.TrimSpace(ref.FlowID) + "::" + ref.DisplayName()
+	refs[key] = ref
+}
+
+func addEventPatternLocal(refs map[string]eventPatternLocal, flowID, eventType string) {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return
+	}
+	ref := eventPatternLocal{Base: eventType, FlowID: strings.TrimSpace(flowID)}
+	key := ref.FlowID + "::" + ref.Base
+	refs[key] = ref
+}
+
+func eventRefConsumedLocal(source semanticview.Source, eventType string, subscribedRefs map[string]semanticview.FlowEventProof, patterns map[string]eventPatternLocal) bool {
+	for _, subscribed := range subscribedRefs {
+		if source.FlowEventMatches(subscribed.FlowID, subscribed.Authored, eventType) {
+			return true
+		}
+	}
+	for _, pattern := range patterns {
+		if source.FlowEventMatches(pattern.FlowID, pattern.Base, eventType) {
+			return true
+		}
+	}
+	return false
+}
+
+func eventRefProducedLocal(source semanticview.Source, ref semanticview.FlowEventProof, emittedRefs map[string]semanticview.FlowEventProof) bool {
+	for _, emitted := range emittedRefs {
+		if source.FlowEventMatches(ref.FlowID, ref.Authored, emitted.Canonical) {
+			return true
+		}
+	}
+	return false
+}
+
+func eventHasExternalConsumerLocal(entry runtimecontracts.EventCatalogEntry) bool {
+	return len(entry.Consumer) > 0 || len(entry.ConsumerType) > 0
+}
+
+func eventProducedExternallyLocal(entry runtimecontracts.EventCatalogEntry) bool {
+	if len(entry.Producer) > 0 {
+		return true
+	}
+	source := strings.ToLower(strings.TrimSpace(entry.Source))
+	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
+}
+
+func (c *checkerContext) eventCycleDetection() []Finding {
+	if c.cycleLoaded {
+		return c.cycleFindings
+	}
+	c.cycleLoaded = true
+	for nodeID := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			trigger := semanticview.ResolveFlowEventProof(c.source, flowID, eventType).EventKey()
+			if trigger == "" {
+				continue
+			}
+			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				continue
+			}
+			for _, emitted := range handlerEmits(handler) {
+				emitted = semanticview.ResolveFlowEventProof(c.source, flowID, emitted).EventKey()
+				if emitted == "" || emitted != trigger {
+					continue
+				}
+				c.cycleFindings = append(c.cycleFindings, Finding{
+					CheckID:  "event_cycle_detection",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s handler %s emits its own trigger event", nodeID, trigger),
+					Location: nodeID,
+				})
+			}
+		}
+	}
+	if err := detectEventCyclesSemanticModel(c.source); err != nil {
+		c.cycleFindings = append(c.cycleFindings, Finding{
+			CheckID:  "event_cycle_detection",
+			Severity: "error",
+			Message:  err.Error(),
+			Location: "global",
+		})
+	}
+	return uniqueFindings(c.cycleFindings)
+}
+
+func detectEventCyclesSemanticModel(source semanticview.Source) error {
+	if source == nil {
+		return nil
+	}
+	graph := map[string]map[string]struct{}{}
+	for nodeID := range source.NodeEntries() {
+		nodeSource, _ := source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range source.NodeHandlerSubscriptions(nodeID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" || strings.Contains(eventType, "*") {
+				continue
+			}
+			trigger := semanticview.ResolveFlowEventProof(source, flowID, eventType).EventKey()
+			if trigger == "" {
+				continue
+			}
+			handler, ok := source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				continue
+			}
+			for _, emitted := range handlerEmits(handler) {
+				emitted = semanticview.ResolveFlowEventProof(source, flowID, emitted).EventKey()
+				if emitted == "" || strings.Contains(emitted, "*") || emitted == trigger {
+					continue
+				}
+				if graph[trigger] == nil {
+					graph[trigger] = map[string]struct{}{}
+				}
+				graph[trigger][emitted] = struct{}{}
+			}
+		}
+	}
+	cycles := workflowFindEventCyclesLocal(graph)
+	if len(cycles) == 0 {
+		return nil
+	}
+	return fmt.Errorf("EVENT-CYCLE: node handler emit cycle: %s", strings.Join(cycles[0], " -> "))
+}


### PR DESCRIPTION
Part of #126

## Human Summary
Extract the event-topology / event-catalog integrity bootverify cluster out of the monolithic checks file into its own boundary-owned module, and add direct `Run(...)` proofs for the weakest remaining event-topology manifestations in that cluster.

## What Changed
- moved the event-topology / event-catalog integrity cluster out of `internal/runtime/bootverify/checks.go` into `internal/runtime/bootverify/workflow_event_topology_checks.go`
- kept the existing registry/report/startup surface unchanged
- moved the concept-local helpers with the cluster:
  - `eventWarningsByCheck(...)`
  - `eventWarnings()`
  - `addEventProofLocal(...)`
  - `addEventPatternLocal(...)`
  - `eventRefConsumedLocal(...)`
  - `eventRefProducedLocal(...)`
  - `eventHasExternalConsumerLocal(...)`
  - `eventProducedExternallyLocal(...)`
  - `eventCycleDetection()`
  - `detectEventCyclesSemanticModel(...)`
- added direct report-surface coverage for:
  - multi-hop semantic-model event cycles
  - event-catalog consumer metadata suppressing `event_consumer_exists`
  - external/planned producer metadata suppressing `event_producer_exists`
- preserved the existing warning/no-warning proofs for:
  - missing schema
  - missing consumer
  - missing producer
  - self-emit cycle detection
  - localized flow event routing / flow-owned outputs

## Why This Is Needed
`#126` is still decomposing the bootverify startup gate by honest concept boundaries instead of helper adjacency. Event-topology / event-catalog integrity was still a coherent live cluster inside `checks.go`, and its direct `Run(...)` proof was weaker than the already-extracted slices.

## Scope Boundaries
- this PR closes the event-topology / event-catalog integrity child class only
- it does not close umbrella issue `#126`
- it does not absorb the event-declaration drift cluster (`produces_drift`, `phantom_produces`)
- it does not redesign runtime event routing or catalog semantics outside bootverify maintenance

## Spec References
- none; this is non-semantic maintenance
- justification: the change decomposes the startup verification boundary and adds direct regression proof without changing platform contract semantics

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsEventNoSchemaToEventChainIntegrityWarning|MapsEventNoConsumerToNamedWarning|MapsEventNoProducerToNamedWarning|DoesNotWarnForEventConsumerExistsWhenCatalogDeclaresConsumerMetadata|DoesNotWarnForEventProducerExistsWhenCatalogDeclaresExternalOrPlannedSource|MapsSelfEmitToEventCycleDetection|MapsSelfEmitToEventCycleDetectionForFlowLocalHandlers|ReportsSemanticModelMultiHopEventCycle|DoesNotWarnForLocalizedCrossFlowEventRouting|DoesNotWarnForFlowLocalEmittedEventsWithOwningFlowSchemas|DoesNotWarnForFlowOwnedAgentEmissionsDeclaredAsFlowOutputs)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
- the remaining `#126` tail still contains adjacent event-declaration drift checks (`produces_drift`, `phantom_produces`) and broader handler/runtime/platform tails, so helper adjacency in `checks.go` can still look like shared semantics until those child classes are pressure-tested directly

## Follow-Up
- continue `#126` with the remaining parent tail tracked on the umbrella issue
- current remaining child-slice estimate after this PR:
  - entity-target / state-schema coverage
  - handler/runtime contract compliance
  - event declaration drift
  - platform/tooling/environment verification tail
