### PR TITLE
[agent-b][issue #157] Remove dead mailbox legacy scanner

### DIFF
--- a/internal/store/mailbox.go
+++ b/internal/store/mailbox.go
@@ -426,39 +426,6 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 	return out, nil
 }
 
-func scanLegacyMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
-	out := make([]runtimetools.MailboxItem, 0)
-	for rows.Next() {
-		var it runtimetools.MailboxItem
-		var timeout sql.NullTime
-		if err := rows.Scan(
-			&it.ID,
-			&it.EventID,
-			&it.EntityID,
-			&it.FromAgent,
-			&it.Type,
-			&it.Priority,
-			&it.Status,
-			&it.Notified,
-			&it.Context,
-			&it.Summary,
-			&timeout,
-			&it.Decision,
-			&it.DecisionNotes,
-		); err != nil {
-			return nil, fmt.Errorf("scan mailbox item: %w", err)
-		}
-		if timeout.Valid {
-			it.TimeoutAt = timeout.Time
-		}
-		out = append(out, it)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate mailbox items: %w", err)
-	}
-	return out, nil
-}
-
 func normalizeMailboxSeverity(priority string) string {
 	switch strings.TrimSpace(priority) {
 	case "critical", "urgent":

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1860,6 +1860,18 @@ func TestPostgresStore_Mailbox_CRUD_Expire_Notify(t *testing.T) {
 	if err != nil || len(items) == 0 {
 		t.Fatalf("list pending: n=%d err=%v", len(items), err)
 	}
+	foundPending := false
+	for _, item := range items {
+		if item.ID == id {
+			foundPending = true
+			if item.Status != "pending" || item.Priority != "normal" || item.Summary != "need approval" {
+				t.Fatalf("unexpected listed mailbox item: %+v", item)
+			}
+		}
+	}
+	if !foundPending {
+		t.Fatalf("expected inserted pending mailbox item %q in list", id)
+	}
 
 	if err := s.DecideMailboxItem(ctx, id, "decided", "approve", "ok"); err != nil {
 		t.Fatalf("decide: %v", err)
@@ -1915,6 +1927,18 @@ func TestPostgresStore_Mailbox_CRUD_Expire_Notify(t *testing.T) {
 	crit, err := s.ListUnnotifiedCriticalMailboxItems(ctx, 10)
 	if err != nil || len(crit) == 0 {
 		t.Fatalf("list unnotified critical: n=%d err=%v", len(crit), err)
+	}
+	foundCritical := false
+	for _, item := range crit {
+		if item.ID == critID {
+			foundCritical = true
+			if item.Status != "pending" || item.Priority != "critical" || item.Summary != "critical" {
+				t.Fatalf("unexpected critical mailbox item: %+v", item)
+			}
+		}
+	}
+	if !foundCritical {
+		t.Fatalf("expected critical mailbox item %q in unnotified list", critID)
 	}
 	if err := s.MarkMailboxItemNotified(ctx, critID); err != nil {
 		t.Fatalf("mark notified: %v", err)


### PR DESCRIPTION
## Human Summary

Removes a dead legacy mailbox row scanner from the canonical mailbox store owner.

## What Changed

- deleted `scanLegacyMailboxItems(...)` from `internal/store/mailbox.go`
- kept the canonical mailbox read path unchanged:
  - mailbox entrypoints still gate on `caps.Mailbox == SchemaFlavorCanonical`
  - `scanSpecMailboxItems(...)` remains the only active mailbox row scanner
- strengthened mailbox store coverage so the real list and unnotified-critical read surfaces assert canonical returned values instead of only checking for non-empty results

## Why This Is Needed

The canonical mailbox persistence path is already the only active production path in this seam. Keeping an uncalled legacy row-shape helper beside the active scanner leaves avoidable ownership ambiguity in a runtime/store hot path.

## Scope Boundaries

- `Part of #157`
- this PR only removes dead mailbox helper residue in the canonical mailbox seam
- it does not change live schema-capability boundaries, receipt compatibility, conversation visibility compatibility, or broader store design

## Spec References

- none
- non-semantic maintenance: this change removes dead compatibility residue and tightens regression coverage without changing platform contract semantics

## Tests Run

- `go test ./internal/store -run 'Test(PostgresStore_Mailbox_CRUD_Expire_Notify|PostgresStore_Smoke)$' -count=1`
- `go test ./internal/runtime/pipeline ./internal/runtime ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

Low. The canonical mailbox path was already the only active production path; this PR removes dead residue and adds direct read-surface assertions.

## Follow-Up

- `#157` remains open for the next runtime/store legacy-helper removal child slice
- umbrella/watchpoint `#159` remains the broader tracking stream for legacy compatibility removal
