### PR TITLE
[agent-a][issue #334] Canonicalize startup manager replay diagnostics

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -518,6 +518,61 @@ func (conformanceTimerRecoveryEventStore) ListEventDeliveryRecipients(context.Co
 
 func (conformanceTimerRecoveryEventStore) SupportsPersistedReplay() bool { return false }
 
+type conformanceManagerReplayStore struct {
+	agents   []runtimemanager.PersistedAgent
+	pending  map[string][]events.Event
+	receipts map[string]runtimemanager.EventReceipt
+}
+
+func (*conformanceManagerReplayStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (s *conformanceManagerReplayStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return append([]runtimemanager.PersistedAgent(nil), s.agents...), nil
+}
+
+func (*conformanceManagerReplayStore) MarkAgentTerminated(context.Context, string) error { return nil }
+func (*conformanceManagerReplayStore) EnsureEntitySchema(context.Context, string) error  { return nil }
+func (s *conformanceManagerReplayStore) UpsertEventReceipt(_ context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+	if s.receipts == nil {
+		s.receipts = map[string]runtimemanager.EventReceipt{}
+	}
+	s.receipts[strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)] = runtimemanager.EventReceipt{
+		EventID: eventID,
+		AgentID: agentID,
+		Status:  status,
+		Error:   errText,
+	}
+	return nil
+}
+func (s *conformanceManagerReplayStore) ListPendingEventsForAgent(_ context.Context, agentID string, _ time.Time, _ int) ([]events.Event, error) {
+	return append([]events.Event(nil), s.pending[strings.TrimSpace(agentID)]...), nil
+}
+func (*conformanceManagerReplayStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (s *conformanceManagerReplayStore) GetEventReceipt(_ context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
+	receipt, ok := s.receipts[strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)]
+	return receipt, ok, nil
+}
+
+type conformanceManagerReplayAgent struct{ id string }
+
+func (a conformanceManagerReplayAgent) ID() string                      { return a.id }
+func (conformanceManagerReplayAgent) Type() string                      { return "generic" }
+func (conformanceManagerReplayAgent) Subscriptions() []events.EventType { return nil }
+func (conformanceManagerReplayAgent) OnEvent(_ context.Context, evt events.Event) ([]events.Event, error) {
+	switch evt.Type {
+	case events.EventType("support.replay.drop"):
+		return nil, fmt.Errorf("boom")
+	case events.EventType("support.replay.leased"):
+		return nil, fmt.Errorf("session currently leased")
+	default:
+		return nil, nil
+	}
+}
+
 func loadConformanceRuntimeWorkflowModule(t *testing.T) conformanceSemanticOnlyWorkflowRuntime {
 	t.Helper()
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
@@ -869,6 +924,133 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	}
 	if terminationDetail != "builder_api" {
 		t.Fatalf("termination_detail = %q, want builder_api", terminationDetail)
+	}
+}
+
+func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+	module := loadConformanceRuntimeWorkflowModule(t)
+	managerStore := &conformanceManagerReplayStore{
+		agents: []runtimemanager.PersistedAgent{{
+			Config:    runtimeactors.AgentConfig{ID: "agent-a"},
+			StartedAt: time.Now().UTC(),
+		}},
+		pending: map[string][]events.Event{
+			"agent-a": {
+				{ID: "evt-replay", Type: events.EventType("support.replay.ok"), CreatedAt: time.Now().Add(-4 * time.Minute).UTC()},
+				{ID: "evt-skip", Type: events.EventType("support.replay.skip"), CreatedAt: time.Now().Add(-3 * time.Minute).UTC()},
+				{ID: "evt-leased", Type: events.EventType("support.replay.leased"), CreatedAt: time.Now().Add(-2 * time.Minute).UTC()},
+				{ID: "evt-drop", Type: events.EventType("support.replay.drop"), CreatedAt: time.Now().Add(-time.Minute).UTC()},
+			},
+		},
+		receipts: map[string]runtimemanager.EventReceipt{
+			"evt-skip|agent-a": {
+				EventID: "evt-skip",
+				AgentID: "agent-a",
+				Status:  runtimemanager.ReceiptStatusProcessed,
+			},
+		},
+	}
+
+	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: true,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}, runtimepkg.Stores{
+		SQLDB:        db,
+		EventStore:   conformanceTimerRecoveryEventStore{},
+		ManagerStore: managerStore,
+	}, runtimepkg.RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     conformanceNoopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	rt.Manager = runtimemanager.NewAgentManager(rt.Bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return conformanceManagerReplayAgent{id: cfg.ID}, nil
+	}, managerStore)
+
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "agent-manager",
+		Type:      "startup_recovery_manager_replay_aftermath",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 4 {
+		t.Fatalf("runtime log rows = %d, want 4: %#v", len(logs), logs)
+	}
+	findByEventID := func(eventID string) int {
+		t.Helper()
+		for idx, log := range logs {
+			if strings.TrimSpace(log.EventID) == strings.TrimSpace(eventID) {
+				return idx
+			}
+		}
+		t.Fatalf("missing runtime log for event %q in %#v", eventID, logs)
+		return -1
+	}
+
+	replayed := logs[findByEventID("evt-replay")]
+	replayedDetail, _ := replayed.Detail.(map[string]any)
+	if got := readString(replayedDetail["decision_outcome"]); got != "replayed" {
+		t.Fatalf("replayed detail.decision_outcome = %q, want replayed", got)
+	}
+	if got := readString(replayedDetail["decision_reason_code"]); got != "persisted_event_replayed" {
+		t.Fatalf("replayed detail.decision_reason_code = %q, want persisted_event_replayed", got)
+	}
+
+	skippedReceipt := logs[findByEventID("evt-skip")]
+	skippedReceiptDetail, _ := skippedReceipt.Detail.(map[string]any)
+	if got := readString(skippedReceiptDetail["decision_outcome"]); got != "skipped" {
+		t.Fatalf("receipt skip detail.decision_outcome = %q, want skipped", got)
+	}
+	if got := readString(skippedReceiptDetail["decision_reason_code"]); got != "event_receipt_already_processed" {
+		t.Fatalf("receipt skip detail.decision_reason_code = %q, want event_receipt_already_processed", got)
+	}
+
+	skippedLeased := logs[findByEventID("evt-leased")]
+	skippedLeasedDetail, _ := skippedLeased.Detail.(map[string]any)
+	if got := readString(skippedLeasedDetail["decision_reason_code"]); got != "session_currently_leased" {
+		t.Fatalf("leased skip detail.decision_reason_code = %q, want session_currently_leased", got)
+	}
+
+	dropped := logs[findByEventID("evt-drop")]
+	droppedDetail, _ := dropped.Detail.(map[string]any)
+	if got := readString(droppedDetail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped detail.decision_outcome = %q, want dropped", got)
+	}
+	if got := readString(droppedDetail["decision_reason_code"]); got != "event_processing_failed" {
+		t.Fatalf("dropped detail.decision_reason_code = %q, want event_processing_failed", got)
+	}
+	if readString(droppedDetail["error_code"]) != "event_processing_failed" {
+		t.Fatalf("dropped detail.error_code = %q, want event_processing_failed", readString(droppedDetail["error_code"]))
+	}
+	if strings.TrimSpace(dropped.Error) == "" {
+		t.Fatal("dropped startup manager replay log missing explicit error text")
 	}
 }
 

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -29,20 +29,42 @@ type deliveryProgressWriter interface {
 }
 
 func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt events.Event) error {
+	result := am.processEventDetailed(ctx, agent, evt)
+	return result.err
+}
+
+type eventProcessResult struct {
+	record startupManagerReplayRecord
+	err    error
+}
+
+func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, evt events.Event) eventProcessResult {
+	record := startupManagerReplayRecord{
+		Event:   evt,
+		AgentID: agent.ID(),
+	}
 	if !am.markEventInFlight(agent.ID(), evt.ID) {
-		return nil
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = startupManagerReplayReasonDuplicateInFlight
+		return eventProcessResult{record: record}
 	}
 	defer am.unmarkEventInFlight(agent.ID(), evt.ID)
-	if am.shouldSkipEvent(agent.ID(), evt.ID) {
-		return nil
+	if skip, reason := am.shouldSkipEventDetailed(agent.ID(), evt.ID); skip {
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = reason
+		return eventProcessResult{record: record}
 	}
 	if suppress, reason := am.shouldSuppressForBudget(agent.ID(), evt); suppress {
 		am.writeReceipt(ctx, evt.ID, agent.ID(), ReceiptStatusProcessed, reason)
-		return nil
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = startupManagerReplayReasonBudgetSuppressed
+		return eventProcessResult{record: record}
 	}
 	if am.shouldInterceptDirective(agent.ID(), evt) {
 		am.writeReceipt(ctx, evt.ID, agent.ID(), ReceiptStatusProcessed, "intercepted simple directive (runtime-handled)")
-		return nil
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = startupManagerReplayReasonDirectiveIntercepted
+		return eventProcessResult{record: record}
 	}
 	ctx = runtimecorrelation.WithInboundEvent(ctx, evt)
 	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(evt.RunID))
@@ -84,7 +106,9 @@ func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt event
 	if err != nil {
 		if isTransientAgentError(err) {
 			// Transient lock/contention errors should be retried without poisoning receipts.
-			return nil
+			record.Outcome = startupManagerReplayOutcomeSkipped
+			record.ReasonCode = transientReplayReason(err)
+			return eventProcessResult{record: record}
 		}
 		agentErr := runtimerterr.WrapRuntimeError(
 			"agent_on_event_failed",
@@ -99,7 +123,10 @@ func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt event
 		)
 		am.maybeTripAuthCircuitBreaker(agent.ID(), evt.ID, err)
 		am.writeReceipt(ctx, evt.ID, agent.ID(), ReceiptStatusError, runtimerterr.FormatRuntimeError(agentErr))
-		return agentErr
+		record.Outcome = startupManagerReplayOutcomeDropped
+		record.ReasonCode = startupManagerReplayReasonProcessFailed
+		record.ErrorText = agentErr.Error()
+		return eventProcessResult{record: record, err: agentErr}
 	}
 	for idx, e := range out {
 		if strings.TrimSpace(e.ID) == "" {
@@ -121,11 +148,16 @@ func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt event
 				agent.ID(),
 			)
 			am.writeReceipt(ctx, evt.ID, agent.ID(), ReceiptStatusError, runtimerterr.FormatRuntimeError(pubErr))
-			return pubErr
+			record.Outcome = startupManagerReplayOutcomeDropped
+			record.ReasonCode = startupManagerReplayReasonPublishFailed
+			record.ErrorText = pubErr.Error()
+			return eventProcessResult{record: record, err: pubErr}
 		}
 	}
 	am.writeReceipt(ctx, evt.ID, agent.ID(), ReceiptStatusProcessed, "")
