### PR TITLE
[agent-e][issue #325] Preserve replay scope across crash recovery

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -123,12 +123,14 @@ nodes:
     known_manifestations:
       - direct-recipient delivery as a shadow semantic path
       - descriptor-aware recipient policy can silently exclude non-agent in-memory subscribers such as startup control-plane checks, workflow-runtime, and system-node subscribers when publish planning treats all recipients as active-agent descriptors
+      - crash/restart replay can drift direct-vs-subscribed recipient scope unless the committed event carries one durable authoritative replay-scope owner
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
     representative_issues:
       - 112
       - 144
       - 145
+      - 325
     common_framing_mistakes:
       too_broad:
         - delivery is flaky

--- a/internal/runtime/bus/committed_replay_scope.go
+++ b/internal/runtime/bus/committed_replay_scope.go
@@ -1,0 +1,63 @@
+package bus
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/events"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+)
+
+func (eb *EventBus) authoritativeReplayScopeForEvent(ctx context.Context, eventID string) (runtimereplayclaim.CommittedReplayScope, error) {
+	reader, ok := eb.store.(runtimereplayclaim.ScopeReader)
+	if !ok || reader == nil {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	scope, err := reader.LoadCommittedReplayScope(ctx, eventID)
+	if err != nil {
+		return "", err
+	}
+	switch scope {
+	case runtimereplayclaim.CommittedReplayScopeDirect, runtimereplayclaim.CommittedReplayScopeSubscribed:
+		return scope, nil
+	default:
+		return "", fmt.Errorf("authoritative replay scope: unsupported scope %q", strings.TrimSpace(string(scope)))
+	}
+}
+
+func (eb *EventBus) currentInternalRecipientsForCommittedEvent(ctx context.Context, evt events.Event) ([]string, error) {
+	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	if err != nil {
+		return nil, err
+	}
+	return filterOutAgentIDs(plan.Recipients, plan.PersistedRecipients), nil
+}
+
+func (eb *EventBus) replayRecipientsForCommittedEvent(
+	ctx context.Context,
+	evt events.Event,
+	persisted []string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) ([]string, []string, error) {
+	persisted = uniqueStrings(persisted)
+	switch scope {
+	case runtimereplayclaim.CommittedReplayScopeDirect:
+		return persisted, nil, nil
+	case runtimereplayclaim.CommittedReplayScopeSubscribed:
+		internal, err := eb.currentInternalRecipientsForCommittedEvent(ctx, evt)
+		if err != nil {
+			return nil, nil, err
+		}
+		live := uniqueStrings(append(append([]string(nil), persisted...), internal...))
+		return live, internal, nil
+	default:
+		return nil, nil, fmt.Errorf("replay recipients: unsupported scope %q", strings.TrimSpace(string(scope)))
+	}
+}
+
+func replayScopePersistenceRequired(store any) bool {
+	_, hasLister := store.(runtimereplayclaim.Lister)
+	_, hasOwner := store.(runtimereplayclaim.Owner)
+	return hasLister && hasOwner
+}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -14,6 +14,7 @@ import (
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type pipelineTransitionSchemaCapabilityProvider interface {
@@ -100,7 +101,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		}
 		persisted = true
 	} else {
-		if err := eb.persistEventRecord(ictx, evt, nil); err != nil {
+		if err := eb.persistEventRecord(ictx, evt, nil, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 			return err
 		}
 		persisted = true
@@ -166,6 +167,13 @@ func (eb *EventBus) publishTransactional(
 		if err := txStore.InsertEventDeliveriesTx(txctx, tx, evt.ID, inboundPlan.PersistedRecipients); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
+	}
+	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
+		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+			return fmt.Errorf("persist committed replay scope: %w", err)
+		}
+	} else if replayScopePersistenceRequired(eb.store) {
+		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
 	}
 
 	passthrough, deferred, err := eb.runInterceptors(txctx, evt)
@@ -299,7 +307,7 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		return err
 	}
 	eb.recordPublishDiagnostic(ctx, evt, plan)
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
+	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
 	}
 	persisted = true
@@ -387,7 +395,7 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 		return err
 	}
 	eb.recordPublishDiagnostic(ctx, evt, plan)
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
+	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
 	}
 	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
@@ -408,22 +416,50 @@ func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error
 	return nil
 }
 
