### PR TITLE
[maintenance][issue #411] Remove hot-path schema capability shims

### DIFF
--- a/docs/watchlists/maintenance-and-cleanup.yaml
+++ b/docs/watchlists/maintenance-and-cleanup.yaml
@@ -52,6 +52,10 @@ active_issues:
     title: Remove task-conversation mixed-rollout compatibility between agent_sessions and agent_conversation_audits
     maps_to:
       - legacy_compatibility_removal
+  - id: 411
+    title: Collapse residual schema-capability branching toward a narrower canonical store schema
+    maps_to:
+      - legacy_compatibility_removal
   - id: 173
     title: Completed-seam hygiene with canonical-owner notes and reusable invariant suites
     maps_to:
@@ -101,6 +105,7 @@ nodes:
       - 159
       - 360
       - 403
+      - 411
     common_framing_mistakes:
       too_broad:
         - delete all legacy code

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -13,9 +13,6 @@ import (
 )
 
 func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.PersistedAgent) error {
-	if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
-		return err
-	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -46,9 +43,6 @@ func (s *PostgresStore) UpsertAgent(ctx context.Context, rec runtimemanager.Pers
 }
 
 func (s *PostgresStore) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
-	if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
-		return nil, err
-	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -29,13 +29,6 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	targetTable := "agent_sessions"
 	hasConversationRunID := caps.Conversations.SessionRunID
 	if runtimeMode.IsStateless() {
-		if err := s.ensureConversationAuditTable(ctx); err != nil {
-			return err
-		}
-		caps, err = s.schemaCapabilities(ctx)
-		if err != nil {
-			return err
-		}
 		if caps.Conversations.Audits != SchemaFlavorCanonical {
 			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 		}
@@ -456,18 +449,6 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			return err
 		}
 	}
-	if tx == nil {
-		if err := s.ensureConversationAuditTable(ctx); err != nil {
-			return err
-		}
-		if caps.Conversations.Audits == "" {
-			var err error
-			caps, err = s.schemaCapabilities(ctx)
-			if err != nil {
-				return err
-			}
-		}
-	}
 	if caps.Conversations.Audits != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 	}
@@ -627,13 +608,6 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if resolved.Stateless {
 		if sessionID == "" {
 			sessionID = uuid.NewString()
-		}
-		if err := s.ensureConversationAuditTable(ctx); err != nil {
-			return err
-		}
-		caps, err = s.schemaCapabilities(ctx)
-		if err != nil {
-			return err
 		}
 		if caps.Conversations.Audits != SchemaFlavorCanonical {
 			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -4102,6 +4102,73 @@ func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *test
 	}
 }
 
+func TestManagerStore_StatelessConversationFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pg := &PostgresStore{DB: db}
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_conversation_audits CASCADE`); err != nil {
+		t.Fatalf("drop agent_conversation_audits: %v", err)
+	}
+	pg = &PostgresStore{DB: db}
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: uuid.NewString(),
+		AgentID:   "a1",
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "user", Content: "one-shot"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	})
+	if err == nil || !strings.Contains(err.Error(), "store: agent_conversation_audits schema is unavailable") {
+		t.Fatalf("UpsertConversation(task) error = %v, want unavailable audit capability failure", err)
+	}
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.agent_conversation_audits') IS NOT NULL`).Scan(&exists); err != nil {
+		t.Fatalf("check agent_conversation_audits existence: %v", err)
+	}
+	if exists {
+		t.Fatal("expected task conversation hot path not to recreate agent_conversation_audits")
+	}
+}
+
+func TestManagerStore_TaskAppendTurnFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pg := &PostgresStore{DB: db}
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_conversation_audits CASCADE`); err != nil {
+		t.Fatalf("drop agent_conversation_audits: %v", err)
+	}
+	pg = &PostgresStore{DB: db}
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      uuid.NewString(),
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "store: agent_conversation_audits schema is unavailable") {
+		t.Fatalf("AppendAgentTurn(task) error = %v, want unavailable audit capability failure", err)
+	}
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.agent_conversation_audits') IS NOT NULL`).Scan(&exists); err != nil {
+		t.Fatalf("check agent_conversation_audits existence: %v", err)
+	}
+	if exists {
+		t.Fatal("expected task turn hot path not to recreate agent_conversation_audits")
+	}
+}
+
 func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -4950,6 +5017,65 @@ func TestManagerStore_UpsertAgent_RejectsInvalidConversationModeAtAdmission(t *t
 	}
 }
 
