### PR TITLE
[agent-a][issue #328] Canonicalize startup timer recovery diagnostics

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -364,6 +364,77 @@ func (conformanceNoopLLMRuntime) ContinueSession(context.Context, *runtimellm.Se
 	return &runtimellm.Response{}, nil
 }
 
+type conformanceScheduleClaim struct {
+	claimed bool
+	err     error
+}
+
+type conformanceTimerRecoveryScheduleStore struct {
+	active []runtimepipeline.Schedule
+	claims []conformanceScheduleClaim
+}
+
+func (*conformanceTimerRecoveryScheduleStore) UpsertSchedule(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*conformanceTimerRecoveryScheduleStore) CancelScheduleExact(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*conformanceTimerRecoveryScheduleStore) CancelScheduleExactTerminal(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (s *conformanceTimerRecoveryScheduleStore) LoadActiveSchedules(context.Context) ([]runtimepipeline.Schedule, error) {
+	return append([]runtimepipeline.Schedule(nil), s.active...), nil
+}
+
+func (s *conformanceTimerRecoveryScheduleStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
+	if len(s.claims) == 0 {
+		return true, nil
+	}
+	claim := s.claims[0]
+	s.claims = s.claims[1:]
+	return claim.claimed, claim.err
+}
+
+func (*conformanceTimerRecoveryScheduleStore) ReleaseSchedule(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*conformanceTimerRecoveryScheduleStore) ReleaseScheduleClaims(context.Context) error {
+	return nil
+}
+
+func (*conformanceTimerRecoveryScheduleStore) MarkScheduleFiredExact(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (*conformanceTimerRecoveryScheduleStore) CompleteScheduleFireExact(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+type conformanceTimerRecoveryEventStore struct{}
+
+func (conformanceTimerRecoveryEventStore) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (conformanceTimerRecoveryEventStore) AppendEvent(context.Context, events.Event) error {
+	return nil
+}
+
+func (conformanceTimerRecoveryEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (conformanceTimerRecoveryEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (conformanceTimerRecoveryEventStore) SupportsPersistedReplay() bool { return false }
+
 func loadConformanceRuntimeWorkflowModule(t *testing.T) conformanceSemanticOnlyWorkflowRuntime {
 	t.Helper()
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
@@ -455,6 +526,136 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 	classes, _ := detail["recoverable_work_classes"].([]any)
 	if len(classes) != 1 || readString(classes[0]) != "active schedules" {
 		t.Fatalf("detail.recoverable_work_classes = %#v, want [active schedules]", detail["recoverable_work_classes"])
+	}
+}
+
+func TestStartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+
+	scheduleStore := &conformanceTimerRecoveryScheduleStore{
+		active: []runtimepipeline.Schedule{
+			{
+				AgentID:   "runtime",
+				EventType: "timer.replay",
+				Mode:      "once",
+				At:        time.Now().Add(time.Minute),
+				TaskID:    "replay-me",
+			},
+			{
+				AgentID:   "runtime",
+				EventType: "timer.skip",
+				Mode:      "once",
+				At:        time.Now().Add(2 * time.Minute),
+				TaskID:    "skip-me",
+			},
+			{
+				AgentID:   "runtime",
+				EventType: "timer.drop",
+				Mode:      "once",
+				At:        time.Now().Add(3 * time.Minute),
+				TaskID:    "drop-me",
+			},
+		},
+		claims: []conformanceScheduleClaim{
+			{claimed: true},
+			{claimed: false},
+			{err: fmt.Errorf("claim failed")},
+		},
+	}
+
+	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: true,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}, runtimepkg.Stores{
+		SQLDB:         db,
+		EventStore:    conformanceTimerRecoveryEventStore{},
+		ManagerStore:  pg,
+		ScheduleStore: scheduleStore,
+	}, runtimepkg.RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
+		LLMRuntime:     conformanceNoopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "scheduler",
+		Type:      "startup_recovery_timer_aftermath",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 3 {
+		t.Fatalf("runtime log rows = %d, want 3: %#v", len(logs), logs)
+	}
+	findByEventType := func(eventType string) int {
+		t.Helper()
+		for idx, log := range logs {
+			if strings.TrimSpace(log.EventType) == eventType {
+				return idx
+			}
+		}
+		t.Fatalf("missing runtime log for event type %q in %#v", eventType, logs)
+		return -1
+	}
+
+	replayed := logs[findByEventType("timer.replay")]
+	if replayed.Action != "startup_recovery_timer_aftermath" {
+		t.Fatalf("replayed action = %q, want startup_recovery_timer_aftermath", replayed.Action)
+	}
+	replayedDetail, _ := replayed.Detail.(map[string]any)
+	if got := readString(replayedDetail["decision_outcome"]); got != "replayed" {
+		t.Fatalf("replayed detail.decision_outcome = %q, want replayed", got)
+	}
+	if got := readString(replayedDetail["decision_reason_code"]); got != "persisted_schedule_restored" {
+		t.Fatalf("replayed detail.decision_reason_code = %q, want persisted_schedule_restored", got)
+	}
+
+	skipped := logs[findByEventType("timer.skip")]
+	skippedDetail, _ := skipped.Detail.(map[string]any)
+	if got := readString(skippedDetail["decision_outcome"]); got != "skipped" {
+		t.Fatalf("skipped detail.decision_outcome = %q, want skipped", got)
+	}
+	if got := readString(skippedDetail["decision_reason_code"]); got != "schedule_claim_not_acquired" {
+		t.Fatalf("skipped detail.decision_reason_code = %q, want schedule_claim_not_acquired", got)
+	}
+
+	dropped := logs[findByEventType("timer.drop")]
+	droppedDetail, _ := dropped.Detail.(map[string]any)
+	if got := readString(droppedDetail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped detail.decision_outcome = %q, want dropped", got)
+	}
+	if got := readString(droppedDetail["decision_reason_code"]); got != "schedule_restore_failed" {
+		t.Fatalf("dropped detail.decision_reason_code = %q, want schedule_restore_failed", got)
+	}
+	if readString(droppedDetail["error_code"]) != "schedule_restore_failed" {
+		t.Fatalf("dropped detail.error_code = %q, want schedule_restore_failed", readString(droppedDetail["error_code"]))
+	}
+	if strings.TrimSpace(dropped.Error) == "" {
+		t.Fatal("dropped timer recovery log missing explicit error text")
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -581,7 +581,10 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		}
 		startupRecoveryDecision.ScheduleRestoreAttempted = len(schedules) > 0
 		results := restoreStartupTimerSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Logger, schedules)
-		startupRecoveryDecision.ScheduleReplayCount, startupRecoveryDecision.ScheduleSkipCount, startupRecoveryDecision.ScheduleDropCount, startupRecoveryDecision.ErrorText = summarizeStartupTimerRecovery(results)
+		timerReplayCount, timerSkipCount, timerDropCount, timerRecoveryErrText := summarizeStartupTimerRecovery(results)
+		startupRecoveryDecision.ScheduleReplayCount = timerReplayCount
+		startupRecoveryDecision.ScheduleSkipCount = timerSkipCount
+		startupRecoveryDecision.ScheduleDropCount = timerDropCount
 		if err := ensureLifecycleWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_lifecycle_failed", rt.Logger.Error(ctx, "scheduler", "ensure_lifecycle_failed", nil, err))
@@ -590,6 +593,15 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		if err := ensureRecurringWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_recurring_failed", rt.Logger.Error(ctx, "scheduler", "ensure_recurring_failed", nil, err))
+			}
+		}
+		if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleDropCount > 0 {
+			startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
+			startupRecoveryDecision.ReasonCode = startupRecoveryReasonScheduleRestore
+			if strings.TrimSpace(timerRecoveryErrText) != "" {
+				startupRecoveryDecision.ErrorText = timerRecoveryErrText
+			} else {
+				startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleDropCount)
 			}
 		}
 	}
