### PR TITLE
[agent-a][issue #362] Canonicalize live-turn projection for operator readers

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -29,6 +29,18 @@ active_issues:
     title: Canonicalize native capability visibility and recording in CLI execution
     maps_to:
       - shared_observability_contract
+  - id: 362
+    title: Expose live agent turn progress without container transcript spelunking
+    maps_to:
+      - typed_persisted_operator_reads
+  - id: 363
+    title: Make conversation audit and runtime logging reliable enough for first-line investigations
+    maps_to:
+      - shared_observability_contract
+  - id: 364
+    title: Add run-centric trace view across run, event, delivery, session, and turn
+    maps_to:
+      - run_scoped_operator_identity
   - id: 148
     title: Make run_id canonical across replay, diagnostics, API/dashboard scoping, and operator surfaces
     maps_to:
@@ -77,9 +89,11 @@ nodes:
     known_manifestations:
       - CLI, dashboard, and builder observe different canonical facts
       - native capability visibility/recording diverges from the operator contract
+      - first-line investigation surfaces remain too weak, pushing operators to transcript/container spelunking
     representative_issues:
       - 131
       - 138
+      - 363
     common_framing_mistakes:
       too_broad:
         - observability is inconsistent
@@ -95,10 +109,12 @@ nodes:
     known_manifestations:
       - conversation and turn APIs widen typed persisted data
       - summary/runtime-log/mutation completeness may be inferred or silently omitted
+      - first-line latest-turn progress is flattened differently across dashboard/API readers
     representative_issues:
       - 134
       - 224
       - 300
+      - 362
     common_framing_mistakes:
       too_broad:
         - API contracts are messy
@@ -119,6 +135,7 @@ nodes:
       - 148
       - 344
       - 345
+      - 364
     common_framing_mistakes:
       too_broad:
         - run scoping is inconsistent

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -95,8 +95,11 @@ type agentOperatorProjection struct {
 	DeadLetters24h      int
 	TurnCount           int
 	Turns24h            int
+	SessionID           string
+	ProviderSessionID   string
 	CurrentTaskID       string
 	LastTool            *AgentLastTool
+	LiveTurn            *OperatorLiveTurn
 }
 
 type pendingAgentDeliveryFactSource interface {
@@ -123,23 +126,28 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 		SELECT
 			a.agent_id,
 			COALESCE(a.status, 'active'),
+			COALESCE(sess.session_id::text, ''),
 			COALESCE(sess.turn_count, 0),
 			COALESCE(sess.lease_holder, ''),
 			sess.lease_expires_at,
+			COALESCE(sess.runtime_state, '{}'::jsonb),
 			0,
 			0,
 			COALESCE(f.failures_24h, 0),
 			COALESCE(f.dead_letters_24h, 0),
 			0,
+			COALESCE(latest_turn.turn_id, ''),
 			COALESCE(latest_turn.task_id, ''),
 			COALESCE(latest_turn.parse_ok, false),
 			COALESCE(latest_turn.turn_blocks, '[]'::jsonb)
 		FROM agents a
 		LEFT JOIN LATERAL (
 			SELECT
+				session_id,
 				turn_count,
 				lease_holder,
-				lease_expires_at
+				lease_expires_at,
+				runtime_state
 			FROM agent_sessions
 			WHERE agent_id = a.agent_id
 			  AND status = 'active'
@@ -149,6 +157,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 		) sess ON true
 		LEFT JOIN LATERAL (
 			SELECT
+				turn_id::text AS turn_id,
 				COALESCE(task_id, '') AS task_id,
 				parse_ok,
 				%s AS turn_blocks
@@ -178,24 +187,29 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 	agentIDs := make([]string, 0)
 	for rows.Next() {
 		var (
-			id            string
-			projection    agentOperatorProjection
-			lockExpiresAt sql.NullTime
-			latestTaskID  string
-			latestParseOK bool
-			latestTurnRaw []byte
+			id              string
+			projection      agentOperatorProjection
+			lockExpiresAt   sql.NullTime
+			runtimeStateRaw []byte
+			latestTurnID    string
+			latestTaskID    string
+			latestParseOK   bool
+			latestTurnRaw   []byte
 		)
 		if err := rows.Scan(
 			&id,
 			&projection.Status,
+			&projection.SessionID,
 			&projection.TurnCount,
 			&projection.LockOwner,
 			&lockExpiresAt,
+			&runtimeStateRaw,
 			&projection.PendingEvents,
 			&projection.OldestPendingAgeSec,
 			&projection.Failures24h,
 			&projection.DeadLetters24h,
 			&projection.Turns24h,
+			&latestTurnID,
 			&latestTaskID,
 			&latestParseOK,
 			&latestTurnRaw,
@@ -208,7 +222,7 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 				projection.InFlightTurn = true
 			}
 		}
-		if err := enrichAgentOperatorProjectionFromLatestTurn(&projection, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
+		if err := enrichAgentOperatorProjectionFromLatestTurn(&projection, runtimeStateRaw, latestTurnID, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
 			return nil, err
 		}
 		id = strings.TrimSpace(id)
@@ -275,8 +289,11 @@ func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjec
 	agent.TurnCount = projection.TurnCount
 	agent.TurnLimit = maxInt(turnLimit, 0)
 	agent.Turns24h = maxInt(projection.Turns24h, 0)
+	agent.SessionID = strings.TrimSpace(projection.SessionID)
+	agent.ProviderSessionID = strings.TrimSpace(projection.ProviderSessionID)
 	agent.CurrentTaskID = strings.TrimSpace(projection.CurrentTaskID)
 	agent.LastTool = projection.LastTool
+	agent.LiveTurn = projection.LiveTurn
 	if agent.TurnLimit > 0 {
 		agent.NearBreaker = agent.TurnCount*100 >= agent.TurnLimit*85
 	}
@@ -307,21 +324,25 @@ func (p agentOperatorProjection) blockingLayer() string {
 	return ""
 }
 
-func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjection, taskID string, parseOK bool, turnBlocksRaw []byte) error {
+func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjection, runtimeStateRaw []byte, turnID, taskID string, parseOK bool, turnBlocksRaw []byte) error {
 	if projection == nil {
 		return nil
 	}
-	projection.CurrentTaskID = strings.TrimSpace(taskID)
-	summary, ok, err := decodeTurnSummaryProjection(turnBlocksRaw)
+	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
 	if err != nil {
-		return fmt.Errorf("decode latest agent turn turn_summary: %w", err)
+		return fmt.Errorf("decode latest agent session runtime_state: %w", err)
 	}
-	if ok {
-		projection.LastTool, err = projectedTurnSummaryLastToolTransport(summary, parseOK)
-		if err != nil {
-			return fmt.Errorf("decode latest agent turn last_tool: %w", err)
-		}
+	projection.ProviderSessionID = strings.TrimSpace(runtimeState.ProviderSessionID)
+	projection.LiveTurn, err = projectLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
+	if err != nil {
+		return fmt.Errorf("decode latest agent turn live_turn: %w", err)
 	}
+	if projection.LiveTurn != nil {
+		projection.CurrentTaskID = strings.TrimSpace(projection.LiveTurn.TaskID)
+		projection.LastTool = projection.LiveTurn.LastTool
+		return nil
+	}
+	projection.CurrentTaskID = strings.TrimSpace(taskID)
 	return nil
 }
 

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -163,6 +163,8 @@ func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[strin
 				%s AS turn_blocks
 			FROM agent_turns
 			WHERE agent_id = a.agent_id
+			  AND sess.session_id IS NOT NULL
+			  AND session_id = sess.session_id
 			ORDER BY created_at DESC, turn_id DESC
 			LIMIT 1
 		) latest_turn ON true

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -43,25 +43,48 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 	if err := requireConversationSurfaceCapabilities(caps); err != nil {
 		return nil, err
 	}
+	if err := requireConversationTurnCapabilities(caps); err != nil {
+		return nil, err
+	}
 	sources := conversationQuerySources(caps)
+	latestTurnBlocksExpr := `'[]'::jsonb`
+	if caps.Conversations.TurnBlocks {
+		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
+	}
 	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
-			session_id,
-			agent_id,
-			kind,
-			COALESCE(scope_key, ''),
-			COALESCE(scope, ''),
-			COALESCE(runtime_mode, ''),
-			COALESCE(status, ''),
-			COALESCE(turn_count, 0),
-			COALESCE(runtime_state, '{}'::jsonb),
-			updated_at
+			conversations.session_id,
+			conversations.agent_id,
+			conversations.kind,
+			COALESCE(conversations.scope_key, ''),
+			COALESCE(conversations.scope, ''),
+			COALESCE(conversations.runtime_mode, ''),
+			COALESCE(conversations.status, ''),
+			COALESCE(conversations.turn_count, 0),
+			COALESCE(conversations.runtime_state, '{}'::jsonb),
+			COALESCE(latest_turn.turn_id, ''),
+			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.turn_blocks, '[]'::jsonb),
+			conversations.updated_at
 		FROM (
 			%s
 		) conversations
+		LEFT JOIN LATERAL (
+			SELECT
+				turn_id::text AS turn_id,
+				COALESCE(task_id, '') AS task_id,
+				parse_ok,
+				%s AS turn_blocks
+			FROM agent_turns
+			WHERE agent_id = conversations.agent_id
+			  AND session_id::text = conversations.session_id
+			ORDER BY created_at DESC, turn_id DESC
+			LIMIT 1
+		) latest_turn ON true
 		ORDER BY updated_at DESC, agent_id ASC
 		LIMIT $1
-	`, strings.Join(sources, "\nUNION ALL\n")), limit)
+	`, strings.Join(sources, "\nUNION ALL\n"), latestTurnBlocksExpr), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
 	}
@@ -140,6 +163,10 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 	var (
 		item            ConversationSummary
 		runtimeStateRaw []byte
+		turnID          string
+		taskID          string
+		parseOK         bool
+		turnBlocksRaw   []byte
 	)
 	if err := scanner.Scan(
 		&item.SessionID,
@@ -151,6 +178,10 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 		&item.Status,
 		&item.TurnCount,
 		&runtimeStateRaw,
+		&turnID,
+		&taskID,
+		&parseOK,
+		&turnBlocksRaw,
 		&item.UpdatedAt,
 	); err != nil {
 		return ConversationSummary{}, err
@@ -161,6 +192,10 @@ func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
 	}
 	item.Summary = runtimeState.Summary
 	item.Metadata = projectConversationSummaryMetadata(runtimeState)
+	item.Metadata.LiveTurn, err = projectLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
+	if err != nil {
+		return ConversationSummary{}, fmt.Errorf("decode conversation live_turn: %w", err)
+	}
 	return item, nil
 }
 

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
@@ -26,6 +27,33 @@ func projectConversationSummaryMetadata(p store.ConversationRuntimeStateDescript
 		}
 	}
 	return meta
