### PR TITLE
[agent-a][issue #346] Canonicalize run lifecycle accounting ownership

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -15,14 +15,50 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	builderpkg "swarm/internal/builder"
+	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
+
+type delayedRunStatusAgent struct {
+	id            string
+	subscriptions []events.EventType
+	started       chan struct{}
+	release       chan struct{}
+}
+
+func (a delayedRunStatusAgent) ID() string { return a.id }
+func (delayedRunStatusAgent) Type() string { return "test" }
+func (a delayedRunStatusAgent) Subscriptions() []events.EventType {
+	return append([]events.EventType(nil), a.subscriptions...)
+}
+func (a delayedRunStatusAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Event, error) {
+	select {
+	case a.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-a.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	out := (events.Event{
+		ID:          uuid.NewString(),
+		RunID:       evt.RunID,
+		Type:        events.EventType("scan.completed"),
+		SourceAgent: a.id,
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(evt.EntityID())
+	return []events.Event{out}, nil
+}
 
 func TestPrintRunStatusReport(t *testing.T) {
 	var buf bytes.Buffer
@@ -406,6 +442,153 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 		if strings.Contains(heuristic, "runs table still says running") {
 			t.Fatalf("unexpected running heuristic after durable completion: %#v", report.Heuristics)
 		}
+	}
+}
+
+func TestLoadRunStatusReport_KeepsSupportedRunRunningUntilManagerWorkSettles(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	agentStarted := make(chan struct{}, 1)
+	releaseAgent := make(chan struct{})
+	testAgent := delayedRunStatusAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"scan.requested"},
+		started:       agentStarted,
+		release:       releaseAgent,
+	}
+	am := runtimemanager.NewAgentManager(eb, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		if cfg.ID != testAgent.id {
+			t.Fatalf("unexpected agent id: %q", cfg.ID)
+		}
+		return testAgent, nil
+	}, pg)
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{ID: testAgent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	am.Run(context.Background())
+	defer func() { _ = am.Shutdown() }()
+
+	rt := &runtimepkg.Runtime{Bus: eb, Manager: am}
+	handler := builderpkg.NewHandler(builderpkg.Options{
+		CurrentRuntime: func() *runtimepkg.Runtime { return rt },
+		AuthToken:      "builder-test-token",
+	})
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	reqBody, err := json.Marshal(builderpkg.Request{
+		JSONRPC: "2.0",
+		ID:      "run-start-1",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": runID,
+			"inputs": map[string]any{
+				"scan.requested": map[string]any{
+					"entity_id": entityID,
+					"topic":     "sample",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal run.start request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer builder-test-token")
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case <-agentStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for agent work to start")
+	}
+
+	ctx := context.Background()
+	var (
+		status           string
+		eventCount       int
+		entityCount      int
+		activeDeliveries int
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), event_count, entity_count
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &eventCount, &entityCount); err != nil {
+		t.Fatalf("load in-flight run row: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("in-flight run status = %q, want running", status)
+	}
+	if eventCount != 1 {
+		t.Fatalf("in-flight event_count = %d, want 1 root event", eventCount)
+	}
+	if entityCount != 1 {
+		t.Fatalf("in-flight entity_count = %d, want 1", entityCount)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND status IN ('pending', 'in_progress')
+	`, runID).Scan(&activeDeliveries); err != nil {
+		t.Fatalf("count active deliveries: %v", err)
+	}
+	if activeDeliveries == 0 {
+		t.Fatal("expected active delivery while agent work is blocked")
+	}
+
+	close(releaseAgent)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, ''), event_count, entity_count
+			FROM runs
+			WHERE run_id = $1::uuid
+		`, runID).Scan(&status, &eventCount, &entityCount)
+		if err == nil && status == "completed" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("run %s did not reach coherent completed state: last err=%v status=%q event_count=%d entity_count=%d", runID, err, status, eventCount, entityCount)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if eventCount < 2 {
+		t.Fatalf("completed event_count = %d, want downstream event activity", eventCount)
+	}
+	if entityCount != 1 {
+		t.Fatalf("completed entity_count = %d, want 1", entityCount)
+	}
+	var extraRunningRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE run_id <> $1::uuid
+		  AND status = 'running'
+	`, runID).Scan(&extraRunningRows); err != nil {
+		t.Fatalf("count extra running rows: %v", err)
+	}
+	if extraRunningRows != 0 {
+		t.Fatalf("extra running rows = %d, want 0", extraRunningRows)
+	}
+
+	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	if err != nil {
+		t.Fatalf("loadRunStatusReport: %v", err)
+	}
+	if report.RunTableStatus != "completed" {
+		t.Fatalf("RunTableStatus = %q, want completed", report.RunTableStatus)
 	}
 }
 

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -101,6 +101,10 @@ active_issues:
     title: Expose recovery and restart decisions through canonical diagnostics
     maps_to:
       - recovery_restart_diagnostics
+  - id: 346
+    title: Reconcile run lifecycle ownership and accounting across builder, store, and runtime writers
+    maps_to:
+      - run_lifecycle_and_accounting_coherence
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -311,6 +315,26 @@ nodes:
         - restart is confusing
       too_narrow:
         - one missing restart log line
+    current_action_pressure: active
+  - id: run_lifecycle_and_accounting_coherence
+    title: Run Lifecycle And Accounting Coherence
+    parent_class: runtime run ownership, terminality, and persisted accounting truth
+    canonical_owners:
+      - one canonical persisted owner for run terminality and run-scoped accounting across builder, store, and runtime writers
+    why_this_node_exists: run correctness drifts when builder quiescence, persisted events/deliveries, runtime-log bootstrap activity, and operator readers each carry partial run lifecycle truth
+    known_manifestations:
+      - runs can be marked terminal while same-run work, events, or deliveries are still active
+      - run-scoped counters can stay zero because no canonical persisted accounting owner updates them
+      - bootstrap or diagnostics-side run row creation can leave extra running rows outside the authoritative accepted run lifecycle
+      - reader/report surfaces compensate after the fact instead of consuming one canonical lifecycle owner
+    representative_issues:
+      - 120
+      - 346
+    common_framing_mistakes:
+      too_broad:
+        - run status is inconsistent
+      too_narrow:
+        - one run row or one counter field is wrong
     current_action_pressure: active
   - id: tool_execution_outcome_diagnostics
     title: Tool Execution Outcome Diagnostics

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -367,11 +367,11 @@ func (h *runHub) awaitCompletion(runID string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), runCompletionTimeout)
 	defer cancel()
-	if err := session.runtime.Bus.WaitForQuiescence(ctx); err != nil {
+	if err := session.runtime.WaitForQuiescence(ctx); err != nil {
 		if h.isTerminal(runID) {
 			return
 		}
-		if persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
+		if _, persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
 			h.markTerminal(runID)
 			h.emit(runID, map[string]any{
 				"id":        uuid.NewString(),
@@ -397,7 +397,8 @@ func (h *runHub) awaitCompletion(runID string) {
 	if h.isTerminal(runID) {
 		return
 	}
-	if err := h.persistTerminalState(runID, "completed", "", time.Now().UTC()); err != nil {
+	snapshot, err := h.persistTerminalState(runID, "completed", "", time.Now().UTC())
+	if err != nil {
 		h.markTerminal(runID)
 		h.emit(runID, map[string]any{
 			"id":        uuid.NewString(),
@@ -416,7 +417,14 @@ func (h *runHub) awaitCompletion(runID string) {
 		"id":        uuid.NewString(),
 		"type":      "run.completed",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
-		"payload":   map[string]any{"run_id": runID, "summary": map[string]any{"duration_ms": 0, "total_events": 0}},
+		"payload": map[string]any{
+			"run_id": runID,
+			"summary": map[string]any{
+				"duration_ms":  durationMillis(snapshot),
+				"total_events": snapshot.EventCount,
+				"entity_count": snapshot.EntityCount,
+			},
+		},
 	})
 }
 
@@ -437,16 +445,37 @@ func (h *runHub) markTerminal(runID string) {
 	}
 }
 
-func (h *runHub) persistTerminalState(runID, status, errorSummary string, endedAt time.Time) error {
+func (h *runHub) persistTerminalState(runID, status, errorSummary string, endedAt time.Time) (runtimebus.RunLifecycleSnapshot, error) {
 	session := h.session(runID)
 	if session == nil || session.runtime == nil || session.runtime.Bus == nil {
-		return fmt.Errorf("run terminal persistence is not configured")
+		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("run terminal persistence is not configured")
 	}
 	writer, ok := session.runtime.Bus.Store().(runtimebus.RunLifecyclePersistence)
 	if !ok || writer == nil {
-		return fmt.Errorf("run terminal persistence is not supported")
+		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("run terminal persistence is not supported")
 	}
-	return writer.MarkRunTerminal(context.Background(), runID, status, errorSummary, endedAt)
+	if err := writer.MarkRunTerminal(context.Background(), runID, status, errorSummary, endedAt); err != nil {
+		return runtimebus.RunLifecycleSnapshot{}, err
+	}
+	reader, ok := session.runtime.Bus.Store().(runtimebus.RunLifecycleReadPersistence)
+	if !ok || reader == nil {
+		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("run lifecycle snapshot persistence is not supported")
+	}
+	return reader.LoadRunLifecycleSnapshot(context.Background(), runID)
+}
+
+func durationMillis(snapshot runtimebus.RunLifecycleSnapshot) int64 {
+	if snapshot.StartedAt.IsZero() {
+		return 0
+	}
+	endedAt := time.Now().UTC()
+	if snapshot.EndedAt != nil && !snapshot.EndedAt.IsZero() {
+		endedAt = snapshot.EndedAt.UTC()
+	}
+	if endedAt.Before(snapshot.StartedAt) {
+		return 0
+	}
+	return endedAt.Sub(snapshot.StartedAt).Milliseconds()
 }
 
 func (h *runHub) isTerminal(runID string) bool {

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -9,6 +9,24 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 )
 
+type snapshotRunStore struct {
+	runtimebus.InMemoryEventStore
+	snapshot runtimebus.RunLifecycleSnapshot
+}
+
+func (s *snapshotRunStore) MarkRunTerminal(_ context.Context, runID, status, errorSummary string, endedAt time.Time) error {
+	s.snapshot.RunID = runID
+	s.snapshot.Status = status
+	s.snapshot.ErrorSummary = errorSummary
+	ended := endedAt
+	s.snapshot.EndedAt = &ended
+	return nil
+}
+
+func (s *snapshotRunStore) LoadRunLifecycleSnapshot(context.Context, string) (runtimebus.RunLifecycleSnapshot, error) {
+	return s.snapshot, nil
+}
+
 func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
 	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
 	if err != nil {
@@ -73,5 +91,53 @@ func TestRunHubAwaitCompletion_MarksSessionTerminalWhenCompletionPersistenceFail
 	payload, _ := last["payload"].(map[string]any)
 	if _, ok := payload["persistence_error"]; !ok {
 		t.Fatalf("last payload = %#v, want persistence_error", payload)
+	}
+}
+
+func TestRunHubAwaitCompletion_EmitsAuthoritativeRunSummary(t *testing.T) {
+	store := &snapshotRunStore{
+		snapshot: runtimebus.RunLifecycleSnapshot{
+			RunID:       "run-123",
+			EventCount:  3,
+			EntityCount: 2,
+			StartedAt:   time.Now().UTC().Add(-2 * time.Second),
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: eb}
+	hub := &runHub{
+		sessions: map[string]*runSession{
+			"run-123": {
+				runID:   "run-123",
+				runtime: rt,
+				subs:    map[string]func(RunEventEnvelope){},
+				events:  []RunEventEnvelope{},
+			},
+		},
+	}
+
+	hub.awaitCompletion("run-123")
+
+	session := hub.session("run-123")
+	if session == nil || len(session.events) == 0 {
+		t.Fatal("expected terminal event to be emitted")
+	}
+	last := session.events[len(session.events)-1]
+	if got, _ := last["type"].(string); got != "run.completed" {
+		t.Fatalf("last event type = %q, want run.completed", got)
+	}
+	payload, _ := last["payload"].(map[string]any)
+	summary, _ := payload["summary"].(map[string]any)
+	if got := int(summary["total_events"].(int)); got != 3 {
+		t.Fatalf("summary.total_events = %d, want 3", got)
+	}
+	if got := int(summary["entity_count"].(int)); got != 2 {
+		t.Fatalf("summary.entity_count = %d, want 2", got)
+	}
+	if got, ok := summary["duration_ms"].(int64); !ok || got <= 0 {
+		t.Fatalf("summary.duration_ms = %#v, want positive int64", summary["duration_ms"])
 	}
 }

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -121,6 +121,9 @@ func (stubBuilderRunStore) ListEventDeliveryRecipients(context.Context, string) 
 func (stubBuilderRunStore) MarkRunTerminal(context.Context, string, string, string, time.Time) error {
 	return nil
 }
+func (stubBuilderRunStore) LoadRunLifecycleSnapshot(context.Context, string) (runtimebus.RunLifecycleSnapshot, error) {
+	return runtimebus.RunLifecycleSnapshot{}, nil
+}
 
 type stubConversationCaps struct {
 	caps store.StoreSchemaCapabilities

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -67,6 +67,20 @@ type RunLifecyclePersistence interface {
 	MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error
 }
 
+type RunLifecycleSnapshot struct {
+	RunID        string
+	Status       string
+	EventCount   int
+	EntityCount  int
+	ErrorSummary string
+	StartedAt    time.Time
+	EndedAt      *time.Time
+}
+
+type RunLifecycleReadPersistence interface {
+	LoadRunLifecycleSnapshot(ctx context.Context, runID string) (RunLifecycleSnapshot, error)
+}
+
 // AtomicEventPersistence is an optional capability for transactionally
 // persisting an event row and its delivery manifest together.
 type AtomicEventPersistence interface {

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -281,7 +281,7 @@ func ensureRuntimeLogRunRow(ctx context.Context, db *sql.DB, runID string) error
 	if _, err := uuid.Parse(runID); err != nil {
 		return err
 	}
-	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "")
+	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{})
 }
 
 func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detailMap map[string]any, runID, parentEventID, handlerID string) map[string]any {

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -11,6 +11,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 // RuntimeLogEntry is a structured runtime operation record (spec v2.0.14).
@@ -248,7 +249,10 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 				0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
 			)
 		`, runID, string(encoded), parentEventID)
-		return err
+		if err != nil {
+			return err
+		}
+		return storerunlifecycle.SyncCounts(ctx, db, runID)
 	}
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO events (
@@ -277,12 +281,7 @@ func ensureRuntimeLogRunRow(ctx context.Context, db *sql.DB, runID string) error
 	if _, err := uuid.Parse(runID); err != nil {
 		return err
 	}
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES ($1::uuid, 'running', now())
-		ON CONFLICT (run_id) DO NOTHING
-	`, runID)
-	return err
+	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "")
 }
 
 func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detailMap map[string]any, runID, parentEventID, handlerID string) map[string]any {

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -152,10 +152,13 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
 	mock.ExpectExec(`INSERT INTO runs`).
-		WithArgs(runID).
+		WithArgs(runID, "", "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO events`).
 		WithArgs(runID, sqlmock.AnyArg(), "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE runs`).
+		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -152,7 +152,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
 	mock.ExpectExec(`INSERT INTO runs`).
-		WithArgs(runID, "", "").
+		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO events`).
 		WithArgs(runID, sqlmock.AnyArg(), "").

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 var syntheticRunNamespace = uuid.MustParse("7e7e89e6-0d4f-4eeb-a8a0-99a3e8ec2ef1")
@@ -20,6 +21,7 @@ func ErrInvalidMutationLogWriter(message string) error {
 
 type DBTX interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
 type Record struct {
@@ -63,11 +65,7 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	}
 
 	runID := normalizeRunID(runtimecorrelation.RunIDFromContext(ctx))
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO runs (run_id)
-		VALUES ($1::uuid)
-		ON CONFLICT (run_id) DO NOTHING
-	`, runID); err != nil {
+	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", ""); err != nil {
 		return err
 	}
 

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -65,7 +65,7 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	}
 
 	runID := normalizeRunID(runtimecorrelation.RunIDFromContext(ctx))
-	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", ""); err != nil {
+	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{}); err != nil {
 		return err
 	}
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 const (
@@ -24,6 +26,11 @@ const (
 )
 
 type rowQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type execQueryer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
@@ -423,7 +430,7 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 	`
 	args := []any{id, name, entityID, flowInstance, scope, string(payload), chainDepth, producedBy, producedByType, sourceEventID, createdAt}
 	if caps.Events.LogRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name); err != nil {
 			return err
 		}
 		q = `
@@ -441,6 +448,11 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 	}
 	if _, err := execFn(ctx, q, args...); err != nil {
 		return fmt.Errorf("append event: %w", err)
+	}
+	if caps.Events.LogRunID {
+		if err := storerunlifecycle.SyncCounts(ctx, chooseExecQueryer(s.DB, tx), runID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -750,6 +762,13 @@ func chooseRowQueryer(db *sql.DB, tx *sql.Tx) rowQueryer {
 	return db
 }
 
+func chooseExecQueryer(db *sql.DB, tx *sql.Tx) execQueryer {
+	if tx != nil {
+		return tx
+	}
+	return db
+}
+
 func lookupEventRunID(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, eventID string) string {
 	eventID = strings.TrimSpace(eventID)
 	if q == nil || eventID == "" || caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID {
@@ -767,38 +786,32 @@ func lookupEventRunID(ctx context.Context, caps StoreSchemaCapabilities, q rowQu
 	return strings.TrimSpace(runID)
 }
 
-func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, runID string) error {
+func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, runID, triggerEventID, triggerEventType string) error {
 	runID = nullUUIDString(runID)
 	if runID == "" || !caps.Events.HasRuns {
 		return nil
 	}
-	execFn := s.DB.ExecContext
-	if tx != nil {
-		execFn = tx.ExecContext
-	}
-	if _, err := execFn(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES ($1::uuid, 'running', now())
-		ON CONFLICT (run_id) DO NOTHING
-	`, runID); err != nil {
-		return fmt.Errorf("ensure run row: %w", err)
-	}
-	return nil
+	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType)
 }
 
 func canonicalRunTerminalStatus(raw string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "completed":
-		return "completed", nil
-	case "failed":
-		return "failed", nil
-	case "cancelled":
-		return "cancelled", nil
-	case "forked":
-		return "forked", nil
-	default:
-		return "", fmt.Errorf("unsupported terminal run status %q", raw)
+	return storerunlifecycle.CanonicalTerminalStatus(raw)
+}
+
+func (s *PostgresStore) LoadRunLifecycleSnapshot(ctx context.Context, runID string) (runtimebus.RunLifecycleSnapshot, error) {
+	snap, err := storerunlifecycle.LoadSnapshot(ctx, s.DB, nullUUIDString(runID))
+	if err != nil {
+		return runtimebus.RunLifecycleSnapshot{}, err
 	}
+	return runtimebus.RunLifecycleSnapshot{
+		RunID:        snap.RunID,
+		Status:       snap.Status,
+		EventCount:   snap.EventCount,
+		EntityCount:  snap.EntityCount,
+		ErrorSummary: snap.ErrorSummary,
+		StartedAt:    snap.StartedAt,
+		EndedAt:      snap.EndedAt,
+	}, nil
 }
 
 func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error {
@@ -824,38 +837,8 @@ func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status, erro
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
 	}
-	result, err := s.DB.ExecContext(ctx, `
-		UPDATE runs
-		SET status = $2,
-		    error_summary = NULLIF($3, ''),
-		    ended_at = COALESCE(ended_at, $4)
-		WHERE run_id = $1::uuid
-		  AND (status IN ('running', 'paused') OR status = $2)
-	`, runID, status, errorSummary, endedAt.UTC())
-	if err != nil {
-		return fmt.Errorf("mark run terminal: %w", err)
-	}
-	if rows, err := result.RowsAffected(); err == nil && rows > 0 {
-		return nil
-	}
-
-	var currentStatus string
-	err = s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(status, '')
-		FROM runs
-		WHERE run_id = $1::uuid
-	`, runID).Scan(&currentStatus)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return fmt.Errorf("run %s not found", runID)
-		}
-		return fmt.Errorf("load run terminal state: %w", err)
-	}
-	currentStatus = strings.TrimSpace(currentStatus)
-	if currentStatus == status {
-		return nil
-	}
-	return fmt.Errorf("run %s already terminal with status %s", runID, currentStatus)
+	_, err = storerunlifecycle.MarkTerminal(ctx, s.DB, runID, status, errorSummary, endedAt)
+	return err
 }
 
 func runIDOrEventID(runID, eventID string) string {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -801,13 +801,9 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	if runID == "" || !caps.Events.HasRuns {
 		return nil
 	}
-	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, storerunlifecycle.EnsureActiveOptions{
-		ReopenCompleted: reopenCompleted,
-		HasStartedAtCol: caps.Events.RunStartedAt,
-		HasTriggerCols:  caps.Events.RunTriggerColumns,
-		HasCounterCols:  caps.Events.RunCounterColumns,
-		HasTerminalCols: caps.Events.RunTerminalFields,
-	})
+	opts := runLifecycleOptions(caps)
+	opts.ReopenCompleted = reopenCompleted
+	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
 }
 
 func canonicalRunTerminalStatus(raw string) (string, error) {
@@ -815,7 +811,11 @@ func canonicalRunTerminalStatus(raw string) (string, error) {
 }
 
 func (s *PostgresStore) LoadRunLifecycleSnapshot(ctx context.Context, runID string) (runtimebus.RunLifecycleSnapshot, error) {
-	snap, err := storerunlifecycle.LoadSnapshot(ctx, s.DB, nullUUIDString(runID))
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimebus.RunLifecycleSnapshot{}, err
+	}
+	snap, err := storerunlifecycle.LoadSnapshot(ctx, s.DB, nullUUIDString(runID), runLifecycleOptions(caps))
 	if err != nil {
 		return runtimebus.RunLifecycleSnapshot{}, err
 	}
@@ -853,8 +853,17 @@ func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status, erro
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
 	}
-	_, err = storerunlifecycle.MarkTerminal(ctx, s.DB, runID, status, errorSummary, endedAt)
+	_, err = storerunlifecycle.MarkTerminal(ctx, s.DB, runID, status, errorSummary, endedAt, runLifecycleOptions(caps))
 	return err
+}
+
+func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {
+	return storerunlifecycle.EnsureActiveOptions{
+		HasStartedAtCol: caps.Events.RunStartedAt,
+		HasTriggerCols:  caps.Events.RunTriggerColumns,
+		HasCounterCols:  caps.Events.RunCounterColumns,
+		HasTerminalCols: caps.Events.RunTerminalFields,
+	}
 }
 
 func runIDOrEventID(runID, eventID string) string {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -430,7 +430,7 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 	`
 	args := []any{id, name, entityID, flowInstance, scope, string(payload), chainDepth, producedBy, producedByType, sourceEventID, createdAt}
 	if caps.Events.LogRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name, false); err != nil {
 			return err
 		}
 		q = `
@@ -446,12 +446,22 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 		`
 		args = []any{id, runID, name, entityID, flowInstance, scope, string(payload), chainDepth, producedBy, producedByType, sourceEventID, createdAt}
 	}
-	if _, err := execFn(ctx, q, args...); err != nil {
+	res, err := execFn(ctx, q, args...)
+	if err != nil {
 		return fmt.Errorf("append event: %w", err)
 	}
 	if caps.Events.LogRunID {
-		if err := storerunlifecycle.SyncCounts(ctx, chooseExecQueryer(s.DB, tx), runID); err != nil {
+		rows, rowsErr := res.RowsAffected()
+		if rowsErr == nil && rows == 0 {
+			return nil
+		}
+		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name, true); err != nil {
 			return err
+		}
+		if caps.Events.RunCounterColumns {
+			if err := storerunlifecycle.SyncCounts(ctx, chooseExecQueryer(s.DB, tx), runID); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -786,12 +796,18 @@ func lookupEventRunID(ctx context.Context, caps StoreSchemaCapabilities, q rowQu
 	return strings.TrimSpace(runID)
 }
 
-func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, runID, triggerEventID, triggerEventType string) error {
+func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, runID, triggerEventID, triggerEventType string, reopenCompleted bool) error {
 	runID = nullUUIDString(runID)
 	if runID == "" || !caps.Events.HasRuns {
 		return nil
 	}
-	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType)
+	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, storerunlifecycle.EnsureActiveOptions{
+		ReopenCompleted: reopenCompleted,
+		HasStartedAtCol: caps.Events.RunStartedAt,
+		HasTriggerCols:  caps.Events.RunTriggerColumns,
+		HasCounterCols:  caps.Events.RunCounterColumns,
+		HasTerminalCols: caps.Events.RunTerminalFields,
+	})
 }
 
 func canonicalRunTerminalStatus(raw string) (string, error) {

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -180,7 +180,7 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 	`
 	args := []any{entityID, string(payload), provider, idempotencyKey}
 	if caps.Events.LogRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
 			return false, err
 		}
 		insertQ = `

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -180,7 +180,7 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 	`
 	args := []any{entityID, string(payload), provider, idempotencyKey}
 	if caps.Events.LogRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
 			return false, err
 		}
 		insertQ = `

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -105,7 +105,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		rec.Error,
 	}
 	if hasConversationRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
 			return err
 		}
 		updateQ = fmt.Sprintf(`
