### PR TITLE
[agent-a][issue #369] Add create_entity field initialization verify slice

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -928,6 +928,42 @@ func loadWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *run
 	return bundle
 }
 
+func firstWorkflowValidationFlowHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle) (string, string, string, runtimecontracts.SystemNodeEventHandler) {
+	t.Helper()
+	for _, view := range bundle.FlowViews() {
+		flowID := strings.TrimSpace(view.Paths.ID)
+		for nodeID, node := range view.Nodes {
+			for eventType, handler := range node.EventHandlers {
+				return flowID, nodeID, eventType, handler
+			}
+		}
+	}
+	t.Fatal("expected fixture to include at least one flow handler")
+	return "", "", "", runtimecontracts.SystemNodeEventHandler{}
+}
+
+func writeWorkflowValidationFlowHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	node := flowView.Nodes[nodeID]
+	node.EventHandlers[eventType] = handler
+	flowView.Nodes[nodeID] = node
+	if bundle.Nodes == nil {
+		bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{}
+	}
+	bundle.Nodes[nodeID] = node
+	if bundle.Semantics.NodeHandlers == nil {
+		bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	if bundle.Semantics.NodeHandlers[nodeID] == nil {
+		bundle.Semantics.NodeHandlers[nodeID] = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	bundle.Semantics.NodeHandlers[nodeID][eventType] = handler
+}
+
 func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t *testing.T) {
 	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
@@ -1077,5 +1113,41 @@ func TestVerifyBundle_DoesNotWarnForFlowOwnedAgentOutputEvents(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "'analysis.done' emitted but nobody subscribes") {
 		t.Fatalf("unexpected flow-owned agent output warning: %v", err)
+	}
+}
+
+func TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-missing-pin"))
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "expected_count", Type: "integer", Initial: 1},
+				{Name: "composite_score", Type: "number"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstWorkflowValidationFlowHandler(t, bundle)
+	handler.CreateEntity = true
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{ExpectedFrom: "entity.expected_count"}
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.composite_score",
+	}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.composite_score >= 0",
+	}}
+	writeWorkflowValidationFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	err := verifyBundle(context.Background(), semanticview.Wrap(bundle))
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from degraded compute proof")
+	}
+	if !strings.Contains(err.Error(), "entity.composite_score") {
+		t.Fatalf("verifyBundle error = %v, want composite_score warning", err)
+	}
+	if !strings.Contains(err.Error(), "dynamic") {
+		t.Fatalf("verifyBundle error = %v, want dynamic expected_from degradation detail", err)
 	}
 }

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3328,3 +3328,56 @@ workspace_model:
       /opt/swarm/contracts: Read-only volume from deployment artifact.
     portability_rule: A product contract that works on local dev MUST work on Docker and production without contract changes.
       Mount paths are invariant. Only the backing storage implementation changes.