-func (eb *EventBus) persistEventRecord(ctx context.Context, evt events.Event, recipients []string) error {
+func (eb *EventBus) persistEventRecord(
+	ctx context.Context,
+	evt events.Event,
+	recipients []string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
 	recipients = uniqueStrings(recipients)
+	if atomicStore, ok := eb.store.(AtomicEventReplayScopePersistence); ok {
+		if err := atomicStore.PersistEventWithDeliveriesAndScope(ctx, evt, recipients, scope); err != nil {
+			return fmt.Errorf("persist event transaction: %w", err)
+		}
+		return nil
+	}
 	if atomicStore, ok := eb.store.(AtomicEventPersistence); ok {
 		if err := atomicStore.PersistEventWithDeliveries(ctx, evt, recipients); err != nil {
 			return fmt.Errorf("persist event transaction: %w", err)
+		}
+		if scopeWriter, ok := eb.store.(EventReplayScopePersistence); ok && scopeWriter != nil {
+			if err := scopeWriter.UpsertCommittedReplayScope(ctx, evt.ID, scope); err != nil {
+				return fmt.Errorf("persist committed replay scope: %w", err)
+			}
+			return nil
+		}
+		if replayScopePersistenceRequired(eb.store) {
+			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
 		}
 		return nil
 	}
 	if err := eb.store.AppendEvent(ctx, evt); err != nil {
 		return fmt.Errorf("persist event: %w", err)
 	}
-	if len(recipients) == 0 {
+	if len(recipients) > 0 {
+		if err := eb.store.InsertEventDeliveries(ctx, evt.ID, recipients); err != nil {
+			return fmt.Errorf("persist event deliveries: %w", err)
+		}
+	}
+	if scopeWriter, ok := eb.store.(EventReplayScopePersistence); ok && scopeWriter != nil {
+		if err := scopeWriter.UpsertCommittedReplayScope(ctx, evt.ID, scope); err != nil {
+			return fmt.Errorf("persist committed replay scope: %w", err)
+		}
 		return nil
 	}
-	if err := eb.store.InsertEventDeliveries(ctx, evt.ID, recipients); err != nil {
-		return fmt.Errorf("persist event deliveries: %w", err)
+	if replayScopePersistenceRequired(eb.store) {
+		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
 	}
 	return nil
 }
@@ -618,7 +654,7 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	if err != nil {
 		return err
 	}
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients); err != nil {
+	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		return err
 	}
 	persisted = true
@@ -638,17 +674,14 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	return nil
 }
 
-// PublishPersistedRecipients delivers an already-persisted authoritative
-// recipient manifest without re-running direct recipient planning.
+// PublishPersistedRecipients delivers an already-committed event using the
+// persisted agent manifest plus the authoritative committed replay scope.
 func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
 	recipients = uniqueStrings(recipients)
-	if len(recipients) == 0 {
-		return errors.New("persisted recipients are required")
-	}
 	if evt.Type == "" {
 		return errors.New("event type is required")
 	}
@@ -661,16 +694,34 @@ func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.E
 	if evt.CreatedAt.IsZero() {
 		evt.CreatedAt = time.Now()
 	}
-	if err := eb.deliverToAgents(ctx, evt, recipients); err != nil {
+	scope, err := eb.authoritativeReplayScopeForEvent(ctx, evt.ID)
+	if err != nil {
 		return err
 	}
+	liveRecipients, internalRecipients, err := eb.replayRecipientsForCommittedEvent(ctx, evt, recipients, scope)
+	if err != nil {
+		return err
+	}
+	if len(liveRecipients) == 0 {
+		return nil
+	}
+	if err := eb.deliverToAgents(ctx, evt, liveRecipients); err != nil {
+		return err
+	}
+	owner := "event_deliveries"
+	if scope == runtimereplayclaim.CommittedReplayScopeSubscribed {
+		owner = "event_deliveries+committed_replay_scope"
+	}
 	eb.logRuntime(ctx, "debug", "Persisted event was delivered to authoritative recipients", "eventbus", "delivered", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
-		"direct":                     true,
-		"delivery_manifest_owner":    "event_deliveries",
-		"recipients_count":           len(recipients),
+		"direct":                     scope == runtimereplayclaim.CommittedReplayScopeDirect,
+		"delivery_manifest_owner":    owner,
+		"recipients_count":           len(liveRecipients),
 		"parent_event_id":            strings.TrimSpace(evt.ParentEventID),
-		"requested_recipients":       append([]string(nil), recipients...),
-		"requested_recipients_count": len(recipients),
+		"requested_recipients":       append([]string(nil), liveRecipients...),
+		"requested_recipients_count": len(liveRecipients),
+		"persisted_recipients":       append([]string(nil), recipients...),
+		"internal_recipients":        append([]string(nil), internalRecipients...),
+		"replay_scope":               string(scope),
 	}, "", 0)
 	return nil
 }

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -15,10 +15,12 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/flowmodel"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -178,6 +180,11 @@ type descriptorAwareEventStore struct {
 	listErr     error
 }
 