@@ -643,13 +655,6 @@ func (rt *Runtime) Start(ctx context.Context) error {
 					handleRuntimeLogPersistenceError("runtime", "recovery_failed_publish_failed", rt.Logger.Error(ctx, "runtime", "recovery_failed_publish_failed", nil, publishErr))
 				}
 			}
-		}
-	}
-	if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleDropCount > 0 {
-		startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
-		startupRecoveryDecision.ReasonCode = startupRecoveryReasonScheduleRestore
-		if strings.TrimSpace(startupRecoveryDecision.ErrorText) == "" {
-			startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleDropCount)
 		}
 	}
 	rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -580,20 +580,8 @@ func (rt *Runtime) Start(ctx context.Context) error {
 			return fmt.Errorf("load schedules failed: %w", err)
 		}
 		startupRecoveryDecision.ScheduleRestoreAttempted = len(schedules) > 0
-		for _, sc := range schedules {
-			if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, rt.Stores.ScheduleStore, rt.Scheduler, sc); err != nil {
-				startupRecoveryDecision.ScheduleRestoreFailures++
-				if rt.Logger != nil {
-					handleRuntimeLogPersistenceError("scheduler", "restore_schedule_failed", rt.Logger.Error(ctx, "scheduler", "restore_schedule_failed", map[string]any{
-						"agent_id":   sc.AgentID,
-						"event_type": sc.EventType,
-						"entity_id":  sc.EffectiveEntityID(),
-					}, err))
-				}
-				continue
-			}
-			startupRecoveryDecision.ScheduleRestoreSuccesses++
-		}
+		results := restoreStartupTimerSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Logger, schedules)
+		startupRecoveryDecision.ScheduleReplayCount, startupRecoveryDecision.ScheduleSkipCount, startupRecoveryDecision.ScheduleDropCount, startupRecoveryDecision.ErrorText = summarizeStartupTimerRecovery(results)
 		if err := ensureLifecycleWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_lifecycle_failed", rt.Logger.Error(ctx, "scheduler", "ensure_lifecycle_failed", nil, err))