+static_analyzer:
+  description: Accepted static analyzer slices promoted from review drafts into the authoritative platform contract spec.
+    These slices are verify-owned and must not be widened beyond their recorded scope without a spec change.
+  slice_1_create_entity_field_initialization:
+    id: semantic_validity_create_entity_field_initialization
+    domain: semantic_validity
+    authority: hard_invalidity
+    severity: error
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - handler_specification.expression_context.boot_validation
+    - handler_specification.expression_context.namespaces.entity
+    - handler_specification.handler_fields.create_entity
+    - handler_specification.dependency_graph
+    scope:
+      description: 'For handlers with create_entity: true, every entity.X value read must be provably initialized before the
+        read position using only the accepted slice-1 proof carriers.
+        '
+      applies_to:
+      - 'create_entity: true handlers only'
+      - 'entity.X value reads only'
+      excludes:
+      - full reaching-definitions across handlers or flows
+      - agent write proof via save_entity_field
+      - declared event/timer dead-surface drift
+    proof_carriers:
+      schema_initial_value:
+        valid_for: all create_entity read positions
+      same_handler_unconditional_top_level_data_accumulation:
+        valid_for: positions strictly after top-level data_accumulation in the same handler
+        not_valid_for:
+        - guard
+        - filter
+        - reduce
+        - count
+        - compute
+        - on_complete.condition
+        - rules.condition
+        - same-handler data_accumulation.expression
+      same_handler_compute_store_as:
+        valid_for: positions that run after compute in the same handler
+        degradation: If the proof depends on accumulate.expected_from resolving from a dynamic entity field, degrade the
+          finding to warning with an explicit assumption instead of claiming hard proof.
+      presence_check_positions:
+      - has(entity.X)
+      - entity.X == null
+      - entity.X != null
+    rule: A create_entity handler value read of entity.X is invalid unless one of the accepted proof carriers proves X is initialized
+      before that read position.
+    authority_notes:
+      hard_invalidity: Missing proof is error-level semantic invalidity on the verify surface.
+      degraded_warning: Same-handler compute.store_as proof becomes warning-grade only when it depends on dynamic expected_from.

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1185,6 +1185,7 @@ func TestRun_DoesNotWarnForFlowOwnedAgentEmissionsDeclaredAsFlowOutputs(t *testi
 func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = false
 	handler.Condition = "entity.missing_score >= 70"
 	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
 
@@ -1653,6 +1654,7 @@ func TestRun_PreservesSiblingWriteErrorWhenGuardAlsoReadsSparseField(t *testing.
 func TestRun_AllowsTopLevelDataAccumulationExpressionToReadRuleProducedField(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = false
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
 		Condition: "payload.score >= 70",
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
@@ -1694,6 +1696,74 @@ func TestRun_SuppressesExpressionFieldReferenceFindingWhenComputeMakesFieldAvail
 	}
 	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
 		t.Fatalf("unexpected expression_field_reference_validation warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_WarnsWhenCreateEntityComputeProofDependsOnDynamicExpectedFrom(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "expected_count", Type: "integer", Initial: 1},
+				{Name: "composite_score", Type: "number"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{ExpectedFrom: "entity.expected_count"}
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.composite_score",
+	}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.composite_score >= 0",
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.composite_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
+		t.Fatalf("expected degraded compute/store_as warning, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Warnings(), "expression_field_reference_validation", "dynamic") {
+		t.Fatalf("expected dynamic expected_from warning detail, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_AllowsCreateEntityComputeProofWhenExpectedFromIsNotDynamicEntityField(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
+		Groups: []runtimecontracts.EntitySchemaGroup{{
+			Name: "tracking",
+			Fields: []runtimecontracts.EntitySchemaField{
+				{Name: "composite_score", Type: "number"},
+			},
+		}},
+	}
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	handler.CreateEntity = true
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{Threshold: 1}
+	handler.Compute = &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpCount,
+		StoreAs:   "entity.composite_score",
+	}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
+		Condition: "entity.composite_score >= 0",
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.composite_score") {
+		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
+		t.Fatalf("unexpected degraded warning for non-dynamic expected_from, got %#v", report.Warnings())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepaths "swarm/internal/runtime/core/paths"
 	runtimeengine "swarm/internal/runtime/engine"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/workflowexpr"
@@ -160,6 +161,17 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						if _, ok := schemaInitials[field]; ok {
 							continue
 						}
+						if handler.CreateEntity {
+							if finding := createEntityFieldInitializationFinding(flowID, nodeID, eventType, handler, expr, field); finding != nil {
+								key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, field, finding.Severity}, "|")
+								if _, ok := seen[key]; ok {
+									continue
+								}
+								seen[key] = struct{}{}
+								c.entityRefFindings = append(c.entityRefFindings, *finding)
+							}
+							continue
+						}
 						key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, field}, "|")
 						if _, ok := seen[key]; ok {
 							continue
@@ -202,6 +214,74 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 	}
 
 	return c.entityRefFindings