-	return nil
+	record.Outcome = startupManagerReplayOutcomeReplayed
+	record.ReasonCode = startupManagerReplayReasonReplayed
+	return eventProcessResult{record: record}
 }
 
 func (am *AgentManager) shouldInterceptDirective(agentID string, evt events.Event) bool {
@@ -192,21 +224,33 @@ func (am *AgentManager) unmarkEventInFlight(agentID, eventID string) {
 }
 
 func (am *AgentManager) shouldSkipEvent(agentID, eventID string) bool {
+	skip, _ := am.shouldSkipEventDetailed(agentID, eventID)
+	return skip
+}
+
+func (am *AgentManager) shouldSkipEventDetailed(agentID, eventID string) (bool, startupManagerReplayReasonCode) {
 	reader, ok := am.store.(eventReceiptReader)
 	if !ok || reader == nil {
-		return false
+		return false, ""
 	}
 	eventID = strings.TrimSpace(eventID)
 	agentID = strings.TrimSpace(agentID)
 	if eventID == "" || agentID == "" {
-		return false
+		return false, ""
 	}
 	receipt, found, err := reader.GetEventReceipt(am.runtimeContext(), eventID, agentID)
 	if err != nil || !found {
-		return false
+		return false, ""
 	}
 	status := ReceiptStatus(strings.TrimSpace(string(receipt.Status)))
-	return status == ReceiptStatusProcessed || status == ReceiptStatusDeadLetter
+	switch status {
+	case ReceiptStatusProcessed:
+		return true, startupManagerReplayReasonReceiptProcessed
+	case ReceiptStatusDeadLetter:
+		return true, startupManagerReplayReasonReceiptDeadLettered
+	default:
+		return false, ""
+	}
 }
 
 func isTransientAgentError(err error) bool {

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,43 @@ func (s *recoveryTestStore) ListPendingEventsForAgent(context.Context, string, t
 }
 func (s *recoveryTestStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
 	return nil, nil
+}
+
+type startupReplayTestStore struct {
+	recoveryTestStore
+	pending  map[string][]events.Event
+	receipts map[string]EventReceipt
+}
+
+func (s *startupReplayTestStore) ListPendingEventsForAgent(_ context.Context, agentID string, _ time.Time, _ int) ([]events.Event, error) {
+	out := append([]events.Event(nil), s.pending[strings.TrimSpace(agentID)]...)
+	return out, nil
+}
+
+func (*startupReplayTestStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+
+func (s *startupReplayTestStore) GetEventReceipt(_ context.Context, eventID, agentID string) (EventReceipt, bool, error) {
+	key := strings.TrimSpace(eventID) + "|" + strings.TrimSpace(agentID)
+	receipt, ok := s.receipts[key]
+	return receipt, ok, nil
+}
+
+type startupReplayTestAgent struct{ id string }
+
+func (a startupReplayTestAgent) ID() string                      { return a.id }
+func (startupReplayTestAgent) Type() string                      { return "generic" }
+func (startupReplayTestAgent) Subscriptions() []events.EventType { return nil }
+func (startupReplayTestAgent) OnEvent(_ context.Context, evt events.Event) ([]events.Event, error) {
+	switch evt.Type {
+	case events.EventType("system.recover.drop"):
+		return nil, errors.New("boom")
+	case events.EventType("system.recover.leased"):
+		return nil, errors.New("session currently leased")
+	default:
+		return nil, nil
+	}
 }
 
 func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
@@ -209,6 +247,121 @@ func TestRecover_UsesCanonicalPipelineReplayAftermathDiagnostics(t *testing.T) {
 	entry := findManagerRecoveryAftermathLog(t, bus.runtimeLogs, childID, "replayed", "persisted_recipients_replayed")
 	if strings.TrimSpace(entry.Component) != "pipeline-recovery" {
 		t.Fatalf("runtime log component = %q, want pipeline-recovery", entry.Component)
+	}
+}
+
+func TestRecoverWithStartupReplayDiagnostics_LogsCanonicalManagerReplayAftermath(t *testing.T) {
+	now := time.Now().UTC()
+	store := &startupReplayTestStore{
+		recoveryTestStore: recoveryTestStore{
+			agents: []PersistedAgent{{
+				Config: models.AgentConfig{
+					ID: "agent-a",
+				},
+				StartedAt: now,
+			}},
+		},
+		pending: map[string][]events.Event{
+			"agent-a": {
+				{ID: "evt-replay", Type: events.EventType("system.recover.ok"), CreatedAt: now.Add(-5 * time.Minute)},
+				{ID: "evt-receipt", Type: events.EventType("system.recover.receipt"), CreatedAt: now.Add(-4 * time.Minute)},
+				{ID: "evt-inflight", Type: events.EventType("system.recover.inflight"), CreatedAt: now.Add(-3 * time.Minute)},
+				{ID: "evt-leased", Type: events.EventType("system.recover.leased"), CreatedAt: now.Add(-2 * time.Minute)},
+				{ID: "evt-drop", Type: events.EventType("system.recover.drop"), CreatedAt: now.Add(-time.Minute)},
+			},
+		},
+		receipts: map[string]EventReceipt{
+			"evt-receipt|agent-a": {
+				EventID: "evt-receipt",
+				AgentID: "agent-a",
+				Status:  ReceiptStatusProcessed,
+			},
+		},
+	}
+	bus := &recoveryTestBus{}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return startupReplayTestAgent{id: cfg.ID}, nil
+	}, store)
+	am.inFlight["agent-a|evt-inflight"] = struct{}{}
+
+	summary, err := am.RecoverWithStartupReplayDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("RecoverWithStartupReplayDiagnostics: %v", err)
+	}
+	if summary.ReplayedCount != 1 || summary.SkippedCount != 3 || summary.DroppedCount != 1 {
+		t.Fatalf("summary = %#v, want replayed=1 skipped=3 dropped=1", summary)
+	}
+	if !strings.Contains(summary.FirstDroppedError, "boom") {
+		t.Fatalf("summary.FirstDroppedError = %q, want boom", summary.FirstDroppedError)
+	}
+	if len(bus.runtimeLogs) != 5 {
+		t.Fatalf("runtime log count = %d, want 5", len(bus.runtimeLogs))
+	}
+	assertReplayAftermathLog := func(eventID, outcome, reason string) {
+		t.Helper()
+		for _, entry := range bus.runtimeLogs {
+			if strings.TrimSpace(entry.Action) != startupManagerReplayAction {
+				continue
+			}
+			if strings.TrimSpace(entry.EventID) != strings.TrimSpace(eventID) {
+				continue
+			}
+			detail, _ := entry.Detail.(map[string]any)
+			if got := strings.TrimSpace(detail["decision_outcome"].(string)); got != outcome {
+				t.Fatalf("event %s decision_outcome = %q, want %q", eventID, got, outcome)
+			}
+			if got := strings.TrimSpace(detail["decision_reason_code"].(string)); got != reason {
+				t.Fatalf("event %s decision_reason_code = %q, want %q", eventID, got, reason)
+			}
+			return
+		}
+		t.Fatalf("missing startup manager replay log for %s in %#v", eventID, bus.runtimeLogs)
+	}
+	assertReplayAftermathLog("evt-replay", "replayed", string(startupManagerReplayReasonReplayed))
+	assertReplayAftermathLog("evt-receipt", "skipped", string(startupManagerReplayReasonReceiptProcessed))
+	assertReplayAftermathLog("evt-inflight", "skipped", string(startupManagerReplayReasonDuplicateInFlight))
+	assertReplayAftermathLog("evt-leased", "skipped", string(startupManagerReplayReasonSessionLeased))
+	assertReplayAftermathLog("evt-drop", "dropped", string(startupManagerReplayReasonProcessFailed))
+	for _, entry := range bus.runtimeLogs {
+		if strings.TrimSpace(entry.Action) == "pending_replay_failed" || strings.TrimSpace(entry.Action) == "pending_replay_event_failed" {
+			t.Fatalf("unexpected legacy startup replay action %q in %#v", entry.Action, bus.runtimeLogs)
+		}
+	}
+}
+
+func TestReplayAgentBacklog_DoesNotEmitStartupAftermathOutsideStartupRecovery(t *testing.T) {
+	now := time.Now().UTC()
+	store := &startupReplayTestStore{
+		pending: map[string][]events.Event{
+			"agent-a": {
+				{ID: "evt-drop", Type: events.EventType("system.recover.drop"), CreatedAt: now.Add(-time.Minute)},
+			},
+		},
+	}
+	bus := &recoveryTestBus{}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return startupReplayTestAgent{id: cfg.ID}, nil
+	}, store)
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: models.AgentConfig{ID: "agent-a"},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	if err := am.ReplayAgentBacklog(context.Background(), "agent-a"); err != nil {
+		t.Fatalf("ReplayAgentBacklog: %v", err)
+	}
+	foundLegacyFailure := false
+	for _, entry := range bus.runtimeLogs {
+		if strings.TrimSpace(entry.Action) == startupManagerReplayAction {
+			t.Fatalf("unexpected startup replay aftermath action on direct ReplayAgentBacklog: %#v", bus.runtimeLogs)
+		}
+		if strings.TrimSpace(entry.Action) == "pending_replay_event_failed" {
+			foundLegacyFailure = true
+		}
+	}
+	if !foundLegacyFailure {
+		t.Fatalf("runtime logs = %#v, want legacy pending_replay_event_failed outside startup recovery", bus.runtimeLogs)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -468,13 +468,23 @@ func (am *AgentManager) Run(ctx context.Context) {
 }
 
 func (am *AgentManager) Recover(ctx context.Context) error {
+	_, err := am.recover(ctx, false)
+	return err
+}
+
+func (am *AgentManager) RecoverWithStartupReplayDiagnostics(ctx context.Context) (StartupReplaySummary, error) {
+	return am.recover(ctx, true)
+}
+
+func (am *AgentManager) recover(ctx context.Context, startupReplayDiagnostics bool) (StartupReplaySummary, error) {
+	summary := StartupReplaySummary{}
 	if am.store == nil {
-		return nil
+		return summary, nil
 	}
 
 	agents, err := am.store.LoadAgents(ctx)
 	if err != nil {
-		return fmt.Errorf("load agents: %w", err)
+		return summary, fmt.Errorf("load agents: %w", err)
 	}
 	sort.SliceStable(agents, func(i, j int) bool {
 		return agents[i].StartedAt.Before(agents[j].StartedAt)
@@ -484,21 +494,23 @@ func (am *AgentManager) Recover(ctx context.Context) error {
 			continue
 		}
 		if err := am.spawnAgentInternal(ctx, rec, false); err != nil && !strings.Contains(err.Error(), "already exists") {
-			return fmt.Errorf("hydrate agent %s: %w", rec.Config.ID, err)
+			return summary, fmt.Errorf("hydrate agent %s: %w", rec.Config.ID, err)
 		}
 	}
 	if err := am.restoreFlowInstanceRoutes(ctx); err != nil {
-		return err
+		return summary, err
 	}
 
 	if err := runtimepipeline.NewRecoveryManagerWith(am.bus.Store(), am.bus).Recover(ctx); err != nil {
-		return fmt.Errorf("recover pipeline receipts: %w", err)
+		return summary, fmt.Errorf("recover pipeline receipts: %w", err)
 	}
 
-	if err := am.replayPendingEvents(ctx); err != nil {
-		return err
+	if startupReplayDiagnostics {
+		ctx = withStartupManagerReplayDiagnostics(ctx)
 	}
-	return nil
+	replaySummary, err := am.replayPendingEventsDetailed(ctx)
+	summary.merge(replaySummary)
+	return summary, err
 }
 
 type RecoverableStateSnapshot struct {
@@ -621,11 +633,17 @@ func (am *AgentManager) retryLoop(ctx context.Context) {
 }
 
 func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
+	_, err := am.replayPendingEventsDetailed(ctx)
+	return err
+}
+
+func (am *AgentManager) replayPendingEventsDetailed(ctx context.Context) (StartupReplaySummary, error) {
+	summary := StartupReplaySummary{}
 	if am.store == nil {
-		return nil
+		return summary, nil
 	}
 	if am.isAuthBreakerTripped() {
-		return nil
+		return summary, nil
 	}
 
 	am.mu.RLock()
@@ -637,16 +655,18 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 
 	for _, id := range ids {
 		if am.shutdownAdmissionClosed() {
-			return nil
+			return summary, nil
 		}
 		if am.isAuthBreakerTripped() {
-			return nil
+			return summary, nil
 		}
-		if err := am.ReplayAgentBacklog(ctx, id); err != nil {
+		backlogSummary, err := am.replayAgentBacklogDetailed(ctx, id)
+		summary.merge(backlogSummary)
+		if err != nil {
 			if errors.Is(err, errRuntimeShuttingDown) {
-				return nil
+				return summary, nil
 			}
-			if am.bus != nil {
+			if !startupManagerReplayDiagnosticsEnabled(ctx) && am.bus != nil {
 				am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 					Level:     "error",
 					Component: "agent-manager",
@@ -657,22 +677,28 @@ func (am *AgentManager) replayPendingEvents(ctx context.Context) error {
 			}
 		}
 	}
-	return nil
+	return summary, nil
 }
 
 func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) error {
+	_, err := am.replayAgentBacklogDetailed(ctx, agentID)
+	return err
+}
+
+func (am *AgentManager) replayAgentBacklogDetailed(ctx context.Context, agentID string) (StartupReplaySummary, error) {
+	summary := StartupReplaySummary{}
 	if am.shutdownAdmissionClosed() {
-		return errRuntimeShuttingDown
+		return summary, errRuntimeShuttingDown
 	}
 	if am.store == nil {
-		return fmt.Errorf("manager store unavailable")
+		return summary, fmt.Errorf("manager store unavailable")
 	}
 	if am.isAuthBreakerTripped() {
-		return nil
+		return summary, nil
 	}
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
-		return errors.New("agent id is required")
+		return summary, errors.New("agent id is required")
 	}
 	am.mu.RLock()
 	agent := am.agents[agentID]
@@ -683,18 +709,34 @@ func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) 
 	}
 	am.mu.RUnlock()
 	if !ok || agent == nil {
-		return fmt.Errorf("agent not found: %s", agentID)
+		return summary, fmt.Errorf("agent not found: %s", agentID)
 	}
 	pending, err := am.pendingEventsForAgent(ctx, agentID, cfg, agent, since)
 	if err != nil {
-		return err
+		if startupManagerReplayDiagnosticsEnabled(ctx) {
+			record := startupManagerReplayRecord{
+				AgentID:    agentID,
+				Outcome:    startupManagerReplayOutcomeDropped,
+				ReasonCode: startupManagerReplayReasonBacklogLoadFailed,
+				ErrorText:  err.Error(),
+			}
+			summary.observe(record)
+			logStartupManagerReplayAftermath(ctx, am.bus, record)
+			return summary, nil
+		}
+		return summary, err
 	}
 	for _, evt := range pending {
 		if am.isAuthBreakerTripped() {
-			return nil
+			return summary, nil
 		}
-		if err := am.processEvent(ctx, agent, evt); err != nil {
-			if am.bus != nil {
+		result := am.processEventDetailed(ctx, agent, evt)
+		if startupManagerReplayDiagnosticsEnabled(ctx) {
+			summary.observe(result.record)
+			logStartupManagerReplayAftermath(ctx, am.bus, result.record)
+		}
+		if result.err != nil {
+			if !startupManagerReplayDiagnosticsEnabled(ctx) && am.bus != nil {
 				evtCtx := runtimecorrelation.WithInboundEvent(ctx, evt)
 				evtCtx = runtimecorrelation.WithRunID(evtCtx, strings.TrimSpace(evt.RunID))
 				am.bus.LogRuntime(evtCtx, runtimepipeline.RuntimeLogEntry{
@@ -705,15 +747,15 @@ func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) 
 					EventType: strings.TrimSpace(string(evt.Type)),
 					AgentID:   agentID,
 					EntityID:  strings.TrimSpace(evt.EntityID()),
-					Error:     strings.TrimSpace(err.Error()),
+					Error:     strings.TrimSpace(result.err.Error()),
 				})
 			}
-			if isClaudeAuthError(err) {
-				return nil
+			if isClaudeAuthError(result.err) {
+				return summary, nil
 			}
 		}
 	}
-	return nil
+	return summary, nil
 }
 
 func (am *AgentManager) pendingEventsForAgent(

--- a/internal/runtime/manager/startup_replay_diagnostics.go
+++ b/internal/runtime/manager/startup_replay_diagnostics.go
@@ -1,0 +1,174 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/events"
+	"swarm/internal/runtime/diaglog"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+const startupManagerReplayAction = "startup_recovery_manager_replay_aftermath"
+
+type startupManagerReplayContextKey struct{}
+
+func withStartupManagerReplayDiagnostics(ctx context.Context) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	return context.WithValue(ctx, startupManagerReplayContextKey{}, true)
+}
+
+func startupManagerReplayDiagnosticsEnabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(startupManagerReplayContextKey{}).(bool)
+	return enabled
+}
+
+type startupManagerReplayOutcome string
+
+const (
+	startupManagerReplayOutcomeReplayed startupManagerReplayOutcome = "replayed"
+	startupManagerReplayOutcomeSkipped  startupManagerReplayOutcome = "skipped"
+	startupManagerReplayOutcomeDropped  startupManagerReplayOutcome = "dropped"
+)
+
+type startupManagerReplayReasonCode string
+
+const (
+	startupManagerReplayReasonReplayed             startupManagerReplayReasonCode = "persisted_event_replayed"
+	startupManagerReplayReasonReceiptProcessed     startupManagerReplayReasonCode = "event_receipt_already_processed"
+	startupManagerReplayReasonReceiptDeadLettered  startupManagerReplayReasonCode = "event_receipt_dead_lettered"
+	startupManagerReplayReasonDuplicateInFlight    startupManagerReplayReasonCode = "event_already_in_flight"
+	startupManagerReplayReasonBudgetSuppressed     startupManagerReplayReasonCode = "budget_suppressed"
+	startupManagerReplayReasonDirectiveIntercepted startupManagerReplayReasonCode = "directive_intercepted"
+	startupManagerReplayReasonSessionLeased        startupManagerReplayReasonCode = "session_currently_leased"
+	startupManagerReplayReasonBudgetEmergency      startupManagerReplayReasonCode = "budget_emergency"
+	startupManagerReplayReasonTransientAgentError  startupManagerReplayReasonCode = "transient_agent_error"
+	startupManagerReplayReasonProcessFailed        startupManagerReplayReasonCode = "event_processing_failed"
+	startupManagerReplayReasonPublishFailed        startupManagerReplayReasonCode = "publish_output_failed"
+	startupManagerReplayReasonBacklogLoadFailed    startupManagerReplayReasonCode = "pending_backlog_load_failed"
+)
+
+type startupManagerReplayRecord struct {
+	Event      events.Event
+	AgentID    string
+	Outcome    startupManagerReplayOutcome
+	ReasonCode startupManagerReplayReasonCode
+	ErrorText  string
+}
+
+func (r startupManagerReplayRecord) detail() map[string]any {
+	detail := map[string]any{
+		"decision_family":      "startup_manager_replay",
+		"decision_outcome":     string(r.Outcome),
+		"decision_reason_code": string(r.ReasonCode),
+		"event_id":             strings.TrimSpace(r.Event.ID),
+		"event_type":           strings.TrimSpace(string(r.Event.Type)),
+		"agent_id":             strings.TrimSpace(r.AgentID),
+		"entity_id":            r.Event.EntityID(),
+		"flow_instance":        r.Event.FlowInstance(),
+		"parent_event_id":      strings.TrimSpace(r.Event.ParentEventID),
+		"persisted_run_id":     strings.TrimSpace(r.Event.RunID),
+	}
+	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
+		detail["error"] = errText
+		detail["error_code"] = string(r.ReasonCode)
+	}
+	return detail
+}
+
+func (r startupManagerReplayRecord) level() diaglog.Level {
+	if r.Outcome == startupManagerReplayOutcomeDropped {
+		return diaglog.LevelWarn
+	}
+	return diaglog.LevelInfo
+}
+
+func (r startupManagerReplayRecord) message() string {
+	switch r.Outcome {
+	case startupManagerReplayOutcomeDropped:
+		return "Startup recovery dropped persisted manager replay event"
+	case startupManagerReplayOutcomeSkipped:
+		return "Startup recovery skipped persisted manager replay event"
+	default:
+		return "Startup recovery replayed persisted manager event"
+	}
+}
+
+func logStartupManagerReplayAftermath(ctx context.Context, bus Bus, record startupManagerReplayRecord) {
+	if bus == nil {
+		return
+	}
+	_ = bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+		Level:     record.level(),
+		Component: "agent-manager",
+		Action:    startupManagerReplayAction,
+		Message:   record.message(),
+		EventID:   strings.TrimSpace(record.Event.ID),
+		EventType: strings.TrimSpace(string(record.Event.Type)),
+		AgentID:   strings.TrimSpace(record.AgentID),
+		EntityID:  record.Event.EntityID(),
+		Detail:    record.detail(),
+		Error:     strings.TrimSpace(record.ErrorText),
+	})
+}
+
+type StartupReplaySummary struct {
+	ReplayedCount     int
+	SkippedCount      int
+	DroppedCount      int
+	FirstDroppedError string
+}
+
+func (s *StartupReplaySummary) observe(record startupManagerReplayRecord) {
+	if s == nil {
+		return
+	}
+	switch record.Outcome {
+	case startupManagerReplayOutcomeReplayed:
+		s.ReplayedCount++
+	case startupManagerReplayOutcomeSkipped:
+		s.SkippedCount++
+	case startupManagerReplayOutcomeDropped:
+		s.DroppedCount++
+		if strings.TrimSpace(s.FirstDroppedError) == "" {
+			if errText := strings.TrimSpace(record.ErrorText); errText != "" {
+				s.FirstDroppedError = errText
+			} else {
+				s.FirstDroppedError = fmt.Sprintf("startup manager replay dropped persisted work for agent %s", strings.TrimSpace(record.AgentID))
+			}
+		}
+	}
+}
+
+func (s *StartupReplaySummary) merge(other StartupReplaySummary) {
+	if s == nil {
+		return
+	}
+	s.ReplayedCount += other.ReplayedCount
+	s.SkippedCount += other.SkippedCount
+	s.DroppedCount += other.DroppedCount
+	if strings.TrimSpace(s.FirstDroppedError) == "" {
+		s.FirstDroppedError = strings.TrimSpace(other.FirstDroppedError)
+	}
+}
+
+func transientReplayReason(err error) startupManagerReplayReasonCode {
+	if err == nil {
+		return startupManagerReplayReasonTransientAgentError
+	}
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(msg, "session currently leased"):
+		return startupManagerReplayReasonSessionLeased
+	case strings.Contains(msg, "budget emergency"):
+		return startupManagerReplayReasonBudgetEmergency
+	default:
+		return startupManagerReplayReasonTransientAgentError
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -607,7 +607,11 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	if rt.Config.Runtime.RecoveryOnStartup && rt.Manager != nil {
 		startupRecoveryDecision.ManagerRecoveryAttempted = true
-		if err := rt.Manager.Recover(ctx); err != nil {
+		managerReplaySummary, err := rt.Manager.RecoverWithStartupReplayDiagnostics(ctx)
+		startupRecoveryDecision.ManagerReplayCount = managerReplaySummary.ReplayedCount
+		startupRecoveryDecision.ManagerSkipCount = managerReplaySummary.SkippedCount
+		startupRecoveryDecision.ManagerDropCount = managerReplaySummary.DroppedCount
+		if err != nil {
 			startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
 			startupRecoveryDecision.ReasonCode = startupRecoveryReasonRecoverFailed
 			startupRecoveryDecision.ErrorText = err.Error()
@@ -654,6 +658,14 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				if rt.Logger != nil {
 					handleRuntimeLogPersistenceError("runtime", "recovery_failed_publish_failed", rt.Logger.Error(ctx, "runtime", "recovery_failed_publish_failed", nil, publishErr))
 				}
+			}
+		} else if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ManagerDropCount > 0 {
+			startupRecoveryDecision.Outcome = startupRecoveryOutcomeDegraded
+			startupRecoveryDecision.ReasonCode = startupRecoveryReasonRecoverFailed
+			if strings.TrimSpace(managerReplaySummary.FirstDroppedError) != "" {
+				startupRecoveryDecision.ErrorText = strings.TrimSpace(managerReplaySummary.FirstDroppedError)
+			} else {
+				startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to replay %d pending event(s) during startup recovery", startupRecoveryDecision.ManagerDropCount)
 			}
 		}
 	}

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"swarm/internal/config"
 	"swarm/internal/events"
+	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -81,6 +82,65 @@ func (*startupRecoveryFlakyManagerStore) ListPendingEventsForAgent(context.Conte
 }
 func (*startupRecoveryFlakyManagerStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
 	return nil, nil
+}
+
+type startupManagerReplayRuntimeStore struct {
+	agents   []runtimemanager.PersistedAgent
+	pending  map[string][]events.Event
+	receipts map[string]runtimemanager.EventReceipt
+}
+
+func (*startupManagerReplayRuntimeStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
+	return nil
+}
+
+func (s *startupManagerReplayRuntimeStore) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return append([]runtimemanager.PersistedAgent(nil), s.agents...), nil
+}
+
+func (*startupManagerReplayRuntimeStore) MarkAgentTerminated(context.Context, string) error {
+	return nil
+}
+func (*startupManagerReplayRuntimeStore) EnsureEntitySchema(context.Context, string) error {
+	return nil
+}
+func (s *startupManagerReplayRuntimeStore) UpsertEventReceipt(_ context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+	if s.receipts == nil {
+		s.receipts = map[string]runtimemanager.EventReceipt{}
+	}
+	s.receipts[strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)] = runtimemanager.EventReceipt{
+		EventID: eventID,
+		AgentID: agentID,
+		Status:  status,
+		Error:   errText,
+	}
+	return nil
+}
+func (s *startupManagerReplayRuntimeStore) ListPendingEventsForAgent(_ context.Context, agentID string, _ time.Time, _ int) ([]events.Event, error) {
+	return append([]events.Event(nil), s.pending[strings.TrimSpace(agentID)]...), nil
+}
+func (*startupManagerReplayRuntimeStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+func (s *startupManagerReplayRuntimeStore) GetEventReceipt(_ context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
+	receipt, ok := s.receipts[strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)]
+	return receipt, ok, nil
+}
+
+type startupManagerReplayRuntimeAgent struct{ id string }
+
+func (a startupManagerReplayRuntimeAgent) ID() string                      { return a.id }
+func (startupManagerReplayRuntimeAgent) Type() string                      { return "generic" }
+func (startupManagerReplayRuntimeAgent) Subscriptions() []events.EventType { return nil }
+func (startupManagerReplayRuntimeAgent) OnEvent(_ context.Context, evt events.Event) ([]events.Event, error) {
+	switch evt.Type {
+	case events.EventType("support.replay.drop"):
+		return nil, errors.New("boom")
+	case events.EventType("support.replay.leased"):
+		return nil, errors.New("session currently leased")
+	default:
+		return nil, nil
+	}
 }
 
 type startupRecoveryCapabilityEventStore struct{}