@@ -159,7 +159,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			rec.SessionID,
 		}
 		if hasConversationRunID {
-			if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+			if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
 				return err
 			}
 			updateQ = `
@@ -320,7 +320,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 	if hasRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
 			return err
 		}
 		insertTurn = `
@@ -473,7 +473,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 	}
 	scopeKey := strings.TrimSpace(rec.ScopeKey)
 	if caps.Conversations.AuditRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID, "", ""); err != nil {
 			return err
 		}
 	}
@@ -791,7 +791,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			status,
 		}
 		if caps.Conversations.AuditRunID {
-			if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
+			if err := s.ensureRunRow(ctx, caps, nil, runID, "", ""); err != nil {
 				return err
 			}
 			q = `
@@ -878,7 +878,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		mode.String(),
 	}
 	if caps.Conversations.SessionRunID {
-		if err := s.ensureRunRow(ctx, caps, nil, runID); err != nil {
+		if err := s.ensureRunRow(ctx, caps, nil, runID, "", ""); err != nil {
 			return err
 		}
 		q = `

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -105,7 +105,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		rec.Error,
 	}
 	if hasConversationRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
 			return err
 		}
 		updateQ = fmt.Sprintf(`
@@ -159,7 +159,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			rec.SessionID,
 		}
 		if hasConversationRunID {
-			if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
+			if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
 				return err
 			}
 			updateQ = `
@@ -320,7 +320,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		}
 	}
 	if hasRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", ""); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
 			return err
 		}
 		insertTurn = `
@@ -473,7 +473,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 	}
 	scopeKey := strings.TrimSpace(rec.ScopeKey)
 	if caps.Conversations.AuditRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID, "", ""); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID, "", "", true); err != nil {
 			return err
 		}
 	}
@@ -791,7 +791,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			status,
 		}
 		if caps.Conversations.AuditRunID {
-			if err := s.ensureRunRow(ctx, caps, nil, runID, "", ""); err != nil {
+			if err := s.ensureRunRow(ctx, caps, nil, runID, "", "", true); err != nil {
 				return err
 			}
 			q = `
