### PR TITLE
[agent-a][issue #377] Add emitted payload completeness analyzer slice

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1160,3 +1160,76 @@ func TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface(t *te
 		t.Fatalf("verifyBundle error = %v, want dynamic expected_from degradation detail", err)
 	}
 }
+
+func TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Platform: runtimecontracts.PlatformSpecDocument{},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "default",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "scan_id", Type: "string"},
+						{Name: "geography", Type: "string"},
+					},
+				}},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"dispatcher": {
+					"scan.corpus_dispatch": {
+						Emits: runtimecontracts.EventEmission{Single: "market_research.scan_assigned"},
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"dispatcher": {
+				SubscribesTo: []string{"scan.corpus_dispatch"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"scan.corpus_dispatch": {
+						Emits: runtimecontracts.EventEmission{Single: "market_research.scan_assigned"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.corpus_dispatch": {
+				Source: "external",
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"scan_id":   {Type: "string"},
+						"geography": {Type: "string"},
+					},
+				},
+				Required: []string{"scan_id", "geography"},
+			},
+			"market_research.scan_assigned": {
+				ConsumerType: []string{"dashboard"},
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"entity_id":          {Type: "string"},
+						"current_state":      {Type: "string"},
+						"trigger_event_type": {Type: "string"},
+						"scan_id":            {Type: "string"},
+					},
+				},
+				Required: []string{"entity_id", "scan_id"},
+			},
+		},
+	}
+	bundle.Platform.Platform.Name = "test"
+	bundle.Platform.Platform.Version = "1.0.0"
+
+	err := verifyBundle(context.Background(), semanticview.Wrap(bundle))
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from emitted payload completeness")
+	}
+	if !strings.Contains(err.Error(), "scan_id is not statically provable") {
+		t.Fatalf("verifyBundle error = %v, want emitted payload completeness warning", err)
+	}
+	if strings.Contains(err.Error(), "definitely missing") {
+		t.Fatalf("verifyBundle error = %v, want approved warning wording only", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3381,3 +3381,41 @@ static_analyzer:
     authority_notes:
       hard_invalidity: Missing proof is error-level semantic invalidity on the verify surface.
       degraded_warning: Same-handler compute.store_as proof becomes warning-grade only when it depends on dynamic expected_from.
+  slice_2_emitted_event_payload_completeness:
+    id: semantic_drift_payload_completeness
+    domain: semantic_drift
+    authority: semantic_drift_warning
+    severity: warning
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - handler_specification.handler_fields.emits
+    - handler_specification.handler_fields.payload_transform
+    - contract_formats.event_schema
+    - observation_model.emitted_events.payload_rules
+    scope:
+      description: For every event emitted by a system node handler, verify that the emitted payload statically covers all required
+        event-schema fields using only the accepted slice-2 proof carriers.
+      applies_to:
+      - all system-node emitted events
+      excludes:
+      - cross-handler reaching-definitions
+      - prompt lint / provenance / handoff audit work
+      - lower-authority heuristic checks
+      - agent write proof via save_entity_field
+    proof_carriers:
+      platform_forced_fields:
+        valid_fields:
+        - entity_id
+        - trigger_event_type
+        - current_state
+      explicit_payload_transform_fields:
+        valid_for: keys explicitly declared in payload_transform.fields
+      transform_replacement_rule:
+        description: When payload_transform is present, implicit passthrough does not count. Only payload_transform.fields keys plus
+          platform-forced fields are provable.
+    no_transform_rule:
+      description: When payload_transform is absent, trigger-schema context and entity-schema context may enrich the finding message
+        but do not clear the finding. Only platform-forced fields are provable in this slice.
+    rule: For each required emitted-event field, emit semantic_drift_warning unless the field is platform-forced or explicitly covered
+      by payload_transform.fields. The finding message must say the field is not statically provable.

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -72,6 +72,9 @@ type checkerContext struct {
 	payloadCoverageLoaded   bool
 	payloadCoverageFindings []Finding
 
+	payloadCompletenessLoaded   bool
+	payloadCompletenessFindings []Finding
+
 	dialectLoaded   bool
 	dialectFindings []Finding
 
@@ -162,6 +165,7 @@ var bootCheckRegistry = []Check{
 	{ID: "event_consumer_exists", Severity: "warning", Run: checkEventConsumerExists},
 	{ID: "event_producer_exists", Severity: "warning", Run: checkEventProducerExists},
 	{ID: "payload_field_coverage", Severity: "error", Run: checkPayloadFieldCoverage},
+	{ID: "semantic_drift_payload_completeness", Severity: "warning", Run: checkSemanticDriftPayloadCompleteness},
 	{ID: "condition_payload_alignment", Severity: "error", Run: checkConditionPayloadAlignment},
 	{ID: "condition_policy_alignment", Severity: "warning", Run: checkConditionPolicyAlignment},
 	{ID: "state_machine_coherence", Severity: "error", Run: checkStateMachineCoherence},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1108,6 +1108,92 @@ func TestRun_DoesNotWarnForPhantomProducesWhenDeclaredEventsMatchEmits(t *testin
 	}
 }
 
+func TestRun_WarnsWhenPayloadTransformOmitsRequiredEmittedField(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"geography": "payload.geography",
+			"mode":      "payload.mode",
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected payload completeness warning for scan_id, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "payload_transform: present") {
+		t.Fatalf("expected payload completeness warning to mention payload_transform presence, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_WarnsWithoutPayloadTransformEvenWhenContextSuggestsPassthrough(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"entity_id", "scan_id"}
+	bundle.Events["market_research.scan_assigned"] = entry
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected payload completeness warning for scan_id, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "payload_transform: absent") {
+		t.Fatalf("expected payload completeness warning to mention missing payload_transform, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "trigger schema declares scan_id: yes (required)") {
+		t.Fatalf("expected payload completeness warning to mention trigger schema context, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "entity schema declares scan_id: yes") {
+		t.Fatalf("expected payload completeness warning to mention entity schema context, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnWhenTransformAndPlatformForcedFieldsCoverRequiredPayload(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.PayloadTransform = &runtimecontracts.PayloadTransformSpec{
+		Fields: map[string]string{
+			"scan_id":   "payload.scan_id",
+			"geography": "payload.geography",
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("unexpected payload completeness warning when transform covers required fields, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"entity_id", "current_state"}
+	bundle.Events["market_research.scan_assigned"] = entry
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "not statically provable") {
+		t.Fatalf("unexpected payload completeness warning for platform-forced-only schema, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_ReportsInputPinWiringWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-missing-pin")
 
@@ -2012,8 +2098,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 38 {
-		t.Fatalf("bootCheckRegistry count = %d, want 38", got)
+	if got := len(bootCheckRegistry); got != 39 {
+		t.Fatalf("bootCheckRegistry count = %d, want 39", got)
 	}
 	if got := len(supplementalChecks); got != 2 {
 		t.Fatalf("supplementalChecks count = %d, want 2", got)
@@ -2639,6 +2725,69 @@ func bootverifyDeclarationDriftBundle() *runtimecontracts.WorkflowContractBundle
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"task.start": {Source: "external"},
 			"task.done":  {ConsumerType: []string{"dashboard"}},
+		},
+	}
+	bundle.Platform.Platform.Name = "test"
+	bundle.Platform.Platform.Version = "1.0.0"
+	return bundle
+}
+
+func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBundle {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Platform: runtimecontracts.PlatformSpecDocument{},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "default",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "scan_id"},
+						{Name: "geography"},
+					},
+				}},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"dispatcher": {
+					"scan.corpus_dispatch": {
+						Emits: runtimecontracts.EventEmission{Single: "market_research.scan_assigned"},
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"dispatcher": {
+				SubscribesTo: []string{"scan.corpus_dispatch"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"scan.corpus_dispatch": {
+						Emits: runtimecontracts.EventEmission{Single: "market_research.scan_assigned"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.corpus_dispatch": {
+				Source: "external",
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"scan_id":   {Type: "string"},
+						"geography": {Type: "string"},
+						"mode":      {Type: "string"},
+					},
+				},
+				Required: []string{"scan_id", "geography"},
+			},
+			"market_research.scan_assigned": {
+				ConsumerType: []string{"dashboard"},
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"entity_id":          {Type: "string"},
+						"current_state":      {Type: "string"},
+						"trigger_event_type": {Type: "string"},
+						"scan_id":            {Type: "string"},
+						"geography":          {Type: "string"},
+					},
+				},
+				Required: []string{"entity_id", "scan_id"},
+			},
 		},
 	}
 	bundle.Platform.Platform.Name = "test"

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -1178,6 +1179,56 @@ func TestRun_DoesNotWarnWhenTransformAndPlatformForcedFieldsCoverRequiredPayload
 
 	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
 		t.Fatalf("unexpected payload completeness warning when transform covers required fields, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnWhenNormalizedTransformTargetsCoverRequiredPayload(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		body      string
+		transform *runtimecontracts.PayloadTransformSpec
+	}{
+		{
+			name: "mappings",
+			body: "payload_transform:\n  mappings:\n    scan_id: payload.scan_id\n",
+		},
+		{
+			name: "entries",
+			transform: &runtimecontracts.PayloadTransformSpec{
+				Entries: []runtimecontracts.TransformSpec{{
+					Target: "scan_id",
+					Value:  runtimecontracts.CELExpression("payload.scan_id"),
+				}},
+			},
+		},
+		{
+			name: "shorthand",
+			body: "payload_transform:\n  scan_id: payload.scan_id\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := bootverifyPayloadCompletenessBundle()
+			node := bundle.Nodes["dispatcher"]
+			handler := node.EventHandlers["scan.corpus_dispatch"]
+			if tc.transform != nil {
+				handler.PayloadTransform = tc.transform
+			} else {
+				handler.PayloadTransform = mustPayloadCompletenessTransform(t, tc.body)
+			}
+			node.EventHandlers["scan.corpus_dispatch"] = handler
+			bundle.Nodes["dispatcher"] = node
+			bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+				t.Fatalf("unexpected payload completeness warning for %s transform form, got %#v", tc.name, report.Warnings())
+			}
+		})
 	}
 }
 
@@ -2793,6 +2844,18 @@ func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBun
 	bundle.Platform.Platform.Name = "test"
 	bundle.Platform.Platform.Version = "1.0.0"
 	return bundle
+}
+
+func mustPayloadCompletenessTransform(t *testing.T, body string) *runtimecontracts.PayloadTransformSpec {
+	t.Helper()
+
+	var decoded struct {
+		PayloadTransform runtimecontracts.PayloadTransformSpec `yaml:"payload_transform"`
+	}
+	if err := yaml.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("unmarshal payload_transform: %v", err)
+	}
+	return &decoded.PayloadTransform
 }
 
 func reportContains(items []Finding, checkID, contains string) bool {

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -1,0 +1,212 @@
+package bootverify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkSemanticDriftPayloadCompleteness(c *checkerContext) []Finding {
+	return c.payloadCompleteness()
+}
+
+func (c *checkerContext) payloadCompleteness() []Finding {
+	if c.payloadCompletenessLoaded {
+		return c.payloadCompletenessFindings
+	}
+	c.payloadCompletenessLoaded = true
+
+	entityFields := entitySchemaFields(c.source)
+	forced := payloadCompletenessForcedFields()
+
+	for nodeID := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+
+		for triggerEventType, handler := range c.source.NodeEventHandlers(nodeID) {
+			triggerEventType = strings.TrimSpace(triggerEventType)
+			triggerProof := semanticview.ResolveFlowEventProof(c.source, flowID, triggerEventType)
+			transformTargets := payloadCompletenessTransformTargets(handler)
+			hasTransform := handler.PayloadTransform != nil
+
+			for _, emitted := range uniquePayloadCompletenessStrings(handlerEmits(handler)...) {
+				emitted = strings.TrimSpace(emitted)
+				if emitted == "" {
+					continue
+				}
+				emittedProof := semanticview.ResolveFlowEventProof(c.source, flowID, emitted)
+				if !emittedProof.HasSchema {
+					continue
+				}
+				required := payloadCompletenessRequiredFields(emittedProof.Entry)
+				if len(required) == 0 {
+					continue
+				}
+
+				for _, field := range required {
+					if _, ok := forced[field]; ok {
+						continue
+					}
+					if hasTransform {
+						if _, ok := transformTargets[field]; ok {
+							continue
+						}
+					}
+
+					c.payloadCompletenessFindings = append(c.payloadCompletenessFindings, Finding{
+						CheckID:  "semantic_drift_payload_completeness",
+						Severity: "warning",
+						Message: payloadCompletenessMessage(
+							nodeID,
+							triggerEventType,
+							emittedProof.DisplayName(),
+							field,
+							hasTransform,
+							transformTargets,
+							triggerProof.Entry,
+							triggerProof.HasSchema,
+							entityFields,
+						),
+						Location: nodeID,
+					})
+				}
+			}
+		}
+	}
+
+	sort.SliceStable(c.payloadCompletenessFindings, func(i, j int) bool {
+		if c.payloadCompletenessFindings[i].Location == c.payloadCompletenessFindings[j].Location {
+			return c.payloadCompletenessFindings[i].Message < c.payloadCompletenessFindings[j].Message
+		}
+		return c.payloadCompletenessFindings[i].Location < c.payloadCompletenessFindings[j].Location
+	})
+	return c.payloadCompletenessFindings
+}
+
+func payloadCompletenessRequiredFields(entry runtimecontracts.EventCatalogEntry) []string {
+	return uniquePayloadCompletenessStrings(entry.Required...)
+}
+
+func payloadCompletenessForcedFields() map[string]struct{} {
+	return map[string]struct{}{
+		"entity_id":          {},
+		"trigger_event_type": {},
+		"current_state":      {},
+	}
+}
+
+func payloadCompletenessTransformTargets(handler runtimecontracts.SystemNodeEventHandler) map[string]struct{} {
+	out := map[string]struct{}{}
+	if handler.PayloadTransform == nil {
+		return out
+	}
+	for target := range handler.PayloadTransform.Fields {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+		out[target] = struct{}{}
+	}
+	return out
+}
+
+func payloadCompletenessTriggerSchemaState(entry runtimecontracts.EventCatalogEntry, hasSchema bool, field string) string {
+	if !hasSchema {
+		return "no schema"
+	}
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return "no"
+	}
+	required := map[string]struct{}{}
+	for _, item := range entry.Required {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			required[item] = struct{}{}
+		}
+	}
+	if _, ok := required[field]; ok {
+		return "yes (required)"
+	}
+	if _, ok := entry.Payload.Properties[field]; ok {
+		return "yes (optional)"
+	}
+	return "no"
+}
+
+func payloadCompletenessEntitySchemaState(entityFields map[string]struct{}, field string) string {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return "no"
+	}
+	if _, ok := entityFields[field]; ok {
+		return "yes"
+	}
+	return "no"
+}
+
+func payloadCompletenessMessage(nodeID, triggerEventType, emittedEventType, field string, hasTransform bool, transformTargets map[string]struct{}, triggerEntry runtimecontracts.EventCatalogEntry, hasTriggerSchema bool, entityFields map[string]struct{}) string {
+	transformState := "absent"
+	transformCovered := "N/A (no transform)"
+	if hasTransform {
+		transformState = "present"
+		transformCovered = strings.Join(sortedPayloadCompletenessKeys(transformTargets), ", ")
+		if transformCovered == "" {
+			transformCovered = "(none)"
+		}
+	}
+
+	return fmt.Sprintf(
+		"event %s emitted by node %s handler %s: required field %s is not statically provable in the emitted payload. Payload construction: payload_transform: %s; transform covers: %s; platform-forced: entity_id, trigger_event_type, current_state. Context (does not clear finding): trigger schema declares %s: %s; entity schema declares %s: %s.",
+		strings.TrimSpace(emittedEventType),
+		strings.TrimSpace(nodeID),
+		strings.TrimSpace(triggerEventType),
+		strings.TrimSpace(field),
+		transformState,
+		transformCovered,
+		strings.TrimSpace(field),
+		payloadCompletenessTriggerSchemaState(triggerEntry, hasTriggerSchema, field),
+		strings.TrimSpace(field),
+		payloadCompletenessEntitySchemaState(entityFields, field),
+	)
+}
+
+func sortedPayloadCompletenessKeys(items map[string]struct{}) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for item := range items {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniquePayloadCompletenessStrings(values ...string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -104,8 +104,8 @@ func payloadCompletenessTransformTargets(handler runtimecontracts.SystemNodeEven
 	if handler.PayloadTransform == nil {
 		return out
 	}
-	for target := range handler.PayloadTransform.Fields {
-		target = strings.TrimSpace(target)
+	for _, entry := range handler.PayloadTransform.TransformEntries() {
+		target := strings.TrimSpace(entry.Target)
 		if target == "" {
 			continue
 		}


### PR DESCRIPTION
Closes #377

## What changed
- added the verify-owned `semantic_drift_payload_completeness` bootverify check for system-node emitted events
- wired the new analyzer slice through the supported static verify path:
  - `cmd/swarm verify`
  - `runtime.ValidateWorkflowContractSurface(...)`
  - `internal/runtime/bootverify`
- promoted the accepted slice-2 rule into authoritative `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- added direct bootverify proofs for transform and no-transform cases, plus the CLI verify warning-surface proof

## Why
This slice adds warning-grade static findings when a system-node emitted event requires payload fields that are not statically provable from the accepted slice-2 proof carriers. It stays inside the approved scope:
- platform-forced fields count
- explicit `payload_transform.fields` keys count
- implicit passthrough does not count when `payload_transform` is present
- trigger/entity schema context enriches the message when `payload_transform` is absent, but does not clear the finding

## Spec refs
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.verify-analyzer-slice-2.yaml`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Validation
- `go test ./internal/runtime/bootverify -run 'TestRun_(WarnsWhenPayloadTransformOmitsRequiredEmittedField|WarnsWithoutPayloadTransformEvenWhenContextSuggestsPassthrough|DoesNotWarnWhenTransformAndPlatformForcedFieldsCoverRequiredPayload|DoesNotWarnWhenOnlyPlatformForcedFieldsAreRequired)$' -count=1`
- `go test ./cmd/swarm -run 'TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`