### PR TITLE
[agent-a][issue #181] Expose accumulator completion runtime outcomes

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -67,10 +67,13 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
+	afterPublishActions := make([]func(), 0, 4)
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
 	ictx = runtimepipeline.WithPipelineTransitionCollector(ictx, &deferredTransitions, eb.pipelineTransitionCapability())
 	ictx = runtimepipeline.WithPipelinePostCommitActions(ictx, &postCommitActions)
+	ictx = runtimepipeline.WithPipelineAfterPublishActions(ictx, &afterPublishActions)
 	ictx = runtimepipeline.WithPipelineReceiptOverride(ictx, receiptOverride)
+	defer runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
 	if txStore, ok := eb.store.(TransactionalEventStore); ok {
 		return eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore)
 	}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -73,7 +73,9 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	ictx = runtimepipeline.WithPipelinePostCommitActions(ictx, &postCommitActions)
 	ictx = runtimepipeline.WithPipelineAfterPublishActions(ictx, &afterPublishActions)
 	ictx = runtimepipeline.WithPipelineReceiptOverride(ictx, receiptOverride)
-	defer runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
+	defer func() {
+		runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
+	}()
 	if txStore, ok := eb.store.(TransactionalEventStore); ok {
 		return eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore)
 	}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -415,6 +415,131 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 	}
 }
 
+func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier2-accumulation", "test-accumulate-on-complete-rollback")
+	module := loadConformanceWorkflowFixtureModule(t, fixtureRoot)
+
+	entityID := "11111111-1111-4111-8111-111111111111"
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	if err := workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    module.SemanticSource().WorkflowName(),
+		WorkflowVersion: module.SemanticSource().WorkflowVersion(),
+		CurrentState:    "collecting",
+		Metadata: map[string]any{
+			"subject_id":     entityID,
+			"expected_count": 3,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+		Runtime: config.RuntimeConfig{},
+		LLM:     config.LLMConfig{RuntimeMode: "api"},
+	}, runtimepkg.Stores{
+		SQLDB:         db,
+		EventStore:    pg,
+		ManagerStore:  pg,
+		ScheduleStore: pg,
+	}, runtimepkg.RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     conformanceNoopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	for idx, score := range []int{80, 90, 70} {
+		payload, err := json.Marshal(map[string]any{"entity_id": entityID, "score": score})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		if err := rt.Bus.Publish(ctx, (events.Event{
+			ID:        uuid.NewString(),
+			Type:      events.EventType("score.received"),
+			Payload:   payload,
+			CreatedAt: time.Now().UTC().Add(time.Duration(idx) * time.Millisecond),
+		}).WithEntityID(entityID)); err != nil {
+			t.Fatalf("Publish(%d): %v", idx, err)
+		}
+	}
+	if err := rt.Bus.WaitForQuiescence(ctx); err != nil {
+		t.Fatalf("WaitForQuiescence: %v", err)
+	}
+
+	instance, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("Load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := strings.TrimSpace(instance.CurrentState); got != "verified" {
+		t.Fatalf("current_state = %q, want verified", got)
+	}
+
+	reader := dashboardserver.NewSQLObservabilityReader(db, pg)
+	if reader == nil {
+		t.Fatal("NewSQLObservabilityReader returned nil")
+	}
+	logs, err := reader.ListRuntimeLogs(ctx, dashboardserver.RuntimeLogFilter{
+		Component: "workflow-runtime",
+		Type:      "accumulator_completion_outcome",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListRuntimeLogs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("runtime log rows = %d, want 1: %#v", len(logs), logs)
+	}
+	log := logs[0]
+	if log.Action != "accumulator_completion_outcome" {
+		t.Fatalf("log action = %q, want accumulator_completion_outcome", log.Action)
+	}
+	detail, _ := log.Detail.(map[string]any)
+	if got := readString(detail["decision_outcome"]); got != "completed" {
+		t.Fatalf("detail.decision_outcome = %q, want completed", got)
+	}
+	if got := readString(detail["decision_reason_code"]); got != "completion_committed" {
+		t.Fatalf("detail.decision_reason_code = %q, want completion_committed", got)
+	}
+	if got := readString(detail["evaluation_outcome"]); got != "succeeded" {
+		t.Fatalf("detail.evaluation_outcome = %q, want succeeded", got)
+	}
+	if got := readString(detail["commit_outcome"]); got != "committed" {
+		t.Fatalf("detail.commit_outcome = %q, want committed", got)
+	}
+	if got := readString(detail["selected_rule_id"]); got != "" {
+		t.Fatalf("detail.selected_rule_id = %q, want empty for anonymous true branch", got)
+	}
+	if got, _ := detail["received_count"].(float64); int(got) != 3 {
+		t.Fatalf("detail.received_count = %v, want 3", detail["received_count"])
+	}
+	if got, _ := detail["expected_count"].(float64); int(got) != 3 {
+		t.Fatalf("detail.expected_count = %v, want 3", detail["expected_count"])
+	}
+}
+
 type conformanceSemanticOnlyWorkflowRuntime struct {
 	source runtimesemanticview.Source
 }