@@ -878,7 +878,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		mode.String(),
 	}
 	if caps.Conversations.SessionRunID {
-		if err := s.ensureRunRow(ctx, caps, nil, runID, "", ""); err != nil {
+		if err := s.ensureRunRow(ctx, caps, nil, runID, "", "", true); err != nil {
 			return err
 		}
 		q = `

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -143,6 +143,135 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRo
 	}
 }
 
+func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeliveries(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'scan.requested', $3::uuid, 'entity', '{}'::jsonb, 'builder', 'platform', now()
+		)
+	`, eventID, runID, entityID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-1', 'pending', now()
+		)
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err == nil || !strings.Contains(err.Error(), "active deliveries") {
+		t.Fatalf("MarkRunTerminal(active delivery) error = %v, want active delivery rejection", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'delivered', delivered_at = now()
+		WHERE run_id = $1::uuid
+	`, runID); err != nil {
+		t.Fatalf("deliver completion: %v", err)
+	}
+
+	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err != nil {
+		t.Fatalf("MarkRunTerminal(completed): %v", err)
+	}
+
+	var (
+		status      string
+		eventCount  int
+		entityCount int
+		endedAt     time.Time
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), event_count, entity_count, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &eventCount, &entityCount, &endedAt); err != nil {
+		t.Fatalf("load run row: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("run status = %q, want completed", status)
+	}
+	if eventCount != 1 {
+		t.Fatalf("event_count = %d, want 1", eventCount)
+	}
+	if entityCount != 1 {
+		t.Fatalf("entity_count = %d, want 1", entityCount)
+	}
+	if endedAt.IsZero() {
+		t.Fatal("ended_at not persisted")
+	}
+}
+
+func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, ended_at, event_count, entity_count)
+		VALUES ($1::uuid, 'completed', now(), 0, 0)
+	`, runID); err != nil {
+		t.Fatalf("seed completed run: %v", err)
+	}
+
+	evt := events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("scan.completed"),
+		SourceAgent: "agent-1",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	var (
+		status      string
+		eventCount  int
+		entityCount int
+		endedAt     sql.NullTime
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), event_count, entity_count, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &eventCount, &entityCount, &endedAt); err != nil {
+		t.Fatalf("load run row: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("run status = %q, want running", status)
+	}
+	if eventCount != 1 {
+		t.Fatalf("event_count = %d, want 1", eventCount)
+	}
+	if entityCount != 1 {
+		t.Fatalf("entity_count = %d, want 1", entityCount)
+	}
+	if endedAt.Valid {
+		t.Fatalf("ended_at valid = %v, want cleared after reopening", endedAt.Time)
+	}
+}
+
 func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeDependentDDL(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -272,6 +272,131 @@ func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(
 	}
 }
 
+func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	completedAt := time.Now().UTC().Add(-time.Minute).Round(time.Second)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, ended_at, event_count, entity_count)
+		VALUES ($1::uuid, 'completed', $2, 1, 1)
+	`, runID, completedAt); err != nil {
+		t.Fatalf("seed completed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'scan.completed', $3::uuid, 'entity', '{}'::jsonb, 'agent-1', 'agent', now()
+		)
+	`, eventID, runID, entityID); err != nil {
+		t.Fatalf("seed duplicate event: %v", err)
+	}
+
+	evt := events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("scan.completed"),
+		SourceAgent: "agent-1",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent(duplicate): %v", err)
+	}
+
+	var (
+		status      string
+		eventCount  int
+		entityCount int
+		endedAt     sql.NullTime
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), event_count, entity_count, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &eventCount, &entityCount, &endedAt); err != nil {
+		t.Fatalf("load run row: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("run status = %q, want completed", status)
+	}
+	if eventCount != 1 {
+		t.Fatalf("event_count = %d, want 1", eventCount)
+	}
+	if entityCount != 1 {
+		t.Fatalf("entity_count = %d, want 1", entityCount)
+	}
+	if !endedAt.Valid || !endedAt.Time.Equal(completedAt) {
+		t.Fatalf("ended_at = %#v, want preserved %s", endedAt, completedAt)
+	}
+}
+
+func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	for _, ddl := range []string{
+		`DROP TABLE IF EXISTS event_deliveries CASCADE`,
+		`DROP TABLE IF EXISTS events CASCADE`,
+		`DROP TABLE IF EXISTS runs CASCADE`,
+		`CREATE TABLE runs (
+			run_id UUID PRIMARY KEY,
+			status TEXT NOT NULL,
+			started_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE events (
+			event_id UUID PRIMARY KEY,
+			run_id UUID REFERENCES runs(run_id),
+			event_name TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope TEXT NOT NULL,
+			payload JSONB NOT NULL,
+			chain_depth INTEGER NOT NULL DEFAULT 0,
+			produced_by TEXT,
+			produced_by_type TEXT NOT NULL,
+			source_event_id UUID,
+			created_at TIMESTAMPTZ NOT NULL
+		)`,
+	} {
+		if _, err := db.ExecContext(ctx, ddl); err != nil {
+			t.Fatalf("exec schema ddl %q: %v", ddl, err)
+		}
+	}
+
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	evt := events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("scan.requested"),
+		SourceAgent: "builder",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(status, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&status); err != nil {
+		t.Fatalf("load run row: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("run status = %q, want running", status)
+	}
+}
+
 func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeDependentDDL(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -397,6 +397,76 @@ func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T)
 	}
 }
 