@@ -657,10 +645,12 @@ func (rt *Runtime) Start(ctx context.Context) error {
 			}
 		}
 	}
-	if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleRestoreFailures > 0 {
+	if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleDropCount > 0 {
 		startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
 		startupRecoveryDecision.ReasonCode = startupRecoveryReasonScheduleRestore
-		startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleRestoreFailures)
+		if strings.TrimSpace(startupRecoveryDecision.ErrorText) == "" {
+			startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleDropCount)
+		}
 	}
 	rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
 	if rt.Bus != nil {

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -136,6 +136,52 @@ func latestStartupRecoveryDecisionLog(t *testing.T, db *sql.DB) (level, message,
 	return payload.LogLevel, payload.Message, payload.Error, payload.Detail
 }
 
+type runtimeAftermathLog struct {
+	level     string
+	action    string
+	errorText string
+	eventType string
+	detail    map[string]any
+}
+
+func listRuntimeLogsByAction(t *testing.T, db *sql.DB, action string) []runtimeAftermathLog {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->'details'->>'action' = $1
+		ORDER BY created_at ASC
+	`, action)
+	if err != nil {
+		t.Fatalf("query runtime logs by action: %v", err)
+	}
+	defer rows.Close()
+
+	out := []runtimeAftermathLog{}
+	for rows.Next() {
+		var payloadRaw []byte
+		if err := rows.Scan(&payloadRaw); err != nil {
+			t.Fatalf("scan runtime log payload: %v", err)
+		}
+		payload, err := DecodeCanonicalRuntimeLogPayload(payloadRaw)
+		if err != nil {
+			t.Fatalf("DecodeCanonicalRuntimeLogPayload: %v", err)
+		}
+		out = append(out, runtimeAftermathLog{
+			level:     payload.LogLevel,
+			action:    payload.Action,
+			errorText: payload.Error,
+			eventType: payload.EventType,
+			detail:    payload.Detail,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("runtime log rows: %v", err)
+	}
+	return out
+}
+
 func detailString(v any) string {
 	switch typed := v.(type) {
 	case string:
@@ -340,13 +386,149 @@ func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
 	if !detailBool(detail["schedule_restore_attempted"]) {
 		t.Fatalf("schedule_restore_attempted = %#v, want true", detail["schedule_restore_attempted"])
 	}
-	if got := detailInt(detail["schedule_restore_success_count"]); got != 1 {
-		t.Fatalf("schedule_restore_success_count = %d, want 1", got)
+	if got := detailInt(detail["schedule_replayed_count"]); got != 1 {
+		t.Fatalf("schedule_replayed_count = %d, want 1", got)
 	}
-	if got := detailInt(detail["schedule_restore_failure_count"]); got != 0 {
-		t.Fatalf("schedule_restore_failure_count = %d, want 0", got)
+	if got := detailInt(detail["schedule_skipped_count"]); got != 0 {
+		t.Fatalf("schedule_skipped_count = %d, want 0", got)
+	}
+	if got := detailInt(detail["schedule_dropped_count"]); got != 0 {
+		t.Fatalf("schedule_dropped_count = %d, want 0", got)
 	}
 	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "active schedules")
+}
+
+func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	scheduleStore := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{
+			{
+				AgentID:   "runtime",
+				EventType: "timer.replay",
+				Mode:      "once",
+				At:        time.Now().Add(time.Minute),
+				TaskID:    "replay-me",
+			},
+			{
+				AgentID:   "runtime",
+				EventType: "timer.skip",
+				Mode:      "once",
+				At:        time.Now().Add(2 * time.Minute),
+				TaskID:    "skip-me",
+			},
+			{
+				AgentID:   "runtime",
+				EventType: "timer.drop",
+				Mode:      "once",
+				At:        time.Now().Add(3 * time.Minute),
+				TaskID:    "drop-me",
+			},
+		},
+		claims: []recordedScheduleClaim{
+			{Claimed: true},
+			{Claimed: false},
+			{Err: errors.New("claim failed")},
+		},
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:         db,
+		EventStore:    startupRecoveryCapabilityEventStore{},
+		ManagerStore:  &recoveryGuardManagerStore{},
+		ScheduleStore: scheduleStore,
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "error" {
+		t.Fatalf("log level = %q, want error", level)
+	}
+	if !strings.Contains(errorText, "claim failed") {
+		t.Fatalf("log error = %q, want claim failed", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "degraded" {
+		t.Fatalf("decision_outcome = %q, want degraded", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonScheduleRestore) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonScheduleRestore)
+	}
+	if got := detailInt(detail["schedule_replayed_count"]); got != 1 {
+		t.Fatalf("schedule_replayed_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["schedule_skipped_count"]); got != 1 {
+		t.Fatalf("schedule_skipped_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["schedule_dropped_count"]); got != 1 {
+		t.Fatalf("schedule_dropped_count = %d, want 1", got)
+	}
+
+	logs := listRuntimeLogsByAction(t, db, startupTimerRecoveryAction)
+	if len(logs) != 3 {
+		t.Fatalf("timer recovery runtime logs = %d, want 3", len(logs))
+	}
+	findByEventType := func(eventType string) runtimeAftermathLog {
+		t.Helper()
+		for _, entry := range logs {
+			if strings.TrimSpace(entry.eventType) == eventType {
+				return entry
+			}
+		}
+		t.Fatalf("missing timer recovery log for event type %q in %#v", eventType, logs)
+		return runtimeAftermathLog{}
+	}
+
+	replayed := findByEventType("timer.replay")
+	if replayed.level != "info" {
+		t.Fatalf("replayed log level = %q, want info", replayed.level)
+	}
+	if got := detailString(replayed.detail["decision_outcome"]); got != "replayed" {
+		t.Fatalf("replayed decision_outcome = %q, want replayed", got)
+	}
+	if got := detailString(replayed.detail["decision_reason_code"]); got != string(startupTimerRecoveryReasonRestored) {
+		t.Fatalf("replayed decision_reason_code = %q, want %q", got, startupTimerRecoveryReasonRestored)
+	}
+
+	skipped := findByEventType("timer.skip")
+	if skipped.level != "info" {
+		t.Fatalf("skipped log level = %q, want info", skipped.level)
+	}
+	if got := detailString(skipped.detail["decision_outcome"]); got != "skipped" {
+		t.Fatalf("skipped decision_outcome = %q, want skipped", got)
+	}
+	if got := detailString(skipped.detail["decision_reason_code"]); got != string(startupTimerRecoveryReasonClaimNotAcquired) {
+		t.Fatalf("skipped decision_reason_code = %q, want %q", got, startupTimerRecoveryReasonClaimNotAcquired)
+	}
+
+	dropped := findByEventType("timer.drop")
+	if dropped.level != "warn" {
+		t.Fatalf("dropped log level = %q, want warn", dropped.level)
+	}
+	if got := detailString(dropped.detail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped decision_outcome = %q, want dropped", got)
+	}
+	if got := detailString(dropped.detail["decision_reason_code"]); got != string(startupTimerRecoveryReasonRestoreFailed) {
+		t.Fatalf("dropped decision_reason_code = %q, want %q", got, startupTimerRecoveryReasonRestoreFailed)
+	}
+	if !strings.Contains(dropped.errorText, "claim failed") {
+		t.Fatalf("dropped error = %q, want claim failed", dropped.errorText)
+	}
 }
 
 func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) {

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -48,6 +48,41 @@ func (startupRecoveryManagerStore) ListPendingSubscribedEvents(context.Context, 
 	return nil, nil
 }
 
+type startupRecoveryFlakyManagerStore struct {
+	remainingFailures int
+	loadErr           error
+}
+
+func (s *startupRecoveryFlakyManagerStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (s *startupRecoveryFlakyManagerStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	if s.remainingFailures > 0 {
+		s.remainingFailures--
+		if s.loadErr != nil {
+			return nil, s.loadErr
+		}
+	}
+	return nil, nil
+}
+
+func (*startupRecoveryFlakyManagerStore) MarkAgentTerminated(context.Context, string) error {
+	return nil
+}
+func (*startupRecoveryFlakyManagerStore) EnsureEntitySchema(context.Context, string) error {
+	return nil
+}
+func (*startupRecoveryFlakyManagerStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
+	return nil
+}
+func (*startupRecoveryFlakyManagerStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (*startupRecoveryFlakyManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+
 type startupRecoveryCapabilityEventStore struct{}
 
 func (startupRecoveryCapabilityEventStore) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
@@ -634,5 +669,122 @@ func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartu
 	}
 	if !detailBool(detail["manager_recovery_attempted"]) {
 		t.Fatalf("manager_recovery_attempted = %#v, want true", detail["manager_recovery_attempted"])
+	}
+}
+
+func TestRuntimeStart_InspectionFailurePreservesDecisionErrorAcrossTimerSkipAndDrop(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	scheduleStore := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{
+			{
+				AgentID:   "runtime",
+				EventType: "timer.skip",
+				Mode:      "once",
+				At:        time.Now().Add(2 * time.Minute),
+				TaskID:    "skip-me",
+			},
+			{
+				AgentID:   "runtime",
+				EventType: "timer.drop",
+				Mode:      "once",
+				At:        time.Now().Add(3 * time.Minute),
+				TaskID:    "drop-me",
+			},
+		},
+		claims: []recordedScheduleClaim{
+			{Claimed: false},
+			{Err: errors.New("claim failed")},
+		},
+	}
+	managerStore := &startupRecoveryFlakyManagerStore{
+		remainingFailures: 1,
+		loadErr:           errors.New("load agents failed"),
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:         db,
+		EventStore:    startupRecoveryCapabilityEventStore{},
+		ManagerStore:  managerStore,
+		ScheduleStore: scheduleStore,
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "error" {
+		t.Fatalf("log level = %q, want error", level)
+	}
+	if !strings.Contains(errorText, "inspect recoverable manager state: load persisted agents: load agents failed") {
+		t.Fatalf("log error = %q, want preserved inspection failure detail", errorText)
+	}
+	if strings.Contains(errorText, "claim failed") {
+		t.Fatalf("log error = %q, want timer restore failure kept out of decision error", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "degraded" {
+		t.Fatalf("decision_outcome = %q, want degraded", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonInspectFailed) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonInspectFailed)
+	}
+	if got := detailBool(detail["recovery_inspection_complete"]); got {
+		t.Fatalf("recovery_inspection_complete = %#v, want false", detail["recovery_inspection_complete"])
+	}
+	if got := detailString(detail["recovery_inspection_error"]); !strings.Contains(got, "inspect recoverable manager state: load persisted agents: load agents failed") {
+		t.Fatalf("recovery_inspection_error = %q, want preserved inspection failure detail", got)
+	}
+	if !detailBool(detail["manager_recovery_attempted"]) {
+		t.Fatalf("manager_recovery_attempted = %#v, want true", detail["manager_recovery_attempted"])
+	}
+	if got := detailInt(detail["schedule_replayed_count"]); got != 0 {
+		t.Fatalf("schedule_replayed_count = %d, want 0", got)
+	}
+	if got := detailInt(detail["schedule_skipped_count"]); got != 1 {
+		t.Fatalf("schedule_skipped_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["schedule_dropped_count"]); got != 1 {
+		t.Fatalf("schedule_dropped_count = %d, want 1", got)
+	}
+
+	logs := listRuntimeLogsByAction(t, db, startupTimerRecoveryAction)
+	if len(logs) != 2 {
+		t.Fatalf("timer recovery runtime logs = %d, want 2", len(logs))
+	}
+	findByEventType := func(eventType string) runtimeAftermathLog {
+		t.Helper()
+		for _, entry := range logs {
+			if strings.TrimSpace(entry.eventType) == eventType {
+				return entry
+			}
+		}
+		t.Fatalf("missing timer recovery log for event type %q in %#v", eventType, logs)
+		return runtimeAftermathLog{}
+	}
+
+	skipped := findByEventType("timer.skip")
+	if got := detailString(skipped.detail["decision_outcome"]); got != "skipped" {
+		t.Fatalf("skipped decision_outcome = %q, want skipped", got)
+	}
+	dropped := findByEventType("timer.drop")
+	if got := detailString(dropped.detail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped decision_outcome = %q, want dropped", got)
+	}
+	if !strings.Contains(dropped.errorText, "claim failed") {
+		t.Fatalf("dropped error = %q, want claim failed", dropped.errorText)
 	}
 }

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -103,9 +103,15 @@ func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
 type recordingRuntimeScheduleStore struct {
 	schedules  []runtimepipeline.Schedule
 	active     []runtimepipeline.Schedule
+	claims     []recordedScheduleClaim
 	firedExact atomic.Int32
 	firedOwned atomic.Int32
 	fired      chan runtimepipeline.Schedule
+}
+
+type recordedScheduleClaim struct {
+	Claimed bool
+	Err     error
 }
 
 func (s *recordingRuntimeScheduleStore) UpsertSchedule(_ context.Context, sc runtimepipeline.Schedule) error {
@@ -125,8 +131,13 @@ func (s *recordingRuntimeScheduleStore) LoadActiveSchedules(context.Context) ([]
 	return append([]runtimepipeline.Schedule(nil), s.active...), nil
 }
 
-func (*recordingRuntimeScheduleStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
-	return true, nil
+func (s *recordingRuntimeScheduleStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
+	if len(s.claims) == 0 {
+		return true, nil
+	}
+	claim := s.claims[0]
+	s.claims = s.claims[1:]
+	return claim.Claimed, claim.Err
 }
 
 func (*recordingRuntimeScheduleStore) ReleaseSchedule(context.Context, runtimepipeline.Schedule) error {

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -74,8 +74,9 @@ type startupRecoveryDecisionReport struct {
 	ReasonCode               startupRecoveryReasonCode
 	ErrorText                string
 	ScheduleRestoreAttempted bool
-	ScheduleRestoreSuccesses int
-	ScheduleRestoreFailures  int
+	ScheduleReplayCount      int
+	ScheduleSkipCount        int
+	ScheduleDropCount        int
 	ManagerRecoveryAttempted bool
 	ManagerResetAttempted    bool
 	ManagerResetError        string
@@ -135,8 +136,9 @@ func (r startupRecoveryDecisionReport) detail() map[string]any {
 	detail["decision_outcome"] = string(r.Outcome)
 	detail["decision_reason_code"] = string(r.ReasonCode)
 	detail["schedule_restore_attempted"] = r.ScheduleRestoreAttempted
-	detail["schedule_restore_success_count"] = r.ScheduleRestoreSuccesses
-	detail["schedule_restore_failure_count"] = r.ScheduleRestoreFailures
+	detail["schedule_replayed_count"] = r.ScheduleReplayCount
+	detail["schedule_skipped_count"] = r.ScheduleSkipCount
+	detail["schedule_dropped_count"] = r.ScheduleDropCount
 	detail["manager_recovery_attempted"] = r.ManagerRecoveryAttempted
 	detail["manager_reset_attempted"] = r.ManagerResetAttempted
 	if errText := strings.TrimSpace(r.ErrorText); errText != "" {

--- a/internal/runtime/startup_timer_recovery.go
+++ b/internal/runtime/startup_timer_recovery.go
@@ -1,0 +1,154 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/runtime/diaglog"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+const startupTimerRecoveryAction = "startup_recovery_timer_aftermath"
+
+type startupTimerRecoveryOutcome string
+
+const (
+	startupTimerRecoveryOutcomeReplayed startupTimerRecoveryOutcome = "replayed"
+	startupTimerRecoveryOutcomeSkipped  startupTimerRecoveryOutcome = "skipped"
+	startupTimerRecoveryOutcomeDropped  startupTimerRecoveryOutcome = "dropped"
+)
+
+type startupTimerRecoveryReasonCode string
+
+const (
+	startupTimerRecoveryReasonRestored         startupTimerRecoveryReasonCode = "persisted_schedule_restored"
+	startupTimerRecoveryReasonClaimNotAcquired startupTimerRecoveryReasonCode = "schedule_claim_not_acquired"
+	startupTimerRecoveryReasonRestoreFailed    startupTimerRecoveryReasonCode = "schedule_restore_failed"
+)
+
+type startupTimerRecoveryResult struct {
+	Schedule   runtimepipeline.Schedule
+	Outcome    startupTimerRecoveryOutcome
+	ReasonCode startupTimerRecoveryReasonCode
+	ErrorText  string
+}
+
+func (r startupTimerRecoveryResult) detail() map[string]any {
+	sc := r.Schedule
+	detail := map[string]any{
+		"decision_family":      "startup_timer_recovery",
+		"decision_outcome":     string(r.Outcome),
+		"decision_reason_code": string(r.ReasonCode),
+		"agent_id":             strings.TrimSpace(sc.AgentID),
+		"event_type":           strings.TrimSpace(sc.EventType),
+		"entity_id":            sc.EffectiveEntityID(),
+		"flow_instance":        sc.EffectiveFlowInstance(),
+		"task_id":              strings.TrimSpace(sc.TaskID),
+		"schedule_mode":        strings.TrimSpace(sc.Mode),
+	}
+	if !sc.At.IsZero() {
+		detail["scheduled_fire_at"] = sc.At.UTC().Format(time.RFC3339Nano)
+	}
+	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
+		detail["error"] = errText
+		detail["error_code"] = string(r.ReasonCode)
+	}
+	return detail
+}
+
+func (r startupTimerRecoveryResult) level() diaglog.Level {
+	if r.Outcome == startupTimerRecoveryOutcomeDropped {
+		return diaglog.LevelWarn
+	}
+	return diaglog.LevelInfo
+}
+
+func (r startupTimerRecoveryResult) message() string {
+	switch r.Outcome {
+	case startupTimerRecoveryOutcomeDropped:
+		return "Startup recovery dropped persisted timer"
+	case startupTimerRecoveryOutcomeSkipped:
+		return "Startup recovery skipped persisted timer"
+	default:
+		return "Startup recovery replayed persisted timer"
+	}
+}
+
+func logStartupTimerRecoveryAftermath(ctx context.Context, logger *RuntimeLogger, result startupTimerRecoveryResult) {
+	if logger == nil {
+		return
+	}
+	entry := RuntimeLogEntry{
+		Level:     result.level(),
+		Message:   result.message(),
+		Component: "scheduler",
+		Action:    startupTimerRecoveryAction,
+		EventType: strings.TrimSpace(result.Schedule.EventType),
+		AgentID:   strings.TrimSpace(result.Schedule.AgentID),
+		EntityID:  result.Schedule.EffectiveEntityID(),
+		Detail:    result.detail(),
+		Error:     strings.TrimSpace(result.ErrorText),
+	}
+	handleRuntimeLogPersistenceError("scheduler", startupTimerRecoveryAction, logger.Log(ctx, entry))
+}
+
+func restoreStartupTimerSchedule(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, logger *RuntimeLogger, sc runtimepipeline.Schedule) startupTimerRecoveryResult {
+	claimed, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, store, scheduler, sc)
+	switch {
+	case err != nil:
+		result := startupTimerRecoveryResult{
+			Schedule:   sc,
+			Outcome:    startupTimerRecoveryOutcomeDropped,
+			ReasonCode: startupTimerRecoveryReasonRestoreFailed,
+			ErrorText:  err.Error(),
+		}
+		logStartupTimerRecoveryAftermath(ctx, logger, result)
+		return result
+	case !claimed:
+		result := startupTimerRecoveryResult{
+			Schedule:   sc,
+			Outcome:    startupTimerRecoveryOutcomeSkipped,
+			ReasonCode: startupTimerRecoveryReasonClaimNotAcquired,
+		}
+		logStartupTimerRecoveryAftermath(ctx, logger, result)
+		return result
+	default:
+		result := startupTimerRecoveryResult{
+			Schedule:   sc,
+			Outcome:    startupTimerRecoveryOutcomeReplayed,
+			ReasonCode: startupTimerRecoveryReasonRestored,
+		}
+		logStartupTimerRecoveryAftermath(ctx, logger, result)
+		return result
+	}
+}
+
+func restoreStartupTimerSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, logger *RuntimeLogger, schedules []runtimepipeline.Schedule) []startupTimerRecoveryResult {
+	results := make([]startupTimerRecoveryResult, 0, len(schedules))
+	for _, sc := range schedules {
+		results = append(results, restoreStartupTimerSchedule(ctx, store, scheduler, logger, sc))
+	}
+	return results
+}
+
+func summarizeStartupTimerRecovery(results []startupTimerRecoveryResult) (replayed, skipped, dropped int, errText string) {
+	for _, result := range results {
+		switch result.Outcome {
+		case startupTimerRecoveryOutcomeReplayed:
+			replayed++
+		case startupTimerRecoveryOutcomeSkipped:
+			skipped++
+		case startupTimerRecoveryOutcomeDropped:
+			dropped++
+			if strings.TrimSpace(errText) == "" && strings.TrimSpace(result.ErrorText) != "" {
+				errText = strings.TrimSpace(result.ErrorText)
+			}
+		}
+	}
+	if dropped > 0 && strings.TrimSpace(errText) == "" {
+		errText = fmt.Sprintf("failed to restore %d active schedule(s)", dropped)
+	}
+	return replayed, skipped, dropped, errText
+}


### PR DESCRIPTION
Closes #328

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`

## Human summary
Startup timer recovery during restart now has one canonical runtime-owned replay/skip/drop aftermath model. The startup restore loop, the startup recovery decision summary, and the supported runtime-log reader surface now tell the same story for persisted active schedules.

## What changed
- introduced a typed startup timer-recovery aftermath owner in `internal/runtime/startup_timer_recovery.go`
- moved `Runtime.Start()` schedule restore onto that owner instead of local success/failure counting plus an ad hoc `restore_schedule_failed` branch
- updated `startupRecoveryDecisionReport` to summarize timer recovery as replayed / skipped / dropped counts
- added focused runtime and conformance proofs for replayed, skipped, and dropped timer recovery outcomes

## Why needed
The current startup timer recovery path had live semantic drift: `ClaimAndRegisterSchedule(...)=false,nil` was silently treated as a restore success because the boolean result was discarded. Operators also lacked one canonical aftermath surface for replayed / skipped / dropped timer recovery outcomes.

## Scope boundaries
- in scope: startup timer recovery replay/skip/drop aftermath for persisted active schedules
- out of scope: manager backlog / in-flight recovery visibility, boot recurring/lifecycle timer synthesis diagnostics, broad observability redesign

## Tests run
- `go test ./internal/runtime -run 'TestRuntimeStart_(RecoveryEnabledEmitsAllowedDecisionSummary|RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary|RecoveryFailureEmitsDegradedDecisionSummary|RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartup|RecoveryDisabledEmitsDeniedDecisionForActiveSchedules|RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork)$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(StartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader|StartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityReader|StartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityReader|ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/conformance ./internal/dashboard/server -count=1`
- `go test ./internal/runtime ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual risk
This PR is intentionally limited to the startup timer-recovery child class. The broader `recovery_restart_diagnostics` parent remains open for manager backlog / in-flight recovery visibility.

## Follow-up / not in scope
- parent watchlist node remains `recovery_restart_diagnostics`
- remaining child tail after this PR is the manager backlog / in-flight recovery visibility sibling
