### PR TITLE
[agent-c][issue #342] Align gateway request lifetime

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -93,6 +93,10 @@ active_issues:
     title: Eliminate string-based startup tool probe classification with an explicit validation/probe contract
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 342
+    title: Align request-context propagation across /mcp and /tools transport execution paths
+    maps_to:
+      - transport_policy_and_surface_parity
   - id: 179
     title: Expose recovery and restart decisions through canonical diagnostics
     maps_to:
@@ -106,6 +110,7 @@ nodes:
     why_this_node_exists: transport-visible behavior drifts when prompt, managed startup, and live transport paths enforce different policies
     known_manifestations:
       - context-token policy differs across transport surfaces
+      - request-lifetime semantics differ across /mcp and /tools after the same turn is resolved
       - startup validation does not prove the real filtered transport path
       - startup reachability probe conflates tool-call transport proof with tool-specific required-input validity
       - startup callable proof lacks an explicit typed probe outcome contract
@@ -115,6 +120,7 @@ nodes:
       - 136
       - 137
       - 218
+      - 342
       - 305
     common_framing_mistakes:
       too_broad:

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -332,15 +332,15 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *Gateway) mcpExecutionContext(r *http.Request, _ string) (context.Context, error) {
-	turn, err := g.runtimeTurnContextForRequest(r, "mcp.context.resolve")
-	if err != nil {
-		return nil, err
-	}
-	return g.contextForResolvedTurn(context.Background(), turn), nil
+	return g.transportExecutionContext(r, "mcp.context.resolve")
 }
 
 func (g *Gateway) toolExecutionContext(r *http.Request, _ string) (context.Context, error) {
-	turn, err := g.runtimeTurnContextForRequest(r, "tool.context.resolve")
+	return g.transportExecutionContext(r, "tool.context.resolve")
+}
+
+func (g *Gateway) transportExecutionContext(r *http.Request, operation string) (context.Context, error) {
+	turn, err := g.runtimeTurnContextForRequest(r, operation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -244,6 +244,83 @@ func putTestTurnContext(t testing.TB, registry *TurnContextRegistry, token strin
 	})
 }
 