@@ -435,6 +560,34 @@ func (conformanceSemanticOnlyWorkflowRuntime) GuardRegistry() runtimepipeline.Gu
 }
 func (conformanceSemanticOnlyWorkflowRuntime) ActionRegistry() runtimepipeline.ActionRegistry {
 	return nil
+}
+
+type conformanceLoadedWorkflowModule struct {
+	source   runtimesemanticview.Source
+	workflow *runtimepipeline.WorkflowDefinition
+	nodes    []runtimepipeline.WorkflowNode
+	guards   runtimepipeline.GuardRegistry
+	actions  runtimepipeline.ActionRegistry
+}
+
+func (m conformanceLoadedWorkflowModule) SemanticSource() runtimesemanticview.Source {
+	return m.source
+}
+
+func (m conformanceLoadedWorkflowModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return m.workflow
+}
+
+func (m conformanceLoadedWorkflowModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+
+func (m conformanceLoadedWorkflowModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guards
+}
+
+func (m conformanceLoadedWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actions
 }
 
 type conformanceNoopLLMRuntime struct{}
@@ -582,6 +735,31 @@ func loadConformanceRuntimeWorkflowModule(t *testing.T) conformanceSemanticOnlyW
 		t.Fatalf("load bundle: %v", err)
 	}
 	return conformanceSemanticOnlyWorkflowRuntime{source: runtimesemanticview.Wrap(bundle)}
+}
+
+func loadConformanceWorkflowFixtureModule(t *testing.T, fixtureRoot string) conformanceLoadedWorkflowModule {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	source := runtimesemanticview.Wrap(bundle)
+	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	return conformanceLoadedWorkflowModule{
+		source:   source,
+		workflow: workflow,
+		nodes:    nodes,
+		guards:   runtimepipeline.NewContractGuardRegistry(source),
+		actions:  runtimepipeline.NewContractActionRegistry(source),
+	}
 }
 
 func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *testing.T) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -219,6 +219,9 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 		})
 	})
 	if err != nil {
+		if result.AccumulatorCompletionDiagnostics.Relevant {
+			result.AccumulatorCompletionDiagnostics.CommitOutcome = AccumulatorCompletionCommitRolledBack
+		}
 		if errors.Is(err, ErrEmitPersistencePrerequisite) {
 			result.Status = OutcomeRejected
 		}
@@ -226,6 +229,9 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 			result.Status = OutcomeRejected
 		}
 		return result, err
+	}
+	if result.AccumulatorCompletionDiagnostics.Relevant {
+		result.AccumulatorCompletionDiagnostics.CommitOutcome = AccumulatorCompletionCommitCommitted
 	}
 	if len(intents) > 0 {
 		if err := e.deps.Dispatcher.DispatchPostCommit(ctx, intents); err != nil {
@@ -468,6 +474,10 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	if spec == nil {
 		return false, nil
 	}
+	frame.result.AccumulatorCompletionDiagnostics.Relevant = true
+	frame.result.AccumulatorCompletionDiagnostics.CompletionMode = spec.Completion.String()
+	frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = len(frame.req.Handler.OnComplete) > 0 || len(spec.OnComplete) > 0
+	frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationNotAttempted
 	bucketRef := timeridentity.NewAccumulatorBucketRef(frame.req.NodeID.String(), string(frame.req.Event.Type))
 	if isAccumulationTimeoutEvent(frame.req.Event.Type) {
 		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
@@ -513,6 +523,11 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	acc.LastEventType = strings.TrimSpace(string(frame.req.Event.Type))
 	acc.LastSource = strings.TrimSpace(frame.req.Event.SourceAgent)
 	acc.LastReceivedAt = frame.req.Event.CreatedAt.UTC().Format(time.RFC3339Nano)
+	frame.result.AccumulatorCompletionDiagnostics.ReceivedCount = len(acc.Received)
+	frame.result.AccumulatorCompletionDiagnostics.ExpectedCount = acc.ExpectedCount
+	if len(acc.Expected) > 0 {
+		frame.result.AccumulatorCompletionDiagnostics.ExpectedCount = len(acc.Expected)
+	}
 	storeAccumulatorForBucket(&frame.state.State, bucketRef, acc)
 	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateCarrier.StateBuckets)
 	frame.state.Accumulated = accumulatorExpressionValue(acc)
@@ -538,6 +553,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 		frame.result.Status = OutcomeWaiting
 		return true, nil
 	}
+	frame.result.AccumulatorCompletionDiagnostics.CompletionReached = true
 	return false, nil
 }
 
