### PR TITLE
[agent-b][issue #391] Harden local startup smoke failure paths

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -12,10 +12,11 @@ import (
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
-	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	workspace "swarm/internal/runtime/workspace"
 )
 
 type runtimeProjectSupervisor struct {
@@ -26,6 +27,11 @@ type runtimeProjectSupervisor struct {
 	ready            *atomic.Bool
 	startRuntime     func(context.Context, *runtime.Runtime) error
 	shutdownRuntime  func(context.Context, *runtime.Runtime) error
+	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
+	validateSource   func(context.Context, semanticview.Source) error
+	initStateStores  func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
+	newWorkspaces    func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle
+	createRuntime    func(context.Context, *config.Config, runtime.Stores, runtime.RuntimeOptions) (*runtime.Runtime, error)
 
 	mu            sync.RWMutex
 	currentRoot   string
@@ -56,6 +62,19 @@ func newRuntimeProjectSupervisor(
 		},
 		shutdownRuntime: func(_ context.Context, rt *runtime.Runtime) error {
 			return rt.Shutdown()
+		},
+		loadWorkflow: func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
+			return newSwarmWorkflowModule(repoRoot, contractsRoot, platformSpecPath)
+		},
+		validateSource: func(ctx context.Context, source semanticview.Source) error {
+			return verifyBundle(ctx, source)
+		},
+		initStateStores: initializeStateStores,
+		newWorkspaces: func(stores storeBundle, repoRoot, contractsRoot string, source semanticview.Source) workspace.Lifecycle {
+			return configuredWorkspaceLifecycle(stores.SQLDB, repoRoot, contractsRoot, source)
+		},
+		createRuntime: func(ctx context.Context, cfg *config.Config, stores runtime.Stores, opts runtime.RuntimeOptions) (*runtime.Runtime, error) {
+			return runtime.NewRuntime(ctx, cfg, stores, opts)
 		},
 		currentRoot:   strings.TrimSpace(initialRoot),
 		currentSource: initialSource,
@@ -116,22 +135,18 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return builderpkg.ProjectStatus{}, err
 	}
 
-	module, bundle, err := newSwarmWorkflowModule(s.repoRoot, resolvedRoot, s.platformSpecPath)
+	module, bundle, err := s.loadWorkflow(s.repoRoot, resolvedRoot, s.platformSpecPath)
 	if err != nil {
 		return builderpkg.ProjectStatus{}, fmt.Errorf("load project: %w", err)
 	}
-	if err := runtimecontracts.ValidatePromptSchemaGuardsForBundle(bundle); err != nil {
-		return builderpkg.ProjectStatus{}, err
-	}
 	source := semanticview.Wrap(bundle)
-	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
-	if report.HasErrors() {
-		return builderpkg.ProjectStatus{}, fmt.Errorf("%s", report.Errors()[0].Message)
-	}
-	if _, err := initializeStateStores(ctx, s.stores, bundle); err != nil {
+	if err := s.validateSource(ctx, source); err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
-	workspaces := configuredWorkspaceLifecycle(s.stores.SQLDB, s.repoRoot, resolvedRoot, source)
+	if _, err := s.initStateStores(ctx, s.stores, bundle); err != nil {
+		return builderpkg.ProjectStatus{}, err
+	}
+	workspaces := s.newWorkspaces(s.stores, s.repoRoot, resolvedRoot, source)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
@@ -142,7 +157,7 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return builderpkg.ProjectStatus{}, err
 	}
 
-	newRT, err := runtime.NewRuntime(ctx, s.cfg, s.stores.runtimeStores(), runtime.RuntimeOptions{
+	newRT, err := s.createRuntime(ctx, s.cfg, s.stores.runtimeStores(), runtime.RuntimeOptions{
 		SelfCheck:          false,
 		WorkflowModule:     module,
 		WorkspaceLifecycle: workspaces,

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -2,16 +2,23 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 
+	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	workspace "swarm/internal/runtime/workspace"
 )
 
 func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShutdown(t *testing.T) {
@@ -87,6 +94,152 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShut
 	}
 	if status.ProjectDir != "/tmp/new-project" {
 		t.Fatalf("status.ProjectDir = %q, want /tmp/new-project", status.ProjectDir)
+	}
+}
+
+type stubWorkflowModule struct{ source semanticview.Source }
+
+func (m stubWorkflowModule) SemanticSource() semanticview.Source { return m.source }
+func (stubWorkflowModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return &runtimepipeline.WorkflowDefinition{}
+}
+func (stubWorkflowModule) WorkflowNodes() []runtimepipeline.WorkflowNode  { return nil }
+func (stubWorkflowModule) GuardRegistry() runtimepipeline.GuardRegistry   { return nil }
+func (stubWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry { return nil }
+
+type stubWorkspaceLifecycle struct {
+	validateErr error
+	prereqErr   error
+	systemErr   error
+}
+
+func (s stubWorkspaceLifecycle) ResolveWorkspace(context.Context, runtimeactors.AgentConfig) (*workspace.Target, error) {
+	return nil, nil
+}
+func (s stubWorkspaceLifecycle) ValidateSource(context.Context, semanticview.Source) error {
+	return s.validateErr
+}
+func (s stubWorkspaceLifecycle) EnsurePrereqs(context.Context) error { return s.prereqErr }
+func (s stubWorkspaceLifecycle) EnsureSystemWorkspaces(context.Context) error {
+	return s.systemErr
+}
+func (stubWorkspaceLifecycle) EnsureEntityWorkspace(context.Context, string) error { return nil }
+func (stubWorkspaceLifecycle) StopEntityWorkspace(context.Context, string) error   { return nil }
+
+func writeProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.yaml"), []byte("name: test\nversion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	return dir
+}
+
+func newSupervisorForLoadProjectFailureTest(
+	t *testing.T,
+	projectRoot string,
+	lifecycle workspace.Lifecycle,
+	createRuntime func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error),
+) *runtimeProjectSupervisor {
+	t.Helper()
+	bundle := testWorkflowValidationBundle()
+	source := semanticview.Wrap(bundle)
+	module := stubWorkflowModule{source: source}
+	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), "", nil, nil, nil)
+	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
+		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {
+			return nil, nil, fmt.Errorf("contracts root = %q, want %q", got, projectRoot)
+		}
+		return module, bundle, nil
+	}
+	supervisor.validateSource = func(context.Context, semanticview.Source) error { return nil }
+	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
+		return "store wiring ready", nil
+	}
+	supervisor.newWorkspaces = func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle {
+		return lifecycle
+	}
+	if createRuntime != nil {
+		supervisor.createRuntime = createRuntime
+	}
+	return supervisor
+}
+
+func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailures(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	cases := []struct {
+		name      string
+		lifecycle workspace.Lifecycle
+		wantErr   string
+	}{
+		{
+			name:      "validate source",
+			lifecycle: stubWorkspaceLifecycle{validateErr: errors.New("workspace validation failed: workspace image is required")},
+			wantErr:   "workspace validation failed: workspace image is required",
+		},
+		{
+			name:      "ensure prereqs",
+			lifecycle: stubWorkspaceLifecycle{prereqErr: errors.New("docker unavailable")},
+			wantErr:   "docker unavailable",
+		},
+		{
+			name:      "ensure system workspaces",
+			lifecycle: stubWorkspaceLifecycle{systemErr: errors.New("ensure system workspace: permission denied")},
+			wantErr:   "ensure system workspace: permission denied",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, tc.lifecycle, func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
+				t.Fatal("createRuntime should not be called when workspace admission fails")
+				return nil, nil
+			})
+
+			_, err := supervisor.OpenProject(context.Background(), projectRoot)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("OpenProject err = %v, want substring %q", err, tc.wantErr)
+			}
+			if got := supervisor.CurrentProject(); got.Loaded {
+				t.Fatalf("CurrentProject.Loaded = true after %s failure, want false", tc.name)
+			}
+			if supervisor.CurrentRuntime() != nil {
+				t.Fatalf("CurrentRuntime = %p after %s failure, want nil", supervisor.CurrentRuntime(), tc.name)
+			}
+		})
+	}
+}
+
+func TestRuntimeProjectSupervisorLoadProject_PropagatesRuntimeStartFailure(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	var ready atomic.Bool
+	oldRT := &runtimepkg.Runtime{}
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
+		return &runtimepkg.Runtime{}, nil
+	})
+	supervisor.ready = &ready
+	supervisor.currentRoot = "/tmp/old"
+	supervisor.currentBundle = &runtimecontracts.WorkflowContractBundle{}
+	supervisor.currentSource = semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	supervisor.currentRT = oldRT
+	ready.Store(true)
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error {
+		return errors.New("runtime start denied by workspace dependency failure")
+	}
+
+	_, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err == nil || !strings.Contains(err.Error(), "runtime start denied by workspace dependency failure") {
+		t.Fatalf("OpenProject err = %v, want start failure", err)
+	}
+	if ready.Load() {
+		t.Fatal("ready flag remained true after project.open start failure")
+	}
+	if got := supervisor.CurrentProject(); got.Loaded {
+		t.Fatalf("CurrentProject.Loaded = true after start failure, want false")
+	}
+	if supervisor.CurrentRuntime() != nil {
+		t.Fatalf("CurrentRuntime = %p after start failure, want nil", supervisor.CurrentRuntime())
 	}
 }
 

