### PR TITLE
[agent-b][issue #360] Remove receipt retry-owner compatibility bridge

### DIFF
--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -40,6 +40,10 @@ active_issues:
     title: Legacy compatibility removal wave
     maps_to:
       - legacy_compatibility_removal
+  - id: 360
+    title: Remove receipt retry-owner and delivery backfill compatibility from pending-delivery hot path
+    maps_to:
+      - legacy_compatibility_removal
   - id: 173
     title: Completed-seam hygiene with canonical-owner notes and reusable invariant suites
     maps_to:
@@ -83,6 +87,7 @@ nodes:
       - 157
       - 158
       - 159
+      - 360
     common_framing_mistakes:
       too_broad:
         - delete all legacy code

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -70,9 +70,6 @@ func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID s
 	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
 		return nil, err
 	}
-	if err := s.normalizeLegacyAgentRetryOwners(ctx, agentID, since); err != nil {
-		return nil, err
-	}
 	return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
 }
 
@@ -97,9 +94,6 @@ func (s *PostgresStore) ListPendingSubscribedEvents(
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
 	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
-		return nil, err
-	}
-	if err := s.normalizeLegacyAgentRetryOwners(ctx, agentID, since); err != nil {
 		return nil, err
 	}
 	return s.listPendingSubscribedEventsSpec(ctx, agentID, subscriptions, since, limit)
@@ -140,15 +134,6 @@ type lockedAgentDelivery struct {
 	found           bool
 }
 
-type lockedAgentReceiptState struct {
-	status      runtimemanager.ReceiptStatus
-	retryCount  int
-	reasonCode  string
-	errorText   string
-	processedAt time.Time
-	found       bool
-}
-
 type deliveryBackedTerminalTransitionRequest struct {
 	reasonCode   string
 	errorText    string
@@ -156,10 +141,6 @@ type deliveryBackedTerminalTransitionRequest struct {
 }
 
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
-	}
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
@@ -172,10 +153,7 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 			return err
 		}
 		if !delivery.found {
-			delivery, err = s.ensureAgentDeliveryRetryOwnerTx(ctx, caps, tx, eventID, agentID)
-			if err != nil {
-				return err
-			}
+			return fmt.Errorf("upsert event receipt: delivery row required for event %s agent %s", strings.TrimSpace(eventID), strings.TrimSpace(agentID))
 		}
 		state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
 		if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
@@ -298,199 +276,6 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 		RetryCount: state.retryCount,
 		Error:      state.errorText,
 	}, nil