+type replayCapableAtomicStoreMissingScope struct {
+	mu         sync.Mutex
+	deliveries []string
+}
+
 func (*descriptorAwareEventStore) AppendEvent(context.Context, events.Event) error { return nil }
 
 func (s *descriptorAwareEventStore) InsertEventDeliveries(_ context.Context, _ string, agentIDs []string) error {
@@ -202,6 +209,35 @@ func (s *descriptorAwareEventStore) persistedDeliveries() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.deliveries...)
+}
+
+func (*replayCapableAtomicStoreMissingScope) AppendEvent(context.Context, events.Event) error {
+	return nil
+}
+
+func (s *replayCapableAtomicStoreMissingScope) InsertEventDeliveries(_ context.Context, _ string, agentIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveries = append([]string(nil), agentIDs...)
+	return nil
+}
+
+func (s *replayCapableAtomicStoreMissingScope) PersistEventWithDeliveries(ctx context.Context, evt events.Event, agentIDs []string) error {
+	return s.InsertEventDeliveries(ctx, evt.ID, agentIDs)
+}
+
+func (s *replayCapableAtomicStoreMissingScope) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deliveries...), nil
+}
+
+func (*replayCapableAtomicStoreMissingScope) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return nil, nil
+}
+
+func (*replayCapableAtomicStoreMissingScope) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	return nil, false, nil
 }
 
 func waitForNoEvent(t *testing.T, ch <-chan events.Event) {
@@ -309,6 +345,25 @@ func TestEventBusPublish_PayloadValidatorFailureAbortsPublish(t *testing.T) {
 	})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
+	}
+}
+
+func TestEventBusPublish_FailsClosedWhenReplayCapableAtomicStoreOmitsCommittedReplayScope(t *testing.T) {
+	store := &replayCapableAtomicStoreMissingScope{}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	eb.Subscribe("agent-a", events.EventType("custom.replay.checked"))
+
+	err = eb.Publish(context.Background(), events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("custom.replay.checked"),
+		Payload:   []byte(`{"ok":true}`),
+		CreatedAt: time.Now().UTC(),
+	})
+	if !errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
+		t.Fatalf("Publish error = %v, want missing committed replay scope", err)
 	}
 }
 

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -64,6 +64,13 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if err := txStore.InsertEventDeliveriesTx(ctx, tx, intent.Event.ID, recipients); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
+		if scopeWriter, ok := o.bus.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
+			if err := scopeWriter.UpsertCommittedReplayScopeTx(ctx, tx, intent.Event.ID, replayScopeForEmitIntent(*intent)); err != nil {
+				return fmt.Errorf("persist committed replay scope: %w", err)
+			}
+		} else if replayScopePersistenceRequired(o.bus.store) {
+			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		}
 		o.bus.setPendingInternalRecipients(intent.Event.ID, internalRecipients)
 	}
 	return nil
@@ -180,6 +187,13 @@ func normalizeOutboxEvent(evt events.Event) events.Event {
 		evt.CreatedAt = time.Now().UTC()
 	}
 	return evt
+}
+
+func replayScopeForEmitIntent(intent runtimeengine.EmitIntent) runtimereplayclaim.CommittedReplayScope {
+	if len(intent.Recipients) > 0 {
+		return runtimereplayclaim.CommittedReplayScopeDirect
+	}
+	return runtimereplayclaim.CommittedReplayScopeSubscribed
 }
 
 func (eb *EventBus) setPendingInternalRecipients(eventID string, recipients []string) {

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -73,6 +73,18 @@ type AtomicEventPersistence interface {
 	PersistEventWithDeliveries(ctx context.Context, evt events.Event, agentIDs []string) error
 }
 
+type AtomicEventReplayScopePersistence interface {
+	PersistEventWithDeliveriesAndScope(ctx context.Context, evt events.Event, agentIDs []string, scope runtimereplayclaim.CommittedReplayScope) error
+}
+
+type EventReplayScopePersistence interface {
+	UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
+}
+
+type TransactionalEventReplayScopePersistence interface {
+	UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
+}
+
 // TransactionalEventStore is an optional capability for full publish-time
 // transactional semantics: interceptor state writes + event persistence +
 // deferred event persistence in one DB transaction.

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	runtimeengine "swarm/internal/runtime/engine"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
@@ -93,7 +92,6 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if err != nil {
 		return 0, err
 	}
-	dispatcher := engineDispatcher{bus: eb}
 	redelivered := 0
 	for _, record := range events {
 		evt := record.Event
@@ -115,8 +113,7 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			_ = lease.Release(ctx)
 			return redelivered, err
 		}
-		intent := runtimeengine.EmitIntent{Event: evt, Recipients: recipients}
-		if err := dispatcher.dispatchIntent(ctx, intent); err != nil {
+		if err := eb.PublishPersistedRecipients(ctx, evt, recipients); err != nil {
 			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
 				eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
 			}

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -9,11 +9,13 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type sweeperTestStore struct {
 	events      []events.PersistedReplayEvent
 	deliveries  map[string][]string
+	scopes      map[string]runtimereplayclaim.CommittedReplayScope
 	receipts    map[string]string
 	receiptErrs map[string]string
 	claimMu     sync.Mutex
@@ -47,6 +49,13 @@ func (s *sweeperTestStore) ListEventsMissingPipelineReceipt(context.Context, tim
 }
 func (s *sweeperTestStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
 	return append([]string(nil), s.deliveries[eventID]...), nil
+}
+func (s *sweeperTestStore) LoadCommittedReplayScope(_ context.Context, eventID string) (runtimereplayclaim.CommittedReplayScope, error) {
+	scope, ok := s.scopes[eventID]
+	if !ok {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	return scope, nil
 }
 func (s *sweeperTestStore) ClaimPipelineReplay(_ context.Context, eventID string) (runtimeownership.Lease, bool, error) {
 	s.claimMu.Lock()
@@ -107,6 +116,7 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 			}).WithEntityID("ent-1")},
 		},
 		deliveries: map[string][]string{"evt-1": {"agent-a"}},
+		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-1": runtimereplayclaim.CommittedReplayScopeSubscribed},
 	}
 	eb, err := runtimebus.NewEventBus(store)
 	if err != nil {
@@ -145,6 +155,7 @@ func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback
 			}).WithEntityID("ent-2")},
 		},
 		deliveries: map[string][]string{},
