### PR TITLE
[agent-b][issue #173] Harden builtin tool parity seam hygiene

### DIFF
--- a/cmd/swarm/builtin_tool_parity_invariants_test.go
+++ b/cmd/swarm/builtin_tool_parity_invariants_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+
+	runtimepkg "swarm/internal/runtime"
+	runtimebootverify "swarm/internal/runtime/bootverify"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+func TestBuiltinToolParityInvariant_SupportedSurfacesShareRuntimeToolTruth_V2(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	cases := []struct {
+		name               string
+		configuredTool     string
+		permissions        []string
+		wantToolResolution bool
+	}{
+		{
+			name:               "builtin runtime tool stays accepted across verify and boot",
+			configuredTool:     "schedule",
+			permissions:        []string{"schedule"},
+			wantToolResolution: false,
+		},
+		{
+			name:               "truly missing tool still warns across boot surfaces",
+			configuredTool:     "missing_tool",
+			wantToolResolution: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := testWorkflowValidationBundle()
+			bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+				"agent-1": {
+					ID:          "agent-1",
+					Tools:       []string{tc.configuredTool},
+					Permissions: tc.permissions,
+				},
+			}
+			source := semanticview.Wrap(bundle)
+
+			directReport := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+			assertToolResolutionWarning(t, directReport.Warnings(), tc.configuredTool, tc.wantToolResolution)
+
+			result, runtimeErr := runtimepkg.ValidateWorkflowContractSurface(context.Background(), source, runtimepkg.DefaultWorkflowContractValidationOptions(nil))
+			if runtimeErr != nil {
+				t.Fatalf("ValidateWorkflowContractSurface: %v", runtimeErr)
+			}
+			assertToolResolutionWarning(t, result.BootReport.Warnings(), tc.configuredTool, tc.wantToolResolution)
+
+			if err := verifyBundle(context.Background(), source); err != nil {
+				t.Fatalf("verifyBundle: %v", err)
+			}
+
+			assertBootSkeletonUsesRuntimeToolInventory(t, source, result.BootReport)
+		})
+	}
+}
+
+func assertToolResolutionWarning(t *testing.T, warnings []runtimebootverify.Finding, toolID string, want bool) {
+	t.Helper()
+	found := false
+	for _, warning := range warnings {
+		if strings.TrimSpace(warning.CheckID) != "tool_resolution" {
+			continue
+		}
+		if strings.Contains(warning.Message, toolID) {
+			found = true
+			break
+		}
+	}
+	if found != want {
+		t.Fatalf("tool_resolution warning mismatch for %q: found=%v want=%v warnings=%#v", toolID, found, want, warnings)
+	}
+}
+
+func assertBootSkeletonUsesRuntimeToolInventory(t *testing.T, source semanticview.Source, report runtimebootverify.Report) {
+	t.Helper()
+
+	wantTools := len(runtimetools.RuntimeAvailableToolNamesForSource(source))
+	if wantTools == 0 {
+		t.Fatal("runtime tool inventory unexpectedly empty")
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	previous := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(previous)
+
+	logBootSkeleton(source, "/tmp/contracts", "/tmp/platform-spec.yaml", report, "state stores ready")
+
+	out := buf.String()
+	if !strings.Contains(out, "name=build_registries") {
+		t.Fatalf("log output missing build_registries step:\n%s", out)
+	}
+	if !strings.Contains(out, "tools="+strconv.Itoa(wantTools)) {
+		t.Fatalf("log output missing runtime tool count %d:\n%s", wantTools, out)
+	}
+	if strings.Contains(out, "tools=0") {
+		t.Fatalf("log output still reports zero tools:\n%s", out)
+	}
+}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -402,6 +402,8 @@ func (c *checkerContext) toolResolution() []Finding {
 	c.toolLoaded = true
 	mcpPrefixes := declaredMCPPrefixes(c.source)
 	discoveredTools := c.mcpDiscovered()
+	// Boot tool warnings must consume the same runtime inventory truth that the
+	// generic runtime ships, then layer MCP discovery on top of it.
 	runtimeToolNames := c.runtimeAvailableToolNames()
 	for agentID, agent := range c.source.AgentEntries() {
 		agentID = strings.TrimSpace(agentID)

--- a/internal/runtime/tools/contracts.go
+++ b/internal/runtime/tools/contracts.go
@@ -55,6 +55,9 @@ func LoadContractSchemasForSource(source semanticview.Source) (map[string]Contra
 	return parsed, nil
 }
 
+// This is the canonical builtin/non-MCP runtime tool inventory for supported
+// verify, boot-warning, and operator-diagnostic surfaces. Authored ToolEntries
+// alone are not the full runtime-available tool truth.
 func RuntimeAvailableToolNamesForSource(source semanticview.Source) []string {
 	names := make(map[string]struct{})
 	for name := range supportedRuntimeToolNames {


### PR DESCRIPTION
## Human Summary
Harden the merged builtin-tool parity seam with sparse owner notes and a reusable invariant suite. The implementation stays on the completed `#356` / `#358` seam only and does not reopen active semantic or maintenance siblings.

Part of #173

## What Changed
- added two short seam-bearing canonical-owner notes at the real join points:
  - `RuntimeAvailableToolNamesForSource(...)`
  - `checkerContext.toolResolution()`
- added `cmd/swarm/builtin_tool_parity_invariants_test.go`
- the new invariant suite proves the same builtin-tool truth across:
  - direct `bootverify.Run(...)`
  - `ValidateWorkflowContractSurface(...)`
  - `verifyBundle(...)`
  - `logBootSkeleton(...)` tool-count diagnostics

## Why This Is Needed
The builtin-tool parity seam is already canonicalized, but the local code still relied mostly on issue-specific parity regressions and issue/PR prose to explain ownership. This PR hardens that completed seam in two bounded ways: sparse local owner notes at the canonical owner chain, and reusable invariants that keep verify, boot warnings, and boot tool-count diagnostics aligned to the same runtime tool inventory truth.

## Scope Boundaries
In scope:
- completed-seam hygiene for the merged builtin-tool parity seam from `#356` / `#358`
- sparse seam-bearing owner notes only at the canonical owner chain
- reusable invariant coverage for the same completed seam

Out of scope:
- MCP discovery warning semantics
- contract-declared tool implementation validation
- active semantic redesign or maintenance siblings

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: boot_verification.checks.tool_resolution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.tool_implementation_classes.platform_builtin`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.platform_builtin_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: tool_model.generic_runtime_rule`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: agent_tool_filtering.rule`

## Tests Run
- `go test ./internal/runtime/bootverify ./cmd/swarm -run 'Test(BuiltinToolParityInvariant_SupportedSurfacesShareRuntimeToolTruth_V2|Run_DoesNotWarnForBuiltinRuntimeToolReference|Run_MapsMissingToolToToolResolutionWarning|LogBootSkeleton_UsesRuntimeToolInventoryCount|VerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/tools ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`

## Residual Risk
- Parent `#173` remains open for additional completed seams that may still need hygiene hardening.
- This PR does not claim hygiene closure beyond the merged builtin-tool parity seam.

## Follow-Up
- Continue `#173` with the next completed seam only after a fresh pre-audit picks that seam explicitly.
