### PR TITLE
[agent-b][issue #402] Normalize annotated entity-tool schema types

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -78,6 +78,10 @@ active_issues:
     title: Align targeted verify and runtime boot on event-schema and tool-registry validation
     maps_to:
       - verify_vs_boot_contract_acceptance_drift
+  - id: 402
+    title: Align entity-tool schema normalization with authored entity schema annotations
+    maps_to:
+      - entity_tool_schema_annotation_normalization_drift
   - id: 181
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
@@ -218,6 +222,25 @@ nodes:
       too_narrow:
         - one stale tier8 fixture
         - one missing if statement in a helper
+  - id: entity_tool_schema_annotation_normalization_drift
+    title: Entity-Tool Schema Annotation Normalization Drift
+    parent_class: runtime entity-tool semantics drift from authored entity_schema type annotations
+    canonical_owners:
+      - shared entity-tool schema type normalization in internal/runtime/tools/entity_schema.go
+    why_this_node_exists: entity_schema annotations are authored as human-readable notes, but runtime entity-tool validation can still interpret annotated type strings literally or inconsistently across tool surfaces
+    known_manifestations:
+      - save_entity_field rejects schema-declared annotated jsonb fields on supported runtime paths
+      - create_entity initial field writes and search_entities field filters would reject the same annotated entity types through the shared normalizer
+      - adjacent entity-tool surfaces either bypass shared type normalization entirely or carry stale local interpreters of schema type handling
+    representative_issues:
+      - 402
+    common_framing_mistakes:
+      too_broad:
+        - entity tools are broken
+        - all schema handling is inconsistent
+      too_narrow:
+        - one save_entity_field error string
+        - one validation-agent transcript line
     current_action_pressure: active
 reserve_backlog:
   - ordinal: 7

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -68,7 +68,7 @@ func (s entityToolSchema) field(name string) (runtimecontracts.EntitySchemaField
 }
 
 func normalizeEntityFieldValue(field runtimecontracts.EntitySchemaField, value any) (any, error) {
-	fieldType := strings.ToLower(strings.TrimSpace(field.Type))
+	fieldType := normalizeEntityFieldType(field.Type)
 	if fieldType == "" {
 		return value, nil
 	}
@@ -178,7 +178,7 @@ func parseEntityFilterValue(field runtimecontracts.EntitySchemaField, raw string
 	if unquoted, ok := unquoteEntityFilterValue(raw); ok {
 		return normalizeEntityFieldValue(field, unquoted)
 	}
-	switch strings.ToLower(strings.TrimSpace(field.Type)) {
+	switch normalizeEntityFieldType(field.Type) {
 	case "boolean":
 		switch strings.ToLower(raw) {
 		case "true":
@@ -192,7 +192,7 @@ func parseEntityFilterValue(field runtimecontracts.EntitySchemaField, raw string
 			return v, nil
 		}
 	default:
-		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(field.Type)), "numeric(") {
+		if strings.HasPrefix(normalizeEntityFieldType(field.Type), "numeric(") {
 			if f, ok := runtimesharedjson.AsFloat64(parseLooseNumeric(raw)); ok {
 				return normalizeEntityFieldValue(field, f)
 			}
@@ -229,19 +229,38 @@ func metricExpression(metric string, field runtimecontracts.EntitySchemaField) (
 	case "count":
 		return "COUNT(*)", nil
 	case "sum", "avg":
-		fieldType := strings.ToLower(strings.TrimSpace(field.Type))
+		fieldType := normalizeEntityFieldType(field.Type)
 		if fieldType != "integer" && !strings.HasPrefix(fieldType, "numeric(") {
 			return "", fmt.Errorf("metric %s requires numeric field, got %s", metric, field.Type)
 		}
 		return strings.ToUpper(metric) + "(" + entityQuoteIdent(strings.TrimSpace(field.Name)) + ")", nil
 	case "min", "max":
-		if strings.EqualFold(strings.TrimSpace(field.Type), "jsonb") {
+		if normalizeEntityFieldType(field.Type) == "jsonb" {
 			return "", fmt.Errorf("metric %s does not support jsonb field %s", metric, strings.TrimSpace(field.Name))
 		}
 		return strings.ToUpper(metric) + "(" + entityQuoteIdent(strings.TrimSpace(field.Name)) + ")", nil
 	default:
 		return "", fmt.Errorf("unsupported metric %q", metric)
 	}
+}
+
+func normalizeEntityFieldType(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "numeric(") {
+		if end := strings.Index(raw, ")"); end >= 0 {
+			return strings.TrimSpace(raw[:end+1])
+		}
+		return raw
+	}
+	for _, base := range []string{"text", "string", "integer", "boolean", "jsonb", "timestamp", "uuid"} {
+		if raw == base || strings.HasPrefix(raw, base+" ") || strings.HasPrefix(raw, base+"(") {
+			return base
+		}
+	}
+	return raw
 }
 
 func defaultEntitySearchLimit(value int) int {

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -256,7 +256,13 @@ func normalizeEntityFieldType(raw string) string {
 		return raw
 	}
 	for _, base := range []string{"text", "string", "integer", "boolean", "jsonb", "timestamp", "uuid"} {
-		if raw == base || strings.HasPrefix(raw, base+" ") || strings.HasPrefix(raw, base+"(") {
+		if raw == base {
+			return base
+		}
+		if strings.HasPrefix(raw, base+"(") {
+			return base
+		}
+		if strings.HasPrefix(raw, base+" ") && strings.HasPrefix(strings.TrimPrefix(raw, base), " (") {
 			return base
 		}
 	}

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -328,6 +328,46 @@ func TestEntityTools_SearchEntitiesAcceptsAnnotatedJSONBFilter(t *testing.T) {
 	}
 }
 
+func TestEntityTools_SaveEntityFieldRejectsMalformedAnnotatedTypeSuffix(t *testing.T) {
+	ctx, exec := newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "save_entity_field"},
+	}, &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "queued",
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "validation",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "mvp_spec", Type: "jsonb from spec.approved", Nullable: true},
+					},
+				}},
+			},
+		},
+	})
+	entityID := uuid.NewString()
+
+	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
+		"entity_id":     entityID,
+		"flow_instance": "validation/inst-1",
+	}); err != nil {
+		t.Fatalf("create_entity: %v", err)
+	}
+
+	_, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "mvp_spec",
+		"value":     map[string]any{"headline": "launch fast"},
+	})
+	if err == nil {
+		t.Fatal("expected malformed annotated type suffix to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsupported schema type jsonb from spec.approved") {
+		t.Fatalf("err = %v, want unsupported malformed suffix rejection", err)
+	}
+}
+
 func TestEntityTools_SaveEntityField_LogsMutationRow(t *testing.T) {
 	ctx, exec, db := newEntityToolTestHarness(t)
 	entityID := uuid.NewString()

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -214,6 +214,120 @@ func TestEntityTools_SaveEntityField_JSONBRoundTripsPlainTextWithoutBase64(t *te
 	}
 }
 
