### PR TITLE
[agent-c][issue #345] Move builder run debug stream onto canonical owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -639,7 +639,13 @@ func runStatusReportFromStore(detail store.RunDebugReport) runStatusReport {
 		report.RuntimeLogSummary = append(report.RuntimeLogSummary, runStatusRuntimeSummary(item))
 	}
 	for _, item := range detail.RuntimeLogs {
-		report.RuntimeLogs = append(report.RuntimeLogs, runStatusRuntimeLog(item))
+		report.RuntimeLogs = append(report.RuntimeLogs, runStatusRuntimeLog{
+			Level:     item.Level,
+			Component: item.Component,
+			Action:    item.Action,
+			Error:     item.Error,
+			CreatedAt: item.CreatedAt,
+		})
 	}
 	for _, item := range detail.EventCounts {
 		report.EventCounts = append(report.EventCounts, runStatusEventCount(item))
@@ -1188,6 +1194,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		CurrentSource:  sourceProvider,
 		CurrentRuntime: runtimeProvider,
 		ProjectControl: projectControl,
+		RunDebug:       stores.Postgres,
 	})
 	return dashboardserver.Options{
 		Health:        healthFn,

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -45,6 +45,10 @@ active_issues:
     title: Add one canonical run-debug read surface for runs, events, mutations, and runtime logs
     maps_to:
       - run_scoped_operator_identity
+  - id: 345
+    title: Move builder run event streams onto canonical run-bound diagnostics
+    maps_to:
+      - run_scoped_operator_identity
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -110,9 +114,11 @@ nodes:
     known_manifestations:
       - run_id drift across replay and diagnostics
       - API/dashboard query ownership not aligned on the same run-scoped identity
+      - builder live run/debug streams reconstruct operator-visible run truth from in-memory state and fresh timestamps instead of consuming canonical run-bound diagnostics
     representative_issues:
       - 148
       - 344
+      - 345
     common_framing_mistakes:
       too_broad:
         - run scoping is inconsistent

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -10,6 +10,7 @@ import (
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
 )
 
 type HealthChecker func(ctx context.Context) (map[string]any, error)
@@ -28,6 +29,10 @@ type RuntimeController interface {
 type SourceProvider func() semanticview.Source
 
 type RuntimeProvider func() *runtimepkg.Runtime
+
+type RunDebugReader interface {
+	LoadRunDebugReport(ctx context.Context, runID string, opts store.RunDebugQueryOptions) (store.RunDebugReport, error)
+}
 
 type ProjectStatus struct {
 	ProjectDir      string `json:"project_dir,omitempty"`
@@ -55,6 +60,7 @@ type Options struct {
 	CurrentSource  SourceProvider
 	CurrentRuntime RuntimeProvider
 	ProjectControl ProjectController
+	RunDebug       RunDebugReader
 }
 
 type Request struct {
@@ -181,6 +187,7 @@ func NewHandler(opts Options) http.Handler {
 				h.runtime.ResumeIngress()
 				return nil
 			},
+			opts.RunDebug,
 		)
 	}
 	return h

--- a/internal/builder/run_debug_stream.go
+++ b/internal/builder/run_debug_stream.go
@@ -64,10 +64,21 @@ func (h *runHub) runIDsForRuntimeEntry(entry interface{ EffectiveEntityID() stri
 	return runIDs
 }
 
-func (h *runHub) canonicalReplay(ctx context.Context, runID string) []RunEventEnvelope {
+func (h *runHub) correlatedRunIDsForRuntimeEntry(entry interface{ EffectiveEntityID() string }) []string {
+	if h == nil {
+		return nil
+	}
+	entityID := strings.TrimSpace(entry.EffectiveEntityID())
+	if entityID == "" {
+		return nil
+	}
+	return h.runIDsForRuntimeEntry(entry)
+}
+
+func (h *runHub) canonicalReplay(ctx context.Context, runID string) ([]RunEventEnvelope, runDebugStreamState) {
 	report, ok := h.loadRunDebugReport(ctx, runID)
 	if !ok {
-		return nil
+		return nil, runDebugStreamState{}
 	}
 	return projectCanonicalRunDebugReplay(report)
 }
@@ -113,12 +124,12 @@ func (h *runHub) loadRunDebugReport(ctx context.Context, runID string) (store.Ru
 	return report, true
 }
 
-func projectCanonicalRunDebugReplay(report store.RunDebugReport) []RunEventEnvelope {
+func projectCanonicalRunDebugReplay(report store.RunDebugReport) ([]RunEventEnvelope, runDebugStreamState) {
 	state := runDebugStreamState{
 		eventIDs:      map[string]struct{}{},
 		runtimeLogIDs: map[string]struct{}{},
 	}
-	return projectCanonicalRunDebugDelta(report, &state)
+	return projectCanonicalRunDebugDelta(report, &state), state
 }
 
 func projectCanonicalRunDebugDelta(report store.RunDebugReport, state *runDebugStreamState) []RunEventEnvelope {

--- a/internal/builder/run_debug_stream.go
+++ b/internal/builder/run_debug_stream.go
@@ -1,0 +1,342 @@
+package builder
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"swarm/internal/store"
+)
+
+const builderRunDebugReplayLimit = 128
+
+type runDebugCandidate struct {
+	key   string
+	at    time.Time
+	order int
+	event RunEventEnvelope
+}
+
+func (s runDebugStreamState) clone() runDebugStreamState {
+	out := runDebugStreamState{
+		startedKey:    s.startedKey,
+		terminalKey:   s.terminalKey,
+		eventIDs:      map[string]struct{}{},
+		runtimeLogIDs: map[string]struct{}{},
+	}
+	for key := range s.eventIDs {
+		out.eventIDs[key] = struct{}{}
+	}
+	for key := range s.runtimeLogIDs {
+		out.runtimeLogIDs[key] = struct{}{}
+	}
+	return out
+}
+
+func (h *runHub) runIDsForRuntimeEntry(entry interface{ EffectiveEntityID() string }) []string {
+	if h == nil {
+		return nil
+	}
+	entityID := strings.TrimSpace(entry.EffectiveEntityID())
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	runIDs := make([]string, 0, len(h.sessions))
+	if entityID == "" {
+		for runID, session := range h.sessions {
+			if session != nil {
+				runIDs = append(runIDs, runID)
+			}
+		}
+		sort.Strings(runIDs)
+		return runIDs
+	}
+	for runID, session := range h.sessions {
+		if session == nil {
+			continue
+		}
+		if _, ok := session.entityIDs[entityID]; ok {
+			runIDs = append(runIDs, runID)
+		}
+	}
+	sort.Strings(runIDs)
+	return runIDs
+}
+
+func (h *runHub) canonicalReplay(ctx context.Context, runID string) []RunEventEnvelope {
+	report, ok := h.loadRunDebugReport(ctx, runID)
+	if !ok {
+		return nil
+	}
+	return projectCanonicalRunDebugReplay(report)
+}
+
+func (h *runHub) syncCanonical(ctx context.Context, runID string) {
+	report, ok := h.loadRunDebugReport(ctx, runID)
+	if !ok {
+		return
+	}
+	h.mu.Lock()
+	session := h.sessions[strings.TrimSpace(runID)]
+	if session == nil {
+		h.mu.Unlock()
+		return
+	}
+	delta := projectCanonicalRunDebugDelta(report, &session.debug)
+	listeners := make([]func(RunEventEnvelope), 0, len(session.subs))
+	for _, listener := range session.subs {
+		listeners = append(listeners, listener)
+	}
+	h.mu.Unlock()
+	for _, event := range delta {
+		for _, listener := range listeners {
+			listener(event)
+		}
+	}
+}
+
+func (h *runHub) loadRunDebugReport(ctx context.Context, runID string) (store.RunDebugReport, bool) {
+	if h == nil || h.runDebug == nil {
+		return store.RunDebugReport{}, false
+	}
+	report, err := h.runDebug.LoadRunDebugReport(ctx, strings.TrimSpace(runID), store.RunDebugQueryOptions{
+		LogsAllLevels:   true,
+		EventLimit:      builderRunDebugReplayLimit,
+		MutationLimit:   1,
+		RuntimeLogLimit: builderRunDebugReplayLimit,
+		DeadLetterLimit: 1,
+	})
+	if err != nil {
+		return store.RunDebugReport{}, false
+	}
+	return report, true
+}
+
+func projectCanonicalRunDebugReplay(report store.RunDebugReport) []RunEventEnvelope {
+	state := runDebugStreamState{
+		eventIDs:      map[string]struct{}{},
+		runtimeLogIDs: map[string]struct{}{},
+	}
+	return projectCanonicalRunDebugDelta(report, &state)
+}
+
+func projectCanonicalRunDebugDelta(report store.RunDebugReport, state *runDebugStreamState) []RunEventEnvelope {
+	if state == nil {
+		state = &runDebugStreamState{eventIDs: map[string]struct{}{}, runtimeLogIDs: map[string]struct{}{}}
+	}
+	if state.eventIDs == nil {
+		state.eventIDs = map[string]struct{}{}
+	}
+	if state.runtimeLogIDs == nil {
+		state.runtimeLogIDs = map[string]struct{}{}
+	}
+	candidates := make([]runDebugCandidate, 0, 2+len(report.Events)+len(report.RuntimeLogs))
+	if started := canonicalRunStartedCandidate(report); started.key != "" && started.key != state.startedKey {
+		candidates = append(candidates, started)
+		state.startedKey = started.key
+	}
+	for i := len(report.Events) - 1; i >= 0; i-- {
+		item := report.Events[i]
+		if strings.TrimSpace(item.EventName) == "platform.runtime_log" {
+			continue
+		}
+		key := strings.TrimSpace(item.EventID)
+		if key == "" {
+			continue
+		}
+		if _, seen := state.eventIDs[key]; seen {
+			continue
+		}
+		state.eventIDs[key] = struct{}{}
+		candidates = append(candidates, canonicalEventFiredCandidate(item))
+	}
+	for i := len(report.RuntimeLogs) - 1; i >= 0; i-- {
+		item := report.RuntimeLogs[i]
+		key := strings.TrimSpace(item.EventID)
+		if key == "" {
+			key = item.CreatedAt.UTC().Format(time.RFC3339Nano) + ":" + item.Component + ":" + item.Action
+		}
+		if _, seen := state.runtimeLogIDs[key]; seen {
+			continue
+		}
+		state.runtimeLogIDs[key] = struct{}{}
+		candidates = append(candidates, canonicalRuntimeLogCandidate(item, key))
+	}
+	if terminal := canonicalRunTerminalCandidate(report); terminal.key != "" && terminal.key != state.terminalKey {
+		candidates = append(candidates, terminal)
+		state.terminalKey = terminal.key
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].at.Equal(candidates[j].at) {
+			if candidates[i].order == candidates[j].order {
+				return candidates[i].key < candidates[j].key
+			}
+			return candidates[i].order < candidates[j].order
+		}
+		return candidates[i].at.Before(candidates[j].at)
+	})
+	out := make([]RunEventEnvelope, 0, len(candidates))
+	for _, item := range candidates {
+		out = append(out, item.event)
+	}
+	return out
+}
+
+func canonicalRunStartedCandidate(report store.RunDebugReport) runDebugCandidate {
+	if strings.TrimSpace(report.RunID) == "" || report.StartedAt.IsZero() {
+		return runDebugCandidate{}
+	}
+	key := "run.started:" + strings.TrimSpace(report.RunID) + ":" + report.StartedAt.UTC().Format(time.RFC3339Nano)
+	return runDebugCandidate{
+		key:   key,
+		at:    report.StartedAt.UTC(),
+		order: 0,
+		event: RunEventEnvelope{
+			"id":        key,
+			"type":      "run.started",
+			"timestamp": report.StartedAt.UTC().Format(time.RFC3339),
+			"payload":   map[string]any{"run_id": strings.TrimSpace(report.RunID)},
+		},
+	}
+}
+
+func canonicalEventFiredCandidate(item store.RunDebugEvent) runDebugCandidate {
+	payload := map[string]any{
+		"event_name": strings.TrimSpace(item.EventName),
+	}
+	if source := firstNonEmpty(strings.TrimSpace(item.Source), strings.TrimSpace(item.SourceType)); source != "" {
+		payload["source"] = source
+	}
+	if raw := strings.TrimSpace(string(item.Payload)); raw != "" && raw != "{}" {
+		var decoded map[string]any
+		if json.Unmarshal(item.Payload, &decoded) == nil && decoded != nil {
+			payload["payload"] = decoded
+		}
+	}
+	event := RunEventEnvelope{
+		"id":        strings.TrimSpace(item.EventID),
+		"type":      "event.fired",
+		"timestamp": item.CreatedAt.UTC().Format(time.RFC3339),
+		"payload":   payload,
+	}
+	if entityID := strings.TrimSpace(item.EntityID); entityID != "" {
+		event["instance_id"] = entityID
+	}
+	return runDebugCandidate{
+		key:   strings.TrimSpace(item.EventID),
+		at:    item.CreatedAt.UTC(),
+		order: 1,
+		event: event,
+	}
+}
+
+func canonicalRuntimeLogCandidate(item store.RunDebugRuntimeLog, key string) runDebugCandidate {
+	payload := map[string]any{
+		"level":     strings.TrimSpace(item.Level),
+		"component": strings.TrimSpace(item.Component),
+		"action":    strings.TrimSpace(item.Action),
+	}
+	if eventType := strings.TrimSpace(item.EventType); eventType != "" {
+		payload["event_type"] = eventType
+	}
+	if agentID := strings.TrimSpace(item.AgentID); agentID != "" {
+		payload["agent_id"] = agentID
+	}
+	if errText := strings.TrimSpace(item.Error); errText != "" {
+		payload["error"] = errText
+	}
+	if raw := strings.TrimSpace(string(item.Detail)); raw != "" && raw != "{}" {
+		var decoded map[string]any
+		if json.Unmarshal(item.Detail, &decoded) == nil && decoded != nil {
+			payload["detail"] = decoded
+		}
+	}
+	event := RunEventEnvelope{
+		"id":        firstNonEmpty(strings.TrimSpace(item.EventID), key),
+		"type":      "runtime.log",
+		"timestamp": item.CreatedAt.UTC().Format(time.RFC3339),
+		"payload":   payload,
+	}
+	if entityID := strings.TrimSpace(item.EntityID); entityID != "" {
+		event["instance_id"] = entityID
+	}
+	if agentID := strings.TrimSpace(item.AgentID); agentID != "" {
+		event["node_id"] = agentID
+	}
+	return runDebugCandidate{
+		key:   key,
+		at:    item.CreatedAt.UTC(),
+		order: 2,
+		event: event,
+	}
+}
+
+func canonicalRunTerminalCandidate(report store.RunDebugReport) runDebugCandidate {
+	runID := strings.TrimSpace(report.RunID)
+	status := strings.TrimSpace(report.RunTableStatus)
+	if runID == "" || report.EndedAt == nil || report.EndedAt.IsZero() {
+		return runDebugCandidate{}
+	}
+	endedAt := report.EndedAt.UTC()
+	key := "run." + status + ":" + runID + ":" + endedAt.Format(time.RFC3339Nano) + ":" + strings.TrimSpace(report.ErrorSummary)
+	switch status {
+	case "completed":
+		payload := map[string]any{
+			"run_id": runID,
+			"summary": map[string]any{
+				"duration_ms":  runDurationMillis(report.StartedAt, endedAt),
+				"total_events": report.EventCount,
+				"entity_count": report.EntityCount,
+			},
+		}
+		return runDebugCandidate{
+			key:   key,
+			at:    endedAt,
+			order: 3,
+			event: RunEventEnvelope{
+				"id":        key,
+				"type":      "run.completed",
+				"timestamp": endedAt.Format(time.RFC3339),
+				"payload":   payload,
+			},
+		}
+	case "failed":
+		payload := map[string]any{"run_id": runID}
+		if errText := strings.TrimSpace(report.ErrorSummary); errText != "" {
+			payload["error"] = errText
+		}
+		return runDebugCandidate{
+			key:   key,
+			at:    endedAt,
+			order: 3,
+			event: RunEventEnvelope{
+				"id":        key,
+				"type":      "run.failed",
+				"timestamp": endedAt.Format(time.RFC3339),
+				"payload":   payload,
+			},
+		}
+	default:
+		return runDebugCandidate{}
+	}
+}
+
+func runDurationMillis(startedAt, endedAt time.Time) int64 {
+	if startedAt.IsZero() {
+		return 0
+	}
+	if endedAt.Before(startedAt) {
+		return 0
+	}
+	return endedAt.Sub(startedAt).Milliseconds()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/builder/runs.go
+++ b/internal/builder/runs.go
@@ -11,6 +11,7 @@ type runHub struct {
 	resetRuntime    func() error
 	pauseRuntime    func() error
 	resumeRuntime   func() error
+	runDebug        RunDebugReader
 
 	mu       sync.RWMutex
 	sessions map[string]*runSession
@@ -26,8 +27,16 @@ type runSession struct {
 	pendingHuman       *pendingHumanDecision
 	pendingStep        *pendingNodeAction
 	subs               map[string]func(RunEventEnvelope)
-	events             []RunEventEnvelope
+	controlEvents      []RunEventEnvelope
 	terminal           bool
+	debug              runDebugStreamState
+}
+
+type runDebugStreamState struct {
+	startedKey    string
+	terminalKey   string
+	eventIDs      map[string]struct{}
+	runtimeLogIDs map[string]struct{}
 }
 
 type pendingHumanDecision struct {

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -16,7 +16,7 @@ import (
 
 var runCompletionTimeout = 30 * time.Second
 
-func newRunHub(runtimeProvider func() *runtimepkg.Runtime, resetRuntime func() error, pauseRuntime func() error, resumeRuntime func() error) *runHub {
+func newRunHub(runtimeProvider func() *runtimepkg.Runtime, resetRuntime func() error, pauseRuntime func() error, resumeRuntime func() error, runDebug RunDebugReader) *runHub {
 	if runtimeProvider == nil {
 		return nil
 	}
@@ -25,6 +25,7 @@ func newRunHub(runtimeProvider func() *runtimepkg.Runtime, resetRuntime func() e
 		resetRuntime:    resetRuntime,
 		pauseRuntime:    pauseRuntime,
 		resumeRuntime:   resumeRuntime,
+		runDebug:        runDebug,
 		sessions:        map[string]*runSession{},
 	}
 }
@@ -49,7 +50,11 @@ func (h *runHub) startRun(ctx context.Context, runID string, inputs map[string]a
 		breakpoints:        stringSet(breakpoints),
 		trippedBreakpoints: map[string]struct{}{},
 		subs:               map[string]func(RunEventEnvelope){},
-		events:             []RunEventEnvelope{},
+		controlEvents:      []RunEventEnvelope{},
+		debug: runDebugStreamState{
+			eventIDs:      map[string]struct{}{},
+			runtimeLogIDs: map[string]struct{}{},
+		},
 	}
 	h.mu.Lock()
 	if existing := h.sessions[runID]; existing != nil {
@@ -59,7 +64,8 @@ func (h *runHub) startRun(ctx context.Context, runID string, inputs map[string]a
 		for entityID := range existing.entityIDs {
 			session.entityIDs[entityID] = struct{}{}
 		}
-		session.events = append(session.events, existing.events...)
+		session.controlEvents = append(session.controlEvents, existing.controlEvents...)
+		session.debug = existing.debug.clone()
 	}
 	h.sessions[runID] = session
 	h.mu.Unlock()
@@ -89,7 +95,7 @@ func (h *runHub) startRun(ctx context.Context, runID string, inputs map[string]a
 			CreatedAt:   time.Now().UTC(),
 		}.WithEntityID(entityID)
 		if err := rt.Bus.Publish(ctx, evt); err != nil {
-			h.emit(runID, map[string]any{
+			h.emitControl(runID, map[string]any{
 				"id":        uuid.NewString(),
 				"type":      "run.failed",
 				"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -98,24 +104,8 @@ func (h *runHub) startRun(ctx context.Context, runID string, inputs map[string]a
 			h.deleteRun(runID)
 			return err
 		}
-		h.emit(runID, map[string]any{
-			"id":          evt.ID,
-			"type":        "event.fired",
-			"timestamp":   evt.CreatedAt.Format(time.RFC3339),
-			"instance_id": entityID,
-			"payload": map[string]any{
-				"event_name": eventName,
-				"source":     evt.SourceAgent,
-				"payload":    payload,
-			},
-		})
 	}
-	h.emit(runID, map[string]any{
-		"id":        uuid.NewString(),
-		"type":      "run.started",
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
-		"payload":   map[string]any{"run_id": runID},
-	})
+	h.syncCanonical(context.Background(), runID)
 	go h.awaitCompletion(runID)
 	return nil
 }
@@ -137,7 +127,7 @@ func (h *runHub) stopRun(runID string) error {
 			return err
 		}
 	}
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":        uuid.NewString(),
 		"type":      "run.stopped",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -163,7 +153,7 @@ func (h *runHub) pauseRun(runID string) error {
 	if err := h.pauseRuntime(); err != nil {
 		return err
 	}
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":        uuid.NewString(),
 		"type":      "run.paused",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -199,7 +189,7 @@ func (h *runHub) continueRun(runID string, instanceIDs []string, decision string
 	if decision = strings.TrimSpace(decision); decision != "" {
 		payload["decision"] = decision
 	}
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":        uuid.NewString(),
 		"type":      "run.resumed",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -241,7 +231,7 @@ func (h *runHub) stepRun(runID string, nodeID string, instanceID string) error {
 		event["instance_id"] = instanceID
 		payload["instance_ids"] = []string{instanceID}
 	}
-	h.emit(runID, event)
+	h.emitControl(runID, event)
 	return nil
 }
 
@@ -286,7 +276,7 @@ func (h *runHub) resumeNodeAction(runID string, actionKind string, nodeID string
 		actionEvent["instance_id"] = instanceID
 		actionEvent["payload"].(map[string]any)["instance_id"] = instanceID
 	}
-	h.emit(runID, actionEvent)
+	h.emitControl(runID, actionEvent)
 	if err := h.resumeRuntime(); err != nil {
 		return err
 	}
@@ -301,7 +291,7 @@ func (h *runHub) resumeNodeAction(runID string, actionKind string, nodeID string
 	if instanceID != "" {
 		resumeEvent["instance_id"] = instanceID
 	}
-	h.emit(runID, resumeEvent)
+	h.emitControl(runID, resumeEvent)
 	return nil
 }
 
@@ -317,13 +307,25 @@ func (h *runHub) subscribe(runID string, listener func(RunEventEnvelope)) func()
 	h.mu.Lock()
 	session, ok := h.sessions[runID]
 	if !ok {
-		session = &runSession{runID: runID, entityIDs: map[string]struct{}{}, subs: map[string]func(RunEventEnvelope){}, events: []RunEventEnvelope{}}
+		session = &runSession{
+			runID:         runID,
+			entityIDs:     map[string]struct{}{},
+			subs:          map[string]func(RunEventEnvelope){},
+			controlEvents: []RunEventEnvelope{},
+			debug: runDebugStreamState{
+				eventIDs:      map[string]struct{}{},
+				runtimeLogIDs: map[string]struct{}{},
+			},
+		}
 		h.sessions[runID] = session
 	}
 	session.subs[subID] = listener
-	replay := append([]RunEventEnvelope(nil), session.events...)
+	controlReplay := append([]RunEventEnvelope(nil), session.controlEvents...)
 	h.mu.Unlock()
-	for _, event := range replay {
+	for _, event := range h.canonicalReplay(context.Background(), runID) {
+		listener(event)
+	}
+	for _, event := range controlReplay {
 		listener(event)
 	}
 	return func() {
@@ -340,16 +342,16 @@ func (h *runHub) subscribe(runID string, listener func(RunEventEnvelope)) func()
 	}
 }
 
-func (h *runHub) emit(runID string, event RunEventEnvelope) {
+func (h *runHub) emitControl(runID string, event RunEventEnvelope) {
 	h.mu.Lock()
 	session := h.sessions[runID]
 	if session == nil {
 		h.mu.Unlock()
 		return
 	}
-	session.events = append(session.events, cloneRunEvent(event))
-	if len(session.events) > 128 {
-		session.events = append([]RunEventEnvelope(nil), session.events[len(session.events)-128:]...)
+	session.controlEvents = append(session.controlEvents, cloneRunEvent(event))
+	if len(session.controlEvents) > 128 {
+		session.controlEvents = append([]RunEventEnvelope(nil), session.controlEvents[len(session.controlEvents)-128:]...)
 	}
 	listeners := make([]func(RunEventEnvelope), 0, len(session.subs))
 	for _, listener := range session.subs {
@@ -382,7 +384,7 @@ func (h *runHub) awaitCompletion(runID string) {
 			}
 			if _, persistErr := h.persistTerminalState(runID, "failed", err.Error(), time.Now().UTC()); persistErr != nil {
 				h.markTerminal(runID)
-				h.emit(runID, map[string]any{
+				h.emitControl(runID, map[string]any{
 					"id":        uuid.NewString(),
 					"type":      "run.failed",
 					"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -395,12 +397,7 @@ func (h *runHub) awaitCompletion(runID string) {
 				return
 			}
 			h.markTerminal(runID)
-			h.emit(runID, map[string]any{
-				"id":        uuid.NewString(),
-				"type":      "run.failed",
-				"timestamp": time.Now().UTC().Format(time.RFC3339),
-				"payload":   map[string]any{"run_id": runID, "error": err.Error()},
-			})
+			h.syncCanonical(context.Background(), runID)
 			return
 		}
 		if h.isTerminal(runID) {
@@ -409,7 +406,7 @@ func (h *runHub) awaitCompletion(runID string) {
 		snapshot, err := h.persistTerminalState(runID, "completed", "", time.Now().UTC())
 		if err != nil {
 			h.markTerminal(runID)
-			h.emit(runID, map[string]any{
+			h.emitControl(runID, map[string]any{
 				"id":        uuid.NewString(),
 				"type":      "run.failed",
 				"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -422,19 +419,8 @@ func (h *runHub) awaitCompletion(runID string) {
 			return
 		}
 		h.markTerminal(runID)
-		h.emit(runID, map[string]any{
-			"id":        uuid.NewString(),
-			"type":      "run.completed",
-			"timestamp": time.Now().UTC().Format(time.RFC3339),
-			"payload": map[string]any{
-				"run_id": runID,
-				"summary": map[string]any{
-					"duration_ms":  durationMillis(snapshot),
-					"total_events": snapshot.EventCount,
-					"entity_count": snapshot.EntityCount,
-				},
-			},
-		})
+		_ = snapshot
+		h.syncCanonical(context.Background(), runID)
 		return
 	}
 }

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -321,8 +321,10 @@ func (h *runHub) subscribe(runID string, listener func(RunEventEnvelope)) func()
 	}
 	session.subs[subID] = listener
 	controlReplay := append([]RunEventEnvelope(nil), session.controlEvents...)
+	canonicalReplay, primedState := h.canonicalReplay(context.Background(), runID)
+	session.debug = primedState
 	h.mu.Unlock()
-	for _, event := range h.canonicalReplay(context.Background(), runID) {
+	for _, event := range canonicalReplay {
 		listener(event)
 	}
 	for _, event := range controlReplay {

--- a/internal/builder/runs_events_test.go
+++ b/internal/builder/runs_events_test.go
@@ -1,66 +1,90 @@
 package builder
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
-	runtimepkg "swarm/internal/runtime"
+	"swarm/internal/store"
 )
 
-func TestRunHubToRunEvent_PublishedEntryMapsToEventFired(t *testing.T) {
-	hub := &runHub{}
-	event := hub.toRunEvent(runtimepkg.RuntimeLogEntry{
-		Component: "eventbus",
-		Action:    "published",
-		EventID:   "evt-1",
-		EventType: "workflow.started",
-		AgentID:   "node-1",
-		EntityID:  "entity-1",
-		Detail:    map[string]any{"source": "builder"},
-	})
+func TestProjectCanonicalRunDebugReplay_PreservesCanonicalEventPayloadAndTimestamp(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	report := store.RunDebugReport{
+		RunID:      "run-123",
+		StartedAt:  now,
+		EventCount: 1,
+		Events: []store.RunDebugEvent{{
+			EventID:    "evt-1",
+			EventName:  "workflow.started",
+			EntityID:   "entity-1",
+			CreatedAt:  now,
+			Source:     "builder",
+			SourceType: "agent",
+			Payload:    json.RawMessage(`{"topic":"sample"}`),
+		}},
+	}
 
-	if event["type"] != "event.fired" {
-		t.Fatalf("event.type = %#v", event["type"])
+	replay := projectCanonicalRunDebugReplay(report)
+	if len(replay) != 2 {
+		t.Fatalf("replay len = %d, want 2", len(replay))
 	}
-	if event["id"] != "evt-1" {
-		t.Fatalf("event.id = %#v", event["id"])
+	if replay[0]["type"] != "run.started" {
+		t.Fatalf("replay[0].type = %#v, want run.started", replay[0]["type"])
 	}
-	if event["node_id"] != "node-1" {
-		t.Fatalf("event.node_id = %#v", event["node_id"])
+	if replay[1]["type"] != "event.fired" {
+		t.Fatalf("replay[1].type = %#v, want event.fired", replay[1]["type"])
 	}
-	payload, _ := event["payload"].(map[string]any)
+	if got := replay[1]["timestamp"]; got != now.Format(time.RFC3339) {
+		t.Fatalf("event timestamp = %#v, want %q", got, now.Format(time.RFC3339))
+	}
+	payload, _ := replay[1]["payload"].(map[string]any)
 	if payload["event_name"] != "workflow.started" {
 		t.Fatalf("payload.event_name = %#v", payload["event_name"])
 	}
 	if payload["source"] != "builder" {
 		t.Fatalf("payload.source = %#v", payload["source"])
 	}
+	rawPayload, _ := payload["payload"].(map[string]any)
+	if rawPayload["topic"] != "sample" {
+		t.Fatalf("payload.payload = %#v", rawPayload)
+	}
 }
 
-func TestRunHubToRunEvent_RuntimeLogEntryMapsDetailAndFallbackID(t *testing.T) {
-	hub := &runHub{}
-	event := hub.toRunEvent(runtimepkg.RuntimeLogEntry{
-		Level:     "warn",
-		Component: "runtime",
-		Action:    "retrying",
-		EventType: "workflow.started",
-		AgentID:   "node-1",
-		EntityID:  "entity-1",
-		Error:     "boom",
-		Detail:    "ignored",
-	})
+func TestProjectCanonicalRunDebugReplay_PreservesCanonicalRuntimeLogDetailAndTimestamp(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	report := store.RunDebugReport{
+		RunID: "run-123",
+		RuntimeLogs: []store.RunDebugRuntimeLog{{
+			EventID:   "evt-log-1",
+			Level:     "warn",
+			Component: "runtime",
+			Action:    "retrying",
+			EventType: "workflow.started",
+			AgentID:   "node-1",
+			EntityID:  "entity-1",
+			Error:     "boom",
+			Detail:    json.RawMessage(`{"component":"runtime","action":"retrying","error":"boom"}`),
+			CreatedAt: now,
+		}},
+	}
 
-	if event["type"] != "runtime.log" {
-		t.Fatalf("event.type = %#v", event["type"])
+	replay := projectCanonicalRunDebugReplay(report)
+	if len(replay) != 1 {
+		t.Fatalf("replay len = %d, want 1", len(replay))
 	}
-	if event["id"] == "" {
-		t.Fatal("expected generated event id")
+	if replay[0]["type"] != "runtime.log" {
+		t.Fatalf("replay[0].type = %#v, want runtime.log", replay[0]["type"])
 	}
-	payload, _ := event["payload"].(map[string]any)
+	if got := replay[0]["timestamp"]; got != now.Format(time.RFC3339) {
+		t.Fatalf("runtime log timestamp = %#v, want %q", got, now.Format(time.RFC3339))
+	}
+	payload, _ := replay[0]["payload"].(map[string]any)
 	if payload["level"] != "warn" || payload["component"] != "runtime" || payload["action"] != "retrying" {
 		t.Fatalf("payload = %#v", payload)
 	}
 	detail, _ := payload["detail"].(map[string]any)
-	if len(detail) != 0 {
-		t.Fatalf("detail = %#v, want empty map", detail)
+	if detail["error"] != "boom" {
+		t.Fatalf("detail = %#v", detail)
 	}
 }

--- a/internal/builder/runs_events_test.go
+++ b/internal/builder/runs_events_test.go
@@ -25,7 +25,7 @@ func TestProjectCanonicalRunDebugReplay_PreservesCanonicalEventPayloadAndTimesta
 		}},
 	}
 
-	replay := projectCanonicalRunDebugReplay(report)
+	replay, _ := projectCanonicalRunDebugReplay(report)
 	if len(replay) != 2 {
 		t.Fatalf("replay len = %d, want 2", len(replay))
 	}
@@ -69,7 +69,7 @@ func TestProjectCanonicalRunDebugReplay_PreservesCanonicalRuntimeLogDetailAndTim
 		}},
 	}
 
-	replay := projectCanonicalRunDebugReplay(report)
+	replay, _ := projectCanonicalRunDebugReplay(report)
 	if len(replay) != 1 {
 		t.Fatalf("replay len = %d, want 1", len(replay))
 	}

--- a/internal/builder/runs_runtime.go
+++ b/internal/builder/runs_runtime.go
@@ -18,11 +18,14 @@ func (h *runHub) handleRuntimeLog(entry runtimepkg.RuntimeLogEntry) {
 	if h == nil {
 		return
 	}
-	runIDs := h.runIDsForRuntimeEntry(entry)
-	for _, runID := range runIDs {
+	controlRunIDs := h.correlatedRunIDsForRuntimeEntry(entry)
+	for _, runID := range controlRunIDs {
 		h.maybeEmitBreakpointHit(runID, entry.AgentID, entry.EffectiveEntityID())
 		h.maybeEmitHumanTaskWaiting(runID, entry)
 		h.maybePauseAfterStep(runID, entry.AgentID, entry.EffectiveEntityID())
+	}
+	runIDs := h.runIDsForRuntimeEntry(entry)
+	for _, runID := range runIDs {
 		h.syncCanonical(context.Background(), runID)
 	}
 }

--- a/internal/builder/runs_runtime.go
+++ b/internal/builder/runs_runtime.go
@@ -18,68 +18,13 @@ func (h *runHub) handleRuntimeLog(entry runtimepkg.RuntimeLogEntry) {
 	if h == nil {
 		return
 	}
-	entityID := strings.TrimSpace(entry.EffectiveEntityID())
-	if entityID == "" {
-		return
-	}
-	runIDs := make([]string, 0, 2)
-	h.mu.RLock()
-	for runID, session := range h.sessions {
-		if _, ok := session.entityIDs[entityID]; ok {
-			runIDs = append(runIDs, runID)
-		}
-	}
-	h.mu.RUnlock()
-	if len(runIDs) == 0 {
-		return
-	}
-	event := h.toRunEvent(entry)
+	runIDs := h.runIDsForRuntimeEntry(entry)
 	for _, runID := range runIDs {
-		if event != nil {
-			h.emit(runID, event)
-		}
-		h.maybeEmitBreakpointHit(runID, strings.TrimSpace(entry.AgentID), entityID)
+		h.maybeEmitBreakpointHit(runID, entry.AgentID, entry.EffectiveEntityID())
 		h.maybeEmitHumanTaskWaiting(runID, entry)
-		h.maybePauseAfterStep(runID, strings.TrimSpace(entry.AgentID), entityID)
+		h.maybePauseAfterStep(runID, entry.AgentID, entry.EffectiveEntityID())
+		h.syncCanonical(context.Background(), runID)
 	}
-}
-
-func (h *runHub) toRunEvent(entry runtimepkg.RuntimeLogEntry) RunEventEnvelope {
-	if strings.TrimSpace(entry.Component) == "eventbus" && strings.TrimSpace(entry.Action) == "published" {
-		event := map[string]any{
-			"id":          strings.TrimSpace(entry.EventID),
-			"type":        "event.fired",
-			"timestamp":   time.Now().UTC().Format(time.RFC3339),
-			"instance_id": strings.TrimSpace(entry.EntityID),
-			"payload": map[string]any{
-				"event_name": strings.TrimSpace(entry.EventType),
-				"source":     payloadMap(entry.Detail)["source"],
-			},
-		}
-		if nodeID := strings.TrimSpace(entry.AgentID); nodeID != "" {
-			event["node_id"] = nodeID
-		}
-		return event
-	}
-	event := map[string]any{
-		"id":          nonEmptyOrUUID(strings.TrimSpace(entry.EventID)),
-		"type":        "runtime.log",
-		"timestamp":   time.Now().UTC().Format(time.RFC3339),
-		"instance_id": strings.TrimSpace(entry.EntityID),
-		"payload": map[string]any{
-			"level":      entry.Level.String(),
-			"component":  strings.TrimSpace(entry.Component),
-			"action":     strings.TrimSpace(entry.Action),
-			"event_type": strings.TrimSpace(entry.EventType),
-			"agent_id":   strings.TrimSpace(entry.AgentID),
-			"detail":     payloadMap(entry.Detail),
-			"error":      strings.TrimSpace(entry.Error),
-		},
-	}
-	if nodeID := strings.TrimSpace(entry.AgentID); nodeID != "" {
-		event["node_id"] = nodeID
-	}
-	return event
 }
 
 func (h *runHub) maybeEmitBreakpointHit(runID string, nodeID string, instanceID string) {
@@ -115,7 +60,7 @@ func (h *runHub) maybeEmitBreakpointHit(runID string, nodeID string, instanceID 
 		event["instance_id"] = instanceID
 		event["payload"].(map[string]any)["instance_id"] = instanceID
 	}
-	h.emit(runID, event)
+	h.emitControl(runID, event)
 }
 
 func (h *runHub) maybeEmitHumanTaskWaiting(runID string, entry runtimepkg.RuntimeLogEntry) {
@@ -141,7 +86,7 @@ func (h *runHub) maybeEmitHumanTaskWaiting(runID string, entry runtimepkg.Runtim
 	if h.pauseRuntime != nil {
 		_ = h.pauseRuntime()
 	}
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":          uuid.NewString(),
 		"type":        "human.task_waiting",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -149,7 +94,7 @@ func (h *runHub) maybeEmitHumanTaskWaiting(runID string, entry runtimepkg.Runtim
 		"instance_id": instanceID,
 		"payload":     map[string]any{"decision_options": []string{"approved", "rejected", "deferred"}},
 	})
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":          uuid.NewString(),
 		"type":        "run.paused",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -200,7 +145,7 @@ func (h *runHub) submitPendingHumanDecision(ctx context.Context, runID string, d
 	}).WithEntityID(pending.instanceID)); err != nil {
 		return err
 	}
-	h.emit(runID, map[string]any{
+	h.emitControl(runID, map[string]any{
 		"id":          uuid.NewString(),
 		"type":        "human.task_submitted",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -247,7 +192,7 @@ func (h *runHub) maybePauseAfterStep(runID string, nodeID string, instanceID str
 		event["instance_id"] = instanceID
 		event["payload"].(map[string]any)["instance_id"] = instanceID
 	}
-	h.emit(runID, event)
+	h.emitControl(runID, event)
 }
 
 func (h *runHub) attachRuntime(rt *runtimepkg.Runtime) {

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -7,6 +7,7 @@ import (
 
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
+	"swarm/internal/store"
 )
 
 type snapshotRunStore struct {
@@ -27,13 +28,29 @@ func (s *snapshotRunStore) LoadRunLifecycleSnapshot(context.Context, string) (ru
 	return s.snapshot, nil
 }
 
+func (s *snapshotRunStore) LoadRunDebugReport(_ context.Context, runID string, _ store.RunDebugQueryOptions) (store.RunDebugReport, error) {
+	report := store.RunDebugReport{
+		RunID:          runID,
+		RunTableStatus: s.snapshot.Status,
+		ErrorSummary:   s.snapshot.ErrorSummary,
+		StartedAt:      s.snapshot.StartedAt,
+		EventCount:     s.snapshot.EventCount,
+		EntityCount:    s.snapshot.EntityCount,
+	}
+	if s.snapshot.EndedAt != nil {
+		ended := s.snapshot.EndedAt.UTC()
+		report.EndedAt = &ended
+	}
+	return report, nil
+}
+
 func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
 	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	rt := &runtimepkg.Runtime{Bus: eb}
-	hub := newRunHub(func() *runtimepkg.Runtime { return rt }, nil, nil, nil)
+	hub := newRunHub(func() *runtimepkg.Runtime { return rt }, nil, nil, nil, nil)
 	ch := eb.Subscribe("observer", "review.requested")
 
 	if err := hub.startRun(context.Background(), "run-123", map[string]any{
@@ -64,10 +81,10 @@ func TestRunHubAwaitCompletion_MarksSessionTerminalWhenCompletionPersistenceFail
 	hub := &runHub{
 		sessions: map[string]*runSession{
 			"run-123": {
-				runID:   "run-123",
-				runtime: rt,
-				subs:    map[string]func(RunEventEnvelope){},
-				events:  []RunEventEnvelope{},
+				runID:         "run-123",
+				runtime:       rt,
+				subs:          map[string]func(RunEventEnvelope){},
+				controlEvents: []RunEventEnvelope{},
 			},
 		},
 	}
@@ -81,10 +98,10 @@ func TestRunHubAwaitCompletion_MarksSessionTerminalWhenCompletionPersistenceFail
 	if session == nil {
 		t.Fatal("expected run session to remain addressable")
 	}
-	if len(session.events) == 0 {
+	if len(session.controlEvents) == 0 {
 		t.Fatal("expected terminal failure event to be emitted")
 	}
-	last := session.events[len(session.events)-1]
+	last := session.controlEvents[len(session.controlEvents)-1]
 	if got, _ := last["type"].(string); got != "run.failed" {
 		t.Fatalf("last event type = %q, want run.failed", got)
 	}
@@ -108,24 +125,33 @@ func TestRunHubAwaitCompletion_EmitsAuthoritativeRunSummary(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	rt := &runtimepkg.Runtime{Bus: eb}
+	var observed []RunEventEnvelope
 	hub := &runHub{
+		runDebug: store,
 		sessions: map[string]*runSession{
 			"run-123": {
 				runID:   "run-123",
 				runtime: rt,
-				subs:    map[string]func(RunEventEnvelope){},
-				events:  []RunEventEnvelope{},
+				subs: map[string]func(RunEventEnvelope){
+					"test": func(event RunEventEnvelope) {
+						observed = append(observed, cloneRunEvent(event))
+					},
+				},
+				controlEvents: []RunEventEnvelope{},
+				debug: runDebugStreamState{
+					eventIDs:      map[string]struct{}{},
+					runtimeLogIDs: map[string]struct{}{},
+				},
 			},
 		},
 	}
 
 	hub.awaitCompletion("run-123")
 
-	session := hub.session("run-123")
-	if session == nil || len(session.events) == 0 {
+	if len(observed) == 0 {
 		t.Fatal("expected terminal event to be emitted")
 	}
-	last := session.events[len(session.events)-1]
+	last := observed[len(observed)-1]
 	if got, _ := last["type"].(string); got != "run.completed" {
 		t.Fatalf("last event type = %q, want run.completed", got)
 	}

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 type snapshotRunStore struct {
 	runtimebus.InMemoryEventStore
 	snapshot runtimebus.RunLifecycleSnapshot
+	report   store.RunDebugReport
 }
 
 func (s *snapshotRunStore) MarkRunTerminal(_ context.Context, runID, status, errorSummary string, endedAt time.Time) error {
@@ -29,6 +31,9 @@ func (s *snapshotRunStore) LoadRunLifecycleSnapshot(context.Context, string) (ru
 }
 
 func (s *snapshotRunStore) LoadRunDebugReport(_ context.Context, runID string, _ store.RunDebugQueryOptions) (store.RunDebugReport, error) {
+	if strings.TrimSpace(s.report.RunID) != "" {
+		return s.report, nil
+	}
 	report := store.RunDebugReport{
 		RunID:          runID,
 		RunTableStatus: s.snapshot.Status,
@@ -42,6 +47,13 @@ func (s *snapshotRunStore) LoadRunDebugReport(_ context.Context, runID string, _
 		report.EndedAt = &ended
 	}
 	return report, nil
+}
+
+type counterPause struct{ calls int }
+
+func (c *counterPause) pause() error {
+	c.calls++
+	return nil
 }
 
 func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
@@ -165,5 +177,85 @@ func TestRunHubAwaitCompletion_EmitsAuthoritativeRunSummary(t *testing.T) {
 	}
 	if got, ok := summary["duration_ms"].(int64); !ok || got <= 0 {
 		t.Fatalf("summary.duration_ms = %#v, want positive int64", summary["duration_ms"])
+	}
+}
+
+func TestRunHubHandleRuntimeLog_NoEntityDoesNotTriggerControlHooksAcrossRuns(t *testing.T) {
+	pause := &counterPause{}
+	hub := &runHub{
+		pauseRuntime: pause.pause,
+		sessions: map[string]*runSession{
+			"run-a": {
+				runID:       "run-a",
+				breakpoints: map[string]struct{}{"node-1": {}},
+				subs:        map[string]func(RunEventEnvelope){},
+				debug: runDebugStreamState{
+					eventIDs:      map[string]struct{}{},
+					runtimeLogIDs: map[string]struct{}{},
+				},
+			},
+			"run-b": {
+				runID:       "run-b",
+				breakpoints: map[string]struct{}{"node-1": {}},
+				subs:        map[string]func(RunEventEnvelope){},
+				debug: runDebugStreamState{
+					eventIDs:      map[string]struct{}{},
+					runtimeLogIDs: map[string]struct{}{},
+				},
+			},
+		},
+	}
+
+	hub.handleRuntimeLog(runtimepkg.RuntimeLogEntry{
+		Component: "scheduler",
+		Action:    "checkpoint",
+		AgentID:   "node-1",
+	})
+
+	if pause.calls != 0 {
+		t.Fatalf("pause calls = %d, want 0", pause.calls)
+	}
+	for runID, session := range hub.sessions {
+		if _, ok := session.trippedBreakpoints["node-1"]; ok {
+			t.Fatalf("%s unexpectedly tripped breakpoint on no-entity log", runID)
+		}
+	}
+}
+
+func TestRunHubSubscribe_PrimesCanonicalReplayDedupeState(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	debugStore := &snapshotRunStore{
+		report: store.RunDebugReport{
+			RunID:      "run-123",
+			StartedAt:  now,
+			EventCount: 1,
+			Events: []store.RunDebugEvent{{
+				EventID:    "evt-1",
+				EventName:  "scan.requested",
+				EntityID:   "entity-1",
+				CreatedAt:  now.Add(1 * time.Second),
+				Source:     "builder",
+				SourceType: "agent",
+			}},
+		},
+	}
+	hub := &runHub{
+		runDebug: debugStore,
+		sessions: map[string]*runSession{},
+	}
+	var seen []RunEventEnvelope
+	cancel := hub.subscribe("run-123", func(event RunEventEnvelope) {
+		seen = append(seen, cloneRunEvent(event))
+	})
+	defer cancel()
+
+	if len(seen) != 2 {
+		t.Fatalf("initial replay len = %d, want 2", len(seen))
+	}
+
+	hub.syncCanonical(context.Background(), "run-123")
+
+	if len(seen) != 2 {
+		t.Fatalf("post-sync len = %d, want 2", len(seen))
 	}
 }

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,19 @@ type builderWSEventFrame = builderpkg.WSEventFrame
 
 const testBuilderAuthToken = "builder-test-token"
 const testOperatorAuthToken = "operator-secret"
+
+func asString(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	default:
+		return ""
+	}
+}
+
+func ptrTime(v time.Time) *time.Time { return &v }
 
 func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 	return store.StoreSchemaCapabilities{
@@ -116,20 +130,149 @@ type stubObservability struct {
 	incidents   []incidentRecord
 }
 
-type stubBuilderRunStore struct{}
+type stubBuilderRunStore struct {
+	mu        sync.Mutex
+	events    []events.Event
+	snapshots map[string]runtimebus.RunLifecycleSnapshot
+}
 
-func (stubBuilderRunStore) AppendEvent(context.Context, events.Event) error { return nil }
-func (stubBuilderRunStore) InsertEventDeliveries(context.Context, string, []string) error {
+func (s *stubBuilderRunStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
 	return nil
 }
-func (stubBuilderRunStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+func (*stubBuilderRunStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*stubBuilderRunStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return []string{}, nil
 }
-func (stubBuilderRunStore) MarkRunTerminal(context.Context, string, string, string, time.Time) error {
+func (s *stubBuilderRunStore) MarkRunTerminal(_ context.Context, runID, status, errorSummary string, endedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.snapshots == nil {
+		s.snapshots = map[string]runtimebus.RunLifecycleSnapshot{}
+	}
+	snap := s.snapshots[runID]
+	snap.RunID = runID
+	snap.Status = status
+	snap.ErrorSummary = errorSummary
+	ended := endedAt
+	snap.EndedAt = &ended
+	seenEntities := map[string]struct{}{}
+	eventCount := 0
+	var startedAt time.Time
+	for _, evt := range s.events {
+		if strings.TrimSpace(evt.RunID) != strings.TrimSpace(runID) {
+			continue
+		}
+		eventCount++
+		if startedAt.IsZero() || evt.CreatedAt.Before(startedAt) {
+			startedAt = evt.CreatedAt
+		}
+		if entityID := strings.TrimSpace(evt.EntityID()); entityID != "" {
+			seenEntities[entityID] = struct{}{}
+		}
+	}
+	snap.EventCount = eventCount
+	snap.EntityCount = len(seenEntities)
+	snap.StartedAt = startedAt
+	s.snapshots[runID] = snap
 	return nil
 }
-func (stubBuilderRunStore) LoadRunLifecycleSnapshot(context.Context, string) (runtimebus.RunLifecycleSnapshot, error) {
-	return runtimebus.RunLifecycleSnapshot{}, nil
+func (s *stubBuilderRunStore) LoadRunLifecycleSnapshot(_ context.Context, runID string) (runtimebus.RunLifecycleSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshots[runID], nil
+}
+
+func (s *stubBuilderRunStore) LoadRunDebugReport(_ context.Context, runID string, _ store.RunDebugQueryOptions) (store.RunDebugReport, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	report := store.RunDebugReport{
+		RunID:             strings.TrimSpace(runID),
+		EventCounts:       []store.RunDebugEventCount{},
+		Deliveries:        []store.RunDebugDeliveryCount{},
+		Events:            []store.RunDebugEvent{},
+		DeadLetters:       []store.RunDebugDeadLetter{},
+		AgentTurns:        []store.RunDebugAgentTurn{},
+		Mutations:         []store.RunDebugMutation{},
+		RuntimeLogs:       []store.RunDebugRuntimeLog{},
+		RuntimeLogSummary: []store.RunDebugRuntimeSummary{},
+	}
+	if snap, ok := s.snapshots[runID]; ok {
+		report.RunTableStatus = snap.Status
+		report.ErrorSummary = snap.ErrorSummary
+		report.EntityCount = snap.EntityCount
+		if snap.EndedAt != nil {
+			ended := snap.EndedAt.UTC()
+			report.EndedAt = &ended
+		}
+		if !snap.StartedAt.IsZero() {
+			report.StartedAt = snap.StartedAt.UTC()
+		}
+	}
+	counts := map[string]int{}
+	for _, evt := range s.events {
+		if strings.TrimSpace(evt.RunID) != report.RunID {
+			continue
+		}
+		report.EventCount++
+		if report.StartedAt.IsZero() || evt.CreatedAt.Before(report.StartedAt) {
+			report.StartedAt = evt.CreatedAt.UTC()
+		}
+		if evt.CreatedAt.After(report.LastEventAt) {
+			report.LastEventAt = evt.CreatedAt.UTC()
+		}
+		counts[string(evt.Type)]++
+		if report.RootEventID == "" || evt.CreatedAt.Before(report.StartedAt) {
+			report.RootEventID = strings.TrimSpace(evt.ID)
+			report.RootEventType = strings.TrimSpace(string(evt.Type))
+		}
+		if evt.Type == events.EventType("platform.runtime_log") {
+			payload := map[string]any{}
+			_ = json.Unmarshal(evt.Payload, &payload)
+			details, _ := payload["details"].(map[string]any)
+			detailJSON, _ := json.Marshal(details)
+			report.RuntimeLogs = append(report.RuntimeLogs, store.RunDebugRuntimeLog{
+				EventID:   strings.TrimSpace(evt.ID),
+				Level:     strings.TrimSpace(asString(payload["log_level"])),
+				Message:   strings.TrimSpace(asString(payload["message"])),
+				Component: strings.TrimSpace(asString(details["component"])),
+				Action:    strings.TrimSpace(asString(details["action"])),
+				EventType: strings.TrimSpace(asString(details["event_type"])),
+				AgentID:   strings.TrimSpace(asString(details["agent_id"])),
+				EntityID:  strings.TrimSpace(asString(details["entity_id"])),
+				Error:     strings.TrimSpace(asString(details["error"])),
+				Detail:    append(json.RawMessage(nil), detailJSON...),
+				CreatedAt: evt.CreatedAt.UTC(),
+			})
+			continue
+		}
+		payload := append(json.RawMessage(nil), evt.Payload...)
+		report.Events = append(report.Events, store.RunDebugEvent{
+			EventID:    strings.TrimSpace(evt.ID),
+			EventName:  strings.TrimSpace(string(evt.Type)),
+			EntityID:   strings.TrimSpace(evt.EntityID()),
+			CreatedAt:  evt.CreatedAt.UTC(),
+			Source:     strings.TrimSpace(evt.SourceAgent),
+			SourceType: "agent",
+			Payload:    payload,
+		})
+	}
+	for eventName, count := range counts {
+		report.EventCounts = append(report.EventCounts, store.RunDebugEventCount{EventName: eventName, Count: count})
+	}
+	slices.SortFunc(report.Events, func(a, b store.RunDebugEvent) int { return b.CreatedAt.Compare(a.CreatedAt) })
+	slices.SortFunc(report.RuntimeLogs, func(a, b store.RunDebugRuntimeLog) int { return b.CreatedAt.Compare(a.CreatedAt) })
+	slices.SortFunc(report.EventCounts, func(a, b store.RunDebugEventCount) int { return strings.Compare(a.EventName, b.EventName) })
+	if report.RootEventID == "" && len(report.Events) > 0 {
+		root := report.Events[len(report.Events)-1]
+		report.RootEventID = root.EventID
+		report.RootEventType = root.EventName
+	}
+	return report, nil
 }
 
 type stubConversationCaps struct {
@@ -356,8 +499,12 @@ func newBuilderHandlerForTest(
 	projectCtl builderpkg.ProjectController,
 ) http.Handler {
 	var runtimeProvider builderpkg.RuntimeProvider
+	var runDebug builderpkg.RunDebugReader
 	if rt != nil {
 		runtimeProvider = func() *runtimepkg.Runtime { return rt }
+		if typed, ok := rt.Bus.Store().(*stubBuilderRunStore); ok {
+			runDebug = typed
+		}
 	}
 	return builderpkg.NewHandler(builderpkg.Options{
 		Health:         builderpkg.HealthChecker(health),
@@ -367,6 +514,7 @@ func newBuilderHandlerForTest(
 		Version:        version,
 		CurrentRuntime: runtimeProvider,
 		ProjectControl: projectCtl,
+		RunDebug:       runDebug,
 	})
 }
 
@@ -2675,7 +2823,7 @@ func TestHandler_HealthzAliases(t *testing.T) {
 }
 
 func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -2768,8 +2916,237 @@ func TestHandler_RunStartStreamsRunEvents(t *testing.T) {
 	}
 }
 
+func TestHandler_RunEventReplayUsesCanonicalPersistedRunDebugOwner(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	runID := "run_replay_001"
+	rootEvent := (events.Event{
+		ID:          "evt-root",
+		RunID:       runID,
+		Type:        events.EventType("scan.requested"),
+		SourceAgent: "builder",
+		Payload:     json.RawMessage(`{"topic":"sample"}`),
+		CreatedAt:   now,
+	}).WithEntityID(runID)
+	storeStub := &stubBuilderRunStore{
+		events: []events.Event{
+			rootEvent,
+			{
+				ID:          "evt-log",
+				RunID:       runID,
+				Type:        events.EventType("platform.runtime_log"),
+				SourceAgent: "runtime",
+				Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"checkpoint","error":"boom"}}`),
+				CreatedAt:   now.Add(2 * time.Second),
+			},
+		},
+		snapshots: map[string]runtimebus.RunLifecycleSnapshot{
+			runID: {
+				RunID:       runID,
+				Status:      "completed",
+				EventCount:  2,
+				EntityCount: 1,
+				StartedAt:   now,
+				EndedAt:     ptrTime(now.Add(3 * time.Second)),
+			},
+		},
+	}
+	bus, err := runtimebus.NewEventBus(storeStub)
+	if err != nil {
+		t.Fatalf("new event bus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: bus}
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+		Version: "swarm-test",
+		Runtime: &stubRuntimeControl{},
+		Builder: newBuilderHandlerForTest(
+			func(context.Context) (map[string]any, error) {
+				return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+			},
+			nil,
+			"swarm-test",
+			nil,
+			rt,
+			nil,
+		),
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{"type": "subscribe", "channel": "run:events:" + runID}); err != nil {
+		t.Fatalf("subscribe run events: %v", err)
+	}
+
+	gotTypes := map[string]map[string]any{}
+	deadline := time.After(1 * time.Second)
+	for len(gotTypes) < 4 {
+		_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for canonical replay, got %#v", gotTypes)
+		default:
+		}
+		var frame builderWSEventFrame
+		if err := conn.ReadJSON(&frame); err != nil {
+			t.Fatalf("read run event: %v", err)
+		}
+		if frame.Channel != "run:events:"+runID {
+			continue
+		}
+		payload, _ := frame.Data.(map[string]any)
+		eventType, _ := payload["type"].(string)
+		if eventType != "" {
+			gotTypes[eventType] = payload
+		}
+	}
+
+	if gotTypes["run.started"]["timestamp"] != now.Format(time.RFC3339) {
+		t.Fatalf("run.started timestamp = %#v, want %q", gotTypes["run.started"]["timestamp"], now.Format(time.RFC3339))
+	}
+	if gotTypes["event.fired"]["timestamp"] != now.Format(time.RFC3339) {
+		t.Fatalf("event.fired timestamp = %#v, want %q", gotTypes["event.fired"]["timestamp"], now.Format(time.RFC3339))
+	}
+	if gotTypes["runtime.log"]["timestamp"] != now.Add(2*time.Second).Format(time.RFC3339) {
+		t.Fatalf("runtime.log timestamp = %#v, want %q", gotTypes["runtime.log"]["timestamp"], now.Add(2*time.Second).Format(time.RFC3339))
+	}
+	runtimePayload, _ := gotTypes["runtime.log"]["payload"].(map[string]any)
+	if runtimePayload["component"] != "scheduler" || runtimePayload["action"] != "checkpoint" {
+		t.Fatalf("runtime.log payload = %#v", runtimePayload)
+	}
+	donePayload, _ := gotTypes["run.completed"]["payload"].(map[string]any)
+	summary, _ := donePayload["summary"].(map[string]any)
+	if summary["entity_count"] != float64(1) && summary["entity_count"] != 1 {
+		t.Fatalf("run.completed summary = %#v", summary)
+	}
+}
+
+func TestHandler_RunEventStreamPreservesCanonicalRuntimeLogWithoutEntityID(t *testing.T) {
+	now := time.Unix(1700000100, 0).UTC()
+	runID := "run_live_001"
+	storeStub := &stubBuilderRunStore{}
+	bus, err := runtimebus.NewEventBus(storeStub)
+	if err != nil {
+		t.Fatalf("new event bus: %v", err)
+	}
+	rt := &runtimepkg.Runtime{Bus: bus}
+	runtimeCtl := &stubRuntimeControl{}
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+		Version: "swarm-test",
+		Runtime: runtimeCtl,
+		Builder: newBuilderHandlerForTest(
+			func(context.Context) (map[string]any, error) {
+				return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+			},
+			nil,
+			"swarm-test",
+			runtimeCtl,
+			rt,
+			nil,
+		),
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, builderAuthHeader())
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{"type": "subscribe", "channel": "run:events:" + runID}); err != nil {
+		t.Fatalf("subscribe run events: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := builderAuthRequest(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":"10","method":"run.start","params":{"run_id":"run_live_001","inputs":{"intake.requested":{"topic":"sample"}}}}`)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.start status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.After(1 * time.Second)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		select {
+		case <-deadline:
+			t.Fatal("timed out draining initial run events")
+		default:
+		}
+		var frame builderWSEventFrame
+		if err := conn.ReadJSON(&frame); err != nil {
+			t.Fatalf("read initial run event: %v", err)
+		}
+		if frame.Channel != "run:events:"+runID {
+			continue
+		}
+		payload, _ := frame.Data.(map[string]any)
+		if payload["type"] == "run.completed" {
+			break
+		}
+	}
+
+	logPayload := json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"canonical-owner","error":"boom"}}`)
+	if err := storeStub.AppendEvent(context.Background(), events.Event{
+		ID:          "evt-runtime-log",
+		RunID:       runID,
+		Type:        events.EventType("platform.runtime_log"),
+		SourceAgent: "runtime",
+		Payload:     logPayload,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("append canonical runtime log: %v", err)
+	}
+
+	typedHandler, ok := handler.(*Handler)
+	if !ok || !builderpkg.HandleRuntimeLogForTest(typedHandler.builder, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Component: "scheduler",
+		Action:    "canonical-owner",
+	}) {
+		t.Fatalf("expected typed handler with builder runtime-log hook")
+	}
+
+	deadline = time.After(1 * time.Second)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for canonical runtime.log event")
+		default:
+		}
+		var frame builderWSEventFrame
+		if err := conn.ReadJSON(&frame); err != nil {
+			t.Fatalf("read run event: %v", err)
+		}
+		if frame.Channel != "run:events:"+runID {
+			continue
+		}
+		payload, _ := frame.Data.(map[string]any)
+		if payload["type"] != "runtime.log" {
+			continue
+		}
+		if payload["timestamp"] != now.Format(time.RFC3339) {
+			t.Fatalf("runtime.log timestamp = %#v, want %q", payload["timestamp"], now.Format(time.RFC3339))
+		}
+		return
+	}
+}
+
 func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -2852,7 +3229,7 @@ func TestHandler_RunStopResetsRuntimeAndStreamsStopped(t *testing.T) {
 }
 
 func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -2952,7 +3329,7 @@ func TestHandler_RunPauseAndContinueStreamStateChanges(t *testing.T) {
 }
 
 func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -3061,7 +3438,7 @@ func TestHandler_RunLifecycleOverAPIAliases(t *testing.T) {
 }
 
 func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -3158,7 +3535,7 @@ func TestHandler_RunBreakpointHitPausesRuntime(t *testing.T) {
 }
 
 func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -3294,7 +3671,7 @@ func TestHandler_HumanTaskWaitingAndDecisionResume(t *testing.T) {
 }
 
 func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}
@@ -3404,7 +3781,7 @@ func TestHandler_RunStepPausesAfterNextRuntimeEvent(t *testing.T) {
 }
 
 func TestHandler_RunRetryEmitsRetriedAndResumed(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(stubBuilderRunStore{})
+	bus, err := runtimebus.NewEventBus(&stubBuilderRunStore{})
 	if err != nil {
 		t.Fatalf("new event bus: %v", err)
 	}

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -29,6 +29,7 @@ type RunDebugRunSummary struct {
 	LastEventAt    time.Time  `json:"last_event_at,omitempty"`
 	EndedAt        *time.Time `json:"ended_at,omitempty"`
 	EventCount     int        `json:"event_count"`
+	EntityCount    int        `json:"entity_count"`
 }
 
 type RunDebugEventCount struct {
@@ -43,11 +44,13 @@ type RunDebugDeliveryCount struct {
 }
 
 type RunDebugEvent struct {
-	EventID    string    `json:"event_id,omitempty"`
-	EventName  string    `json:"event_name"`
-	EntityID   string    `json:"entity_id,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
-	SourceType string    `json:"source_type,omitempty"`
+	EventID    string          `json:"event_id,omitempty"`
+	EventName  string          `json:"event_name"`
+	EntityID   string          `json:"entity_id,omitempty"`
+	CreatedAt  time.Time       `json:"created_at"`
+	Source     string          `json:"source,omitempty"`
+	SourceType string          `json:"source_type,omitempty"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
 }
 
 type RunDebugMutation struct {
@@ -80,11 +83,17 @@ type RunDebugAgentTurn struct {
 }
 
 type RunDebugRuntimeLog struct {
-	Level     string    `json:"level"`
-	Component string    `json:"component"`
-	Action    string    `json:"action"`
-	Error     string    `json:"error,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	EventID   string          `json:"event_id,omitempty"`
+	Level     string          `json:"level"`
+	Message   string          `json:"message,omitempty"`
+	Component string          `json:"component"`
+	Action    string          `json:"action"`
+	EventType string          `json:"event_type,omitempty"`
+	AgentID   string          `json:"agent_id,omitempty"`
+	EntityID  string          `json:"entity_id,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Detail    json.RawMessage `json:"detail,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
 }
 
 type RunDebugRuntimeSummary struct {
@@ -99,10 +108,12 @@ type RunDebugReport struct {
 	RunTableStatus    string                   `json:"run_table_status,omitempty"`
 	RootEventID       string                   `json:"root_event_id,omitempty"`
 	RootEventType     string                   `json:"root_event_type,omitempty"`
+	ErrorSummary      string                   `json:"error_summary,omitempty"`
 	StartedAt         time.Time                `json:"started_at,omitempty"`
 	LastEventAt       time.Time                `json:"last_event_at,omitempty"`
 	EndedAt           *time.Time               `json:"ended_at,omitempty"`
 	EventCount        int                      `json:"event_count"`
+	EntityCount       int                      `json:"entity_count"`
 	WarnErrorLogCount int                      `json:"warn_error_log_count"`
 	EventCounts       []RunDebugEventCount     `json:"event_counts,omitempty"`
 	Deliveries        []RunDebugDeliveryCount  `json:"deliveries,omitempty"`
@@ -147,7 +158,7 @@ func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog 
 		return fmt.Errorf("run debug read surface requires canonical agent_turns.run_id")
 	}
 	required := map[string][]string{
-		"runs":             {"run_id", "status", "started_at", "ended_at"},
+		"runs":             {"run_id", "status", "error_summary", "started_at", "ended_at", "entity_count"},
 		"dead_letters":     {"original_event_id", "original_event", "entity_id", "failure_type", "error_message", "handler_node", "created_at"},
 		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "old_value", "new_value", "caused_by_event", "writer_type", "writer_id", "handler_step", "created_at"},
 	}
@@ -219,7 +230,8 @@ func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunD
 			COALESCE(root.created_at, r.started_at, now()),
 			summary.last_event_at,
 			r.ended_at,
-			COALESCE(summary.event_count, 0)
+			COALESCE(summary.event_count, 0),
+			COALESCE(r.entity_count, 0)
 		FROM runs r
 		LEFT JOIN LATERAL (
 			SELECT e.event_id, e.event_name, e.created_at
@@ -257,6 +269,7 @@ func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunD
 			&lastEvent,
 			&endedAt,
 			&item.EventCount,
+			&item.EntityCount,
 		); err != nil {
 			return nil, fmt.Errorf("scan run debug summary: %w", err)
 		}
@@ -290,22 +303,28 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	report := RunDebugReport{RunID: runID}
 
 	var (
-		runStatus string
-		started   sql.NullTime
-		ended     sql.NullTime
+		runStatus    string
+		errorSummary string
+		started      sql.NullTime
+		ended        sql.NullTime
+		entityCount  sql.NullInt64
 	)
 	if err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(status, ''), started_at, ended_at
+		SELECT COALESCE(status, ''), COALESCE(error_summary, ''), started_at, ended_at, COALESCE(entity_count, 0)
 		FROM runs
 		WHERE run_id = $1::uuid
-	`, report.RunID).Scan(&runStatus, &started, &ended); err == nil {
+	`, report.RunID).Scan(&runStatus, &errorSummary, &started, &ended, &entityCount); err == nil {
 		report.RunTableStatus = strings.TrimSpace(runStatus)
+		report.ErrorSummary = strings.TrimSpace(errorSummary)
 		if started.Valid {
 			report.StartedAt = started.Time
 		}
 		if ended.Valid {
 			tm := ended.Time
 			report.EndedAt = &tm
+		}
+		if entityCount.Valid {
+			report.EntityCount = int(entityCount.Int64)
 		}
 	} else if err != sql.ErrNoRows {
 		return RunDebugReport{}, fmt.Errorf("load run row: %w", err)
@@ -373,7 +392,14 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	}
 
 	eventRows, err := s.DB.QueryContext(ctx, `
-		SELECT event_id::text, event_name, COALESCE(entity_id::text, ''), created_at, COALESCE(produced_by_type, '')
+		SELECT
+			event_id::text,
+			event_name,
+			COALESCE(entity_id::text, ''),
+			created_at,
+			COALESCE(produced_by, ''),
+			COALESCE(produced_by_type, ''),
+			COALESCE(payload, '{}'::jsonb)
 		FROM events
 		WHERE run_id = $1::uuid
 		ORDER BY created_at DESC, event_id DESC
@@ -385,9 +411,11 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	defer eventRows.Close()
 	for eventRows.Next() {
 		var item RunDebugEvent
-		if err := eventRows.Scan(&item.EventID, &item.EventName, &item.EntityID, &item.CreatedAt, &item.SourceType); err != nil {
+		var payload []byte
+		if err := eventRows.Scan(&item.EventID, &item.EventName, &item.EntityID, &item.CreatedAt, &item.Source, &item.SourceType, &payload); err != nil {
 			return RunDebugReport{}, fmt.Errorf("scan run events: %w", err)
 		}
+		item.Payload = append(json.RawMessage(nil), payload...)
 		report.Events = append(report.Events, item)
 	}
 	if err := eventRows.Err(); err != nil {
@@ -553,10 +581,16 @@ func (s *PostgresStore) loadRunDebugRuntimeLogs(ctx context.Context, runID strin
 	}
 	logRows, err := s.DB.QueryContext(ctx, `
 		SELECT
+			event_id::text,
 			COALESCE(payload->>'log_level', ''),
+			COALESCE(payload->>'message', ''),
 			COALESCE(payload->'details'->>'component', ''),
 			COALESCE(payload->'details'->>'action', ''),
+			COALESCE(payload->'details'->>'event_type', ''),
+			COALESCE(payload->'details'->>'agent_id', ''),
+			COALESCE(payload->'details'->>'entity_id', ''),
 			COALESCE(payload->'details'->>'error', ''),
+			COALESCE(payload->'details', '{}'::jsonb),
 			created_at
 		FROM events
 		WHERE event_name = 'platform.runtime_log'
@@ -572,9 +606,11 @@ func (s *PostgresStore) loadRunDebugRuntimeLogs(ctx context.Context, runID strin
 	defer logRows.Close()
 	for logRows.Next() {
 		var item RunDebugRuntimeLog
-		if err := logRows.Scan(&item.Level, &item.Component, &item.Action, &item.Error, &item.CreatedAt); err != nil {
+		var detail []byte
+		if err := logRows.Scan(&item.EventID, &item.Level, &item.Message, &item.Component, &item.Action, &item.EventType, &item.AgentID, &item.EntityID, &item.Error, &detail, &item.CreatedAt); err != nil {
 			return fmt.Errorf("scan runtime logs: %w", err)
 		}
+		item.Detail = append(json.RawMessage(nil), detail...)
 		report.RuntimeLogs = append(report.RuntimeLogs, item)
 	}
 	if err := logRows.Err(); err != nil {


### PR DESCRIPTION
Closes #345

This PR builds on the canonical store-backed run-debug read owner merged in `#361` and moves the builder `run:events:<run_id>` debug stream onto that owner instead of reconstructing run-visible truth from local `runHub` heuristics.

Spec refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: flight_recorder`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: runs_list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: run_detail`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: run_events`
- `docs/RUNTIME_LOGGING_BOUNDARY.md`

What changed:
- extended the canonical run-debug read owner to carry the builder-facing fields needed for run event/debug streaming, including authoritative timestamps, payload/detail data, and terminal error/summary fields
- wired the builder `runHub` to consume that canonical owner for replay and live run-debug facts on `run:events:<run_id>`
- kept builder control-plane notifications on the same transport, but out of the canonical run-debug ownership path
- updated builder/server/store tests to prove canonical replay, no-entity runtime-log preservation, and authoritative terminal summaries

Root cause:
- after `#361`, the CLI already read run-debug truth from the store-backed owner, but the builder WebSocket/debug surface still used in-memory run session state, local runtime-log correlation by entity membership, fresh `time.Now()` timestamps, and synthetic replay/terminal envelopes

Scope:
- in scope: builder run event/debug stream owner path and the canonical store-backed run-debug owner fields it needs
- out of scope: broader builder control-plane notifications, dashboard/operator redesign outside the touched builder stream, and persisted foundation redesign from `#4`

Validation:
- `go test ./internal/builder ./internal/store ./internal/dashboard/server -run 'Test(ProjectCanonicalRunDebugReplay_|RunDebugReadSurface_|Handler_Run(EventReplayUsesCanonicalPersistedRunDebugOwner|EventStreamPreservesCanonicalRuntimeLogWithoutEntityID)|RunHubAwaitCompletion_)' -count=1`
- `go test ./internal/builder ./internal/store ./internal/dashboard/server ./cmd/swarm -count=1`
- `go test ./... -count=1`

Residual risk:
- the builder WebSocket channel still carries both canonical run-debug facts and builder control-plane notifications on one transport; this PR removes the debug-truth ownership drift in that channel but does not redesign the transport split itself

Tracker state:
- `docs/watchlists/operator-surfaces.yaml` now maps `#345` into `run_scoped_operator_identity` as the builder live run/debug follow-on to `#344` and `#361`
