### PR TITLE
[agent-c][issue #387] wire the repaired first cataloge2e fixture slice

### DIFF
--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -15,7 +15,11 @@ active_issues:
     maps_to:
       - invariant_suite_coverage
   - id: 387
-    title: Wire the four harness-ready excluded catalog fixtures into runtime e2e execution
+    title: Wire the three harness-ready excluded catalog fixtures into runtime e2e execution
+    maps_to:
+      - invariant_suite_coverage
+  - id: 393
+    title: Resolve stale or missing boot-owner coverage for test-boot-create-entity-plus-accumulate
     maps_to:
       - invariant_suite_coverage
   - id: 126

--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -14,6 +14,10 @@ active_issues:
     title: Wire excluded runtime catalog conformance fixtures into e2e execution
     maps_to:
       - invariant_suite_coverage
+  - id: 387
+    title: Wire the four harness-ready excluded catalog fixtures into runtime e2e execution
+    maps_to:
+      - invariant_suite_coverage
   - id: 126
     title: Split boot verification into boundary-owned modules and close major test gaps
     maps_to:

--- a/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
@@ -15,6 +15,7 @@ var tier2AccumulationFixtures = []string{
 	"test-accumulate-expected-from-entity",
 	"test-accumulate-from-filter",
 	"test-accumulate-idempotent",
+	"test-accumulate-on-complete-rollback",
 	"test-accumulate-on-timeout",
 	"test-accumulate-partial",
 	"test-accumulate-threshold",
@@ -22,9 +23,7 @@ var tier2AccumulationFixtures = []string{
 	"test-accumulate-with-compute",
 }
 
-var tier2ExcludedFixtures = map[string]catalogExcludedFixture{
-	"test-accumulate-on-complete-rollback": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-}
+var tier2ExcludedFixtures = map[string]catalogExcludedFixture{}
 
 func TestTier2AccumulationCatalogFixtures_RealRuntime(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)

--- a/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
@@ -20,11 +20,10 @@ var tier6EventLoopFixtures = []string{
 	"test-event-persisted-before-delivery",
 	"test-event-validation",
 	"test-guards-pre-handler-state",
+	"test-on-complete-atomicity-chain",
 }
 
-var tier6ExcludedFixtures = map[string]catalogExcludedFixture{
-	"test-on-complete-atomicity-chain": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-}
+var tier6ExcludedFixtures = map[string]catalogExcludedFixture{}
 
 func TestTier6EventLoopCatalogFixtures_RealRuntime(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -46,6 +46,7 @@ var tier8SupportedFixtures = []string{
 	"test-boot-event-no-schema",
 	"test-boot-handler-field-undefined",
 	"test-boot-missing-pin",
+	"test-boot-on-complete-and-rules-mutual-exclusion",
 	"test-boot-on-complete-state-invalid",
 	"test-boot-on-complete-dict",
 	"test-boot-payload-mismatch",
@@ -62,9 +63,8 @@ var tier8SupportedFixtures = []string{
 }
 
 var tier8ExcludedFixtures = map[string]tier8ExcludedFixture{
-	"test-boot-create-entity-plus-accumulate":          {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-	"test-boot-on-complete-and-rules-mutual-exclusion": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-	"test-boot-state-machine-unreachable":              {reason: "supported verify warning fixture for analyzer slice 4; not a runtime boot catalog fixture"},
+	"test-boot-create-entity-plus-accumulate": {reason: "split to issue #393: expected boot error no longer reproduces on canonical tier8 path"},
+	"test-boot-state-machine-unreachable":     {reason: "supported verify warning fixture for analyzer slice 4; not a runtime boot catalog fixture"},
 }
 
 func TestTier8BootCatalogFixtures_RealRuntimeBoot(t *testing.T) {


### PR DESCRIPTION
Closes #387
Related to #125
Split from #393 remains out of scope.

## Summary
Wire the repaired first-slice `cataloge2e` child into normal runtime execution by admitting the three fixtures that still terminate at the existing shared owners:
- `tier2-accumulation/test-accumulate-on-complete-rollback`
- `tier6-event-loop/test-on-complete-atomicity-chain`
- `tier8-boot-verification/test-boot-on-complete-and-rules-mutual-exclusion`

This PR also narrows the remaining tier8 exclusion record honestly:
- `test-boot-create-entity-plus-accumulate` stays excluded and now points at `#393`, because its expected boot error no longer reproduces on the canonical tier8 path.

## Why
`#379` showed the excluded fixture set was not one uniform class. During `#387` implementation probing, the original four-fixture grouping broke: three fixtures were simple execution-set registration debt, while `test-boot-create-entity-plus-accumulate` was not. This PR closes the repaired three-fixture child without reopening the split tier8 stale-owner case.

## Scope Boundaries
In scope:
- per-tier `cataloge2e` execution-set registration for the three repaired fixtures
- honest narrowing of the remaining tier8 exclusion reason

Out of scope:
- `test-boot-create-entity-plus-accumulate` in `#393`
- the tier11 sibling child in `#388`
- `swarmflowtest` expansion
- strict tier8 boot parity normalization

## Tests
Focused fixture proofs:
- `go test ./internal/runtime/cataloge2e -run 'TestTier2AccumulationCatalogFixtures_RealRuntime/test-accumulate-on-complete-rollback$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier6EventLoopCatalogFixtures_RealRuntime/test-on-complete-atomicity-chain$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier8BootCatalogFixtures_RealRuntimeBoot/test-boot-on-complete-and-rules-mutual-exclusion$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier2AccumulationCatalogFixtures_AreExplicitlyClassified|TestTier6EventLoopCatalogFixtures_AreExplicitlyClassified|TestTier8BootCatalogFixtures_AreExplicitlyClassified' -count=1`

Broader runs attempted:
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`

Both broader runs hit a pre-existing Postgres harness shutdown cascade (`pq: the database system is shutting down (57P03)` / `connection refused`) across many unrelated `cataloge2e` and conformance tests after startup, so they do not currently provide useful local signal for this slice.

## Caveat
Tier8 boot execution still runs under the existing relaxed env policy in `helpers_test.go`:
- `SWARM_BOOT_WARNINGS_FATAL=false`
- `SWARM_EMIT_SCHEMA_STRICT=false`

This PR wires the remaining harness-ready tier8 fixture into `cataloge2e`, but it does not claim strict tier8 boot parity.
