### PR TITLE
[agent-c][issue #326] Align supported helper with builder auth

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -49,6 +49,10 @@ active_issues:
     title: Require authentication for dashboard and runtime-control surfaces on the default listener
     maps_to:
       - privileged_control_plane_auth
+  - id: 326
+    title: Align the supported run helper with builder RPC auth requirements
+    maps_to:
+      - privileged_control_plane_auth
   - id: 143
     title: Drain in-flight work before runtime shutdown tears down dependencies
     maps_to:
@@ -179,6 +183,7 @@ nodes:
     known_manifestations:
       - gateway auth not fail-closed
       - builder RPC/WebSocket privileged paths unauthenticated
+      - supported helper paths drift from authenticated builder RPC policy and fail after runtime reaches ready
       - delegable privileges not capped on hire/reconfigure
       - dashboard/runtime-control default listener left open
     representative_issues:
@@ -186,6 +191,7 @@ nodes:
       - 140
       - 141
       - 142
+      - 326
     common_framing_mistakes:
       too_broad:
         - auth needs work

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -23,6 +23,9 @@ DIRECTIVE_MESSAGE="${DIRECTIVE_MESSAGE:-}"
 CORPUS_PATH="${CORPUS_PATH:-/data/test-signals-25.jsonl}"
 CORPUS_MODE="${CORPUS_MODE:-corpus}"
 CORPUS_GEOGRAPHY="${CORPUS_GEOGRAPHY:-US}"
+SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+
+export SWARM_BUILDER_AUTH_TOKEN
 
 kill_swarm_processes() {
   local pids=""
@@ -88,7 +91,7 @@ SQL
 echo "Starting Swarm with contracts ${CONTRACTS_ROOT}..."
 : > "${LOG_FILE}"
 launcher_pid="$(
-  LOG_FILE="${LOG_FILE}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" python3 - <<'PY'
+  LOG_FILE="${LOG_FILE}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN}" python3 - <<'PY'
 import os
 import subprocess
 import sys
@@ -140,6 +143,7 @@ run_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 echo "Starting default corpus run ${run_id}..."
 run_response="$(curl -sS "http://${HEALTH_ADDR}/api/rpc" \
   -H 'content-type: application/json' \
+  -H "Authorization: Bearer ${SWARM_BUILDER_AUTH_TOKEN}" \
   --data-binary "{\"jsonrpc\":\"2.0\",\"id\":\"run-clear\",\"method\":\"run.start\",\"params\":{\"run_id\":\"${run_id}\",\"inputs\":{\"scan.requested\":{\"mode\":\"${CORPUS_MODE}\",\"geography\":\"${CORPUS_GEOGRAPHY}\",\"corpus_path\":\"${CORPUS_PATH}\"}}}}")"
 echo "${run_response}"
 if ! grep -q '"status":"started"' <<<"${run_response}"; then

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -1,0 +1,209 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
+	result := runRunClear(t, "")
+
+	if strings.TrimSpace(result.builderToken) == "" {
+		t.Fatal("expected helper to provision SWARM_BUILDER_AUTH_TOKEN")
+	}
+	wantHeader := "Authorization: Bearer " + result.builderToken
+	if !strings.Contains(result.headers, wantHeader) {
+		t.Fatalf("headers = %q, want %q", result.headers, wantHeader)
+	}
+	if got := strings.TrimSpace(result.rpcURL); got != "http://127.0.0.1:8081/api/rpc" {
+		t.Fatalf("rpc url = %q, want helper /api/rpc alias", got)
+	}
+	if !strings.Contains(result.rpcBody, `"method":"run.start"`) {
+		t.Fatalf("rpc body = %q, want run.start request", result.rpcBody)
+	}
+	if !strings.Contains(result.stdout, `"status":"started"`) {
+		t.Fatalf("stdout = %q, want started response", result.stdout)
+	}
+}
+
+func TestRunClear_UsesConfiguredBuilderAuthTokenForRPC(t *testing.T) {
+	const explicitToken = "builder-explicit-token"
+	result := runRunClear(t, explicitToken)
+
+	if got := strings.TrimSpace(result.builderToken); got != explicitToken {
+		t.Fatalf("builder token = %q, want %q", got, explicitToken)
+	}
+	wantHeader := "Authorization: Bearer " + explicitToken
+	if !strings.Contains(result.headers, wantHeader) {
+		t.Fatalf("headers = %q, want %q", result.headers, wantHeader)
+	}
+}
+
+type runClearResult struct {
+	stdout       string
+	builderToken string
+	headers      string
+	rpcBody      string
+	rpcURL       string
+}
+
+func runRunClear(t *testing.T, builderToken string) runClearResult {
+	t.Helper()
+
+	scriptDir := testScriptDir(t)
+	binDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "swarm.log")
+	pidFile := filepath.Join(t.TempDir(), "swarm.pid")
+	builderTokenSink := filepath.Join(t.TempDir(), "builder-token.txt")
+	headersSink := filepath.Join(t.TempDir(), "rpc-headers.txt")
+	bodySink := filepath.Join(t.TempDir(), "rpc-body.txt")
+	urlSink := filepath.Join(t.TempDir(), "rpc-url.txt")
+
+	writeExecutable(t, binDir, "pgrep", "#!/usr/bin/env bash\nexit 1\n")
+	writeExecutable(t, binDir, "lsof", "#!/usr/bin/env bash\nexit 1\n")
+	writeExecutable(t, binDir, "docker", "#!/usr/bin/env bash\nif [[ \"${1:-}\" == \"ps\" ]]; then exit 0; fi\nif [[ \"${1:-}\" == \"stop\" ]]; then exit 0; fi\nexit 0\n")
+	writeExecutable(t, binDir, "psql", "#!/usr/bin/env bash\nexit 0\n")
+	writeExecutable(t, binDir, "uuidgen", "#!/usr/bin/env bash\nprintf '11111111-1111-1111-1111-111111111111\\n'\n")
+	writeExecutable(t, binDir, "python3", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${SWARM_BUILDER_AUTH_TOKEN:-}" > "${PYTHON_ENV_SINK}"
+printf '4242\n'
+`)
+	writeExecutable(t, binDir, "curl", `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+body=""
+headers=()
+while (($#)); do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -w)
+      shift 2
+      ;;
+    -H)
+      headers+=("$2")
+      shift 2
+      ;;
+    --data-binary)
+      body="$2"
+      shift 2
+      ;;
+    -s|-S|-sS)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ "$url" == *"/healthz" || "$url" == *"/readyz" || "$url" == *"/api/health" ]]; then
+  if [[ -n "$out" ]]; then
+    printf '{}' > "$out"
+  fi
+  printf '200'
+  exit 0
+fi
+if [[ "$url" == *"/api/rpc" ]]; then
+  printf '%s' "$url" > "${CURL_URL_SINK}"
+  if ((${#headers[@]})); then
+    printf '%s\n' "${headers[@]}" > "${CURL_HEADERS_SINK}"
+  else
+    : > "${CURL_HEADERS_SINK}"
+  fi
+  printf '%s' "$body" > "${CURL_BODY_SINK}"
+  printf '{"jsonrpc":"2.0","id":"run-clear","result":{"status":"started"}}'
+  exit 0
+fi
+printf '{}'
+`)
+
+	cmd := exec.Command("bash", filepath.Join(scriptDir, "run_clear.sh"))
+	cmd.Env = append(filteredEnv(
+		"SWARM_BUILDER_AUTH_TOKEN",
+	), []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"PYTHON_ENV_SINK=" + builderTokenSink,
+		"CURL_HEADERS_SINK=" + headersSink,
+		"CURL_BODY_SINK=" + bodySink,
+		"CURL_URL_SINK=" + urlSink,
+		"CONTRACTS_ROOT=/tmp/contracts",
+		"HEALTH_ADDR=127.0.0.1:8081",
+		"LOG_FILE=" + logFile,
+		"PID_FILE=" + pidFile,
+		"START_TIMEOUT=1",
+	}...)
+	if builderToken != "" {
+		cmd.Env = append(cmd.Env, "SWARM_BUILDER_AUTH_TOKEN="+builderToken)
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run_clear.sh failed: %v\n%s", err, out)
+	}
+
+	return runClearResult{
+		stdout:       string(out),
+		builderToken: readFileTrimmed(t, builderTokenSink),
+		headers:      readFileTrimmed(t, headersSink),
+		rpcBody:      readFileTrimmed(t, bodySink),
+		rpcURL:       readFileTrimmed(t, urlSink),
+	}
+}
+
+func filteredEnv(removeKeys ...string) []string {
+	base := os.Environ()
+	remove := map[string]struct{}{}
+	for _, key := range removeKeys {
+		remove[key] = struct{}{}
+	}
+	filtered := make([]string, 0, len(base))
+	for _, item := range base {
+		key := item
+		if idx := strings.IndexByte(item, '='); idx >= 0 {
+			key = item[:idx]
+		}
+		if _, drop := remove[key]; drop {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func testScriptDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(file)
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+}
+
+func readFileTrimmed(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(data))
+}


### PR DESCRIPTION
Closes #326

## Human Summary

This PR aligns the supported local full-run helper with the existing fail-closed builder RPC auth policy. `scripts/run_clear.sh` now provisions a builder auth token for the launched runtime when one is not already configured and uses that same bearer token when it calls `/api/rpc` to start the default run.

## Governing Context

No exact `platform-spec.yaml` section governs this helper/auth parity seam directly.

Binding context for this PR is:
- issue `#326`
- the existing fail-closed builder control-plane auth owner in `internal/builder/handler_auth.go`
- the existing builder token wiring in `cmd/swarm/main.go` via `SWARM_BUILDER_AUTH_TOKEN`

`docs/specs/swarm-platform/platform/BUILDER-API.md` was consulted for endpoint shape only; it is a tooling reference rather than an authoritative platform contract.

## What Changed

- `scripts/run_clear.sh`
  - now provisions `SWARM_BUILDER_AUTH_TOKEN` when unset
  - exports that token into the launched `go run ./cmd/swarm` process
  - sends `Authorization: Bearer ...` when calling `/api/rpc` for `run.start`
- `scripts/run_clear_test.go`
  - adds deterministic supported-helper proof that the helper:
    - provisions a builder token when unset
    - preserves an explicitly configured builder token when set
    - sends the matching bearer header on `/api/rpc`
    - still succeeds on the supported helper path
- `docs/watchlists/runtime-operations.yaml`
  - records this helper/auth drift as a manifestation under `privileged_control_plane_auth`

## Why This Is Needed

The runtime can already boot cleanly, but the supported helper still failed at the builder RPC auth boundary because helper behavior and RPC policy drifted apart. That made the supported local full-run path fail even when runtime readiness was healthy.

The honest fix is helper alignment with the existing authenticated builder RPC policy, not a shadow unauthenticated local-dev exception.

## Scope Boundaries

In scope:
- supported helper parity for the default `run.start` path through `/api/rpc`
- builder auth token provisioning/usage in `scripts/run_clear.sh`
- deterministic supported-helper proof for that path

Out of scope:
- builder websocket auth/origin work tracked under `#140`
- dashboard/operator auth for the optional directive path in `run_clear.sh`
- broader builder/runtime redesign

## Tests Run

- `go test ./scripts -count=1`
- `go test ./internal/builder ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk

- the supported helper/auth parity class is closed for the default `/api/rpc run.start` path
- the helper still owns its control-plane request shaping in shell, so broader typed local-helper/client consolidation remains a separate architecture follow-up rather than part of this closure

## Follow-Up

- broader privileged builder surface hardening remains tracked separately under `#140`
- optional directive-send auth in `run_clear.sh` remains a different operator-auth class and was intentionally kept out of scope here
