### PR TITLE
[agent-c][issue #326] Align helper control-plane auth

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -185,7 +185,7 @@ nodes:
     known_manifestations:
       - gateway auth not fail-closed
       - builder RPC/WebSocket privileged paths unauthenticated
-      - supported helper paths drift from authenticated builder RPC policy and fail after runtime reaches ready
+      - supported helper paths drift across local control-plane auth/readiness gates such as operator-authenticated `/api/health` and builder-authenticated `/api/rpc`, causing the helper to fail after runtime reaches ready
       - delegable privileges not capped on hire/reconfigure
       - dashboard/runtime-control default listener left open
     representative_issues:

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -160,6 +160,7 @@ if [[ -n "${DIRECTIVE_AGENT}" && -n "${DIRECTIVE_MESSAGE}" ]]; then
   ruby -rjson -e 'print JSON.generate({message: ARGV[0], kill_previous: true})' "${DIRECTIVE_MESSAGE}" | \
     curl -sS "http://${HEALTH_ADDR}/api/agents/${DIRECTIVE_AGENT}/actions/directive" \
       -H 'content-type: application/json' \
+      -H "Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}" \
       --data-binary @-
   echo
 fi

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -23,8 +23,10 @@ DIRECTIVE_MESSAGE="${DIRECTIVE_MESSAGE:-}"
 CORPUS_PATH="${CORPUS_PATH:-/data/test-signals-25.jsonl}"
 CORPUS_MODE="${CORPUS_MODE:-corpus}"
 CORPUS_GEOGRAPHY="${CORPUS_GEOGRAPHY:-US}"
+SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 
+export SWARM_OPERATOR_AUTH_TOKEN
 export SWARM_BUILDER_AUTH_TOKEN
 
 kill_swarm_processes() {
@@ -91,7 +93,7 @@ SQL
 echo "Starting Swarm with contracts ${CONTRACTS_ROOT}..."
 : > "${LOG_FILE}"
 launcher_pid="$(
-  LOG_FILE="${LOG_FILE}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN}" python3 - <<'PY'
+  LOG_FILE="${LOG_FILE}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN}" SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN}" python3 - <<'PY'
 import os
 import subprocess
 import sys
@@ -118,7 +120,8 @@ ready=0
 for _ in $(seq 1 "${START_TIMEOUT}"); do
   health_code="$(curl -s -o /tmp/swarm-healthz.json -w '%{http_code}' "${HEALTH_URL}" || true)"
   ready_code="$(curl -s -o /tmp/swarm-readyz.json -w '%{http_code}' "${READY_URL}" || true)"
-  api_code="$(curl -s -o /tmp/swarm-api-health.json -w '%{http_code}' "${API_HEALTH_URL}" || true)"
+  api_code="$(curl -s -o /tmp/swarm-api-health.json -w '%{http_code}' "${API_HEALTH_URL}" \
+    -H "Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}" || true)"
   if [[ "${health_code}" == "200" && "${ready_code}" == "200" && "${api_code}" == "200" ]]; then
     ready=1
     break

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -9,8 +9,15 @@ import (
 	"testing"
 )
 
+type runClearConfig struct {
+	operatorToken    string
+	builderToken     string
+	directiveAgent   string
+	directiveMessage string
+}
+
 func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
