### PR TITLE
[agent-b][issue #126] Extract bootverify declaration-drift checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -214,7 +214,6 @@ func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.req
 func checkHandlerFieldCompliance(c *checkerContext) []Finding     { return c.handlerFieldCompliance() }
 func checkToolResolution(c *checkerContext) []Finding             { return c.toolResolution() }
 func checkPromptExists(c *checkerContext) []Finding               { return c.promptExists() }
-func checkProducesDrift(c *checkerContext) []Finding              { return c.producesDrift() }
 func checkInvalidFieldDetection(c *checkerContext) []Finding      { return c.invalidFieldDetection() }
 func checkPolicyConflictDetection(c *checkerContext) []Finding    { return c.policyConflicts() }
 func checkDialectCompliance(c *checkerContext) []Finding          { return c.dialectCompliance() }
@@ -226,7 +225,6 @@ func checkMCPServerReachable(c *checkerContext) []Finding         { return c.mcp
 func checkAgentPermissionValidation(c *checkerContext) []Finding {
 	return uniqueFindings(append(c.permissions(), c.permissionWarnings()...))
 }
-func checkPhantomProduces(c *checkerContext) []Finding            { return c.phantomProduces() }
 func checkPlatformMetadataValidation(c *checkerContext) []Finding { return c.platformMetadata() }
 func checkGateSchemaValidation(c *checkerContext) []Finding       { return c.gateSchemaValidation() }
 func checkDeprecatedContractAlias(c *checkerContext) []Finding    { return c.deprecatedAliases() }
@@ -1104,35 +1102,6 @@ func (c *checkerContext) stateMachineCoherence() []Finding {
 	return c.stateFindings
 }
 
-func (c *checkerContext) producesDrift() []Finding {
-	if c.producesDriftLoaded {
-		return c.producesDriftFindings
-	}
-	c.producesDriftLoaded = true
-	for nodeID, node := range c.source.NodeEntries() {
-		produces := stringSet(node.Produces)
-		for eventType, handler := range node.EventHandlers {
-			eventType = strings.TrimSpace(eventType)
-			for _, emitted := range handlerEmits(handler) {
-				emitted = strings.TrimSpace(emitted)
-				if emitted == "" {
-					continue
-				}
-				if _, ok := produces[emitted]; ok {
-					continue
-				}
-				c.producesDriftFindings = append(c.producesDriftFindings, Finding{
-					CheckID:  "produces_drift",
-					Severity: "warning",
-					Message:  fmt.Sprintf("node %s handler %s emits %s outside produces list", strings.TrimSpace(nodeID), eventType, emitted),
-					Location: strings.TrimSpace(nodeID),
-				})
-			}
-		}
-	}
-	return c.producesDriftFindings
-}
-
 func (c *checkerContext) nativeTools() []Finding {
 	if c.nativeLoaded {
 		return c.nativeFindings
@@ -1398,40 +1367,6 @@ func (c *checkerContext) ensureMCPDiscovery() {
 	client := runtimemcp.NewClient(c.opts.Credentials)
 	c.mcpDiscoveryErrors = client.Refresh(c.ctx, c.source)
 	c.mcpDiscoveredTools = client.DiscoveredTools()
-}
-
-func (c *checkerContext) phantomProduces() []Finding {
-	if c.phantomLoaded {
-		return c.phantomFindings
-	}
-	c.phantomLoaded = true
-	for nodeID, node := range c.source.NodeEntries() {
-		emitted := map[string]struct{}{}
-		for _, handler := range node.EventHandlers {
-			for _, eventType := range handlerEmits(handler) {
-				eventType = strings.TrimSpace(eventType)
-				if eventType != "" {
-					emitted[eventType] = struct{}{}
-				}
-			}
-		}
-		for _, eventType := range node.Produces {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if _, ok := emitted[eventType]; ok {
-				continue
-			}
-			c.phantomFindings = append(c.phantomFindings, Finding{
-				CheckID:  "phantom_produces",
-				Severity: "warning",
-				Message:  fmt.Sprintf("node %s produces lists %s but no handler emits it", strings.TrimSpace(nodeID), eventType),
-				Location: strings.TrimSpace(nodeID),
-			})
-		}
-	}
-	return c.phantomFindings
 }
 
 func promptFindingsForDir(promptsDir, scopeLabel string, agents map[string]runtimecontracts.AgentRegistryEntry) []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1053,6 +1053,42 @@ func TestRun_MapsProducesDriftToNamedWarning(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnForProducesDriftWhenDeclaredEventsMatchEmits(t *testing.T) {
+	report := Run(context.Background(), semanticview.Wrap(bootverifyDeclarationDriftBundle()), Options{})
+
+	if reportContains(report.Warnings(), "produces_drift", "outside produces list") {
+		t.Fatalf("unexpected produces_drift warning for matching declaration/emission, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_MapsPhantomProducesToNamedWarning(t *testing.T) {
+	bundle := bootverifyDeclarationDriftBundle()
+	bundle.Nodes["producer"] = runtimecontracts.SystemNodeContract{
+		Produces: []string{"task.done", "task.unused"},
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"task.start": {Emits: runtimecontracts.EventEmission{Single: "task.done"}},
+		},
+		SubscribesTo: []string{"task.start"},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "phantom_produces", "task.unused") {
+		t.Fatalf("expected phantom_produces warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForPhantomProducesWhenDeclaredEventsMatchEmits(t *testing.T) {
+	report := Run(context.Background(), semanticview.Wrap(bootverifyDeclarationDriftBundle()), Options{})
+
+	if reportContains(report.Warnings(), "phantom_produces", "no handler emits") {
+		t.Fatalf("unexpected phantom_produces warning for matching declaration/emission, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_ReportsInputPinWiringWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-missing-pin")
 
@@ -2490,6 +2526,35 @@ func bootverifyTransitionRuntimeOwnershipBundle() *runtimecontracts.WorkflowCont
 			"ticket.audit": {},
 		},
 	}
+}
+
+func bootverifyDeclarationDriftBundle() *runtimecontracts.WorkflowContractBundle {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Platform: runtimecontracts.PlatformSpecDocument{},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"producer": {
+					"task.start": {Emits: runtimecontracts.EventEmission{Single: "task.done"}},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"producer": {
+				SubscribesTo: []string{"task.start"},
+				Produces:     []string{"task.done"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.start": {Emits: runtimecontracts.EventEmission{Single: "task.done"}},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.start": {Source: "external"},
+			"task.done":  {ConsumerType: []string{"dashboard"}},
+		},
+	}
+	bundle.Platform.Platform.Name = "test"
+	bundle.Platform.Platform.Version = "1.0.0"
+	return bundle
 }
 
 func reportContains(items []Finding, checkID, contains string) bool {

--- a/internal/runtime/bootverify/workflow_event_declaration_drift_checks.go
+++ b/internal/runtime/bootverify/workflow_event_declaration_drift_checks.go
@@ -1,0 +1,72 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+)
+
+func checkProducesDrift(c *checkerContext) []Finding   { return c.producesDrift() }
+func checkPhantomProduces(c *checkerContext) []Finding { return c.phantomProduces() }
+
+func (c *checkerContext) producesDrift() []Finding {
+	if c.producesDriftLoaded {
+		return c.producesDriftFindings
+	}
+	c.producesDriftLoaded = true
+	for nodeID, node := range c.source.NodeEntries() {
+		produces := stringSet(node.Produces)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			for _, emitted := range handlerEmits(handler) {
+				emitted = strings.TrimSpace(emitted)
+				if emitted == "" {
+					continue
+				}
+				if _, ok := produces[emitted]; ok {
+					continue
+				}
+				c.producesDriftFindings = append(c.producesDriftFindings, Finding{
+					CheckID:  "produces_drift",
+					Severity: "warning",
+					Message:  fmt.Sprintf("node %s handler %s emits %s outside produces list", strings.TrimSpace(nodeID), eventType, emitted),
+					Location: strings.TrimSpace(nodeID),
+				})
+			}
+		}
+	}
+	return c.producesDriftFindings
+}
+
+func (c *checkerContext) phantomProduces() []Finding {
+	if c.phantomLoaded {
+		return c.phantomFindings
+	}
+	c.phantomLoaded = true
+	for nodeID, node := range c.source.NodeEntries() {
+		emitted := map[string]struct{}{}
+		for _, handler := range node.EventHandlers {
+			for _, eventType := range handlerEmits(handler) {
+				eventType = strings.TrimSpace(eventType)
+				if eventType != "" {
+					emitted[eventType] = struct{}{}
+				}
+			}
+		}
+		for _, eventType := range node.Produces {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			if _, ok := emitted[eventType]; ok {
+				continue
+			}
+			c.phantomFindings = append(c.phantomFindings, Finding{
+				CheckID:  "phantom_produces",
+				Severity: "warning",
+				Message:  fmt.Sprintf("node %s produces lists %s but no handler emits it", strings.TrimSpace(nodeID), eventType),
+				Location: strings.TrimSpace(nodeID),
+			})
+		}
+	}
+	return c.phantomFindings
+}


### PR DESCRIPTION
Part of #126

## Human Summary
Extract the remaining bootverify event declaration-drift class out of the monolithic `checks.go` file and add direct `Run(...)` proof for both `produces_drift` and `phantom_produces` warning/suppression behavior.

## What Changed
- moved the declaration-drift owner cluster into `internal/runtime/bootverify/workflow_event_declaration_drift_checks.go`
- removed the same-concept implementations from `internal/runtime/bootverify/checks.go`
- added direct report-surface tests for:
  - `produces_drift` suppression when declared and emitted events match
  - `phantom_produces` warning when a declared produced event is never emitted
  - `phantom_produces` suppression when declared and emitted events match
- preserved the existing `produces_drift` warning proof and the existing registry/report/startup surface

## Why This Is Needed
`#126` is decomposing bootverify by real startup-invariant boundaries. The declaration-drift class was still embedded in the monolithic owner and only had asymmetric direct proof. This PR closes that child class cleanly by moving the full class together and filling the direct report-surface coverage gaps.

## Scope Boundaries
- this PR closes the event declaration-drift child class only
- it does not claim closure of umbrella issue `#126`
- it does not reopen already-closed event-cardinality (`#320`) or event-topology / event-catalog integrity (`#327`) work
- it does not widen into broader runtime redesign outside bootverify maintenance

## Spec References
- none; this is non-semantic maintenance
- justification: the change decomposes the startup gate into a boundary-owned module and adds regression coverage without changing platform contract semantics

## Tests Run
- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsProducesDriftToNamedWarning|DoesNotWarnForProducesDriftWhenDeclaredEventsMatchEmits|MapsPhantomProducesToNamedWarning|DoesNotWarnForPhantomProducesWhenDeclaredEventsMatchEmits)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
- `#126` still has remaining child slices outside this declaration-drift class; this PR does not claim the entire parent decomposition tail is closed
- `handlerEmits(...)` remains a shared helper across adjacent bootverify modules, so future refactors should keep pressure-testing that it stays a helper rather than becoming a second semantic owner

## Follow-Up
- continue the remaining `#126` tail from the updated parent estimate after this slice
