### PR TITLE
[agent-b][issue #173] Harden delivery receipt seam hygiene

### DIFF
--- a/internal/store/delivery_receipt_invariants_test.go
+++ b/internal/store/delivery_receipt_invariants_test.go
@@ -1,0 +1,174 @@
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+	runtimemanager "swarm/internal/runtime/manager"
+	"swarm/internal/store"
+)
+
+func TestCanonicalDeliveryOwnerInvariant_PendingSurfacesAgree_V2(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string)
+		wantPending bool
+	}{
+		{
+			name:        "pending delivery remains pending everywhere",
+			setup:       func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {},
+			wantPending: true,
+		},
+		{
+			name: "in progress delivery remains pending everywhere",
+			setup: func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {
+				t.Helper()
+				if err := pg.MarkEventDeliveryInProgress(ctx, eventID, agentID, ""); err != nil {
+					t.Fatalf("MarkEventDeliveryInProgress: %v", err)
+				}
+			},
+			wantPending: true,
+		},
+		{
+			name: "retryable aged failure remains pending everywhere",
+			setup: func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {
+				t.Helper()
+				if err := pg.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(error): %v", err)
+				}
+				rewindCanonicalDeliveryAttempt(t, ctx, pg, eventID, agentID, time.Now().Add(-2*time.Minute))
+			},
+			wantPending: true,
+		},
+		{
+			name: "retryable fresh failure stays out of pending surfaces until backoff elapses",
+			setup: func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {
+				t.Helper()
+				if err := pg.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(error): %v", err)
+				}
+			},
+			wantPending: false,
+		},
+		{
+			name: "processed delivery leaves all pending surfaces",
+			setup: func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {
+				t.Helper()
+				if err := pg.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+					t.Fatalf("UpsertEventReceipt(processed): %v", err)
+				}
+			},
+			wantPending: false,
+		},
+		{
+			name: "dead letter leaves all pending surfaces",
+			setup: func(t *testing.T, ctx context.Context, pg *store.PostgresStore, eventID, agentID string) {
+				t.Helper()
+				if err := pg.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(first error): %v", err)
+				}
+				if err := pg.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+					t.Fatalf("UpsertEventReceipt(second error): %v", err)
+				}
+			},
+			wantPending: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg, cleanup := newTestPostgresStore(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+			evt := seedEvent(t, ctx, pg, entityID, "test.delivery_receipt.invariant."+strings.ReplaceAll(tt.name, " ", "_"))
+			if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+				t.Fatalf("InsertEventDeliveries: %v", err)
+			}
+
+			tt.setup(t, ctx, pg, evt.ID, agentID)
+			assertCanonicalPendingTruthAcrossSurfaces(t, ctx, pg, agentID, evt, tt.wantPending)
+		})
+	}
+}
+
+func TestCanonicalDeliveryOwnerInvariant_ReceiptRowsRemainOutcomeOnly_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.delivery_receipt.invariant.legacy_receipt_only")
+	insertLegacyAgentReceiptState(t, ctx, pg, evt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", time.Now().Add(-2*time.Minute))
+
+	assertCanonicalPendingTruthAcrossSurfaces(t, ctx, pg, agentID, evt, false)
+
+	err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "boom")
+	if err == nil {
+		t.Fatal("expected receipt-only state to fail closed without a canonical delivery row")
+	}
+	if !strings.Contains(err.Error(), "delivery row required") {
+		t.Fatalf("UpsertEventReceipt receipt-only error = %v, want delivery row required", err)
+	}
+}
+
+func assertCanonicalPendingTruthAcrossSurfaces(
+	t *testing.T,
+	ctx context.Context,
+	pg *store.PostgresStore,
+	agentID string,
+	evt events.Event,
+	wantPending bool,
+) {
+	t.Helper()
+
+	since := time.Now().Add(-2 * time.Hour)
+
+	direct, err := pg.ListPendingEventsForAgent(ctx, agentID, since, 100)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	assertPendingEventPresence(t, "direct pending reads", direct, evt.ID, wantPending)
+
+	subscribed, err := pg.ListPendingSubscribedEvents(ctx, agentID, []events.EventType{evt.Type}, since, 100)
+	if err != nil {
+		t.Fatalf("ListPendingSubscribedEvents: %v", err)
+	}
+	assertPendingEventPresence(t, "subscribed pending reads", subscribed, evt.ID, wantPending)
+
+	factsByAgent, err := pg.ListPendingAgentDeliveryFacts(ctx, []string{agentID}, since)
+	if err != nil {
+		t.Fatalf("ListPendingAgentDeliveryFacts: %v", err)
+	}
+	facts := factsByAgent[agentID]
+	if wantPending {
+		if facts.PendingCount != 1 {
+			t.Fatalf("pending delivery facts count = %d, want 1", facts.PendingCount)
+		}
+		if facts.OldestPendingAgeSec <= 0 {
+			t.Fatalf("oldest pending age = %d, want > 0", facts.OldestPendingAgeSec)
+		}
+		return
+	}
+	if facts.PendingCount != 0 || facts.OldestPendingAgeSec != 0 {
+		t.Fatalf("pending delivery facts = %+v, want zero pending truth", facts)
+	}
+}
+
+func assertPendingEventPresence(t *testing.T, surface string, evts []events.Event, eventID string, want bool) {
+	t.Helper()
+	found := false
+	for _, evt := range evts {
+		if strings.TrimSpace(evt.ID) == strings.TrimSpace(eventID) {
+			found = true
+			break
+		}
+	}
+	if found != want {
+		t.Fatalf("%s presence mismatch for %s: found=%v want=%v", surface, eventID, found, want)
+	}
+}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -140,6 +140,8 @@ type deliveryBackedTerminalTransitionRequest struct {
 	retryAdvance int
 }
 