@@ -563,6 +623,119 @@ func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *te
 	}
 	if !strings.Contains(dropped.errorText, "claim failed") {
 		t.Fatalf("dropped error = %q, want claim failed", dropped.errorText)
+	}
+}
+
+func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	managerStore := &startupManagerReplayRuntimeStore{
+		agents: []runtimemanager.PersistedAgent{{
+			Config:    runtimeactors.AgentConfig{ID: "agent-a"},
+			StartedAt: time.Now().UTC(),
+		}},
+		pending: map[string][]events.Event{
+			"agent-a": {
+				{ID: "evt-replay", Type: events.EventType("support.replay.ok"), CreatedAt: time.Now().Add(-4 * time.Minute).UTC()},
+				{ID: "evt-skip", Type: events.EventType("support.replay.skip"), CreatedAt: time.Now().Add(-3 * time.Minute).UTC()},
+				{ID: "evt-leased", Type: events.EventType("support.replay.leased"), CreatedAt: time.Now().Add(-2 * time.Minute).UTC()},
+				{ID: "evt-drop", Type: events.EventType("support.replay.drop"), CreatedAt: time.Now().Add(-time.Minute).UTC()},
+			},
+		},
+		receipts: map[string]runtimemanager.EventReceipt{
+			"evt-skip|agent-a": {
+				EventID: "evt-skip",
+				AgentID: "agent-a",
+				Status:  runtimemanager.ReceiptStatusProcessed,
+			},
+		},
+	}
+
+	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+		SQLDB:        db,
+		EventStore:   startupRecoveryCapabilityEventStore{},
+		ManagerStore: managerStore,
+	}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	rt.Manager = runtimemanager.NewAgentManagerWithOptions(rt.Bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return startupManagerReplayRuntimeAgent{id: cfg.ID}, nil
+	}, runtimemanager.AgentManagerOptions{
+		SemanticSource:                 module.SemanticSource(),
+		RuntimeShutdownAdmissionClosed: rt.shutdownAdmissionClosed,
+	}, managerStore)
+
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	level, _, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
+	if level != "error" {
+		t.Fatalf("log level = %q, want error", level)
+	}
+	if !strings.Contains(errorText, "boom") {
+		t.Fatalf("log error = %q, want boom", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "degraded" {
+		t.Fatalf("decision_outcome = %q, want degraded", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonRecoverFailed) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonRecoverFailed)
+	}
+	if got := detailInt(detail["manager_replayed_count"]); got != 1 {
+		t.Fatalf("manager_replayed_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["manager_skipped_count"]); got != 2 {
+		t.Fatalf("manager_skipped_count = %d, want 2", got)
+	}
+	if got := detailInt(detail["manager_dropped_count"]); got != 1 {
+		t.Fatalf("manager_dropped_count = %d, want 1", got)
+	}
+
+	logs := listRuntimeLogsByAction(t, db, "startup_recovery_manager_replay_aftermath")
+	if len(logs) != 4 {
+		t.Fatalf("manager replay runtime logs = %d, want 4", len(logs))
+	}
+	findByEventType := func(eventType string) runtimeAftermathLog {
+		t.Helper()
+		for _, entry := range logs {
+			if strings.TrimSpace(entry.eventType) == eventType {
+				return entry
+			}
+		}
+		t.Fatalf("missing manager replay log for event type %q in %#v", eventType, logs)
+		return runtimeAftermathLog{}
+	}
+	replayed := findByEventType("support.replay.ok")
+	if got := detailString(replayed.detail["decision_outcome"]); got != "replayed" {
+		t.Fatalf("replayed decision_outcome = %q, want replayed", got)
+	}
+	skippedReceipt := findByEventType("support.replay.skip")
+	if got := detailString(skippedReceipt.detail["decision_reason_code"]); got != "event_receipt_already_processed" {
+		t.Fatalf("receipt skip decision_reason_code = %q, want event_receipt_already_processed", got)
+	}
+	skippedLeased := findByEventType("support.replay.leased")
+	if got := detailString(skippedLeased.detail["decision_reason_code"]); got != "session_currently_leased" {
+		t.Fatalf("leased skip decision_reason_code = %q, want session_currently_leased", got)
+	}
+	dropped := findByEventType("support.replay.drop")
+	if got := detailString(dropped.detail["decision_outcome"]); got != "dropped" {
+		t.Fatalf("dropped decision_outcome = %q, want dropped", got)
+	}
+	if !strings.Contains(dropped.errorText, "boom") {
+		t.Fatalf("dropped error = %q, want boom", dropped.errorText)
 	}
 }
 

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -78,6 +78,9 @@ type startupRecoveryDecisionReport struct {
 	ScheduleSkipCount        int
 	ScheduleDropCount        int
 	ManagerRecoveryAttempted bool
+	ManagerReplayCount       int
+	ManagerSkipCount         int
+	ManagerDropCount         int
 	ManagerResetAttempted    bool
 	ManagerResetError        string
 	InspectionError          string
@@ -140,6 +143,9 @@ func (r startupRecoveryDecisionReport) detail() map[string]any {
 	detail["schedule_skipped_count"] = r.ScheduleSkipCount
 	detail["schedule_dropped_count"] = r.ScheduleDropCount
 	detail["manager_recovery_attempted"] = r.ManagerRecoveryAttempted
+	detail["manager_replayed_count"] = r.ManagerReplayCount
+	detail["manager_skipped_count"] = r.ManagerSkipCount
+	detail["manager_dropped_count"] = r.ManagerDropCount
 	detail["manager_reset_attempted"] = r.ManagerResetAttempted
 	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
 		detail["error"] = errText


### PR DESCRIPTION
Closes #334

## Summary
- canonicalize startup manager replay aftermath diagnostics for the approved widened startup replay owner cluster
- make startup recovery consume typed replay/skip/drop truth instead of coarse startup-only failure logs and silent lower-gate skips
- prove the supported runtime-log reader surfaces the same aftermath truth

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: timer_model.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: error_model.handler_execution_failure.retry_policy`

## What changed
- added a typed startup manager replay aftermath contract in `internal/runtime/manager/startup_replay_diagnostics.go`
- moved startup recovery onto `AgentManager.RecoverWithStartupReplayDiagnostics(...)`
- widened the startup replay owner cluster to absorb the lower `processEvent(...)` / receipt / in-flight / transient lease gates needed for honest `skip`
- replaced startup-path coarse `pending_replay_failed` / `pending_replay_event_failed` semantics with canonical `startup_recovery_manager_replay_aftermath` records
- added startup decision summary counts for manager replayed/skipped/dropped work and degrade startup recovery when startup replay drops persisted work
- preserved non-startup replay semantics by keeping startup diagnostics behind an explicit startup replay context and proving direct `ReplayAgentBacklog(...)` does not emit the startup-only aftermath action

## Why needed
- the backlog-only slice was not closure-credible once `skip` remained mandatory
- the lower receipt/session/in-flight gates already owned honest startup replay `skip` truth, so the startup owner boundary had to widen or it would have required local inference

## Scope boundaries
- in scope: startup manager replay / skip / drop aftermath truth across `Runtime.Start(...)` -> `AgentManager.Recover(...)` -> `replayPendingEvents(...)` / `ReplayAgentBacklog(...)` -> lower replay gates
- out of scope: already-closed startup admission/timer/pipeline/orphan slices and non-startup replay concepts such as direct operator replay and steady-state retry replay

## Tests run
- `go test ./internal/runtime/manager -run 'Test(RecoverWithStartupReplayDiagnostics_LogsCanonicalManagerReplayAftermath|ReplayAgentBacklog_DoesNotEmitStartupAftermathOutsideStartupRecovery|Recover_UsesCanonicalPipelineReplayAftermathDiagnostics)$' -count=1`
- `go test ./internal/runtime -run 'TestRuntimeStart_(RecoveryEnabledEmitsManagerReplayAftermathAndSummary|RecoveryEnabledEmitsAllowedDecisionSummary|RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary|RecoveryFailureEmitsDegradedDecisionSummary|RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartup|InspectionFailurePreservesDecisionErrorAcrossTimerSkipAndDrop|RecoveryDisabledEmitsDeniedDecisionForActiveSchedules|RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork)$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(StartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader|StartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityReader|StartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityReader|ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader|StartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityReader)$' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager ./internal/runtime/conformance ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual risk
- this PR keeps non-startup replay surfaces semantically unchanged by design; if a future issue needs canonical replay diagnostics for direct operator replay or steady-state retry replay, that should be tracked as a separate concept rather than inferred from this startup-only owner

## Follow-up
- none identified on current evidence for the startup replay child class