### PR TITLE
[agent-b][issue #157] Remove dead workflow-instance fallback residue

### DIFF
--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -1171,27 +1171,6 @@ func workflowTimeOrNow(v time.Time) time.Time {
 	return v.UTC()
 }
 
-func shouldFallbackLegacyWorkflowInstanceSchema(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	for _, token := range []string{
-		`relation "entity_state" does not exist`,
-		`relation "flow_instances" does not exist`,
-		`relation "timers" does not exist`,
-		`column "flow_instance" does not exist`,
-		`column "entered_state_at" does not exist`,
-		`column "accumulator" does not exist`,
-		`column "config" does not exist`,
-	} {
-		if strings.Contains(msg, token) {
-			return true
-		}
-	}
-	return false
-}
-
 func workflowInstanceLookupKeys(ref string) []string {
 	return runtimeflowidentity.LookupKeys(ref)
 }


### PR DESCRIPTION
Part of #157

## Human Summary
Remove dead legacy schema/error fallback residue from the canonical workflow-instance projection/load hot path so the touched store/runtime seam keeps one clear active owner.

## What Changed
- removed `shouldFallbackLegacyWorkflowInstanceSchema(...)` from `internal/runtime/pipeline/workflow_instance_store.go`
- left the canonical workflow-instance projection/load owner unchanged:
  - `Load(...)`
  - `Mutate(...)`
  - `Upsert(...)`
  - `loadSpec(...)`
  - `listSpec(...)`
  - canonical persisted projection/config decoding
- did not add any new compatibility seam or replacement fallback path

## Why This Is Needed
`#157` targets residual legacy schema/error helpers that still blur ownership inside runtime/store hot paths even after the canonical path is already the only active production path. In this seam, the helper was dead, but its presence still suggested that workflow-instance loading might fall back based on SQL error strings. Removing it leaves one explicit active path.

## Scope Boundaries
- this PR closes the dead workflow-instance fallback-residue child class only
- it does not claim closure of all of `#157`
- it does not redesign explicit startup schema-capability negotiation
- it does not touch legacy agent-config sanitization or receipt/conversation compatibility seams

## Spec References
- none; this is non-semantic maintenance
- justification: the change removes dead compatibility residue from a hot-path owner without changing platform contract semantics

## Tests Run
- `go test ./internal/runtime/pipeline -run 'TestWorkflowInstanceStore(Projection_RoundTripPreservesCanonicalState|Projection_StaticRowsDoNotGainMaterializedFlowPathOnRoundTrip|Projection_RejectsMalformedPersistedShapes|Mutate_SerializesOverlappingMutations|Mutate_PersistsSingleWriterUpdates|Mutate_IgnoresSchedulerOwnedTimerRows)$' -count=1`
- `go test ./internal/runtime/pipeline ./internal/runtime ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk
- `#157` still has remaining compatibility-removal child slices outside this workflow-instance residue cleanup
- broader explicit schema-capability boundaries still exist in the store layer by design and are intentionally out of scope for this PR

## Follow-Up
- continue the remaining `#157` tail from the updated parent estimate after this slice
