### PR TITLE
[agent-e][issue #128] Consolidate non-transactional subscribed publish path

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -96,7 +96,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	}
 
 	if passthrough {
-		if err := eb.routeAndDeliver(ictx, evt); err != nil {
+		if err := eb.publishSubscribedNonTransactional(ictx, evt); err != nil {
 			return err
 		}
 		persisted = true
@@ -302,34 +302,21 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		status, errText := pipelineReceiptStatus(ctx, err)
 		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 	}()
-	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	plan, err := eb.planSubscribedPublish(ctx, evt)
 	if err != nil {
 		return err
 	}
-	eb.recordPublishDiagnostic(ctx, evt, plan)
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+	if err := eb.persistSubscribedPublishPlan(ctx, evt, plan); err != nil {
 		return err
 	}
 	persisted = true
-	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
 	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
 	if err != nil {
 		return err
 	}
 	if passthrough {
-		if len(plan.Recipients) > 0 {
-			if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
-				return err
-			}
-			eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
-		}
-		if plan.BlockedByCycle && plan.CycleEscalation != nil {
-			if err := eb.publishDeferred(ctx, *plan.CycleEscalation); err != nil {
-				return err
-			}
-		}
-		if strings.TrimSpace(plan.ContradictionReason) != "" {
-			_ = eb.emitContradiction(ctx, evt, plan.ContradictionReason)
+		if err := eb.deliverSubscribedPublishPlan(ctx, evt, plan); err != nil {
+			return err
 		}
 	}
 	eb.logPublished(ctx, evt, 0)
@@ -341,46 +328,6 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 	return nil
 }
 
-func (eb *EventBus) publishDeferredNoIntercept(ctx context.Context, evt events.Event) (err error) {
-	ctx = WithCurrentRuntimeEpoch(ctx)
-	if err := ensurePublishEpoch(ctx); err != nil {
-		return err
-	}
-	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
-	ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
-	eb.inFlightPublishes.Add(1)
-	defer eb.inFlightPublishes.Add(-1)
-	if evt.Type == "" {
-		return errors.New("deferred event type is required")
-	}
-	if !isValidEventTypeName(string(evt.Type)) {
-		return fmt.Errorf("invalid deferred event type: %s", strings.TrimSpace(string(evt.Type)))
-	}
-	if evt.ID == "" {
-		evt.ID = uuid.NewString()
-	}
-	if evt.CreatedAt.IsZero() {
-		evt.CreatedAt = time.Now()
-	}
-	if strings.TrimSpace(evt.SourceAgent) == "" {
-		evt.SourceAgent = "runtime"
-	}
-	persisted := false
-	defer func() {
-		if !shouldPersistPipelineReceipt(persisted, err) {
-			return
-		}
-		status, errText := pipelineReceiptStatus(ctx, err)
-		eb.markPipelineReceipt(ctx, evt.ID, status, errText)
-	}()
-	if err := eb.routeAndDeliver(ctx, evt); err != nil {
-		return err
-	}
-	persisted = true
-	eb.logPublished(ctx, evt, 0)
-	return nil
-}
-
 func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, durationUS int) {
 	eb.logRuntime(ctx, "debug", "Event was published to the event bus", "eventbus", "published", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
 		"type":            string(evt.Type),
@@ -389,16 +336,35 @@ func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, duration
 	}, "", durationUS)
 }
 
-func (eb *EventBus) routeAndDeliver(ctx context.Context, evt events.Event) error {
-	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+func (eb *EventBus) publishSubscribedNonTransactional(ctx context.Context, evt events.Event) error {
+	plan, err := eb.planSubscribedPublish(ctx, evt)
 	if err != nil {
 		return err
 	}
+	if err := eb.persistSubscribedPublishPlan(ctx, evt, plan); err != nil {
+		return err
+	}
+	return eb.deliverSubscribedPublishPlan(ctx, evt, plan)
+}
+
+func (eb *EventBus) planSubscribedPublish(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
+	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
 	eb.recordPublishDiagnostic(ctx, evt, plan)
+	return plan, nil
+}
+
+func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
 	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
 	}
 	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
+	return nil
+}
+
+func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
 	if len(plan.Recipients) > 0 {
 		if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
 			return err

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -108,6 +108,18 @@ func (deferredChainInterceptor) Intercept(_ context.Context, evt events.Event) (
 	}).WithEntityID(evt.EntityID())}, nil
 }
 
