### PR TITLE
[agent-d][issue #368] Align Claude turn tool surface with provider visibility

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -96,10 +96,13 @@ nodes:
       - context-token policy differs across transport surfaces
       - startup validation does not prove the real filtered transport path
       - agent-visible tool availability differs between prompt and transport
+      - supported agent turns can persist a canonical visible tool surface that is broader than the provider-callable surface actually available on that turn
+      - fallback relay on a supported turn can degrade file-backed work by clamping large relayed tool results to preview-only text
     representative_issues:
       - 111
       - 136
       - 137
+      - 368
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -434,6 +434,25 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 		return nil, err
 	}
+	if err := validateCLIResponseToolCallsForTurn(actor, s.Tools, resp); err != nil {
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:     s.AgentID,
+			RuntimeMode: resolved.RuntimeMode.String(),
+			SessionID:   s.ID,
+			RequestPayload: jsonBytes(map[string]any{
+				"args":                          args,
+				"message":                       message,
+				"provider_session_id":           strings.TrimSpace(s.ProviderSessionID),
+				"prompt_arg_fallback_attempted": transportFallback.Attempted,
+				"prompt_arg_fallback_used":      transportFallback.Used,
+			}),
+			ResponseRaw: resp.Raw,
+			ParseOK:     true,
+			Latency:     latency,
+			Error:       err.Error(),
+		}, resp))
+		return nil, err
+	}
 
 	s.Messages = append(s.Messages, message, resp.Message)
 	if sid := strings.TrimSpace(resp.SessionID); sid != "" && sid != s.ProviderSessionID {
@@ -494,4 +513,17 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 	}
 	return resp, nil
+}
+
+func validateCLIResponseToolCallsForTurn(actor runtimeactors.AgentConfig, tools []ToolDefinition, resp *Response) error {
+	if resp == nil || len(resp.ToolCalls) == 0 {
+		return nil
+	}
+	for _, call := range resp.ToolCalls {
+		if cliToolCallAllowedForTurn(actor, tools, resp, call.Name) {
+			continue
+		}
+		return fmt.Errorf("tool %q was not provider-visible or locally allowed on this turn", strings.TrimSpace(call.Name))
+	}
+	return nil
 }

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -553,9 +553,21 @@ func observedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []Too
 	return filterCanonicalVisibleToolsForActor(actor, tools, observed)
 }
 
+func plannedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	return append([]string(nil), surface.CanonicalVisibleTools...)
+}
+
 func cliLocalFallbackVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	return append([]string(nil), surface.LocalFallbackTools...)
+}
+
+func hasObservedCLIExecutionSurface(resp *Response) bool {
+	if resp == nil {
+		return false
+	}
+	return len(resp.VisibleTools) > 0 || len(resp.MCPVisibleTools) > 0 || len(resp.MCPServers) > 0
 }
 
 func cliToolCallAllowedForTurn(actor models.AgentConfig, tools []ToolDefinition, resp *Response, name string) bool {
@@ -569,6 +581,14 @@ func cliToolCallAllowedForTurn(actor models.AgentConfig, tools []ToolDefinition,
 		}
 	}
 	for _, visible := range observedCanonicalVisibleToolsForActor(actor, tools, resp) {
+		if visible == name {
+			return true
+		}
+	}
+	if hasObservedCLIExecutionSurface(resp) {
+		return false
+	}
+	for _, visible := range plannedCanonicalVisibleToolsForActor(actor, tools) {
 		if visible == name {
 			return true
 		}

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -242,6 +242,8 @@ type CLIExecutionToolSurface struct {
 	RuntimeToolNames      []string
 	PromptRuntimeTools    []string
 	ProviderBuiltinTools  []string
+	ProviderMCPTools      []string
+	LocalFallbackTools    []string
 }
 
 func cliExecutionToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefinition) CLIExecutionToolSurface {
@@ -311,22 +313,38 @@ func cliExecutionToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 	}
 
 	promptRuntime := make([]string, 0, len(runtimeNames))
+	providerMCPTools := make([]string, 0, len(runtimeNames))
+	localFallbackTools := make([]string, 0, len(runtimeNames))
 	for _, name := range runtimeNames {
-		if _, ok := nativeCapabilityTools[name]; ok {
+		canonical := toolidentity.CanonicalName(name)
+		if canonical == "" {
 			continue
 		}
-		promptRuntime = append(promptRuntime, name)
+		providerMCPTools = append(providerMCPTools, toolidentity.RuntimeToolsMCPPrefix+canonical)
+		if strings.HasPrefix(canonical, "emit_") {
+			localFallbackTools = append(localFallbackTools, canonical)
+			promptRuntime = append(promptRuntime, canonical)
+			continue
+		}
+		if _, ok := nativeCapabilityTools[canonical]; ok {
+			continue
+		}
+		promptRuntime = append(promptRuntime, toolidentity.RuntimeToolsMCPPrefix+canonical)
 	}
 
 	slices.Sort(providerBuiltins)
 	slices.Sort(canonicalVisible)
 	slices.Sort(promptRuntime)
+	slices.Sort(providerMCPTools)
+	slices.Sort(localFallbackTools)
 
 	return CLIExecutionToolSurface{
 		CanonicalVisibleTools: canonicalVisible,
 		RuntimeToolNames:      runtimeNames,
 		PromptRuntimeTools:    promptRuntime,
 		ProviderBuiltinTools:  providerBuiltins,
+		ProviderMCPTools:      providerMCPTools,
+		LocalFallbackTools:    localFallbackTools,
 	}
 }
 