-}
-
-func (s *PostgresStore) ensureAgentDeliveryRetryOwnerTx(
-	ctx context.Context,
-	caps StoreSchemaCapabilities,
-	tx *sql.Tx,
-	eventID, agentID string,
-) (lockedAgentDelivery, error) {
-	receipt, err := s.lockAgentReceiptStateTx(ctx, tx, eventID, agentID)
-	if err != nil {
-		return lockedAgentDelivery{}, err
-	}
-	if err := s.insertEventDeliveriesSpec(ctx, caps, tx, eventID, []string{agentID}); err != nil {
-		return lockedAgentDelivery{}, err
-	}
-	delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
-	if err != nil {
-		return lockedAgentDelivery{}, err
-	}
-	if !delivery.found {
-		return lockedAgentDelivery{}, fmt.Errorf("ensure agent delivery retry owner: event %s not found", strings.TrimSpace(eventID))
-	}
-	if err := s.backfillLegacyAgentDeliveryFromReceiptTx(ctx, tx, eventID, agentID, &delivery, receipt); err != nil {
-		return lockedAgentDelivery{}, err
-	}
-	return delivery, nil
-}
-
-func (s *PostgresStore) lockAgentReceiptStateTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	eventID, agentID string,
-) (lockedAgentReceiptState, error) {
-	var (
-		sideEffects []byte
-		receipt     lockedAgentReceiptState
-	)
-	err := tx.QueryRowContext(ctx, `
-		SELECT
-			COALESCE(side_effects, '{}'::jsonb),
-			COALESCE(reason_code, ''),
-			processed_at
-		FROM event_receipts
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-		FOR UPDATE
-	`, eventID, agentID).Scan(&sideEffects, &receipt.reasonCode, &receipt.processedAt)
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		return lockedAgentReceiptState{}, nil
-	case err != nil:
-		return lockedAgentReceiptState{}, fmt.Errorf("lock event receipt row: %w", err)
-	}
-	payload, err := decodeAgentReceiptSideEffects(sideEffects)
-	if err != nil {
-		return lockedAgentReceiptState{}, fmt.Errorf("decode event receipt side effects: %w", err)
-	}
-	receipt.status = payload.ManagerStatus
-	receipt.retryCount = payload.RetryCount
-	receipt.errorText = payload.Error
-	if strings.TrimSpace(payload.ReasonCode) != "" {
-		receipt.reasonCode = payload.ReasonCode
-	}
-	if strings.TrimSpace(receipt.reasonCode) == "" {
-		receipt.reasonCode = managerReceiptReasonCode(receipt.status, receipt.errorText)
-	}
-	receipt.found = true
-	return receipt, nil
-}
-
-func legacyAgentDeliveryCode(status runtimemanager.ReceiptStatus) string {
-	switch status {
-	case runtimemanager.ReceiptStatusProcessed:
-		return "delivered"
-	case runtimemanager.ReceiptStatusError:
-		return "failed"
-	case runtimemanager.ReceiptStatusDeadLetter:
-		return "dead_letter"
-	default:
-		return ""
-	}
-}
-
-func (s *PostgresStore) backfillLegacyAgentDeliveryFromReceiptTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	eventID, agentID string,
-	delivery *lockedAgentDelivery,
-	receipt lockedAgentReceiptState,
-) error {
-	if delivery == nil || !delivery.found || !receipt.found {
-		return nil
-	}
-	deliveryCode := legacyAgentDeliveryCode(receipt.status)
-	if deliveryCode == "" {
-		return fmt.Errorf("backfill legacy agent delivery: invalid receipt status %q", receipt.status)
-	}
-	needsBackfill := delivery.retryCount < receipt.retryCount
-	if !needsBackfill && delivery.retryCount == receipt.retryCount {
-		switch strings.TrimSpace(delivery.status) {
-		case "", "pending", "in_progress":
-			needsBackfill = true
-		}
-	}
-	if !needsBackfill {
-		return nil
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET
-			status = $3,
-			retry_count = $4,
-			reason_code = NULLIF($5, ''),
-			last_error = NULLIF($6, ''),
-			active_session_id = NULL,
-			delivered_at = $7
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = $2
-	`, eventID, agentID, deliveryCode, receipt.retryCount, receipt.reasonCode, receipt.errorText, receipt.processedAt); err != nil {
-		return fmt.Errorf("backfill legacy agent delivery: %w", err)
-	}
-	delivery.retryCount = receipt.retryCount
-	delivery.status = deliveryCode
-	delivery.activeSessionID = ""
-	return nil
-}
-
-func (s *PostgresStore) normalizeLegacyAgentRetryOwners(ctx context.Context, agentID string, since time.Time) error {
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT r.event_id::text
-		FROM event_receipts r
-		INNER JOIN events e ON e.event_id = r.event_id
-		LEFT JOIN event_deliveries d
-			ON d.event_id = r.event_id
-			AND d.subscriber_type = 'agent'
-			AND d.subscriber_id = r.subscriber_id
-		WHERE r.subscriber_type = 'agent'
-		  AND r.subscriber_id = $1
-		  AND ($2::timestamptz IS NULL OR e.created_at >= $2::timestamptz)
-		  AND d.delivery_id IS NULL
-	`, agentID, pendingDeliverySinceArg(since))
-	if err != nil {
-		return fmt.Errorf("query legacy agent retry owners: %w", err)
-	}
-	defer rows.Close()
-
-	var eventIDs []string
-	for rows.Next() {
-		var eventID string
-		if err := rows.Scan(&eventID); err != nil {
-			return fmt.Errorf("scan legacy agent retry owner event: %w", err)
-		}
-		eventIDs = append(eventIDs, strings.TrimSpace(eventID))
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate legacy agent retry owners: %w", err)
-	}
-	if len(eventIDs) == 0 {
-		return nil
-	}
-
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
-	}
-	for _, eventID := range eventIDs {
-		if err := withEventStoreRetry(ctx, nil, func() error {
-			tx, err := s.DB.BeginTx(ctx, nil)
-			if err != nil {
-				return fmt.Errorf("begin legacy agent retry owner tx: %w", err)
-			}
-			defer func() { _ = tx.Rollback() }()
-
-			delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
-			if err != nil {
-				return err
-			}
-			if !delivery.found {
-				if _, err := s.ensureAgentDeliveryRetryOwnerTx(ctx, caps, tx, eventID, agentID); err != nil {
-					return err
-				}
-			}
-			if err := tx.Commit(); err != nil {
-				return fmt.Errorf("commit legacy agent retry owner tx: %w", err)
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *PostgresStore) updateAgentDeliveryRowTx(

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -420,19 +420,12 @@ func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, age
 			AND r.subscriber_type = 'agent'
 			AND r.subscriber_id = $1
 		WHERE e.created_at >= $2
-		  AND (
-				NOT EXISTS (
-					SELECT 1
-					FROM event_deliveries d_any
-					WHERE d_any.event_id = e.event_id
-				)
-				OR EXISTS (
-					SELECT 1
-					FROM event_deliveries d_me
-					WHERE d_me.event_id = e.event_id
-					  AND d_me.subscriber_type = 'agent'
-					  AND d_me.subscriber_id = $1
-				)
+		  AND EXISTS (
+				SELECT 1
+				FROM event_deliveries d_me
+				WHERE d_me.event_id = e.event_id
+				  AND d_me.subscriber_type = 'agent'
+				  AND d_me.subscriber_id = $1
 			)
 		  AND `+canonicalPendingDeliveryPredicateSQL("d", "r")+`
 		ORDER BY e.created_at ASC

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -24,6 +24,9 @@ func TestUpsertEventReceipt_DeadLettersAfterOneRetry_V2(t *testing.T) {
 	ctx := context.Background()
 	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
 	evt := seedEvent(t, ctx, pg, entityID, "test.retry_upsert")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
 
 	for i := 1; i <= 2; i++ {
 		if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, "error", "boom"); err != nil {
@@ -119,101 +122,19 @@ func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *tes
 	}
 }
 
-func TestUpsertEventReceipt_AlignsRetryOwnershipAcrossDeliveryBackedAndReceiptOnly_V2(t *testing.T) {
-	tests := []struct {
-		name           string
-		insertDelivery bool
-	}{
-		{name: "delivery_backed", insertDelivery: true},
-		{name: "receipt_only_normalized_to_delivery", insertDelivery: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pg, cleanup := newTestPostgresStore(t)
-			defer cleanup()
-
-			ctx := context.Background()
-			entityID, agentID := seedEntityAndAgent(t, ctx, pg)
-			evt := seedEvent(t, ctx, pg, entityID, "test.retry_alignment."+tt.name)
-			if tt.insertDelivery {
-				if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
-					t.Fatalf("insert deliveries: %v", err)
-				}
-			}
-
-			if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
-				t.Fatalf("upsert retryable error: %v", err)
-			}
-
-			var (
-				deliveryStatus string
-				deliveryRetry  int
-				reasonCode     string
-				managerStatus  string
-				receiptRetry   int
-			)
-			if err := pg.DB.QueryRowContext(ctx, `
-				SELECT
-					COALESCE(d.status, ''),
-					COALESCE(d.retry_count, 0),
-					COALESCE(d.reason_code, ''),
-					COALESCE(r.side_effects->>'manager_status', ''),
-					COALESCE((r.side_effects->>'retry_count')::int, 0)
-				FROM event_deliveries d
-				INNER JOIN event_receipts r
-					ON r.event_id = d.event_id
-					AND r.subscriber_type = 'agent'
-					AND r.subscriber_id = d.subscriber_id
-				WHERE d.event_id = $1::uuid
-				  AND d.subscriber_type = 'agent'
-				  AND d.subscriber_id = $2
-			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
-				t.Fatalf("query retryable aligned state: %v", err)
-			}
-			if deliveryStatus != "failed" || deliveryRetry != 1 || reasonCode != "handler_error" || managerStatus != "error" || receiptRetry != 1 {
-				t.Fatalf("retryable aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
-			}
-
-			if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
-				t.Fatalf("upsert exhausted error: %v", err)
-			}
-			if err := pg.DB.QueryRowContext(ctx, `
-				SELECT
-					COALESCE(d.status, ''),
-					COALESCE(d.retry_count, 0),
-					COALESCE(d.reason_code, ''),
-					COALESCE(r.side_effects->>'manager_status', ''),
-					COALESCE((r.side_effects->>'retry_count')::int, 0)
-				FROM event_deliveries d
-				INNER JOIN event_receipts r
-					ON r.event_id = d.event_id
-					AND r.subscriber_type = 'agent'
-					AND r.subscriber_id = d.subscriber_id
-				WHERE d.event_id = $1::uuid
-				  AND d.subscriber_type = 'agent'
-				  AND d.subscriber_id = $2
-			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
-				t.Fatalf("query exhausted aligned state: %v", err)
-			}
-			if deliveryStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" || managerStatus != "dead_letter" || receiptRetry != 2 {
-				t.Fatalf("exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
-			}
-		})
-	}
-}
-
-func TestUpsertEventReceipt_PreservesLegacyReceiptOnlyRetryHistory_V2(t *testing.T) {
+func TestUpsertEventReceipt_AlignsRetryOwnershipOnCanonicalDelivery_V2(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()
 
 	ctx := context.Background()
 	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
-	evt := seedEvent(t, ctx, pg, entityID, "test.retry_legacy_receipt_only")
-	insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+	evt := seedEvent(t, ctx, pg, entityID, "test.retry_alignment.delivery_backed")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
 
 	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
-		t.Fatalf("upsert exhausted legacy receipt-only error: %v", err)
+		t.Fatalf("upsert retryable error: %v", err)
 	}
 
 	var (
@@ -239,10 +160,85 @@ func TestUpsertEventReceipt_PreservesLegacyReceiptOnlyRetryHistory_V2(t *testing
 		  AND d.subscriber_type = 'agent'
 		  AND d.subscriber_id = $2
 	`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
-		t.Fatalf("query legacy exhausted aligned state: %v", err)
+		t.Fatalf("query retryable aligned state: %v", err)
+	}
+	if deliveryStatus != "failed" || deliveryRetry != 1 || reasonCode != "handler_error" || managerStatus != "error" || receiptRetry != 1 {
+		t.Fatalf("retryable aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
+	}
+
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert exhausted error: %v", err)
+	}
+
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.reason_code, ''),
+			COALESCE(r.side_effects->>'manager_status', ''),
+			COALESCE((r.side_effects->>'retry_count')::int, 0)
+		FROM event_deliveries d
+		INNER JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode, &managerStatus, &receiptRetry); err != nil {
+		t.Fatalf("query exhausted aligned state: %v", err)
 	}
 	if deliveryStatus != "dead_letter" || deliveryRetry != 2 || reasonCode != "retry_exhausted" || managerStatus != "dead_letter" || receiptRetry != 2 {
-		t.Fatalf("legacy exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
+		t.Fatalf("exhausted aligned state mismatch: delivery=%q retry=%d reason=%q manager=%q receiptRetry=%d", deliveryStatus, deliveryRetry, reasonCode, managerStatus, receiptRetry)
+	}
+}
+
+func TestUpsertEventReceipt_FailsClosedOnLegacyReceiptOnlyRetryHistory_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.retry_legacy_receipt_only")
+	insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+
+	err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom")
+	if err == nil {
+		t.Fatal("expected legacy receipt-only retry history write to fail closed")
+	}
+	if !strings.Contains(err.Error(), "delivery row required") {
+		t.Fatalf("upsert legacy receipt-only error = %v, want delivery row required", err)
+	}
+
+	var deliveryCount int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryCount); err != nil {
+		t.Fatalf("query delivery count: %v", err)
+	}
+	if deliveryCount != 0 {
+		t.Fatalf("delivery_count = %d, want 0", deliveryCount)
+	}
+
+	var managerStatus string
+	var receiptRetry int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(side_effects->>'manager_status', ''),
+			COALESCE((side_effects->>'retry_count')::int, 0)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&managerStatus, &receiptRetry); err != nil {
+		t.Fatalf("query receipt after fail-closed write: %v", err)
+	}
+	if managerStatus != "error" || receiptRetry != 1 {
+		t.Fatalf("legacy receipt mutated after fail-closed write: status=%q retry=%d", managerStatus, receiptRetry)
 	}
 }
 
@@ -466,6 +462,9 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 	ctx := context.Background()
 	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
 	evt := seedEvent(t, ctx, pg, entityID, "test.pending_subscribed")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
 
 	since := time.Now().Add(-2 * time.Hour)
 	subs := []events.EventType{evt.Type}
@@ -502,7 +501,7 @@ func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
 	}
 }
 
-func TestPendingAgentEvents_NormalizesLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
+func TestPendingAgentEvents_IgnoreLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
 	tests := []struct {
 		name       string
 		subscribed bool
@@ -534,31 +533,57 @@ func TestPendingAgentEvents_NormalizesLegacyReceiptOnlyRetryOwner_V2(t *testing.
 			if err != nil {
 				t.Fatalf("list pending legacy receipt-only event: %v", err)
 			}
-			if len(evts) != 1 || evts[0].ID != evt.ID {
-				t.Fatalf("pending legacy receipt-only event mismatch: got %d events, want 1 (%s)", len(evts), evt.ID)
+			if len(evts) != 0 {
+				t.Fatalf("pending legacy receipt-only event mismatch: got %d events, want 0", len(evts))
 			}
 
-			var (
-				deliveryStatus string
-				deliveryRetry  int
-				reasonCode     string
-			)
+			var deliveryCount int
 			if err := pg.DB.QueryRowContext(ctx, `
-				SELECT
-					COALESCE(status, ''),
-					COALESCE(retry_count, 0),
-					COALESCE(reason_code, '')
+				SELECT COUNT(*)
 				FROM event_deliveries
 				WHERE event_id = $1::uuid
 				  AND subscriber_type = 'agent'
 				  AND subscriber_id = $2
-			`, evt.ID, agentID).Scan(&deliveryStatus, &deliveryRetry, &reasonCode); err != nil {
-				t.Fatalf("query normalized legacy delivery: %v", err)
+			`, evt.ID, agentID).Scan(&deliveryCount); err != nil {
+				t.Fatalf("query delivery count: %v", err)
 			}
-			if deliveryStatus != "failed" || deliveryRetry != 1 || reasonCode != "handler_error" {
-				t.Fatalf("normalized legacy delivery mismatch: status=%q retry=%d reason=%q", deliveryStatus, deliveryRetry, reasonCode)
+			if deliveryCount != 0 {
+				t.Fatalf("delivery_count = %d, want 0", deliveryCount)
 			}
 		})
+	}
+}
+
+func TestListPendingAgentDeliveryFacts_IgnoresLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.pending_facts.legacy_receipt_only")
+	insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+
+	factsByAgent, err := pg.ListPendingAgentDeliveryFacts(ctx, []string{agentID}, time.Now().Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingAgentDeliveryFacts: %v", err)
+	}
+	facts := factsByAgent[agentID]
+	if facts.PendingCount != 0 || facts.OldestPendingAgeSec != 0 {
+		t.Fatalf("legacy receipt-only pending facts = %+v, want zero", facts)
+	}
+
+	var deliveryCount int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&deliveryCount); err != nil {
+		t.Fatalf("query delivery count: %v", err)
+	}
+	if deliveryCount != 0 {
+		t.Fatalf("delivery_count = %d, want 0", deliveryCount)
 	}
 }
 

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -711,6 +711,11 @@ func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
 	segment := seedEvent(t, ctx, pg, entityID, "review.ready")
 	tooDeep := seedEvent(t, ctx, pg, entityID, "scoring/a/b")
 	invalidPattern := seedEvent(t, ctx, pg, entityID, "budget.alert")