--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -53,6 +53,10 @@ active_issues:
     title: Improve local lifecycle and harness reliability so tooling stops hiding runtime semantics
     maps_to:
       - harness_reliability_and_local_smoke
+  - id: 391
+    title: Strengthen supported local startup smoke for run_clear and builder project-open
+    maps_to:
+      - harness_reliability_and_local_smoke
 nodes:
   - id: boundary_owned_decomposition
     title: Boundary-Owned Decomposition
@@ -144,6 +148,7 @@ nodes:
       - optional infrastructure gaps are unclear during local startup
     representative_issues:
       - 182
+      - 391
     common_framing_mistakes:
       too_broad:
         - the harness is flaky

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -133,8 +133,47 @@ PY
 )"
 echo "${launcher_pid}" > "${PID_FILE}"
 
+launcher_process_signature() {
+  local pid="${1:-}"
+  [[ -n "${pid}" ]] || return 1
+  local state start command
+  state="$(ps -o state= -p "${pid}" 2>/dev/null | head -n 1 | sed 's/^ *//')"
+  start="$(ps -o lstart= -p "${pid}" 2>/dev/null | head -n 1 | sed 's/^ *//')"
+  command="$(ps -o command= -p "${pid}" 2>/dev/null | head -n 1 | sed 's/^ *//')"
+  if [[ -z "${state}" || -z "${start}" || -z "${command}" ]]; then
+    return 1
+  fi
+  printf '%s\t%s\t%s\n' "${state}" "${start}" "${command}"
+}
+
+launcher_signature="$(launcher_process_signature "${launcher_pid}" || true)"
+
+launcher_exited_before_ready() {
+  local pid="${1:-}"
+  local expected_signature="${2:-}"
+  [[ -n "${pid}" && -n "${expected_signature}" ]] || return 1
+  local current_signature current_state
+  current_signature="$(launcher_process_signature "${pid}" || true)"
+  if [[ -z "${current_signature}" ]]; then
+    return 0
+  fi
+  current_state="${current_signature%%$'\t'*}"
+  if [[ "${current_state}" == *Z* ]]; then
+    return 0
+  fi
+  if [[ "${current_signature}" != "${expected_signature}" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 ready=0
 for _ in $(seq 1 "${START_TIMEOUT}"); do
+  if launcher_exited_before_ready "${launcher_pid}" "${launcher_signature}"; then
+    echo "Swarm exited before becoming ready. Current log:"
+    tail -n 200 "${LOG_FILE}"
+    exit 1
+  fi
   health_code="$(curl -s -o /tmp/swarm-healthz.json -w '%{http_code}' "${HEALTH_URL}" || true)"
   ready_code="$(curl -s -o /tmp/swarm-readyz.json -w '%{http_code}' "${READY_URL}" || true)"
   api_code="$(curl -s -o /tmp/swarm-api-health.json -w '%{http_code}' "${API_HEALTH_URL}" \

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -16,6 +16,11 @@ type runClearConfig struct {
 	directiveMessage string
 	hostGatewayURL   string
 	containerURL     string
+	launcherMode     string
+	launcherLogText  string
+	readyCode        string
+	apiHealthCode    string
+	startTimeout     string
 }
 
 func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
@@ -134,6 +139,28 @@ func TestRunClear_IgnoresPartialGatewayOverrideAndDerivesCoherentPair(t *testing
 	}
 }
 
+func TestRunClear_FailsFastWhenSwarmExitsBeforeReady(t *testing.T) {
+	result, err := runRunClearResult(t, runClearConfig{
+		launcherMode:    "exit_fast",
+		launcherLogText: "workspace validation failed: workspace image is required",
+		readyCode:       "503",
+		apiHealthCode:   "503",
+		startTimeout:    "5",
+	})
+	if err == nil {
+		t.Fatalf("run_clear.sh err = nil, want startup failure\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "Swarm exited before becoming ready. Current log:") {
+		t.Fatalf("stdout = %q, want early-exit startup failure text", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "workspace validation failed: workspace image is required") {
+		t.Fatalf("stdout = %q, want startup failure log detail", result.stdout)
+	}
+	if strings.TrimSpace(result.rpcBody) != "" {
+		t.Fatalf("rpc body = %q, want no run.start after startup failure", result.rpcBody)
+	}
+}
+
 type runClearResult struct {
 	stdout              string
 	operatorToken       string
@@ -151,6 +178,15 @@ type runClearResult struct {
 }
 
 func runRunClear(t *testing.T, cfg runClearConfig) runClearResult {
+	t.Helper()
+	result, err := runRunClearResult(t, cfg)
+	if err != nil {
+		t.Fatalf("run_clear.sh failed: %v\n%s", err, result.stdout)
+	}
+	return result
+}
+
+func runRunClearResult(t *testing.T, cfg runClearConfig) (runClearResult, error) {
 	t.Helper()
 
 	scriptDir := testScriptDir(t)
@@ -181,7 +217,25 @@ printf '%s' "${SWARM_OPERATOR_AUTH_TOKEN:-}" > "${PYTHON_OPERATOR_TOKEN_SINK}"
 printf '%s' "${SWARM_BUILDER_AUTH_TOKEN:-}" > "${PYTHON_ENV_SINK}"
 printf '%s' "${SWARM_TOOL_GATEWAY_URL:-}" > "${PYTHON_HOST_GATEWAY_URL_SINK}"
 printf '%s' "${SWARM_TOOL_GATEWAY_CONTAINER_URL:-}" > "${PYTHON_CONTAINER_GATEWAY_URL_SINK}"
-printf '4242\n'
+mode="${PYTHON_LAUNCHER_MODE:-steady}"
+case "$mode" in
+  exit_fast)
+    if [[ -n "${PYTHON_LAUNCHER_LOG_TEXT:-}" ]]; then
+      printf '%s\n' "${PYTHON_LAUNCHER_LOG_TEXT}" >> "${LOG_FILE}"
+    fi
+    (sleep 0.2 >/dev/null 2>&1 </dev/null) &
+    pid="$!"
+    (
+      sleep 0.3
+      kill "${pid}" >/dev/null 2>&1 || true
+    ) >/dev/null 2>&1 </dev/null &
+    printf '%s\n' "${pid}"
+    ;;
+  *)
+    (sleep 30 >/dev/null 2>&1 </dev/null) &
+    printf '%s\n' "$!"
+    ;;
+esac
 `)
 	writeExecutable(t, binDir, "curl", `#!/usr/bin/env bash
 set -euo pipefail
@@ -221,11 +275,18 @@ while (($#)); do
       ;;
   esac
 done
-if [[ "$url" == *"/healthz" || "$url" == *"/readyz" ]]; then
+if [[ "$url" == *"/healthz" ]]; then
   if [[ -n "$out" ]]; then
     printf '{}' > "$out"
   fi
-  printf '200'
+  printf '%s' "${CURL_HEALTHZ_CODE:-200}"
+  exit 0
+fi
+if [[ "$url" == *"/readyz" ]]; then
+  if [[ -n "$out" ]]; then
+    printf '{}' > "$out"
+  fi
+  printf '%s' "${CURL_READYZ_CODE:-200}"
   exit 0
 fi
 if [[ "$url" == *"/api/health" ]]; then
@@ -241,7 +302,7 @@ if [[ "$url" == *"/api/health" ]]; then
       if [[ -n "$out" ]]; then
         printf '{}' > "$out"
       fi
-      printf '200'
+      printf '%s' "${CURL_API_HEALTH_CODE:-200}"
       exit 0
     fi
   done
@@ -294,14 +355,21 @@ printf '{}'
 	cmd.Env = append(filteredEnv(
 		"SWARM_OPERATOR_AUTH_TOKEN",
 		"SWARM_BUILDER_AUTH_TOKEN",
+		"SWARM_TOOL_GATEWAY_URL",
+		"SWARM_TOOL_GATEWAY_CONTAINER_URL",
 	), []string{
 		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"PYTHON_OPERATOR_TOKEN_SINK=" + operatorTokenSink,
 		"PYTHON_ENV_SINK=" + builderTokenSink,
 		"PYTHON_HOST_GATEWAY_URL_SINK=" + hostGatewayURLSink,
 		"PYTHON_CONTAINER_GATEWAY_URL_SINK=" + containerGatewayURLSink,
+		"PYTHON_LAUNCHER_MODE=" + defaultString(cfg.launcherMode, "steady"),
+		"PYTHON_LAUNCHER_LOG_TEXT=" + cfg.launcherLogText,
 		"CURL_API_HEALTH_HEADERS_SINK=" + healthHeadersSink,
 		"CURL_API_HEALTH_URL_SINK=" + healthURLSink,
+		"CURL_HEALTHZ_CODE=200",
+		"CURL_READYZ_CODE=" + defaultString(cfg.readyCode, "200"),
+		"CURL_API_HEALTH_CODE=" + defaultString(cfg.apiHealthCode, "200"),
 		"CURL_HEADERS_SINK=" + rpcHeadersSink,
 		"CURL_BODY_SINK=" + bodySink,
 		"CURL_URL_SINK=" + urlSink,
@@ -312,7 +380,7 @@ printf '{}'
 		"HEALTH_ADDR=127.0.0.1:8081",
 		"LOG_FILE=" + logFile,
 		"PID_FILE=" + pidFile,
-		"START_TIMEOUT=1",
+		"START_TIMEOUT=" + defaultString(cfg.startTimeout, "1"),
 	}...)
 	if cfg.operatorToken != "" {
 		cmd.Env = append(cmd.Env, "SWARM_OPERATOR_AUTH_TOKEN="+cfg.operatorToken)
@@ -334,8 +402,8 @@ printf '{}'
 	}
 
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("run_clear.sh failed: %v\n%s", err, out)
+	if pid := readFileTrimmedOptional(t, pidFile); strings.TrimSpace(pid) != "" {
+		_ = exec.Command("kill", pid).Run()
 	}
 
 	return runClearResult{
@@ -346,13 +414,13 @@ printf '{}'
 		containerGatewayURL: readFileTrimmed(t, containerGatewayURLSink),
 		healthHeaders:       readFileTrimmed(t, healthHeadersSink),
 		healthURL:           readFileTrimmed(t, healthURLSink),
-		rpcHeaders:          readFileTrimmed(t, rpcHeadersSink),
-		rpcBody:             readFileTrimmed(t, bodySink),
-		rpcURL:              readFileTrimmed(t, urlSink),
+		rpcHeaders:          readFileTrimmedOptional(t, rpcHeadersSink),
+		rpcBody:             readFileTrimmedOptional(t, bodySink),
+		rpcURL:              readFileTrimmedOptional(t, urlSink),
 		directiveHeaders:    readFileTrimmedOptional(t, directiveHeadersSink),
 		directiveBody:       readFileTrimmedOptional(t, directiveBodySink),
 		directiveURL:        readFileTrimmedOptional(t, directiveURLSink),
-	}
+	}, err
 }
 
 func filteredEnv(removeKeys ...string) []string {
@@ -411,4 +479,11 @@ func readFileTrimmedOptional(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return strings.TrimSpace(string(data))
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }


### PR DESCRIPTION
## Human Summary

This closes the approved first `#391` startup-smoke child by hardening the two supported local startup entrypoints against the real startup owner chain. `run_clear.sh` now fails fast when the spawned Swarm process dies before readiness instead of waiting out the full timeout, and builder project-load now has focused proof for workspace admission and runtime-start failures through the real supervisor seam.

Closes #391

Part of #182

## What Changed

- added one explicit fail-fast path to `scripts/run_clear.sh` when the spawned Swarm process exits before readiness
- expanded `scripts/run_clear_test.go` to prove startup-failure smoke rather than only auth/header/RPC happy path
- added explicit injectable seams in `cmd/swarm/builder_project_supervisor.go` so project-load failure classes can be proven against the real startup owner chain
- added focused `cmd/swarm/builder_project_supervisor_test.go` coverage for:
  - `ValidateSource(...)` failure
  - `EnsurePrereqs(...)` failure
  - `EnsureSystemWorkspaces(...)` failure
  - runtime start / replacement failure through `OpenProject(...)`
- moved builder project-load validation onto the canonical `verifyBundle(...)` owner instead of a local prompt-guard + `runtimebootverify.Run(...)` combination

## Why This Is Needed

Before this PR, the supported local startup entrypoints were skewed toward happy-path transport and readiness proof. That left real startup-admission and dependency-failure behavior under-proven, and in `run_clear.sh` it also left an actively misleading local behavior: if the child Swarm process died immediately, the script still waited for readiness timeout before surfacing failure. This PR removes that hidden false-green/false-confusing behavior in the touched local startup seam.

## Scope Boundaries

In scope:
- `scripts/run_clear.sh` startup smoke / failure classification
- builder project-load through `cmd/swarm/builder_project_supervisor.go`
- focused proof for the shared startup owner chain behind those entrypoints

Out of scope:
- broader optional infrastructure UX across unrelated local startup surfaces
- analyzer / bootverify lane work
- generic script cleanup or broad infrastructure redesign

## Spec References

- none
- justification: this is non-semantic maintenance on local startup smoke, harness reliability, and failure-surface clarity

## Tests Run

- `go test ./cmd/swarm -run 'TestRuntimeProjectSupervisor(ReplaceCurrentRuntime_ClearsReadinessBeforeShutdown|LoadProject_PropagatesWorkspaceAdmissionFailures|LoadProject_PropagatesRuntimeStartFailure)|TestDashboardDynamicAgentControl_DeniesWhenRuntimeShutdownAdmissionClosed$' -count=1`
- `go test ./scripts -run 'TestRunClear_(ProvisionsBuilderAuthTokenAndUsesBearerForRPC|UsesConfiguredBuilderAuthTokenForRPC|UsesOperatorBearerForDirective|FailsFastWhenSwarmExitsBeforeReady)$' -count=1`
- `go test ./cmd/swarm ./scripts ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk

- broader optional dependency UX during local startup remains outside this first slice
- builder RPC transport still only has happy-path proof; this PR keeps transport proof subordinate to the supervisor/startup owner seam

## Follow-Up

- parent `#182` remains open only if broader sibling local lifecycle / harness seams still remain after this child lands
