### PR TITLE
[agent-c][issue #393] Enforce create_entity + accumulate at startup validation

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1165,9 +1165,9 @@ func TestVerifyBundle_DoesNotWarnForFlowOwnedAgentOutputEvents(t *testing.T) {
 	}
 }
 
-func TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface(t *testing.T) {
+func TestVerifyBundle_CreateEntityAccumulatePreemptsDynamicComputeWarningSurface(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
-	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-missing-pin"))
+	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{
 			Name: "tracking",
@@ -1177,7 +1177,13 @@ func TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface(t *te
 			},
 		}},
 	}
-	flowID, nodeID, eventType, handler := firstWorkflowValidationFlowHandler(t, bundle)
+	nodeID := "complete-task"
+	eventType := "task.requested"
+	node, ok := bundle.Nodes[nodeID]
+	if !ok {
+		t.Fatalf("node %s missing from test fixture bundle", nodeID)
+	}
+	handler := node.EventHandlers[eventType]
 	handler.CreateEntity = true
 	handler.Accumulate = &runtimecontracts.AccumulateSpec{ExpectedFrom: "entity.expected_count"}
 	handler.Compute = &runtimecontracts.ComputeSpec{
@@ -1187,17 +1193,19 @@ func TestVerifyBundle_CreateEntityDynamicComputeProofReturnsWarningSurface(t *te
 	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
 		Condition: "entity.composite_score >= 0",
 	}}