+func TestManagerStore_UpsertAgent_FailsClosedWithoutHotPathSchemaRepair(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agents CASCADE`); err != nil {
+		t.Fatalf("drop agents: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agents (
+			id TEXT PRIMARY KEY,
+			type TEXT,
+			role TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			entity_id UUID,
+			parent_agent_id TEXT,
+			status TEXT,
+			coordinator_id TEXT,
+			config JSONB NOT NULL DEFAULT '{}'::jsonb,
+			budget_envelope JSONB NOT NULL DEFAULT '{}'::jsonb,
+			hired_by TEXT,
+			template_version TEXT,
+			started_at TIMESTAMPTZ,
+			last_active_at TIMESTAMPTZ
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agents: %v", err)
+	}
+
+	err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "legacy-agent",
+			Role:             "reviewer",
+			Type:             "review-worker",
+			ConversationMode: "task",
+		},
+		Status: "active",
+	})
+	if err == nil || !strings.Contains(err.Error(), "store: agents schema is unsupported by the explicit capability boundary") {
+		t.Fatalf("UpsertAgent error = %v, want unsupported canonical schema failure", err)
+	}
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = 'agents'
+			  AND column_name = 'runtime_descriptor'
+		)
+	`).Scan(&exists); err != nil {
+		t.Fatalf("check agents.runtime_descriptor existence: %v", err)
+	}
+	if exists {
+		t.Fatal("expected UpsertAgent not to backfill agents.runtime_descriptor on the hot path")
+	}
+}
+
 func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeKeys(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -5003,6 +5129,63 @@ func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelTierMissing(t *tes
 	_, err := pg.LoadAgents(ctx)
 	if err == nil || !strings.Contains(err.Error(), "missing model_tier") {
 		t.Fatalf("LoadAgents error = %v, want missing model_tier failure", err)
+	}
+}
+
+func TestManagerStore_LoadAgents_FailsClosedWithoutHotPathSchemaRepair(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agents CASCADE`); err != nil {
+		t.Fatalf("drop agents: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE agents (
+			id TEXT PRIMARY KEY,
+			type TEXT,
+			role TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			entity_id UUID,
+			parent_agent_id TEXT,
+			status TEXT,
+			coordinator_id TEXT,
+			config JSONB NOT NULL DEFAULT '{}'::jsonb,
+			budget_envelope JSONB NOT NULL DEFAULT '{}'::jsonb,
+			hired_by TEXT,
+			template_version TEXT,
+			started_at TIMESTAMPTZ,
+			last_active_at TIMESTAMPTZ
+		)
+	`); err != nil {
+		t.Fatalf("create legacy agents: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (id, type, role, mode, status, config)
+		VALUES ('legacy-agent', 'review-worker', 'reviewer', 'task', 'active', '{}'::jsonb)
+	`); err != nil {
+		t.Fatalf("seed legacy agent row: %v", err)
+	}
+
+	_, err := pg.LoadAgents(ctx)
+	if err == nil || !strings.Contains(err.Error(), "store: agents schema is unsupported by the explicit capability boundary") {
+		t.Fatalf("LoadAgents error = %v, want unsupported canonical schema failure", err)
+	}
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = 'agents'
+			  AND column_name = 'runtime_descriptor'
+		)
+	`).Scan(&exists); err != nil {
+		t.Fatalf("check agents.runtime_descriptor existence: %v", err)
+	}
+	if exists {
+		t.Fatal("expected LoadAgents not to backfill agents.runtime_descriptor on the hot path")
 	}
 }
 
@@ -5192,9 +5375,6 @@ func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	if err := pg.ensureSchemaCompatibilityColumns(ctx); err != nil {
-		t.Fatalf("ensureSchemaCompatibilityColumns: %v", err)
-	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO agents (
 			agent_id, role, model_tier, llm_backend, conversation_mode,
@@ -5208,6 +5388,9 @@ func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *
 		)
 	`); err != nil {
 		t.Fatalf("seed legacy agent row: %v", err)
+	}
+	if err := pg.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
+		t.Fatalf("ensureAgentRuntimeDescriptorColumn: %v", err)
 	}
 
 	_, err := pg.LoadAgents(ctx)
@@ -5277,6 +5460,10 @@ func TestPostgresStore_LoadAgents_BackfillsRuntimeDescriptorTypeFromModelTierOnC
 		)
 	`); err != nil {
 		t.Fatalf("seed pre-column agent row: %v", err)
+	}
+
+	if err := pg.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
+		t.Fatalf("ensureAgentRuntimeDescriptorColumn: %v", err)
 	}
 
 	agents, err := pg.LoadAgents(ctx)


