### PR TITLE
[agent-a][issue #355] Keep accepted runs running until same-run quiescence

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -589,6 +590,164 @@ func TestLoadRunStatusReport_KeepsSupportedRunRunningUntilManagerWorkSettles(t *
 	}
 	if report.RunTableStatus != "completed" {
 		t.Fatalf("RunTableStatus = %q, want completed", report.RunTableStatus)
+	}
+}
+
+func TestLoadRunStatusReport_PreservesRunningTruthAcrossBuilderQuiescenceTimeout(t *testing.T) {
+	restore := builderpkg.SetRunCompletionTimeoutForTest(25 * time.Millisecond)
+	defer restore()
+
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	agentStarted := make(chan struct{}, 1)
+	releaseAgent := make(chan struct{})
+	testAgent := delayedRunStatusAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"scan.requested"},
+		started:       agentStarted,
+		release:       releaseAgent,
+	}
+	am := runtimemanager.NewAgentManager(eb, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		if cfg.ID != testAgent.id {
+			t.Fatalf("unexpected agent id: %q", cfg.ID)
+		}
+		return testAgent, nil
+	}, pg)
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{ID: testAgent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	am.Run(context.Background())
+	defer func() { _ = am.Shutdown() }()
+
+	rt := &runtimepkg.Runtime{Bus: eb, Manager: am}
+	handler := builderpkg.NewHandler(builderpkg.Options{
+		CurrentRuntime: func() *runtimepkg.Runtime { return rt },
+		AuthToken:      "builder-test-token",
+	})
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	reqBody, err := json.Marshal(builderpkg.Request{
+		JSONRPC: "2.0",
+		ID:      "run-start-timeout-1",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": runID,
+			"inputs": map[string]any{
+				"scan.requested": map[string]any{
+					"entity_id": entityID,
+					"topic":     "sample",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal run.start request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer builder-test-token")
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case <-agentStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for agent work to start")
+	}
+
+	time.Sleep(120 * time.Millisecond)
+
+	ctx := context.Background()
+	var (
+		status           string
+		activeDeliveries int
+		endedAt          sql.NullTime
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &endedAt); err != nil {
+		t.Fatalf("load timed-out run row: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("timed-out run status = %q, want running", status)
+	}
+	if endedAt.Valid {
+		t.Fatalf("timed-out run ended_at = %s, want NULL while same-run work remains active", endedAt.Time)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND status IN ('pending', 'in_progress')
+	`, runID).Scan(&activeDeliveries); err != nil {
+		t.Fatalf("count active deliveries after timeout window: %v", err)
+	}
+	if activeDeliveries == 0 {
+		t.Fatal("expected same-run active delivery after builder timeout window")
+	}
+	if got := am.InFlightCount(); got == 0 {
+		t.Fatal("expected live in-flight manager work after builder timeout window")
+	}
+
+	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	if err != nil {
+		t.Fatalf("loadRunStatusReport: %v", err)
+	}
+	if report.RunTableStatus != "running" {
+		t.Fatalf("RunTableStatus after timeout window = %q, want running", report.RunTableStatus)
+	}
+	if report.OperationalState != "running" {
+		t.Fatalf("OperationalState after timeout window = %q, want running", report.OperationalState)
+	}
+	foundActiveDelivery := false
+	for _, item := range report.Deliveries {
+		if item.SubscriberID == "agent-1" && item.Status == "in_progress" && item.Count > 0 {
+			foundActiveDelivery = true
+			break
+		}
+	}
+	if !foundActiveDelivery {
+		t.Fatalf("expected supported status report to preserve active same-run delivery, got %#v", report.Deliveries)
+	}
+
+	close(releaseAgent)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, ''), ended_at
+			FROM runs
+			WHERE run_id = $1::uuid
+		`, runID).Scan(&status, &endedAt)
+		if err == nil && status == "completed" && endedAt.Valid {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("run %s did not reach coherent completed state after release: last err=%v status=%q ended_at_valid=%v", runID, err, status, endedAt.Valid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	var lastEventAt time.Time
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(created_at), '-infinity'::timestamptz)
+		FROM events
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&lastEventAt); err != nil {
+		t.Fatalf("load last event timestamp: %v", err)
+	}
+	if !endedAt.Time.IsZero() && lastEventAt.After(endedAt.Time) {
+		t.Fatalf("last same-run event at %s is after ended_at %s", lastEventAt, endedAt.Time)
 	}
 }
 

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -109,6 +109,10 @@ active_issues:
     title: Reconcile run lifecycle ownership and accounting across builder, store, and runtime writers
     maps_to:
       - run_lifecycle_and_accounting_coherence
+  - id: 355
+    title: Keep accepted run terminal-failed state aligned with same-run delivery and live work truth
+    maps_to:
+      - run_lifecycle_and_accounting_coherence
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -330,12 +334,14 @@ nodes:
     why_this_node_exists: run correctness drifts when builder quiescence, persisted events/deliveries, runtime-log bootstrap activity, and operator readers each carry partial run lifecycle truth
     known_manifestations:
       - runs can be marked terminal while same-run work, events, or deliveries are still active
+      - accepted runs can persist terminal `failed` while same-run deliveries, live agent work, or later same-run activity remain active
       - run-scoped counters can stay zero because no canonical persisted accounting owner updates them
       - bootstrap or diagnostics-side run row creation can leave extra running rows outside the authoritative accepted run lifecycle
       - reader/report surfaces compensate after the fact instead of consuming one canonical lifecycle owner
     representative_issues:
       - 120
       - 346
+      - 355
     common_framing_mistakes:
       too_broad:
         - run status is inconsistent

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -194,6 +194,14 @@ func SetHealthHeartbeatIntervalForTest(d time.Duration) func() {
 	}
 }
 
+func SetRunCompletionTimeoutForTest(d time.Duration) func() {
+	old := runCompletionTimeout
+	runCompletionTimeout = d
+	return func() {
+		runCompletionTimeout = old
+	}
+}
+
 func HandleRuntimeLogForTest(h http.Handler, entry runtimepkg.RuntimeLogEntry) bool {
 	typed, ok := h.(*handler)
 	if !ok || typed == nil || typed.runHub == nil {

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 )
 
-const runCompletionTimeout = 30 * time.Second
+var runCompletionTimeout = 30 * time.Second
 
 func newRunHub(runtimeProvider func() *runtimepkg.Runtime, resetRuntime func() error, pauseRuntime func() error, resumeRuntime func() error) *runHub {
 	if runtimeProvider == nil {
@@ -361,17 +362,52 @@ func (h *runHub) emit(runID string, event RunEventEnvelope) {
 }
 
 func (h *runHub) awaitCompletion(runID string) {
-	session := h.session(runID)
-	if session == nil || session.runtime == nil || session.runtime.Bus == nil {
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), runCompletionTimeout)
-	defer cancel()
-	if err := session.runtime.WaitForQuiescence(ctx); err != nil {
+	for {
+		session := h.session(runID)
+		if session == nil || session.runtime == nil || session.runtime.Bus == nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), runCompletionTimeout)
+		err := session.runtime.WaitForQuiescence(ctx)
+		cancel()
+		if err != nil {
+			if h.isTerminal(runID) {
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				// A local quiescence timeout is not authoritative proof that the
+				// accepted run should become terminal while same-run work may still
+				// be active. Keep waiting until authoritative quiescence is true.
+				continue
+			}
+			if _, persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
+				h.markTerminal(runID)
+				h.emit(runID, map[string]any{
+					"id":        uuid.NewString(),
+					"type":      "run.failed",
+					"timestamp": time.Now().UTC().Format(time.RFC3339),
+					"payload": map[string]any{
+						"run_id":            runID,
+						"error":             err.Error(),
+						"persistence_error": persistErr.Error(),
+					},
+				})
+				return
+			}
+			h.markTerminal(runID)
+			h.emit(runID, map[string]any{
+				"id":        uuid.NewString(),
+				"type":      "run.failed",
+				"timestamp": time.Now().UTC().Format(time.RFC3339),
+				"payload":   map[string]any{"run_id": runID, "error": err.Error()},
+			})
+			return
+		}
 		if h.isTerminal(runID) {
 			return
 		}
-		if _, persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
+		snapshot, err := h.persistTerminalState(runID, "completed", "", time.Now().UTC())
+		if err != nil {
 			h.markTerminal(runID)
 			h.emit(runID, map[string]any{
 				"id":        uuid.NewString(),
@@ -379,8 +415,8 @@ func (h *runHub) awaitCompletion(runID string) {
 				"timestamp": time.Now().UTC().Format(time.RFC3339),
 				"payload": map[string]any{
 					"run_id":            runID,
-					"error":             err.Error(),
-					"persistence_error": persistErr.Error(),
+					"error":             "persisting canonical run completion failed",
+					"persistence_error": err.Error(),
 				},
 			})
 			return
@@ -388,44 +424,19 @@ func (h *runHub) awaitCompletion(runID string) {
 		h.markTerminal(runID)
 		h.emit(runID, map[string]any{
 			"id":        uuid.NewString(),
-			"type":      "run.failed",
-			"timestamp": time.Now().UTC().Format(time.RFC3339),
-			"payload":   map[string]any{"run_id": runID, "error": err.Error()},
-		})
-		return
-	}
-	if h.isTerminal(runID) {
-		return
-	}
-	snapshot, err := h.persistTerminalState(runID, "completed", "", time.Now().UTC())
-	if err != nil {
-		h.markTerminal(runID)
-		h.emit(runID, map[string]any{
-			"id":        uuid.NewString(),
-			"type":      "run.failed",
+			"type":      "run.completed",
 			"timestamp": time.Now().UTC().Format(time.RFC3339),
 			"payload": map[string]any{
-				"run_id":            runID,
-				"error":             "persisting canonical run completion failed",
-				"persistence_error": err.Error(),
+				"run_id": runID,
+				"summary": map[string]any{
+					"duration_ms":  durationMillis(snapshot),
+					"total_events": snapshot.EventCount,
+					"entity_count": snapshot.EntityCount,
+				},
 			},
 		})
 		return
 	}
-	h.markTerminal(runID)
-	h.emit(runID, map[string]any{
-		"id":        uuid.NewString(),
-		"type":      "run.completed",
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
-		"payload": map[string]any{
-			"run_id": runID,
-			"summary": map[string]any{
-				"duration_ms":  durationMillis(snapshot),
-				"total_events": snapshot.EventCount,
-				"entity_count": snapshot.EntityCount,
-			},
-		},
-	})
 }
 
 func (h *runHub) deleteRun(runID string) {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -176,8 +176,11 @@ func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeli
 		t.Fatalf("seed delivery: %v", err)
 	}
 
-	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err == nil || !strings.Contains(err.Error(), "active deliveries") {
-		t.Fatalf("MarkRunTerminal(active delivery) error = %v, want active delivery rejection", err)
+	for _, status := range []string{"completed", "failed"} {
+		err := pg.MarkRunTerminal(ctx, runID, status, "quiescence timeout", time.Now().UTC())
+		if err == nil || !strings.Contains(err.Error(), "active deliveries") {
+			t.Fatalf("MarkRunTerminal(%s active delivery) error = %v, want active delivery rejection", status, err)
+		}
 	}
 
 	if _, err := db.ExecContext(ctx, `

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -285,7 +285,7 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 			return Snapshot{}, err
 		}
 	}
-	if status == "completed" {
+	if status == "completed" || status == "failed" {
 		active, err := HasActiveDeliveries(ctx, db, runID)
 		if err != nil {
 			return Snapshot{}, err


### PR DESCRIPTION
Closes #355

## Summary

Keep accepted helper-started runs from persisting terminal `failed` while same-run delivery and live agent work are still active.

## Governing context

- No exact spec refs are cited for `#355`.
- The issue body and the `Bug Repro / Identification` comment are the binding context for this bug.

## What changed

- Builder completion waiting no longer treats local quiescence timeout as authoritative terminal failure.
- The canonical store-owned run lifecycle owner now rejects terminal `failed` as well as `completed` while same-run deliveries are still active.
- Added a supported `run.start` smoke that crosses the builder timeout window and proves the accepted run stays `running` until same-run delivery and live in-flight work settle.

## Why

The reproduced bug was an accepted run being marked `failed | context deadline exceeded` while the same run still had `in_progress` delivery, live in-flight agent work, and later persisted same-run activity. This patch keeps terminal persistence aligned with authoritative same-run quiescence truth instead of letting the builder timeout outrun it.

## Scope boundary

This PR is scoped to the chosen `#355` child class only:
- accepted-run terminal `failed` outrunning same-run delivery / live-agent / later same-run activity truth

It does not claim closure for the adjacent siblings unless later review proves they share the same immediate owner gap:
- sibling bootstrap/internal `running` row participation
- `running` + `stalled/no_active_deliveries` contradiction

## Tests

- `go test ./internal/store -run 'TestPostgresStore_(MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeliveries)$' -count=1`
- `go test ./cmd/swarm -run 'TestLoadRunStatusReport_(KeepsSupportedRunRunningUntilManagerWorkSettles|PreservesRunningTruthAcrossBuilderQuiescenceTimeout)$' -count=1`
- `go test ./internal/builder ./internal/store ./cmd/swarm ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual risk

This keeps the accepted run from terminal-failing early on local timeout, which is the bug in scope. If later evidence shows the sibling bootstrap row or the `running` + `stalled/no_active_deliveries` contradiction share the same immediate owner gap, that scope needs to reopen rather than be treated as closed by this PR.