+	for _, eventID := range []string{deep.ID, segment.ID, tooDeep.ID, invalidPattern.ID} {
+		if err := pg.InsertEventDeliveries(ctx, eventID, []string{agentID}); err != nil {
+			t.Fatalf("insert deliveries for %s: %v", eventID, err)
+		}
+	}
 
 	since := time.Now().Add(-2 * time.Hour)
 	tests := []struct {

--- a/internal/store/pending_delivery_read_surface.go
+++ b/internal/store/pending_delivery_read_surface.go
@@ -147,11 +147,6 @@ func (s *PostgresStore) ListPendingAgentDeliveryFacts(ctx context.Context, agent
 	if len(normalized) == 0 {
 		return map[string]PendingAgentDeliveryFacts{}, nil
 	}
-	for _, agentID := range normalized {
-		if err := s.normalizeLegacyAgentRetryOwners(ctx, agentID, since); err != nil {
-			return nil, err
-		}
-	}
 	records, err := s.listPendingAgentDeliveryFactRecordsSpec(ctx, normalized, since)
 	if err != nil {
 		return nil, err

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3011,7 +3011,8 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	broadcastID := uuid.NewString()
 	directOtherID := uuid.NewString()
 	directSelfID := uuid.NewString()
-	for idx, id := range []string{broadcastID, directOtherID, directSelfID} {
+	noDeliveryID := uuid.NewString()
+	for idx, id := range []string{broadcastID, directOtherID, directSelfID, noDeliveryID} {
 		if err := pg.AppendEvent(ctx, events.Event{
 			ID:          id,
 			Type:        "inbound.alert",
@@ -3026,9 +3027,10 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (event_id, subscriber_type, subscriber_id, created_at)
 		VALUES
-			($1::uuid, 'agent', 'a2', now()),
-			($2::uuid, 'agent', 'a1', now())
-	`, directOtherID, directSelfID); err != nil {
+			($1::uuid, 'agent', 'a1', now()),
+			($2::uuid, 'agent', 'a2', now()),
+			($3::uuid, 'agent', 'a1', now())
+	`, broadcastID, directOtherID, directSelfID); err != nil {
 		t.Fatalf("seed deliveries: %v", err)
 	}
 
@@ -3054,6 +3056,9 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	}
 	if _, ok := gotSet[directOtherID]; ok {
 		t.Fatalf("did not expect direct-other event %s in subscribed backlog, got=%v", directOtherID, gotSet)
+	}
+	if _, ok := gotSet[noDeliveryID]; ok {
+		t.Fatalf("did not expect delivery-less event %s in subscribed backlog, got=%v", noDeliveryID, gotSet)
 	}
 }
 


### PR DESCRIPTION
## Human Summary
Remove the live receipt retry-owner / delivery-backfill compatibility bridge from the pending-delivery and receipt hot path. Pending-delivery reads now use the canonical delivery/receipt owner directly, and receipt writes fail closed instead of manufacturing or repairing delivery ownership from receipt state.

Closes #360
Part of #157

## What Changed
- removed `normalizeLegacyAgentRetryOwners(...)` from:
  - `ListPendingEventsForAgent(...)`
  - `ListPendingSubscribedEvents(...)`
  - `ListPendingAgentDeliveryFacts(...)`
- removed the live bridge helpers from `internal/store/event_receipt_store.go`:
  - `ensureAgentDeliveryRetryOwnerTx(...)`
  - `backfillLegacyAgentDeliveryFromReceiptTx(...)`
  - the now-dead receipt-state lock helper used only by that bridge
- changed `upsertAgentReceiptSpec(...)` to fail closed when the canonical agent delivery row is missing instead of manufacturing or backfilling delivery ownership from receipt state
- rewrote legacy bridge regressions to canonical-owner regressions and added a delivery-facts proof for legacy receipt-only state

## Why This Is Needed
The current seam was still letting receipt state front the canonical delivery/receipt owner in both pending-delivery reads and receipt writes. That preserved a live compatibility boundary in a store hot path and kept ownership ambiguous. This PR removes that bridge and leaves one canonical owner path in the touched seam.

## Scope Boundaries
In scope:
- receipt retry-owner / delivery-backfill compatibility removal in pending-delivery reads and receipt writes
- canonical fail-closed behavior when delivery ownership is missing

Out of scope:
- explicit schema-capability boundary cleanup
- task-conversation visibility mixed-rollout cleanup
- broad event store redesign

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: engine.event_loop.lifecycle.step_6.agent_delivery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: engine.event_loop.crash_recovery`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: engine.error_model.handler_execution_failure.retry_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.tables.event_deliveries`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_tables.tables.event_receipts`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: run_model.lifecycle.completion`

## Tests Run
- `go test ./internal/store -run 'Test(UpsertEventReceipt_AlignsRetryOwnershipOnCanonicalDelivery_V2|UpsertEventReceipt_FailsClosedOnLegacyReceiptOnlyRetryHistory_V2|PendingAgentEvents_IgnoreLegacyReceiptOnlyRetryOwner_V2|ListPendingAgentDeliveryFacts_IgnoresLegacyReceiptOnlyRetryOwner_V2|ListPendingAgentDeliveryFacts_AlignsWithCanonicalPendingStates_V2|ListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending|EventReceipts_RetryToDeadLetter_AndPendingQueries)$' -count=1`
- `go test ./internal/store ./internal/runtime ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
- Parent `#157` remains open for at least two sibling classes:
  - task-conversation visibility mixed-rollout cleanup
  - broader schema-capability boundary cleanup / decomposition follow-up
- This PR does not claim closure for those sibling classes.

## Follow-Up
- Continue parent `#157` with the remaining sibling compatibility classes after this child merges.