+type singleDeferredInterceptor struct{}
+
+func (singleDeferredInterceptor) Intercept(_ context.Context, evt events.Event) (bool, []events.Event, error) {
+	if evt.Type != events.EventType("custom.root") {
+		return true, nil, nil
+	}
+	return false, []events.Event{(events.Event{
+		Type:      events.EventType("custom.middle"),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(evt.EntityID())}, nil
+}
+
 type eventVisibleInTxInterceptor struct {
 	t       *testing.T
 	eventID string
@@ -613,6 +625,52 @@ func TestEventBusPublish_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning
 		t.Fatal("agent did not receive event")
 	}
 	waitForNoEvent(t, missingCh)
+
+	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
+}
+
+func TestEventBusPublishDeferred_UsesCanonicalSubscribedRecipientFiltering(t *testing.T) {
+	store := &descriptorAwareEventStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "agent-a"},
+			{AgentID: "agent-b", EntityID: "ent-2"},
+		},
+	}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{singleDeferredInterceptor{}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.middle"))
+	agentCh := eb.Subscribe("agent-a", events.EventType("custom.middle"))
+	otherCh := eb.Subscribe("agent-b", events.EventType("custom.middle"))
+
+	if err := eb.Publish(context.Background(), (events.Event{
+		Type:      events.EventType("custom.root"),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-1")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case evt := <-workflowCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("workflow-runtime did not receive deferred event")
+	}
+	select {
+	case evt := <-agentCh:
+		if got := evt.EntityID(); got != "ent-1" {
+			t.Fatalf("agent event entity_id = %q, want ent-1", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("agent did not receive deferred event")
+	}
+	waitForNoEvent(t, otherCh)
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
 }


### PR DESCRIPTION
## Summary
Remove the dead no-intercept subscribed publish variant and collapse the live non-transactional subscribed publish path onto one canonical helper around planning, persistence, and delivery bookkeeping.

Closes #128

## What Changed
- removed the dead `publishDeferredNoIntercept(...)` local variant
- removed the duplicate `routeAndDeliver(...)` wrapper path
- introduced one shared non-transactional subscribed publish helper sequence for:
  - subscribed recipient planning
  - persistence of the event row plus authoritative delivery manifest/replay scope
  - queued-delivery logging
  - recipient delivery / contradiction / cycle escalation handling
- moved `Publish(...)` and `publishDeferred(...)` onto that shared helper sequence without changing their distinct interceptor ordering semantics
- added a focused regression proving deferred subscribed publish still uses the canonical recipient-filtering and persistence path

## Why
`eventbus_publish.go` still had multiple near-duplicate local implementations of the same non-transactional subscribed publish mechanics. That made one dead variant linger in source and left the live subscribed path split across multiple wrappers in one correctness-sensitive seam. This PR removes the dead path and leaves one canonical non-transactional subscribed orchestration owner in the touched slice.

## Scope Boundaries
In scope:
- non-transactional subscribed publish orchestration cleanup in `internal/runtime/bus/eventbus_publish.go`
- deletion of the dead no-intercept variant
- focused regression coverage for the touched subscribed publish behavior

Out of scope:
- `publishTransactional(...)` cleanup or decomposition
- direct-recipient ownership already closed by #112
- replay/recovery ownership already closed by #325
- broad event-bus redesign

## Validation
- `go test ./internal/runtime/bus -run 'Test(EventBusPublish_(KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning|Deferred_UsesCanonicalSubscribedRecipientFiltering|InterceptsMultiHopDeferredChains|Deferred_PersistsInboundEventBeforeInterceptorsRun)|EventBusPublishDirect_(PersistsButDoesNotMarkDeliveredBeforeRealFanOut|FiltersEntityScopedRecipientsByExplicitMetadata))' -count=1`
- `go test ./internal/runtime/bus ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk
- transactional subscribed publish orchestration still has adjacent but distinct tx-specific mechanics in the same file; this PR does not claim to decompose or canonicalize that separate tx-scoped class
- no additional same-class non-transactional subscribed interpreter is currently known after deleting the dead helper and collapsing the duplicate wrapper path