@@ -711,9 +727,18 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 	if len(rules) == 0 && frame.req.Handler.Accumulate != nil {
 		rules = frame.req.Handler.Accumulate.OnComplete
 	}
+	if frame.result.AccumulatorCompletionDiagnostics.Relevant && len(rules) > 0 {
+		frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = true
+	}
 	rule, err := e.selectRule(frame, rules)
 	if err != nil {
+		if frame.result.AccumulatorCompletionDiagnostics.Relevant {
+			frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationFailed
+		}
 		return err
+	}
+	if frame.result.AccumulatorCompletionDiagnostics.Relevant && len(rules) > 0 {
+		frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationSucceeded
 	}
 	if rule != nil {
 		frame.rule = rule
@@ -1292,6 +1317,9 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 	}
 	if id := strings.TrimSpace(rule.ID); id != "" {
 		frame.result.RuleID = id
+		if frame.result.AccumulatorCompletionDiagnostics.Relevant {
+			frame.result.AccumulatorCompletionDiagnostics.SelectedRuleID = id
+		}
 	}
 }
 

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -322,6 +322,34 @@ func (m *StateMutation) SetStateBuckets(raw map[string]map[string]any) {
 	m.StateCarrier.StateBuckets = cloneStateBucketSet(raw)
 }
 
