### PR TITLE
[agent-b][issue #182] Make catalog harness startup policy explicit

### DIFF
--- a/internal/runtime/cataloge2e/boot_helpers_test.go
+++ b/internal/runtime/cataloge2e/boot_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	runtime "swarm/internal/runtime"
 	runtimebootverify "swarm/internal/runtime/bootverify"
 	"swarm/internal/runtime/semanticview"
 )
@@ -45,6 +46,16 @@ func runBootCatalogFixture(t *testing.T, fixtureRoot string) {
 		}
 		if !findingsContain(report.Warnings(), expected.Expected.ErrorCategory, expected.Expected.ErrorContains) {
 			t.Fatalf("expected warning %s containing %q, got %#v", expected.Expected.ErrorCategory, expected.Expected.ErrorContains, report.Warnings())
+		}
+		strictCatalogFixtureStartupPolicy().apply(t)
+		_, validationErr := runtime.ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), runtime.DefaultWorkflowContractValidationOptions(nil))
+		if validationErr != nil {
+			if _, err := newTier8Runtime(t, bundle); err == nil {
+				t.Fatal("expected NewRuntime to fail when authoritative startup validation fails")
+			} else if !strings.Contains(err.Error(), validationErr.Error()) {
+				t.Fatalf("newTier8Runtime error = %q, want authoritative validation error substring %q", err.Error(), validationErr.Error())
+			}
+			return
 		}
 		rt, err := newTier8Runtime(t, bundle)
 		if err != nil {

--- a/internal/runtime/cataloge2e/helpers_test.go
+++ b/internal/runtime/cataloge2e/helpers_test.go
@@ -104,11 +104,41 @@ func testRuntimeConfig() *config.Config {
 	}
 }
 