+}
+
+func createEntityFieldInitializationFinding(flowID, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler, expr expressionReference, field string) *Finding {
+	if createEntityTopLevelDataAccumulationWritesField(handler, field) && createEntityTopLevelDataAccumulationMakesFieldAvailable(expr.Phase) {
+		return nil
+	}
+	if createEntityComputeStoresField(handler, field) && createEntityComputeMakesFieldAvailable(expr.Phase) {
+		if createEntityDynamicExpectedFrom(handler.Accumulate) {
+			return &Finding{
+				CheckID:  "expression_field_reference_validation",
+				Severity: "warning",
+				Message:  fmt.Sprintf("flow %s node %s handler %s references entity.%s in %s through same-handler compute.store_as, but accumulate.expected_from %q is dynamic so initialization proof degrades on the create_entity slice", flowID, nodeID, eventType, field, expr.Kind, strings.TrimSpace(handler.Accumulate.ExpectedFrom)),
+				Location: nodeID,
+			}
+		}
+		return nil
+	}
+	return &Finding{
+		CheckID:  "expression_field_reference_validation",
+		Severity: "error",
+		Message:  fmt.Sprintf("flow %s node %s handler %s references entity.%s in %s but the create_entity handler does not provably initialize %s before that position", flowID, nodeID, eventType, field, expr.Kind, field),
+		Location: nodeID,
+	}
+}
+
+func createEntityTopLevelDataAccumulationWritesField(handler runtimecontracts.SystemNodeEventHandler, field string) bool {
+	for _, write := range handler.DataAccumulation.Writes {
+		targetField, ok := runtimepipeline.WorkflowEntityFieldNameFromTarget(write.Target())
+		if ok && targetField == field {
+			return true
+		}
+	}
+	return false
+}
+
+func createEntityComputeStoresField(handler runtimecontracts.SystemNodeEventHandler, field string) bool {
+	if handler.Compute == nil {
+		return false
+	}
+	targetField, ok := runtimepipeline.WorkflowEntityFieldNameFromTarget(handler.Compute.StoreAs)
+	return ok && targetField == field
+}
+
+func createEntityTopLevelDataAccumulationMakesFieldAvailable(phase runtimepipeline.WorkflowEntityFieldLifecyclePhase) bool {
+	return phase == runtimepipeline.WorkflowEntityFieldLifecyclePayloadTransform
+}
+
+func createEntityComputeMakesFieldAvailable(phase runtimepipeline.WorkflowEntityFieldLifecyclePhase) bool {
+	switch phase {
+	case runtimepipeline.WorkflowEntityFieldLifecycleOnComplete,
+		runtimepipeline.WorkflowEntityFieldLifecycleRule,
+		runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation,
+		runtimepipeline.WorkflowEntityFieldLifecyclePayloadTransform:
+		return true
+	default:
+		return false
+	}
+}
+
+func createEntityDynamicExpectedFrom(spec *runtimecontracts.AccumulateSpec) bool {
+	if spec == nil {
+		return false
+	}
+	path := spec.ExpectedPath
+	if path.IsZero() {
+		path = runtimepaths.Parse(spec.ExpectedFrom)
+	}
+	return path.Root == runtimepaths.RootEntity
 }
 
 type expressionReference struct {


### PR DESCRIPTION
Closes #369

## Scope

Implements accepted analyzer slice 1 for verify-owned `create_entity` entity-field value reads only.

This PR stays inside the temporary binding slice spec accepted on `#369`, read together with the checked-in platform spec:
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.verify-analyzer-slice-1.yaml` (accepted temporary binding draft in the root `dev/swarm` repo)
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## What changed

- adds slice-1 create_entity field-initialization checks in canonical verify/bootverify ownership
- promotes the accepted slice-1 rule into checked-in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- keeps same-handler `compute.store_as` dynamic `expected_from` as degraded warning behavior only
- adds supported verify-surface proof in `cmd/swarm`

## Explicitly out of scope

- full reaching-definitions across handlers or flows
- `save_entity_field` write proof
- declared event/timer dead-surface drift work from `#366`

## Tests

- `go test ./internal/runtime/bootverify -run 'TestRun_(RejectsCreateEntityGuardReferenceToFieldInitializedOnlyBySameHandlerDataAccumulation|AllowsCreateEntityPayloadTransformReadOfSameHandlerTopLevelWrite|WarnsWhenCreateEntityComputeProofDependsOnDynamicExpectedFrom|AllowsCreateEntityComputeProofWhenExpectedFromIsNotDynamicEntityField)$' -count=1`
- `go test ./cmd/swarm -run 'TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`