+type AccumulatorCompletionEvaluationOutcome string
+
+const (
+	AccumulatorCompletionEvaluationNotAttempted AccumulatorCompletionEvaluationOutcome = "not_attempted"
+	AccumulatorCompletionEvaluationSucceeded    AccumulatorCompletionEvaluationOutcome = "succeeded"
+	AccumulatorCompletionEvaluationFailed       AccumulatorCompletionEvaluationOutcome = "failed"
+)
+
+type AccumulatorCompletionCommitOutcome string
+
+const (
+	AccumulatorCompletionCommitUnknown    AccumulatorCompletionCommitOutcome = "unknown"
+	AccumulatorCompletionCommitCommitted  AccumulatorCompletionCommitOutcome = "committed"
+	AccumulatorCompletionCommitRolledBack AccumulatorCompletionCommitOutcome = "rolled_back"
+)
+
+type AccumulatorCompletionDiagnostics struct {
+	Relevant           bool
+	CompletionReached  bool
+	ReceivedCount      int
+	ExpectedCount      int
+	CompletionMode     string
+	OnCompleteDeclared bool
+	EvaluationOutcome  AccumulatorCompletionEvaluationOutcome
+	SelectedRuleID     string
+	CommitOutcome      AccumulatorCompletionCommitOutcome
+}
+
 type RuleMatch struct {
 	ID         string
 	AdvancesTo string
@@ -347,6 +375,7 @@ type ExecutionResult struct {
 	EmitIntents       []EmitIntent
 	DeadLetterIntents []EmitIntent
 	ChainDepth        int
+	AccumulatorCompletionDiagnostics AccumulatorCompletionDiagnostics
 }
 
 func (r ExecutionResult) ComputedBucket() values.Bucket {

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -358,23 +358,23 @@ type RuleMatch struct {
 }
 
 type ExecutionResult struct {
-	Status            OutcomeStatus
-	FailureClass      FailureClass
-	ExecutedSteps     []Step
-	CurrentState      string
-	NextState         string
-	GuardsEvaluated   []string
-	ActionsExecuted   []string
-	ClearGates        []string
-	SetsGate          string
-	RuleID            string
-	FanOutCount       int
-	Computed          map[string]any
-	StateMutation     StateMutation
-	TimerIntents      []TimerIntent
-	EmitIntents       []EmitIntent
-	DeadLetterIntents []EmitIntent
-	ChainDepth        int
+	Status                           OutcomeStatus
+	FailureClass                     FailureClass
+	ExecutedSteps                    []Step
+	CurrentState                     string
+	NextState                        string
+	GuardsEvaluated                  []string
+	ActionsExecuted                  []string
+	ClearGates                       []string
+	SetsGate                         string
+	RuleID                           string
+	FanOutCount                      int
+	Computed                         map[string]any
+	StateMutation                    StateMutation
+	TimerIntents                     []TimerIntent
+	EmitIntents                      []EmitIntent
+	DeadLetterIntents                []EmitIntent
+	ChainDepth                       int
 	AccumulatorCompletionDiagnostics AccumulatorCompletionDiagnostics
 }
 

--- a/internal/runtime/pipeline/accumulator_completion_diagnostics.go
+++ b/internal/runtime/pipeline/accumulator_completion_diagnostics.go
@@ -21,10 +21,10 @@ const (
 type accumulatorCompletionDecisionReason string
 
 const (
-	accumulatorCompletionReasonCommitted         accumulatorCompletionDecisionReason = "completion_committed"
-	accumulatorCompletionReasonEvaluationFailed  accumulatorCompletionDecisionReason = "on_complete_evaluation_failed"
-	accumulatorCompletionReasonCommitFailed      accumulatorCompletionDecisionReason = "transaction_commit_failed"
-	accumulatorCompletionReasonPreCommitFailed   accumulatorCompletionDecisionReason = "pre_commit_failure"
+	accumulatorCompletionReasonCommitted        accumulatorCompletionDecisionReason = "completion_committed"
+	accumulatorCompletionReasonEvaluationFailed accumulatorCompletionDecisionReason = "on_complete_evaluation_failed"
+	accumulatorCompletionReasonCommitFailed     accumulatorCompletionDecisionReason = "transaction_commit_failed"
+	accumulatorCompletionReasonPreCommitFailed  accumulatorCompletionDecisionReason = "pre_commit_failure"
 )
 
 type accumulatorCompletionRuntimeRecord struct {

--- a/internal/runtime/pipeline/accumulator_completion_diagnostics.go
+++ b/internal/runtime/pipeline/accumulator_completion_diagnostics.go
@@ -1,0 +1,156 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+
+	"swarm/internal/events"
+	"swarm/internal/runtime/diaglog"
+	runtimeengine "swarm/internal/runtime/engine"
+)
+
+const accumulatorCompletionOutcomeAction = "accumulator_completion_outcome"
+
+type accumulatorCompletionDecisionOutcome string
+
+const (
+	accumulatorCompletionDecisionCompleted  accumulatorCompletionDecisionOutcome = "completed"
+	accumulatorCompletionDecisionRolledBack accumulatorCompletionDecisionOutcome = "rolled_back"
+)
+
+type accumulatorCompletionDecisionReason string
+
+const (
+	accumulatorCompletionReasonCommitted         accumulatorCompletionDecisionReason = "completion_committed"
+	accumulatorCompletionReasonEvaluationFailed  accumulatorCompletionDecisionReason = "on_complete_evaluation_failed"
+	accumulatorCompletionReasonCommitFailed      accumulatorCompletionDecisionReason = "transaction_commit_failed"
+	accumulatorCompletionReasonPreCommitFailed   accumulatorCompletionDecisionReason = "pre_commit_failure"
+)
+
+type accumulatorCompletionRuntimeRecord struct {
+	NodeID             string
+	Event              events.Event
+	Diagnostics        runtimeengine.AccumulatorCompletionDiagnostics
+	DecisionOutcome    accumulatorCompletionDecisionOutcome
+	DecisionReasonCode accumulatorCompletionDecisionReason
+	ErrorText          string
+}
+
+func newAccumulatorCompletionRuntimeRecord(nodeID string, evt events.Event, diagnostics runtimeengine.AccumulatorCompletionDiagnostics, err error) (accumulatorCompletionRuntimeRecord, bool) {
+	if !diagnostics.Relevant || !diagnostics.CompletionReached || !diagnostics.OnCompleteDeclared {
+		return accumulatorCompletionRuntimeRecord{}, false
+	}
+	record := accumulatorCompletionRuntimeRecord{
+		NodeID:      strings.TrimSpace(nodeID),
+		Event:       evt,
+		Diagnostics: diagnostics,
+		ErrorText:   strings.TrimSpace(errorText(err)),
+	}
+	switch diagnostics.CommitOutcome {
+	case runtimeengine.AccumulatorCompletionCommitCommitted:
+		record.DecisionOutcome = accumulatorCompletionDecisionCompleted
+		record.DecisionReasonCode = accumulatorCompletionReasonCommitted
+	default:
+		record.DecisionOutcome = accumulatorCompletionDecisionRolledBack
+		switch diagnostics.EvaluationOutcome {
+		case runtimeengine.AccumulatorCompletionEvaluationFailed:
+			record.DecisionReasonCode = accumulatorCompletionReasonEvaluationFailed
+		case runtimeengine.AccumulatorCompletionEvaluationSucceeded:
+			record.DecisionReasonCode = accumulatorCompletionReasonCommitFailed
+		default:
+			record.DecisionReasonCode = accumulatorCompletionReasonPreCommitFailed
+		}
+	}
+	return record, true
+}
+
+func (r accumulatorCompletionRuntimeRecord) level() diaglog.Level {
+	if r.DecisionOutcome == accumulatorCompletionDecisionCompleted {
+		return diaglog.LevelInfo
+	}
+	return diaglog.LevelWarn
+}
+
+func (r accumulatorCompletionRuntimeRecord) message() string {
+	switch r.DecisionReasonCode {
+	case accumulatorCompletionReasonEvaluationFailed:
+		return "Accumulator completion rolled back after on_complete evaluation failed"
+	case accumulatorCompletionReasonCommitFailed:
+		return "Accumulator completion rolled back after commit-phase failure"
+	case accumulatorCompletionReasonPreCommitFailed:
+		return "Accumulator completion rolled back before on_complete evaluation completed"
+	default:
+		return "Accumulator completion committed successfully"
+	}
+}
+
+func (r accumulatorCompletionRuntimeRecord) detail() map[string]any {
+	detail := map[string]any{
+		"decision_family":      "accumulator_completion",
+		"decision_outcome":     string(r.DecisionOutcome),
+		"decision_reason_code": string(r.DecisionReasonCode),
+		"completion_reached":   r.Diagnostics.CompletionReached,
+		"completion_mode":      strings.TrimSpace(r.Diagnostics.CompletionMode),
+		"received_count":       r.Diagnostics.ReceivedCount,
+		"expected_count":       r.Diagnostics.ExpectedCount,
+		"on_complete_declared": r.Diagnostics.OnCompleteDeclared,
+		"evaluation_outcome":   string(r.Diagnostics.EvaluationOutcome),
+		"commit_outcome":       string(r.Diagnostics.CommitOutcome),
+		"handler_node":         strings.TrimSpace(r.NodeID),
+		"event_id":             strings.TrimSpace(r.Event.ID),
+		"event_type":           strings.TrimSpace(string(r.Event.Type)),
+		"entity_id":            strings.TrimSpace(r.Event.EntityID()),
+		"flow_instance":        strings.TrimSpace(r.Event.FlowInstance()),
+	}
+	if ruleID := strings.TrimSpace(r.Diagnostics.SelectedRuleID); ruleID != "" {
+		detail["selected_rule_id"] = ruleID
+	}
+	if errText := strings.TrimSpace(r.ErrorText); errText != "" {
+		detail["error"] = errText
+		detail["error_code"] = string(r.DecisionReasonCode)
+	}
+	return detail
+}
+
+func logAccumulatorCompletionOutcome(ctx context.Context, bus Bus, nodeID string, evt events.Event, diagnostics runtimeengine.AccumulatorCompletionDiagnostics, err error) {
+	if bus == nil {
+		return
+	}
+	record, ok := newAccumulatorCompletionRuntimeRecord(nodeID, evt, diagnostics, err)
+	if !ok {
+		return
+	}
+	entry := RuntimeLogEntry{
+		Level:     record.level(),
+		Component: "workflow-runtime",
+		Action:    accumulatorCompletionOutcomeAction,
+		Message:   record.message(),
+		EventID:   strings.TrimSpace(evt.ID),
+		EventType: strings.TrimSpace(string(evt.Type)),
+		EntityID:  strings.TrimSpace(evt.EntityID()),
+		Detail:    record.detail(),
+		Error:     strings.TrimSpace(record.ErrorText),
+	}
+	emit := func() {
+		_ = bus.LogRuntime(ctx, entry)
+	}
+	if _, txActive := PipelineSQLTxFromContext(ctx); txActive {
+		if record.DecisionOutcome == accumulatorCompletionDecisionCompleted {
+			if QueuePipelinePostCommitAction(ctx, emit) {
+				return
+			}
+		} else {
+			if QueuePipelineAfterPublishAction(ctx, emit) {
+				return
+			}
+		}
+	}
+	emit()
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -213,6 +213,9 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 		Preview:    preview,
 		State:      stateSnapshot,
 	})
+	if !preview {
+		logAccumulatorCompletionOutcome(ctx, pc.bus, nodeID, triggerCtx.Event, result.AccumulatorCompletionDiagnostics, err)
+	}
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
 	}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -20,6 +20,7 @@ import (
 type recordingPipelineBus struct {
 	mu         sync.Mutex
 	publishes  []events.Event
+	runtimeLogs []RuntimeLogEntry
 	publishErr error
 }
 
@@ -43,7 +44,12 @@ func (*recordingPipelineBus) Subscribe(string, ...events.EventType) <-chan event
 
 func (*recordingPipelineBus) PublishDirect(context.Context, events.Event, []string) error { return nil }
 func (*recordingPipelineBus) ResolveSubscribedRecipients(string) []string                 { return nil }
-func (*recordingPipelineBus) LogRuntime(context.Context, RuntimeLogEntry) error           { return nil }
+func (b *recordingPipelineBus) LogRuntime(_ context.Context, entry RuntimeLogEntry) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.runtimeLogs = append(b.runtimeLogs, entry)
+	return nil
+}
 func (*recordingPipelineBus) EngineOutbox() runtimeengine.OutboxWriter                    { return noOpEngineOutbox{} }
 func (b *recordingPipelineBus) EngineDispatcher() runtimeengine.PostCommitDispatcher {
 	return recordingPipelineDispatcher{bus: b}
@@ -77,6 +83,14 @@ func (b *recordingPipelineBus) publishedEvent(i int) events.Event {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.publishes[i]
+}
+
+func (b *recordingPipelineBus) runtimeLogEntries() []RuntimeLogEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]RuntimeLogEntry, len(b.runtimeLogs))
+	copy(out, b.runtimeLogs)
+	return out
 }
 
 func TestPipelineCoordinatorPublish_ReturnsBusPublishError(t *testing.T) {
@@ -368,6 +382,219 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 	}
 }
 