@@ -410,7 +428,7 @@ func filterCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolD
 
 func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
-	allowed := make([]string, 0, len(surface.RuntimeToolNames)+len(surface.ProviderBuiltinTools)+len(claudeControlToolNames()))
+	allowed := make([]string, 0, len(surface.ProviderMCPTools)+len(surface.LocalFallbackTools)+len(surface.ProviderBuiltinTools)+len(claudeControlToolNames()))
 	seen := make(map[string]struct{}, cap(allowed))
 	addAllowed := func(name string) {
 		name = strings.TrimSpace(name)
@@ -423,7 +441,10 @@ func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefini
 		seen[name] = struct{}{}
 		allowed = append(allowed, name)
 	}
-	for _, name := range surface.RuntimeToolNames {
+	for _, name := range surface.ProviderMCPTools {
+		addAllowed(name)
+	}
+	for _, name := range surface.LocalFallbackTools {
 		addAllowed(name)
 	}
 	for _, name := range surface.ProviderBuiltinTools {
@@ -482,23 +503,77 @@ func augmentCLISystemPrompt(systemPrompt string, actor models.AgentConfig, tools
 	b.WriteString(cliToolInvocationMarker)
 	b.WriteString("\n")
 	if len(surface.PromptRuntimeTools) > 0 {
-		b.WriteString("Call Swarm runtime tools by these exact names when you need them:\n")
+		b.WriteString("Call Swarm runtime tools by these exact names when they are available in this turn:\n")
 		for _, name := range surface.PromptRuntimeTools {
 			b.WriteString("- ")
 			b.WriteString(name)
 			b.WriteString("\n")
 		}
-		b.WriteString("If Claude CLI also shows MCP-prefixed variants like `mcp__runtime-tools__...`, they map to the same Swarm runtime tools.\n")
+	}
+	nonEmitProviderTools := make([]string, 0, len(surface.ProviderMCPTools))
+	localFallbackSet := make(map[string]struct{}, len(surface.LocalFallbackTools))
+	for _, name := range surface.LocalFallbackTools {
+		localFallbackSet[strings.TrimSpace(name)] = struct{}{}
+	}
+	for _, name := range surface.ProviderMCPTools {
+		canonical := toolidentity.CanonicalName(name)
+		if _, ok := localFallbackSet[canonical]; ok {
+			continue
+		}
+		nonEmitProviderTools = append(nonEmitProviderTools, name)
+	}
+	if len(nonEmitProviderTools) > 0 {
+		b.WriteString("Provider-callable non-emit workflow tools are exposed through these exact MCP names:\n")
+		for _, name := range nonEmitProviderTools {
+			b.WriteString("- ")
+			b.WriteString(name)
+			b.WriteString("\n")
+		}
+	}
+	if len(surface.PromptRuntimeTools) > 0 || len(nonEmitProviderTools) > 0 {
+		b.WriteString("Non-emit workflow tools are exposed through MCP-prefixed names like `mcp__runtime-tools__...`. Raw `emit_*` calls remain local runtime fallbacks.\n")
 	}
 	if len(controlTools) > 0 {
 		b.WriteString("Claude CLI control tools available in this turn: ")
 		b.WriteString(strings.Join(controlTools, ", "))
 		b.WriteString(".\n")
 	}
-	if hasToolPrefix(surface.PromptRuntimeTools, "emit_") {
+	if hasToolPrefix(surface.LocalFallbackTools, "emit_") {
 		b.WriteString("When you need to publish an event, call the matching `emit_*` tool directly. Emit tools may not appear as MCP-prefixed variants in Claude CLI; Swarm will execute the exact `emit_*` call locally. Do not write JSON files under `/workspace/events` as a substitute for emission.\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func observedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition, resp *Response) []string {
+	if resp == nil {
+		return nil
+	}
+	observed := append([]string(nil), resp.VisibleTools...)
+	observed = append(observed, resp.MCPVisibleTools...)
+	return filterCanonicalVisibleToolsForActor(actor, tools, observed)
+}
+
+func cliLocalFallbackVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	return append([]string(nil), surface.LocalFallbackTools...)
+}
+
+func cliToolCallAllowedForTurn(actor models.AgentConfig, tools []ToolDefinition, resp *Response, name string) bool {
+	name = toolidentity.CanonicalName(name)
+	if name == "" {
+		return false
+	}
+	for _, allowed := range cliLocalFallbackVisibleToolsForActor(actor, tools) {
+		if allowed == name {
+			return true
+		}
+	}
+	for _, visible := range observedCanonicalVisibleToolsForActor(actor, tools, resp) {
+		if visible == name {
+			return true
+		}
+	}
+	return false
 }
 
 func hasToolPrefix(names []string, prefix string) bool {

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -266,10 +266,7 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 			dockerBin = "docker"
 		}
 		dockerArgs := []string{"exec", "-i"}
-		gatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
-		if gatewayURL == "" {
-			gatewayURL = "http://orchestrator:8090"
-		}
+		gatewayURL := runtimeMCPGatewayURLForContainerExecution()
 		if gatewayURL != "" {
 			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_URL="+gatewayURL)
 		}

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"swarm/internal/config"
@@ -60,4 +61,22 @@ func TestClaudeCLIRuntimeContinueSession_RejectsHostFallbackWhenTargetMissing(t 
 	}
 
 	_ = session
+}
+
+func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *testing.T) {
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+	runtime.cfg.LLM.ClaudeCLI.Command = "claude"
+
+	cmd := runtime.buildCommand(context.Background(), []string{"--print", "hello"}, &workspace.Target{
+		Container: "swarm-agent-market-research",
+		Workdir:   "/workspace",
+	})
+	got := strings.Join(cmd.Args, " ")
+	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8081/mcp") {
+		t.Fatalf("docker args = %q, want container-reachable MCP gateway URL", got)
+	}
 }

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -55,7 +55,8 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 	if token := strings.TrimSpace(gatewayToken); token != "" {
 		headers["Authorization"] = "Bearer " + token
 	}
-	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), toolNames(s.Tools))
+	surface := cliExecutionToolSurfaceForActor(actor, s.Tools)
+	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), surface.RuntimeToolNames)
 	if contextToken != "" {
 		headers[mcpContextTokenHeader] = contextToken
 	}

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -68,10 +69,7 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 }
 
 func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (configJSON string, contextToken string, enabled bool, err error) {
-	gatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
-	if gatewayURL == "" {
-		gatewayURL = "http://orchestrator:8090"
-	}
+	gatewayURL := runtimeMCPGatewayURLForContainerExecution()
 	binding, enabled, err := BuildMCPHTTPBinding(ctx, r.cfg, r.mcpTurns, s, gatewayURL, strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")))
 	if err != nil || !enabled {
 		return "", "", enabled, err
@@ -149,6 +147,47 @@ func normalizeMCPServerURL(raw string) string {
 		// Respect explicit path when operator already targets a specific endpoint.
 	}
 	return strings.TrimSpace(u.String())
+}
+
+func runtimeMCPGatewayURLForContainerExecution() string {
+	raw := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
+	if raw == "" {
+		raw = "http://orchestrator:8090"
+	}
+	return normalizeContainerExecutionMCPServerURL(raw)
+}
+
+func normalizeContainerExecutionMCPServerURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return normalizeMCPServerURL("http://orchestrator:8090")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || strings.TrimSpace(u.Host) == "" {
+		return normalizeMCPServerURL(raw)
+	}
+	if isLoopbackMCPHost(u.Hostname()) {
+		port := strings.TrimSpace(u.Port())
+		if port != "" {
+			u.Host = "host.docker.internal:" + port
+		} else {
+			u.Host = "host.docker.internal"
+		}
+		return normalizeMCPServerURL(u.String())
+	}
+	return normalizeMCPServerURL(raw)
+}
+
+func isLoopbackMCPHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (r *ClaudeCLIRuntime) runWithPromptTransportFallback(ctx context.Context, args []string, target *workspace.Target, prompt string, meta MonitorTurnMeta) (*Response, promptTransportFallback, error) {

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -285,12 +285,56 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 		t.Fatalf("context header = %#v, want %q", got, contextToken)
 	}
 	urlRaw := runtimeTools["url"].(string)
+	if urlRaw != "http://host.docker.internal:18082/mcp" {
+		t.Fatalf("url = %q, want container-reachable host MCP endpoint", urlRaw)
+	}
 	legacyTraceQuery := "trace" + "_id="
 	if strings.Contains(urlRaw, legacyTraceQuery) {
 		t.Fatalf("url %q should not propagate legacy trace query params", urlRaw)
 	}
 	if strings.Contains(urlRaw, "ctx_token=") {
 		t.Fatalf("url %q should not propagate context token query", urlRaw)
+	}
+}
+
+func TestBuildMCPConfigArg_PreservesNonLoopbackGatewayURLForContainerExecution(t *testing.T) {
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://orchestrator:8090")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+
+	r := &ClaudeCLIRuntime{
+		cfg: &config.Config{},
+		mcpTurns: mcpTurnContextStoreStub{
+			register:   func(_ context.Context, _ time.Duration, _ []string) string { return "ctx-token-456" },
+			unregister: func(string) {},
+		},
+	}
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:   "market-research-agent",
+		Role: "market_research",
+		Mode: "discovery",
+	})
+	s := &Session{
+		AgentID: "market-research-agent",
+		Tools:   []ToolDefinition{{Name: "query_entities"}},
+	}
+
+	cfgJSON, _, enabled, err := r.buildMCPConfigArg(ctx, s)
+	if err != nil {
+		t.Fatalf("buildMCPConfigArg: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected MCP config to be enabled")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &payload); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	servers := payload["mcpServers"].(map[string]any)
+	runtimeTools := servers["runtime-tools"].(map[string]any)
+	if got := runtimeTools["url"]; got != "http://orchestrator:8090/mcp" {
+		t.Fatalf("url = %#v, want orchestrator MCP endpoint preserved", got)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -360,3 +360,19 @@ func TestValidateCLIResponseToolCallsForTurn_AllowsObservedMCPToolAndEmitFallbac
 		t.Fatalf("validateCLIResponseToolCallsForTurn: %v", err)
 	}
 }