+func TestPostgresStore_MarkRunTerminal_AllowsRunsWithoutCounterOrTerminalColumns(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	for _, ddl := range []string{
+		`DROP TABLE IF EXISTS event_deliveries CASCADE`,
+		`DROP TABLE IF EXISTS runs CASCADE`,
+		`CREATE TABLE runs (
+			run_id UUID PRIMARY KEY,
+			status TEXT NOT NULL,
+			started_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE event_deliveries (
+			delivery_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			run_id UUID,
+			status TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+	} {
+		if _, err := db.ExecContext(ctx, ddl); err != nil {
+			t.Fatalf("exec schema ddl %q: %v", ddl, err)
+		}
+	}
+
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err != nil {
+		t.Fatalf("MarkRunTerminal: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(status, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&status); err != nil {
+		t.Fatalf("load run status: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("run status = %q, want completed", status)
+	}
+
+	snap, err := pg.LoadRunLifecycleSnapshot(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	}
+	if snap.Status != "completed" {
+		t.Fatalf("snapshot status = %q, want completed", snap.Status)
+	}
+	if snap.EventCount != 0 {
+		t.Fatalf("snapshot event_count = %d, want 0", snap.EventCount)
+	}
+	if snap.EntityCount != 0 {
+		t.Fatalf("snapshot entity_count = %d, want 0", snap.EntityCount)
+	}
+	if snap.ErrorSummary != "" {
+		t.Fatalf("snapshot error_summary = %q, want empty", snap.ErrorSummary)
+	}
+	if snap.EndedAt != nil {
+		t.Fatalf("snapshot ended_at = %#v, want nil without terminal columns", snap.EndedAt)
+	}
+}
+
 func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeDependentDDL(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -1,0 +1,228 @@
+package runlifecycle
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type Snapshot struct {
+	RunID        string
+	Status       string
+	EventCount   int
+	EntityCount  int
+	ErrorSummary string
+	StartedAt    time.Time
+	EndedAt      *time.Time
+}
+
+func CanonicalTerminalStatus(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "completed":
+		return "completed", nil
+	case "failed":
+		return "failed", nil
+	case "cancelled":
+		return "cancelled", nil
+	case "forked":
+		return "forked", nil
+	default:
+		return "", fmt.Errorf("unsupported terminal run status %q", raw)
+	}
+}
+
+func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string) error {
+	if db == nil {
+		return nil
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	triggerEventID = strings.TrimSpace(triggerEventID)
+	triggerEventType = strings.TrimSpace(triggerEventType)
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, status, trigger_event_id, trigger_event_type, started_at
+		)
+		VALUES (
+			$1::uuid, 'running', NULLIF($2,'')::uuid, NULLIF($3,''), now()
+		)
+		ON CONFLICT (run_id) DO UPDATE SET
+			status = CASE
+				WHEN runs.status = 'completed' THEN 'running'
+				ELSE runs.status
+			END,
+			error_summary = CASE
+				WHEN runs.status = 'completed' THEN NULL
+				ELSE runs.error_summary
+			END,
+			ended_at = CASE
+				WHEN runs.status = 'completed' THEN NULL
+				ELSE runs.ended_at
+			END,
+			trigger_event_id = COALESCE(runs.trigger_event_id, NULLIF($2,'')::uuid),
+			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))
+	`, runID, triggerEventID, triggerEventType)
+	if err != nil {
+		return fmt.Errorf("ensure run row: %w", err)
+	}
+	return nil
+}
+
+func SyncCounts(ctx context.Context, db DBTX, runID string) error {
+	if db == nil {
+		return nil
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	_, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET
+			event_count = counts.event_count,
+			entity_count = counts.entity_count
+		FROM (
+			SELECT
+				COUNT(*)::integer AS event_count,
+				COUNT(DISTINCT entity_id)::integer AS entity_count
+			FROM events
+			WHERE run_id = $1::uuid
+		) AS counts
+		WHERE runs.run_id = $1::uuid
+	`, runID)
+	if err != nil {
+		return fmt.Errorf("sync run counters: %w", err)
+	}
+	return nil
+}
+
+func HasActiveDeliveries(ctx context.Context, db DBTX, runID string) (bool, error) {
+	if db == nil {
+		return false, nil
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return false, nil
+	}
+	var active bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE run_id = $1::uuid
+			  AND status IN ('pending', 'in_progress')
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("load active deliveries: %w", err)
+	}
+	return active, nil
+}
+
+func LoadSnapshot(ctx context.Context, db DBTX, runID string) (Snapshot, error) {
+	runID = strings.TrimSpace(runID)
+	if db == nil || runID == "" {
+		return Snapshot{}, fmt.Errorf("run_id is required")
+	}
+	var (
+		snap  Snapshot
+		ended sql.NullTime
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			run_id::text,
+			COALESCE(status, ''),
+			COALESCE(event_count, 0),
+			COALESCE(entity_count, 0),
+			COALESCE(error_summary, ''),
+			started_at,
+			ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(
+		&snap.RunID,
+		&snap.Status,
+		&snap.EventCount,
+		&snap.EntityCount,
+		&snap.ErrorSummary,
+		&snap.StartedAt,
+		&ended,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return Snapshot{}, fmt.Errorf("run %s not found", runID)
+		}
+		return Snapshot{}, fmt.Errorf("load run snapshot: %w", err)
+	}
+	snap.RunID = strings.TrimSpace(snap.RunID)
+	snap.Status = strings.TrimSpace(snap.Status)
+	snap.ErrorSummary = strings.TrimSpace(snap.ErrorSummary)
+	if ended.Valid {
+		tm := ended.Time
+		snap.EndedAt = &tm
+	}
+	return snap, nil
+}
+
+func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary string, endedAt time.Time) (Snapshot, error) {
+	if db == nil {
+		return Snapshot{}, fmt.Errorf("run lifecycle persistence is not configured")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return Snapshot{}, fmt.Errorf("run_id is required")
+	}
+	var err error
+	status, err = CanonicalTerminalStatus(status)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	errorSummary = strings.TrimSpace(errorSummary)
+	if status != "failed" {
+		errorSummary = ""
+	}
+	if endedAt.IsZero() {
+		endedAt = time.Now().UTC()
+	}
+	if err := SyncCounts(ctx, db, runID); err != nil {
+		return Snapshot{}, err
+	}
+	if status == "completed" {
+		active, err := HasActiveDeliveries(ctx, db, runID)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		if active {
+			return Snapshot{}, fmt.Errorf("run %s still has active deliveries", runID)
+		}
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2,
+		    error_summary = NULLIF($3, ''),
+		    ended_at = COALESCE(ended_at, $4)
+		WHERE run_id = $1::uuid
+		  AND (status IN ('running', 'paused') OR status = $2)
+	`, runID, status, errorSummary, endedAt.UTC())
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("mark run terminal: %w", err)
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		current, loadErr := LoadSnapshot(ctx, db, runID)
+		if loadErr != nil {
+			return Snapshot{}, loadErr
+		}
+		if current.Status != status {
+			return Snapshot{}, fmt.Errorf("run %s already terminal with status %s", runID, current.Status)
+		}
+		return current, nil
+	}
+	return LoadSnapshot(ctx, db, runID)
+}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -23,6 +23,14 @@ type Snapshot struct {
 	EndedAt      *time.Time
 }
 