+func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "researching",
+		Metadata: map[string]any{
+			"subject_id":     entityID,
+			"expected_count": 2,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_count",
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{TargetField: "business_brief"}},
+		},
+		OnComplete: []runtimecontracts.HandlerRuleEntry{
+			{ID: "complete", Condition: "true", AdvancesTo: "mvp_speccing", Emits: runtimecontracts.EventEmission{Single: "spec.requested"}},
+		},
+	}
+
+	for idx := 0; idx < 2; idx++ {
+		payload := map[string]any{"item_id": idx + 1}
+		if idx == 1 {
+			payload["business_brief"] = map[string]any{"summary": "validated"}
+		}
+		result, err := pc.executeNodeContractHandler(context.Background(), "node-a", handler, workflowTriggerContext{
+			Event: events.Event{
+				Type:    events.EventType("research.completed"),
+				Payload: mustJSON(payload),
+			}.WithEntityID(entityID),
+			State: pc.currentWorkflowState(context.Background(), entityID),
+		}, false)
+		if err != nil {
+			t.Fatalf("executeNodeContractHandler(%d): %v", idx, err)
+		}
+		if !result.Handled {
+			t.Fatalf("expected handled result for event %d", idx)
+		}
+	}
+
+	logs := bus.runtimeLogEntries()
+	entry := findRuntimeLogByAction(t, logs, accumulatorCompletionOutcomeAction)
+	if strings.TrimSpace(entry.Level.String()) != "info" {
+		t.Fatalf("log level = %q, want info", entry.Level.String())
+	}
+	detail, _ := entry.Detail.(map[string]any)
+	if got := runtimeLogDetailString(detail["decision_reason_code"]); got != "completion_committed" {
+		t.Fatalf("decision_reason_code = %q, want completion_committed", got)
+	}
+	if got := runtimeLogDetailString(detail["evaluation_outcome"]); got != "succeeded" {
+		t.Fatalf("evaluation_outcome = %q, want succeeded", got)
+	}
+	if got := runtimeLogDetailString(detail["commit_outcome"]); got != "committed" {
+		t.Fatalf("commit_outcome = %q, want committed", got)
+	}
+	if got := detail["received_count"]; got != 2 && got != float64(2) {
+		t.Fatalf("received_count = %#v, want 2", got)
+	}
+
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := strings.TrimSpace(instance.CurrentState); got != "mvp_speccing" {
+		t.Fatalf("current_state = %q, want mvp_speccing", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "researching",
+		Metadata: map[string]any{
+			"subject_id":     entityID,
+			"expected_count": 1,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_count",
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+		},
+		OnComplete: []runtimecontracts.HandlerRuleEntry{
+			{ID: "bad", Condition: `entity.branch_target == "go"`, AdvancesTo: "mvp_speccing"},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("research.completed"),
+			Payload: mustJSON(map[string]any{"item_id": 1}),
+		}.WithEntityID(entityID),
+		State: pc.currentWorkflowState(context.Background(), entityID),
+	}, false)
+	if err == nil {
+		t.Fatal("expected executeNodeContractHandler to fail on on_complete evaluation error")
+	}
+
+	entry := findRuntimeLogByAction(t, bus.runtimeLogEntries(), accumulatorCompletionOutcomeAction)
+	detail, _ := entry.Detail.(map[string]any)
+	if got := runtimeLogDetailString(detail["decision_reason_code"]); got != "on_complete_evaluation_failed" {
+		t.Fatalf("decision_reason_code = %q, want on_complete_evaluation_failed", got)
+	}
+	if got := runtimeLogDetailString(detail["evaluation_outcome"]); got != "failed" {
+		t.Fatalf("evaluation_outcome = %q, want failed", got)
+	}
+	if got := runtimeLogDetailString(detail["commit_outcome"]); got != "rolled_back" {
+		t.Fatalf("commit_outcome = %q, want rolled_back", got)
+	}
+
+	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	if loadErr != nil {
+		t.Fatalf("load workflow instance: %v", loadErr)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to remain available")
+	}
+	if got := strings.TrimSpace(instance.CurrentState); got != "researching" {
+		t.Fatalf("current_state = %q, want researching after rollback", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "validation",
+		WorkflowVersion: "v-test",
+		CurrentState:    "researching",
+		Metadata: map[string]any{
+			"subject_id":     entityID,
+			"expected_count": 1,
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_count",
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{TargetField: "business_brief"}},
+		},
+		OnComplete: []runtimecontracts.HandlerRuleEntry{
+			{ID: "complete", Condition: "true", AdvancesTo: "mvp_speccing", Emits: runtimecontracts.EventEmission{Single: "spec.requested"}},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("research.completed"),
+			Payload: mustJSON(map[string]any{"item_id": 1}),
+		}.WithEntityID(entityID),
+		State: pc.currentWorkflowState(context.Background(), entityID),
+	}, false)
+	if !errors.Is(err, runtimeengine.ErrEmitPersistencePrerequisite) {
+		t.Fatalf("executeNodeContractHandler error = %v, want %v", err, runtimeengine.ErrEmitPersistencePrerequisite)
+	}
+
+	entry := findRuntimeLogByAction(t, bus.runtimeLogEntries(), accumulatorCompletionOutcomeAction)
+	detail, _ := entry.Detail.(map[string]any)
+	if got := runtimeLogDetailString(detail["decision_reason_code"]); got != "transaction_commit_failed" {
+		t.Fatalf("decision_reason_code = %q, want transaction_commit_failed", got)
+	}
+	if got := runtimeLogDetailString(detail["evaluation_outcome"]); got != "succeeded" {
+		t.Fatalf("evaluation_outcome = %q, want succeeded", got)
+	}
+	if got := runtimeLogDetailString(detail["commit_outcome"]); got != "rolled_back" {
+		t.Fatalf("commit_outcome = %q, want rolled_back", got)
+	}
+
+	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	if loadErr != nil {
+		t.Fatalf("load workflow instance: %v", loadErr)
+	}
+	if !ok {
+		t.Fatal("expected seeded workflow instance to remain available")
+	}
+	if got := strings.TrimSpace(instance.CurrentState); got != "researching" {
+		t.Fatalf("current_state = %q, want researching after rollback", got)
+	}
+}
+
 func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -647,6 +874,64 @@ func newEmitPersistenceTestCoordinator(db *sql.DB) (*PipelineCoordinator, *recor
 		},
 	}
 	return pc, bus