-	result := runRunClear(t, "", "")
+	result := runRunClear(t, runClearConfig{})
 
 	if strings.TrimSpace(result.operatorToken) == "" {
 		t.Fatal("expected helper to provision SWARM_OPERATOR_AUTH_TOKEN")
@@ -43,7 +50,10 @@ func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
 func TestRunClear_UsesConfiguredBuilderAuthTokenForRPC(t *testing.T) {
 	const explicitOperatorToken = "operator-explicit-token"
 	const explicitBuilderToken = "builder-explicit-token"
-	result := runRunClear(t, explicitOperatorToken, explicitBuilderToken)
+	result := runRunClear(t, runClearConfig{
+		operatorToken: explicitOperatorToken,
+		builderToken:  explicitBuilderToken,
+	})
 
 	if got := strings.TrimSpace(result.operatorToken); got != explicitOperatorToken {
 		t.Fatalf("operator token = %q, want %q", got, explicitOperatorToken)
@@ -61,18 +71,44 @@ func TestRunClear_UsesConfiguredBuilderAuthTokenForRPC(t *testing.T) {
 	}
 }
 
-type runClearResult struct {
-	stdout        string
-	operatorToken string
-	builderToken  string
-	healthHeaders string
-	healthURL     string
-	rpcHeaders    string
-	rpcBody       string
-	rpcURL        string
+func TestRunClear_UsesOperatorBearerForDirective(t *testing.T) {
+	const explicitOperatorToken = "operator-explicit-token"
+	result := runRunClear(t, runClearConfig{
+		operatorToken:    explicitOperatorToken,
+		directiveAgent:   "agent-7",
+		directiveMessage: "hello from test",
+	})
+
+	wantHeader := "Authorization: Bearer " + explicitOperatorToken
+	if !strings.Contains(result.directiveHeaders, wantHeader) {
+		t.Fatalf("directive headers = %q, want %q", result.directiveHeaders, wantHeader)
+	}
+	if got := strings.TrimSpace(result.directiveURL); got != "http://127.0.0.1:8081/api/agents/agent-7/actions/directive" {
+		t.Fatalf("directive url = %q, want helper directive endpoint", got)
+	}
+	if !strings.Contains(result.directiveBody, `"message":"hello from test"`) {
+		t.Fatalf("directive body = %q, want directive message payload", result.directiveBody)
+	}
+	if !strings.Contains(result.directiveBody, `"kill_previous":true`) {
+		t.Fatalf("directive body = %q, want kill_previous payload", result.directiveBody)
+	}
 }
 
-func runRunClear(t *testing.T, operatorToken, builderToken string) runClearResult {
+type runClearResult struct {
+	stdout           string
+	operatorToken    string
+	builderToken     string
+	healthHeaders    string
+	healthURL        string
+	rpcHeaders       string
+	rpcBody          string
+	rpcURL           string
+	directiveHeaders string
+	directiveBody    string
+	directiveURL     string
+}
+
+func runRunClear(t *testing.T, cfg runClearConfig) runClearResult {
 	t.Helper()
 
 	scriptDir := testScriptDir(t)
@@ -86,6 +122,9 @@ func runRunClear(t *testing.T, operatorToken, builderToken string) runClearResul
 	rpcHeadersSink := filepath.Join(t.TempDir(), "rpc-headers.txt")
 	bodySink := filepath.Join(t.TempDir(), "rpc-body.txt")
 	urlSink := filepath.Join(t.TempDir(), "rpc-url.txt")
+	directiveHeadersSink := filepath.Join(t.TempDir(), "directive-headers.txt")
+	directiveBodySink := filepath.Join(t.TempDir(), "directive-body.txt")
+	directiveURLSink := filepath.Join(t.TempDir(), "directive-url.txt")
 
 	writeExecutable(t, binDir, "pgrep", "#!/usr/bin/env bash\nexit 1\n")
 	writeExecutable(t, binDir, "lsof", "#!/usr/bin/env bash\nexit 1\n")
@@ -119,6 +158,9 @@ while (($#)); do
       ;;
     --data-binary)
       body="$2"
+      if [[ "$body" == "@-" ]]; then
+        body="$(cat)"
+      fi
       shift 2
       ;;
     -s|-S|-sS)
@@ -181,6 +223,24 @@ if [[ "$url" == *"/api/rpc" ]]; then
   printf '{"jsonrpc":"2.0","id":"run-clear","error":{"message":"missing authorization bearer token"}}'
   exit 0
 fi
+if [[ "$url" == *"/api/agents/"*"/actions/directive" ]]; then
+  printf '%s' "$url" > "${CURL_DIRECTIVE_URL_SINK}"
+  if ((${#headers[@]})); then
+    printf '%s\n' "${headers[@]}" > "${CURL_DIRECTIVE_HEADERS_SINK}"
+  else
+    : > "${CURL_DIRECTIVE_HEADERS_SINK}"
+  fi
+  printf '%s' "$body" > "${CURL_DIRECTIVE_BODY_SINK}"
+  want="Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}"
+  for header in "${headers[@]}"; do
+    if [[ "$header" == "$want" ]]; then
+      printf '{"status":"accepted"}'
+      exit 0
+    fi
+  done
+  printf '{"error":"missing authorization bearer token"}'
+  exit 0
+fi
 printf '{}'
 `)
 
@@ -197,17 +257,26 @@ printf '{}'
 		"CURL_HEADERS_SINK=" + rpcHeadersSink,
 		"CURL_BODY_SINK=" + bodySink,
 		"CURL_URL_SINK=" + urlSink,
+		"CURL_DIRECTIVE_HEADERS_SINK=" + directiveHeadersSink,
+		"CURL_DIRECTIVE_BODY_SINK=" + directiveBodySink,
+		"CURL_DIRECTIVE_URL_SINK=" + directiveURLSink,
 		"CONTRACTS_ROOT=/tmp/contracts",
 		"HEALTH_ADDR=127.0.0.1:8081",
 		"LOG_FILE=" + logFile,
 		"PID_FILE=" + pidFile,
 		"START_TIMEOUT=1",
 	}...)
-	if operatorToken != "" {
-		cmd.Env = append(cmd.Env, "SWARM_OPERATOR_AUTH_TOKEN="+operatorToken)
+	if cfg.operatorToken != "" {
+		cmd.Env = append(cmd.Env, "SWARM_OPERATOR_AUTH_TOKEN="+cfg.operatorToken)
 	}
-	if builderToken != "" {
-		cmd.Env = append(cmd.Env, "SWARM_BUILDER_AUTH_TOKEN="+builderToken)
+	if cfg.builderToken != "" {
+		cmd.Env = append(cmd.Env, "SWARM_BUILDER_AUTH_TOKEN="+cfg.builderToken)
+	}
+	if cfg.directiveAgent != "" {
+		cmd.Env = append(cmd.Env, "DIRECTIVE_AGENT="+cfg.directiveAgent)
+	}
+	if cfg.directiveMessage != "" {
+		cmd.Env = append(cmd.Env, "DIRECTIVE_MESSAGE="+cfg.directiveMessage)
 	}
 
 	out, err := cmd.CombinedOutput()
@@ -216,14 +285,17 @@ printf '{}'
 	}
 
 	return runClearResult{
-		stdout:        string(out),
-		operatorToken: readFileTrimmed(t, operatorTokenSink),
-		builderToken:  readFileTrimmed(t, builderTokenSink),
-		healthHeaders: readFileTrimmed(t, healthHeadersSink),
-		healthURL:     readFileTrimmed(t, healthURLSink),
-		rpcHeaders:    readFileTrimmed(t, rpcHeadersSink),
-		rpcBody:       readFileTrimmed(t, bodySink),
-		rpcURL:        readFileTrimmed(t, urlSink),
+		stdout:           string(out),
+		operatorToken:    readFileTrimmed(t, operatorTokenSink),
+		builderToken:     readFileTrimmed(t, builderTokenSink),
+		healthHeaders:    readFileTrimmed(t, healthHeadersSink),
+		healthURL:        readFileTrimmed(t, healthURLSink),
+		rpcHeaders:       readFileTrimmed(t, rpcHeadersSink),
+		rpcBody:          readFileTrimmed(t, bodySink),
+		rpcURL:           readFileTrimmed(t, urlSink),
+		directiveHeaders: readFileTrimmedOptional(t, directiveHeadersSink),
+		directiveBody:    readFileTrimmedOptional(t, directiveBodySink),
+		directiveURL:     readFileTrimmedOptional(t, directiveURLSink),
 	}
 }
 
@@ -268,6 +340,18 @@ func readFileTrimmed(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func readFileTrimmedOptional(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return strings.TrimSpace(string(data))

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -10,14 +10,24 @@ import (
 )
 
 func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
-	result := runRunClear(t, "")
+	result := runRunClear(t, "", "")
 
+	if strings.TrimSpace(result.operatorToken) == "" {
+		t.Fatal("expected helper to provision SWARM_OPERATOR_AUTH_TOKEN")
+	}
 	if strings.TrimSpace(result.builderToken) == "" {
 		t.Fatal("expected helper to provision SWARM_BUILDER_AUTH_TOKEN")
 	}
+	wantOperatorHeader := "Authorization: Bearer " + result.operatorToken
+	if !strings.Contains(result.healthHeaders, wantOperatorHeader) {
+		t.Fatalf("api health headers = %q, want %q", result.healthHeaders, wantOperatorHeader)
+	}
+	if got := strings.TrimSpace(result.healthURL); got != "http://127.0.0.1:8081/api/health" {
+		t.Fatalf("api health url = %q, want helper /api/health readiness gate", got)
+	}
 	wantHeader := "Authorization: Bearer " + result.builderToken
-	if !strings.Contains(result.headers, wantHeader) {
-		t.Fatalf("headers = %q, want %q", result.headers, wantHeader)
+	if !strings.Contains(result.rpcHeaders, wantHeader) {
+		t.Fatalf("rpc headers = %q, want %q", result.rpcHeaders, wantHeader)
 	}
 	if got := strings.TrimSpace(result.rpcURL); got != "http://127.0.0.1:8081/api/rpc" {
 		t.Fatalf("rpc url = %q, want helper /api/rpc alias", got)
@@ -31,35 +41,49 @@ func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
 }
 
 func TestRunClear_UsesConfiguredBuilderAuthTokenForRPC(t *testing.T) {
-	const explicitToken = "builder-explicit-token"
-	result := runRunClear(t, explicitToken)
+	const explicitOperatorToken = "operator-explicit-token"
+	const explicitBuilderToken = "builder-explicit-token"
+	result := runRunClear(t, explicitOperatorToken, explicitBuilderToken)
 
-	if got := strings.TrimSpace(result.builderToken); got != explicitToken {
-		t.Fatalf("builder token = %q, want %q", got, explicitToken)
+	if got := strings.TrimSpace(result.operatorToken); got != explicitOperatorToken {
+		t.Fatalf("operator token = %q, want %q", got, explicitOperatorToken)
 	}
-	wantHeader := "Authorization: Bearer " + explicitToken
-	if !strings.Contains(result.headers, wantHeader) {
-		t.Fatalf("headers = %q, want %q", result.headers, wantHeader)
+	if got := strings.TrimSpace(result.builderToken); got != explicitBuilderToken {
+		t.Fatalf("builder token = %q, want %q", got, explicitBuilderToken)
+	}
+	wantOperatorHeader := "Authorization: Bearer " + explicitOperatorToken
+	if !strings.Contains(result.healthHeaders, wantOperatorHeader) {
+		t.Fatalf("api health headers = %q, want %q", result.healthHeaders, wantOperatorHeader)
+	}
+	wantBuilderHeader := "Authorization: Bearer " + explicitBuilderToken
+	if !strings.Contains(result.rpcHeaders, wantBuilderHeader) {
+		t.Fatalf("rpc headers = %q, want %q", result.rpcHeaders, wantBuilderHeader)
 	}
 }
 
 type runClearResult struct {
-	stdout       string
-	builderToken string
-	headers      string
-	rpcBody      string
-	rpcURL       string
+	stdout        string
+	operatorToken string
+	builderToken  string
+	healthHeaders string
+	healthURL     string
+	rpcHeaders    string
+	rpcBody       string
+	rpcURL        string
 }
 
-func runRunClear(t *testing.T, builderToken string) runClearResult {
+func runRunClear(t *testing.T, operatorToken, builderToken string) runClearResult {
 	t.Helper()
 
 	scriptDir := testScriptDir(t)
 	binDir := t.TempDir()
 	logFile := filepath.Join(t.TempDir(), "swarm.log")
 	pidFile := filepath.Join(t.TempDir(), "swarm.pid")
+	operatorTokenSink := filepath.Join(t.TempDir(), "operator-token.txt")
 	builderTokenSink := filepath.Join(t.TempDir(), "builder-token.txt")
-	headersSink := filepath.Join(t.TempDir(), "rpc-headers.txt")
+	healthHeadersSink := filepath.Join(t.TempDir(), "api-health-headers.txt")
+	healthURLSink := filepath.Join(t.TempDir(), "api-health-url.txt")
+	rpcHeadersSink := filepath.Join(t.TempDir(), "rpc-headers.txt")
 	bodySink := filepath.Join(t.TempDir(), "rpc-body.txt")
 	urlSink := filepath.Join(t.TempDir(), "rpc-url.txt")
 
@@ -70,6 +94,7 @@ func runRunClear(t *testing.T, builderToken string) runClearResult {
 	writeExecutable(t, binDir, "uuidgen", "#!/usr/bin/env bash\nprintf '11111111-1111-1111-1111-111111111111\\n'\n")
 	writeExecutable(t, binDir, "python3", `#!/usr/bin/env bash
 set -euo pipefail
+printf '%s' "${SWARM_OPERATOR_AUTH_TOKEN:-}" > "${PYTHON_OPERATOR_TOKEN_SINK}"
 printf '%s' "${SWARM_BUILDER_AUTH_TOKEN:-}" > "${PYTHON_ENV_SINK}"
 printf '4242\n'
 `)
@@ -108,11 +133,34 @@ while (($#)); do
       ;;
   esac
 done
-if [[ "$url" == *"/healthz" || "$url" == *"/readyz" || "$url" == *"/api/health" ]]; then
+if [[ "$url" == *"/healthz" || "$url" == *"/readyz" ]]; then
   if [[ -n "$out" ]]; then
     printf '{}' > "$out"
   fi
   printf '200'
+  exit 0
+fi
+if [[ "$url" == *"/api/health" ]]; then
+  printf '%s' "$url" > "${CURL_API_HEALTH_URL_SINK}"
+  if ((${#headers[@]})); then
+    printf '%s\n' "${headers[@]}" > "${CURL_API_HEALTH_HEADERS_SINK}"
+  else
+    : > "${CURL_API_HEALTH_HEADERS_SINK}"
+  fi
+  want="Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}"
+  for header in "${headers[@]}"; do
+    if [[ "$header" == "$want" ]]; then
+      if [[ -n "$out" ]]; then
+        printf '{}' > "$out"
+      fi
+      printf '200'
+      exit 0
+    fi
+  done
+  if [[ -n "$out" ]]; then
+    printf '{"error":"operator authentication is not configured"}' > "$out"
+  fi
+  printf '401'
   exit 0
 fi
 if [[ "$url" == *"/api/rpc" ]]; then
@@ -123,7 +171,14 @@ if [[ "$url" == *"/api/rpc" ]]; then
     : > "${CURL_HEADERS_SINK}"
   fi
   printf '%s' "$body" > "${CURL_BODY_SINK}"
-  printf '{"jsonrpc":"2.0","id":"run-clear","result":{"status":"started"}}'
+  want="Authorization: Bearer ${SWARM_BUILDER_AUTH_TOKEN}"
+  for header in "${headers[@]}"; do
+    if [[ "$header" == "$want" ]]; then
+      printf '{"jsonrpc":"2.0","id":"run-clear","result":{"status":"started"}}'
+      exit 0
+    fi
+  done
+  printf '{"jsonrpc":"2.0","id":"run-clear","error":{"message":"missing authorization bearer token"}}'
   exit 0
 fi
 printf '{}'
@@ -131,11 +186,15 @@ printf '{}'
 
 	cmd := exec.Command("bash", filepath.Join(scriptDir, "run_clear.sh"))
 	cmd.Env = append(filteredEnv(
+		"SWARM_OPERATOR_AUTH_TOKEN",
 		"SWARM_BUILDER_AUTH_TOKEN",
 	), []string{
 		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"PYTHON_OPERATOR_TOKEN_SINK=" + operatorTokenSink,
 		"PYTHON_ENV_SINK=" + builderTokenSink,
-		"CURL_HEADERS_SINK=" + headersSink,
+		"CURL_API_HEALTH_HEADERS_SINK=" + healthHeadersSink,
+		"CURL_API_HEALTH_URL_SINK=" + healthURLSink,
+		"CURL_HEADERS_SINK=" + rpcHeadersSink,
 		"CURL_BODY_SINK=" + bodySink,
 		"CURL_URL_SINK=" + urlSink,
 		"CONTRACTS_ROOT=/tmp/contracts",
@@ -144,6 +203,9 @@ printf '{}'
 		"PID_FILE=" + pidFile,
 		"START_TIMEOUT=1",
 	}...)
+	if operatorToken != "" {
+		cmd.Env = append(cmd.Env, "SWARM_OPERATOR_AUTH_TOKEN="+operatorToken)
+	}
 	if builderToken != "" {
 		cmd.Env = append(cmd.Env, "SWARM_BUILDER_AUTH_TOKEN="+builderToken)
 	}
@@ -154,11 +216,14 @@ printf '{}'
 	}
 
 	return runClearResult{
-		stdout:       string(out),
-		builderToken: readFileTrimmed(t, builderTokenSink),
-		headers:      readFileTrimmed(t, headersSink),
-		rpcBody:      readFileTrimmed(t, bodySink),
-		rpcURL:       readFileTrimmed(t, urlSink),
+		stdout:        string(out),
+		operatorToken: readFileTrimmed(t, operatorTokenSink),
+		builderToken:  readFileTrimmed(t, builderTokenSink),
+		healthHeaders: readFileTrimmed(t, healthHeadersSink),
+		healthURL:     readFileTrimmed(t, healthURLSink),
+		rpcHeaders:    readFileTrimmed(t, rpcHeadersSink),
+		rpcBody:       readFileTrimmed(t, bodySink),
+		rpcURL:        readFileTrimmed(t, urlSink),
 	}
 }
 


### PR DESCRIPTION
Closes #326

## Summary
- align the supported `scripts/run_clear.sh` helper with the full local control-plane auth/readiness path it actually traverses
- provision and use operator auth for the closure-bearing `/api/health` readiness gate and the helper's optional directive action
- preserve authenticated builder RPC alignment for `/api/rpc run.start`
- tighten the deterministic helper proof so `/api/health`, `/api/rpc`, and the optional directive branch all enforce real auth behavior instead of being stubbed to unconditional success

## Governing Context
No exact authoritative `platform-spec.yaml` section governs this helper/auth-readiness parity seam directly.

Binding context for this PR is:
- issue `#326`
- `internal/dashboard/server/server.go`
- `internal/builder/handler_auth.go`
- `cmd/swarm/main.go`

## What Changed
- `scripts/run_clear.sh` now provisions `SWARM_OPERATOR_AUTH_TOKEN` when unset, exports it into the launched local runtime, and sends `Authorization: Bearer ...` on `/api/health`
- `scripts/run_clear.sh` keeps the existing builder-token alignment on `/api/rpc`
- `scripts/run_clear.sh` now also sends the operator bearer on the optional directive action so the full helper surface remains aligned under the new helper auth contract
- `scripts/run_clear_test.go` now preserves the real auth behavior on all closure-bearing helper-path gates:
  - `/api/health` only returns `200` when the helper sends the correct operator bearer token
  - `/api/rpc` only returns a started result when the helper sends the correct builder bearer token
  - `/api/agents/{id}/actions/directive` only succeeds when the helper sends the correct operator bearer token
- `docs/watchlists/runtime-operations.yaml` now records the broader helper-path auth/readiness drift, not only the late RPC symptom

## Scope
In scope:
- supported helper / local control-plane auth-readiness parity on the default `scripts/run_clear.sh` path
- closure-bearing gates:
  - `/api/health`
  - `/api/rpc`
  - optional directive action when enabled

Out of scope:
- builder websocket/origin work
- generic runtime health/readiness redesign

## Tests Run
- `go test ./scripts -count=1`
- `go test ./internal/builder ./internal/dashboard/server ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
- broader `privileged_control_plane_auth` parent work remains tracked separately