+type EnsureActiveOptions struct {
+	ReopenCompleted bool
+	HasStartedAtCol bool
+	HasTriggerCols  bool
+	HasCounterCols  bool
+	HasTerminalCols bool
+}
+
 func CanonicalTerminalStatus(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "completed":
@@ -38,7 +46,7 @@ func CanonicalTerminalStatus(raw string) (string, error) {
 	}
 }
 
-func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string) error {
+func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string, opts EnsureActiveOptions) error {
 	if db == nil {
 		return nil
 	}
@@ -48,29 +56,65 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	}
 	triggerEventID = strings.TrimSpace(triggerEventID)
 	triggerEventType = strings.TrimSpace(triggerEventType)
-	_, err := db.ExecContext(ctx, `
+	reopenStatus := "runs.status"
+	reopenErrorSummary := ""
+	reopenEndedAt := ""
+	if opts.ReopenCompleted {
+		reopenStatus = "CASE WHEN runs.status = 'completed' THEN 'running' ELSE runs.status END"
+		if opts.HasTerminalCols {
+			reopenErrorSummary = "CASE WHEN runs.status = 'completed' THEN NULL ELSE runs.error_summary END"
+			reopenEndedAt = "CASE WHEN runs.status = 'completed' THEN NULL ELSE runs.ended_at END"
+		}
+	} else if opts.HasTerminalCols {
+		reopenErrorSummary = "runs.error_summary"
+		reopenEndedAt = "runs.ended_at"
+	}
+	insertCols := "run_id, status"
+	insertVals := "$1::uuid, 'running'"
+	if opts.HasStartedAtCol {
+		insertCols += ", started_at"
+		insertVals += ", now()"
+	}
+	query := `
+		INSERT INTO runs (` + insertCols + `)
+		VALUES (` + insertVals + `)
+		ON CONFLICT (run_id) DO UPDATE SET
+			status = ` + reopenStatus
+	if opts.HasTerminalCols {
+		query += `,
+			error_summary = ` + reopenErrorSummary + `,
+			ended_at = ` + reopenEndedAt
+	}
+	args := []any{runID}
+	if opts.HasTriggerCols {
+		query = `
 		INSERT INTO runs (
-			run_id, status, trigger_event_id, trigger_event_type, started_at
+			run_id, status, trigger_event_id, trigger_event_type`
+		if opts.HasStartedAtCol {
+			query += `, started_at`
+		}
+		query += `
 		)
 		VALUES (
-			$1::uuid, 'running', NULLIF($2,'')::uuid, NULLIF($3,''), now()
+			$1::uuid, 'running', NULLIF($2,'')::uuid, NULLIF($3,'')`
+		if opts.HasStartedAtCol {
+			query += `, now()`
+		}
+		query += `
 		)
 		ON CONFLICT (run_id) DO UPDATE SET
-			status = CASE
-				WHEN runs.status = 'completed' THEN 'running'
-				ELSE runs.status
-			END,
-			error_summary = CASE
-				WHEN runs.status = 'completed' THEN NULL
-				ELSE runs.error_summary
-			END,
-			ended_at = CASE
-				WHEN runs.status = 'completed' THEN NULL
-				ELSE runs.ended_at
-			END,
+			status = ` + reopenStatus
+		if opts.HasTerminalCols {
+			query += `,
+			error_summary = ` + reopenErrorSummary + `,
+			ended_at = ` + reopenEndedAt
+		}
+		query += `,
 			trigger_event_id = COALESCE(runs.trigger_event_id, NULLIF($2,'')::uuid),
-			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))
-	`, runID, triggerEventID, triggerEventType)
+			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))`
+		args = append(args, triggerEventID, triggerEventType)
+	}
+	_, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("ensure run row: %w", err)
 	}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -171,34 +171,76 @@ func HasActiveDeliveries(ctx context.Context, db DBTX, runID string) (bool, erro
 	return active, nil
 }
 
