### PR TITLE
[agent-c][issue #175] Add live session watchdog visibility

### DIFF
--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -10,11 +10,22 @@ import (
 )
 
 func projectConversationSummaryMetadata(p store.ConversationRuntimeStateDescriptor) ConversationSummaryMetadata {
-	return ConversationSummaryMetadata{
+	meta := ConversationSummaryMetadata{
 		ProviderSessionID:    p.ProviderSessionID,
 		RetryReason:          p.RetryReason,
 		RetriesFromSessionID: p.RetriesFromSessionID,
 	}
+	if p.Watchdog != nil {
+		meta.Watchdog = &ConversationRuntimeWatchdog{
+			State:         p.Watchdog.State,
+			BlockingLayer: p.Watchdog.BlockingLayer,
+			Action:        p.Watchdog.Action,
+			Outcome:       p.Watchdog.Outcome,
+			LastOutputAt:  p.Watchdog.LastOutputAt,
+			RecordedAt:    p.Watchdog.RecordedAt,
+		}
+	}
+	return meta
 }
 
 func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor) ConversationRuntimeState {
@@ -28,6 +39,16 @@ func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor)
 		state.LastTurn = &ConversationRuntimeLastTurn{
 			TaskID:  p.LastTurn.TaskID,
 			ParseOK: p.LastTurn.ParseOK,
+		}
+	}
+	if p.Watchdog != nil {
+		state.Watchdog = &ConversationRuntimeWatchdog{
+			State:         p.Watchdog.State,
+			BlockingLayer: p.Watchdog.BlockingLayer,
+			Action:        p.Watchdog.Action,
+			Outcome:       p.Watchdog.Outcome,
+			LastOutputAt:  p.Watchdog.LastOutputAt,
+			RecordedAt:    p.Watchdog.RecordedAt,
 		}
 	}
 	return state

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -47,9 +47,10 @@ type ConversationSummary struct {
 }
 
 type ConversationSummaryMetadata struct {
-	ProviderSessionID    string `json:"provider_session_id,omitempty"`
-	RetryReason          string `json:"retry_reason,omitempty"`
-	RetriesFromSessionID string `json:"retries_from_session_id,omitempty"`
+	ProviderSessionID    string                       `json:"provider_session_id,omitempty"`
+	RetryReason          string                       `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string                       `json:"retries_from_session_id,omitempty"`
+	Watchdog             *ConversationRuntimeWatchdog `json:"watchdog,omitempty"`
 }
 
 type ConversationDetail struct {
@@ -105,11 +106,21 @@ type ConversationRuntimeState struct {
 	ProviderSessionID    string                       `json:"provider_session_id,omitempty"`
 	RetryReason          string                       `json:"retry_reason,omitempty"`
 	RetriesFromSessionID string                       `json:"retries_from_session_id,omitempty"`
+	Watchdog             *ConversationRuntimeWatchdog `json:"watchdog,omitempty"`
 }
 
 type ConversationRuntimeLastTurn struct {
 	TaskID  string `json:"task_id,omitempty"`
 	ParseOK bool   `json:"parse_ok"`
+}
+
+type ConversationRuntimeWatchdog struct {
+	State         string `json:"state,omitempty"`
+	BlockingLayer string `json:"blocking_layer,omitempty"`
+	Action        string `json:"action,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	LastOutputAt  string `json:"last_output_at,omitempty"`
+	RecordedAt    string `json:"recorded_at,omitempty"`
 }
 
 type ConversationMessage struct {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1786,6 +1786,34 @@ func TestSQLConversationReader_ListFailsOnMalformedCanonicalRuntimeState(t *test
 	}
 }
 
+func TestSQLConversationReader_ListFailsOnMalformedCanonicalSessionWatchdogState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+		WithArgs(10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"mystery","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-04-10T12:00:30Z"}}`), time.Now().UTC()))
+
+	if _, err := reader.List(context.Background(), 10); err == nil {
+		t.Fatal("expected malformed canonical session watchdog state to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -1812,6 +1840,116 @@ func TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeState(t *testi
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_GetFailsOnMalformedCanonicalSessionWatchdogState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorCanonical,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-04-10T12:00:30Z"}}`), []byte(`[]`), time.Now().UTC()))
+
+	if _, _, err := reader.Get(context.Background(), "sess-1"); err == nil {
+		t.Fatal("expected malformed canonical session watchdog state to fail")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_ListProjectsCanonicalSessionWatchdogState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+		WithArgs(10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-04-10T12:00:00Z","recorded_at":"2026-04-10T12:00:30Z"}}`), time.Now().UTC()))
+
+	items, err := reader.List(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 || items[0].Metadata.Watchdog == nil {
+		t.Fatalf("expected one watchdog-bearing row, got %+v", items)
+	}
+	if items[0].Metadata.Watchdog.State != "healthy_long_running" || items[0].Metadata.Watchdog.Action != "turn_long_running" {
+		t.Fatalf("unexpected summary watchdog: %+v", items[0].Metadata.Watchdog)
+	}
+}
+
+func TestHandler_ConversationDetail_ProjectsSessionWatchdogState(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(Options{
+		AuthToken: testOperatorAuthToken,
+		Conversations: stubConversations{
+			bySession: map[string]ConversationDetail{
+				"sess-1": {
+					AgentID:   "agent-1",
+					SessionID: "sess-1",
+					UpdatedAt: now.Format(time.RFC3339),
+					RuntimeState: ConversationRuntimeState{
+						Summary: "summarized",
+						Watchdog: &ConversationRuntimeWatchdog{
+							State:         "no_output",
+							BlockingLayer: "session_execution",
+							Action:        "session_no_output",
+							Outcome:       "warning_emitted",
+							RecordedAt:    "2026-04-10T12:00:30Z",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/conversations/sess-1", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("conversation detail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal conversation detail: %v", err)
+	}
+	runtimeState, ok := payload["runtime_state"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime_state missing or invalid: %#v", payload["runtime_state"])
+	}
+	watchdog, ok := runtimeState["watchdog"].(map[string]any)
+	if !ok {
+		t.Fatalf("watchdog missing or invalid: %#v", runtimeState["watchdog"])
+	}
+	if watchdog["state"] != "no_output" || watchdog["action"] != "session_no_output" || watchdog["outcome"] != "warning_emitted" {
+		t.Fatalf("unexpected watchdog payload: %#v", watchdog)
 	}
 }
 

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -31,6 +31,19 @@ import (
 	"swarm/internal/testutil"
 )
 
+func acquireLiveConversationSession(t *testing.T, ctx context.Context, db *sql.DB, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, scopeKey string) string {
+	t.Helper()
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	lease, err := registry.Acquire(ctx, agentID, runtimeMode, sessionScope, "test-owner", scopeKey)
+	if err != nil {
+		t.Fatalf("Acquire(%s,%s,%s): %v", agentID, runtimeMode, scopeKey, err)
+	}
+	if err := registry.Release(ctx, lease); err != nil {
+		t.Fatalf("Release(%s,%s): %v", agentID, lease.SessionID, err)
+	}
+	return lease.SessionID
+}
+
 func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
@@ -104,6 +117,76 @@ func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *test
 	}
 	if strings.TrimSpace(turn.ToolResults[0].ToolName) != "schedule" {
 		t.Fatalf("tool_result.tool_name = %#v, want schedule", turn.ToolResults[0].ToolName)
+	}
+}
+
+func TestCanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	sessionID := acquireLiveConversationSession(t, ctx, db, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
+		AgentID:      "agent-1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Messages: []runtimellm.Message{
+			{Role: "assistant", Content: "Still working on it."},
+		},
+		Summary:   "Working",
+		TurnCount: 3,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(session): %v", err)
+	}
+	if err := pg.UpdateLiveSessionWatchdog(ctx, runtimellm.ConversationWatchdogUpdate{
+		SessionID:    sessionID,
+		AgentID:      "agent-1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Watchdog: &runtimellm.ConversationWatchdog{
+			State:         "no_output",
+			BlockingLayer: "session_execution",
+			Action:        "session_no_output",
+			Outcome:       "warning_emitted",
+			RecordedAt:    "2026-04-10T12:00:30Z",
+		},
+	}); err != nil {
+		t.Fatalf("UpdateLiveSessionWatchdog: %v", err)
+	}
+
+	reader := dashboardserver.NewSQLConversationReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLConversationReader returned nil")
+	}
+	item, ok, err := reader.Get(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Get conversation: %v", err)
+	}
+	if !ok {
+		t.Fatalf("conversation %s not found", sessionID)
+	}
+	if item.RuntimeState.Watchdog == nil {
+		t.Fatal("expected runtime_state.watchdog to round-trip")
+	}
+	if item.RuntimeState.Watchdog.State != "no_output" || item.RuntimeState.Watchdog.Action != "session_no_output" {
+		t.Fatalf("unexpected runtime_state.watchdog: %+v", item.RuntimeState.Watchdog)
+	}
+	items, err := reader.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("List conversations: %v", err)
+	}
+	if len(items) == 0 || items[0].Metadata.Watchdog == nil {
+		t.Fatalf("expected list metadata watchdog, got %#v", items)
+	}
+	if items[0].Metadata.Watchdog.Outcome != "warning_emitted" {
+		t.Fatalf("list watchdog outcome = %q, want warning_emitted", items[0].Metadata.Watchdog.Outcome)
 	}
 }
 

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -70,6 +70,7 @@ func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s
 		AgentID:      s.AgentID,
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
 		Mode:         mode.String(),
 		Messages:     s.Messages,
@@ -137,6 +138,7 @@ func (r *AnthropicAPIRuntime) StartSession(ctx context.Context, agentID, systemP
 			s.TurnCount = rec.TurnCount
 			s.RetryReason = strings.TrimSpace(rec.RetryReason)
 			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
+			s.Watchdog = rec.Watchdog
 		}
 	}
 	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))
