### PR TITLE
[agent-d][issue #340] Fail closed when startup lacks callable proof

### DIFF
--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -127,22 +127,24 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 		if !equalSortedStrings(actualNames, expectedNames) {
 			return fmt.Errorf("mcp tools/list returned unexpected tool surface for agent %s: expected [%s], got [%s]", agentID, strings.Join(expectedNames, ", "), strings.Join(actualNames, ", "))
 		}
-		if probeName, ok := selectStartupCallableTool(actualTools, capabilities); ok {
-			binding, enabled, err = llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
-				AgentID: agentID,
-				Tools:   sessionTools,
-			}, gatewayURL, gatewayToken)
-			if err != nil {
-				return fmt.Errorf("build mcp startup call probe transport for agent %s: %w", agentID, err)
-			}
-			if !enabled || strings.TrimSpace(binding.ContextToken) == "" {
-				return fmt.Errorf("mcp startup call probe missing transport binding for agent %s", agentID)
-			}
-			err = startupProbeMCPToolsCall(agentCtx, client, binding, probeName)
-			turnStore.UnregisterTurnContext(binding.ContextToken)
-			if err != nil {
-				return fmt.Errorf("mcp tools/call startup probe failed for agent %s tool %s: %w", agentID, probeName, err)
-			}
+		probeName, ok := selectStartupCallableTool(actualTools, capabilities)
+		if !ok {
+			return fmt.Errorf("mcp startup probe found no probe-safe callable non-emit tool for agent %s", agentID)
+		}
+		binding, enabled, err = llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
+			AgentID: agentID,
+			Tools:   sessionTools,
+		}, gatewayURL, gatewayToken)
+		if err != nil {
+			return fmt.Errorf("build mcp startup call probe transport for agent %s: %w", agentID, err)
+		}
+		if !enabled || strings.TrimSpace(binding.ContextToken) == "" {
+			return fmt.Errorf("mcp startup call probe missing transport binding for agent %s", agentID)
+		}
+		err = startupProbeMCPToolsCall(agentCtx, client, binding, probeName)
+		turnStore.UnregisterTurnContext(binding.ContextToken)
+		if err != nil {
+			return fmt.Errorf("mcp tools/call startup probe failed for agent %s tool %s: %w", agentID, probeName, err)
 		}
 	}
 	return nil

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -309,20 +309,17 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_SkipsCallableProbeWhenVisibleToolsRequireInput(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsRequireInput(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	for _, tc := range []struct {
-		name    string
-		execErr error
+		name string
 	}{
 		{
-			name:    "structured_invalid_tool_input",
-			execErr: WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.filter", false, nil, "query is required"),
+			name: "structured_invalid_tool_input",
 		},
 		{
-			name:    "plain_required_field_message",
-			execErr: errors.New("bash.command is required"),
+			name: "plain_required_field_message",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -343,19 +340,50 @@ func TestValidateClaudeMCPToolsForManagedAgents_SkipsCallableProbeWhenVisibleToo
 						ContextRequirement: toolcapabilities.ContextRequirementActorContext,
 					},
 				},
-				execErrs: map[string]error{
-					"query_entities": tc.execErr,
-				},
 			}
 			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager); err != nil {
-				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+			err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+			if err == nil || !strings.Contains(err.Error(), "found no probe-safe callable non-emit tool") {
+				t.Fatalf("expected no probe-safe callable tool error, got %v", err)
 			}
 			if len(exec.executed) != 0 {
 				t.Fatalf("executed = %#v, want no tools/call smoke for required-input-only surface", exec.executed)
 			}
 		})
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsAreEmitOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{{
+			Name:   "emit_category_assessed",
+			Schema: map[string]any{"type": "object", "properties": map[string]any{}},
+		}},
+		caps: map[string]toolcapabilities.Capability{
+			"emit_category_assessed": {
+				Name:               "emit_category_assessed",
+				Kind:               toolcapabilities.KindEmit,
+				Visible:            true,
+				Callable:           true,
+				ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+			},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "found no probe-safe callable non-emit tool") {
+		t.Fatalf("expected no probe-safe callable tool error, got %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no tools/call smoke for emit-only surface", exec.executed)
 	}
 }
 


### PR DESCRIPTION
Closes #340

## Spec references
- `engine.boot_sequence.failure_handling`
- `engine.boot_verification.description`
- `engine.boot_verification.checks[id=mcp_server_reachable]`
- `tool_model.tool_implementation_classes.mcp`
- `tool_model.mcp_client.protocol`
- `tool_model.mcp_client.boot_sequence`

## Human Summary
Managed-agent startup no longer reports green after `tools/list` alone when it cannot honestly prove a callable MCP path. If no visible probe-safe callable non-emit tool exists, startup now fails closed instead of silently skipping `tools/call`.

## What Changed
- changed `validateClaudeMCPToolsForManagedAgents(...)` to require a probe-safe callable non-emit tool after successful `tools/list`
- removed the silent skip branch when `selectStartupCallableTool(...)` finds no callable probe target
- updated the required-input-only startup regression to fail closed instead of passing green
- added a second counterexample for emit-only visible tool surfaces

## Why This Is Needed
The current startup seam could still claim callable MCP proof without ever executing `tools/call` when every visible callable tool required input. That left startup green on exactly the surfaces where real callable reachability was still unproven.

## Scope Boundaries
- scoped to managed-agent Claude MCP startup callable-proof semantics
- does not reopen filtered `tools/list` transport proof, typed startup-probe result contracts, or unrelated transport request-context work
- does not redesign startup around a new dedicated probe capability

## Tests Run
- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents_(UsesRealFilteredTransport|AcceptsExplicitValidationOnlyProbeOutcome|FailsOnEmptyVisibleToolSurface|FailsClosedWhenVisibleToolsRequireInput|FailsClosedWhenVisibleToolsAreEmitOnly|FailsClosedOnConfiguredGatewayTokenMismatch|FailsClosedOnUnexpectedCallableProbeError|FailsClosedOnGenericPhraseNonValidationProbeError)' -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
This closes the startup green-path omission class, but the longer-run design still relies on incidental ordinary tools whose schemas happen to accept `{}` rather than a dedicated probeable startup capability.

## Follow-Up
- No currently concrete open sibling child remains in this startup callable-proof lane
- The broader parent remains tracked by audit issue `#104` and watchlist node `transport_policy_and_surface_parity`
- Longer-run architecture direction remains watchlist-only for now: explicit probeable startup capability if the current fail-closed contract proves too restrictive in practice