-func LoadSnapshot(ctx context.Context, db DBTX, runID string) (Snapshot, error) {
+func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveOptions) (Snapshot, error) {
 	runID = strings.TrimSpace(runID)
 	if db == nil || runID == "" {
 		return Snapshot{}, fmt.Errorf("run_id is required")
 	}
 	var (
-		snap  Snapshot
-		ended sql.NullTime
+		snap      Snapshot
+		startedAt sql.NullTime
+		endedAt   sql.NullTime
 	)
-	if err := db.QueryRowContext(ctx, `
+	query := `
 		SELECT
 			run_id::text,
 			COALESCE(status, ''),
-			COALESCE(event_count, 0),
-			COALESCE(entity_count, 0),
-			COALESCE(error_summary, ''),
-			started_at,
-			ended_at
+			0,
+			0,
+			'',
+			NULL::timestamptz,
+			NULL::timestamptz
 		FROM runs
 		WHERE run_id = $1::uuid
-	`, runID).Scan(
+	`
+	if opts.HasCounterCols || opts.HasTerminalCols || opts.HasStartedAtCol {
+		query = `
+		SELECT
+			run_id::text,
+			COALESCE(status, ''), `
+		if opts.HasCounterCols {
+			query += `
+			COALESCE(event_count, 0),
+			COALESCE(entity_count, 0),`
+		} else {
+			query += `
+			0,
+			0,`
+		}
+		if opts.HasTerminalCols {
+			query += `
+			COALESCE(error_summary, ''),`
+		} else {
+			query += `
+			'',`
+		}
+		if opts.HasStartedAtCol {
+			query += `
+			started_at,`
+		} else {
+			query += `
+			NULL::timestamptz,`
+		}
+		if opts.HasTerminalCols {
+			query += `
+			ended_at`
+		} else {
+			query += `
+			NULL::timestamptz`
+		}
+		query += `
+		FROM runs
+		WHERE run_id = $1::uuid
+	`
+	}
+	if err := db.QueryRowContext(ctx, query, runID).Scan(
 		&snap.RunID,
 		&snap.Status,
 		&snap.EventCount,
 		&snap.EntityCount,
 		&snap.ErrorSummary,
-		&snap.StartedAt,
-		&ended,
+		&startedAt,
+		&endedAt,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return Snapshot{}, fmt.Errorf("run %s not found", runID)
@@ -208,14 +250,17 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string) (Snapshot, error) 
 	snap.RunID = strings.TrimSpace(snap.RunID)
 	snap.Status = strings.TrimSpace(snap.Status)
 	snap.ErrorSummary = strings.TrimSpace(snap.ErrorSummary)
-	if ended.Valid {
-		tm := ended.Time
+	if startedAt.Valid {
+		snap.StartedAt = startedAt.Time
+	}
+	if endedAt.Valid {
+		tm := endedAt.Time
 		snap.EndedAt = &tm
 	}
 	return snap, nil
 }
 
-func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary string, endedAt time.Time) (Snapshot, error) {
+func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary string, endedAt time.Time, opts EnsureActiveOptions) (Snapshot, error) {
 	if db == nil {
 		return Snapshot{}, fmt.Errorf("run lifecycle persistence is not configured")
 	}
@@ -235,8 +280,10 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
 	}
-	if err := SyncCounts(ctx, db, runID); err != nil {
-		return Snapshot{}, err
+	if opts.HasCounterCols {
+		if err := SyncCounts(ctx, db, runID); err != nil {
+			return Snapshot{}, err
+		}
 	}
 	if status == "completed" {
 		active, err := HasActiveDeliveries(ctx, db, runID)
@@ -247,19 +294,26 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 			return Snapshot{}, fmt.Errorf("run %s still has active deliveries", runID)
 		}
 	}
+	setClauses := []string{"status = $2"}
+	args := []any{runID, status}
+	if opts.HasTerminalCols {
+		setClauses = append(setClauses,
+			"error_summary = NULLIF($3, '')",
+			"ended_at = COALESCE(ended_at, $4)",
+		)
+		args = append(args, errorSummary, endedAt.UTC())
+	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE runs
-		SET status = $2,
-		    error_summary = NULLIF($3, ''),
-		    ended_at = COALESCE(ended_at, $4)
+		SET `+strings.Join(setClauses, ", ")+`
 		WHERE run_id = $1::uuid
 		  AND (status IN ('running', 'paused') OR status = $2)
-	`, runID, status, errorSummary, endedAt.UTC())
+	`, args...)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("mark run terminal: %w", err)
 	}
 	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