+}
+
+func projectLatestTurn(taskID string, parseOK bool, turnID string, turnBlocksRaw []byte) (*OperatorLiveTurn, error) {
+	taskID = strings.TrimSpace(taskID)
+	turnID = strings.TrimSpace(turnID)
+	summary, ok, err := decodeTurnSummaryProjection(turnBlocksRaw)
+	if err != nil {
+		return nil, err
+	}
+	if !ok && taskID == "" && turnID == "" {
+		return nil, nil
+	}
+	out := &OperatorLiveTurn{
+		TurnID:  turnID,
+		TaskID:  taskID,
+		ParseOK: parseOK,
+	}
+	if ok {
+		out.AssistantVisibleOutput = summary.AssistantVisibleOutput
+		out.Outcome = summary.Outcome
+		out.ProgressUpdates = cloneStringSlice(summary.ProgressUpdates)
+		out.LastTool, err = projectedTurnSummaryLastToolTransport(summary, parseOK)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 func projectConversationRuntimeState(p store.ConversationRuntimeStateDescriptor) ConversationRuntimeState {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -51,6 +51,7 @@ type ConversationSummaryMetadata struct {
 	RetryReason          string                       `json:"retry_reason,omitempty"`
 	RetriesFromSessionID string                       `json:"retries_from_session_id,omitempty"`
 	Watchdog             *ConversationRuntimeWatchdog `json:"watchdog,omitempty"`
+	LiveTurn             *OperatorLiveTurn            `json:"live_turn,omitempty"`
 }
 
 type ConversationDetail struct {
@@ -121,6 +122,16 @@ type ConversationRuntimeWatchdog struct {
 	Outcome       string `json:"outcome,omitempty"`
 	LastOutputAt  string `json:"last_output_at,omitempty"`
 	RecordedAt    string `json:"recorded_at,omitempty"`
+}
+
+type OperatorLiveTurn struct {
+	TurnID                 string         `json:"turn_id,omitempty"`
+	TaskID                 string         `json:"task_id,omitempty"`
+	ParseOK                bool           `json:"parse_ok"`
+	AssistantVisibleOutput string         `json:"assistant_visible_output,omitempty"`
+	Outcome                string         `json:"outcome,omitempty"`
+	ProgressUpdates        []string       `json:"progress_updates,omitempty"`
+	LastTool               *AgentLastTool `json:"last_tool,omitempty"`
 }
 
 type ConversationMessage struct {
@@ -311,37 +322,40 @@ func (h *Handler) writeAuthError(w http.ResponseWriter, err error) {
 }
 
 type genericAgent struct {
-	ID                  string         `json:"id"`
-	Type                string         `json:"type,omitempty"`
-	Role                string         `json:"role,omitempty"`
-	Mode                string         `json:"mode,omitempty"`
-	Status              string         `json:"status,omitempty"`
-	State               string         `json:"state,omitempty"`
-	BlockingLayer       string         `json:"blocking_layer,omitempty"`
-	EntityID            string         `json:"entity_id,omitempty"`
-	ParentAgentID       string         `json:"parent_agent_id,omitempty"`
-	CoordinatorID       string         `json:"coordinator_id,omitempty"`
-	HiredBy             string         `json:"hired_by,omitempty"`
-	TemplateVersion     string         `json:"template_version,omitempty"`
-	BudgetEnvelope      float64        `json:"budget_envelope,omitempty"`
-	Subscriptions       []string       `json:"subscriptions,omitempty"`
-	Permissions         []string       `json:"permissions,omitempty"`
-	PendingEvents       int            `json:"pending_events,omitempty"`
-	OldestPendingAgeSec int            `json:"oldest_pending_age_sec,omitempty"`
-	InFlightTurn        bool           `json:"in_flight_turn,omitempty"`
-	InFlightSeconds     int            `json:"in_flight_seconds,omitempty"`
-	LockOwner           string         `json:"lock_owner,omitempty"`
-	LockExpiresAt       string         `json:"lock_expires_at,omitempty"`
-	Failures24h         int            `json:"failures_24h,omitempty"`
-	DeadLetters24h      int            `json:"dead_letters_24h,omitempty"`
-	TurnCount           int            `json:"turn_count,omitempty"`
-	TurnLimit           int            `json:"turn_limit,omitempty"`
-	Turns24h            int            `json:"turns_24h,omitempty"`
-	TotalTokens24h      int            `json:"total_tokens_24h,omitempty"`
-	NearBreaker         bool           `json:"near_breaker,omitempty"`
-	CurrentTaskID       string         `json:"current_task_id,omitempty"`
-	LastTool            *AgentLastTool `json:"last_tool,omitempty"`
-	StartedAt           string         `json:"started_at,omitempty"`
+	ID                  string            `json:"id"`
+	Type                string            `json:"type,omitempty"`
+	Role                string            `json:"role,omitempty"`
+	Mode                string            `json:"mode,omitempty"`
+	Status              string            `json:"status,omitempty"`
+	State               string            `json:"state,omitempty"`
+	BlockingLayer       string            `json:"blocking_layer,omitempty"`
+	EntityID            string            `json:"entity_id,omitempty"`
+	ParentAgentID       string            `json:"parent_agent_id,omitempty"`
+	CoordinatorID       string            `json:"coordinator_id,omitempty"`
+	HiredBy             string            `json:"hired_by,omitempty"`
+	TemplateVersion     string            `json:"template_version,omitempty"`
+	BudgetEnvelope      float64           `json:"budget_envelope,omitempty"`
+	Subscriptions       []string          `json:"subscriptions,omitempty"`
+	Permissions         []string          `json:"permissions,omitempty"`
+	PendingEvents       int               `json:"pending_events,omitempty"`
+	OldestPendingAgeSec int               `json:"oldest_pending_age_sec,omitempty"`
+	InFlightTurn        bool              `json:"in_flight_turn,omitempty"`
+	InFlightSeconds     int               `json:"in_flight_seconds,omitempty"`
+	LockOwner           string            `json:"lock_owner,omitempty"`
+	LockExpiresAt       string            `json:"lock_expires_at,omitempty"`
+	Failures24h         int               `json:"failures_24h,omitempty"`
+	DeadLetters24h      int               `json:"dead_letters_24h,omitempty"`
+	TurnCount           int               `json:"turn_count,omitempty"`
+	TurnLimit           int               `json:"turn_limit,omitempty"`
+	Turns24h            int               `json:"turns_24h,omitempty"`
+	TotalTokens24h      int               `json:"total_tokens_24h,omitempty"`
+	NearBreaker         bool              `json:"near_breaker,omitempty"`
+	SessionID           string            `json:"session_id,omitempty"`
+	ProviderSessionID   string            `json:"provider_session_id,omitempty"`
+	CurrentTaskID       string            `json:"current_task_id,omitempty"`
+	LastTool            *AgentLastTool    `json:"last_tool,omitempty"`
+	LiveTurn            *OperatorLiveTurn `json:"live_turn,omitempty"`
+	StartedAt           string            `json:"started_at,omitempty"`
 }
 
 type AgentLastTool struct {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1740,6 +1740,84 @@ func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *
 	}
 }
 
+func TestSQLAgentReader_ListGenericAgents_ScopesLiveTurnToSelectedActiveSession(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:   "agent-1",
+			Role: "researcher",
+			Mode: "entity",
+			Type: "managed",
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	sessionOlder := uuid.NewString()
+	sessionSelected := uuid.NewString()
+	olderUpdatedAt := time.Date(2026, 4, 15, 3, 0, 0, 0, time.UTC)
+	selectedUpdatedAt := olderUpdatedAt.Add(5 * time.Minute)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, scope_key, scope, conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES
+			($1::uuid, 'agent-1', 'entity-1', 'entity', '[]'::jsonb, 1, 'session_per_entity', '{"provider_session_id":"provider-older"}'::jsonb, 'active', $3, $3),
+			($2::uuid, 'agent-1', 'entity-2', 'entity', '[]'::jsonb, 7, 'session_per_entity', '{"provider_session_id":"provider-selected"}'::jsonb, 'active', $4, $4)
+	`, sessionOlder, sessionSelected, olderUpdatedAt, selectedUpdatedAt); err != nil {
+		t.Fatalf("seed agent_sessions: %v", err)
+	}
+
+	olderTurnBlocks := `[{"kind":"turn_summary","data":{"assistant_visible_output":"older session turn","outcome":"working","tool_results":[{"tool_name":"older_tool","tool_use_id":"toolu-old","output":{"status":"old"}}]}}]`
+	selectedTurnBlocks := `[{"kind":"turn_summary","data":{"assistant_visible_output":"selected session turn","outcome":"waiting","tool_results":[{"tool_name":"selected_tool","tool_use_id":"toolu-selected","output":{"status":"selected"}}]}}]`
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, agent_id, session_id, runtime_mode, scope_key, task_id, turn_blocks, parse_ok, created_at
+		) VALUES
+			($1::uuid, 'agent-1', $2::uuid, 'session_per_entity', 'entity-1', 'task-older', $3::jsonb, true, $5),
+			($4::uuid, 'agent-1', $6::uuid, 'session_per_entity', 'entity-2', 'task-selected', $7::jsonb, true, $8)
+	`, uuid.NewString(), sessionOlder, olderTurnBlocks, uuid.NewString(), selectedUpdatedAt.Add(2*time.Minute), sessionSelected, selectedTurnBlocks, selectedUpdatedAt.Add(-1*time.Minute)); err != nil {
+		t.Fatalf("seed agent_turns: %v", err)
+	}
+
+	reader := NewSQLAgentReader(db, pg, 12)
+	items, err := reader.ListGenericAgents(ctx)
+	if err != nil {
+		t.Fatalf("ListGenericAgents: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one agent, got %+v", items)
+	}
+	if items[0].SessionID != sessionSelected {
+		t.Fatalf("session_id = %q, want %q", items[0].SessionID, sessionSelected)
+	}
+	if items[0].ProviderSessionID != "provider-selected" {
+		t.Fatalf("provider_session_id = %q, want provider-selected", items[0].ProviderSessionID)
+	}
+	if items[0].CurrentTaskID != "task-selected" {
+		t.Fatalf("current_task_id = %q, want task-selected", items[0].CurrentTaskID)
+	}
+	if items[0].LiveTurn == nil {
+		t.Fatalf("expected live_turn, got nil")
+	}
+	if items[0].LiveTurn.TaskID != "task-selected" || items[0].LiveTurn.AssistantVisibleOutput != "selected session turn" {
+		t.Fatalf("live_turn = %+v", items[0].LiveTurn)
+	}
+	if items[0].LastTool == nil || items[0].LastTool.Name != "selected_tool" || items[0].LastTool.ToolUseID != "toolu-selected" {
+		t.Fatalf("last_tool = %#v", items[0].LastTool)
+	}
+}
+
 type pendingFactsOverrideStore struct {
 	*store.PostgresStore
 	facts map[string]store.PendingAgentDeliveryFacts

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -973,20 +973,21 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions:   store.SchemaFlavorCanonical,
 			Turns:      store.SchemaFlavorCanonical,
-			TurnBlocks: false,
+			TurnBlocks: true,
 		},
 	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"brief","last_turn":{"parse_ok":true},"provider_session_id":"sess-1","retry_reason":"session not found","retries_from_session_id":"sess-0"}`
+	latestTurnSummary := `[{"kind":"turn_summary","data":{"assistant_visible_output":"working","outcome":"in_progress","progress_updates":["thinking"],"tool_results":[{"tool_name":"schedule","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`
 	messagePayload := `[{"role":"assistant","content":"hello"}]`
 	toolCallsPayload := `[{"name":"schedule","arguments":{"delay_seconds":1209600}}]`
 	responsePayload := `{"result":"14-day review scheduled.","raw":"{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"status\\\":\\\"scheduled\\\"}\"}]}]}}\n{\"type\":\"result\",\"result\":\"14-day review scheduled.\"}"}`
 
-	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.kind,.*FROM \\(").
 		WithArgs(25).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(summaryState), "turn-live-1", "task-live-1", true, []byte(latestTurnSummary), now))
 
 	items, err := reader.List(context.Background(), 25)
 	if err != nil {
@@ -1003,6 +1004,18 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 	}
 	if items[0].Metadata.RetryReason != "session not found" || items[0].Metadata.RetriesFromSessionID != "sess-0" {
 		t.Fatalf("expected retry lineage metadata, got %+v", items[0].Metadata)
+	}
+	if items[0].Metadata.LiveTurn == nil || items[0].Metadata.LiveTurn.TurnID != "turn-live-1" || items[0].Metadata.LiveTurn.TaskID != "task-live-1" {
+		t.Fatalf("expected latest turn projection, got %+v", items[0].Metadata.LiveTurn)
+	}
+	if items[0].Metadata.LiveTurn.AssistantVisibleOutput != "working" || items[0].Metadata.LiveTurn.Outcome != "in_progress" {
+		t.Fatalf("unexpected latest turn summary: %+v", items[0].Metadata.LiveTurn)
+	}
+	if len(items[0].Metadata.LiveTurn.ProgressUpdates) != 1 || items[0].Metadata.LiveTurn.ProgressUpdates[0] != "thinking" {
+		t.Fatalf("unexpected live_turn progress updates: %+v", items[0].Metadata.LiveTurn)
+	}
+	if items[0].Metadata.LiveTurn.LastTool == nil || items[0].Metadata.LiveTurn.LastTool.Name != "schedule" {
+		t.Fatalf("unexpected live_turn last_tool: %+v", items[0].Metadata.LiveTurn)
 	}
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
@@ -1059,9 +1072,9 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(turnBlocksPayload)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1072,6 +1085,12 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	}
 	if items[0].CurrentTaskID != "task-1" {
 		t.Fatalf("current_task_id = %q", items[0].CurrentTaskID)
+	}
+	if items[0].SessionID != "sess-1" || items[0].ProviderSessionID != "provider-sess-1" {
+		t.Fatalf("expected canonical session linkage, got %+v", items[0])
+	}
+	if items[0].LiveTurn == nil || items[0].LiveTurn.TurnID != "turn-1" || items[0].LiveTurn.TaskID != "task-1" {
+		t.Fatalf("live_turn = %#v", items[0].LiveTurn)
 	}
 	if items[0].LastTool == nil || items[0].LastTool.Name != "schedule" {
 		t.Fatalf("last_tool = %#v", items[0].LastTool)
@@ -1117,9 +1136,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
@@ -1152,9 +1171,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
@@ -1188,9 +1207,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResul
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 3, "", nil, 0, 0, 0, 0, 0, "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
 		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
@@ -1230,9 +1249,9 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 7, "lease-owner", time.Now().Add(time.Minute), 2, 45, 0, 0, 0, "task-7", false, []byte(`[]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-7", 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, 0, "turn-7", "task-7", false, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1255,6 +1274,9 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	}
 	if items[0].CurrentTaskID != "task-7" {
 		t.Fatalf("current_task_id = %q, want task-7", items[0].CurrentTaskID)
+	}
+	if items[0].SessionID != "sess-7" || items[0].ProviderSessionID != "provider-sess-7" {
+		t.Fatalf("session linkage = %+v", items[0])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -1290,9 +1312,9 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 3, "lease-owner", time.Now().Add(time.Minute), 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -1306,6 +1328,9 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	}
 	if item.BlockingLayer != "session_execution" {
 		t.Fatalf("blocking_layer = %q, want session_execution", item.BlockingLayer)
+	}
+	if item.SessionID != "sess-1" || item.ProviderSessionID != "provider-sess-1" {
+		t.Fatalf("session linkage = %+v", item)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -1341,9 +1366,9 @@ func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenD
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 2, "lease-owner", time.Now().Add(time.Minute), 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "sess-1", 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1389,8 +1414,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
 		}))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent operator projection") {
@@ -1511,9 +1536,9 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "turn_count", "lease_holder", "lease_expires_at", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", 0, "", nil, 0, 0, 0, 0, 0, "", false, []byte(`[]`)))
+			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
+		}).AddRow("agent-1", "active", "", 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
 		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)
@@ -1878,13 +1903,14 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 	}})
 	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
 	summaryState := `{"summary":"one-shot","last_turn":{"parse_ok":true}}`
+	latestTurnSummary := `[{"kind":"turn_summary","data":{"assistant_visible_output":"done","outcome":"done","progress_updates":["finalized"]}}]`
 	messagePayload := `[{"role":"assistant","content":"done"}]`
 
-	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.kind,.*FROM \\(").
 		WithArgs(10).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("audit-1", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), now))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "updated_at",
+		}).AddRow("audit-1", "agent-1", "turn_audit", "", "global", "task", "active", 1, []byte(summaryState), "turn-1", "task-1", true, []byte(latestTurnSummary), now))
 
 	items, err := reader.List(context.Background(), 10)
 	if err != nil {
@@ -1892,6 +1918,9 @@ func TestSQLConversationReader_ListAndGet_TaskAudit(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].Kind != "turn_audit" || items[0].RuntimeMode != "task" || items[0].SessionID != "audit-1" {
 		t.Fatalf("unexpected audit summaries: %+v", items)
+	}
+	if items[0].Metadata.LiveTurn == nil || items[0].Metadata.LiveTurn.TurnID != "turn-1" || items[0].Metadata.LiveTurn.Outcome != "done" {
+		t.Fatalf("expected task audit live_turn projection, got %+v", items[0].Metadata.LiveTurn)
 	}
 
 	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
@@ -2079,14 +2108,15 @@ func TestSQLConversationReader_ListFailsOnMalformedCanonicalRuntimeState(t *test
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorCanonical,
 		},
 	}})
 
-	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.kind,.*FROM \\(").
 		WithArgs(10).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":123}`), time.Now().UTC()))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":123}`), "", "", false, []byte(`[]`), time.Now().UTC()))
 
 	if _, err := reader.List(context.Background(), 10); err == nil {
 		t.Fatal("expected malformed canonical runtime_state to fail")
@@ -2107,14 +2137,15 @@ func TestSQLConversationReader_ListFailsOnMalformedCanonicalSessionWatchdogState
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorCanonical,
 		},
 	}})
 
-	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.kind,.*FROM \\(").
 		WithArgs(10).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"mystery","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-04-10T12:00:30Z"}}`), time.Now().UTC()))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"mystery","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-04-10T12:00:30Z"}}`), "", "", false, []byte(`[]`), time.Now().UTC()))
 
 	if _, err := reader.List(context.Background(), 10); err == nil {
 		t.Fatal("expected malformed canonical session watchdog state to fail")
@@ -2193,14 +2224,15 @@ func TestSQLConversationReader_ListProjectsCanonicalSessionWatchdogState(t *test
 	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
 		Conversations: store.ConversationSchemaCapabilities{
 			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorCanonical,
 		},
 	}})
 
