### PR TITLE
[agent-e][issue #344] Add canonical run-debug read surface for runs, events, mutations, and runtime logs

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -22,7 +22,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/lib/pq"
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
@@ -250,6 +249,7 @@ type runStatusReport struct {
 	EventCounts       []runStatusEventCount     `json:"event_counts"`
 	Deliveries        []runStatusDeliveryCount  `json:"deliveries"`
 	RecentEvents      []runStatusEvent          `json:"recent_events"`
+	Mutations         []runStatusMutation       `json:"mutations,omitempty"`
 	DeadLetters       []runStatusDeadLetter     `json:"dead_letters,omitempty"`
 	AgentTurns        []runStatusAgentTurn      `json:"agent_turns,omitempty"`
 	Heuristics        []string                  `json:"heuristics,omitempty"`
@@ -311,6 +311,19 @@ type runStatusRuntimeSummary struct {
 	Count     int    `json:"count"`
 }
 
+type runStatusMutation struct {
+	MutationID    string          `json:"mutation_id,omitempty"`
+	EntityID      string          `json:"entity_id,omitempty"`
+	Field         string          `json:"field"`
+	OldValue      json.RawMessage `json:"old_value,omitempty"`
+	NewValue      json.RawMessage `json:"new_value,omitempty"`
+	WriterType    string          `json:"writer_type,omitempty"`
+	WriterID      string          `json:"writer_id,omitempty"`
+	HandlerStep   string          `json:"handler_step,omitempty"`
+	CausedByEvent string          `json:"caused_by_event,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
 type runStatusOptions struct {
 	LogsOnly      bool
 	LogsAllLevels bool
@@ -360,7 +373,13 @@ func runStatusCommand(ctx context.Context, repo string, args []string, out io.Wr
 		}
 		return 1
 	}
-	report, err := loadRunStatusReport(ctx, stores.SQLDB, strings.TrimSpace(*runID), runStatusOptions{
+	if stores.Postgres == nil {
+		if out != nil {
+			fmt.Fprintln(out, "status failed: postgres store required")
+		}
+		return 1
+	}
+	report, err := loadRunStatusReport(ctx, stores.Postgres, strings.TrimSpace(*runID), runStatusOptions{
 		LogsOnly:      *logsOnly,
 		LogsAllLevels: *logsAll,
 		Component:     strings.TrimSpace(*component),
@@ -384,192 +403,33 @@ func runStatusCommand(ctx context.Context, repo string, args []string, out io.Wr
 	return 0
 }
 
-func loadRunStatusReport(ctx context.Context, db *sql.DB, runID string, opts runStatusOptions) (runStatusReport, error) {
-	if db == nil {
-		return runStatusReport{}, errors.New("db is required")
+func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID string, opts runStatusOptions) (runStatusReport, error) {
+	if pg == nil || pg.DB == nil {
+		return runStatusReport{}, errors.New("postgres store is required")
 	}
-	report := runStatusReport{}
 	if strings.TrimSpace(runID) == "" {
-		if err := db.QueryRowContext(ctx, `
-			SELECT COALESCE(run_id::text, '')
-			FROM events
-			WHERE event_name = 'scan.requested'
-			  AND run_id IS NOT NULL
-			ORDER BY created_at DESC
-			LIMIT 1
-		`).Scan(&runID); err != nil {
-			if err == sql.ErrNoRows {
-				return runStatusReport{}, errors.New("no current run found")
-			}
-			return runStatusReport{}, fmt.Errorf("resolve latest run: %w", err)
-		}
-	}
-	report.RunID = strings.TrimSpace(runID)
-	if report.RunID == "" {
-		return runStatusReport{}, errors.New("run_id is required")
-	}
-
-	var (
-		runStatus string
-		trigger   string
-		started   sql.NullTime
-		ended     sql.NullTime
-	)
-	if err := db.QueryRowContext(ctx, `
-		SELECT COALESCE(status, ''), COALESCE(trigger_event_type, ''), started_at, ended_at
-		FROM runs
-		WHERE run_id = $1::uuid
-	`, report.RunID).Scan(&runStatus, &trigger, &started, &ended); err == nil {
-		report.RunTableStatus = strings.TrimSpace(runStatus)
-		if started.Valid {
-			report.StartedAt = started.Time
-		}
-		if ended.Valid {
-			tm := ended.Time
-			report.EndedAt = &tm
-		}
-		_ = trigger
-	}
-
-	if err := db.QueryRowContext(ctx, `
-		SELECT event_id::text, event_name, created_at
-		FROM events
-		WHERE run_id = $1::uuid
-		ORDER BY created_at ASC
-		LIMIT 1
-	`, report.RunID).Scan(&report.RootEventID, &report.RootEventType, &report.StartedAt); err != nil {
-		return runStatusReport{}, fmt.Errorf("load root event: %w", err)
-	}
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*), MAX(created_at)
-		FROM events
-		WHERE run_id = $1::uuid
-	`, report.RunID).Scan(&report.EventCount, &report.LastEventAt); err != nil {
-		return runStatusReport{}, fmt.Errorf("load event summary: %w", err)
-	}
-
-	eventRows, err := db.QueryContext(ctx, `
-		SELECT event_name, COUNT(*)
-		FROM events
-		WHERE run_id = $1::uuid
-		GROUP BY event_name
-		ORDER BY event_name
-	`, report.RunID)
-	if err != nil {
-		return runStatusReport{}, fmt.Errorf("load event counts: %w", err)
-	}
-	defer eventRows.Close()
-	for eventRows.Next() {
-		var item runStatusEventCount
-		if err := eventRows.Scan(&item.EventName, &item.Count); err != nil {
-			return runStatusReport{}, fmt.Errorf("scan event counts: %w", err)
-		}
-		report.EventCounts = append(report.EventCounts, item)
-	}
-	if err := eventRows.Err(); err != nil {
-		return runStatusReport{}, fmt.Errorf("read event counts: %w", err)
-	}
-
-	deliveryRows, err := db.QueryContext(ctx, `
-		SELECT COALESCE(subscriber_id, ''), COALESCE(status, ''), COUNT(*)
-		FROM event_deliveries
-		WHERE run_id = $1::uuid
-		GROUP BY subscriber_id, status
-		ORDER BY subscriber_id, status
-	`, report.RunID)
-	if err != nil {
-		return runStatusReport{}, fmt.Errorf("load deliveries: %w", err)
-	}
-	defer deliveryRows.Close()
-	for deliveryRows.Next() {
-		var item runStatusDeliveryCount
-		if err := deliveryRows.Scan(&item.SubscriberID, &item.Status, &item.Count); err != nil {
-			return runStatusReport{}, fmt.Errorf("scan deliveries: %w", err)
-		}
-		report.Deliveries = append(report.Deliveries, item)
-	}
-	if err := deliveryRows.Err(); err != nil {
-		return runStatusReport{}, fmt.Errorf("read deliveries: %w", err)
-	}
-
-	recentRows, err := db.QueryContext(ctx, `
-		SELECT event_name, COALESCE(entity_id::text, ''), created_at
-		FROM events
-		WHERE run_id = $1::uuid
-		ORDER BY created_at DESC
-		LIMIT 15
-	`, report.RunID)
-	if err != nil {
-		return runStatusReport{}, fmt.Errorf("load recent events: %w", err)
-	}
-	defer recentRows.Close()
-	for recentRows.Next() {
-		var item runStatusEvent
-		if err := recentRows.Scan(&item.EventName, &item.EntityID, &item.CreatedAt); err != nil {
-			return runStatusReport{}, fmt.Errorf("scan recent events: %w", err)
-		}
-		report.RecentEvents = append(report.RecentEvents, item)
-	}
-	if err := recentRows.Err(); err != nil {
-		return runStatusReport{}, fmt.Errorf("read recent events: %w", err)
-	}
-
-	deadRows, err := db.QueryContext(ctx, `
-		SELECT
-			COALESCE(dl.original_event, ''),
-			COALESCE(dl.entity_id::text, ''),
-			COALESCE(dl.failure_type, ''),
-			COALESCE(dl.error_message, ''),
-			COALESCE(dl.handler_node, ''),
-			dl.created_at
-		FROM dead_letters dl
-		INNER JOIN events e ON e.event_id = dl.original_event_id
-		WHERE e.run_id = $1::uuid
-		ORDER BY dl.created_at DESC
-		LIMIT 10
-	`, report.RunID)
-	if err != nil {
-		return runStatusReport{}, fmt.Errorf("load dead letters: %w", err)
-	}
-	defer deadRows.Close()
-	for deadRows.Next() {
-		var item runStatusDeadLetter
-		if err := deadRows.Scan(&item.OriginalEvent, &item.EntityID, &item.FailureType, &item.ErrorMessage, &item.HandlerNode, &item.CreatedAt); err != nil {
-			return runStatusReport{}, fmt.Errorf("scan dead letters: %w", err)
-		}
-		report.DeadLetters = append(report.DeadLetters, item)
-	}
-	if err := deadRows.Err(); err != nil {
-		return runStatusReport{}, fmt.Errorf("read dead letters: %w", err)
-	}
-
-	turnRows, err := db.QueryContext(ctx, `
-		SELECT agent_id, COUNT(*), COUNT(*) FILTER (WHERE COALESCE(error, '') <> ''), MAX(created_at)
-		FROM agent_turns
-		WHERE run_id = $1::uuid
-		GROUP BY agent_id
-		ORDER BY agent_id
-	`, report.RunID)
-	if err != nil {
-		return runStatusReport{}, fmt.Errorf("load agent turns: %w", err)
-	}
-	defer turnRows.Close()
-	for turnRows.Next() {
-		var item runStatusAgentTurn
-		if err := turnRows.Scan(&item.AgentID, &item.Turns, &item.ErrorCount, &item.LastAt); err != nil {
-			return runStatusReport{}, fmt.Errorf("scan agent turns: %w", err)
-		}
-		report.AgentTurns = append(report.AgentTurns, item)
-	}
-	if err := turnRows.Err(); err != nil {
-		return runStatusReport{}, fmt.Errorf("read agent turns: %w", err)
-	}
-
-	if report.RunID != "" {
-		if err := loadRunStatusRuntimeLogs(ctx, db, report.RunID, opts, &report); err != nil {
+		resolvedRunID, err := pg.ResolveLatestRunDebugRunID(ctx)
+		if err != nil {
 			return runStatusReport{}, err
 		}
+		runID = resolvedRunID
 	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return runStatusReport{}, errors.New("run_id is required")
+	}
+	detail, err := pg.LoadRunDebugReport(ctx, runID, store.RunDebugQueryOptions{
+		LogsAllLevels:   opts.LogsAllLevels,
+		Component:       opts.Component,
+		EventLimit:      15,
+		MutationLimit:   20,
+		RuntimeLogLimit: logLimitForStatus(opts),
+		DeadLetterLimit: 10,
+	})
+	if err != nil {
+		return runStatusReport{}, err
+	}
+	report := runStatusReportFromStore(detail)
 	operational := projectRunOperationalStatus(report)
 	report.OperationalState = operational.State
 	report.BlockingLayer = operational.BlockingLayer
@@ -577,89 +437,6 @@ func loadRunStatusReport(ctx context.Context, db *sql.DB, runID string, opts run
 	report.Heuristics = deriveRunStatusHeuristics(report)
 
 	return report, nil
-}
-
-func loadRunStatusRuntimeLogs(ctx context.Context, db *sql.DB, runID string, opts runStatusOptions, report *runStatusReport) error {
-	if db == nil {
-		return errors.New("db is required")
-	}
-	if report == nil {
-		return errors.New("report is required")
-	}
-	logLevels := []string{"warn", "error"}
-	if opts.LogsAllLevels {
-		logLevels = []string{"info", "warn", "error"}
-	}
-	componentFilter := strings.TrimSpace(opts.Component)
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM events
-		WHERE event_name = 'platform.runtime_log'
-		  AND run_id = $1::uuid
-		  AND payload->>'log_level' = ANY($2::text[])
-		  AND ($3 = '' OR payload->'details'->>'component' = $3)
-	`, runID, pq.Array(logLevels), componentFilter).Scan(&report.WarnErrorLogCount); err != nil {
-		return fmt.Errorf("load runtime log summary: %w", err)
-	}
-	logSummaryRows, err := db.QueryContext(ctx, `
-		SELECT
-			COALESCE(payload->>'log_level', ''),
-			COALESCE(payload->'details'->>'component', ''),
-			COALESCE(payload->'details'->>'action', ''),
-			COUNT(*)
-		FROM events
-		WHERE event_name = 'platform.runtime_log'
-		  AND run_id = $1::uuid
-		  AND payload->>'log_level' = ANY($2::text[])
-		  AND ($3 = '' OR payload->'details'->>'component' = $3)
-		GROUP BY payload->>'log_level', payload->'details'->>'component', payload->'details'->>'action'
-		ORDER BY COUNT(*) DESC, payload->'details'->>'component', payload->'details'->>'action'
-		LIMIT 12
-	`, runID, pq.Array(logLevels), componentFilter)
-	if err != nil {
-		return fmt.Errorf("load runtime log rollup: %w", err)
-	}
-	defer logSummaryRows.Close()
-	for logSummaryRows.Next() {
-		var item runStatusRuntimeSummary
-		if err := logSummaryRows.Scan(&item.Level, &item.Component, &item.Action, &item.Count); err != nil {
-			return fmt.Errorf("scan runtime log rollup: %w", err)
-		}
-		report.RuntimeLogSummary = append(report.RuntimeLogSummary, item)
-	}
-	if err := logSummaryRows.Err(); err != nil {
-		return fmt.Errorf("read runtime log rollup: %w", err)
-	}
-	logRows, err := db.QueryContext(ctx, `
-		SELECT
-			COALESCE(payload->>'log_level', ''),
-			COALESCE(payload->'details'->>'component', ''),
-			COALESCE(payload->'details'->>'action', ''),
-			COALESCE(payload->'details'->>'error', ''),
-			created_at
-		FROM events
-		WHERE event_name = 'platform.runtime_log'
-		  AND run_id = $1::uuid
-		  AND payload->>'log_level' = ANY($2::text[])
-		  AND ($3 = '' OR payload->'details'->>'component' = $3)
-		ORDER BY created_at DESC
-		LIMIT $4
-	`, runID, pq.Array(logLevels), componentFilter, logLimitForStatus(opts))
-	if err != nil {
-		return fmt.Errorf("load runtime logs: %w", err)
-	}
-	defer logRows.Close()
-	for logRows.Next() {
-		var item runStatusRuntimeLog
-		if err := logRows.Scan(&item.Level, &item.Component, &item.Action, &item.Error, &item.CreatedAt); err != nil {
-			return fmt.Errorf("scan runtime logs: %w", err)
-		}
-		report.RuntimeLogs = append(report.RuntimeLogs, item)
-	}
-	if err := logRows.Err(); err != nil {
-		return fmt.Errorf("read runtime logs: %w", err)
-	}
-	return nil
 }
 
 func logLimitForStatus(opts runStatusOptions) int {
@@ -773,6 +550,19 @@ func printRunStatusReport(w io.Writer, report runStatusReport) {
 			fmt.Fprintf(w, "  %s  turns=%d errors=%d last=%s\n", item.AgentID, item.Turns, item.ErrorCount, item.LastAt.Format(time.RFC3339))
 		}
 	}
+	if len(report.Mutations) > 0 {
+		fmt.Fprintln(w, "\nRecent Mutations:")
+		for _, item := range report.Mutations {
+			fmt.Fprintf(w, "  %s  entity=%s  writer=%s/%s  step=%s  at=%s\n",
+				item.Field,
+				item.EntityID,
+				item.WriterType,
+				item.WriterID,
+				item.HandlerStep,
+				item.CreatedAt.Format(time.RFC3339),
+			)
+		}
+	}
 	if len(report.DeadLetters) > 0 {
 		fmt.Fprintln(w, "\nDead Letters:")
 		for _, item := range report.DeadLetters {
@@ -823,6 +613,57 @@ func printRunStatusReport(w io.Writer, report runStatusReport) {
 			)
 		}
 	}
+}
+
+func runStatusReportFromStore(detail store.RunDebugReport) runStatusReport {
+	report := runStatusReport{
+		RunID:             detail.RunID,
+		RunTableStatus:    detail.RunTableStatus,
+		RootEventID:       detail.RootEventID,
+		RootEventType:     detail.RootEventType,
+		StartedAt:         detail.StartedAt,
+		LastEventAt:       detail.LastEventAt,
+		EndedAt:           detail.EndedAt,
+		EventCount:        detail.EventCount,
+		WarnErrorLogCount: detail.WarnErrorLogCount,
+		RuntimeLogSummary: make([]runStatusRuntimeSummary, 0, len(detail.RuntimeLogSummary)),
+		RuntimeLogs:       make([]runStatusRuntimeLog, 0, len(detail.RuntimeLogs)),
+		EventCounts:       make([]runStatusEventCount, 0, len(detail.EventCounts)),
+		Deliveries:        make([]runStatusDeliveryCount, 0, len(detail.Deliveries)),
+		RecentEvents:      make([]runStatusEvent, 0, len(detail.Events)),
+		Mutations:         make([]runStatusMutation, 0, len(detail.Mutations)),
+		DeadLetters:       make([]runStatusDeadLetter, 0, len(detail.DeadLetters)),
+		AgentTurns:        make([]runStatusAgentTurn, 0, len(detail.AgentTurns)),
+	}
+	for _, item := range detail.RuntimeLogSummary {
+		report.RuntimeLogSummary = append(report.RuntimeLogSummary, runStatusRuntimeSummary(item))
+	}
+	for _, item := range detail.RuntimeLogs {
+		report.RuntimeLogs = append(report.RuntimeLogs, runStatusRuntimeLog(item))
+	}
+	for _, item := range detail.EventCounts {
+		report.EventCounts = append(report.EventCounts, runStatusEventCount(item))
+	}
+	for _, item := range detail.Deliveries {
+		report.Deliveries = append(report.Deliveries, runStatusDeliveryCount(item))
+	}
+	for _, item := range detail.Events {
+		report.RecentEvents = append(report.RecentEvents, runStatusEvent{
+			EventName: item.EventName,
+			EntityID:  item.EntityID,
+			CreatedAt: item.CreatedAt,
+		})
+	}
+	for _, item := range detail.Mutations {
+		report.Mutations = append(report.Mutations, runStatusMutation(item))
+	}
+	for _, item := range detail.DeadLetters {
+		report.DeadLetters = append(report.DeadLetters, runStatusDeadLetter(item))
+	}
+	for _, item := range detail.AgentTurns {
+		report.AgentTurns = append(report.AgentTurns, runStatusAgentTurn(item))
+	}
+	return report
 }
 
 func verifyBundle(ctx context.Context, source semanticview.Source) error {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -595,7 +595,7 @@ func TestLoadRunStatusReport_KeepsSupportedRunRunningUntilManagerWorkSettles(t *
 		t.Fatalf("extra running rows = %d, want 0", extraRunningRows)
 	}
 
-	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	report, err := loadRunStatusReport(ctx, pg, runID, runStatusOptions{})
 	if err != nil {
 		t.Fatalf("loadRunStatusReport: %v", err)
 	}
@@ -710,7 +710,7 @@ func TestLoadRunStatusReport_PreservesRunningTruthAcrossBuilderQuiescenceTimeout
 		t.Fatal("expected live in-flight manager work after builder timeout window")
 	}
 
-	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	report, err := loadRunStatusReport(ctx, pg, runID, runStatusOptions{})
 	if err != nil {
 		t.Fatalf("loadRunStatusReport: %v", err)
 	}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/events"
@@ -24,6 +23,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -103,6 +103,9 @@ func TestPrintRunStatusReport(t *testing.T) {
 		RecentEvents: []runStatusEvent{
 			{EventName: "vertical.discovered", EntityID: "ent-1", CreatedAt: last},
 		},
+		Mutations: []runStatusMutation{
+			{Field: "current_state", EntityID: "ent-1", WriterType: "workflow", WriterID: "router", HandlerStep: "step-1", CreatedAt: last},
+		},
 	}
 
 	printRunStatusReport(&buf, report)
@@ -125,6 +128,8 @@ func TestPrintRunStatusReport(t *testing.T) {
 		"WARN  mcp-gateway/mcp.context.fallback_used",
 		"Recent Events:",
 		"vertical.discovered  entity=ent-1",
+		"Recent Mutations:",
+		"current_state  entity=ent-1  writer=workflow/router  step=step-1",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output missing %q:\n%s", want, out)
@@ -222,62 +227,15 @@ func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveries
 	}
 }
 
-func TestLoadRunStatusRuntimeLogs_UsesSpecShapedPayload(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
-	}
-	defer db.Close()
-
-	summaryCount := sqlmock.NewRows([]string{"count"}).AddRow(2)
-	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM events`).
-		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor").
-		WillReturnRows(summaryCount)
-
-	rollupRows := sqlmock.NewRows([]string{"log_level", "component", "action", "count"}).
-		AddRow("warn", "tool-executor", "tool_execution_denied", 2)
-	mock.ExpectQuery(`SELECT\s+COALESCE\(payload->>'log_level', ''\)`).
-		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor").
-		WillReturnRows(rollupRows)
-
-	logRows := sqlmock.NewRows([]string{"log_level", "component", "action", "error", "created_at"}).
-		AddRow("warn", "tool-executor", "tool_execution_denied", "tool not allowed", time.Unix(1700000000, 0).UTC())
-	mock.ExpectQuery(`SELECT\s+COALESCE\(payload->>'log_level', ''\)`).
-		WithArgs("run-123", sqlmock.AnyArg(), "tool-executor", 100).
-		WillReturnRows(logRows)
-
-	var report runStatusReport
-	err = loadRunStatusRuntimeLogs(context.Background(), db, "run-123", runStatusOptions{
-		LogsOnly:  true,
-		Component: "tool-executor",
-	}, &report)
-	if err != nil {
-		t.Fatalf("loadRunStatusRuntimeLogs: %v", err)
-	}
-	if report.WarnErrorLogCount != 2 {
-		t.Fatalf("WarnErrorLogCount = %d, want 2", report.WarnErrorLogCount)
-	}
-	if len(report.RuntimeLogSummary) != 1 {
-		t.Fatalf("RuntimeLogSummary len = %d, want 1", len(report.RuntimeLogSummary))
-	}
-	if got := report.RuntimeLogSummary[0]; got.Level != "warn" || got.Component != "tool-executor" || got.Action != "tool_execution_denied" || got.Count != 2 {
-		t.Fatalf("RuntimeLogSummary[0] = %#v", got)
-	}
-	if len(report.RuntimeLogs) != 1 {
-		t.Fatalf("RuntimeLogs len = %d, want 1", len(report.RuntimeLogs))
-	}
-	if got := report.RuntimeLogs[0]; got.Level != "warn" || got.Component != "tool-executor" || got.Action != "tool_execution_denied" || got.Error != "tool not allowed" {
-		t.Fatalf("RuntimeLogs[0] = %#v", got)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("sql expectations: %v", err)
-	}
-}
-
-func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
+func TestLoadRunStatusReport_UsesCanonicalPersistedRunIDForRuntimeLogsAndMutations(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
 	targetRunID := uuid.NewString()
 	otherRunID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	otherEntityID := uuid.NewString()
+	targetEventID := uuid.NewString()
+	otherEventID := uuid.NewString()
 	now := time.Unix(1700000000, 0).UTC()
 
 	insertRuntimeLog := func(runID string, payloadRunID string, component string, action string, createdAt time.Time) {
@@ -296,13 +254,6 @@ func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
 			t.Fatalf("marshal runtime log payload: %v", err)
 		}
 		if _, err := db.Exec(`
-			INSERT INTO runs (run_id, status)
-			VALUES ($1::uuid, 'running')
-			ON CONFLICT (run_id) DO NOTHING
-		`, runID); err != nil {
-			t.Fatalf("insert run %s: %v", runID, err)
-		}
-		if _, err := db.Exec(`
 			INSERT INTO events (
 				run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 			)
@@ -314,16 +265,63 @@ func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
 		}
 	}
 
+	for _, runID := range []string{targetRunID, otherRunID} {
+		if _, err := db.Exec(`
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES ($1::uuid, 'running', $2)
+			ON CONFLICT (run_id) DO NOTHING
+		`, runID, now.Add(-5*time.Minute)); err != nil {
+			t.Fatalf("insert run %s: %v", runID, err)
+		}
+	}
+	if _, err := db.Exec(`
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'scan.requested', $3::uuid, NULL, 'global', '{}'::jsonb, 'test', 'agent', $4),
+			($5::uuid, $6::uuid, 'scan.requested', $7::uuid, NULL, 'global', '{}'::jsonb, 'test', 'agent', $8)
+	`, targetRunID, targetEventID, targetEntityID, now.Add(-4*time.Minute), otherRunID, otherEventID, otherEntityID, now.Add(-3*time.Minute)); err != nil {
+		t.Fatalf("insert root events: %v", err)
+	}
 	insertRuntimeLog(targetRunID, otherRunID, "scheduler", "canonical-owner", now)
 	insertRuntimeLog(otherRunID, targetRunID, "scheduler", "payload-only", now.Add(1*time.Minute))
+	if _, err := db.Exec(`
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', $4::jsonb, $5::jsonb, $3::uuid, 'platform', 'runner', 'step-a', $6),
+			($7::uuid, $8::uuid, 'current_state', $10::jsonb, $11::jsonb, $9::uuid, 'platform', 'runner', 'step-b', $12)
+	`, targetRunID, targetEntityID, targetEventID, `"queued"`, `"running"`, now.Add(2*time.Minute), otherRunID, otherEntityID, otherEventID, `"queued"`, `"failed"`, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("insert mutations: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'delivered', $3, $4)
+	`, targetRunID, targetEventID, now.Add(10*time.Second), now.Add(5*time.Second)); err != nil {
+		t.Fatalf("insert delivery: %v", err)
+	}
+	if err := runtimedeadletters.Insert(context.Background(), db, runtimedeadletters.Record{
+		OriginalEventID: targetEventID,
+		OriginalEvent:   "scan.requested",
+		EntityID:        targetEntityID,
+		FailureType:     "handler_error",
+		ErrorMessage:    "boom",
+		HandlerNode:     "node-a",
+		Timestamp:       now.Add(4 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("insert dead letter: %v", err)
+	}
 
-	var report runStatusReport
-	err := loadRunStatusRuntimeLogs(context.Background(), db, targetRunID, runStatusOptions{
+	report, err := loadRunStatusReport(context.Background(), pg, targetRunID, runStatusOptions{
 		LogsOnly:  true,
 		Component: "scheduler",
-	}, &report)
+	})
 	if err != nil {
-		t.Fatalf("loadRunStatusRuntimeLogs: %v", err)
+		t.Fatalf("loadRunStatusReport: %v", err)
 	}
 	if report.WarnErrorLogCount != 1 {
 		t.Fatalf("WarnErrorLogCount = %d, want 1", report.WarnErrorLogCount)
@@ -339,6 +337,15 @@ func TestLoadRunStatusRuntimeLogs_UsesCanonicalPersistedRunID(t *testing.T) {
 	}
 	if got := report.RuntimeLogs[0]; got.Component != "scheduler" || got.Action != "canonical-owner" || got.Error != "canonical-owner-error" {
 		t.Fatalf("RuntimeLogs[0] = %#v", got)
+	}
+	if len(report.Mutations) != 1 {
+		t.Fatalf("Mutations len = %d, want 1", len(report.Mutations))
+	}
+	if got := report.Mutations[0]; got.EntityID != targetEntityID || got.Field != "current_state" || got.WriterType != "platform" || got.WriterID != "runner" {
+		t.Fatalf("Mutations[0] = %#v", got)
+	}
+	if len(report.DeadLetters) != 1 {
+		t.Fatalf("DeadLetters len = %d, want 1", len(report.DeadLetters))
 	}
 }
 
@@ -433,7 +440,7 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	report, err := loadRunStatusReport(ctx, pg, runID, runStatusOptions{})
 	if err != nil {
 		t.Fatalf("loadRunStatusReport: %v", err)
 	}
@@ -757,6 +764,7 @@ func TestLoadRunStatusReport_PreservesRunningTruthAcrossBuilderQuiescenceTimeout
 
 func TestLoadRunStatusReport_ProjectsExplicitStalledRunState(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 
 	runID := uuid.NewString()
@@ -789,7 +797,7 @@ func TestLoadRunStatusReport_ProjectsExplicitStalledRunState(t *testing.T) {
 		t.Fatalf("seed delivery: %v", err)
 	}
 
-	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	report, err := loadRunStatusReport(ctx, pg, runID, runStatusOptions{})
 	if err != nil {
 		t.Fatalf("loadRunStatusReport: %v", err)
 	}
@@ -814,6 +822,7 @@ func TestLoadRunStatusReport_ProjectsExplicitStalledRunState(t *testing.T) {
 
 func TestLoadRunStatusReport_ProjectsScoringOutcomeStall(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 
 	runID := uuid.NewString()
@@ -835,7 +844,7 @@ func TestLoadRunStatusReport_ProjectsScoringOutcomeStall(t *testing.T) {
 		t.Fatalf("seed events: %v", err)
 	}
 
-	report, err := loadRunStatusReport(ctx, db, runID, runStatusOptions{})
+	report, err := loadRunStatusReport(ctx, pg, runID, runStatusOptions{})
 	if err != nil {
 		t.Fatalf("loadRunStatusReport: %v", err)
 	}

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -41,6 +41,10 @@ active_issues:
     title: Add completeness invariants for canonical mutation surfaces and touched conformance/read-model seams
     maps_to:
       - typed_persisted_operator_reads
+  - id: 344
+    title: Add one canonical run-debug read surface for runs, events, mutations, and runtime logs
+    maps_to:
+      - run_scoped_operator_identity
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -108,6 +112,7 @@ nodes:
       - API/dashboard query ownership not aligned on the same run-scoped identity
     representative_issues:
       - 148
+      - 344
     common_framing_mistakes:
       too_broad:
         - run scoping is inconsistent

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -1,0 +1,584 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+type RunDebugQueryOptions struct {
+	LogsAllLevels   bool
+	Component       string
+	EventLimit      int
+	MutationLimit   int
+	RuntimeLogLimit int
+	DeadLetterLimit int
+}
+
+type RunDebugRunSummary struct {
+	RunID          string     `json:"run_id"`
+	RunTableStatus string     `json:"run_table_status,omitempty"`
+	RootEventID    string     `json:"root_event_id,omitempty"`
+	RootEventType  string     `json:"root_event_type,omitempty"`
+	StartedAt      time.Time  `json:"started_at,omitempty"`
+	LastEventAt    time.Time  `json:"last_event_at,omitempty"`
+	EndedAt        *time.Time `json:"ended_at,omitempty"`
+	EventCount     int        `json:"event_count"`
+}
+
+type RunDebugEventCount struct {
+	EventName string `json:"event_name"`
+	Count     int    `json:"count"`
+}
+
+type RunDebugDeliveryCount struct {
+	SubscriberID string `json:"subscriber_id"`
+	Status       string `json:"status"`
+	Count        int    `json:"count"`
+}
+
+type RunDebugEvent struct {
+	EventID    string    `json:"event_id,omitempty"`
+	EventName  string    `json:"event_name"`
+	EntityID   string    `json:"entity_id,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	SourceType string    `json:"source_type,omitempty"`
+}
+
+type RunDebugMutation struct {
+	MutationID    string          `json:"mutation_id,omitempty"`
+	EntityID      string          `json:"entity_id,omitempty"`
+	Field         string          `json:"field"`
+	OldValue      json.RawMessage `json:"old_value,omitempty"`
+	NewValue      json.RawMessage `json:"new_value,omitempty"`
+	WriterType    string          `json:"writer_type,omitempty"`
+	WriterID      string          `json:"writer_id,omitempty"`
+	HandlerStep   string          `json:"handler_step,omitempty"`
+	CausedByEvent string          `json:"caused_by_event,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+type RunDebugDeadLetter struct {
+	OriginalEvent string    `json:"original_event"`
+	EntityID      string    `json:"entity_id,omitempty"`
+	FailureType   string    `json:"failure_type"`
+	ErrorMessage  string    `json:"error_message,omitempty"`
+	HandlerNode   string    `json:"handler_node,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+type RunDebugAgentTurn struct {
+	AgentID    string    `json:"agent_id"`
+	Turns      int       `json:"turns"`
+	ErrorCount int       `json:"error_count"`
+	LastAt     time.Time `json:"last_at"`
+}
+
+type RunDebugRuntimeLog struct {
+	Level     string    `json:"level"`
+	Component string    `json:"component"`
+	Action    string    `json:"action"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type RunDebugRuntimeSummary struct {
+	Level     string `json:"level"`
+	Component string `json:"component"`
+	Action    string `json:"action"`
+	Count     int    `json:"count"`
+}
+
+type RunDebugReport struct {
+	RunID             string                   `json:"run_id"`
+	RunTableStatus    string                   `json:"run_table_status,omitempty"`
+	RootEventID       string                   `json:"root_event_id,omitempty"`
+	RootEventType     string                   `json:"root_event_type,omitempty"`
+	StartedAt         time.Time                `json:"started_at,omitempty"`
+	LastEventAt       time.Time                `json:"last_event_at,omitempty"`
+	EndedAt           *time.Time               `json:"ended_at,omitempty"`
+	EventCount        int                      `json:"event_count"`
+	WarnErrorLogCount int                      `json:"warn_error_log_count"`
+	EventCounts       []RunDebugEventCount     `json:"event_counts,omitempty"`
+	Deliveries        []RunDebugDeliveryCount  `json:"deliveries,omitempty"`
+	Events            []RunDebugEvent          `json:"events,omitempty"`
+	DeadLetters       []RunDebugDeadLetter     `json:"dead_letters,omitempty"`
+	AgentTurns        []RunDebugAgentTurn      `json:"agent_turns,omitempty"`
+	Mutations         []RunDebugMutation       `json:"mutations,omitempty"`
+	RuntimeLogSummary []RunDebugRuntimeSummary `json:"runtime_log_summary,omitempty"`
+	RuntimeLogs       []RunDebugRuntimeLog     `json:"runtime_logs,omitempty"`
+}
+
+func defaultRunDebugQueryOptions(opts RunDebugQueryOptions) RunDebugQueryOptions {
+	if opts.EventLimit <= 0 {
+		opts.EventLimit = 15
+	}
+	if opts.MutationLimit <= 0 {
+		opts.MutationLimit = 20
+	}
+	if opts.RuntimeLogLimit <= 0 {
+		opts.RuntimeLogLimit = 20
+	}
+	if opts.DeadLetterLimit <= 0 {
+		opts.DeadLetterLimit = 10
+	}
+	opts.Component = strings.TrimSpace(opts.Component)
+	return opts
+}
+
+func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	switch {
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case !caps.Events.LogRunID:
+		return fmt.Errorf("run debug read surface requires canonical events.run_id")
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case !caps.Events.DeliveryRunID:
+		return fmt.Errorf("run debug read surface requires canonical event_deliveries.run_id")
+	case caps.Conversations.Turns != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
+	case !caps.Conversations.TurnRunID:
+		return fmt.Errorf("run debug read surface requires canonical agent_turns.run_id")
+	}
+	required := map[string][]string{
+		"runs":             {"run_id", "status", "started_at", "ended_at"},
+		"dead_letters":     {"original_event_id", "original_event", "entity_id", "failure_type", "error_message", "handler_node", "created_at"},
+		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "old_value", "new_value", "caused_by_event", "writer_type", "writer_id", "handler_step", "created_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run debug read surface requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunDebugCapabilities(ctx context.Context) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return RequireCanonicalRunDebugCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context) (string, error) {
+	if s == nil || s.DB == nil {
+		return "", fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunDebugCapabilities(ctx); err != nil {
+		return "", err
+	}
+	var runID string
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(run_id::text, '')
+		FROM events
+		WHERE event_name = 'scan.requested'
+		  AND run_id IS NOT NULL
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&runID); err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("no current run found")
+		}
+		return "", fmt.Errorf("resolve latest run: %w", err)
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return "", fmt.Errorf("no current run found")
+	}
+	return runID, nil
+}
+
+func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunDebugRunSummary, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunDebugCapabilities(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			r.run_id::text,
+			COALESCE(r.status, ''),
+			COALESCE(root.event_id::text, ''),
+			COALESCE(root.event_name, ''),
+			COALESCE(root.created_at, r.started_at, now()),
+			summary.last_event_at,
+			r.ended_at,
+			COALESCE(summary.event_count, 0)
+		FROM runs r
+		LEFT JOIN LATERAL (
+			SELECT e.event_id, e.event_name, e.created_at
+			FROM events e
+			WHERE e.run_id = r.run_id
+			ORDER BY e.created_at ASC, e.event_id ASC
+			LIMIT 1
+		) root ON TRUE
+		LEFT JOIN LATERAL (
+			SELECT COUNT(*)::int AS event_count, MAX(created_at) AS last_event_at
+			FROM events
+			WHERE run_id = r.run_id
+		) summary ON TRUE
+		WHERE root.event_id IS NOT NULL
+		ORDER BY COALESCE(summary.last_event_at, root.created_at, r.started_at) DESC, r.run_id DESC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list run debug runs: %w", err)
+	}
+	defer rows.Close()
+	out := make([]RunDebugRunSummary, 0, limit)
+	for rows.Next() {
+		var (
+			item      RunDebugRunSummary
+			lastEvent sql.NullTime
+			endedAt   sql.NullTime
+		)
+		if err := rows.Scan(
+			&item.RunID,
+			&item.RunTableStatus,
+			&item.RootEventID,
+			&item.RootEventType,
+			&item.StartedAt,
+			&lastEvent,
+			&endedAt,
+			&item.EventCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan run debug summary: %w", err)
+		}
+		if lastEvent.Valid {
+			item.LastEventAt = lastEvent.Time
+		}
+		if endedAt.Valid {
+			tm := endedAt.Time
+			item.EndedAt = &tm
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read run debug summaries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, opts RunDebugQueryOptions) (RunDebugReport, error) {
+	if s == nil || s.DB == nil {
+		return RunDebugReport{}, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunDebugCapabilities(ctx); err != nil {
+		return RunDebugReport{}, err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return RunDebugReport{}, fmt.Errorf("run_id is required")
+	}
+	opts = defaultRunDebugQueryOptions(opts)
+	report := RunDebugReport{RunID: runID}
+
+	var (
+		runStatus string
+		started   sql.NullTime
+		ended     sql.NullTime
+	)
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), started_at, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, report.RunID).Scan(&runStatus, &started, &ended); err == nil {
+		report.RunTableStatus = strings.TrimSpace(runStatus)
+		if started.Valid {
+			report.StartedAt = started.Time
+		}
+		if ended.Valid {
+			tm := ended.Time
+			report.EndedAt = &tm
+		}
+	} else if err != sql.ErrNoRows {
+		return RunDebugReport{}, fmt.Errorf("load run row: %w", err)
+	}
+
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT event_id::text, event_name, created_at
+		FROM events
+		WHERE run_id = $1::uuid
+		ORDER BY created_at ASC, event_id ASC
+		LIMIT 1
+	`, report.RunID).Scan(&report.RootEventID, &report.RootEventType, &report.StartedAt); err != nil {
+		return RunDebugReport{}, fmt.Errorf("load root event: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*), MAX(created_at)
+		FROM events
+		WHERE run_id = $1::uuid
+	`, report.RunID).Scan(&report.EventCount, &report.LastEventAt); err != nil {
+		return RunDebugReport{}, fmt.Errorf("load event summary: %w", err)
+	}
+
+	eventCountRows, err := s.DB.QueryContext(ctx, `
+		SELECT event_name, COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		GROUP BY event_name
+		ORDER BY event_name
+	`, report.RunID)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load event counts: %w", err)
+	}
+	defer eventCountRows.Close()
+	for eventCountRows.Next() {
+		var item RunDebugEventCount
+		if err := eventCountRows.Scan(&item.EventName, &item.Count); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan event counts: %w", err)
+		}
+		report.EventCounts = append(report.EventCounts, item)
+	}
+	if err := eventCountRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read event counts: %w", err)
+	}
+
+	deliveryRows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(subscriber_id, ''), COALESCE(status, ''), COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		GROUP BY subscriber_id, status
+		ORDER BY subscriber_id, status
+	`, report.RunID)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load deliveries: %w", err)
+	}
+	defer deliveryRows.Close()
+	for deliveryRows.Next() {
+		var item RunDebugDeliveryCount
+		if err := deliveryRows.Scan(&item.SubscriberID, &item.Status, &item.Count); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan deliveries: %w", err)
+		}
+		report.Deliveries = append(report.Deliveries, item)
+	}
+	if err := deliveryRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read deliveries: %w", err)
+	}
+
+	eventRows, err := s.DB.QueryContext(ctx, `
+		SELECT event_id::text, event_name, COALESCE(entity_id::text, ''), created_at, COALESCE(produced_by_type, '')
+		FROM events
+		WHERE run_id = $1::uuid
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT $2
+	`, report.RunID, opts.EventLimit)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load run events: %w", err)
+	}
+	defer eventRows.Close()
+	for eventRows.Next() {
+		var item RunDebugEvent
+		if err := eventRows.Scan(&item.EventID, &item.EventName, &item.EntityID, &item.CreatedAt, &item.SourceType); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan run events: %w", err)
+		}
+		report.Events = append(report.Events, item)
+	}
+	if err := eventRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read run events: %w", err)
+	}
+
+	deadRows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(dl.original_event, ''),
+			COALESCE(dl.entity_id::text, ''),
+			COALESCE(dl.failure_type, ''),
+			COALESCE(dl.error_message, ''),
+			COALESCE(dl.handler_node, ''),
+			dl.created_at
+		FROM dead_letters dl
+		INNER JOIN events e ON e.event_id = dl.original_event_id
+		WHERE e.run_id = $1::uuid
+		ORDER BY dl.created_at DESC
+		LIMIT $2
+	`, report.RunID, opts.DeadLetterLimit)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load dead letters: %w", err)
+	}
+	defer deadRows.Close()
+	for deadRows.Next() {
+		var item RunDebugDeadLetter
+		if err := deadRows.Scan(&item.OriginalEvent, &item.EntityID, &item.FailureType, &item.ErrorMessage, &item.HandlerNode, &item.CreatedAt); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan dead letters: %w", err)
+		}
+		report.DeadLetters = append(report.DeadLetters, item)
+	}
+	if err := deadRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read dead letters: %w", err)
+	}
+
+	turnRows, err := s.DB.QueryContext(ctx, `
+		SELECT agent_id, COUNT(*), COUNT(*) FILTER (WHERE COALESCE(error, '') <> ''), MAX(created_at)
+		FROM agent_turns
+		WHERE run_id = $1::uuid
+		GROUP BY agent_id
+		ORDER BY agent_id
+	`, report.RunID)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load agent turns: %w", err)
+	}
+	defer turnRows.Close()
+	for turnRows.Next() {
+		var item RunDebugAgentTurn
+		if err := turnRows.Scan(&item.AgentID, &item.Turns, &item.ErrorCount, &item.LastAt); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan agent turns: %w", err)
+		}
+		report.AgentTurns = append(report.AgentTurns, item)
+	}
+	if err := turnRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read agent turns: %w", err)
+	}
+
+	mutationRows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			mutation_id::text,
+			COALESCE(entity_id::text, ''),
+			COALESCE(field, ''),
+			COALESCE(old_value, 'null'::jsonb),
+			COALESCE(new_value, 'null'::jsonb),
+			COALESCE(writer_type, ''),
+			COALESCE(writer_id, ''),
+			COALESCE(handler_step, ''),
+			COALESCE(caused_by_event::text, ''),
+			created_at
+		FROM entity_mutations
+		WHERE run_id = $1::uuid
+		ORDER BY created_at DESC, mutation_id DESC
+		LIMIT $2
+	`, report.RunID, opts.MutationLimit)
+	if err != nil {
+		return RunDebugReport{}, fmt.Errorf("load run mutations: %w", err)
+	}
+	defer mutationRows.Close()
+	for mutationRows.Next() {
+		var (
+			item     RunDebugMutation
+			oldValue []byte
+			newValue []byte
+		)
+		if err := mutationRows.Scan(
+			&item.MutationID,
+			&item.EntityID,
+			&item.Field,
+			&oldValue,
+			&newValue,
+			&item.WriterType,
+			&item.WriterID,
+			&item.HandlerStep,
+			&item.CausedByEvent,
+			&item.CreatedAt,
+		); err != nil {
+			return RunDebugReport{}, fmt.Errorf("scan run mutations: %w", err)
+		}
+		item.OldValue = append(json.RawMessage(nil), oldValue...)
+		item.NewValue = append(json.RawMessage(nil), newValue...)
+		report.Mutations = append(report.Mutations, item)
+	}
+	if err := mutationRows.Err(); err != nil {
+		return RunDebugReport{}, fmt.Errorf("read run mutations: %w", err)
+	}
+
+	if err := s.loadRunDebugRuntimeLogs(ctx, report.RunID, opts, &report); err != nil {
+		return RunDebugReport{}, err
+	}
+
+	return report, nil
+}
+
+func (s *PostgresStore) loadRunDebugRuntimeLogs(ctx context.Context, runID string, opts RunDebugQueryOptions, report *RunDebugReport) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	if report == nil {
+		return fmt.Errorf("report is required")
+	}
+	logLevels := []string{"warn", "error"}
+	if opts.LogsAllLevels {
+		logLevels = []string{"info", "warn", "error"}
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND run_id = $1::uuid
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+	`, runID, pq.Array(logLevels), opts.Component).Scan(&report.WarnErrorLogCount); err != nil {
+		return fmt.Errorf("load runtime log summary: %w", err)
+	}
+	logSummaryRows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(payload->>'log_level', ''),
+			COALESCE(payload->'details'->>'component', ''),
+			COALESCE(payload->'details'->>'action', ''),
+			COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND run_id = $1::uuid
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+		GROUP BY payload->>'log_level', payload->'details'->>'component', payload->'details'->>'action'
+		ORDER BY COUNT(*) DESC, payload->'details'->>'component', payload->'details'->>'action'
+		LIMIT 12
+	`, runID, pq.Array(logLevels), opts.Component)
+	if err != nil {
+		return fmt.Errorf("load runtime log rollup: %w", err)
+	}
+	defer logSummaryRows.Close()
+	for logSummaryRows.Next() {
+		var item RunDebugRuntimeSummary
+		if err := logSummaryRows.Scan(&item.Level, &item.Component, &item.Action, &item.Count); err != nil {
+			return fmt.Errorf("scan runtime log rollup: %w", err)
+		}
+		report.RuntimeLogSummary = append(report.RuntimeLogSummary, item)
+	}
+	if err := logSummaryRows.Err(); err != nil {
+		return fmt.Errorf("read runtime log rollup: %w", err)
+	}
+	logRows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(payload->>'log_level', ''),
+			COALESCE(payload->'details'->>'component', ''),
+			COALESCE(payload->'details'->>'action', ''),
+			COALESCE(payload->'details'->>'error', ''),
+			created_at
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND run_id = $1::uuid
+		  AND payload->>'log_level' = ANY($2::text[])
+		  AND ($3 = '' OR payload->'details'->>'component' = $3)
+		ORDER BY created_at DESC
+		LIMIT $4
+	`, runID, pq.Array(logLevels), opts.Component, opts.RuntimeLogLimit)
+	if err != nil {
+		return fmt.Errorf("load runtime logs: %w", err)
+	}
+	defer logRows.Close()
+	for logRows.Next() {
+		var item RunDebugRuntimeLog
+		if err := logRows.Scan(&item.Level, &item.Component, &item.Action, &item.Error, &item.CreatedAt); err != nil {
+			return fmt.Errorf("scan runtime logs: %w", err)
+		}
+		report.RuntimeLogs = append(report.RuntimeLogs, item)
+	}
+	if err := logRows.Err(); err != nil {
+		return fmt.Errorf("read runtime logs: %w", err)
+	}
+	return nil
+}

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -1,0 +1,194 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	runtimedeadletters "swarm/internal/runtime/deadletters"
+	"swarm/internal/testutil"
+)
+
+func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	olderRunID := uuid.NewString()
+	newerRunID := uuid.NewString()
+	olderEventID := uuid.NewString()
+	newerEventID := uuid.NewString()
+	now := time.Unix(1700000000, 0).UTC()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at, ended_at)
+		VALUES
+			($1::uuid, 'completed', $3, $4),
+			($2::uuid, 'running', $5, NULL)
+	`, olderRunID, newerRunID, now.Add(-2*time.Hour), now.Add(-90*time.Minute), now.Add(-1*time.Hour)); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $5),
+			($1::uuid, gen_random_uuid(), 'scan.completed', 'global', '{}'::jsonb, 'test', 'agent', $6),
+			($3::uuid, $4::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $7)
+	`, olderRunID, olderEventID, newerRunID, newerEventID, now.Add(-119*time.Minute), now.Add(-91*time.Minute), now.Add(-59*time.Minute)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	runs, err := pg.ListRunDebugRuns(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListRunDebugRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("ListRunDebugRuns len = %d, want 2", len(runs))
+	}
+	if runs[0].RunID != newerRunID {
+		t.Fatalf("runs[0].RunID = %q, want %q", runs[0].RunID, newerRunID)
+	}
+	if runs[0].RootEventID != newerEventID || runs[0].RootEventType != "scan.requested" {
+		t.Fatalf("runs[0] root = %#v", runs[0])
+	}
+	if runs[1].RunID != olderRunID {
+		t.Fatalf("runs[1].RunID = %q, want %q", runs[1].RunID, olderRunID)
+	}
+	if runs[1].EventCount != 2 {
+		t.Fatalf("runs[1].EventCount = %d, want 2", runs[1].EventCount)
+	}
+}
+
+func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMutations(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	targetRunID := uuid.NewString()
+	otherRunID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	otherEntityID := uuid.NewString()
+	targetEventID := uuid.NewString()
+	otherEventID := uuid.NewString()
+	now := time.Unix(1700000000, 0).UTC()
+
+	for _, runID := range []string{targetRunID, otherRunID} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES ($1::uuid, 'running', $2)
+		`, runID, now.Add(-5*time.Minute)); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'scan.requested', $3::uuid, 'global', '{}'::jsonb, 'test', 'agent', $4),
+			($5::uuid, $6::uuid, 'scan.requested', $7::uuid, 'global', '{}'::jsonb, 'test', 'agent', $8)
+	`, targetRunID, targetEventID, targetEntityID, now.Add(-4*time.Minute), otherRunID, otherEventID, otherEntityID, now.Add(-3*time.Minute)); err != nil {
+		t.Fatalf("seed root events: %v", err)
+	}
+
+	insertRuntimeLog := func(runID string, payloadRunID string, component string, action string, createdAt time.Time) {
+		t.Helper()
+		payload, err := json.Marshal(map[string]any{
+			"log_level": "warn",
+			"message":   action,
+			"details": map[string]any{
+				"run_id":    payloadRunID,
+				"component": component,
+				"action":    action,
+				"error":     action + "-error",
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal runtime log payload: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			)
+			VALUES ($1::uuid, gen_random_uuid(), 'platform.runtime_log', 'global', $2::jsonb, 'test', 'agent', $3)
+		`, runID, string(payload), createdAt); err != nil {
+			t.Fatalf("seed runtime log for run %s: %v", runID, err)
+		}
+	}
+
+	insertRuntimeLog(targetRunID, otherRunID, "scheduler", "canonical-owner", now)
+	insertRuntimeLog(otherRunID, targetRunID, "scheduler", "payload-only", now.Add(1*time.Minute))
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', $4::jsonb, $5::jsonb, $3::uuid, 'platform', 'runner', 'step-a', $6),
+			($7::uuid, $8::uuid, 'current_state', $10::jsonb, $11::jsonb, $9::uuid, 'platform', 'runner', 'step-b', $12)
+	`, targetRunID, targetEntityID, targetEventID, `"queued"`, `"running"`, now.Add(2*time.Minute), otherRunID, otherEntityID, otherEventID, `"queued"`, `"failed"`, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'delivered', $3, $4)
+	`, targetRunID, targetEventID, now.Add(10*time.Second), now.Add(5*time.Second)); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if err := runtimedeadletters.Insert(ctx, db, runtimedeadletters.Record{
+		OriginalEventID: targetEventID,
+		OriginalEvent:   "scan.requested",
+		EntityID:        targetEntityID,
+		FailureType:     "handler_error",
+		ErrorMessage:    "boom",
+		HandlerNode:     "node-a",
+		Timestamp:       now.Add(4 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("seed dead letter: %v", err)
+	}
+
+	report, err := pg.LoadRunDebugReport(ctx, targetRunID, RunDebugQueryOptions{
+		LogsAllLevels:   false,
+		Component:       "scheduler",
+		EventLimit:      10,
+		MutationLimit:   10,
+		RuntimeLogLimit: 10,
+		DeadLetterLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport: %v", err)
+	}
+	if report.RunID != targetRunID {
+		t.Fatalf("RunID = %q, want %q", report.RunID, targetRunID)
+	}
+	if report.RootEventID != targetEventID {
+		t.Fatalf("RootEventID = %q, want %q", report.RootEventID, targetEventID)
+	}
+	if report.WarnErrorLogCount != 1 {
+		t.Fatalf("WarnErrorLogCount = %d, want 1", report.WarnErrorLogCount)
+	}
+	if len(report.RuntimeLogs) != 1 {
+		t.Fatalf("RuntimeLogs len = %d, want 1", len(report.RuntimeLogs))
+	}
+	if got := report.RuntimeLogs[0]; got.Component != "scheduler" || got.Action != "canonical-owner" {
+		t.Fatalf("RuntimeLogs[0] = %#v", got)
+	}
+	if len(report.Mutations) != 1 {
+		t.Fatalf("Mutations len = %d, want 1", len(report.Mutations))
+	}
+	if got := report.Mutations[0]; got.EntityID != targetEntityID || got.Field != "current_state" || got.WriterType != "platform" || got.WriterID != "runner" {
+		t.Fatalf("Mutations[0] = %#v", got)
+	}
+	if len(report.DeadLetters) != 1 {
+		t.Fatalf("DeadLetters len = %d, want 1", len(report.DeadLetters))
+	}
+	if len(report.Deliveries) != 1 {
+		t.Fatalf("Deliveries len = %d, want 1", len(report.Deliveries))
+	}
+}


### PR DESCRIPTION
## Summary

Adds one store-backed canonical run-debug read surface for run-scoped reads across runs, events, mutations, and runtime logs, and moves `swarm status` off its bespoke direct SQL report onto that owner.

Closes #344.
Related to #345.

## What changed

- added `internal/store/run_debug_read_surface.go` as the canonical run-debug read owner for:
  - latest-run resolution
  - run list summaries
  - run detail aggregation
  - run-scoped events
  - run-scoped mutations
  - run-scoped runtime-log summaries and recent logs
- moved `cmd/swarm status` to consume that store owner instead of reconstructing run truth with local SQL joins
- surfaced recent mutations in `swarm status` JSON/text output so the supported consumer path now exercises the canonical mutation read too
- added focused store and CLI regression coverage for canonical `run_id` scoping and run-debug aggregation
- repaired watchlist state by mapping active issue `#344` into `run_scoped_operator_identity`

## Why this is needed

The persisted flight-recorder foundation from `#4` is present, but there was still no canonical run-scoped read owner above it. That left the primary supported consumer path (`swarm status`) reconstructing run truth directly from raw tables. This PR establishes the first canonical run-debug read owner so later surfaces can depend on one store-backed source of truth instead of inventing more local aggregations.

## Scope

In scope:
- canonical run-debug read ownership above persisted runs / events / entity mutations / runtime-log facts
- moving the primary supported CLI consumer onto that owner
- focused proof for canonical `run_id` scoping across runtime logs and mutations

Out of scope:
- builder live run-stream adoption in `#345`
- broader operator observability contract work from adjacent closed stream `#131`
- reopening the persisted foundation work from `#4`

## Spec refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `flight_recorder`
  - `runs_list`
  - `run_detail`
  - `run_events`
  - `run_mutations`
- `docs/specs/swarm-platform/platform/FLIGHT-RECORDER.md`

## Tests

- `go test ./internal/store -run 'TestRunDebugReadSurface_' -count=1`
- `go test ./cmd/swarm -run 'Test(PrintRunStatusReport|LoadRunStatusReport_)' -count=1`
- `go test ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual risk

- `#345` still owns the live builder run-stream reconstruction follow-on; this PR only closes the approved first slice for the store-backed run-debug read owner.
- Generic dashboard observability readers remain lower-level table readers and are not being widened into this aggregate owner in this PR.