### PR TITLE
[agent-a][issue #382] Tighten input pin producer path checks

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1233,3 +1233,25 @@ func TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface(t *testing
 		t.Fatalf("verifyBundle error = %v, want approved warning wording only", err)
 	}
 }
+
+func TestVerifyBundle_InputPinProducerPathReturnsWarningSurface(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	err := verifyBundle(context.Background(), semanticview.Wrap(loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-missing-pin"))))
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from missing producer path")
+	}
+	for _, want := range []string{
+		"no producer path was found in the authored bundle",
+		"Sibling flow output pin: not found",
+		"Root agent emit_events: not found",
+		"Root node handler emits: not found",
+		"Platform event catalog: not matched",
+		"External source annotation (_source): not found",
+		"Same-flow timer declaration: not found",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("verifyBundle error = %v, want substring %q", err, want)
+		}
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1759,8 +1759,10 @@ engine:
     - id: input_pin_wiring
       severity: warning
       scope: per-flow
-      trigger: A flow's required input event pin (from schema.yaml pins.inputs.events) has no emitter — no other flow's node
-        or agent produces this event. The flow cannot be triggered.
+      trigger: 'A flow''s required input event pin (from schema.yaml pins.inputs.events) has no satisfiable authored producer
+        path on the static verify surface. The warning checks only sibling flow output pins, root agent emit_events, root
+        node handler emits, exact platform_events catalog matches, _source values starting with external, and same-flow timer
+        declarations. It does not use produces or _status: planned as proof.'
       when: boot-only
     severity_behavior:
       error: Boot aborts. System does not start.
@@ -3419,3 +3421,41 @@ static_analyzer:
         but do not clear the finding. Only platform-forced fields are provable in this slice.
     rule: For each required emitted-event field, emit semantic_drift_warning unless the field is platform-forced or explicitly covered
       by payload_transform.fields. The finding message must say the field is not statically provable.
+  slice_3_input_pin_producer_path_satisfaction:
+    id: input_pin_wiring
+    domain: semantic_drift
+    authority: semantic_drift_warning
+    severity: warning
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - flow_model.state_composition.cross_flow_handoff
+    - engine.cross_flow_routing.auto_wiring
+    - engine.event_identity
+    - contract_formats.event_schema
+    scope:
+      description: For every flow input pin event declared in schema.yaml pins.inputs.events, verify that at least one accepted
+        producer path exists in the authored bundle on the static verify surface.
+      applies_to:
+      - schema.yaml pins.inputs.events
+      excludes:
+      - runtime routing correctness
+      - payload compatibility
+      - multi-hop reachability or liveness
+      - produces-based proof
+      - _status-based lifecycle suppression
+    accepted_producer_paths:
+      sibling_flow_output_pin:
+        rule: Another flow declares the same local event name in schema.yaml pins.outputs.events.
+      root_agent_emit_events:
+        rule: A root-level agent declares the event in emit_events.
+      root_node_handler_emits:
+        rule: A root-level system node emits the event from handler emits, rules emits, on_complete emits, or fan_out emit_per_item.
+      platform_event_catalog:
+        rule: The input pin event exactly matches a platform_events.catalog key.
+      external_source_annotation:
+        rule: The consuming flow or root event entry for the event has _source beginning with external.
+      same_flow_timer_declaration:
+        rule: A timer declared within the consuming flow fires the same event.
+    rule: Emit warning when none of the accepted producer-path forms are found. The finding message must say no producer path
+      was found in the authored bundle and list the checked producer-path forms.

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1268,6 +1268,129 @@ func TestRun_DoesNotWarnForExternalInputPinWithoutEmitter(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnForSiblingFlowOutputPinInputProducerPath(t *testing.T) {
+	root := writeCrossFlowPinAmbiguityFixture(t, false)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+	bundle.Semantics.FlowOutputs["producer_b"] = nil
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "ticket.ready") {
+		t.Fatalf("unexpected input_pin_wiring warning for sibling output pin proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForRootAgentEmitInputProducerPath(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Agents["lifecycle-coordinator"] = runtimecontracts.AgentRegistryEntry{
+		ID:         "lifecycle-coordinator",
+		EmitEvents: []string{"task.feedback"},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring warning for root agent emit proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForRootNodeHandlerEmitInputProducerPath(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	node := bundle.Nodes["dispatcher"]
+	node.EventHandlers["task.requested"] = runtimecontracts.SystemNodeEventHandler{
+		Emits: runtimecontracts.EventEmission{Single: "child/task.feedback"},
+	}
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["task.requested"] = node.EventHandlers["task.requested"]
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring warning for root handler emit proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForPlatformEventCatalogInputProducerPath(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	bundle.Platform.PlatformEvents.Catalog = map[string]yaml.Node{
+		"platform.runtime_log": {},
+	}
+	renameFlowHandlerEvent(t, bundle, "child", "worker", "task.feedback", "platform.runtime_log", runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		AdvancesTo:   "done",
+		Emits:        runtimecontracts.EventEmission{Single: "task.result"},
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "platform.runtime_log") {
+		t.Fatalf("unexpected input_pin_wiring warning for platform event proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForSameFlowTimerInputProducerPath(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	node := bundle.Nodes["worker"]
+	node.Timers = append(node.Timers, runtimecontracts.WorkflowTimerContract{
+		ID:     "feedback-timeout",
+		Event:  "task.feedback",
+		FlowID: "child",
+		NodeID: "worker",
+	})
+	bundle.Nodes["worker"] = node
+	bundle.Semantics.Timers = append(bundle.Semantics.Timers, runtimecontracts.WorkflowTimerContract{
+		ID:     "feedback-timeout",
+		Event:  "task.feedback",
+		FlowID: "child",
+		NodeID: "worker",
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring warning for same-flow timer proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotUseProducesOrPlannedAsInputProducerPathProof(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*runtimecontracts.WorkflowContractBundle)
+	}{
+		{
+			name: "produces only",
+			mutate: func(bundle *runtimecontracts.WorkflowContractBundle) {
+				node := bundle.Nodes["dispatcher"]
+				node.Produces = append(node.Produces, "child/task.feedback")
+				bundle.Nodes["dispatcher"] = node
+			},
+		},
+		{
+			name: "planned status",
+			mutate: func(bundle *runtimecontracts.WorkflowContractBundle) {
+				entry := bundle.Events["task.feedback"]
+				entry.Status = "planned"
+				bundle.Events["task.feedback"] = entry
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+			tc.mutate(bundle)
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
+				t.Fatalf("expected input_pin_wiring warning for %s, got %#v", tc.name, report.Warnings())
+			}
+		})
+	}
+}
+
 func TestRun_ReportsConflictingWritePinOwners(t *testing.T) {
 	root := writeCrossFlowPinAmbiguityFixture(t, false)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
@@ -2943,6 +3066,31 @@ func renameFlowHandlerEvent(t *testing.T, bundle *runtimecontracts.WorkflowContr
 		}
 		bundle.Semantics.FlowInputs[flowID] = inputs
 	}
+}
+
+func flowEventEntry(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string) runtimecontracts.EventCatalogEntry {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	entry, ok := flowView.Events[eventType]
+	if !ok {
+		t.Fatalf("flow %s event %s missing", flowID, eventType)
+	}
+	return entry
+}
+
+func writeFlowEventEntry(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string, entry runtimecontracts.EventCatalogEntry) {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	if flowView.Events == nil {
+		flowView.Events = map[string]runtimecontracts.EventCatalogEntry{}
+	}
+	flowView.Events[eventType] = entry
 }
 
 func addProjectHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1268,6 +1268,35 @@ func TestRun_DoesNotWarnForExternalInputPinWithoutEmitter(t *testing.T) {
 	}
 }
 
+func TestRun_ConstrainsExternalInputProducerPathToConsumingScope(t *testing.T) {
+	root := writeInputPinExternalScopeFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	var (
+		externalCleared bool
+		plainWarned     bool
+	)
+	for _, finding := range report.Warnings() {
+		if finding.CheckID != "input_pin_wiring" || !strings.Contains(finding.Message, "ticket.ready") {
+			continue
+		}
+		switch finding.Location {
+		case "external_consumer":
+			externalCleared = true
+		case "plain_consumer":
+			plainWarned = true
+		}
+	}
+	if externalCleared {
+		t.Fatalf("unexpected input_pin_wiring warning for external_consumer, got %#v", report.Warnings())
+	}
+	if !plainWarned {
+		t.Fatalf("expected input_pin_wiring warning for plain_consumer, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_DoesNotWarnForSiblingFlowOutputPinInputProducerPath(t *testing.T) {
 	root := writeCrossFlowPinAmbiguityFixture(t, false)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
@@ -2687,6 +2716,54 @@ consumer-node:
       advances_to: done
       emits: consumer.started
 `)
+
+	return root
+}
+
+func writeInputPinExternalScopeFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: input-pin-external-scope
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: external_consumer
+    flow: external_consumer
+    mode: static
+  - id: plain_consumer
+    flow: plain_consumer
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: input-pin-external-scope\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	for _, flowID := range []string{"external_consumer", "plain_consumer"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events:
+      - ticket.ready
+  outputs:
+    events: []
+`)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+		entry := "ticket.ready:\n  payload:\n    entity_id: string\n"
+		if flowID == "external_consumer" {
+			entry = "ticket.ready:\n  _source: external (manual handoff)\n  payload:\n    entity_id: string\n"
+		}
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), entry)
+	}
 
 	return root
 }

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
 	"swarm/internal/runtime/semanticview"
 )
@@ -56,30 +57,7 @@ func (c *checkerContext) inputPinWiring() []Finding {
 	}
 	c.inputPinLoaded = true
 
-	eventsEmitted := map[string]struct{}{}
-	for _, scope := range c.source.FlowScopes() {
-		if eventType := strings.TrimSpace(scope.AutoEmitEvent); eventType != "" {
-			eventsEmitted[eventType] = struct{}{}
-		}
-	}
-	for _, node := range c.source.NodeEntries() {
-		for _, handler := range node.EventHandlers {
-			for _, emitted := range handlerEmits(handler) {
-				emitted = strings.TrimSpace(emitted)
-				if emitted != "" {
-					eventsEmitted[emitted] = struct{}{}
-				}
-			}
-		}
-	}
-	for _, agent := range c.source.AgentEntries() {
-		for _, eventType := range agent.EmitEvents {
-			eventType = strings.TrimSpace(eventType)
-			if eventType != "" {
-				eventsEmitted[eventType] = struct{}{}
-			}
-		}
-	}
+	flowScopedNodes, flowScopedAgents := inputPinRootParticipants(c.source)
 
 	for flowID := range c.source.FlowSchemaEntries() {
 		flowID = strings.TrimSpace(flowID)
@@ -91,26 +69,266 @@ func (c *checkerContext) inputPinWiring() []Finding {
 			if eventType == "" {
 				continue
 			}
-			entry, ok := c.source.EventEntry(eventType)
-			if !ok {
-				continue
-			}
-			if _, emitted := eventsEmitted[eventType]; emitted {
-				continue
-			}
-			if strings.EqualFold(strings.TrimSpace(entry.Source), "external") || strings.EqualFold(strings.TrimSpace(entry.Status), "planned") {
+			producerPaths := c.inputPinProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
+			if producerPaths.hasAny() {
 				continue
 			}
 			c.inputPinFindings = append(c.inputPinFindings, Finding{
 				CheckID:  "input_pin_wiring",
 				Severity: "warning",
-				Message:  fmt.Sprintf("flow %s input pin %s has no emitter", flowID, eventType),
+				Message:  producerPaths.message(flowID, eventType),
 				Location: flowID,
 			})
 		}
 	}
 
 	return c.inputPinFindings
+}
+
+type inputPinProducerPaths struct {
+	siblingFlowOutputPin string
+	rootAgentEmit        string
+	rootNodeHandlerEmit  string
+	platformEventCatalog string
+	externalSource       string
+	sameFlowTimer        string
+}
+
+func (p inputPinProducerPaths) hasAny() bool {
+	for _, detail := range []string{
+		p.siblingFlowOutputPin,
+		p.rootAgentEmit,
+		p.rootNodeHandlerEmit,
+		p.platformEventCatalog,
+		p.externalSource,
+		p.sameFlowTimer,
+	} {
+		if !strings.HasPrefix(strings.TrimSpace(detail), "not ") {
+			return true
+		}
+	}
+	return false
+}
+
+func (p inputPinProducerPaths) message(flowID, eventType string) string {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	return fmt.Sprintf(
+		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source annotation (_source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add _source: external (...) to %s's events.yaml entry if produced externally",
+		flowID,
+		eventType,
+		p.siblingFlowOutputPin,
+		p.rootAgentEmit,
+		p.rootNodeHandlerEmit,
+		p.platformEventCatalog,
+		p.externalSource,
+		p.sameFlowTimer,
+		eventType,
+		eventType,
+		eventType,
+	)
+}
+
+func inputPinRootParticipants(source semanticview.Source) (map[string]struct{}, map[string]struct{}) {
+	flowScopedNodes := map[string]struct{}{}
+	flowScopedAgents := map[string]struct{}{}
+	if source == nil {
+		return flowScopedNodes, flowScopedAgents
+	}
+	for _, scope := range source.FlowScopes() {
+		for nodeID := range scope.Nodes {
+			nodeID = strings.TrimSpace(nodeID)
+			if nodeID != "" {
+				flowScopedNodes[nodeID] = struct{}{}
+			}
+		}
+		for agentID := range scope.Agents {
+			agentID = strings.TrimSpace(agentID)
+			if agentID != "" {
+				flowScopedAgents[agentID] = struct{}{}
+			}
+		}
+	}
+	return flowScopedNodes, flowScopedAgents
+}
+
+func (c *checkerContext) inputPinProducerPaths(flowID, eventType string, flowScopedNodes, flowScopedAgents map[string]struct{}) inputPinProducerPaths {
+	localEvent := eventidentity.Normalize(eventType)
+	canonicalEvent := eventidentity.Normalize(c.source.ResolveFlowEventReference(flowID, eventType))
+	return inputPinProducerPaths{
+		siblingFlowOutputPin: c.inputPinSiblingFlowOutputPath(flowID, localEvent),
+		rootAgentEmit:        c.inputPinRootAgentPath(localEvent, canonicalEvent, flowScopedAgents),
+		rootNodeHandlerEmit:  c.inputPinRootNodeHandlerPath(localEvent, canonicalEvent, flowScopedNodes),
+		platformEventCatalog: inputPinPlatformEventPath(c.source.PlatformSpec(), localEvent),
+		externalSource:       c.inputPinExternalSourcePath(flowID, eventType),
+		sameFlowTimer:        c.inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent),
+	}
+}
+
+func (c *checkerContext) inputPinSiblingFlowOutputPath(flowID, localEvent string) string {
+	matches := map[string]struct{}{}
+	for otherFlowID := range c.source.FlowSchemaEntries() {
+		otherFlowID = strings.TrimSpace(otherFlowID)
+		if otherFlowID == "" || otherFlowID == strings.TrimSpace(flowID) {
+			continue
+		}
+		for _, output := range c.source.FlowOutputEvents(otherFlowID) {
+			if eventidentity.Normalize(output) == localEvent {
+				matches[otherFlowID] = struct{}{}
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	flows := sortedSetKeysLocal(matches)
+	if len(flows) == 1 {
+		return fmt.Sprintf("found in flow %s", flows[0])
+	}
+	return fmt.Sprintf("found in flows %s", strings.Join(flows, ", "))
+}
+
+func (c *checkerContext) inputPinRootAgentPath(localEvent, canonicalEvent string, flowScopedAgents map[string]struct{}) string {
+	matches := map[string]struct{}{}
+	for agentID, agent := range c.source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		if _, ok := flowScopedAgents[agentID]; ok {
+			continue
+		}
+		for _, emitted := range agent.EmitEvents {
+			if inputPinRootProducerMatches(c.source, localEvent, canonicalEvent, emitted) {
+				matches[agentID] = struct{}{}
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	agents := sortedSetKeysLocal(matches)
+	if len(agents) == 1 {
+		return fmt.Sprintf("found on agent %s", agents[0])
+	}
+	return fmt.Sprintf("found on agents %s", strings.Join(agents, ", "))
+}
+
+func (c *checkerContext) inputPinRootNodeHandlerPath(localEvent, canonicalEvent string, flowScopedNodes map[string]struct{}) string {
+	matches := map[string]struct{}{}
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		if nodeID == "" {
+			continue
+		}
+		if _, ok := flowScopedNodes[nodeID]; ok {
+			continue
+		}
+		for handlerEvent, handler := range node.EventHandlers {
+			for _, emitted := range handlerEmits(handler) {
+				if inputPinRootProducerMatches(c.source, localEvent, canonicalEvent, emitted) {
+					matches[fmt.Sprintf("%s handler %s", nodeID, strings.TrimSpace(handlerEvent))] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	handlers := sortedSetKeysLocal(matches)
+	if len(handlers) == 1 {
+		return fmt.Sprintf("found on %s", handlers[0])
+	}
+	return fmt.Sprintf("found on %s", strings.Join(handlers, ", "))
+}
+
+func inputPinPlatformEventPath(platform runtimecontracts.PlatformSpecDocument, localEvent string) string {
+	for eventName := range platform.PlatformEvents.Catalog {
+		if eventidentity.Normalize(eventName) == localEvent {
+			return "matched"
+		}
+	}
+	return "not matched"
+}
+
+func (c *checkerContext) inputPinExternalSourcePath(flowID, eventType string) string {
+	if entry, ok := c.source.EventEntry(eventType); ok && inputPinExternalSourceMatch(entry.Source) {
+		return "found"
+	}
+	candidates := map[string]struct{}{}
+	for _, candidate := range []string{
+		eventidentity.Normalize(eventType),
+		eventidentity.Normalize(c.source.ResolveFlowEventReference(flowID, eventType)),
+	} {
+		if candidate != "" {
+			candidates[candidate] = struct{}{}
+		}
+	}
+	for eventName, entry := range c.source.ResolvedEventCatalog() {
+		if _, ok := candidates[eventidentity.Normalize(eventName)]; !ok {
+			continue
+		}
+		if inputPinExternalSourceMatch(entry.Source) {
+			return "found"
+		}
+	}
+	return "not found"
+}
+
+func inputPinExternalSourceMatch(source string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "external")
+}
+
+func (c *checkerContext) inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent string) string {
+	matches := map[string]struct{}{}
+	for _, timer := range c.source.WorkflowTimers() {
+		if strings.TrimSpace(timer.FlowID) != strings.TrimSpace(flowID) {
+			continue
+		}
+		if !inputPinTimerMatches(c.source, flowID, eventType, canonicalEvent, timer.Event) {
+			continue
+		}
+		label := fmt.Sprintf("node %s", strings.TrimSpace(timer.NodeID))
+		if timerID := strings.TrimSpace(timer.ID); timerID != "" {
+			label = fmt.Sprintf("%s timer %s", label, timerID)
+		}
+		matches[label] = struct{}{}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	timers := sortedSetKeysLocal(matches)
+	if len(timers) == 1 {
+		return fmt.Sprintf("found on %s", timers[0])
+	}
+	return fmt.Sprintf("found on %s", strings.Join(timers, ", "))
+}
+
+func inputPinRootProducerMatches(source semanticview.Source, localEvent, canonicalEvent, candidate string) bool {
+	candidate = eventidentity.Normalize(candidate)
+	if candidate == "" {
+		return false
+	}
+	if candidate == localEvent {
+		return true
+	}
+	if canonicalEvent == "" || source == nil {
+		return false
+	}
+	return eventidentity.Normalize(source.ResolveFlowEventReference("", candidate)) == canonicalEvent
+}
+
+func inputPinTimerMatches(source semanticview.Source, flowID, eventType, canonicalEvent, candidate string) bool {
+	if source == nil {
+		return false
+	}
+	if canonicalEvent != "" && eventidentity.Normalize(source.ResolveFlowEventReference(flowID, candidate)) == canonicalEvent {
+		return true
+	}
+	return eventidentity.Normalize(candidate) == eventidentity.Normalize(eventType)
 }
 
 func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -255,31 +255,57 @@ func inputPinPlatformEventPath(platform runtimecontracts.PlatformSpecDocument, l
 }
 
 func (c *checkerContext) inputPinExternalSourcePath(flowID, eventType string) string {
-	if entry, ok := c.source.EventEntry(eventType); ok && inputPinExternalSourceMatch(entry.Source) {
+	bundle, ok := semanticview.Bundle(c.source)
+	if !ok || bundle == nil {
+		return "not found"
+	}
+	if entry, ok := inputPinRootEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.Source) {
 		return "found"
 	}
-	candidates := map[string]struct{}{}
-	for _, candidate := range []string{
-		eventidentity.Normalize(eventType),
-		eventidentity.Normalize(c.source.ResolveFlowEventReference(flowID, eventType)),
-	} {
-		if candidate != "" {
-			candidates[candidate] = struct{}{}
-		}
-	}
-	for eventName, entry := range c.source.ResolvedEventCatalog() {
-		if _, ok := candidates[eventidentity.Normalize(eventName)]; !ok {
-			continue
-		}
-		if inputPinExternalSourceMatch(entry.Source) {
-			return "found"
-		}
+	if entry, ok := inputPinFlowEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.Source) {
+		return "found"
 	}
 	return "not found"
 }
 
 func inputPinExternalSourceMatch(source string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "external")
+}
+
+func inputPinRootEventEntry(bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string) (runtimecontracts.EventCatalogEntry, bool) {
+	if bundle == nil {
+		return runtimecontracts.EventCatalogEntry{}, false
+	}
+	for _, candidate := range []string{
+		eventidentity.Normalize(eventType),
+		eventidentity.Normalize(bundle.ResolveFlowEventReference(flowID, eventType)),
+	} {
+		if candidate == "" {
+			continue
+		}
+		if entry, ok := bundle.Events[candidate]; ok {
+			return entry, true
+		}
+	}
+	return runtimecontracts.EventCatalogEntry{}, false
+}
+
+func inputPinFlowEventEntry(bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string) (runtimecontracts.EventCatalogEntry, bool) {
+	if bundle == nil {
+		return runtimecontracts.EventCatalogEntry{}, false
+	}
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		return runtimecontracts.EventCatalogEntry{}, false
+	}
+	candidate := eventidentity.Normalize(eventType)
+	if candidate == "" {
+		return runtimecontracts.EventCatalogEntry{}, false
+	}
+	if entry, ok := flowView.Events[candidate]; ok {
+		return entry, true
+	}
+	return runtimecontracts.EventCatalogEntry{}, false
 }
 
 func (c *checkerContext) inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent string) string {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -865,6 +865,9 @@ type PlatformSpecDocument struct {
 		Name    string `yaml:"name"`
 		Version string `yaml:"version"`
 	} `yaml:"platform"`
+	PlatformEvents struct {
+		Catalog map[string]yaml.Node `yaml:"catalog"`
+	} `yaml:"platform_events"`
 	PermissionsModel struct {
 		Permissions []string `yaml:"permissions"`
 	} `yaml:"permissions_model"`


### PR DESCRIPTION
Closes #382

## Summary
- tighten `input_pin_wiring` onto the approved slice-3 producer-path taxonomy on the supported static verify path
- remove `produces` and `_status: planned` as proof for this warning seam
- add focused bootverify and `cmd/swarm verify` proofs for the accepted producer-path forms
- promote the matching slice-3 rule into `platform-spec.yaml`

## Spec Refs
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.verify-analyzer-slice-3.yaml`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`