-	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*FROM \\(").
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.kind,.*FROM \\(").
 		WithArgs(10).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "updated_at",
-		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-04-10T12:00:00Z","recorded_at":"2026-04-10T12:00:30Z"}}`), time.Now().UTC()))
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 3, []byte(`{"summary":"ok","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-04-10T12:00:00Z","recorded_at":"2026-04-10T12:00:30Z"}}`), "", "", false, []byte(`[]`), time.Now().UTC()))
 
 	items, err := reader.List(context.Background(), 10)
 	if err != nil {
@@ -2477,6 +2509,24 @@ func TestSQLConversationReader_ListFailsClosedWhenCapabilityOwnerReportsUnavaila
 	}})
 	if _, err := reader.List(context.Background(), 10); err == nil || !strings.Contains(err.Error(), "schema is unavailable at the explicit capability boundary") {
 		t.Fatalf("expected unavailable conversation surface capability error, got %v", err)
+	}
+}
+
+func TestSQLConversationReader_ListFailsClosedWithoutTurnCapability(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions: store.SchemaFlavorCanonical,
+			Turns:    store.SchemaFlavorLegacy,
+		},
+	}})
+	if _, err := reader.List(context.Background(), 10); err == nil || !strings.Contains(err.Error(), "agent_turns schema is unsupported") {
+		t.Fatalf("expected unsupported turn capability error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #362

## Summary
- add one shared typed latest-turn projection for the supported dashboard conversation and generic-agent readers
- drive conversation list and agent list from canonical `agent_turns` turn summary plus persisted `runtime_state` linkage metadata
- scope generic-agent latest-turn selection to the chosen active session so session linkage and live-turn/task context cannot mix across concurrent sessions
- preserve the live-session ownership split by keeping `agent_sessions.runtime_state` free of live `last_turn` persistence

## Governing Context
- binding context for this slice is the approved issue `#362` pre-audit and lead gate outcome
- there is no tighter platform spec section governing this operator-surface child directly

## Scope Boundaries
- in scope:
  - `SQLConversationReader.List(...)`
  - `SQLConversationReader.Get(...)` proof preservation
  - `SQLAgentReader.ListGenericAgents(...)`
  - `GetGenericAgent(...)`
  - stable linkage already persisted in conversation `runtime_state`
  - active-session-scoped latest-turn selection for generic-agent operator projection
- out of scope:
  - process/runtime-log first-line reliability under `#363`
  - run-centric joined trace under `#364`
  - product transcript UX

## Residual Risk
- `genericAgent` still carries compatibility flattening fields (`current_task_id`, `last_tool`) beside the new `live_turn` transport
- broader first-line investigation surfaces remain open at parent `#363`

## Testing
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_ListGenericAgents_ScopesLiveTurnToSelectedActiveSession$' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_(ListGenericAgents_ScopesLiveTurnToSelectedActiveSession|ListGenericAgents_UsesCanonicalTurnSummary|GetGenericAgent_UsesCanonicalLifecycleProjection)|TestSQLConversationReader_(ListAndGet|ListAndGet_TaskAudit|ListProjectsCanonicalSessionWatchdogState)' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(CanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader|ConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions|TaskConversationReader_HidesLegacyTaskRowsWithoutCanonicalAudit)$' -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`