+}
+
+func newAccumulatorOutcomeTestCoordinator(db *sql.DB) (*PipelineCoordinator, *recordingPipelineBus) {
+	bus := &recordingPipelineBus{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "validation",
+			Version: "v-test",
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{
+					{
+						Name: "validation_phase",
+						Fields: []runtimecontracts.EntitySchemaField{
+							{Name: "expected_count", Type: "integer"},
+							{Name: "business_brief", Type: "jsonb"},
+						},
+					},
+				},
+			},
+		},
+	}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("validation", []WorkflowStage{
+				{Name: "researching"},
+				{Name: "mvp_speccing"},
+			}, []WorkflowTransition{
+				{
+					Name: "research_to_spec",
+					From: []WorkflowStateID{"researching"},
+					To:   "mvp_speccing",
+				},
+			}),
+		},
+	}
+	return pc, bus
+}
+
+func findRuntimeLogByAction(t *testing.T, logs []RuntimeLogEntry, action string) RuntimeLogEntry {
+	t.Helper()
+	for _, entry := range logs {
+		if strings.TrimSpace(entry.Action) == strings.TrimSpace(action) {
+			return entry
+		}
+	}
+	t.Fatalf("missing runtime log action %q in %#v", action, logs)
+	return RuntimeLogEntry{}
+}
+
+func runtimeLogDetailString(v any) string {
+	text, _ := v.(string)
+	return strings.TrimSpace(text)
 }
 
 func TestResolveHandlerEntityIDForFlowPreservesCrossFlowEntityWithoutCreateEntity(t *testing.T) {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 type recordingPipelineBus struct {
-	mu         sync.Mutex
-	publishes  []events.Event
+	mu          sync.Mutex
+	publishes   []events.Event
 	runtimeLogs []RuntimeLogEntry
-	publishErr error
+	publishErr  error
 }
 
 type recordingPipelineDispatcher struct {
@@ -50,7 +50,7 @@ func (b *recordingPipelineBus) LogRuntime(_ context.Context, entry RuntimeLogEnt
 	b.runtimeLogs = append(b.runtimeLogs, entry)
 	return nil
 }
-func (*recordingPipelineBus) EngineOutbox() runtimeengine.OutboxWriter                    { return noOpEngineOutbox{} }
+func (*recordingPipelineBus) EngineOutbox() runtimeengine.OutboxWriter { return noOpEngineOutbox{} }
 func (b *recordingPipelineBus) EngineDispatcher() runtimeengine.PostCommitDispatcher {
 	return recordingPipelineDispatcher{bus: b}
 }

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -273,6 +273,7 @@ func asObject(v any) (map[string]any, bool) {
 
 type sqlTxContextKey struct{}
 type pipelinePostCommitActionsKey struct{}
+type pipelineAfterPublishActionsKey struct{}
 type pipelineReceiptOverrideKey struct{}
 
 type PipelineReceiptOverride struct {
@@ -347,6 +348,45 @@ func flushPipelinePostCommitActions(actions []func()) {
 
 func FlushPipelinePostCommitActions(actions []func()) {
 	flushPipelinePostCommitActions(actions)
+}
+
+func withPipelineAfterPublishActions(ctx context.Context, actions *[]func()) context.Context {
+	if actions == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, pipelineAfterPublishActionsKey{}, actions)
+}
+
+func WithPipelineAfterPublishActions(ctx context.Context, actions *[]func()) context.Context {
+	return withPipelineAfterPublishActions(ctx, actions)
+}
+
+func queuePipelineAfterPublishAction(ctx context.Context, fn func()) bool {
+	if ctx == nil || fn == nil {
+		return false
+	}
+	actions, ok := ctx.Value(pipelineAfterPublishActionsKey{}).(*[]func())
+	if !ok || actions == nil {
+		return false
+	}
+	*actions = append(*actions, fn)
+	return true
+}
+
+func QueuePipelineAfterPublishAction(ctx context.Context, fn func()) bool {
+	return queuePipelineAfterPublishAction(ctx, fn)
+}
+
+func flushPipelineAfterPublishActions(actions []func()) {
+	for _, fn := range actions {
+		if fn != nil {
+			fn()
+		}
+	}
+}
+
+func FlushPipelineAfterPublishActions(actions []func()) {
+	flushPipelineAfterPublishActions(actions)
 }
 
 func withPipelineReceiptOverride(ctx context.Context, override *PipelineReceiptOverride) context.Context {


### PR DESCRIPTION
Closes #181

## Summary

Expose one persisted runtime-log diagnostics surface for final-item accumulator completion so operators can distinguish:
- successful completion
- `on_complete` evaluation failure
- rollback / commit-phase failure

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: dependency_graph`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_state`

## What Changed

- added typed accumulator-completion diagnostics to the authoritative engine execution result
- projected that typed outcome onto a canonical runtime-log action: `accumulator_completion_outcome`
- recorded committed outcomes after the real publish transaction commits and rollback outcomes after publish finalization, so the diagnostics path no longer deadlocks inside the active SQL transaction
- added focused final-item transaction tests and a supported-surface proof through `SQLObservabilityReader.ListRuntimeLogs(...)`

## Scope Boundaries

This PR closes the chosen persisted runtime-log / observability proof surface only. It does not redesign preview or mutation-log surfaces.

## Tests Run

- `go test ./internal/runtime/pipeline -run 'TestExecuteNodeContractHandler(LogsAccumulatorCompletionCommittedOutcome|LogsAccumulatorCompletionEvaluationFailure|LogsAccumulatorCompletionCommitFailure)$' -count=1`
- `go test ./internal/runtime/conformance -run 'TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReader$' -count=1 -timeout 30s`
- `go test ./internal/runtime ./internal/runtime/pipeline ./internal/runtime/conformance ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

Preview and mutation-log proof paths remain separate surfaces for this broader parent class; this PR does not claim parity there.