+		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-2": runtimereplayclaim.CommittedReplayScopeDirect},
 	}
 	eb, err := runtimebus.NewEventBus(store)
 	if err != nil {
@@ -163,6 +174,164 @@ func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
 	waitForNoEvent(t, ch)
+}
+
+func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-internal-only",
+				Type:      events.EventType("custom.internal"),
+				Payload:   []byte(`{"entity_id":"ent-internal"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-internal")},
+		},
+		deliveries: map[string][]string{},
+		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-internal-only": runtimereplayclaim.CommittedReplayScopeSubscribed},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.internal"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	if got := store.receipts["evt-internal-only"]; got != "processed" {
+		t.Fatalf("receipt status = %q, want processed", got)
+	}
+	select {
+	case evt := <-internalCh:
+		if evt.ID != "evt-internal-only" {
+			t.Fatalf("delivered event id = %q, want evt-internal-only", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal subscriber to receive replayed event")
+	}
+}
+
+func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-mixed",
+				Type:      events.EventType("custom.mixed"),
+				Payload:   []byte(`{"entity_id":"ent-mixed"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-mixed")},
+		},
+		deliveries: map[string][]string{"evt-mixed": {"agent-a"}},
+		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-mixed": runtimereplayclaim.CommittedReplayScopeSubscribed},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.mixed"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.mixed"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	select {
+	case evt := <-internalCh:
+		if evt.ID != "evt-mixed" {
+			t.Fatalf("internal delivered event id = %q, want evt-mixed", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal subscriber to receive replayed event")
+	}
+	select {
+	case evt := <-agentCh:
+		if evt.ID != "evt-mixed" {
+			t.Fatalf("agent delivered event id = %q, want evt-mixed", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected persisted agent to receive replayed event")
+	}
+}
+
+func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-direct-mixed",
+				Type:      events.EventType("custom.direct"),
+				Payload:   []byte(`{"entity_id":"ent-direct"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-direct")},
+		},
+		deliveries: map[string][]string{"evt-direct-mixed": {"agent-a"}},
+		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
+			"evt-direct-mixed": runtimereplayclaim.CommittedReplayScopeDirect,
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.direct"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.direct"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	select {
+	case evt := <-agentCh:
+		if evt.ID != "evt-direct-mixed" {
+			t.Fatalf("agent delivered event id = %q, want evt-direct-mixed", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected direct persisted agent recipient to receive replayed event")
+	}
+	waitForNoEvent(t, internalCh)
+}
+
+func TestSweepUndispatched_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: (events.Event{
+				ID:        "evt-direct-empty",
+				Type:      events.EventType("custom.direct.empty"),
+				Payload:   []byte(`{"entity_id":"ent-direct-empty"}`),
+				CreatedAt: time.Now().UTC(),
+			}).WithEntityID("ent-direct-empty")},
+		},
+		deliveries: map[string][]string{},
+		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
+			"evt-direct-empty": runtimereplayclaim.CommittedReplayScopeDirect,
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.direct.empty"))
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	if got := store.receipts["evt-direct-empty"]; got != "processed" {
+		t.Fatalf("receipt status = %q, want processed", got)
+	}
+	waitForNoEvent(t, internalCh)
 }
 
 func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
@@ -186,6 +355,7 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 			},
 		},
 		deliveries: map[string][]string{"evt-good": {"agent-good"}},
+		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-good": runtimereplayclaim.CommittedReplayScopeSubscribed},
 	}
 	eb, err := runtimebus.NewEventBus(store)
 	if err != nil {
@@ -230,6 +400,7 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 			}).WithEntityID("ent-claim")},
 		},
 		deliveries:  map[string][]string{"evt-claim": {"agent-claim"}},
+		scopes:      map[string]runtimereplayclaim.CommittedReplayScope{"evt-claim": runtimereplayclaim.CommittedReplayScopeSubscribed},
 		releaseGate: make(chan struct{}),
 		releasing:   make(chan struct{}, 1),
 	}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -23,6 +23,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	runtimesemanticview "swarm/internal/runtime/semanticview"
 	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -632,6 +633,9 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 	if err := pg.InsertEventDeliveries(ctx, replayChildID, []string{replayRecipient}); err != nil {
 		t.Fatalf("InsertEventDeliveries(replay child): %v", err)
 	}
+	if err := pg.UpsertCommittedReplayScope(ctx, replayChildID, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+		t.Fatalf("UpsertCommittedReplayScope(replay child): %v", err)
+	}
 	if err := pg.UpsertPipelineReceipt(ctx, replayParentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(replay parent): %v", err)
 	}
@@ -659,6 +663,9 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 		CreatedAt:     time.Now().Add(-2 * time.Minute).UTC(),
 	}); err != nil {
 		t.Fatalf("AppendEvent(skip child): %v", err)
+	}
+	if err := pg.UpsertCommittedReplayScope(ctx, skipChildID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
+		t.Fatalf("UpsertCommittedReplayScope(skip child): %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, skipParentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(skip parent): %v", err)

--- a/internal/runtime/pipeline/coordinator_recovery.go
+++ b/internal/runtime/pipeline/coordinator_recovery.go
@@ -204,21 +204,33 @@ func (r *RecoveryManager) Recover(ctx context.Context) error {
 			continue
 		}
 		if len(persistedRecipients) == 0 {
-			if recorder == nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("mark replay event %s delivered receipt: missing pipeline receipt recorder", evt.ID)
+			if scopeReader, ok := r.store.(runtimereplayclaim.ScopeReader); ok && scopeReader != nil {
+				scope, err := scopeReader.LoadCommittedReplayScope(ctx, evt.ID)
+				if err != nil {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("load committed replay scope for replay event %s: %w", evt.ID, err)
+					}
+					_ = lease.Release(ctx)
+					continue
 				}
-				_ = lease.Release(ctx)
-				continue
-			}
-			if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
+				if scope == runtimereplayclaim.CommittedReplayScopeDirect {
+					if recorder == nil {
+						if firstErr == nil {
+							firstErr = fmt.Errorf("mark replay event %s delivered receipt: missing pipeline receipt recorder", evt.ID)
+						}
+						_ = lease.Release(ctx)
+						continue
+					}
+					if err := recorder.UpsertPipelineReceipt(ctx, evt.ID, "processed", ""); err != nil {
+						if firstErr == nil {
+							firstErr = fmt.Errorf("mark replay event %s delivered receipt: %w", evt.ID, err)
+						}
+					}
+					logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeSkipped, startupRecoveryPipelineReplayReasonNoPersistedRecipients, "", nil)
+					_ = lease.Release(ctx)
+					continue
 				}
 			}
-			logStartupRecoveryPipelineReplayAftermath(ctx, logger, evt, startupRecoveryPipelineReplayOutcomeSkipped, startupRecoveryPipelineReplayReasonNoPersistedRecipients, "", nil)
-			_ = lease.Release(ctx)
-			continue
 		}
 		if err := r.bus.PublishPersistedRecipients(ctx, evt, persistedRecipients); err != nil {
 			if firstErr == nil {

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -12,6 +12,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
@@ -116,6 +117,13 @@ func findRecoveryAftermathLog(t *testing.T, logs []runtimepipeline.RuntimeLogEnt
 	return runtimepipeline.RuntimeLogEntry{}
 }
 
+func persistCommittedReplayScope(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID string, scope runtimereplayclaim.CommittedReplayScope) {
+	t.Helper()
+	if err := pg.UpsertCommittedReplayScope(ctx, eventID, scope); err != nil {
+		t.Fatalf("UpsertCommittedReplayScope(%s): %v", eventID, err)
+	}
+}
+
 func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
@@ -161,6 +169,7 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	if err := pg.InsertEventDeliveries(ctx, childID, []string{recipientID}); err != nil {
 		t.Fatalf("InsertEventDeliveries(child): %v", err)
 	}
+	persistCommittedReplayScope(t, ctx, pg, childID, runtimereplayclaim.CommittedReplayScopeSubscribed)
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
@@ -281,6 +290,7 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	if err := pg.InsertEventDeliveries(ctx, goodEventID, []string{goodRecipientID}); err != nil {
 		t.Fatalf("InsertEventDeliveries(good child): %v", err)
 	}
+	persistCommittedReplayScope(t, ctx, pg, goodEventID, runtimereplayclaim.CommittedReplayScopeSubscribed)
 	if err := pg.UpsertPipelineReceipt(ctx, goodParentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(good parent): %v", err)
 	}
@@ -423,6 +433,7 @@ func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 	if err := pg1.InsertEventDeliveries(ctx, childID, []string{"agent-recovery"}); err != nil {
 		t.Fatalf("InsertEventDeliveries(child): %v", err)
 	}
+	persistCommittedReplayScope(t, ctx, pg1, childID, runtimereplayclaim.CommittedReplayScopeSubscribed)
 	if err := pg1.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
@@ -516,6 +527,7 @@ func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *test
 	if err := pg.AppendEvent(ctx, child); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
+	persistCommittedReplayScope(t, ctx, pg, childID, runtimereplayclaim.CommittedReplayScopeDirect)
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
@@ -637,6 +649,7 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"agent-a"}); err != nil {
 		t.Fatalf("InsertEventDeliveries: %v", err)
 	}
+	persistCommittedReplayScope(t, ctx, pg, eventID, runtimereplayclaim.CommittedReplayScopeDirect)
 
 	agentA := bus.Subscribe("agent-a")
 	agentB := bus.Subscribe("agent-b", events.EventType("system.recover.explicit"))
@@ -675,6 +688,126 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 	if receiptStatus != "success" {
 		t.Fatalf("child receipt outcome = %q, want success", receiptStatus)
 	}
+}
+
+func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	eventID := uuid.NewString()
+
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            eventID,
+		Type:          events.EventType("system.recover.internal"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	persistCommittedReplayScope(t, ctx, pg, eventID, runtimereplayclaim.CommittedReplayScopeSubscribed)
+
+	internalCh := bus.SubscribeInternal("workflow-runtime", events.EventType("system.recover.internal"))
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 1 || capture.direct[0].ID != eventID {
+		t.Fatalf("direct replayed events = %#v, want [%s]", capture.direct, eventID)
+	}
+	select {
+	case evt := <-internalCh:
+		if evt.ID != eventID {
+			t.Fatalf("internal replayed event id = %q, want %q", evt.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected internal subscriber to receive replayed subscribed event")
+	}
+}
+
+func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+
+	runID := uuid.NewString()
+	parentID := uuid.NewString()
+	eventID := uuid.NewString()
+
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          parentID,
+		Type:        events.EventType("system.parent"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"ok":true}`),
+		RunID:       runID,
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(parent): %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
+	}
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:            eventID,
+		Type:          events.EventType("system.recover.direct_empty"),
+		SourceAgent:   "runtime",
+		Payload:       []byte(`{"ok":true}`),
+		RunID:         runID,
+		ParentEventID: parentID,
+		CreatedAt:     time.Now().Add(-time.Minute).UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(child): %v", err)
+	}
+	persistCommittedReplayScope(t, ctx, pg, eventID, runtimereplayclaim.CommittedReplayScopeDirect)
+
+	internalCh := bus.SubscribeInternal("workflow-runtime", events.EventType("system.recover.direct_empty"))
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 0 {
+		t.Fatalf("direct replayed events = %#v, want none", capture.direct)
+	}
+	select {
+	case evt := <-internalCh:
+		t.Fatalf("direct replay should not broaden to internal subscriber: %#v", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+	findRecoveryAftermathLog(t, capture.logs, eventID, "skipped", "no_persisted_recipients")
 }
 
 func TestRecoveryManager_FailsClosedWithoutReplayClaimOwner(t *testing.T) {

--- a/internal/runtime/replayclaim/contracts.go
+++ b/internal/runtime/replayclaim/contracts.go
@@ -13,6 +13,14 @@ var (
 	ErrMissingReplayEventReader                  = errors.New("store does not support replay-eligible event reads")
 	ErrMissingReplayClaimOwner                   = errors.New("store does not support explicit pipeline replay claims")
 	ErrAuthoritativeRecipientManifestUnavailable = errors.New("authoritative delivery recipient manifest is unavailable for non-persistent event stores")
+	ErrMissingCommittedReplayScope               = errors.New("store does not support authoritative committed replay scope for persisted replay")
+)
+
+type CommittedReplayScope string
+
+const (
+	CommittedReplayScopeDirect     CommittedReplayScope = "direct"
+	CommittedReplayScopeSubscribed CommittedReplayScope = "subscribed"
 )
 
 type Participation interface {
@@ -34,6 +42,10 @@ type Store interface {
 
 type RecipientReader interface {
 	ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error)
+}
+
+type ScopeReader interface {
+	LoadCommittedReplayScope(ctx context.Context, eventID string) (CommittedReplayScope, error)
 }
 
 type composedStore struct {

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -12,6 +12,7 @@ import (
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type recoveryGuardManagerStore struct {
@@ -44,6 +45,9 @@ type recoveryGuardEventStore struct {
 
 func (*recoveryGuardEventStore) AppendEvent(context.Context, events.Event) error { return nil }
 func (*recoveryGuardEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*recoveryGuardEventStore) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
 	return nil
 }
 func (*recoveryGuardEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -13,6 +13,7 @@ import (
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/testutil"
 )
 
@@ -79,6 +80,10 @@ func (startupRecoveryEventStore) CanonicalRuntimeLogCapability(context.Context) 
 func (startupRecoveryEventStore) AppendEvent(context.Context, events.Event) error { return nil }
 
 func (startupRecoveryEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (startupRecoveryEventStore) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
 	return nil
 }
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -13,6 +13,14 @@ import (
 	"swarm/internal/events"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+)
+
+const (
+	replayScopeMarkerSubscriberType = "node"
+	replayScopeMarkerSubscriberID   = "__runtime_replay_scope__"
+	replayScopeReasonDirect         = "replay_scope_direct"
+	replayScopeReasonSubscribed     = "replay_scope_subscribed"
 )
 
 type rowQueryer interface {
@@ -77,6 +85,28 @@ func (s *PostgresStore) PersistEventWithDeliveries(ctx context.Context, evt even
 	return nil
 }
 
+func (s *PostgresStore) PersistEventWithDeliveriesAndScope(
+	ctx context.Context,
+	evt events.Event,
+	agentIDs []string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	switch {
+	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
+		return s.persistEventWithDeliveriesAndScopeSpec(ctx, caps, evt, agentIDs, scope)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	}
+	return nil
+}
+
 func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.Event {
 	parentID := strings.TrimSpace(evt.ParentEventID)
 	if parentID == "" {
@@ -133,6 +163,35 @@ func (s *PostgresStore) InsertEventDeliveriesTx(ctx context.Context, tx *sql.Tx,
 	switch {
 	case caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Log == SchemaFlavorCanonical:
 		return s.insertEventDeliveriesSpec(ctx, caps, tx, eventID, agentIDs)
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	return nil
+}
+
+func (s *PostgresStore) UpsertCommittedReplayScope(
+	ctx context.Context,
+	eventID string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
+	return s.UpsertCommittedReplayScopeTx(ctx, nil, eventID, scope)
+}
+
+func (s *PostgresStore) UpsertCommittedReplayScopeTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case caps.Events.Deliveries == SchemaFlavorCanonical && caps.Events.Log == SchemaFlavorCanonical:
+		return s.upsertCommittedReplayScopeSpec(ctx, caps, tx, eventID, scope)
 	case caps.Events.Deliveries != SchemaFlavorCanonical:
 		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
 	case caps.Events.Log != SchemaFlavorCanonical:
@@ -299,6 +358,46 @@ func (s *PostgresStore) ListEventDeliveryRecipients(ctx context.Context, eventID
 	return recipients, nil
 }
 
+func (s *PostgresStore) LoadCommittedReplayScope(
+	ctx context.Context,
+	eventID string,
+) (runtimereplayclaim.CommittedReplayScope, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return "", err
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	switch caps.Events.Deliveries {
+	case SchemaFlavorCanonical:
+	default:
+		return "", unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	}
+	var reasonCode string
+	err = s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+		ORDER BY created_at DESC, delivery_id DESC
+		LIMIT 1
+	`, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID).Scan(&reasonCode)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	case err != nil:
+		return "", fmt.Errorf("load committed replay scope: %w", err)
+	}
+	scope, ok := committedReplayScopeFromReasonCode(reasonCode)
+	if !ok {
+		return "", fmt.Errorf("load committed replay scope: unrecognized reason_code %q", strings.TrimSpace(reasonCode))
+	}
+	return scope, nil
+}
+
 func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, evt events.Event) error {
 	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt, err := eventStorageEnvelope(evt)
 	if err != nil {
@@ -357,6 +456,35 @@ func (s *PostgresStore) persistEventWithDeliveriesSpec(ctx context.Context, caps
 			return err
 		}
 		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID, agentIDs); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit event tx: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *PostgresStore) persistEventWithDeliveriesAndScopeSpec(
+	ctx context.Context,
+	caps StoreSchemaCapabilities,
+	evt events.Event,
+	agentIDs []string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
+	return withEventStoreRetry(ctx, nil, func() error {
+		tx, err := s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin event tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
+			return err
+		}
+		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID, agentIDs); err != nil {
+			return err
+		}
+		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID, scope); err != nil {
 			return err
 		}
 		if err := tx.Commit(); err != nil {
@@ -435,6 +563,89 @@ func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, caps Stor
 		}
 	}
 	return nil
+}
+
+func (s *PostgresStore) upsertCommittedReplayScopeSpec(
+	ctx context.Context,
+	caps StoreSchemaCapabilities,
+	tx *sql.Tx,
+	eventID string,
+	scope runtimereplayclaim.CommittedReplayScope,
+) error {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	reasonCode, err := committedReplayScopeReasonCode(scope)
+	if err != nil {
+		return err
+	}
+	execFn := s.DB.ExecContext
+	if tx != nil {
+		execFn = tx.ExecContext
+	}
+	res, err := execFn(ctx, `
+		UPDATE event_deliveries
+		SET reason_code = $4,
+		    status = 'delivered',
+		    delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+	`, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, reasonCode)
+	if err != nil {
+		return fmt.Errorf("update committed replay scope: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update committed replay scope rows: %w", err)
+	}
+	if rows > 0 {
+		return nil
+	}
+	q := `
+		INSERT INTO event_deliveries (
+			event_id, subscriber_type, subscriber_id, status, reason_code, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2, $3, 'delivered', $4, now(), now())
+	`
+	if caps.Events.DeliveryRunID {
+		q = `
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status, reason_code, delivered_at, created_at
+			)
+			SELECT
+				e.run_id, e.event_id, $2, $3, 'delivered', $4, now(), now()
+			FROM events e
+			WHERE e.event_id = $1::uuid
+		`
+	}
+	if _, err := execFn(ctx, q, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, reasonCode); err != nil {
+		return fmt.Errorf("insert committed replay scope: %w", err)
+	}
+	return nil
+}
+
+func committedReplayScopeReasonCode(scope runtimereplayclaim.CommittedReplayScope) (string, error) {
+	switch scope {
+	case runtimereplayclaim.CommittedReplayScopeDirect:
+		return replayScopeReasonDirect, nil
+	case runtimereplayclaim.CommittedReplayScopeSubscribed:
+		return replayScopeReasonSubscribed, nil
+	default:
+		return "", fmt.Errorf("committed replay scope: unsupported scope %q", strings.TrimSpace(string(scope)))
+	}
+}
+
+func committedReplayScopeFromReasonCode(reasonCode string) (runtimereplayclaim.CommittedReplayScope, bool) {
+	switch strings.TrimSpace(reasonCode) {
+	case replayScopeReasonDirect:
+		return runtimereplayclaim.CommittedReplayScopeDirect, true
+	case replayScopeReasonSubscribed:
+		return runtimereplayclaim.CommittedReplayScopeSubscribed, true
+	default:
+		return "", false
+	}
 }
 
 func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {


### PR DESCRIPTION
## Summary
Preserve committed-event recipient scope across the crash boundary by giving replay one durable authoritative owner for `direct` vs `subscribed` semantics.

Closes #325

## What Changed
- persisted a committed replay-scope marker alongside canonical `event_deliveries`
- taught publish/outbox persistence to fail closed when a replay-capable store cannot persist that scope
- made `PublishPersistedRecipients(...)` and `SweepUndispatched(...)` reconstruct replay recipients from the persisted agent manifest plus the committed replay scope
- kept empty direct manifests fail-closed on recovery while allowing subscribed empty manifests to re-derive current internal subscribers
- updated recovery, conformance, and runtime test fixtures to satisfy the new canonical replay-scope contract
- refined the `delivery_and_replay_ownership` watchlist node with the direct-vs-subscribed replay manifestation

## Why
`#322` showed that replay only had the persisted agent manifest and could not distinguish an originally direct-scoped committed event from a subscribed event whose live internal recipients were never persisted. That let crash/restart replay either drop valid internal subscribers or risk broadening direct delivery semantics. This PR closes that ownership gap by persisting the replay scope at commit time and consuming the same owner during recovery.

## Governing Spec Refs
- `event_loop.lifecycle.step 3 persist_event`
- `event_loop.lifecycle.step 4 resolve_subscribers`
- `event_loop.lifecycle.step 6 agent_delivery`
- `event_loop.lifecycle.step 8 mark_delivered`
- `event_loop.crash_recovery`
- `routing_rules.routable_events`

## Scope Boundaries
- closes the durable direct-vs-subscribed replay ownership child class tracked by #325
- does not reopen the already-closed live publish / same-process visibility work from #317
- does not redesign the broader event bus beyond the owner needed to keep replay semantics authoritative across restart

## Validation
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/store -count=1`
- `go test ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
- no remaining live same-concept interpreter is known in the committed replay path after this change
- the broader `delivery_and_replay_ownership` watchlist parent remains active as a historical parent class, but this direct-vs-subscribed replay child slice is intended to be fully closed here