+// Receipts are outcome-only for an existing agent delivery. This write path must
+// never mint or repair delivery ownership from receipt state.
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)

--- a/internal/store/pending_delivery_read_surface.go
+++ b/internal/store/pending_delivery_read_surface.go
@@ -50,6 +50,8 @@ func (r pendingAgentDeliveryRecord) isPending(now time.Time) bool {
 	return !r.ReceiptFound
 }
 
+// Pending truth is delivery-backed. Receipts can only confirm that a delivery-backed
+// attempt already completed; they must not become a substitute ownership source.
 func canonicalPendingDeliveryPredicateSQL(deliveryAlias, receiptAlias string) string {
 	return fmt.Sprintf(`(
 		(


### PR DESCRIPTION
## Human Summary
Harden the merged delivery/receipt canonical-owner seam with sparse owner notes and a reusable invariant suite. The implementation stays on the completed `#360` / `#367` seam only and does not reopen active `#157` compatibility-removal siblings.

Part of #173

## What Changed
- added two short seam-bearing canonical-owner notes at the real join points:
  - `canonicalPendingDeliveryPredicateSQL(...)`
  - `upsertAgentReceiptSpec(...)`
- added `internal/store/delivery_receipt_invariants_test.go`
- the new invariant suite proves the same canonical delivery-owner model across:
  - direct pending reads
  - subscribed pending reads
  - delivery-fact reads
  - delivery-backed receipt writes and fail-closed receipt-only state

## Why This Is Needed
The delivery/receipt seam is already canonicalized, but the local code still relied mostly on issue-specific regressions and issue/PR prose to explain ownership. This PR hardens that completed seam in two bounded ways: sparse local owner notes at the canonical join points, and reusable invariants that keep pending truth delivery-backed and receipt rows outcome-only.

## Scope Boundaries
In scope:
- completed-seam hygiene for the merged delivery/receipt canonical-owner seam from `#360` / `#367`
- sparse seam-bearing owner notes only at the canonical join points
- reusable invariant coverage for the same completed seam

Out of scope:
- active `#157` sibling compatibility-removal seams
- broad store cleanup or additional compatibility removal
- comment/test expansion outside the chosen completed seam

## Spec References
- No exact platform-spec refs govern this maintenance slice.
- Governing context is issue `#173`, merged issue `#360`, merged PR `#367`, and the canonical store owner chain for pending-delivery reads and receipt writes.

## Tests Run
- `go test ./internal/store -run 'TestCanonicalDeliveryOwnerInvariant_(PendingSurfacesAgree|ReceiptRowsRemainOutcomeOnly)_V2$' -count=1`
- `go test ./internal/store ./internal/runtime ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
- Parent `#173` remains open for additional completed seams that may still need hygiene hardening.
- This PR does not claim hygiene closure beyond the merged delivery/receipt seam.

## Follow-Up
- Continue `#173` with the next completed seam only after a fresh pre-audit picks that seam explicitly.
