### PR TITLE
[agent-b][issue #356] Align boot builtin tool warnings with runtime truth

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -37,6 +37,7 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
+	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
 )
@@ -1184,6 +1185,7 @@ func logBootSkeleton(source semanticview.Source, contractsRoot, platformSpecPath
 	for _, finding := range report.Warnings() {
 		warningCounts[strings.TrimSpace(finding.CheckID)]++
 	}
+	availableToolNames := runtimetools.RuntimeAvailableToolNamesForSource(source)
 	steps := []struct {
 		index int
 		name  string
@@ -1193,7 +1195,7 @@ func logBootSkeleton(source semanticview.Source, contractsRoot, platformSpecPath
 		{2, "walk_flow_tree", fmt.Sprintf("discovered %d flow(s)", len(source.FlowSchemaEntries()))},
 		{3, "construct_paths", "constructed hierarchical contract paths from package tree"},
 		{4, "register_templates", fmt.Sprintf("registered %d template flow(s)", templateFlowCount(source))},
-		{5, "build_registries", fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(source.ToolEntries()))},
+		{5, "build_registries", fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(availableToolNames))},
 		{6, "resolve_subscriptions", "subscription resolution skeleton in place; full validation lands in CP4"},
 		{7, "validate_pins", fmt.Sprintf("validated flow pins and event wiring; warnings=%d", warningCounts["event_chain_integrity"]+warningCounts["event_consumer_exists"]+warningCounts["event_producer_exists"])},
 		{8, "validate_required_agents", "validated required_agents coverage and state-machine targets"},

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,12 +19,14 @@ import (
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
+	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
@@ -786,6 +790,17 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 			wantErr: false,
 		},
 		{
+			name: "builtin runtime tool reference",
+			bundle: func() *runtimecontracts.WorkflowContractBundle {
+				bundle := testWorkflowValidationBundle()
+				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+					"agent-1": {ID: "agent-1", Tools: []string{"schedule"}, Permissions: []string{"schedule"}},
+				}
+				return bundle
+			}(),
+			wantErr: false,
+		},
+		{
 			name: "missing emitted event schema warning",
 			bundle: func() *runtimecontracts.WorkflowContractBundle {
 				bundle := testWorkflowValidationBundle()
@@ -835,10 +850,47 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 			if runtimeErr != nil {
 				t.Fatalf("ValidateWorkflowContractSurface error = %v, want nil", runtimeErr)
 			}
-			if warnings := result.BootReport.Warnings(); len(warnings) == 0 || !strings.Contains(warnings[0].Message, "missing tool missing_tool") {
-				t.Fatalf("BootReport warnings = %#v, want tool_resolution warning", warnings)
+			switch tc.name {
+			case "missing tool reference":
+				if warnings := result.BootReport.Warnings(); len(warnings) == 0 || !strings.Contains(warnings[0].Message, "missing tool missing_tool") {
+					t.Fatalf("BootReport warnings = %#v, want tool_resolution warning", warnings)
+				}
+			case "builtin runtime tool reference":
+				for _, warning := range result.BootReport.Warnings() {
+					if strings.TrimSpace(warning.CheckID) == "tool_resolution" && strings.Contains(warning.Message, "schedule") {
+						t.Fatalf("BootReport warnings = %#v, unexpected builtin tool_resolution warning", result.BootReport.Warnings())
+					}
+				}
 			}
 		})
+	}
+}
+
+func TestLogBootSkeleton_UsesRuntimeToolInventoryCount(t *testing.T) {
+	source := semanticview.Wrap(testWorkflowValidationBundle())
+	wantTools := len(runtimetools.RuntimeAvailableToolNamesForSource(source))
+	if wantTools == 0 {
+		t.Fatal("runtime tool inventory unexpectedly empty")
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	previous := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(previous)
+
+	logBootSkeleton(source, "/tmp/contracts", "/tmp/platform-spec.yaml", runtimebootverify.Report{}, "state stores ready")
+
+	out := buf.String()
+	want := "name=build_registries"
+	if !strings.Contains(out, want) {
+		t.Fatalf("log output missing %q:\n%s", want, out)
+	}
+	if !strings.Contains(out, "tools="+strconv.Itoa(wantTools)) {
+		t.Fatalf("log output missing runtime tool count %d:\n%s", wantTools, out)
+	}
+	if strings.Contains(out, "tools=0") {
+		t.Fatalf("log output still reports zero tools:\n%s", out)
 	}
 }
 

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -78,6 +78,10 @@ active_issues:
     title: Align targeted verify and runtime boot on event-schema and tool-registry validation
     maps_to:
       - verify_vs_boot_contract_acceptance_drift
+  - id: 356
+    title: Verify can pass while runtime boot emits missing-tool warnings on the same startup
+    maps_to:
+      - verify_vs_boot_contract_acceptance_drift
   - id: 181
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
@@ -167,6 +171,8 @@ nodes:
     known_manifestations:
       - event-schema validation drift between targeted verify and runtime boot
       - tool-registry validation drift between targeted verify and runtime boot
+      - boot warns that builtin runtime tools are missing because validation only counts contract tool entries
+      - operator-visible boot diagnostics report tools=0 even when the generic runtime ships callable builtin tools
       - future supported-surface agreement gaps in shared contract validation ownership
     representative_issues:
       - 270

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -51,6 +51,9 @@ type checkerContext struct {
 	toolLoaded   bool
 	toolFindings []Finding
 
+	runtimeToolNamesLoaded bool
+	runtimeToolNames       map[string]struct{}
+
 	policyLoaded   bool
 	policyFindings []Finding
 
@@ -399,6 +402,7 @@ func (c *checkerContext) toolResolution() []Finding {
 	c.toolLoaded = true
 	mcpPrefixes := declaredMCPPrefixes(c.source)
 	discoveredTools := c.mcpDiscovered()
+	runtimeToolNames := c.runtimeAvailableToolNames()
 	for agentID, agent := range c.source.AgentEntries() {
 		agentID = strings.TrimSpace(agentID)
 		for _, toolID := range agent.ConfiguredTools() {
@@ -420,6 +424,9 @@ func (c *checkerContext) toolResolution() []Finding {
 			if toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
 				continue
 			}
+			if _, ok := runtimeToolNames[toolID]; ok {
+				continue
+			}
 			c.toolFindings = append(c.toolFindings, Finding{
 				CheckID:  "tool_resolution",
 				Severity: "warning",
@@ -429,6 +436,18 @@ func (c *checkerContext) toolResolution() []Finding {
 		}
 	}
 	return c.toolFindings
+}
+
+func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {
+	if c.runtimeToolNamesLoaded {
+		return c.runtimeToolNames
+	}
+	c.runtimeToolNamesLoaded = true
+	c.runtimeToolNames = make(map[string]struct{})
+	for _, name := range runtimetools.RuntimeAvailableToolNamesForSource(c.source) {
+		c.runtimeToolNames[strings.TrimSpace(name)] = struct{}{}
+	}
+	return c.runtimeToolNames
 }
 
 func (c *checkerContext) policyConflicts() []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -28,6 +28,25 @@ func TestRun_MapsMissingToolToToolResolutionWarning(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnForBuiltinRuntimeToolReference(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+		"agent-1": {ID: "agent-1", Tools: []string{"schedule"}, Permissions: []string{"schedule"}},
+	}
+	source := semanticview.Wrap(bundle)
+
+	report := Run(context.Background(), source, Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "tool_resolution", "schedule") {
+		t.Fatalf("unexpected tool_resolution warning for builtin runtime tool, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_MapsMissingDiscoveredMCPToolToToolResolutionWarning(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any

--- a/internal/runtime/tools/contracts.go
+++ b/internal/runtime/tools/contracts.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"encoding/json"
+	"sort"
+	"strings"
 
 	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
@@ -51,6 +53,36 @@ func LoadContractSchemasForSource(source semanticview.Source) (map[string]Contra
 		}
 	}
 	return parsed, nil
+}
+
+func RuntimeAvailableToolNamesForSource(source semanticview.Source) []string {
+	names := make(map[string]struct{})
+	for name := range supportedRuntimeToolNames {
+		name = strings.TrimSpace(name)
+		if name == "" || runtimeToolHiddenFromAgents(name) {
+			continue
+		}
+		names[name] = struct{}{}
+	}
+	if source != nil {
+		for name, entry := range source.ToolEntries() {
+			name = strings.TrimSpace(name)
+			if name == "" || runtimeToolHiddenFromAgents(name) {
+				continue
+			}
+			handlerType := normalizeImplementationClass(name, entry)
+			if handlerType == "" || handlerType == implementationMCP {
+				continue
+			}
+			names[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func ContractDefinitionsForSource(source semanticview.Source) ([]llm.ToolDefinition, error) {


### PR DESCRIPTION
## Human Summary
This PR fixes the current `#356` parity bug where targeted `verify` can pass while supported boot still warns that shipped builtin runtime tools are missing and logs `build_registries ... tools=0` on the same source.

## What Changed
- added `runtimetools.RuntimeAvailableToolNamesForSource(...)` as the shared non-MCP runtime tool inventory for the touched seam
- moved boot `tool_resolution` builtin-tool checks onto that runtime inventory instead of treating contract `ToolEntries()` as the full truth
- moved boot `build_registries` tool counting onto that same runtime inventory
- added focused parity tests across bootverify and `cmd/swarm` for builtin-tool warning suppression, verify/runtime agreement, and boot logging count truth

## Why This Is Needed
The generic runtime already ships builtin handlers like `schedule`, `agent_hire`, `agent_fire`, `agent_reconfigure`, `human_task_request`, `human_task_decide`, and `query_entities`. The touched boot surfaces were warning as if those tools were missing because they only looked at authored contract tool entries instead of the real builtin runtime inventory.

## Scope Boundaries
- closes the builtin runtime tool-resolution / boot warning-semantics child class for `#356`
- does not widen into MCP discovery warning semantics
- does not change `native_tools` validation or generic contract-declared tool implementation validation

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_verification.checks.tool_resolution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.tool_implementation_classes.platform_builtin`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.platform_builtin_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.generic_runtime_rule`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_tool_filtering.rule`

## Tests Run
- `go test ./internal/runtime/bootverify ./cmd/swarm -run 'Test(Run_DoesNotWarnForBuiltinRuntimeToolReference|Run_MapsMissingToolToToolResolutionWarning|VerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses|LogBootSkeleton_UsesRuntimeToolInventoryCount)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/tools ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
The touched seam is now aligned to the runtime builtin/non-MCP tool inventory. MCP discovery warnings remain a separate class and are intentionally unchanged here.

## Follow-Up
None identified inside the chosen `#356` child class.

Closes #356
