### PR TITLE
[agent-d][issue #127] Remove the inert post-turn enforcement path in the LLM agent

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -85,6 +85,10 @@ active_issues:
     title: Add structured tool-call diagnostics for payload validation, enrichment, and publish outcomes
     maps_to:
       - tool_execution_outcome_diagnostics
+  - id: 127
+    title: Remove or implement the inert post-turn contract enforcement path in the LLM agent
+    maps_to:
+      - inert_execution_boundary_scaffolding
   - id: 218
     title: Eliminate string-based startup tool probe classification with an explicit validation/probe contract
     maps_to:
@@ -248,6 +252,23 @@ nodes:
         - config is confusing
       too_narrow:
         - one flag is inert
+    current_action_pressure: active
+  - id: inert_execution_boundary_scaffolding
+    title: Inert Execution-Boundary Scaffolding
+    parent_class: execution-path ownership drift
+    canonical_owners:
+      - one honest production execution path in the touched runtime family, without dead post-step enforcement or remediation scaffolding
+    why_this_node_exists: execution boundaries drift when production code keeps structurally wired but inert side paths that look live even though they never own any real behavior
+    known_manifestations:
+      - post-step enforcement/remediation path is wired in production but functionally inert
+      - dead remediation loops survive as if they are part of the runtime contract
+    representative_issues:
+      - 127
+    common_framing_mistakes:
+      too_broad:
+        - runtime cleanup is generally needed
+      too_narrow:
+        - one helper returns nil
     current_action_pressure: active
   - id: runtime_lifecycle_observability
     title: Runtime Lifecycle Observability

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -208,12 +208,6 @@ func (a *LLMAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Even
 		return nil, err
 	}
 	_ = resp
-	if err := a.enforcePostTurnExpectations(evt, recorder); err != nil {
-		if remediateErr := a.attemptPostTurnContractRemediation(ctx, evt, recorder, err); remediateErr == nil {
-			return nil, nil
-		}
-		return nil, err
-	}
 	return nil, nil
 }
 
@@ -406,23 +400,6 @@ func (a *LLMAgent) shouldRetryAfterTaskScopeFatalCLIError(err error) bool {
 		return false
 	}
 	return llm.ShouldResetTaskScopedConversationOnCLIError(err)
-}
-
-func (a *LLMAgent) attemptPostTurnContractRemediation(ctx context.Context, inbound events.Event, recorder *runtimebus.EmittedEventsRecorder, contractErr error) error {
-	prompt, ok := contractRemediationPrompt(a.cfg, inbound, contractErr)
-	if !ok {
-		return contractErr
-	}
-	if _, err := a.conversation.Step(ctx, prompt); err != nil {
-		return err
-	}
-	return a.enforcePostTurnExpectations(inbound, recorder)
-}
-
-func (a *LLMAgent) enforcePostTurnExpectations(inbound events.Event, recorder *runtimebus.EmittedEventsRecorder) error {
-	_ = inbound
-	_ = recorder
-	return nil
 }
 
 func isHumanTaskOutcomeEvent(t events.EventType) bool {
@@ -794,13 +771,6 @@ func uniqueStrings(in []string) []string {
 		out = append(out, item)
 	}
 	return out
-}
-
-func contractRemediationPrompt(cfg models.AgentConfig, evt events.Event, contractErr error) (string, bool) {
-	_ = cfg
-	_ = evt
-	_ = contractErr
-	return "", false
 }
 
 func transitionContextKey(primary events.Event, fallback events.Event) string {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -377,6 +377,34 @@ func (r *boardTestRuntime) ContinueSession(_ context.Context, s *llm.Session, me
 	return resp, nil
 }
 
+func TestLLMAgent_OnEvent_UsesSinglePostStepExecutionPath(t *testing.T) {
+	rt := &boardTestRuntime{
+		steps: []*llm.Response{
+			{Message: llm.Message{Role: "assistant", Content: "Handled."}},
+		},
+	}
+	agent := mustNewLLMAgent(t,
+		models.AgentConfig{ID: "analysis-1", Role: "analysis"},
+		rt,
+		nil,
+		nil,
+	)
+
+	evt := (events.Event{
+		ID:          "evt-1",
+		Type:        "analysis/requested",
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"entity_id":"ent-1"}`),
+	}).WithEntityID("ent-1")
+
+	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
+		t.Fatalf("OnEvent: %v", err)
+	}
+	if rt.call != 1 {
+		t.Fatalf("runtime call count = %d, want 1", rt.call)
+	}
+}
+
 type boardEmitExecutor struct{}
 
 func (boardEmitExecutor) Execute(ctx context.Context, name string, input any) (any, error) {


### PR DESCRIPTION
Closes #127

## Spec references

- none; this is non-semantic maintenance
- justification: this PR removes an inert production call path and its dead remediation scaffolding without changing platform contract semantics

## Human Summary

This removes the inert post-turn contract enforcement/remediation path from `LLMAgent.OnEvent()` and leaves one honest production post-step execution path.

## What Changed

- removed the dead post-turn enforcement/remediation branch from `internal/runtime/agents/agent_llm.go`
- deleted the inert helper functions that never owned real behavior:
  - `attemptPostTurnContractRemediation(...)`
  - `enforcePostTurnExpectations(...)`
  - `contractRemediationPrompt(...)`
- added focused `OnEvent()` regression coverage proving the post-`conversation.Step(...)` execution path remains a single path
- refined `docs/watchlists/runtime-operations.yaml` with the concrete maintenance node `inert_execution_boundary_scaffolding`

## Why This Is Needed

The old structure made it look like post-turn contract enforcement and remediation were live parts of the LLM-agent runtime boundary, but the enforcement hook always returned success and the remediation prompt hook always declined. That left a false second owner in production code and made the execution boundary harder to reason about than the actual behavior.

## Scope Boundaries

In scope:
- the inert post-turn enforcement/remediation chain in `LLMAgent.OnEvent()`
- focused regression coverage for that exact execution boundary
- explicit watchlist tracking for this maintenance class

Out of scope:
- broad runtime redesign
- unrelated execution-boundary audit/watchpoint work from `#104`
- the separate live remediation behavior in `BoardStep(...)`

## Tests Run

- `go test ./internal/runtime/agents -run 'Test(LLMAgent_OnEvent_UsesSinglePostStepExecutionPath|LLMAgent_TaskScopedFatalCLIErrorResetsConversationAndRetries|LLMAgent_OnEvent_SeedsRunIDIntoConversationContext|BoardStep_)' -count=1`
- `go test ./... -count=1`

## Residual Risk

This closes the inert post-turn scaffolding class in `LLMAgent.OnEvent()`. The broader file still contains other future-facing seams, but I did not find another live same-class inert post-step owner on current repo evidence.

## Follow-Up

- no same-class follow-up is currently needed
- the broader architecture note stays watchlist-only: if similar inert execution scaffolding appears elsewhere, track it under `inert_execution_boundary_scaffolding` rather than treating it as ad hoc cleanup