+
+func TestValidateCLIResponseToolCallsForTurn_AllowsPlannedNonEmitSurfaceWhenObservedMetadataIsAbsent(t *testing.T) {
+	actor := models.AgentConfig{
+		ID: "market-research-agent",
+	}
+	err := validateCLIResponseToolCallsForTurn(actor, []ToolDefinition{
+		{Name: "query_entities"},
+	}, &Response{
+		ToolCalls: []ToolCall{
+			{Name: "query_entities", Arguments: map[string]any{"entity_type": "company"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validateCLIResponseToolCallsForTurn: %v", err)
+	}
+}

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -96,7 +96,9 @@ func TestClaudeAllowedToolsArgForActor_IncludesPostCompositionAndNativeTools(t *
 	for _, name := range []string{
 		"emit_category_assessed",
 		"emit_market_research_scan_complete",
-		"query_entities",
+		"mcp__runtime-tools__emit_category_assessed",
+		"mcp__runtime-tools__emit_market_research_scan_complete",
+		"mcp__runtime-tools__query_entities",
 		"Read",
 		"Write",
 		"Edit",
@@ -106,7 +108,7 @@ func TestClaudeAllowedToolsArgForActor_IncludesPostCompositionAndNativeTools(t *
 			t.Fatalf("expected %q in allowed tools %q", name, got)
 		}
 	}
-	for _, name := range []string{"Bash", "WebSearch", "ToolSearch"} {
+	for _, name := range []string{"Bash", "WebSearch", "ToolSearch", "query_entities"} {
 		if slices.Contains(gotNames, name) {
 			t.Fatalf("did not expect %q in allowed tools %q", name, got)
 		}
@@ -129,12 +131,19 @@ func TestClaudeToolSurface_PrefersFallbackRuntimeToolsOverNativeBuiltins(t *test
 
 	allowed := claudeAllowedToolsArgForActor(actor, tools)
 	allowedNames := strings.Split(allowed, ",")
-	for _, name := range []string{"read_file", "write_file", "bash", "emit_category_assessed", "ExitPlanMode"} {
+	for _, name := range []string{
+		"mcp__runtime-tools__read_file",
+		"mcp__runtime-tools__write_file",
+		"mcp__runtime-tools__bash",
+		"mcp__runtime-tools__emit_category_assessed",
+		"emit_category_assessed",
+		"ExitPlanMode",
+	} {
 		if !slices.Contains(allowedNames, name) {
 			t.Fatalf("expected %q in allowed tools %q", name, allowed)
 		}
 	}
-	for _, name := range []string{"Read", "Write", "Edit", "Bash"} {
+	for _, name := range []string{"Read", "Write", "Edit", "Bash", "read_file", "write_file", "bash"} {
 		if slices.Contains(allowedNames, name) {
 			t.Fatalf("did not expect native builtin %q in allowed tools %q", name, allowed)
 		}
@@ -153,11 +162,16 @@ func TestClaudeToolSurface_PrefersFallbackRuntimeToolsOverNativeBuiltins(t *test
 		t.Fatalf("expected runtime tool prompt section, got %q", prompt)
 	}
 	if !strings.Contains(prompt, "emit_category_assessed") {
-		t.Fatalf("expected non-native runtime tools in prompt, got %q", prompt)
+		t.Fatalf("expected emit fallback tool in prompt, got %q", prompt)
 	}
 	for _, name := range []string{"read_file", "write_file", "bash"} {
-		if strings.Contains(prompt, name) {
+		if strings.Contains(prompt, "\n- "+name+"\n") {
 			t.Fatalf("did not expect native capability tool %q in prompt, got %q", name, prompt)
+		}
+	}
+	for _, name := range []string{"mcp__runtime-tools__read_file", "mcp__runtime-tools__write_file", "mcp__runtime-tools__bash"} {
+		if !strings.Contains(prompt, name) {
+			t.Fatalf("expected provider-visible MCP tool %q in prompt, got %q", name, prompt)
 		}
 	}
 	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
@@ -181,6 +195,12 @@ func TestCLIExecutionToolSurface_CanonicalizesProviderBuiltins(t *testing.T) {
 	if !slices.Equal(surface.ProviderBuiltinTools, []string{"Edit", "Read", "WebSearch", "Write"}) {
 		t.Fatalf("provider builtin tools = %#v", surface.ProviderBuiltinTools)
 	}
+	if !slices.Equal(surface.ProviderMCPTools, []string{"mcp__runtime-tools__emit_category_assessed"}) {
+		t.Fatalf("provider mcp tools = %#v", surface.ProviderMCPTools)
+	}
+	if !slices.Equal(surface.LocalFallbackTools, []string{"emit_category_assessed"}) {
+		t.Fatalf("local fallback tools = %#v", surface.LocalFallbackTools)
+	}
 	if !slices.Equal(surface.PromptRuntimeTools, []string{"emit_category_assessed"}) {
 		t.Fatalf("prompt runtime tools = %#v", surface.PromptRuntimeTools)
 	}
@@ -201,6 +221,12 @@ func TestCLIExecutionToolSurface_FileIOMixedFallbacksStayExecutable(t *testing.T
 	}
 	if !slices.Equal(surface.ProviderBuiltinTools, []string{"Edit", "Write"}) {
 		t.Fatalf("provider builtin tools = %#v", surface.ProviderBuiltinTools)
+	}
+	if !slices.Equal(surface.ProviderMCPTools, []string{"mcp__runtime-tools__emit_category_assessed", "mcp__runtime-tools__read_file"}) {
+		t.Fatalf("provider mcp tools = %#v", surface.ProviderMCPTools)
+	}
+	if !slices.Equal(surface.LocalFallbackTools, []string{"emit_category_assessed"}) {
+		t.Fatalf("local fallback tools = %#v", surface.LocalFallbackTools)
 	}
 }
 
@@ -285,5 +311,52 @@ func TestBuildMCPConfigArg_FailsClosedWithoutTurnContextStore(t *testing.T) {
 	_, _, _, err := r.buildMCPConfigArg(ctx, s)
 	if err == nil || !strings.Contains(err.Error(), "mcp turn context store is required") {
 		t.Fatalf("buildMCPConfigArg err = %v, want missing store error", err)
+	}
+}
+
+func TestValidateCLIResponseToolCallsForTurn_FailsClosedForNonEmitToolOutsideObservedSurface(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:          "market-research-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	}
+	err := validateCLIResponseToolCallsForTurn(actor, []ToolDefinition{
+		{Name: "emit_category_assessed"},
+		{Name: "read_file"},
+	}, &Response{
+		MCPServers: map[string]string{
+			"runtime-tools": "failed",
+		},
+		ToolCalls: []ToolCall{
+			{Name: "read_file", Arguments: map[string]any{"path": "/workspace/corpus.json"}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "read_file") {
+		t.Fatalf("validateCLIResponseToolCallsForTurn err = %v, want read_file visibility failure", err)
+	}
+}
+
+func TestValidateCLIResponseToolCallsForTurn_AllowsObservedMCPToolAndEmitFallback(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:          "market-research-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	}
+	err := validateCLIResponseToolCallsForTurn(actor, []ToolDefinition{
+		{Name: "emit_category_assessed"},
+		{Name: "read_file"},
+	}, &Response{
+		MCPServers: map[string]string{
+			"runtime-tools": "connected",
+		},
+		VisibleTools: []string{
+			"emit_category_assessed",
+			"read_file",
+		},
+		ToolCalls: []ToolCall{
+			{Name: "read_file", Arguments: map[string]any{"path": "/workspace/corpus.json"}},
+			{Name: "emit_category_assessed", Arguments: map[string]any{"category": "x"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validateCLIResponseToolCallsForTurn: %v", err)
 	}
 }

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -185,7 +185,6 @@ func (a *cliStreamAccumulator) mergeStreamEvent(obj map[string]any) {
 			}
 		}
 		if strings.TrimSpace(call.Name) != "" {
-			a.appendVisibleTool(call.Name)
 			a.streamedCalls = append(a.streamedCalls, cliRecordedToolCall{
 				ID: strings.TrimSpace(call.ID),
 				Call: ToolCall{

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -62,10 +62,29 @@ func TestCLIStreamAccumulator_ReconstructsStreamedToolInput(t *testing.T) {
 	if got := resp.MCPServers["runtime-tools"]; got != "connected" {
 		t.Fatalf("mcp servers = %#v", resp.MCPServers)
 	}
-	if len(resp.VisibleTools) != 3 || resp.VisibleTools[0] != "emit_category_assessed" || resp.VisibleTools[1] != "query_metrics" || resp.VisibleTools[2] != "read_file" {
+	if len(resp.VisibleTools) != 2 || resp.VisibleTools[0] != "query_metrics" || resp.VisibleTools[1] != "read_file" {
 		t.Fatalf("visible tools = %#v", resp.VisibleTools)
 	}
-	if len(resp.MCPVisibleTools) != 2 || resp.MCPVisibleTools[0] != "mcp__runtime-tools__emit_category_assessed" || resp.MCPVisibleTools[1] != "mcp__runtime-tools__query_metrics" {
+	if len(resp.MCPVisibleTools) != 1 || resp.MCPVisibleTools[0] != "mcp__runtime-tools__query_metrics" {
+		t.Fatalf("mcp visible tools = %#v", resp.MCPVisibleTools)
+	}
+}
+
+func TestCLIStreamAccumulator_DoesNotPromoteAttemptedStreamedToolUseIntoVisibleSurface(t *testing.T) {
+	acc := newCLIStreamAccumulator()
+	acc.AddLine([]byte(`{"type":"system","subtype":"init","session_id":"sess-attempted","mcp_servers":[{"name":"runtime-tools","status":"failed"}],"tools":["ExitPlanMode"]}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","name":"mcp__runtime-tools__read_file","input":{}}},"session_id":"sess-attempted"}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/workspace/corpus.json\"}"}},"session_id":"sess-attempted"}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_stop","index":2},"session_id":"sess-attempted"}`))
+
+	resp := acc.Response()
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("tool calls = %#v", resp.ToolCalls)
+	}
+	if len(resp.VisibleTools) != 0 {
+		t.Fatalf("visible tools = %#v", resp.VisibleTools)
+	}
+	if len(resp.MCPVisibleTools) != 0 {
 		t.Fatalf("mcp visible tools = %#v", resp.MCPVisibleTools)
 	}
 }

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -9,6 +9,7 @@ import (
 
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
+	"swarm/internal/runtime/core/toolidentity"
 	"swarm/internal/runtime/sessions"
 )
 
@@ -25,6 +26,8 @@ const defaultMaxToolRounds = 8
 const (
 	maxToolResultBytes        = 16 * 1024
 	maxToolMessageBytes       = 64 * 1024
+	maxReadFileResultBytes    = 256 * 1024
+	maxReadFileMessageBytes   = 256 * 1024
 	maxToolErrorTextRunes     = 600
 	maxToolResultPreviewRunes = 1200
 )
@@ -222,7 +225,7 @@ func (c *Conversation) executeToolCalls(ctx context.Context, calls []ToolCall) (
 			entry["error"] = clampRunes(err.Error(), maxToolErrorTextRunes)
 		} else {
 			entry["ok"] = true
-			entry["result"] = clampToolResult(out)
+			entry["result"] = clampToolResult(tc.Name, out)
 		}
 		results = append(results, entry)
 		executed = append(executed, executedToolCall{
@@ -238,11 +241,11 @@ func (c *Conversation) executeToolCalls(ctx context.Context, calls []ToolCall) (
 	if err != nil {
 		return fmt.Sprintf(`[%q]`, err.Error()), executed
 	}
-	if len(b) > maxToolMessageBytes {
+	if len(b) > toolRelayMessageLimit(calls) {
 		overflow := []map[string]any{{
 			"name":  "__runtime_guardrail__",
 			"ok":    false,
-			"error": fmt.Sprintf("tool output exceeded %d bytes and was truncated", maxToolMessageBytes),
+			"error": fmt.Sprintf("tool output exceeded %d bytes and was truncated", toolRelayMessageLimit(calls)),
 		}}
 		guarded, gerr := json.Marshal(overflow)
 		if gerr != nil {
@@ -313,7 +316,7 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 	return toolcapabilities.WithContext(ctx, c.toolExecutor.ToolCapabilitiesForActor(actor, names, nil))
 }
 
-func clampToolResult(result any) any {
+func clampToolResult(name string, result any) any {
 	if result == nil {
 		return nil
 	}
@@ -324,7 +327,8 @@ func clampToolResult(result any) any {
 			"error":     "marshal tool result",
 		}
 	}
-	if len(b) <= maxToolResultBytes {
+	limit := toolRelayResultLimit(name)
+	if len(b) <= limit {
 		return result
 	}
 	return map[string]any{
@@ -332,6 +336,26 @@ func clampToolResult(result any) any {
 		"bytes":     len(b),
 		"preview":   clampRunes(string(b), maxToolResultPreviewRunes),
 	}
+}
+
+func toolRelayResultLimit(name string) int {
+	if toolIsLargeRelayFileRead(name) {
+		return maxReadFileResultBytes
+	}
+	return maxToolResultBytes
+}
+
+func toolRelayMessageLimit(calls []ToolCall) int {
+	for _, call := range calls {
+		if toolIsLargeRelayFileRead(call.Name) {
+			return maxReadFileMessageBytes
+		}
+	}
+	return maxToolMessageBytes
+}
+
+func toolIsLargeRelayFileRead(name string) bool {
+	return toolidentity.CanonicalName(name) == "read_file"
 }
 
 func clampRunes(s string, maxRunes int) string {

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -319,6 +319,35 @@ func TestConversation_ExecuteToolCalls_TruncatesLargeResult(t *testing.T) {
 	}
 }
 
+func TestConversation_ExecuteToolCalls_PreservesLargeReadFileResultOnSupportedRelayPath(t *testing.T) {
+	huge := strings.Repeat("x", maxToolMessageBytes+8*1024)
+	c := NewConversation("a1", "t1", "sys", nil, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(largeToolExec{payload: map[string]any{
+		"content":    huge,
+		"size_bytes": len(huge),
+	}})
+
+	raw, _ := c.executeToolCalls(context.Background(), []ToolCall{{Name: "read_file", Arguments: map[string]any{"path": "/workspace/corpus.json"}}})
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != true {
+		t.Fatalf("expected successful tool payload, got %#v", arr)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	if resultMap == nil {
+		t.Fatalf("expected result map, got %#v", arr[0]["result"])
+	}
+	if truncated, _ := resultMap["truncated"].(bool); truncated {
+		t.Fatalf("expected supported read_file relay to preserve full content, got %#v", resultMap)
+	}
+	content, _ := resultMap["content"].(string)
+	if len(content) != len(huge) {
+		t.Fatalf("content length = %d, want %d", len(content), len(huge))
+	}
+}
+
 func TestConversationStep_TerminatesAfterSuccessfulEmitToolCalls(t *testing.T) {
 	rt := &scriptedRuntime{
 		responses: []*Response{{

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -73,6 +73,8 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		actor, _ := runtimeactors.ActorFromContext(ctx)
 		if observed := observedCanonicalVisibleToolsForActor(actor, sessionTools(s), resp); len(observed) > 0 {
 			rec.AvailableTools = append([]string(nil), observed...)
+		} else if hasObservedCLIExecutionSurface(resp) {
+			rec.AvailableTools = append([]string(nil), cliLocalFallbackVisibleToolsForActor(actor, s.Tools)...)
 		}
 	}
 	if resp != nil && len(rec.MCPToolsVisible) == 0 {
@@ -111,7 +113,7 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	}
 	if len(rec.AvailableTools) == 0 && s != nil {
 		actor, _ := runtimeactors.ActorFromContext(ctx)
-		rec.AvailableTools = append([]string(nil), cliLocalFallbackVisibleToolsForActor(actor, s.Tools)...)
+		rec.AvailableTools = append([]string(nil), plannedCanonicalVisibleToolsForActor(actor, s.Tools)...)
 	}
 	return rec
 }

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -69,9 +69,11 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	if resp != nil && len(rec.ToolCalls) == 0 {
 		rec.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
 	}
-	if resp != nil && len(rec.AvailableTools) == 0 && len(resp.VisibleTools) > 0 {
+	if resp != nil && len(rec.AvailableTools) == 0 {
 		actor, _ := runtimeactors.ActorFromContext(ctx)
-		rec.AvailableTools = append([]string(nil), filterCanonicalVisibleToolsForActor(actor, sessionTools(s), resp.VisibleTools)...)
+		if observed := observedCanonicalVisibleToolsForActor(actor, sessionTools(s), resp); len(observed) > 0 {
+			rec.AvailableTools = append([]string(nil), observed...)
+		}
 	}
 	if resp != nil && len(rec.MCPToolsVisible) == 0 {
 		rec.MCPToolsVisible = append([]string(nil), resp.MCPVisibleTools...)
@@ -109,7 +111,7 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	}
 	if len(rec.AvailableTools) == 0 && s != nil {
 		actor, _ := runtimeactors.ActorFromContext(ctx)
-		rec.AvailableTools = append([]string(nil), cliExecutionToolSurfaceForActor(actor, s.Tools).CanonicalVisibleTools...)
+		rec.AvailableTools = append([]string(nil), cliLocalFallbackVisibleToolsForActor(actor, s.Tools)...)
 	}
 	return rec
 }

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -262,7 +262,7 @@ func TestEnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities(t *test
 		SessionID:   "session-1",
 	}, nil)
 
-	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed"}) {
+	if !slices.Equal(rec.AvailableTools, []string{"bash", "emit_category_assessed", "read_file", "write_file"}) {
 		t.Fatalf("available_tools = %#v", rec.AvailableTools)
 	}
 }
@@ -288,6 +288,59 @@ func TestEnrichTurnRecord_FiltersCLIControlToolsFromObservedVisibleTools(t *test
 	})
 
 	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+}
+
+func TestEnrichTurnRecord_UsesEmitFallbackWhenObservedCLISurfaceExistsWithoutVisibleNonEmitTools(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+		NativeTools: runtimeactors.NativeToolConfig{
+			FileIO: true,
+		},
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+			{Name: "read_file"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, &Response{
+		MCPServers: map[string]string{
+			"runtime-tools": "failed",
+		},
+	})
+
+	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed"}) {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+}
+
+func TestEnrichTurnRecord_UsesPlannedConfiguredSurfaceWhenObservedMetadataIsAbsent(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+			{Name: "query_entities"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, &Response{
+		ToolCalls: []ToolCall{
+			{Name: "query_entities", Arguments: map[string]any{"entity_type": "company"}},
+		},
+	})
+
+	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed", "query_entities"}) {
 		t.Fatalf("available_tools = %#v", rec.AvailableTools)
 	}
 }

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -200,8 +200,11 @@ func TestClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools(t *test
 	if !strings.Contains(s.SystemPrompt, "emit_market_research_scan_complete") {
 		t.Fatalf("expected emit tool name in system prompt, got %q", s.SystemPrompt)
 	}
-	if !strings.Contains(s.SystemPrompt, "read_file") {
-		t.Fatalf("expected runtime tool name in system prompt, got %q", s.SystemPrompt)
+	if !strings.Contains(s.SystemPrompt, "mcp__runtime-tools__read_file") {
+		t.Fatalf("expected provider-visible runtime tool name in system prompt, got %q", s.SystemPrompt)
+	}
+	if strings.Contains(s.SystemPrompt, "\n- read_file\n") {
+		t.Fatalf("did not expect raw non-emit runtime tool fallback in system prompt, got %q", s.SystemPrompt)
 	}
 	if strings.Contains(s.SystemPrompt, "Claude CLI native tools available in this turn") {
 		t.Fatalf("did not expect native builtin prompt section, got %q", s.SystemPrompt)
@@ -259,10 +262,7 @@ func TestEnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities(t *test
 		SessionID:   "session-1",
 	}, nil)
 
-	if len(rec.AvailableTools) != 4 {
-		t.Fatalf("available_tools = %#v", rec.AvailableTools)
-	}
-	if !slices.Equal(rec.AvailableTools, []string{"bash", "emit_category_assessed", "read_file", "write_file"}) {
+	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed"}) {
 		t.Fatalf("available_tools = %#v", rec.AvailableTools)
 	}
 }
@@ -311,8 +311,13 @@ func TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble(
 		t.Fatalf("expected non-native runtime tool in prompt, got %q", prompt)
 	}
 	for _, name := range []string{"read_file", "write_file", "bash"} {
-		if strings.Contains(prompt, name) {
+		if strings.Contains(prompt, "\n- "+name+"\n") {
 			t.Fatalf("did not expect native capability tool %q in prompt, got %q", name, prompt)
+		}
+	}
+	for _, name := range []string{"mcp__runtime-tools__read_file", "mcp__runtime-tools__write_file", "mcp__runtime-tools__bash"} {
+		if !strings.Contains(prompt, name) {
+			t.Fatalf("expected provider-visible MCP tool %q in prompt, got %q", name, prompt)
 		}
 	}
 	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
@@ -604,7 +609,7 @@ func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	if rec.EntityID != "22222222-2222-2222-2222-222222222222" {
 		t.Fatalf("entity_id = %q", rec.EntityID)
 	}
-	if len(rec.AvailableTools) != 2 || rec.AvailableTools[0] != "emit_category_assessed" || rec.AvailableTools[1] != "read_file" {
+	if len(rec.AvailableTools) != 1 || rec.AvailableTools[0] != "emit_category_assessed" {
 		t.Fatalf("available_tools = %#v", rec.AvailableTools)
 	}
 	if len(rec.ToolCalls) != 1 || rec.ToolCalls[0].Name != "emit_category_assessed" {


### PR DESCRIPTION
Closes #368

## Spec references
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: native_tools.relationship_to_tool_filtering`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: native_tools.runtime_resolution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.tool_implementation_classes.mcp`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.agent_tool_filtering.default_deny`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.mcp_client.protocol`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.mcp_client.boot_sequence`

## Human Summary
This closes the narrowed `#368` execution-boundary class by making Claude CLI turns tell one honest tool-visibility story on the supported file-backed path. Non-emit workflow tools now ride the provider-visible MCP surface, local raw fallback is constrained to `emit_*`, and turn persistence stops advertising non-emit tools when the provider never surfaced them.

## What Changed
- aligned Claude turn projections so runtime workflow tools are exposed to the provider as `mcp__runtime-tools__...`, while raw local fallback stays emit-only
- moved MCP turn-context registration onto the same helper-owned runtime tool surface instead of raw session tool names
- made CLI turn validation fail closed when a response tries to execute a non-emit tool that was not provider-visible on that turn
- changed persisted `available_tools` shaping to use observed provider-visible tools when present and emit-only local fallback when not
- refined the `transport_policy_and_surface_parity` watchlist node with the concrete `#368` manifestations

## Why This Is Needed
Current head could let the supported file-backed turn persist / narrate `read_file` and similar tools even when the provider-visible runtime tool surface was narrower or failed, then continue through a local relay path that degrades large file-backed work. That left helper projections, transport binding, persistence, and fallback behavior telling different truths about the same turn.

## Scope Boundaries
- in scope: first live supported Claude CLI turn up to successful workflow-event emission
- in scope: provider-visible tool surface, MCP turn binding, persisted `available_tools`, and same-turn fallback gating
- out of scope: downstream `category.assessed -> signals.batch_ready / entity_state / discovery-coordinator / vertical.discovered` propagation tracked in `#373`
- out of scope: broad expression/tooling redesign outside this Claude live-turn usability class

## Tests Run
- `go test ./internal/runtime/llm -run 'Test(ClaudeAllowedToolsArgForActor_IncludesPostCompositionAndNativeTools|ClaudeToolSurface_PrefersFallbackRuntimeToolsOverNativeBuiltins|CLIExecutionToolSurface_CanonicalizesProviderBuiltins|CLIExecutionToolSurface_FileIOMixedFallbacksStayExecutable|BuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation|BuildMCPConfigArg_FailsClosedWithoutTurnContextStore|ValidateCLIResponseToolCallsForTurn_FailsClosedForNonEmitToolOutsideObservedSurface|ValidateCLIResponseToolCallsForTurn_AllowsObservedMCPToolAndEmitFallback|ClaudeCLIRuntime_StartSessionAugmentsSystemPromptWithSwarmTools|EnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities|EnrichTurnRecord_FiltersCLIControlToolsFromObservedVisibleTools)' -count=1`
- `go test ./internal/runtime/llm ./internal/runtime/agents ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk
I could not rerun the real helper-path shell repro locally because this shell does not have the required `SWARM_TOOL_GATEWAY_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` startup prerequisites. The runtime and repo-wide proof is therefore code/test based rather than a fresh live helper execution on this machine.

## Follow-Up
- no new same-class concrete sibling is open in this live-turn usability lane after this change
- broader post-agent propagation remains explicitly split to `#373`