+type gatewayCtxProbeKey string
+
+type gatewayCtxObservation struct {
+	value       string
+	hasDeadline bool
+	deadline    time.Time
+	err         error
+}
+
+func runGatewayTransportPair(t *testing.T, reqCtx context.Context) (gatewayCtxObservation, gatewayCtxObservation) {
+	t.Helper()
+
+	registry := newTestTurnContextRegistry()
+	observations := make([]gatewayCtxObservation, 0, 2)
+	g := NewGateway(testToolExecutor(func(ctx context.Context, name string, input any) (any, error) {
+		t.Helper()
+		if name != "query_entities" {
+			t.Fatalf("tool name = %q, want query_entities", name)
+		}
+		value, _ := ctx.Value(gatewayCtxProbeKey("probe")).(string)
+		deadline, hasDeadline := ctx.Deadline()
+		observations = append(observations, gatewayCtxObservation{
+			value:       value,
+			hasDeadline: hasDeadline,
+			deadline:    deadline,
+			err:         ctx.Err(),
+		})
+		return map[string]any{"ok": true}, nil
+	}), testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-transport-probe", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	mcpBody, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"query": "kind = 'vertical'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal mcp request: %v", err)
+	}
+	mcpReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(mcpBody))), "ctx-transport-probe").WithContext(reqCtx)
+	authorizeGatewayRequest(mcpReq)
+	mcpRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(mcpRec, mcpReq)
+	if mcpRec.Code != http.StatusOK {
+		t.Fatalf("mcp status = %d body=%s", mcpRec.Code, mcpRec.Body.String())
+	}
+
+	toolBody, err := json.Marshal(ToolGatewayRequest{
+		Input: map[string]any{"query": "kind = 'vertical'"},
+	})
+	if err != nil {
+		t.Fatalf("marshal tool request: %v", err)
+	}
+	toolReq := withContextToken(httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(string(toolBody))), "ctx-transport-probe").WithContext(reqCtx)
+	authorizeGatewayRequest(toolReq)
+	toolRec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(toolRec, toolReq)
+	if toolRec.Code != http.StatusOK {
+		t.Fatalf("tool status = %d body=%s", toolRec.Code, toolRec.Body.String())
+	}
+
+	if len(observations) != 2 {
+		t.Fatalf("observation count = %d, want 2", len(observations))
+	}
+	return observations[0], observations[1]
+}
+
 func TestGatewayHydrateActor_PrefersResolvedRuntimeConfig(t *testing.T) {
 	g := NewGateway(nil, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
@@ -1449,6 +1526,56 @@ func TestGatewayTransports_AlignReadOnlyToolSuccessWithResolvedTurnContext(t *te
 	}
 	if strings.Contains(toolRec.Body.String(), "missing or invalid mcp context token") {
 		t.Fatalf("tool body = %s", toolRec.Body.String())
+	}
+}
+
+func TestGatewayTransports_PreserveRequestContextValueAfterResolvedTurn(t *testing.T) {
+	base := context.WithValue(context.Background(), gatewayCtxProbeKey("probe"), "value-from-request")
+	mcpObs, toolObs := runGatewayTransportPair(t, base)
+
+	if mcpObs.value != "value-from-request" {
+		t.Fatalf("mcp context value = %q, want propagated request value", mcpObs.value)
+	}
+	if toolObs.value != "value-from-request" {
+		t.Fatalf("tool context value = %q, want propagated request value", toolObs.value)
+	}
+	if mcpObs.value != toolObs.value {
+		t.Fatalf("transport value mismatch: mcp=%q tool=%q", mcpObs.value, toolObs.value)
+	}
+}
+
+func TestGatewayTransports_PreserveRequestDeadlineAfterResolvedTurn(t *testing.T) {
+	wantDeadline := time.Now().UTC().Add(5 * time.Minute).Round(0)
+	base, cancel := context.WithDeadline(context.WithValue(context.Background(), gatewayCtxProbeKey("probe"), "deadline"), wantDeadline)
+	defer cancel()
+
+	mcpObs, toolObs := runGatewayTransportPair(t, base)
+
+	if !mcpObs.hasDeadline {
+		t.Fatal("mcp context missing propagated deadline")
+	}
+	if !toolObs.hasDeadline {
+		t.Fatal("tool context missing propagated deadline")
+	}
+	if !mcpObs.deadline.Equal(wantDeadline) {
+		t.Fatalf("mcp deadline = %s, want %s", mcpObs.deadline, wantDeadline)
+	}
+	if !toolObs.deadline.Equal(wantDeadline) {
+		t.Fatalf("tool deadline = %s, want %s", toolObs.deadline, wantDeadline)
+	}
+}
+
+func TestGatewayTransports_PreserveRequestCancellationAfterResolvedTurn(t *testing.T) {
+	base, cancel := context.WithCancel(context.WithValue(context.Background(), gatewayCtxProbeKey("probe"), "cancel"))
+	cancel()
+
+	mcpObs, toolObs := runGatewayTransportPair(t, base)
+
+	if mcpObs.err != context.Canceled {
+		t.Fatalf("mcp ctx err = %v, want %v", mcpObs.err, context.Canceled)
+	}
+	if toolObs.err != context.Canceled {
+		t.Fatalf("tool ctx err = %v, want %v", toolObs.err, context.Canceled)
 	}
 }
 


### PR DESCRIPTION
Closes #342

## Summary
- align `/mcp` and `/tools/*` on the same post-resolution request-lifetime contract
- remove the transport-specific `context.Background()` interpreter after the same turn is resolved
- add focused gateway regressions proving value, deadline, and cancellation parity across both transport paths

## Governing Context
No exact authoritative `platform-spec.yaml` section governs this gateway transport-lifetime seam directly.

Binding context for this PR is:
- issue `#342`
- audit parent `#104`
- `internal/runtime/mcp/gateway.go`

## What Changed
- both `mcpExecutionContext(...)` and `toolExecutionContext(...)` now consume one shared `transportExecutionContext(...)` helper
- the shared helper resolves the turn once and feeds `r.Context()` into `contextForResolvedTurn(...)` for both transports
- `internal/runtime/mcp/gateway_test.go` now proves that, after the same turn is resolved, `/mcp` and `/tools/*` preserve:
  - request-scoped context values
  - deadlines
  - cancellation

## Scope
In scope:
- post-resolution request-lifetime parity for gateway tool execution on `/mcp` and `/tools/*`

Out of scope:
- startup callable-proof parity (`#340`)
- broad MCP redesign
- tool authorization redesign

## Tests Run
- `go test ./internal/runtime/mcp -run 'TestGatewayTransports_(AlignReadOnlyToolSuccessWithResolvedTurnContext|PreserveRequestContextValueAfterResolvedTurn|PreserveRequestDeadlineAfterResolvedTurn|PreserveRequestCancellationAfterResolvedTurn)$' -count=1`
- `go test ./internal/runtime/mcp -count=1`
- `go test ./... -count=1`

## Residual Risk
- broader `transport_policy_and_surface_parity` parent work remains open only for the separately tracked startup callable-proof child `#340`