-func relaxCatalogFixtureBootStrictness(t testing.TB) {
+type catalogFixtureStartupPolicy struct {
+	FatalBootWarnings bool
+	StrictEmitSchemas bool
+}
+
+func (p catalogFixtureStartupPolicy) apply(t testing.TB) {
 	t.Helper()
 	if setter, ok := any(t).(interface{ Setenv(string, string) }); ok {
-		setter.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
-		setter.Setenv("SWARM_EMIT_SCHEMA_STRICT", "false")
+		if p.FatalBootWarnings {
+			setter.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+		} else {
+			setter.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+		}
+		if p.StrictEmitSchemas {
+			setter.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+		} else {
+			setter.Setenv("SWARM_EMIT_SCHEMA_STRICT", "false")
+		}
+	}
+}
+
+func strictCatalogFixtureStartupPolicy() catalogFixtureStartupPolicy {
+	return catalogFixtureStartupPolicy{
+		FatalBootWarnings: true,
+		StrictEmitSchemas: true,
+	}
+}
+
+func runtimeCatalogHarnessStartupPolicy() catalogFixtureStartupPolicy {
+	// Runtime-backed catalog fixtures still exercise post-boot runtime semantics for
+	// flows that intentionally carry boot warnings, so only emit-schema strictness
+	// stays forced here; "real runtime boot" fixtures use the strict policy instead.
+	return catalogFixtureStartupPolicy{
+		FatalBootWarnings: false,
+		StrictEmitSchemas: true,
 	}
 }
 

--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -144,7 +144,7 @@ type agentFixtureEmit struct {
 
 func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHarness {
 	t.Helper()
-	relaxCatalogFixtureBootStrictness(t)
+	runtimeCatalogHarnessStartupPolicy().apply(t)
 	bundle := loadFixtureBundle(t, fixtureRoot)
 	var rootSchema struct {
 		InitialState string `yaml:"initial_state"`

--- a/internal/runtime/cataloge2e/startup_policy_test.go
+++ b/internal/runtime/cataloge2e/startup_policy_test.go
@@ -1,0 +1,101 @@
+package cataloge2e
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtime "swarm/internal/runtime"
+	runtimebootverify "swarm/internal/runtime/bootverify"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestCatalogFixtureStartupPolicies_AreExplicit(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "false")
+
+	strictCatalogFixtureStartupPolicy().apply(t)
+
+	if got := runtime.DefaultWorkflowContractValidationOptions(nil).FatalBootWarnings; !got {
+		t.Fatal("FatalBootWarnings = false, want true")
+	}
+	if got := runtime.DefaultWorkflowContractValidationOptions(nil).StrictEmitSchemas; !got {
+		t.Fatal("StrictEmitSchemas = false, want true")
+	}
+
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "false")
+
+	runtimeCatalogHarnessStartupPolicy().apply(t)
+
+	if got := runtime.DefaultWorkflowContractValidationOptions(nil).FatalBootWarnings; got {
+		t.Fatal("FatalBootWarnings = true, want false for runtime-backed catalog harness")
+	}
+	if got := runtime.DefaultWorkflowContractValidationOptions(nil).StrictEmitSchemas; !got {
+		t.Fatal("StrictEmitSchemas = false, want true for runtime-backed catalog harness")
+	}
+}
+
+func TestTier8RuntimeBootMatchesAuthoritativeStartupTruthForWarningFixtures(t *testing.T) {
+	repoRoot := repoRootFromCatalogE2E(t)
+	cases := []struct {
+		name              string
+		fixtureDir        string
+		wantValidationErr bool
+		wantBootWarnings  bool
+	}{
+		{
+			name:              "event-no-schema warning follows authoritative startup failure",
+			fixtureDir:        filepath.Join("tests", "tier8-boot-verification", "test-boot-event-no-schema"),
+			wantValidationErr: true,
+			wantBootWarnings:  true,
+		},
+		{
+			name:              "tool-missing warning fixture no longer hides authoritative startup failure",
+			fixtureDir:        filepath.Join("tests", "tier8-boot-verification", "test-boot-tool-missing"),
+			wantValidationErr: true,
+			wantBootWarnings:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			strictCatalogFixtureStartupPolicy().apply(t)
+
+			fixtureRoot := filepath.Join(repoRoot, tc.fixtureDir)
+			bundle, err := loadFixtureBundleMaybe(fixtureRoot)
+			if err != nil {
+				t.Fatalf("loadFixtureBundleMaybe(%s): %v", fixtureRoot, err)
+			}
+			source := semanticview.Wrap(bundle)
+
+			report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+			if got := len(report.Warnings()) > 0; got != tc.wantBootWarnings {
+				t.Fatalf("boot warnings present = %v, want %v", got, tc.wantBootWarnings)
+			}
+
+			_, validationErr := runtime.ValidateWorkflowContractSurface(context.Background(), source, runtime.DefaultWorkflowContractValidationOptions(nil))
+			if got := validationErr != nil; got != tc.wantValidationErr {
+				t.Fatalf("ValidateWorkflowContractSurface error = %v, want error=%v", validationErr, tc.wantValidationErr)
+			}
+
+			rt, err := newTier8Runtime(t, bundle)
+			if validationErr != nil {
+				if err == nil {
+					t.Fatal("newTier8Runtime unexpectedly succeeded under authoritative startup failure")
+				}
+				if got := err.Error(); !strings.Contains(got, validationErr.Error()) {
+					t.Fatalf("newTier8Runtime error = %q, want authoritative validation error substring %q", got, validationErr.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newTier8Runtime error = %v, want nil", err)
+			}
+			if err := startRuntimeAndReturnError(rt); err != nil {
+				t.Fatalf("startRuntimeAndReturnError: %v", err)
+			}
+		})
+	}
+}

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -67,8 +67,6 @@ var tier8ExcludedFixtures = map[string]tier8ExcludedFixture{
 }
 
 func TestTier8BootCatalogFixtures_RealRuntimeBoot(t *testing.T) {
-	relaxCatalogFixtureBootStrictness(t)
-
 	repoRoot := repoRootFromCatalogE2E(t)
 	for _, fixtureName := range tier8SupportedFixtures {
 		fixtureRoot := filepath.Join(repoRoot, "tests", "tier8-boot-verification", fixtureName)
@@ -106,11 +104,7 @@ func TestTier8BootCatalogFixtures_RealRuntimeBoot(t *testing.T) {
 				if !findingsContain(report.Warnings(), expected.Expected.ErrorCategory, expected.Expected.ErrorContains) {
 					t.Fatalf("expected warning %s containing %q, got %#v", expected.Expected.ErrorCategory, expected.Expected.ErrorContains, report.Warnings())
 				}
-				rt, err := newTier8Runtime(t, bundle)
-				if err != nil {
-					t.Fatalf("NewRuntime: %v", err)
-				}
-				startRuntimeForBootTest(t, rt)
+				assertTier8RuntimeBootMatchesAuthoritativeStartupTruth(t, bundle, expected)
 			case "error":
 				if !report.HasErrors() {
 					t.Fatal("expected validation error")
@@ -165,7 +159,7 @@ func TestTier8BootCatalogFixtures_AreExplicitlyClassified(t *testing.T) {
 
 func newTier8Runtime(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle) (*runtime.Runtime, error) {
 	t.Helper()
-	relaxCatalogFixtureBootStrictness(t)
+	strictCatalogFixtureStartupPolicy().apply(t)
 	module, err := newFixtureWorkflowModule(bundle)
 	if err != nil {
 		return nil, err
@@ -174,6 +168,26 @@ func newTier8Runtime(t testing.TB, bundle *runtimecontracts.WorkflowContractBund
 		SelfCheck:      false,
 		WorkflowModule: module,
 	})
+}
+
+func assertTier8RuntimeBootMatchesAuthoritativeStartupTruth(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle, expected tier8ExpectedDocument) {
+	t.Helper()
+	strictCatalogFixtureStartupPolicy().apply(t)
+	source := semanticview.Wrap(bundle)
+	_, validationErr := runtime.ValidateWorkflowContractSurface(context.Background(), source, runtime.DefaultWorkflowContractValidationOptions(nil))
+	if validationErr != nil {
+		if _, err := newTier8Runtime(t, bundle); err == nil {
+			t.Fatal("expected NewRuntime to fail when authoritative startup validation fails")
+		} else if !strings.Contains(err.Error(), validationErr.Error()) {
+			t.Fatalf("newTier8Runtime error = %q, want authoritative validation error substring %q", err.Error(), validationErr.Error())
+		}
+		return
+	}
+	rt, err := newTier8Runtime(t, bundle)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	startRuntimeForBootTest(t, rt)
 }
 
 func startRuntimeForBootTest(t testing.TB, rt *runtime.Runtime) {


### PR DESCRIPTION
## Human Summary

This keeps the first `#182` slice on one catalog E2E harness seam: the startup policy defaults that were hiding real runtime startup semantics. The broad hidden helper is gone. Runtime-backed catalog fixtures now use an explicit warning-tolerant harness policy, while tier8 "real runtime boot" fixtures use authoritative strict startup truth and prove runtime construction/start against that truth.

Part of #182

## What Changed

- replaced the broad `relaxCatalogFixtureBootStrictness(...)` helper with explicit startup-policy helpers in `internal/runtime/cataloge2e`
- made `newRuntimeHarness(...)` use an explicit runtime-backed catalog harness policy instead of a hidden global relax helper
- made `newTier8Runtime(...)` and shared boot fixture helpers use strict authoritative startup policy
- updated warning-fixture boot helpers to compare runtime construction/start against `ValidateWorkflowContractSurface(...)` rather than assuming relaxed success
- added smaller invariant coverage for catalog startup-policy behavior

## Why This Is Needed

The previous harness default silently changed authoritative runtime startup policy before runtime construction. That made catalog tests and local repro paths look greener than the real startup semantics. This PR removes that hidden default drift in the touched seam and makes any remaining warning-tolerant behavior explicit and localized.

## Scope Boundaries

In scope:
- `internal/runtime/cataloge2e` startup-policy defaults and boot-helper behavior
- smaller invariant tests for that seam

Out of scope:
- analyzer/simple-harness eligibility work
- `run_clear` / builder lifecycle smoke
- optional infrastructure/startup diagnostics
- broader env-policy redesign across unrelated test surfaces

## Spec References

- none
- justification: non-semantic maintenance on catalog harness behavior and proof shape only

## Tests Run

- `go test ./internal/runtime/cataloge2e -run 'Test(CatalogFixtureStartupPolicies_AreExplicit|Tier8RuntimeBootMatchesAuthoritativeStartupTruthForWarningFixtures|Tier8BootCatalogFixtures_RealRuntimeBoot|Tier11FlowCompositionCatalogFixtures_RealRuntime)$' -count=1`
- `go test ./internal/runtime/cataloge2e ./internal/runtime/swarmflowtest ./internal/runtime -count=1`
- `go test ./... -count=1`

## Residual Risk

- runtime-backed catalog fixtures still intentionally tolerate boot warnings at one explicit harness boundary
- the broader architectural smell of env-driven startup policy transport remains outside this first slice

## Follow-Up

- parent `#182` remains open for other local lifecycle / harness slices if still needed after this seam lands