@@ -322,6 +324,7 @@ func (r *AnthropicAPIRuntime) persistConversation(ctx context.Context, s *Sessio
 		AgentID:      s.AgentID,
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
 		Mode:         mode.String(),
 		Messages:     s.Messages,
 		Summary:      BuildSessionSummary(s),

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -107,6 +107,7 @@ func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *S
 		AgentID:      s.AgentID,
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
 		Mode:         mode.String(),
 		Messages:     s.Messages,
@@ -175,6 +176,7 @@ func (r *ClaudeCLIRuntime) StartSession(ctx context.Context, agentID, systemProm
 			s.TurnCount = rec.TurnCount
 			s.RetryReason = strings.TrimSpace(rec.RetryReason)
 			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
+			s.Watchdog = rec.Watchdog
 		}
 	}
 	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))
@@ -296,13 +298,18 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 	}
 
 	start := time.Now()
+	longRunningAfter, noOutputAfter := conversationWatchdogThresholds(r.effectiveCLITimeout(ctx))
 	monitorMeta := MonitorTurnMeta{
-		AgentID:   s.AgentID,
-		Runtime:   "cli_test",
-		SessionID: sessionToken(s),
-		ScopeKey:  s.ScopeKey,
-		InputRole: message.Role,
-		InputText: prompt,
+		AgentID:                  s.AgentID,
+		Runtime:                  "cli_test",
+		SessionID:                s.ID,
+		ScopeKey:                 s.ScopeKey,
+		SessionScope:             s.SessionScope,
+		ConversationMode:         resolved.RuntimeMode.String(),
+		InputRole:                message.Role,
+		InputText:                prompt,
+		WatchdogLongRunningAfter: longRunningAfter,
+		WatchdogNoOutputAfter:    noOutputAfter,
 		TargetName: func() string {
 			if target == nil {
 				return ""
@@ -374,7 +381,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 				if mcpEnabled {
 					args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 				}
-				monitorMeta.SessionID = sessionToken(s)
+				monitorMeta.SessionID = s.ID
 				resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, message.Content, monitorMeta)
 				transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 				transportFallback.Used = transportFallback.Used || fallback.Used

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -46,6 +46,7 @@ func (r *ClaudeCLIRuntime) persistConversation(ctx context.Context, s *Session) 
 		AgentID:      s.AgentID,
 		SessionScope: strings.TrimSpace(s.SessionScope),
 		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
 		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
 		Mode:         mode.String(),
 		Messages:     s.Messages,

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -167,13 +167,20 @@ func (r *ClaudeCLIRuntime) runStreaming(ctx context.Context, cmd *exec.Cmd, time
 }
 
 func (r *ClaudeCLIRuntime) openMonitorTurn(ctx context.Context, meta MonitorTurnMeta) (MonitorTurnWriter, error) {
-	if r == nil || r.monitor == nil {
+	if r == nil {
 		return nil, nil
 	}
-	if strings.TrimSpace(meta.AgentID) == "" {
-		return nil, nil
+	var (
+		base MonitorTurnWriter
+		err  error
+	)
+	if r.monitor != nil && strings.TrimSpace(meta.AgentID) != "" {
+		base, err = r.monitor.OpenTurn(ctx, meta)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return r.monitor.OpenTurn(ctx, meta)
+	return newSessionWatchdogMonitorWriter(ctx, base, r.conversations, r.events, meta), nil
 }
 
 func readStreamLines(rc io.ReadCloser, monitor MonitorTurnWriter, stderr bool) [][]byte {

--- a/internal/runtime/llm/monitor_sink.go
+++ b/internal/runtime/llm/monitor_sink.go
@@ -13,13 +13,17 @@ import (
 const defaultMonitorDir = "/tmp/runtime-monitor"
 
 type MonitorTurnMeta struct {
-	AgentID    string
-	Runtime    string
-	SessionID  string
-	ScopeKey   string
-	InputRole  string
-	InputText  string
-	TargetName string
+	AgentID                  string
+	Runtime                  string
+	SessionID                string
+	ScopeKey                 string
+	SessionScope             string
+	ConversationMode         string
+	InputRole                string
+	InputText                string
+	TargetName               string
+	WatchdogLongRunningAfter time.Duration
+	WatchdogNoOutputAfter    time.Duration
 }
 
 type MonitorTurnWriter interface {

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -151,6 +151,7 @@ type ConversationRecord struct {
 	ScopeKey             string
 	RetryReason          string
 	RetriesFromSessionID string
+	Watchdog             *ConversationWatchdog
 	RunID                string
 	TaskID               string
 	Mode                 string
@@ -160,7 +161,26 @@ type ConversationRecord struct {
 	Status               string
 }
 
+type ConversationWatchdog struct {
+	State         string
+	BlockingLayer string
+	Action        string
+	Outcome       string
+	LastOutputAt  string
+	RecordedAt    string
+}
+
+type ConversationWatchdogUpdate struct {
+	SessionID    string
+	AgentID      string
+	SessionScope string
+	ScopeKey     string
+	Mode         string
+	Watchdog     *ConversationWatchdog
+}
+
 type ConversationPersistence interface {
 	UpsertConversation(ctx context.Context, rec ConversationRecord) error
 	LoadActiveConversation(ctx context.Context, agentID, mode, sessionScope, scopeKey string) (ConversationRecord, bool, error)
+	UpdateLiveSessionWatchdog(ctx context.Context, update ConversationWatchdogUpdate) error
 }

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -60,10 +60,15 @@ func (s *failingConversationStore) LoadActiveConversation(context.Context, strin
 	return ConversationRecord{}, false, nil
 }
 
+func (s *failingConversationStore) UpdateLiveSessionWatchdog(context.Context, ConversationWatchdogUpdate) error {
+	return s.err
+}
+
 type captureConversationStore struct {
-	record ConversationRecord
-	load   ConversationRecord
-	loadOK bool
+	record         ConversationRecord
+	load           ConversationRecord
+	loadOK         bool
+	watchdogUpdate ConversationWatchdogUpdate
 }
 
 func (s *captureConversationStore) UpsertConversation(_ context.Context, rec ConversationRecord) error {
@@ -73,6 +78,11 @@ func (s *captureConversationStore) UpsertConversation(_ context.Context, rec Con
 
 func (s *captureConversationStore) LoadActiveConversation(context.Context, string, string, string, string) (ConversationRecord, bool, error) {
 	return s.load, s.loadOK, nil
+}
+
+func (s *captureConversationStore) UpdateLiveSessionWatchdog(_ context.Context, update ConversationWatchdogUpdate) error {
+	s.watchdogUpdate = update
+	return nil
 }
 
 type failingTurnStore struct {

--- a/internal/runtime/llm/session_watchdog.go
+++ b/internal/runtime/llm/session_watchdog.go
@@ -1,0 +1,202 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	conversationWatchdogStateHealthyLongRunning = "healthy_long_running"
+	conversationWatchdogStateNoOutput           = "no_output"
+	conversationWatchdogBlockingLayerSession    = "session_execution"
+	conversationWatchdogActionTurnLongRunning   = "turn_long_running"
+	conversationWatchdogActionSessionNoOutput   = "session_no_output"
+	conversationWatchdogOutcomeObserved         = "observed"
+	conversationWatchdogOutcomeWarningEmitted   = "warning_emitted"
+)
+
+var sessionWatchdogPollInterval = time.Second
+
+type sessionWatchdogMonitorWriter struct {
+	base    MonitorTurnWriter
+	cancel  context.CancelFunc
+	done    chan struct{}
+	meta    MonitorTurnMeta
+	store   ConversationPersistence
+	events  EventPublisher
+	nowFn   func() time.Time
+	startAt time.Time
+
+	mu           sync.Mutex
+	lastOutputAt time.Time
+	sawOutput    bool
+	firedLong    bool
+	firedSilent  bool
+}
+
+func conversationWatchdogThresholds(turnTimeout time.Duration) (time.Duration, time.Duration) {
+	if turnTimeout <= 0 {
+		turnTimeout = 120 * time.Second
+	}
+	longRunningAfter := turnTimeout / 4
+	if longRunningAfter < 30*time.Second {
+		longRunningAfter = 30 * time.Second
+	}
+	if longRunningAfter > 2*time.Minute {
+		longRunningAfter = 2 * time.Minute
+	}
+	noOutputAfter := longRunningAfter * 2
+	if noOutputAfter <= longRunningAfter {
+		noOutputAfter = longRunningAfter + 30*time.Second
+	}
+	return longRunningAfter, noOutputAfter
+}
+
+func newSessionWatchdogMonitorWriter(ctx context.Context, base MonitorTurnWriter, store ConversationPersistence, events EventPublisher, meta MonitorTurnMeta) MonitorTurnWriter {
+	if store == nil || strings.TrimSpace(meta.AgentID) == "" || strings.TrimSpace(meta.SessionID) == "" || strings.TrimSpace(meta.ConversationMode) == "" {
+		return base
+	}
+	longRunningAfter := meta.WatchdogLongRunningAfter
+	noOutputAfter := meta.WatchdogNoOutputAfter
+	if longRunningAfter <= 0 || noOutputAfter <= 0 {
+		longRunningAfter, noOutputAfter = conversationWatchdogThresholds(0)
+	}
+	if longRunningAfter <= 0 || noOutputAfter <= 0 {
+		return base
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	nowFn := time.Now
+	w := &sessionWatchdogMonitorWriter{
+		base:    base,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		meta:    meta,
+		store:   store,
+		events:  events,
+		nowFn:   nowFn,
+		startAt: nowFn(),
+	}
+	go w.loop(loopCtx, longRunningAfter, noOutputAfter)
+	return w
+}
+
+func (w *sessionWatchdogMonitorWriter) WriteStdout(line []byte) {
+	if w.base != nil {
+		w.base.WriteStdout(line)
+	}
+	if len(strings.TrimSpace(string(line))) == 0 {
+		return
+	}
+	w.mu.Lock()
+	w.sawOutput = true
+	w.lastOutputAt = w.nowFn()
+	w.mu.Unlock()
+}
+
+func (w *sessionWatchdogMonitorWriter) WriteStderr(line []byte) {
+	if w.base != nil {
+		w.base.WriteStderr(line)
+	}
+}
+
+func (w *sessionWatchdogMonitorWriter) WriteNotice(format string, args ...any) {
+	if w.base != nil {
+		w.base.WriteNotice(format, args...)
+	}
+}
+
+func (w *sessionWatchdogMonitorWriter) Close() error {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	if w.done != nil {
+		<-w.done
+	}
+	if w.base != nil {
+		return w.base.Close()
+	}
+	return nil
+}
+
+func (w *sessionWatchdogMonitorWriter) loop(ctx context.Context, longRunningAfter, noOutputAfter time.Duration) {
+	defer close(w.done)
+	ticker := time.NewTicker(sessionWatchdogPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.evaluate(longRunningAfter, noOutputAfter)
+		}
+	}
+}
+
+func (w *sessionWatchdogMonitorWriter) evaluate(longRunningAfter, noOutputAfter time.Duration) {
+	now := w.nowFn()
+	w.mu.Lock()
+	elapsed := now.Sub(w.startAt)
+	lastOutputAt := w.lastOutputAt
+	sawOutput := w.sawOutput
+	firedLong := w.firedLong
+	firedSilent := w.firedSilent
+	w.mu.Unlock()
+
+	if !firedLong && sawOutput && elapsed >= longRunningAfter {
+		w.emit(conversationWatchdogStateHealthyLongRunning, conversationWatchdogActionTurnLongRunning, conversationWatchdogOutcomeObserved, lastOutputAt, now)
+		w.mu.Lock()
+		w.firedLong = true
+		w.mu.Unlock()
+	}
+
+	silentFor := elapsed
+	if sawOutput && !lastOutputAt.IsZero() {
+		silentFor = now.Sub(lastOutputAt)
+	}
+	if !firedSilent && elapsed >= noOutputAfter && silentFor >= noOutputAfter {
+		w.emit(conversationWatchdogStateNoOutput, conversationWatchdogActionSessionNoOutput, conversationWatchdogOutcomeWarningEmitted, lastOutputAt, now)
+		w.mu.Lock()
+		w.firedSilent = true
+		w.mu.Unlock()
+	}
+}
+
+func (w *sessionWatchdogMonitorWriter) emit(state, action, outcome string, lastOutputAt, now time.Time) {
+	if w.store == nil {
+		return
+	}
+	payload := &ConversationWatchdog{
+		State:         state,
+		BlockingLayer: conversationWatchdogBlockingLayerSession,
+		Action:        action,
+		Outcome:       outcome,
+		RecordedAt:    now.UTC().Format(time.RFC3339Nano),
+	}
+	if !lastOutputAt.IsZero() {
+		payload.LastOutputAt = lastOutputAt.UTC().Format(time.RFC3339Nano)
+	}
+	if err := w.store.UpdateLiveSessionWatchdog(context.Background(), ConversationWatchdogUpdate{
+		SessionID:    strings.TrimSpace(w.meta.SessionID),
+		AgentID:      strings.TrimSpace(w.meta.AgentID),
+		SessionScope: strings.TrimSpace(w.meta.SessionScope),
+		ScopeKey:     strings.TrimSpace(w.meta.ScopeKey),
+		Mode:         strings.TrimSpace(w.meta.ConversationMode),
+		Watchdog:     payload,
+	}); err != nil {
+		logPublisherRuntime(context.Background(), w.events, "warn", "persist_session_watchdog_failed", "Persisting live session watchdog state failed", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
+			"watchdog_state":  payload.State,
+			"watchdog_action": payload.Action,
+		}, err)
+		return
+	}
+	logPublisherRuntime(context.Background(), w.events, "info", action, "Live session watchdog state updated", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
+		"watchdog_state":   payload.State,
+		"blocking_layer":   payload.BlockingLayer,
+		"watchdog_action":  payload.Action,
+		"watchdog_outcome": payload.Outcome,
+		"last_output_at":   payload.LastOutputAt,
+		"recorded_at":      payload.RecordedAt,
+	}, nil)
+}

--- a/internal/runtime/llm/session_watchdog.go
+++ b/internal/runtime/llm/session_watchdog.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"swarm/internal/runtime/sessions"
 )
 
 const (
@@ -23,6 +25,7 @@ type sessionWatchdogMonitorWriter struct {
 	base    MonitorTurnWriter
 	cancel  context.CancelFunc
 	done    chan struct{}
+	ctx     context.Context
 	meta    MonitorTurnMeta
 	store   ConversationPersistence
 	events  EventPublisher
@@ -58,6 +61,10 @@ func newSessionWatchdogMonitorWriter(ctx context.Context, base MonitorTurnWriter
 	if store == nil || strings.TrimSpace(meta.AgentID) == "" || strings.TrimSpace(meta.SessionID) == "" || strings.TrimSpace(meta.ConversationMode) == "" {
 		return base
 	}
+	mode, err := sessions.ParseConversationRuntimeMode(meta.ConversationMode)
+	if err != nil || mode.IsStateless() {
+		return base
+	}
 	longRunningAfter := meta.WatchdogLongRunningAfter
 	noOutputAfter := meta.WatchdogNoOutputAfter
 	if longRunningAfter <= 0 || noOutputAfter <= 0 {
@@ -72,6 +79,7 @@ func newSessionWatchdogMonitorWriter(ctx context.Context, base MonitorTurnWriter
 		base:    base,
 		cancel:  cancel,
 		done:    make(chan struct{}),
+		ctx:     loopCtx,
 		meta:    meta,
 		store:   store,
 		events:  events,
@@ -177,7 +185,7 @@ func (w *sessionWatchdogMonitorWriter) emit(state, action, outcome string, lastO
 	if !lastOutputAt.IsZero() {
 		payload.LastOutputAt = lastOutputAt.UTC().Format(time.RFC3339Nano)
 	}
-	if err := w.store.UpdateLiveSessionWatchdog(context.Background(), ConversationWatchdogUpdate{
+	if err := w.store.UpdateLiveSessionWatchdog(w.ctx, ConversationWatchdogUpdate{
 		SessionID:    strings.TrimSpace(w.meta.SessionID),
 		AgentID:      strings.TrimSpace(w.meta.AgentID),
 		SessionScope: strings.TrimSpace(w.meta.SessionScope),
@@ -185,13 +193,13 @@ func (w *sessionWatchdogMonitorWriter) emit(state, action, outcome string, lastO
 		Mode:         strings.TrimSpace(w.meta.ConversationMode),
 		Watchdog:     payload,
 	}); err != nil {
-		logPublisherRuntime(context.Background(), w.events, "warn", "persist_session_watchdog_failed", "Persisting live session watchdog state failed", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
+		logPublisherRuntime(w.ctx, w.events, "warn", "persist_session_watchdog_failed", "Persisting live session watchdog state failed", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
 			"watchdog_state":  payload.State,
 			"watchdog_action": payload.Action,
 		}, err)
 		return
 	}
-	logPublisherRuntime(context.Background(), w.events, "info", action, "Live session watchdog state updated", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
+	logPublisherRuntime(w.ctx, w.events, "info", action, "Live session watchdog state updated", strings.TrimSpace(w.meta.AgentID), strings.TrimSpace(w.meta.SessionID), "", map[string]any{
 		"watchdog_state":   payload.State,
 		"blocking_layer":   payload.BlockingLayer,
 		"watchdog_action":  payload.Action,

--- a/internal/runtime/llm/session_watchdog_test.go
+++ b/internal/runtime/llm/session_watchdog_test.go
@@ -15,6 +15,34 @@ func (noopMonitorWriter) WriteStderr([]byte)         {}
 func (noopMonitorWriter) WriteNotice(string, ...any) {}
 func (noopMonitorWriter) Close() error               { return nil }
 
+type noopMonitorWriterPtr struct{}
+
+func (*noopMonitorWriterPtr) WriteStdout([]byte)         {}
+func (*noopMonitorWriterPtr) WriteStderr([]byte)         {}
+func (*noopMonitorWriterPtr) WriteNotice(string, ...any) {}
+func (*noopMonitorWriterPtr) Close() error               { return nil }
+
+type blockingWatchdogStore struct {
+	started chan struct{}
+}
+
+func (s *blockingWatchdogStore) UpsertConversation(context.Context, ConversationRecord) error {
+	return nil
+}
+
+func (s *blockingWatchdogStore) LoadActiveConversation(context.Context, string, string, string, string) (ConversationRecord, bool, error) {
+	return ConversationRecord{}, false, nil
+}
+
+func (s *blockingWatchdogStore) UpdateLiveSessionWatchdog(ctx context.Context, _ ConversationWatchdogUpdate) error {
+	select {
+	case s.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
 func waitForWatchdogUpdate(t *testing.T, store *captureConversationStore) ConversationWatchdogUpdate {
 	t.Helper()
 	deadline := time.Now().Add(500 * time.Millisecond)
@@ -64,6 +92,22 @@ func TestSessionWatchdogMonitorWriter_PersistsHealthyLongRunningStateAfterOutput
 	}
 }
 
+func TestSessionWatchdogMonitorWriter_SkipsStatelessModes(t *testing.T) {
+	base := &noopMonitorWriterPtr{}
+	writer := newSessionWatchdogMonitorWriter(context.Background(), base, &captureConversationStore{}, nil, MonitorTurnMeta{
+		AgentID:                  "agent-1",
+		SessionID:                "sess-1",
+		ScopeKey:                 "task-1",
+		SessionScope:             "",
+		ConversationMode:         sessions.RuntimeModeTask.String(),
+		WatchdogLongRunningAfter: 20 * time.Millisecond,
+		WatchdogNoOutputAfter:    20 * time.Millisecond,
+	})
+	if writer != base {
+		t.Fatalf("expected stateless mode to return base writer, got %T", writer)
+	}
+}
+
 func TestSessionWatchdogMonitorWriter_PersistsNoOutputStateWithoutStdout(t *testing.T) {
 	prevPoll := sessionWatchdogPollInterval
 	sessionWatchdogPollInterval = 5 * time.Millisecond
@@ -96,5 +140,40 @@ func TestSessionWatchdogMonitorWriter_PersistsNoOutputStateWithoutStdout(t *test
 	}
 	if update.Watchdog.LastOutputAt != "" {
 		t.Fatalf("last_output_at = %q, want empty", update.Watchdog.LastOutputAt)
+	}
+}
+
+func TestSessionWatchdogMonitorWriter_CloseCancelsBlockedWatchdogPersistence(t *testing.T) {
+	prevPoll := sessionWatchdogPollInterval
+	sessionWatchdogPollInterval = 5 * time.Millisecond
+	defer func() { sessionWatchdogPollInterval = prevPoll }()
+
+	store := &blockingWatchdogStore{started: make(chan struct{}, 1)}
+	writer := newSessionWatchdogMonitorWriter(context.Background(), noopMonitorWriter{}, store, nil, MonitorTurnMeta{
+		AgentID:                  "agent-1",
+		SessionID:                "sess-1",
+		ScopeKey:                 "global",
+		SessionScope:             "global",
+		ConversationMode:         sessions.RuntimeModeSession.String(),
+		WatchdogLongRunningAfter: 20 * time.Millisecond,
+		WatchdogNoOutputAfter:    20 * time.Millisecond,
+	})
+
+	select {
+	case <-store.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for watchdog persistence to start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = writer.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Close did not unblock after canceling watchdog persistence")
 	}
 }

--- a/internal/runtime/llm/session_watchdog_test.go
+++ b/internal/runtime/llm/session_watchdog_test.go
@@ -1,0 +1,100 @@
+package llm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarm/internal/runtime/sessions"
+)
+
+type noopMonitorWriter struct{}
+
+func (noopMonitorWriter) WriteStdout([]byte)         {}
+func (noopMonitorWriter) WriteStderr([]byte)         {}
+func (noopMonitorWriter) WriteNotice(string, ...any) {}
+func (noopMonitorWriter) Close() error               { return nil }
+
+func waitForWatchdogUpdate(t *testing.T, store *captureConversationStore) ConversationWatchdogUpdate {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if store.watchdogUpdate.Watchdog != nil {
+			return store.watchdogUpdate
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for watchdog update")
+	return ConversationWatchdogUpdate{}
+}
+
+func TestSessionWatchdogMonitorWriter_PersistsHealthyLongRunningStateAfterOutput(t *testing.T) {
+	prevPoll := sessionWatchdogPollInterval
+	sessionWatchdogPollInterval = 5 * time.Millisecond
+	defer func() { sessionWatchdogPollInterval = prevPoll }()
+
+	store := &captureConversationStore{}
+	writer := newSessionWatchdogMonitorWriter(context.Background(), noopMonitorWriter{}, store, nil, MonitorTurnMeta{
+		AgentID:                  "agent-1",
+		SessionID:                "sess-1",
+		ScopeKey:                 "global",
+		SessionScope:             "global",
+		ConversationMode:         sessions.RuntimeModeSession.String(),
+		WatchdogLongRunningAfter: 20 * time.Millisecond,
+		WatchdogNoOutputAfter:    60 * time.Millisecond,
+	})
+	t.Cleanup(func() { _ = writer.Close() })
+
+	writer.WriteStdout([]byte(`{"type":"assistant","message":"working"}`))
+	update := waitForWatchdogUpdate(t, store)
+	if update.Watchdog.State != conversationWatchdogStateHealthyLongRunning {
+		t.Fatalf("watchdog state = %q, want %q", update.Watchdog.State, conversationWatchdogStateHealthyLongRunning)
+	}
+	if update.Watchdog.Action != conversationWatchdogActionTurnLongRunning {
+		t.Fatalf("watchdog action = %q, want %q", update.Watchdog.Action, conversationWatchdogActionTurnLongRunning)
+	}
+	if update.Watchdog.Outcome != conversationWatchdogOutcomeObserved {
+		t.Fatalf("watchdog outcome = %q, want %q", update.Watchdog.Outcome, conversationWatchdogOutcomeObserved)
+	}
+	if update.Watchdog.BlockingLayer != conversationWatchdogBlockingLayerSession {
+		t.Fatalf("watchdog blocking_layer = %q, want %q", update.Watchdog.BlockingLayer, conversationWatchdogBlockingLayerSession)
+	}
+	if update.Watchdog.LastOutputAt == "" {
+		t.Fatal("expected last_output_at to be recorded")
+	}
+}
+
+func TestSessionWatchdogMonitorWriter_PersistsNoOutputStateWithoutStdout(t *testing.T) {
+	prevPoll := sessionWatchdogPollInterval
+	sessionWatchdogPollInterval = 5 * time.Millisecond
+	defer func() { sessionWatchdogPollInterval = prevPoll }()
+
+	store := &captureConversationStore{}
+	writer := newSessionWatchdogMonitorWriter(context.Background(), noopMonitorWriter{}, store, nil, MonitorTurnMeta{
+		AgentID:                  "agent-1",
+		SessionID:                "sess-1",
+		ScopeKey:                 "global",
+		SessionScope:             "global",
+		ConversationMode:         sessions.RuntimeModeSession.String(),
+		WatchdogLongRunningAfter: 20 * time.Millisecond,
+		WatchdogNoOutputAfter:    20 * time.Millisecond,
+	})
+	t.Cleanup(func() { _ = writer.Close() })
+
+	update := waitForWatchdogUpdate(t, store)
+	if update.Watchdog.State != conversationWatchdogStateNoOutput {
+		t.Fatalf("watchdog state = %q, want %q", update.Watchdog.State, conversationWatchdogStateNoOutput)
+	}
+	if update.Watchdog.Action != conversationWatchdogActionSessionNoOutput {
+		t.Fatalf("watchdog action = %q, want %q", update.Watchdog.Action, conversationWatchdogActionSessionNoOutput)
+	}
+	if update.Watchdog.Outcome != conversationWatchdogOutcomeWarningEmitted {
+		t.Fatalf("watchdog outcome = %q, want %q", update.Watchdog.Outcome, conversationWatchdogOutcomeWarningEmitted)
+	}
+	if update.Watchdog.BlockingLayer != conversationWatchdogBlockingLayerSession {
+		t.Fatalf("watchdog blocking_layer = %q, want %q", update.Watchdog.BlockingLayer, conversationWatchdogBlockingLayerSession)
+	}
+	if update.Watchdog.LastOutputAt != "" {
+		t.Fatalf("last_output_at = %q, want empty", update.Watchdog.LastOutputAt)
+	}
+}

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -38,6 +38,7 @@ type Session struct {
 	ScopeKey             string
 	RetryReason          string
 	RetriesFromSessionID string
+	Watchdog             *ConversationWatchdog
 	TurnCount            int
 	ParseFailures        int
 	SystemPrompt         string

--- a/internal/store/conversation_runtime_state.go
+++ b/internal/store/conversation_runtime_state.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"time"
 )
 
 type ConversationRuntimeStateDescriptor struct {
@@ -11,11 +13,21 @@ type ConversationRuntimeStateDescriptor struct {
 	ProviderSessionID    string                                 `json:"provider_session_id,omitempty"`
 	RetryReason          string                                 `json:"retry_reason,omitempty"`
 	RetriesFromSessionID string                                 `json:"retries_from_session_id,omitempty"`
+	Watchdog             *ConversationRuntimeWatchdogDescriptor `json:"watchdog,omitempty"`
 }
 
 type ConversationRuntimeLastTurnDescriptor struct {
 	TaskID  string `json:"task_id,omitempty"`
 	ParseOK bool   `json:"parse_ok"`
+}
+
+type ConversationRuntimeWatchdogDescriptor struct {
+	State         string `json:"state,omitempty"`
+	BlockingLayer string `json:"blocking_layer,omitempty"`
+	Action        string `json:"action,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	LastOutputAt  string `json:"last_output_at,omitempty"`
+	RecordedAt    string `json:"recorded_at,omitempty"`
 }
 
 func DecodeConversationRuntimeStateDescriptor(raw []byte) (ConversationRuntimeStateDescriptor, error) {
@@ -33,5 +45,54 @@ func DecodeConversationRuntimeStateDescriptor(raw []byte) (ConversationRuntimeSt
 	if payload.LastTurn != nil {
 		payload.LastTurn.TaskID = strings.TrimSpace(payload.LastTurn.TaskID)
 	}
+	if payload.Watchdog != nil {
+		payload.Watchdog.State = strings.TrimSpace(payload.Watchdog.State)
+		payload.Watchdog.BlockingLayer = strings.TrimSpace(payload.Watchdog.BlockingLayer)
+		payload.Watchdog.Action = strings.TrimSpace(payload.Watchdog.Action)
+		payload.Watchdog.Outcome = strings.TrimSpace(payload.Watchdog.Outcome)
+		payload.Watchdog.LastOutputAt = strings.TrimSpace(payload.Watchdog.LastOutputAt)
+		payload.Watchdog.RecordedAt = strings.TrimSpace(payload.Watchdog.RecordedAt)
+		if err := validateConversationRuntimeWatchdogDescriptor(*payload.Watchdog); err != nil {
+			return ConversationRuntimeStateDescriptor{}, err
+		}
+	}
 	return payload, nil
+}
+
+func validateConversationRuntimeWatchdogDescriptor(payload ConversationRuntimeWatchdogDescriptor) error {
+	switch payload.State {
+	case "", "healthy_long_running", "no_output":
+	default:
+		return fmt.Errorf("canonical runtime_state watchdog.state %q is invalid", payload.State)
+	}
+	switch payload.BlockingLayer {
+	case "", "session_execution":
+	default:
+		return fmt.Errorf("canonical runtime_state watchdog.blocking_layer %q is invalid", payload.BlockingLayer)
+	}
+	switch payload.Action {
+	case "", "turn_long_running", "session_no_output":
+	default:
+		return fmt.Errorf("canonical runtime_state watchdog.action %q is invalid", payload.Action)
+	}
+	switch payload.Outcome {
+	case "", "observed", "warning_emitted":
+	default:
+		return fmt.Errorf("canonical runtime_state watchdog.outcome %q is invalid", payload.Outcome)
+	}
+	if payload.State == "healthy_long_running" && payload.LastOutputAt == "" {
+		return fmt.Errorf("canonical runtime_state watchdog.last_output_at is required for healthy_long_running state")
+	}
+	if payload.RecordedAt == "" {
+		return fmt.Errorf("canonical runtime_state watchdog.recorded_at is required")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.RecordedAt); err != nil {
+		return fmt.Errorf("canonical runtime_state watchdog.recorded_at is invalid: %w", err)
+	}
+	if payload.LastOutputAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, payload.LastOutputAt); err != nil {
+			return fmt.Errorf("canonical runtime_state watchdog.last_output_at is invalid: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -718,6 +718,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		return fmt.Errorf("marshal conversation messages: %w", err)
 	}
 	summary := strings.ToValidUTF8(rec.Summary, "\uFFFD")
+	runtimeStatePatch, err := marshalConversationRuntimeStatePatch(&summary, rec.Watchdog)
+	if err != nil {
+		return fmt.Errorf("marshal conversation runtime_state patch: %w", err)
+	}
 	sessionID := strings.TrimSpace(rec.SessionID)
 	runID := nullUUIDString(rec.RunID)
 
@@ -755,7 +759,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				$7::jsonb,
 				$8,
 				$9,
-				jsonb_build_object('summary', NULLIF($10,'')),
+				$10::jsonb,
 				$11,
 				now(),
 				now()
@@ -769,7 +773,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				conversation = EXCLUDED.conversation,
 				turn_count = EXCLUDED.turn_count,
 				runtime_mode = EXCLUDED.runtime_mode,
-				runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($10,'')),
+				runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || EXCLUDED.runtime_state,
 				status = EXCLUDED.status,
 				updated_at = now()
 		`
@@ -783,7 +787,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			string(msgJSON),
 			rec.TurnCount,
 			mode.String(),
-			summary,
+			runtimeStatePatch,
 			status,
 		}
 		if caps.Conversations.AuditRunID {
@@ -806,7 +810,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 					$8::jsonb,
 					$9,
 					$10,
-					jsonb_build_object('summary', NULLIF($11,'')),
+					$11::jsonb,
 					$12,
 					now(),
 					now()
@@ -821,7 +825,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 					conversation = EXCLUDED.conversation,
 					turn_count = EXCLUDED.turn_count,
 					runtime_mode = EXCLUDED.runtime_mode,
-					runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($11,'')),
+					runtime_state = COALESCE(agent_conversation_audits.runtime_state, '{}'::jsonb) || EXCLUDED.runtime_state,
 					status = EXCLUDED.status,
 					updated_at = now()
 			`
@@ -836,7 +840,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				string(msgJSON),
 				rec.TurnCount,
 				mode.String(),
-				summary,
+				runtimeStatePatch,
 				status,
 			}
 		}
@@ -856,7 +860,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		UPDATE agent_sessions
 		SET conversation = $1::jsonb,
 			turn_count = $2,
-			runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($3,'')),
+			runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || $3::jsonb,
 			updated_at = now()
 		WHERE session_id = $4::uuid
 		  AND agent_id = $5
@@ -867,7 +871,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	args := []any{
 		string(msgJSON),
 		rec.TurnCount,
-		summary,
+		runtimeStatePatch,
 		sessionID,
 		rec.AgentID,
 		resolved.ScopeKey,
@@ -881,7 +885,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			UPDATE agent_sessions
 			SET conversation = $1::jsonb,
 				turn_count = $2,
-				runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || jsonb_build_object('summary', NULLIF($3,'')),
+				runtime_state = COALESCE(agent_sessions.runtime_state, '{}'::jsonb) || $3::jsonb,
 				run_id = COALESCE(NULLIF($4,'')::uuid, run_id),
 				updated_at = now()
 			WHERE session_id = $5::uuid
@@ -893,7 +897,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		args = []any{
 			string(msgJSON),
 			rec.TurnCount,
-			summary,
+			runtimeStatePatch,
 			runID,
 			sessionID,
 			rec.AgentID,
@@ -920,6 +924,28 @@ func nullUUIDString(raw string) string {
 		return ""
 	}
 	return raw
+}
+
+func marshalConversationRuntimeStatePatch(summary *string, watchdog *runtimellm.ConversationWatchdog) (string, error) {
+	payload := map[string]any{}
+	if summary != nil && strings.TrimSpace(*summary) != "" {
+		payload["summary"] = *summary
+	}
+	if watchdog != nil {
+		payload["watchdog"] = map[string]any{
+			"state":          strings.TrimSpace(watchdog.State),
+			"blocking_layer": strings.TrimSpace(watchdog.BlockingLayer),
+			"action":         strings.TrimSpace(watchdog.Action),
+			"outcome":        strings.TrimSpace(watchdog.Outcome),
+			"last_output_at": strings.TrimSpace(watchdog.LastOutputAt),
+			"recorded_at":    strings.TrimSpace(watchdog.RecordedAt),
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
 }
 
 func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mode, sessionScope, scopeKey string) (runtimellm.ConversationRecord, bool, error) {
@@ -991,6 +1017,16 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 	rec.Summary = runtimeState.Summary
 	rec.RetryReason = runtimeState.RetryReason
 	rec.RetriesFromSessionID = runtimeState.RetriesFromSessionID
+	if runtimeState.Watchdog != nil {
+		rec.Watchdog = &runtimellm.ConversationWatchdog{
+			State:         runtimeState.Watchdog.State,
+			BlockingLayer: runtimeState.Watchdog.BlockingLayer,
+			Action:        runtimeState.Watchdog.Action,
+			Outcome:       runtimeState.Watchdog.Outcome,
+			LastOutputAt:  runtimeState.Watchdog.LastOutputAt,
+			RecordedAt:    runtimeState.Watchdog.RecordedAt,
+		}
+	}
 	if len(rawMessages) > 0 {
 		var msgs []runtimellm.Message
 		if json.Unmarshal(rawMessages, &msgs) == nil {
@@ -998,4 +1034,57 @@ func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mod
 		}
 	}
 	return rec, true, nil
+}
+
+func (s *PostgresStore) UpdateLiveSessionWatchdog(ctx context.Context, update runtimellm.ConversationWatchdogUpdate) error {
+	agentID := strings.TrimSpace(update.AgentID)
+	if agentID == "" {
+		return fmt.Errorf("agent_id is required")
+	}
+	sessionID := strings.TrimSpace(update.SessionID)
+	if sessionID == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	mode, err := runtimesessions.ParseConversationRuntimeMode(update.Mode)
+	if err != nil {
+		return err
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, mode, runtimesessions.NormalizeSessionScope(update.SessionScope), update.ScopeKey)
+	if err != nil {
+		return err
+	}
+	if resolved.Stateless {
+		return fmt.Errorf("live session watchdog updates require session runtime mode")
+	}
+	if update.Watchdog == nil {
+		return fmt.Errorf("watchdog is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
+	patch, err := marshalConversationRuntimeStatePatch(nil, update.Watchdog)
+	if err != nil {
+		return fmt.Errorf("marshal live session watchdog patch: %w", err)
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = COALESCE(runtime_state, '{}'::jsonb) || $1::jsonb,
+		    updated_at = now()
+		WHERE session_id = $2::uuid
+		  AND agent_id = $3
+		  AND scope_key = $4
+		  AND runtime_mode = $5
+		  AND status = 'active'
+	`, patch, sessionID, agentID, resolved.ScopeKey, mode.String())
+	if err != nil {
+		return fmt.Errorf("update live session watchdog: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, sessionID, mode.String(), resolved.ScopeKey)
+	}
+	return nil
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3240,6 +3240,122 @@ func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalRuntimeStat
 	}
 }
 
+func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalWatchdogRuntimeState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = '{"summary":"ok","watchdog":{"state":"mystery","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-04-10T12:00:00Z","recorded_at":"2026-04-10T12:00:30Z"}}'::jsonb
+		WHERE session_id = $1::uuid
+	`, sessionID); err != nil {
+		t.Fatalf("seed malformed watchdog runtime_state: %v", err)
+	}
+
+	if _, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global"); err == nil || ok {
+		t.Fatalf("expected malformed canonical watchdog runtime_state to fail, ok=%v err=%v", ok, err)
+	} else if !strings.Contains(err.Error(), "decode conversation runtime_state") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagerStore_UpdateLiveSessionWatchdog_RoundTripsThroughLoadActiveConversation(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	err := pg.UpdateLiveSessionWatchdog(ctx, runtimellm.ConversationWatchdogUpdate{
+		SessionID:    sessionID,
+		AgentID:      "a1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Watchdog: &runtimellm.ConversationWatchdog{
+			State:         "healthy_long_running",
+			BlockingLayer: "session_execution",
+			Action:        "turn_long_running",
+			Outcome:       "observed",
+			LastOutputAt:  "2026-04-10T12:00:00Z",
+			RecordedAt:    "2026-04-10T12:00:30Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateLiveSessionWatchdog: %v", err)
+	}
+
+	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global")
+	if err != nil || !ok {
+		t.Fatalf("LoadActiveConversation ok=%v err=%v", ok, err)
+	}
+	if rec.Watchdog == nil {
+		t.Fatal("expected watchdog to round-trip")
+	}
+	if rec.Watchdog.State != "healthy_long_running" || rec.Watchdog.Action != "turn_long_running" || rec.Watchdog.Outcome != "observed" {
+		t.Fatalf("unexpected watchdog: %+v", rec.Watchdog)
+	}
+	if rec.Watchdog.BlockingLayer != "session_execution" {
+		t.Fatalf("watchdog blocking_layer = %q, want session_execution", rec.Watchdog.BlockingLayer)
+	}
+}
+
+func TestManagerStore_UpdateLiveSessionWatchdog_PreservesCanonicalSummary(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    sessionID,
+		AgentID:      "a1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Messages:     []runtimellm.Message{{Role: "assistant", Content: "still working"}},
+		Summary:      "still working",
+		TurnCount:    2,
+		Status:       "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation: %v", err)
+	}
+
+	if err := pg.UpdateLiveSessionWatchdog(ctx, runtimellm.ConversationWatchdogUpdate{
+		SessionID:    sessionID,
+		AgentID:      "a1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Watchdog: &runtimellm.ConversationWatchdog{
+			State:         "no_output",
+			BlockingLayer: "session_execution",
+			Action:        "session_no_output",
+			Outcome:       "warning_emitted",
+			RecordedAt:    "2026-04-10T12:00:30Z",
+		},
+	}); err != nil {
+		t.Fatalf("UpdateLiveSessionWatchdog: %v", err)
+	}
+
+	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global")
+	if err != nil || !ok {
+		t.Fatalf("LoadActiveConversation ok=%v err=%v", ok, err)
+	}
+	if rec.Summary != "still working" {
+		t.Fatalf("summary = %q, want still working", rec.Summary)
+	}
+	if rec.Watchdog == nil || rec.Watchdog.State != "no_output" {
+		t.Fatalf("unexpected watchdog after summary-preserving update: %+v", rec.Watchdog)
+	}
+}
+
 func TestManagerStore_Conversations_AndAgentTurns_PersistRunIDWhenColumnsExist(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #175

## Human Summary
This closes the remaining known `runtime_lifecycle_observability` child class by making long-running and no-output live sessions visible on the first-class conversation/session operator surface. Operators no longer need raw runtime-log archaeology to tell whether a live session is healthy-long-running or stalled with no output.

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: conversation_modes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_scope_intent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: session_termination_metadata`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.agent_sessions`

## What Changed
- added a typed canonical live-session watchdog descriptor on `agent_sessions.runtime_state`
- added runtime watchdog stamping for CLI live sessions, including explicit `state`, `blocking_layer`, `action`, `outcome`, `last_output_at`, and `recorded_at`
- moved live conversation/session store load and dashboard list/detail readback onto that same typed descriptor
- made malformed canonical watchdog state fail closed in the touched store and dashboard paths
- gated the watchdog writer to live reusable session modes only
- made watchdog persistence/log emission use the cancellable loop context so shutdown cannot hang behind a blocked watchdog write
- added focused runtime, store, dashboard, and conformance coverage for healthy long-running, no-output, malformed-state rejection, stateless bypass, cancellation behavior, and summary-preserving watchdog updates

## Why This Is Needed
Before this change, the supported conversation/session surface could show an active live session without any first-class indication that it was healthy-long-running or stalled with no output. The only practical operator path was to inspect raw runtime logs. That left the canonical live-session surface incomplete for the remaining known `#175` child class.

## Scope Boundaries
- in scope: canonical live-session watchdog visibility on the dashboard conversation/session surface and the runtime/store path that owns it
- out of scope: broad observability redesign, raw runtime-log reader redesign, generic-agent lifecycle projection, and run-level stalled-run projection already closed by `#319` and `#323`

## Tests Run
- `go test ./internal/runtime/llm -run 'TestSessionWatchdogMonitorWriter_' -count=1`
- `go test ./internal/store -run 'TestManagerStore_(LoadActiveConversationFailsOnMalformedCanonicalWatchdogRuntimeState|UpdateLiveSessionWatchdog_RoundTripsThroughLoadActiveConversation|UpdateLiveSessionWatchdog_PreservesCanonicalSummary)$' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLConversationReader_(ListFailsOnMalformedCanonicalSessionWatchdogState|GetFailsOnMalformedCanonicalSessionWatchdogState|ListProjectsCanonicalSessionWatchdogState)$|TestHandler_ConversationDetail_ProjectsSessionWatchdogState' -count=1`
- `go test ./internal/runtime/conformance -run 'TestCanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader' -count=1`
- `go test ./internal/runtime/llm ./internal/store ./internal/dashboard/server ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`

## Residual Risk
- watchdog stamping is currently emitted by the CLI live-session runtime path; if another future live-session runtime path wants the same first-class operator visibility, it should write the same canonical watchdog descriptor instead of adding a reader-side fallback

## Follow-Up
- none required to close `#175` on the current repo-wide sweep
- if a future operator surface needs this same session-health view, it should reuse the canonical watchdog descriptor rather than deriving state from runtime logs