### PR DESCRIPTION
## Summary

Removes the remaining non-startup schema mutation/binding bypasses after the explicit store schema-capability boundary already exists.

Closes #411.

## Governing Context

- non-semantic maintenance under parent `#157`
- no exact platform-spec section governs this PR because it removes residual compatibility/mutation behavior around an already-established explicit schema-capability owner rather than changing platform/runtime contract semantics
- binding authority for scope and class comes from:
  - issue `#411`
  - pre-audit on `#411`
  - watchlist node `legacy_compatibility_removal`

## What changed

- removed hot-path `ensureSchemaCompatibilityColumns(...)` calls from `UpsertAgent(...)` and `LoadAgents(...)`
- removed lazy `ensureConversationAuditTable(...)` calls from task/stateless conversation and turn persistence paths
- added focused regressions proving those paths now fail closed instead of mutating schema on demand
- moved runtime-descriptor backfill expectations in tests onto the startup aftermath helper, where that mutation actually belongs

## Why this is needed

`#1` already established the explicit capability owner. The remaining live residue on current head was a small set of store hot paths that still reached back into schema mutation helpers before or alongside capability resolution. That widened the effective store schema story and kept compatibility aftermath alive outside the startup boundary.

This PR removes that residual hot-path bypass so:
- startup provisioning remains the only intentional schema-mutation boundary
- steady-state store paths consume the explicit capability owner and fail closed

## Scope

In scope:
- `internal/store/agent_store.go`
- `internal/store/llm_store.go`
- focused regression coverage for fail-closed behavior and no hot-path schema repair

Out of scope:
- reopening `#1`
- broad store redesign
- task-conversation semantic compatibility work already handled by `#403`
- stylistic deduping of already-canonical fail-closed capability guards across other surfaces

## Tests

- `go test ./internal/store -run 'TestManagerStore_(StatelessConversationFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable|TaskAppendTurnFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable|UpsertAgent_FailsClosedWithoutHotPathSchemaRepair|LoadAgents_FailsClosedWithoutHotPathSchemaRepair|StatelessConversationPersistsAuditRowWithoutReload|UpsertAgent_RejectsInvalidConversationModeAtAdmission|LoadAgents_FailsClosedWhenCanonicalModelTierMissing)$' -count=1`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`

## Residual Risk

- `ensureSchemaCompatibilityColumns(...)` remains an omnibus startup-aftermath helper spanning multiple semantic concerns
- this PR does not decompose that startup helper further; it only removes the remaining non-startup callers for the chosen class