+func TestEntityTools_CreateEntityAcceptsAnnotatedJSONBFields(t *testing.T) {
+	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	entityID := uuid.NewString()
+
+	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
+		"entity_id":     entityID,
+		"flow_instance": "validation/inst-1",
+		"fields": map[string]any{
+			"business_brief": map[string]any{"summary": "validated"},
+			"validation_kit": map[string]any{"checklist": []any{"ux", "brand"}},
+		},
+	}); err != nil {
+		t.Fatalf("create_entity annotated jsonb fields: %v", err)
+	}
+
+	got, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity: %v", err)
+	}
+	entity, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected entity map, got %#v", got)
+	}
+	fields, ok := entity["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %#v", entity["fields"])
+	}
+	brief, ok := fields["business_brief"].(map[string]any)
+	if !ok || strings.TrimSpace(asString(brief["summary"])) != "validated" {
+		t.Fatalf("business_brief = %#v, want persisted annotated jsonb object", fields["business_brief"])
+	}
+	kit, ok := fields["validation_kit"].(map[string]any)
+	if !ok {
+		t.Fatalf("validation_kit = %#v, want persisted annotated jsonb object", fields["validation_kit"])
+	}
+	checklist, ok := kit["checklist"].([]any)
+	if !ok || len(checklist) != 2 {
+		t.Fatalf("validation_kit.checklist = %#v, want persisted array", kit["checklist"])
+	}
+}
+
+func TestEntityTools_SaveEntityFieldAcceptsAnnotatedJSONBFields(t *testing.T) {
+	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	entityID := uuid.NewString()
+
+	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
+		"entity_id":     entityID,
+		"flow_instance": "validation/inst-1",
+	}); err != nil {
+		t.Fatalf("create_entity: %v", err)
+	}
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "mvp_spec",
+		"value":     map[string]any{"headline": "launch fast", "approved": true},
+	}); err != nil {
+		t.Fatalf("save_entity_field annotated jsonb: %v", err)
+	}
+
+	got, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity: %v", err)
+	}
+	entity, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected entity map, got %#v", got)
+	}
+	fields, ok := entity["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %#v", entity["fields"])
+	}
+	spec, ok := fields["mvp_spec"].(map[string]any)
+	if !ok || strings.TrimSpace(asString(spec["headline"])) != "launch fast" {
+		t.Fatalf("mvp_spec = %#v, want persisted annotated jsonb object", fields["mvp_spec"])
+	}
+}
+
+func TestEntityTools_SearchEntitiesAcceptsAnnotatedJSONBFilter(t *testing.T) {
+	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	entityID := uuid.NewString()
+	kit := map[string]any{"checklist": []any{"ux", "brand"}}
+
+	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
+		"entity_id":     entityID,
+		"flow_instance": "validation/inst-1",
+		"fields": map[string]any{
+			"validation_kit": kit,
+		},
+	}); err != nil {
+		t.Fatalf("create_entity: %v", err)
+	}
+
+	out, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"flow_instance": "validation/inst-1",
+		"filter": map[string]any{
+			"validation_kit": kit,
+		},
+	})
+	if err != nil {
+		t.Fatalf("search_entities annotated jsonb filter: %v", err)
+	}
+	result, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected search result map, got %#v", out)
+	}
+	results, ok := result["results"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected search results slice, got %#v", result["results"])
+	}
+	if len(results) != 1 || strings.TrimSpace(asString(results[0]["entity_id"])) != entityID {
+		t.Fatalf("unexpected search results: %#v", results)
+	}
+}
+
 func TestEntityTools_SaveEntityField_LogsMutationRow(t *testing.T) {
 	ctx, exec, db := newEntityToolTestHarness(t)
 	entityID := uuid.NewString()
@@ -961,6 +1075,29 @@ func newEntityToolTestExecutorWithBundle(t *testing.T, actor models.AgentConfig,
 	t.Helper()
 	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
 	return ctx, exec
+}
+
+func newAnnotatedEntityToolExecutor(t *testing.T) (context.Context, *runtimetools.Executor) {
+	t.Helper()
+	return newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities"},
+	}, &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "queued",
+			EntitySchema: runtimecontracts.EntitySchema{
+				Groups: []runtimecontracts.EntitySchemaGroup{{
+					Name: "validation",
+					Fields: []runtimecontracts.EntitySchemaField{
+						{Name: "business_brief", Type: "jsonb (from research.completed)", Nullable: true},
+						{Name: "mvp_spec", Type: "jsonb (from spec.approved)", Nullable: true},
+						{Name: "validation_kit", Type: "jsonb (accumulated validation artifacts)", Nullable: true},
+					},
+				}},
+			},
+		},
+	})
 }
 
 func newEntityToolTestHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB) {


### PR DESCRIPTION
## Human Summary
This fixes the live runtime entity-tool schema normalization bug behind `#402` by moving annotated entity field types back onto one shared canonical normalizer. Supported entity-tool writes and search filters now treat spec-allowed annotations like `jsonb (from spec.approved)` as `jsonb` instead of rejecting them as unknown types.

Closes #402.

## What Changed
- normalized annotated entity field types in `internal/runtime/tools/entity_schema.go`
- kept the fix on the shared runtime owner used by:
  - `create_entity`
  - `save_entity_field`
  - `search_entities` object-filter normalization
- added executor-level proofs in `internal/runtime/tools/executor_entity_test.go` for all three live consumers, including multiple annotated `jsonb (...)` fields

## Why This Is Needed
The platform spec allows parenthetical entity-schema annotations as human-readable notes, not machine-parsed type changes. The contract loader preserves the raw authored string, but the runtime entity-tool normalizer was interpreting the whole string literally on supported paths, so valid fields like `mvp_spec: jsonb (from spec.approved)` were rejected at runtime.

## Scope Boundaries
- in scope: the full live shared-normalizer class for annotated entity field types across `create_entity`, `save_entity_field`, and `search_entities`
- out of scope: `#401` flow-identity / cross-flow write ownership work
- out of scope: broader entity-tool redesign or typed entity field carriers
- out of scope: inert same-file helpers with no live caller on current head

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_schema.annotations`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_schema.types`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: persistence_model.auto_generated_tools`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_tool_schemas.create_entity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_tool_schemas.save_entity_field`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: entity_tool_schemas.search_entities`

## Tests Run
- `go test ./internal/runtime/tools -run 'TestEntityTools_(CreateEntityAcceptsAnnotatedJSONBFields|SaveEntityFieldAcceptsAnnotatedJSONBFields|SearchEntitiesAcceptsAnnotatedJSONBFilter|SaveEntityField_JSONBRoundTripsPlainTextWithoutBase64)$' -count=1`
- `go test ./internal/runtime/tools ./internal/runtime ./internal/runtime/contracts -count=1`
- `go test ./... -count=1`

## Residual Risk
This fixes the shared live runtime normalizer. The longer-run raw-string type-carrier asymmetry between entity schemas and event schemas is still tracked as watchlist-only architecture feedback, but it is not required to close this issue honestly.

## Follow-Up
None required for this issue if review agrees the live shared-normalizer class is fully covered.
