### PR TITLE
[agent-b][issue #348] Remove legacy agent runtime-descriptor migration

### DIFF
--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -40,6 +40,10 @@ active_issues:
     title: Legacy compatibility removal wave
     maps_to:
       - legacy_compatibility_removal
+  - id: 348
+    title: Remove legacy agent runtime-descriptor migration from startup/load hot path
+    maps_to:
+      - legacy_compatibility_removal
   - id: 173
     title: Completed-seam hygiene with canonical-owner notes and reusable invariant suites
     maps_to:
@@ -83,6 +87,7 @@ nodes:
       - 157
       - 158
       - 159
+      - 348
     common_framing_mistakes:
       too_broad:
         - delete all legacy code

--- a/internal/store/manager.go
+++ b/internal/store/manager.go
@@ -232,32 +232,6 @@ func decodePersistedAgentRuntimeDescriptor(raw []byte) (persistedAgentRuntimeDes
 	return desc, nil
 }
 
-func decodePersistedAgentRuntimeDescriptorLoose(raw []byte) (persistedAgentRuntimeDescriptor, bool) {
-	if len(raw) == 0 {
-		return persistedAgentRuntimeDescriptor{}, true
-	}
-	if !json.Valid(raw) {
-		return persistedAgentRuntimeDescriptor{}, false
-	}
-	obj := map[string]json.RawMessage{}
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return persistedAgentRuntimeDescriptor{}, false
-	}
-	if unknown := invalidPersistedAgentRuntimeDescriptorKeys(obj); len(unknown) > 0 {
-		return persistedAgentRuntimeDescriptor{}, false
-	}
-	var desc persistedAgentRuntimeDescriptor
-	if err := json.Unmarshal(raw, &desc); err != nil {
-		return persistedAgentRuntimeDescriptor{}, false
-	}
-	desc.Type = strings.TrimSpace(desc.Type)
-	desc.Mode = strings.TrimSpace(desc.Mode)
-	desc.SessionScope = strings.TrimSpace(desc.SessionScope)
-	desc.WorkspaceClass = strings.TrimSpace(desc.WorkspaceClass)
-	desc.ManagerFallback = strings.TrimSpace(desc.ManagerFallback)
-	return desc, true
-}
-
 func extractSubscriptions(raw []byte) []string {
 	if len(raw) == 0 || !json.Valid(raw) {
 		return nil

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,7 +10,6 @@ import (
 
 	_ "github.com/lib/pq"
 	"swarm/internal/config"
-	runtimeactors "swarm/internal/runtime/core/actors"
 )
 
 type PostgresStore struct {
@@ -376,184 +374,8 @@ func (s *PostgresStore) ensureAgentRuntimeDescriptorColumn(ctx context.Context) 
 			return fmt.Errorf("ensure agents.runtime_descriptor column: %w", err)
 		}
 	}
-	if err := s.migrateLegacyAgentRuntimeDescriptors(ctx); err != nil {
-		return err
-	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
-}
-
-func (s *PostgresStore) migrateLegacyAgentRuntimeDescriptors(ctx context.Context) error {
-	if s == nil || s.DB == nil {
-		return nil
-	}
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT agent_id, COALESCE(model_tier, ''), COALESCE(config, '{}'::jsonb), COALESCE(runtime_descriptor, '{}'::jsonb)
-		FROM agents
-	`)
-	if err != nil {
-		return fmt.Errorf("query agent runtime descriptor migration rows: %w", err)
-	}
-	defer rows.Close()
-
-	type rowUpdate struct {
-		agentID           string
-		config            []byte
-		runtimeDescriptor []byte
-	}
-	updates := make([]rowUpdate, 0)
-	for rows.Next() {
-		var (
-			agentID           string
-			modelTier         string
-			configRaw         []byte
-			runtimeDescriptor []byte
-		)
-		if err := rows.Scan(&agentID, &modelTier, &configRaw, &runtimeDescriptor); err != nil {
-			return fmt.Errorf("scan agent runtime descriptor migration row: %w", err)
-		}
-		desc, ok := decodePersistedAgentRuntimeDescriptorLoose(runtimeDescriptor)
-		if !ok {
-			// Malformed canonical descriptors must fail closed during hydration rather than
-			// being silently rewritten into a new shape by the legacy migration pass.
-			continue
-		}
-		legacy := decodeLegacyAgentRuntimeConfig(configRaw)
-		if desc.Type == "" {
-			desc.Type = coalesce(legacy.Type, strings.TrimSpace(modelTier))
-		}
-		if desc.Mode == "" {
-			desc.Mode = legacy.Mode
-		}
-		if desc.SessionScope == "" {
-			desc.SessionScope = legacy.SessionScope
-		}
-		if desc.MaxTurnsPerTask == 0 {
-			desc.MaxTurnsPerTask = legacy.MaxTurnsPerTask
-		}
-		if !desc.NativeTools.Any() {
-			desc.NativeTools = legacy.NativeTools
-		}
-		if desc.WorkspaceClass == "" {
-			desc.WorkspaceClass = legacy.WorkspaceClass
-		}
-		if desc.ManagerFallback == "" {
-			desc.ManagerFallback = legacy.ManagerFallback
-		}
-		sanitizedConfig, err := sanitizeOpaqueAgentConfig(configRaw)
-		if err != nil {
-			return fmt.Errorf("sanitize legacy agent config for %s: %w", strings.TrimSpace(agentID), err)
-		}
-		nextDescriptor, err := json.Marshal(desc)
-		if err != nil {
-			return fmt.Errorf("marshal runtime descriptor for %s: %w", strings.TrimSpace(agentID), err)
-		}
-		updates = append(updates, rowUpdate{
-			agentID:           agentID,
-			config:            sanitizedConfig,
-			runtimeDescriptor: nextDescriptor,
-		})
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("read agent runtime descriptor migration rows: %w", err)
-	}
-	if len(updates) == 0 {
-		return nil
-	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin agent runtime descriptor migration tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	for _, update := range updates {
-		if _, err := tx.ExecContext(ctx, `
-			UPDATE agents
-			SET config = $2::jsonb,
-			    runtime_descriptor = $3::jsonb
-			WHERE agent_id = $1
-		`, update.agentID, string(update.config), string(update.runtimeDescriptor)); err != nil {
-			return fmt.Errorf("update agent runtime descriptor for %s: %w", strings.TrimSpace(update.agentID), err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit agent runtime descriptor migration tx: %w", err)
-	}
-	committed = true
-	return nil
-}
-
-func decodeLegacyAgentRuntimeConfig(raw []byte) persistedAgentRuntimeDescriptor {
-	if len(raw) == 0 || !json.Valid(raw) {
-		return persistedAgentRuntimeDescriptor{}
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return persistedAgentRuntimeDescriptor{}
-	}
-	desc := persistedAgentRuntimeDescriptor{
-		Type:            strings.TrimSpace(stringValue(payload["type"])),
-		Mode:            strings.TrimSpace(stringValue(payload["mode"])),
-		SessionScope:    strings.TrimSpace(stringValue(payload["session_scope"])),
-		MaxTurnsPerTask: intValue(payload["max_turns_per_task"]),
-		NativeTools:     nativeToolConfigValue(payload["native_tools"]),
-		WorkspaceClass:  strings.TrimSpace(stringValue(payload["workspace_class"])),
-		ManagerFallback: strings.TrimSpace(stringValue(payload["manager_fallback"])),
-	}
-	if desc.MaxTurnsPerTask == 0 {
-		if constraints, ok := payload["constraints"].(map[string]any); ok {
-			desc.MaxTurnsPerTask = intValue(constraints["max_turns_per_task"])
-		}
-	}
-	return desc
-}
-
-func stringValue(v any) string {
-	if value, ok := v.(string); ok {
-		return value
-	}
-	return ""
-}
-
-func intValue(v any) int {
-	switch typed := v.(type) {
-	case int:
-		return typed
-	case int32:
-		return int(typed)
-	case int64:
-		return int(typed)
-	case float64:
-		return int(typed)
-	case float32:
-		return int(typed)
-	case json.Number:
-		out, _ := typed.Int64()
-		return int(out)
-	default:
-		return 0
-	}
-}
-
-func nativeToolConfigValue(v any) runtimeactors.NativeToolConfig {
-	items, ok := v.(map[string]any)
-	if !ok {
-		return runtimeactors.NativeToolConfig{}
-	}
-	return runtimeactors.NativeToolConfig{
-		Bash:      boolValue(items["bash"]),
-		WebSearch: boolValue(items["web_search"]),
-		FileIO:    boolValue(items["file_io"]),
-	}
-}
-
-func boolValue(v any) bool {
-	value, _ := v.(bool)
-	return value
 }
 
 func (s *PostgresStore) ensureConversationAuditTable(ctx context.Context) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -374,6 +374,29 @@ func (s *PostgresStore) ensureAgentRuntimeDescriptorColumn(ctx context.Context) 
 			return fmt.Errorf("ensure agents.runtime_descriptor column: %w", err)
 		}
 	}
+	if _, err := s.DB.ExecContext(ctx, `
+		UPDATE agents
+		SET runtime_descriptor = jsonb_set(
+			CASE
+				WHEN runtime_descriptor IS NULL THEN '{}'::jsonb
+				WHEN jsonb_typeof(runtime_descriptor) = 'object' THEN runtime_descriptor
+				ELSE '{}'::jsonb
+			END,
+			'{type}',
+			to_jsonb(BTRIM(model_tier)),
+			true
+		)
+		WHERE NULLIF(BTRIM(model_tier), '') IS NOT NULL
+		  AND (
+			runtime_descriptor IS NULL
+			OR (
+				jsonb_typeof(runtime_descriptor) = 'object'
+				AND NOT (runtime_descriptor ? 'type')
+			)
+		  )
+	`); err != nil {
+		return fmt.Errorf("backfill agents.runtime_descriptor.type from model_tier: %w", err)
+	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -4562,7 +4562,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	}
 }
 
-func TestPostgresStore_LoadAgents_MigratesLegacySessionScopeIntoRuntimeDescriptor(t *testing.T) {
+func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -4585,22 +4585,9 @@ func TestPostgresStore_LoadAgents_MigratesLegacySessionScopeIntoRuntimeDescripto
 		t.Fatalf("seed legacy agent row: %v", err)
 	}
 
-	agents, err := pg.LoadAgents(ctx)
-	if err != nil {
-		t.Fatalf("LoadAgents: %v", err)
-	}
-	found := false
-	for _, agent := range agents {
-		if agent.Config.ID != "legacy-session-agent" {
-			continue
-		}
-		found = true
-		if agent.Config.SessionScope != "global" {
-			t.Fatalf("SessionScope = %q, want global", agent.Config.SessionScope)
-		}
-	}
-	if !found {
-		t.Fatal("expected migrated legacy agent")
+	_, err := pg.LoadAgents(ctx)
+	if err == nil || !strings.Contains(err.Error(), "invalid opaque config: config contains runtime-owned keys: mode, session_scope, type") {
+		t.Fatalf("LoadAgents error = %v, want fail-closed legacy runtime config error", err)
 	}
 
 	var (
@@ -4612,13 +4599,13 @@ func TestPostgresStore_LoadAgents_MigratesLegacySessionScopeIntoRuntimeDescripto
 		FROM agents
 		WHERE agent_id = 'legacy-session-agent'
 	`).Scan(&configJSON, &runtimeDescriptorJSON); err != nil {
-		t.Fatalf("load migrated agent row: %v", err)
+		t.Fatalf("load legacy agent row: %v", err)
 	}
-	if strings.Contains(configJSON, "session_scope") {
-		t.Fatalf("expected session_scope removed from opaque config, got %s", configJSON)
+	if !strings.Contains(configJSON, "session_scope") {
+		t.Fatalf("expected legacy session_scope to remain untouched in opaque config, got %s", configJSON)
 	}
-	if !strings.Contains(runtimeDescriptorJSON, `"session_scope": "global"`) && !strings.Contains(runtimeDescriptorJSON, `"session_scope":"global"`) {
-		t.Fatalf("expected session_scope in runtime_descriptor, got %s", runtimeDescriptorJSON)
+	if runtimeDescriptorJSON != "{}" {
+		t.Fatalf("expected runtime_descriptor to remain untouched, got %s", runtimeDescriptorJSON)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -4604,8 +4604,91 @@ func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *
 	if !strings.Contains(configJSON, "session_scope") {
 		t.Fatalf("expected legacy session_scope to remain untouched in opaque config, got %s", configJSON)
 	}
-	if runtimeDescriptorJSON != "{}" {
-		t.Fatalf("expected runtime_descriptor to remain untouched, got %s", runtimeDescriptorJSON)
+	if !strings.Contains(runtimeDescriptorJSON, `"type": "sonnet"`) && !strings.Contains(runtimeDescriptorJSON, `"type":"sonnet"`) {
+		t.Fatalf("expected runtime_descriptor.type backfilled from model_tier, got %s", runtimeDescriptorJSON)
+	}
+}
+
+func TestPostgresStore_LoadAgents_BackfillsRuntimeDescriptorTypeFromModelTierOnColumnUpgrade(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agents CASCADE`); err != nil {
+		t.Fatalf("drop agents: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agents (
+			agent_id TEXT PRIMARY KEY,
+			flow_instance TEXT,
+			role TEXT NOT NULL,
+			model_tier TEXT NOT NULL,
+			llm_backend TEXT NOT NULL DEFAULT 'api',
+			conversation_mode TEXT NOT NULL,
+			parent_agent_id TEXT,
+			entity_id UUID,
+			config JSONB NOT NULL DEFAULT '{}'::jsonb,
+			subscriptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+			emit_events JSONB NOT NULL DEFAULT '[]'::jsonb,
+			tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+			permissions JSONB NOT NULL DEFAULT '[]'::jsonb,
+			status TEXT NOT NULL DEFAULT 'active',
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			last_active_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agents table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model_tier, llm_backend, conversation_mode,
+			config, status, created_at
+		) VALUES (
+			'precolumn-agent', 'worker', 'sonnet', 'api', 'task',
+			'{"system_prompt":"x"}'::jsonb,
+			'active',
+			now()
+		)
+	`); err != nil {
+		t.Fatalf("seed pre-column agent row: %v", err)
+	}
+
+	agents, err := pg.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	found := false
+	for _, agent := range agents {
+		if agent.Config.ID != "precolumn-agent" {
+			continue
+		}
+		found = true
+		if agent.Config.Type != "sonnet" {
+			t.Fatalf("Type = %q, want sonnet", agent.Config.Type)
+		}
+		if agent.Config.ModelTier != "sonnet" {
+			t.Fatalf("ModelTier = %q, want sonnet", agent.Config.ModelTier)
+		}
+	}
+	if !found {
+		t.Fatal("expected precolumn-agent in LoadAgents result")
+	}
+
+	var runtimeDescriptorRaw []byte
+	if err := db.QueryRowContext(ctx, `
+		SELECT runtime_descriptor
+		FROM agents
+		WHERE agent_id = 'precolumn-agent'
+	`).Scan(&runtimeDescriptorRaw); err != nil {
+		t.Fatalf("query upgraded runtime_descriptor: %v", err)
+	}
+	desc, err := decodePersistedAgentRuntimeDescriptor(runtimeDescriptorRaw)
+	if err != nil {
+		t.Fatalf("decodePersistedAgentRuntimeDescriptor: %v", err)
+	}
+	if desc.Type != "sonnet" {
+		t.Fatalf("runtime_descriptor.type = %q, want sonnet", desc.Type)
 	}
 }
 


### PR DESCRIPTION
## Human Summary

Removes the live startup/load migration bridge that was still pulling legacy runtime metadata out of opaque agent `config` into canonical `runtime_descriptor`.

## What Changed

- removed `migrateLegacyAgentRuntimeDescriptors(...)` from the `agents.runtime_descriptor` startup compatibility path in `internal/store/postgres.go`
- removed `decodeLegacyAgentRuntimeConfig(...)` and its legacy parsing helpers from `internal/store/postgres.go`
- removed the now-dead loose descriptor decoder from `internal/store/manager.go`
- rewrote the legacy-row regression so `LoadAgents(...)` now fails closed instead of silently rewriting legacy runtime metadata during load

## Why This Is Needed

The canonical persisted runtime-metadata owner is already the `runtime_descriptor` model in `internal/store/manager.go`, consumed by the real store entrypoints in `internal/store/agent_store.go`.

The remaining bridge in `internal/store/postgres.go` kept a second live compatibility interpreter in the startup/load hot path by:
- reading runtime metadata from opaque `config`
- synthesizing `runtime_descriptor`
- mutating stored rows during load

This PR removes that bridge so the touched seam has one canonical production path.

## Scope Boundaries

- `Closes #348`
- child of `#157`
- broader watchpoint: `#159`
- this PR only canonicalizes the persisted-agent runtime-metadata startup/load seam
- out of scope:
  - schema-capability boundary cleanup
  - receipt retry-owner / delivery backfill cleanup
  - task-conversation visibility mixed-rollout cleanup
  - broad store redesign

## Spec References

- none; this is non-semantic maintenance
- justification: this removes a live persistence/startup compatibility bridge without changing platform contract semantics

## Tests Run

- `go test ./internal/store -run 'Test(ManagerStore_LoadAgents_FailsClosedOnMalformedRuntimeDescriptor|PostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig|ManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeKeys|PostgresStore_Mailbox_CRUD_Expire_Notify|PostgresStore_Smoke)$' -count=1`
- `go test ./internal/store ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk

The touched seam is canonicalized, but parent issue `#157` still has separate live compatibility classes left in other store/runtime hot paths.

## Follow-Up

- parent tracker remains `#157`
- broader watchpoint remains `#159`
