### PR TITLE
[agent-a][issue #394] Add dead event schema analyzer

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -937,6 +937,46 @@ func loadWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *run
 	return bundle
 }
 
+func loadWorkflowValidationBundleAt(t *testing.T, fixtureRoot string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", fixtureRoot, err)
+	}
+	return bundle
+}
+
+func writeWorkflowValidationFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeWorkflowValidationDeadEventSchemaFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: dead-event-schema
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: dead-event-schema\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+root.unused: {}
+`)
+	return root
+}
+
 func firstWorkflowValidationFlowHandler(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle) (string, string, string, runtimecontracts.SystemNodeEventHandler) {
 	t.Helper()
 	for _, view := range bundle.FlowViews() {
@@ -1272,5 +1312,42 @@ func TestVerifyBundle_UnreachableStateReturnsWarningSurface(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("verifyBundle error = %v, want substring %q", err, want)
 		}
+	}
+}
+
+func TestVerifyBundle_DeadDeclaredEventSchemaReturnsWarningSurface(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	source := semanticview.Wrap(loadWorkflowValidationBundleAt(t, writeWorkflowValidationDeadEventSchemaFixture(t)))
+
+	verifyErr := verifyBundle(context.Background(), source)
+	if verifyErr == nil {
+		t.Fatal("verifyBundle error = nil, want warning-only failure from dead declared event schema")
+	}
+	for _, want := range []string{
+		"semantic_drift_dead_event_schema",
+		"root.unused",
+		"has no active role in the authored bundle",
+	} {
+		if !strings.Contains(verifyErr.Error(), want) {
+			t.Fatalf("verifyBundle error = %v, want substring %q", verifyErr, want)
+		}
+	}
+
+	result, runtimeErr := runtimepkg.ValidateWorkflowContractSurface(context.Background(), source, runtimepkg.DefaultWorkflowContractValidationOptions(nil))
+	if runtimeErr == nil {
+		t.Fatal("ValidateWorkflowContractSurface error = nil, want warning-only failure from dead declared event schema")
+	}
+	for _, want := range []string{
+		"semantic_drift_dead_event_schema",
+		"root.unused",
+		"has no active role in the authored bundle",
+	} {
+		if !strings.Contains(runtimeErr.Error(), want) {
+			t.Fatalf("ValidateWorkflowContractSurface error = %v, want substring %q", runtimeErr, want)
+		}
+	}
+	if !strings.Contains(strings.TrimSpace(result.BootReport.Warnings()[0].CheckID), "semantic_drift_dead_event_schema") {
+		t.Fatalf("BootReport warnings = %#v, want semantic_drift_dead_event_schema", result.BootReport.Warnings())
 	}
 }

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1763,10 +1763,19 @@ engine:
         node handler emits, exact platform_events catalog matches, _source values starting with external, and same-flow timer
         declarations. It does not use produces or _status: planned as proof.'
       when: boot-only
+    - id: semantic_drift_dead_event_schema
+      severity: warning
+      scope: per-event
+      trigger: A product-declared event schema entry in `events.yaml` has no active authored role on the static verify surface.
+        Active roles are limited to intra-flow local usage, explicit cross-flow qualified usage, root-local usage for root-declared
+        events only, external `_source` / `_consumer` annotations, same-flow timer fire/start/cancel references, same-flow
+        `fan_out.emit_per_item`, and same-flow `auto_emit_on_create`. It does not treat platform catalog membership, root-local
+        references into child-flow declarations, or coincidental same local names in other flows as proof.
+      when: boot-only
     severity_behavior:
       error: Boot aborts. System does not start.
       warning: Boot continues. Warning logged with finding details.
-    check_count: 33 checks (21 error, 12 warning)
+    check_count: 34 checks (21 error, 13 warning)
     implementation_notes:
       framework: Each check is a named function that receives the loaded contract bundle and returns a list of findings. Each
         finding has the check ID, severity, message, and location (flow, node, agent, or event name). The boot sequence runs
@@ -3496,3 +3505,56 @@ static_analyzer:
         rule: terminal states are sinks in this slice.
     rule: Emit warning when a declared state is unreachable from initial_state in the authored transition graph. Keep invalid
       undeclared advances_to targets on hard-invalid state_machine_coherence.
+  slice_5_dead_declared_event_schema_surface:
+    id: semantic_drift_dead_event_schema
+    domain: semantic_drift
+    authority: semantic_drift_warning
+    severity: warning
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - contract_formats.event_schema
+    - engine.event_identity
+    - engine.timer_model
+    - engine.agent_session_management.emit_tool_convention
+    - handler_specification.handler_fields.emits
+    scope:
+      description: For every product-declared event schema entry in `events.yaml`, verify that at least one accepted active
+        authored role exists on the supported static verify path.
+      applies_to:
+      - declared `events.yaml` entries only
+      excludes:
+      - timer-fired-no-consumer ownership
+      - runtime delivery correctness
+      - payload completeness
+      - input-pin producer satisfaction
+      - state reachability
+      - platform catalog membership as proof
+    active_role_carriers:
+      intra_flow_local_usage:
+        rule: Handlers or agents within the same flow as the declaration reference the event by local name or same-flow resolved
+          identity.
+      root_local_usage_for_root_declared_events:
+        rule: Root-level handlers or agents referencing a root-declared event by local name keep only the root declaration alive.
+      cross_flow_qualified_usage:
+        rule: Another flow or root participant references the declaration via an explicitly qualified event name that resolves
+          to the declaring flow.
+      external_annotations:
+        rule: "`_source` beginning with external or `_consumer` metadata on the declared event entry counts as an active external role."
+      same_flow_timer_references:
+        rule: "Timers in the same scope keep the declaration alive through `event`, `start_on: event:...`, or `cancel_on: event:...`."
+      same_flow_fan_out_emit_per_item:
+        rule: "`fan_out.emit_per_item` in the same scope keeps the declaration alive."
+      same_flow_auto_emit_on_create:
+        rule: "`auto_emit_on_create` in the same scope keeps the declaration alive."
+    non_proof_carriers:
+      platform_catalog_membership:
+        rule: "Product-declared `events.yaml` entries are not kept alive by `platform_events.catalog` overlap."
+      root_local_reference_into_child_flow:
+        rule: A root-local reference does not keep a child-flow declaration alive.
+      coincidental_same_local_name:
+        rule: The same local event name in another flow is not proof by coincidence.
+      produces:
+        rule: "Node `produces` lists are not active-role proof."
+    rule: Emit warning when a declared event-schema entry has zero accepted active-role carriers. The message must describe the
+      event as having no active role in the authored bundle, not as definitely unreachable at runtime.

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -75,6 +75,9 @@ type checkerContext struct {
 	payloadCompletenessLoaded   bool
 	payloadCompletenessFindings []Finding
 
+	deadEventSchemaLoaded   bool
+	deadEventSchemaFindings []Finding
+
 	dialectLoaded   bool
 	dialectFindings []Finding
 
@@ -167,6 +170,7 @@ var bootCheckRegistry = []Check{
 	{ID: "event_chain_integrity", Severity: "warning", Run: checkEventChainIntegrity},
 	{ID: "event_consumer_exists", Severity: "warning", Run: checkEventConsumerExists},
 	{ID: "event_producer_exists", Severity: "warning", Run: checkEventProducerExists},
+	{ID: "semantic_drift_dead_event_schema", Severity: "warning", Run: checkSemanticDriftDeadEventSchema},
 	{ID: "payload_field_coverage", Severity: "error", Run: checkPayloadFieldCoverage},
 	{ID: "semantic_drift_payload_completeness", Severity: "warning", Run: checkSemanticDriftPayloadCompleteness},
 	{ID: "condition_payload_alignment", Severity: "error", Run: checkConditionPayloadAlignment},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -210,6 +211,292 @@ func TestRun_MapsEventNoProducerToNamedWarning(t *testing.T) {
 	}
 	if !reportContains(report.Warnings(), "event_producer_exists", "task.requested") {
 		t.Fatalf("expected event_producer_exists warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_MapsDeadDeclaredEventSchemaToNamedWarning(t *testing.T) {
+	root := writeDeadEventSchemaFixture(t, deadEventSchemaFixtureOptions{
+		name:       "dead-event-schema-warning",
+		rootEvents: "root.unused: {}\n",
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "root.unused") {
+		t.Fatalf("expected semantic_drift_dead_event_schema warning for root.unused, got %#v", report.Warnings())
+	}
+	for _, want := range []string{
+		"has no active role in the authored bundle",
+		"Handler emits: 0",
+		"External source annotation (_source): no",
+	} {
+		if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", want) {
+			t.Fatalf("expected semantic_drift_dead_event_schema warning containing %q, got %#v", want, report.Warnings())
+		}
+	}
+}
+
+func TestRun_DoesNotWarnWhenDeclaredEventHasAcceptedActiveRoleCarrier(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		target string
+		opts   deadEventSchemaFixtureOptions
+	}{
+		{
+			name:   "same-flow handler emit",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-same-flow-handler",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready: {}\n",
+						nodes: `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to:
+    - start
+  event_handlers:
+    start:
+      emits: ticket.ready
+`,
+					},
+				},
+			},
+		},
+		{
+			name:   "cross-flow qualified usage",
+			target: "producer/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-cross-flow-qualified",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"producer": {
+						events: "ticket.ready: {}\n",
+					},
+					"consumer": {
+						nodes: `
+consumer-node:
+  id: consumer-node
+  execution_type: system_node
+  subscribes_to:
+    - producer/ticket.ready
+  event_handlers:
+    producer/ticket.ready: {}
+`,
+					},
+				},
+			},
+		},
+		{
+			name:   "root-local root declaration",
+			target: "ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name:       "dead-event-schema-root-local",
+				rootEvents: "ticket.ready: {}\n",
+				rootNodes: `
+root-node:
+  id: root-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.ready
+  event_handlers:
+    ticket.ready: {}
+`,
+			},
+		},
+		{
+			name:   "external source annotation",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-external-source",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready:\n  _source: external (manual handoff)\n",
+					},
+				},
+			},
+		},
+		{
+			name:   "external consumer annotation",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-external-consumer",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready:\n  _consumer: mailbox_system\n",
+					},
+				},
+			},
+		},
+		{
+			name:   "same-flow timer reference",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-timer-reference",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready: {}\nstart.signal: {}\n",
+						nodes: `
+timer-owner:
+  id: timer-owner
+  execution_type: system_node
+  timers:
+    - id: reminder
+      owner: timer-owner
+      event: ticket.ready
+      start_on: event:start.signal
+      cancel_on: event:ticket.ready
+`,
+					},
+				},
+			},
+		},
+		{
+			name:   "fan-out emit_per_item",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-fanout",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready: {}\nstart: {}\n",
+						nodes: `
+fanout-node:
+  id: fanout-node
+  execution_type: system_node
+  subscribes_to:
+    - start
+  event_handlers:
+    start:
+      fan_out:
+        emit_per_item: ticket.ready
+`,
+					},
+				},
+			},
+		},
+		{
+			name:   "auto emit on create",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-auto-emit",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						schema: `
+name: support
+mode: template
+auto_emit_on_create:
+  event: ticket.ready
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+						events: "ticket.ready: {}\n",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeDeadEventSchemaFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Warnings(), "semantic_drift_dead_event_schema", tc.target) {
+				t.Fatalf("unexpected semantic_drift_dead_event_schema warning for %s, got %#v", tc.target, report.Warnings())
+			}
+		})
+	}
+}
+
+func TestRun_DoesNotUseSameLocalNameAcrossFlowsByCoincidenceForDeadEventSchema(t *testing.T) {
+	root := writeDeadEventSchemaFixture(t, deadEventSchemaFixtureOptions{
+		name: "dead-event-schema-coincidental-name",
+		flows: map[string]deadEventSchemaFlowFiles{
+			"alpha": {
+				events: "task.completed: {}\n",
+			},
+			"beta": {
+				events: "task.completed: {}\n",
+				nodes: `
+beta-node:
+  id: beta-node
+  execution_type: system_node
+  subscribes_to:
+    - task.completed
+  event_handlers:
+    task.completed: {}
+`,
+			},
+		},
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "alpha/task.completed") {
+		t.Fatalf("expected semantic_drift_dead_event_schema warning for alpha/task.completed, got %#v", report.Warnings())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "beta/task.completed") {
+		t.Fatalf("unexpected semantic_drift_dead_event_schema warning for beta/task.completed, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotUseRootLocalReferenceAsProofForChildFlowDeadEventSchema(t *testing.T) {
+	root := writeDeadEventSchemaFixture(t, deadEventSchemaFixtureOptions{
+		name: "dead-event-schema-root-local-child-flow",
+		rootNodes: `
+root-node:
+  id: root-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.ready
+  event_handlers:
+    ticket.ready: {}
+`,
+		flows: map[string]deadEventSchemaFlowFiles{
+			"scoring": {
+				events: "ticket.ready: {}\n",
+			},
+		},
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "scoring/ticket.ready") {
+		t.Fatalf("expected semantic_drift_dead_event_schema warning for scoring/ticket.ready, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotUsePlatformCatalogOverlapAsProofForDeadEventSchema(t *testing.T) {
+	root := writeDeadEventSchemaFixture(t, deadEventSchemaFixtureOptions{
+		name:       "dead-event-schema-platform-overlap",
+		rootEvents: "platform.runtime_log: {}\n",
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "platform.runtime_log") {
+		t.Fatalf("expected semantic_drift_dead_event_schema warning for platform.runtime_log, got %#v", report.Warnings())
+	}
+	if !reportContains(report.Errors(), "platform_namespace_violation", "platform.runtime_log") {
+		t.Fatalf("expected platform_namespace_violation error for platform.runtime_log, got %#v", report.Errors())
 	}
 }
 
@@ -2406,8 +2693,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 40 {
-		t.Fatalf("bootCheckRegistry count = %d, want 40", got)
+	if got := len(bootCheckRegistry); got != 41 {
+		t.Fatalf("bootCheckRegistry count = %d, want 41", got)
 	}
 	if got := len(supplementalChecks); got != 2 {
 		t.Fatalf("supplementalChecks count = %d, want 2", got)
@@ -3207,6 +3494,87 @@ func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBun
 	bundle.Platform.Platform.Name = "test"
 	bundle.Platform.Platform.Version = "1.0.0"
 	return bundle
+}
+
+type deadEventSchemaFlowFiles struct {
+	schema string
+	events string
+	agents string
+	nodes  string
+	policy string
+}
+
+type deadEventSchemaFixtureOptions struct {
+	name       string
+	rootSchema string
+	rootEvents string
+	rootAgents string
+	rootNodes  string
+	rootPolicy string
+	flows      map[string]deadEventSchemaFlowFiles
+}
+
+func writeDeadEventSchemaFixture(t *testing.T, opts deadEventSchemaFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	name := strings.TrimSpace(opts.name)
+	if name == "" {
+		name = "dead-event-schema"
+	}
+
+	flowIDs := make([]string, 0, len(opts.flows))
+	for flowID := range opts.flows {
+		flowID = strings.TrimSpace(flowID)
+		if flowID != "" {
+			flowIDs = append(flowIDs, flowID)
+		}
+	}
+	sort.Strings(flowIDs)
+
+	packageYAML := "name: " + name + "\nversion: \"1.0.0\"\nplatform: \">=1.6.0\"\n"
+	if len(flowIDs) > 0 {
+		packageYAML += "flows:\n"
+		for _, flowID := range flowIDs {
+			packageYAML += "  - id: " + flowID + "\n    flow: " + flowID + "\n    mode: static\n"
+		}
+	}
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), packageYAML)
+	rootSchema := strings.TrimSpace(opts.rootSchema)
+	if rootSchema == "" {
+		rootSchema = "name: " + name
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema+"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), defaultFixtureYAML(opts.rootPolicy))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), defaultFixtureYAML(opts.rootAgents))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), defaultFixtureYAML(opts.rootEvents))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), defaultFixtureYAML(opts.rootNodes))
+
+	for _, flowID := range flowIDs {
+		files := opts.flows[flowID]
+		schema := strings.TrimSpace(files.schema)
+		if schema == "" {
+			schema = "name: " + flowID + "\ninitial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: []\n  outputs:\n    events: []"
+		}
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), schema+"\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), defaultFixtureYAML(files.policy))
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), defaultFixtureYAML(files.agents))
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), defaultFixtureYAML(files.events))
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), defaultFixtureYAML(files.nodes))
+	}
+
+	return root
+}
+
+func defaultFixtureYAML(contents string) string {
+	if strings.TrimSpace(contents) == "" {
+		return "{}\n"
+	}
+	if strings.HasSuffix(contents, "\n") {
+		return contents
+	}
+	return contents + "\n"
 }
 
 func mustPayloadCompletenessTransform(t *testing.T, body string) *runtimecontracts.PayloadTransformSpec {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -381,6 +381,60 @@ fanout-node:
 			},
 		},
 		{
+			name:   "accumulate on_complete emit",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-accumulate-on-complete-emit",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready: {}\nstart: {}\n",
+						nodes: `
+accumulate-node:
+  id: accumulate-node
+  execution_type: system_node
+  subscribes_to:
+    - start
+  event_handlers:
+    start:
+      accumulate:
+        expected_from: payload.items
+        threshold: 1
+        on_complete:
+          - emits: ticket.ready
+`,
+					},
+				},
+			},
+		},
+		{
+			name:   "accumulate on_timeout fan-out",
+			target: "support/ticket.ready",
+			opts: deadEventSchemaFixtureOptions{
+				name: "dead-event-schema-accumulate-on-timeout-fanout",
+				flows: map[string]deadEventSchemaFlowFiles{
+					"support": {
+						events: "ticket.ready: {}\nstart: {}\n",
+						nodes: `
+accumulate-timeout-node:
+  id: accumulate-timeout-node
+  execution_type: system_node
+  subscribes_to:
+    - start
+  event_handlers:
+    start:
+      accumulate:
+        expected_from: payload.items
+        threshold: 2
+        timeout_ms: 1000
+        on_timeout:
+          fan_out:
+            emit_per_item: ticket.ready
+`,
+					},
+				},
+			},
+		},
+		{
 			name:   "auto emit on create",
 			target: "support/ticket.ready",
 			opts: deadEventSchemaFixtureOptions{

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -268,7 +268,7 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 }
 
 func deadEventHandlerEmits(handler runtimecontracts.SystemNodeEventHandler) []string {
-	out := make([]string, 0, len(handler.Rules)+4)
+	out := make([]string, 0, len(handler.Rules)+len(handler.OnComplete)+6)
 	for _, emitted := range handler.Emits.Values() {
 		emitted = strings.TrimSpace(emitted)
 		if emitted != "" {
@@ -291,11 +291,29 @@ func deadEventHandlerEmits(handler runtimecontracts.SystemNodeEventHandler) []st
 			}
 		}
 	}
+	if handler.Accumulate != nil {
+		for _, branch := range handler.Accumulate.OnComplete {
+			for _, emitted := range branch.Emits.Values() {
+				emitted = strings.TrimSpace(emitted)
+				if emitted != "" {
+					out = append(out, emitted)
+				}
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			for _, emitted := range handler.Accumulate.OnTimeout.Emits.Values() {
+				emitted = strings.TrimSpace(emitted)
+				if emitted != "" {
+					out = append(out, emitted)
+				}
+			}
+		}
+	}
 	return out
 }
 
 func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler) []string {
-	out := make([]string, 0, 1+len(handler.Rules)+len(handler.OnComplete))
+	out := make([]string, 0, 1+len(handler.Rules)+len(handler.OnComplete)+2)
 	if handler.FanOut != nil {
 		if emitted := strings.TrimSpace(handler.FanOut.EmitPerItem); emitted != "" {
 			out = append(out, emitted)
@@ -311,6 +329,20 @@ func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler
 	for _, rule := range handler.OnComplete {
 		if rule.FanOut != nil {
 			if emitted := strings.TrimSpace(rule.FanOut.EmitPerItem); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+	}
+	if handler.Accumulate != nil {
+		for _, rule := range handler.Accumulate.OnComplete {
+			if rule.FanOut != nil {
+				if emitted := strings.TrimSpace(rule.FanOut.EmitPerItem); emitted != "" {
+					out = append(out, emitted)
+				}
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil && handler.Accumulate.OnTimeout.FanOut != nil {
+			if emitted := strings.TrimSpace(handler.Accumulate.OnTimeout.FanOut.EmitPerItem); emitted != "" {
 				out = append(out, emitted)
 			}
 		}

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -1,0 +1,387 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/eventidentity"
+	"swarm/internal/runtime/semanticview"
+)
+
+func checkSemanticDriftDeadEventSchema(c *checkerContext) []Finding {
+	return c.deadEventSchema()
+}
+
+type deadEventSchemaUsage struct {
+	handlerEmits       int
+	handlerSubscribes  int
+	agentEmitEvents    int
+	agentSubscriptions int
+	timerReferences    int
+	fanOutEmitPerItem  int
+	autoEmitOnCreate   bool
+	externalSource     bool
+	externalConsumer   bool
+}
+
+func (u deadEventSchemaUsage) hasAny() bool {
+	return u.handlerEmits > 0 ||
+		u.handlerSubscribes > 0 ||
+		u.agentEmitEvents > 0 ||
+		u.agentSubscriptions > 0 ||
+		u.timerReferences > 0 ||
+		u.fanOutEmitPerItem > 0 ||
+		u.autoEmitOnCreate ||
+		u.externalSource ||
+		u.externalConsumer
+}
+
+func (c *checkerContext) deadEventSchema() []Finding {
+	if c.deadEventSchemaLoaded {
+		return c.deadEventSchemaFindings
+	}
+	c.deadEventSchemaLoaded = true
+
+	bundle, ok := semanticview.Bundle(c.source)
+	if !ok || bundle == nil {
+		return nil
+	}
+
+	for _, decl := range deadEventDeclarations(c.source) {
+		usage := c.deadEventSchemaUsageFor(decl)
+		if usage.hasAny() {
+			continue
+		}
+		fileLabel := deadEventSchemaFileLabel(strings.TrimSpace(decl.File), strings.TrimSpace(decl.FlowID))
+		c.deadEventSchemaFindings = append(c.deadEventSchemaFindings, Finding{
+			CheckID:  "semantic_drift_dead_event_schema",
+			Severity: "warning",
+			Message: fmt.Sprintf(
+				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source annotation (_source): %s\n- External consumer annotation (_consumer): %s\n- Fan-out emit_per_item: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add _source: external (...) or _consumer: ... to document the external role.",
+				decl.Canonical,
+				fileLabel,
+				usage.handlerEmits,
+				usage.handlerSubscribes,
+				usage.agentEmitEvents,
+				usage.agentSubscriptions,
+				usage.timerReferences,
+				yesNoLocal(usage.externalSource),
+				yesNoLocal(usage.externalConsumer),
+				usage.fanOutEmitPerItem,
+				yesNoLocal(usage.autoEmitOnCreate),
+				fileLabel,
+			),
+			Location: decl.Canonical,
+		})
+	}
+
+	return c.deadEventSchemaFindings
+}
+
+func deadEventDeclarations(source semanticview.Source) []deadEventDeclaration {
+	if source == nil {
+		return nil
+	}
+	out := make([]deadEventDeclaration, 0)
+	for _, scope := range semanticview.ProjectScopes(source) {
+		if strings.TrimSpace(scope.OwningFlowID) != "" {
+			continue
+		}
+		for eventName, entry := range scope.Events {
+			canonical := eventidentity.Normalize(eventName)
+			if canonical == "" {
+				continue
+			}
+			out = append(out, deadEventDeclaration{
+				Canonical: canonical,
+				File:      deadEventProjectFileLabel(scope.Key),
+				Entry:     entry,
+			})
+		}
+	}
+	for _, scope := range semanticview.FlowScopes(source) {
+		flowID := strings.TrimSpace(scope.ID)
+		for eventName, entry := range scope.Events {
+			canonical := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventName))
+			if canonical == "" {
+				continue
+			}
+			out = append(out, deadEventDeclaration{
+				Canonical: canonical,
+				FlowID:    flowID,
+				File:      deadEventSchemaFileLabel("", flowID),
+				Entry:     entry,
+			})
+		}
+	}
+	return out
+}
+
+func deadEventProjectFileLabel(packageKey string) string {
+	packageKey = strings.Trim(strings.TrimSpace(packageKey), "/")
+	if packageKey == "" || packageKey == "." {
+		return "events.yaml"
+	}
+	return fmt.Sprintf("%s/events.yaml", packageKey)
+}
+
+type deadEventDeclaration struct {
+	Canonical string
+	FlowID    string
+	File      string
+	Entry     runtimecontracts.EventCatalogEntry
+}
+
+func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) deadEventSchemaUsage {
+	usage := deadEventSchemaUsage{
+		externalSource:   deadEventExternalSource(decl.Entry),
+		externalConsumer: deadEventExternalConsumer(decl.Entry),
+	}
+
+	for _, required := range c.source.RequiredAgents() {
+		for _, eventType := range required.Emits {
+			if deadEventRoleMatches(c.source, decl, "", eventType) {
+				usage.agentEmitEvents++
+			}
+		}
+		for _, eventType := range required.SubscribesTo {
+			if deadEventRoleMatches(c.source, decl, "", eventType) {
+				usage.agentSubscriptions++
+			}
+		}
+	}
+	for _, scope := range c.source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(c.source, decl, flowID, scope.AutoEmitEvent) {
+			usage.autoEmitOnCreate = true
+		}
+		for _, required := range c.source.FlowRequiredAgents(flowID) {
+			for _, eventType := range required.Emits {
+				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+					usage.agentEmitEvents++
+				}
+			}
+			for _, eventType := range required.SubscribesTo {
+				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+					usage.agentSubscriptions++
+				}
+			}
+		}
+	}
+	for _, scope := range semanticview.ProjectScopes(c.source) {
+		flowID := strings.TrimSpace(scope.OwningFlowID)
+		for _, agent := range scope.Agents {
+			for _, eventType := range agent.EmitEvents {
+				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+					usage.agentEmitEvents++
+				}
+			}
+			for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
+				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+					usage.agentSubscriptions++
+				}
+			}
+		}
+		for _, node := range scope.Nodes {
+			for _, eventType := range node.SubscribesTo {
+				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+					usage.handlerSubscribes++
+				}
+			}
+			for handlerEvent, handler := range node.EventHandlers {
+				if deadEventRoleMatches(c.source, decl, flowID, handlerEvent) {
+					usage.handlerSubscribes++
+				}
+				for _, emitted := range deadEventHandlerEmits(handler) {
+					if deadEventRoleMatches(c.source, decl, flowID, emitted) {
+						usage.handlerEmits++
+					}
+				}
+				for _, emitted := range deadEventHandlerFanOutEmits(handler) {
+					if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(c.source, decl, flowID, emitted) {
+						usage.fanOutEmitPerItem++
+					}
+				}
+			}
+		}
+	}
+	if bundle, ok := semanticview.Bundle(c.source); ok && bundle != nil && bundle.RootSchema != nil {
+		if deadEventSameScope(decl.FlowID, "") && deadEventRoleMatches(c.source, decl, "", bundle.RootSchema.AutoEmitOnCreate.Event) {
+			usage.autoEmitOnCreate = true
+		}
+	}
+
+	for agentID, agent := range c.source.AgentEntries() {
+		agentSource, _ := c.source.AgentContractSource(agentID)
+		flowID := strings.TrimSpace(agentSource.FlowID)
+		for _, eventType := range agent.EmitEvents {
+			if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+				usage.agentEmitEvents++
+			}
+		}
+		for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
+			if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+				usage.agentSubscriptions++
+			}
+		}
+	}
+
+	for nodeID, node := range c.source.NodeEntries() {
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range node.SubscribesTo {
+			if deadEventRoleMatches(c.source, decl, flowID, eventType) {
+				usage.handlerSubscribes++
+			}
+		}
+		for handlerEvent, handler := range node.EventHandlers {
+			if deadEventRoleMatches(c.source, decl, flowID, handlerEvent) {
+				usage.handlerSubscribes++
+			}
+			for _, emitted := range deadEventHandlerEmits(handler) {
+				if deadEventRoleMatches(c.source, decl, flowID, emitted) {
+					usage.handlerEmits++
+				}
+			}
+			for _, emitted := range deadEventHandlerFanOutEmits(handler) {
+				if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(c.source, decl, flowID, emitted) {
+					usage.fanOutEmitPerItem++
+				}
+			}
+		}
+	}
+
+	for _, timer := range c.source.WorkflowTimers() {
+		timerFlowID := strings.TrimSpace(timer.FlowID)
+		if !deadEventSameScope(decl.FlowID, timerFlowID) {
+			continue
+		}
+		for _, eventType := range deadEventTimerReferences(timer) {
+			if deadEventRoleMatches(c.source, decl, timerFlowID, eventType) {
+				usage.timerReferences++
+			}
+		}
+	}
+
+	return usage
+}
+
+func deadEventHandlerEmits(handler runtimecontracts.SystemNodeEventHandler) []string {
+	out := make([]string, 0, len(handler.Rules)+4)
+	for _, emitted := range handler.Emits.Values() {
+		emitted = strings.TrimSpace(emitted)
+		if emitted != "" {
+			out = append(out, emitted)
+		}
+	}
+	for _, rule := range handler.Rules {
+		for _, emitted := range rule.Emits.Values() {
+			emitted = strings.TrimSpace(emitted)
+			if emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+	}
+	for _, branch := range handler.OnComplete {
+		for _, emitted := range branch.Emits.Values() {
+			emitted = strings.TrimSpace(emitted)
+			if emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+	}
+	return out
+}
+
+func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler) []string {
+	out := make([]string, 0, 1+len(handler.Rules)+len(handler.OnComplete))
+	if handler.FanOut != nil {
+		if emitted := strings.TrimSpace(handler.FanOut.EmitPerItem); emitted != "" {
+			out = append(out, emitted)
+		}
+	}
+	for _, rule := range handler.Rules {
+		if rule.FanOut != nil {
+			if emitted := strings.TrimSpace(rule.FanOut.EmitPerItem); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+	}
+	for _, rule := range handler.OnComplete {
+		if rule.FanOut != nil {
+			if emitted := strings.TrimSpace(rule.FanOut.EmitPerItem); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+	}
+	return out
+}
+
+func deadEventTimerReferences(timer runtimecontracts.WorkflowTimerContract) []string {
+	out := make([]string, 0, 3)
+	if eventType := strings.TrimSpace(timer.Event); eventType != "" {
+		out = append(out, eventType)
+	}
+	for _, gate := range []string{timer.StartOn, timer.CancelOn} {
+		gate = strings.TrimSpace(gate)
+		if !strings.HasPrefix(gate, "event:") {
+			continue
+		}
+		if eventType := strings.TrimSpace(strings.TrimPrefix(gate, "event:")); eventType != "" {
+			out = append(out, eventType)
+		}
+	}
+	return out
+}
+
+func deadEventRoleMatches(source semanticview.Source, decl deadEventDeclaration, referenceFlowID, reference string) bool {
+	reference = eventidentity.Normalize(reference)
+	if reference == "" {
+		return false
+	}
+	referenceFlowID = strings.TrimSpace(referenceFlowID)
+	proof := semanticview.ResolveFlowEventProof(source, referenceFlowID, reference)
+	if eventidentity.Normalize(proof.Canonical) != eventidentity.Normalize(decl.Canonical) {
+		return false
+	}
+
+	if strings.TrimSpace(decl.FlowID) == "" {
+		return referenceFlowID == ""
+	}
+	if strings.TrimSpace(decl.FlowID) == referenceFlowID {
+		return true
+	}
+	return strings.Contains(reference, "/")
+}
+
+func deadEventSameScope(a, b string) bool {
+	return strings.TrimSpace(a) == strings.TrimSpace(b)
+}
+
+func deadEventExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
+	source := strings.ToLower(strings.TrimSpace(entry.Source))
+	return strings.HasPrefix(source, "external")
+}
+
+func deadEventExternalConsumer(entry runtimecontracts.EventCatalogEntry) bool {
+	return len(entry.Consumer) > 0 || len(entry.ConsumerType) > 0
+}
+
+func deadEventSchemaFileLabel(path, flowID string) string {
+	path = strings.TrimSpace(path)
+	if path != "" {
+		return path
+	}
+	if strings.TrimSpace(flowID) == "" {
+		return "events.yaml"
+	}
+	return fmt.Sprintf("flows/%s/events.yaml", strings.TrimSpace(flowID))
+}
+
+func yesNoLocal(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -80,6 +80,7 @@ flows:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
+  _source: external (bootstrap fixture)
   payload:
     properties:
       entity_id:
@@ -155,6 +156,7 @@ flows:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
+  _source: external (bootstrap fixture)
   payload:
     properties:
       entity_id:


### PR DESCRIPTION
## Summary
- add the slice-5 verify-owned `semantic_drift_dead_event_schema` warning on the canonical `bootverify` path
- enforce scoped liveness matching for dead declared event-schema surface without counting platform overlap or root-local refs into child flows as proof
- add direct bootverify and supported verify proofs, and promote the accepted slice-5 rule into `platform-spec.yaml`

## Issue
Closes #394

## Spec Refs
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.verify-analyzer-slice-5.yaml`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Proof
- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsDeadDeclaredEventSchemaToNamedWarning|DoesNotWarnWhenDeclaredEventHasAcceptedActiveRoleCarrier|DoesNotUseSameLocalNameAcrossFlowsByCoincidenceForDeadEventSchema|DoesNotUseRootLocalReferenceAsProofForChildFlowDeadEventSchema|DoesNotUsePlatformCatalogOverlapAsProofForDeadEventSchema)$' -count=1`
- `go test ./cmd/swarm -run 'TestVerifyBundle_DeadDeclaredEventSchemaReturnsWarningSurface$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime ./cmd/swarm -count=1`
- `go test ./... -count=1`