-	writeWorkflowValidationFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+	node.EventHandlers[eventType] = handler
+	bundle.Nodes[nodeID] = node
+	if bundle.Semantics.NodeHandlers == nil {
+		bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	if bundle.Semantics.NodeHandlers[nodeID] == nil {
+		bundle.Semantics.NodeHandlers[nodeID] = map[string]runtimecontracts.SystemNodeEventHandler{}
+	}
+	bundle.Semantics.NodeHandlers[nodeID][eventType] = handler
 
 	err := verifyBundle(context.Background(), semanticview.Wrap(bundle))
-	if err == nil {
-		t.Fatal("verifyBundle error = nil, want warning-only failure from degraded compute proof")
-	}
-	if !strings.Contains(err.Error(), "entity.composite_score") {
-		t.Fatalf("verifyBundle error = %v, want composite_score warning", err)
-	}
-	if !strings.Contains(err.Error(), "dynamic") {
-		t.Fatalf("verifyBundle error = %v, want dynamic expected_from degradation detail", err)
+	if err == nil || !strings.Contains(err.Error(), "declares both create_entity and accumulate") {
+		t.Fatalf("verifyBundle error = %v, want create_entity/accumulate boot error", err)
 	}
 }
 
@@ -1315,6 +1323,7 @@ func TestVerifyBundle_UnreachableStateReturnsWarningSurface(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestVerifyBundle_DeadDeclaredEventSchemaReturnsWarningSurface(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 
@@ -1349,5 +1358,17 @@ func TestVerifyBundle_DeadDeclaredEventSchemaReturnsWarningSurface(t *testing.T)
 	}
 	if !strings.Contains(strings.TrimSpace(result.BootReport.Warnings()[0].CheckID), "semantic_drift_dead_event_schema") {
 		t.Fatalf("BootReport warnings = %#v, want semantic_drift_dead_event_schema", result.BootReport.Warnings())
+	}
+}
+
+func TestVerifyBundle_CreateEntityAccumulateReturnsBootError(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	err := verifyBundle(context.Background(), semanticview.Wrap(loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-create-entity-plus-accumulate"))))
+	if err == nil {
+		t.Fatal("verifyBundle error = nil, want create_entity/accumulate boot error")
+	}
+	if !strings.Contains(err.Error(), "declares both create_entity and accumulate") {
+		t.Fatalf("verifyBundle error = %v, want create_entity/accumulate boot error", err)
 	}
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1323,7 +1323,6 @@ func TestVerifyBundle_UnreachableStateReturnsWarningSurface(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestVerifyBundle_DeadDeclaredEventSchemaReturnsWarningSurface(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 

--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -18,10 +18,6 @@ active_issues:
     title: Wire the three harness-ready excluded catalog fixtures into runtime e2e execution
     maps_to:
       - invariant_suite_coverage
-  - id: 393
-    title: Resolve stale or missing boot-owner coverage for test-boot-create-entity-plus-accumulate
-    maps_to:
-      - invariant_suite_coverage
   - id: 126
     title: Split boot verification into boundary-owned modules and close major test gaps
     maps_to:

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -82,6 +82,10 @@ active_issues:
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
       - accumulator_completion_and_atomic_outcome_visibility
+  - id: 393
+    title: Enforce create_entity + accumulate prohibition at canonical boot validation
+    maps_to:
+      - startup_validation_missing_prohibited_handler_enforcement
 nodes:
   - id: boot_verification_false_negative_validation
     title: Boot/Verification False-Negative Validation
@@ -195,6 +199,25 @@ nodes:
       too_narrow:
         - one final-item bug
         - one missing log line
+    current_action_pressure: active
+  - id: startup_validation_missing_prohibited_handler_enforcement
+    title: Startup Validation Missing Prohibited-Handler Enforcement
+    parent_class: semantic correctness drift between authored contracts and startup validation
+    canonical_owners:
+      - internal/runtime/bootverify
+      - internal/runtime/workflow_validation.go
+    why_this_node_exists: authored contracts that the authoritative spec prohibits can still be admitted at boot because startup validation does not encode the prohibition at the canonical owner boundary
+    known_manifestations:
+      - create_entity plus accumulate on the same handler is accepted at startup even though the spec says it must be a boot error
+      - adjacent spec-prohibited handler combinations could drift into runtime-only rejection if boot validation does not own them explicitly
+    representative_issues:
+      - 393
+    common_framing_mistakes:
+      too_broad:
+        - bootverify is incomplete
+      too_narrow:
+        - one stale tier8 fixture
+        - one missing if statement in a helper
     current_action_pressure: active
 reserve_backlog:
   - ordinal: 7

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -560,6 +560,14 @@ func (c *checkerContext) dialectCompliance() []Finding {
 					Location: nodeID,
 				})
 			}
+			if handlerDeclaresConflictingCreateEntityAccumulation(handler) {
+				c.dialectFindings = append(c.dialectFindings, Finding{
+					CheckID:  "dialect_compliance",
+					Severity: "error",
+					Message:  fmt.Sprintf("node %s handler %s declares both create_entity and accumulate", nodeID, eventType),
+					Location: nodeID,
+				})
+			}
 			if strings.TrimSpace(handler.Condition) != "" {
 				c.dialectFindings = append(c.dialectFindings, Finding{
 					CheckID:  "dialect_compliance",
@@ -2111,6 +2119,10 @@ func gateNameLocal(v any) string {
 
 func handlerDeclaresConflictingCompletion(handler runtimecontracts.SystemNodeEventHandler) bool {
 	return len(handler.Rules) > 0 && handlerHasOnComplete(handler)
+}
+
+func handlerDeclaresConflictingCreateEntityAccumulation(handler runtimecontracts.SystemNodeEventHandler) bool {
+	return handler.CreateEntity && handler.Accumulate != nil
 }
 
 func handlerHasOnComplete(handler runtimecontracts.SystemNodeEventHandler) bool {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1040,6 +1040,19 @@ func TestRun_MapsDialectDualToNamedError(t *testing.T) {
 	}
 }
 
+func TestRun_MapsCreateEntityPlusAccumulateToNamedError(t *testing.T) {
+	source := loadTier8Fixture(t, "test-boot-create-entity-plus-accumulate")
+
+	report := Run(context.Background(), source, Options{})
+
+	if !report.HasErrors() {
+		t.Fatalf("expected error report, got %#v", report.Findings)
+	}
+	if !reportContains(report.Errors(), "dialect_compliance", "declares both create_entity and accumulate") {
+		t.Fatalf("expected dialect_compliance create_entity/accumulate error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsInvalidFieldDetectionToNamedError(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Platform: runtimecontracts.PlatformSpecDocument{},
@@ -2434,7 +2447,7 @@ func TestRun_SuppressesExpressionFieldReferenceFindingWhenComputeMakesFieldAvail
 	}
 }
 
-func TestRun_WarnsWhenCreateEntityComputeProofDependsOnDynamicExpectedFrom(t *testing.T) {
+func TestRun_RejectsCreateEntityAccumulateWhenDynamicComputeProofWouldOtherwiseWarn(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{
@@ -2459,18 +2472,12 @@ func TestRun_WarnsWhenCreateEntityComputeProofDependsOnDynamicExpectedFrom(t *te
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.composite_score") {
-		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
-	}
-	if !reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
-		t.Fatalf("expected degraded compute/store_as warning, got %#v", report.Warnings())
-	}
-	if !reportContains(report.Warnings(), "expression_field_reference_validation", "dynamic") {
-		t.Fatalf("expected dynamic expected_from warning detail, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "dialect_compliance", "declares both create_entity and accumulate") {
+		t.Fatalf("expected dialect_compliance create_entity/accumulate error, got %#v", report.Errors())
 	}
 }
 
-func TestRun_AllowsCreateEntityComputeProofWhenExpectedFromIsNotDynamicEntityField(t *testing.T) {
+func TestRun_RejectsCreateEntityAccumulateWhenExpectedFromIsNotDynamicEntityField(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	bundle.Semantics.EntitySchema = runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{
@@ -2494,11 +2501,8 @@ func TestRun_AllowsCreateEntityComputeProofWhenExpectedFromIsNotDynamicEntityFie
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.composite_score") {
-		t.Fatalf("unexpected expression_field_reference_validation error, got %#v", report.Errors())
-	}
-	if reportContains(report.Warnings(), "expression_field_reference_validation", "entity.composite_score") {
-		t.Fatalf("unexpected degraded warning for non-dynamic expected_from, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "dialect_compliance", "declares both create_entity and accumulate") {
+		t.Fatalf("expected dialect_compliance create_entity/accumulate error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -36,6 +36,7 @@ var tier8SupportedFixtures = []string{
 	"test-boot-cel-parse-error",
 	"test-boot-condition-payload-mismatch",
 	"test-boot-condition-policy",
+	"test-boot-create-entity-plus-accumulate",
 	"test-boot-deprecated-field",
 	"test-boot-dialect-dual",
 	"test-boot-dialect-guard",
@@ -63,7 +64,6 @@ var tier8SupportedFixtures = []string{
 }
 
 var tier8ExcludedFixtures = map[string]tier8ExcludedFixture{
-	"test-boot-create-entity-plus-accumulate": {reason: "split to issue #393: expected boot error no longer reproduces on canonical tier8 path"},
 	"test-boot-state-machine-unreachable":     {reason: "supported verify warning fixture for analyzer slice 4; not a runtime boot catalog fixture"},
 }
 

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -64,7 +64,7 @@ var tier8SupportedFixtures = []string{
 }
 
 var tier8ExcludedFixtures = map[string]tier8ExcludedFixture{
-	"test-boot-state-machine-unreachable":     {reason: "supported verify warning fixture for analyzer slice 4; not a runtime boot catalog fixture"},
+	"test-boot-state-machine-unreachable": {reason: "supported verify warning fixture for analyzer slice 4; not a runtime boot catalog fixture"},
 }
 
 func TestTier8BootCatalogFixtures_RealRuntimeBoot(t *testing.T) {

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -2,10 +2,12 @@ package runtime
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -125,4 +127,27 @@ func TestValidateWorkflowContractSurface_FatalToolImplementationWarningsFollowSh
 	if err == nil || !strings.Contains(err.Error(), "tool implementation warnings") {
 		t.Fatalf("ValidateWorkflowContractSurface error = %v, want tool implementation warning failure", err)
 	}
+}
+
+func TestValidateWorkflowContractSurface_RejectsCreateEntityWithAccumulate(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	source := semanticview.Wrap(loadRuntimeWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-create-entity-plus-accumulate")))
+
+	_, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
+	if err == nil || !strings.Contains(err.Error(), "declares both create_entity and accumulate") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want create_entity/accumulate boot error", err)
+	}
+}
+
+func loadRuntimeWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	fixtureRoot := filepath.Join(repoRoot, relativeRoot)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", fixtureRoot, err)
+	}
+	return bundle
 }


### PR DESCRIPTION
Closes #393

## Summary
Enforce the spec-prohibited `create_entity + accumulate` handler combination at the canonical startup-validation owner, and admit the repaired tier8 fixture back into normal runtime boot coverage.

## Spec refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `handler_specification.create_entity.interactions.with_accumulate`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `boot_verification.checks.dialect_compliance`
- `docs/specs/swarm-platform/platform/CHANGELOG.md`: `create_entity + accumulate = PROHIBITED (boot error)`

## What changed
- added the missing `create_entity + accumulate` prohibition to `internal/runtime/bootverify`
- preserved the shared startup-validation owner path through `ValidateWorkflowContractSurface(...)` and runtime startup
- updated stale warning-oriented tests that were previously exercising a now-prohibited handler shape
- moved `test-boot-create-entity-plus-accumulate` back into normal tier8 `cataloge2e` execution

## Why
Current `master` admitted a handler shape that the spec says must fail at boot, while later runtime execution already rejected it. This PR removes that startup-vs-runtime parity drift at the canonical startup owner.

## Scope boundaries
- in scope: startup-validation enforcement for `create_entity + accumulate`
- out of scope: broader tier8 cleanup, loader/runtime rule-table unification, unrelated warning-policy normalization

## Tests
- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsCreateEntityPlusAccumulateToNamedError|RejectsCreateEntityAccumulateWhenDynamicComputeProofWouldOtherwiseWarn|RejectsCreateEntityAccumulateWhenExpectedFromIsNotDynamicEntityField)$' -count=1`
- `go test ./internal/runtime -run 'TestValidateWorkflowContractSurface_RejectsCreateEntityWithAccumulate$' -count=1`
- `go test ./cmd/swarm -run 'TestVerifyBundle_(CreateEntityAccumulateReturnsBootError|CreateEntityAccumulatePreemptsDynamicComputeWarningSurface)$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier8BootCatalogFixtures_(RealRuntimeBoot/test-boot-create-entity-plus-accumulate|AreExplicitlyClassified)$' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime ./cmd/swarm ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`
- `go run ./cmd/swarm verify -contracts ./tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate`

## Residual risk
Prohibited handler-combination semantics are still modeled separately across loader, startup validation, and runtime execution. This PR closes the concrete startup false negative for `create_entity + accumulate`, but it does not unify those rule tables yet.