-		current, loadErr := LoadSnapshot(ctx, db, runID)
+		current, loadErr := LoadSnapshot(ctx, db, runID, opts)
 		if loadErr != nil {
 			return Snapshot{}, loadErr
 		}
@@ -268,5 +322,5 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 		}
 		return current, nil
 	}
-	return LoadSnapshot(ctx, db, runID)
+	return LoadSnapshot(ctx, db, runID, opts)
 }

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -21,6 +21,10 @@ type EventSchemaCapabilities struct {
 	Deliveries        SchemaFlavor
 	Receipts          SchemaFlavor
 	HasRuns           bool
+	RunStartedAt      bool
+	RunTriggerColumns bool
+	RunCounterColumns bool
+	RunTerminalFields bool
 	LogRunID          bool
 	DeliveryRunID     bool
 	LogIdempotencyKey bool
@@ -154,6 +158,10 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			[]string{"event_id", "agent_id", "processed_at", "status", "retry_count", "error"},
 		),
 		HasRuns:           catalog.hasColumns("runs", "run_id", "status"),
+		RunStartedAt:      catalog.hasColumns("runs", "started_at"),
+		RunTriggerColumns: catalog.hasColumns("runs", "trigger_event_id", "trigger_event_type"),
+		RunCounterColumns: catalog.hasColumns("runs", "event_count", "entity_count"),
+		RunTerminalFields: catalog.hasColumns("runs", "error_summary", "ended_at"),
 		LogRunID:          catalog.hasColumns("events", "run_id"),
 		DeliveryRunID:     catalog.hasColumns("event_deliveries", "run_id"),
 		LogIdempotencyKey: catalog.hasColumns("events", "idempotency_key"),


### PR DESCRIPTION
## Summary
- introduce one store-owned run lifecycle/accounting owner for the supported `run.start` path
- move builder terminal persistence, diagnostics runtime-log run-row creation, and mutation-log run-row creation onto that owner
- add deterministic supported `run.start` coherence coverage for `runs.status`, `runs.event_count`, `runs.entity_count`, same-run `events`, same-run `event_deliveries`, and stray runtime-log-created run rows

## Why
Issue `#346` is a runtime correctness bug, not a reader-only or diagnostics-only issue. Builder run control could mark a run `completed` while same-run work and deliveries were still active, counters stayed zero, and other writers could create lifecycle-participating `runs` rows independently.

There are no exact spec refs on `#346`; the issue body/thread are the binding context for this bug.

## What Changed
- added `internal/store/runlifecycle/owner.go` as the store-owned lifecycle/accounting owner
- made `internal/store/events.go` consume that owner for run-row creation, terminality, and snapshot loading
- made `internal/runtime/diagnostics.go` and `internal/runtime/mutationlog/mutationlog.go` consume the same owner instead of writing `runs` rows independently
- updated `internal/builder/runs_control.go` to use `Runtime.WaitForQuiescence(...)` and emit terminal summaries from authoritative persisted snapshots
- added deterministic supported smoke and store regressions in `cmd/swarm/main_test.go` and `internal/store/postgres_store_additional_test.go`
- updated dashboard test stubs to satisfy the new lifecycle snapshot read contract

## Tests
- `go test ./internal/store ./internal/runtime ./internal/builder ./cmd/swarm -run 'Test(PostgresStore_(MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeliveries|AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters)|RuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry|LoadRunStatusReport_(UsesDurableCompletedRunState|KeepsSupportedRunRunningUntilManagerWorkSettles)|RunHubAwaitCompletion_MarksSessionTerminalWhenCompletionPersistenceFails)$' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_Run(StartStreamsRunEvents|LifecycleOverAPIAliases)$' -count=1`
- `go test ./internal/store ./internal/runtime/... ./internal/builder ./cmd/swarm ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
- none identified in the chosen class after the widened owner movement and supported `run.start` coherence proof

Closes #346