### PR TITLE
[agent-b][issue #364] Add canonical run trace surface

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1204,6 +1204,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		Instances:     runtimepipeline.NewWorkflowInstanceStore(stores.SQLDB),
 		Conversations: conversations,
 		Observability: observability,
+		RunTrace:      stores.Postgres,
 		Runtime:       runtimeCtl,
 		AuthToken:     strings.TrimSpace(os.Getenv("SWARM_OPERATOR_AUTH_TOKEN")),
 		Version:       "swarm-dev",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3013,6 +3013,10 @@ run_model:
       FROM events e LEFT JOIN entity_mutations m ON m.caused_by_event = e.event_id
       WHERE e.run_id = :run_id ORDER BY e.created_at, m.created_at.
       Join with agent_turns on trigger_event_id for agent reasoning context.'
+    joined_trace_surface: 'Operator-facing run trace surfaces should extend canonical persisted run-bound diagnostics,
+      not invent a second observability island. The joined trace projection links event identity, delivery lifecycle,
+      session ownership, and turn activity for a single run by consuming canonical rows from events, event_deliveries,
+      agent_sessions or agent_conversation_audits, and agent_turns.'
     entity_timeline: 'To see one entity''s full history across runs:
       SELECT * FROM entity_mutations WHERE entity_id = :entity_id ORDER BY created_at.
       This shows every field change, who made it, and which event caused it.'
@@ -3022,6 +3026,9 @@ run_model:
     run_detail: 'GET /runs/:run_id — full run metadata including fork lineage.'
     run_events: 'GET /runs/:run_id/events — paginated event stream for the run.'
     run_mutations: 'GET /runs/:run_id/mutations — paginated mutation log for the run.'
+    run_trace: 'GET /runs/:run_id/trace — run-centric joined trace rows linking event, delivery, session, and turn identity
+      for operator debugging. This is a persisted joined trace surface built on canonical run-bound diagnostics, not a
+      separate observability store.'
     run_fork: 'POST /runs/:run_id/fork — fork a run at a specific event. Body: {event_id: uuid}.
       Returns the new run_id.'
     run_pause: 'POST /runs/:run_id/pause — pause a running run.'

--- a/docs/specs/swarm-platform/platform/contracts/review/platform-spec.run-trace-surface.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/review/platform-spec.run-trace-surface.yaml
@@ -1,0 +1,56 @@
+# Review Draft: run_model Joined Trace Surface
+# Status: implementation-aligned review draft
+# Target: platform-spec.yaml →
+#   - run_model.flight_recorder.joined_trace_surface
+#   - run_model.builder_api.run_trace
+#
+# This draft captures the supported run-centric joined trace surface added on the
+# `#364` implementation branch. It is intentionally narrow: one canonical
+# persisted run-trace projection layered on the existing run-debug owner, not a
+# broader observability redesign.
+
+run_trace_surface:
+  concept: 'One canonical persisted run-centric joined trace surface for operator debugging.'
+
+  owner_alignment:
+    canonical_owner: 'internal/store/run_debug_read_surface.go'
+    rule: 'Operator-facing run trace surfaces extend the canonical store-backed run-debug
+      owner. They do not create dashboard-local, builder-local, or other parallel
+      observability islands.'
+
+  projection_scope:
+    description: 'The joined trace projection answers "what is happening in this run right
+      now?" by linking one run through event identity, delivery lifecycle, session ownership,
+      and turn activity.'
+    persisted_sources:
+      - runs
+      - events
+      - event_deliveries
+      - agent_sessions
+      - agent_conversation_audits
+      - agent_turns
+    linkage_requirements:
+      - 'events.run_id anchors the projection to the run.'
+      - 'event_deliveries.event_id links deliveries to events.'
+      - 'event_deliveries.active_session_id may link deliveries to live agent_sessions rows.'
+      - 'agent_turns.session_id may link turns to either live agent_sessions rows or
+        canonical agent_conversation_audits rows.'
+      - 'agent_turns.trigger_event_id links turn activity back to the triggering event.'
+
+  supported_surface:
+    api: 'GET /runs/:run_id/trace'
+    contract: 'Returns run-centric joined trace rows that link event identity, delivery
+      state, session ownership, and turn identity for operator debugging.'
+    non_goal: 'This surface is not a provider-internal reasoning transcript and not a generic
+      observability query endpoint.'
+
+  semantics:
+    delivery_truth: 'Delivery lifecycle is read from canonical event_deliveries rows.'
+    session_truth: 'Session ownership comes from canonical agent_sessions rows when present,
+      with canonical agent_conversation_audits allowed as the persisted fallback lineage for
+      task-style sessions.'
+    turn_truth: 'Turn activity is read from canonical agent_turns rows keyed by run_id,
+      session_id, and trigger_event_id.'
+    consumer_rule: 'CLI, dashboard, and builder operator surfaces should consume this
+      projection via the canonical run-debug owner rather than rebuilding the join locally.'
+

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -49,6 +49,10 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
+  - id: 364
+    title: Add run-centric trace view across run, event, delivery, session, and turn
+    maps_to:
+      - run_scoped_operator_identity
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -115,10 +119,12 @@ nodes:
       - run_id drift across replay and diagnostics
       - API/dashboard query ownership not aligned on the same run-scoped identity
       - builder live run/debug streams reconstruct operator-visible run truth from in-memory state and fresh timestamps instead of consuming canonical run-bound diagnostics
+      - investigators must manually correlate run, event, delivery, session, and turn identity across multiple readers because no canonical joined run-trace surface exists
     representative_issues:
       - 148
       - 344
       - 345
+      - 364
     common_framing_mistakes:
       too_broad:
         - run scoping is inconsistent

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -14,6 +14,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/store"
 )
 
 type HealthChecker func(ctx context.Context) (map[string]any, error)
@@ -161,6 +162,10 @@ type ObservabilityReader interface {
 	ListIncidents(ctx context.Context, filter IncidentFilter) ([]incidentRecord, error)
 }
 
+type RunTraceReader interface {
+	LoadRunDebugTrace(ctx context.Context, runID string, opts store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, error)
+}
+
 type AgentController interface {
 	RestartAgent(agentID string) error
 	ReplayAgentBacklog(ctx context.Context, agentID string) error
@@ -181,6 +186,7 @@ type Options struct {
 	Instances     InstanceReader
 	Conversations ConversationReader
 	Observability ObservabilityReader
+	RunTrace      RunTraceReader
 	Runtime       RuntimeController
 	AuthToken     string
 	Version       string
@@ -195,6 +201,7 @@ type Handler struct {
 	instances     InstanceReader
 	conversations ConversationReader
 	observability ObservabilityReader
+	runTrace      RunTraceReader
 	runtime       RuntimeController
 	authToken     string
 	version       string
@@ -211,6 +218,7 @@ func NewHandler(opts Options) http.Handler {
 		instances:     opts.Instances,
 		conversations: opts.Conversations,
 		observability: opts.Observability,
+		runTrace:      opts.RunTrace,
 		runtime:       opts.Runtime,
 		authToken:     strings.TrimSpace(opts.AuthToken),
 		version:       strings.TrimSpace(opts.Version),
@@ -238,6 +246,7 @@ func NewHandler(opts Options) http.Handler {
 	mux.HandleFunc("GET /api/runtime/logs", h.handleRuntimeLogs)
 	mux.HandleFunc("GET /api/runtime/incidents", h.handleRuntimeIncidents)
 	mux.HandleFunc("POST /api/runtime/actions", h.handleRuntimeAction)
+	mux.HandleFunc("GET /api/runs/{runID}/trace", h.handleRunTrace)
 	builderHandler := opts.Builder
 	if builderHandler != nil {
 		h.builder = builderHandler
@@ -714,6 +723,29 @@ func (h *Handler) handleRuntimeIncidents(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"incidents": rows})
+}
+
+func (h *Handler) handleRunTrace(w http.ResponseWriter, r *http.Request) {
+	if h.runTrace == nil {
+		writeJSONError(w, http.StatusNotImplemented, errors.New("run trace reader is not configured"))
+		return
+	}
+	runID := strings.TrimSpace(r.PathValue("runID"))
+	if runID == "" {
+		writeJSONError(w, http.StatusBadRequest, errors.New("run id is required"))
+		return
+	}
+	rows, err := h.runTrace.LoadRunDebugTrace(r.Context(), runID, store.RunDebugTraceQueryOptions{
+		Limit: intQuery(r, "limit", 200),
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"run_id": runID,
+		"trace":  rows,
+	})
 }
 
 func (h *Handler) handleEventStream(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -130,6 +130,18 @@ type stubObservability struct {
 	incidents   []incidentRecord
 }
 
+type stubRunTrace struct {
+	rows map[string][]store.RunDebugTraceRow
+	err  error
+}
+
+func (s stubRunTrace) LoadRunDebugTrace(_ context.Context, runID string, _ store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.rows[strings.TrimSpace(runID)], nil
+}
+
 type stubBuilderRunStore struct {
 	mu        sync.Mutex
 	events    []events.Event
@@ -3026,6 +3038,66 @@ func TestHandler_RunEventReplayUsesCanonicalPersistedRunDebugOwner(t *testing.T)
 	summary, _ := donePayload["summary"].(map[string]any)
 	if summary["entity_count"] != float64(1) && summary["entity_count"] != 1 {
 		t.Fatalf("run.completed summary = %#v", summary)
+	}
+}
+
+func TestHandler_RunTraceUsesCanonicalPersistedRunDebugOwner(t *testing.T) {
+	now := time.Unix(1700000200, 0).UTC()
+	runID := "run_trace_001"
+	handler := NewHandler(Options{
+		Health: func(context.Context) (map[string]any, error) {
+			return map[string]any{"runtime": map[string]any{"ready": true}}, nil
+		},
+		AuthToken: testOperatorAuthToken,
+		RunTrace: stubRunTrace{rows: map[string][]store.RunDebugTraceRow{
+			runID: {{
+				EventID:              "evt-1",
+				EventName:            "scan.requested",
+				EventCreatedAt:       now,
+				DeliveryID:           "del-1",
+				SubscriberType:       "agent",
+				SubscriberID:         "agent-source",
+				DeliveryStatus:       "in_progress",
+				ActiveSessionID:      "sess-1",
+				SessionID:            "sess-1",
+				SessionKind:          "live_session",
+				SessionRuntimeMode:   "session",
+				SessionStatus:        "active",
+				TurnID:               "turn-1",
+				TurnTriggerEventID:   "evt-1",
+				TurnTriggerEventType: "scan.requested",
+				TurnRuntimeMode:      "session",
+				TurnTaskID:           "task-1",
+				TurnCreatedAt:        ptrTime(now.Add(2 * time.Second)),
+			}},
+		}},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/"+runID+"/trace", nil)
+	setOperatorAuth(req)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/runs/{runID}/trace status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, _ := body["run_id"].(string); got != runID {
+		t.Fatalf("run_id = %q, want %q", got, runID)
+	}
+	rows, _ := body["trace"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("trace len = %d, want 1", len(rows))
+	}
+	row, _ := rows[0].(map[string]any)
+	if row["event_id"] != "evt-1" || row["delivery_id"] != "del-1" || row["session_id"] != "sess-1" || row["turn_id"] != "turn-1" {
+		t.Fatalf("trace row = %#v", row)
+	}
+	if row["turn_trigger_event_id"] != "evt-1" {
+		t.Fatalf("turn_trigger_event_id = %#v", row["turn_trigger_event_id"])
 	}
 }
 

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -125,6 +125,45 @@ type RunDebugReport struct {
 	RuntimeLogs       []RunDebugRuntimeLog     `json:"runtime_logs,omitempty"`
 }
 
+type RunDebugTraceQueryOptions struct {
+	Limit int
+}
+
+type RunDebugTraceRow struct {
+	EventID              string     `json:"event_id,omitempty"`
+	EventName            string     `json:"event_name,omitempty"`
+	SourceEventID        string     `json:"source_event_id,omitempty"`
+	EntityID             string     `json:"entity_id,omitempty"`
+	EventSource          string     `json:"event_source,omitempty"`
+	EventSourceType      string     `json:"event_source_type,omitempty"`
+	EventCreatedAt       time.Time  `json:"event_created_at"`
+	DeliveryID           string     `json:"delivery_id,omitempty"`
+	SubscriberType       string     `json:"subscriber_type,omitempty"`
+	SubscriberID         string     `json:"subscriber_id,omitempty"`
+	DeliveryStatus       string     `json:"delivery_status,omitempty"`
+	DeliveryReasonCode   string     `json:"delivery_reason_code,omitempty"`
+	ActiveSessionID      string     `json:"active_session_id,omitempty"`
+	DeliveryCreatedAt    *time.Time `json:"delivery_created_at,omitempty"`
+	DeliveryStartedAt    *time.Time `json:"delivery_started_at,omitempty"`
+	DeliveryDeliveredAt  *time.Time `json:"delivery_delivered_at,omitempty"`
+	SessionID            string     `json:"session_id,omitempty"`
+	SessionKind          string     `json:"session_kind,omitempty"`
+	SessionRuntimeMode   string     `json:"session_runtime_mode,omitempty"`
+	SessionStatus        string     `json:"session_status,omitempty"`
+	SessionUpdatedAt     *time.Time `json:"session_updated_at,omitempty"`
+	TurnID               string     `json:"turn_id,omitempty"`
+	TurnTriggerEventID   string     `json:"turn_trigger_event_id,omitempty"`
+	TurnTriggerEventType string     `json:"turn_trigger_event_type,omitempty"`
+	TurnRuntimeMode      string     `json:"turn_runtime_mode,omitempty"`
+	TurnScopeKey         string     `json:"turn_scope_key,omitempty"`
+	TurnEntityID         string     `json:"turn_entity_id,omitempty"`
+	TurnTaskID           string     `json:"turn_task_id,omitempty"`
+	TurnParseOK          bool       `json:"turn_parse_ok,omitempty"`
+	TurnRetryCount       int        `json:"turn_retry_count,omitempty"`
+	TurnError            string     `json:"turn_error,omitempty"`
+	TurnCreatedAt        *time.Time `json:"turn_created_at,omitempty"`
+}
+
 func defaultRunDebugQueryOptions(opts RunDebugQueryOptions) RunDebugQueryOptions {
 	if opts.EventLimit <= 0 {
 		opts.EventLimit = 15
@@ -139,6 +178,13 @@ func defaultRunDebugQueryOptions(opts RunDebugQueryOptions) RunDebugQueryOptions
 		opts.DeadLetterLimit = 10
 	}
 	opts.Component = strings.TrimSpace(opts.Component)
+	return opts
+}
+
+func defaultRunDebugTraceQueryOptions(opts RunDebugTraceQueryOptions) RunDebugTraceQueryOptions {
+	if opts.Limit <= 0 {
+		opts.Limit = 200
+	}
 	return opts
 }
 
@@ -527,6 +573,204 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	}
 
 	return report, nil
+}
+
+func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunDebugCapabilities(ctx); err != nil {
+		return nil, err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, fmt.Errorf("run_id is required")
+	}
+	opts = defaultRunDebugTraceQueryOptions(opts)
+
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sessionSources := runDebugTraceSessionSources(caps)
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		WITH trace_sessions AS (
+			%s
+		)
+		SELECT
+			e.event_id::text,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.source_event_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.produced_by_type, ''),
+			e.created_at,
+			COALESCE(d.delivery_id::text, ''),
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id::text, ''),
+			d.created_at,
+			d.started_at,
+			d.delivered_at,
+			COALESCE(sess.session_id::text, ''),
+			COALESCE(sess.session_kind, ''),
+			COALESCE(sess.runtime_mode, ''),
+			COALESCE(sess.status, ''),
+			sess.updated_at,
+			COALESCE(t.turn_id::text, ''),
+			COALESCE(t.trigger_event_id::text, ''),
+			COALESCE(t.trigger_event_type, ''),
+			COALESCE(t.runtime_mode, ''),
+			COALESCE(t.scope_key, ''),
+			COALESCE(t.entity_id::text, ''),
+			COALESCE(t.task_id, ''),
+			COALESCE(t.parse_ok, false),
+			COALESCE(t.retry_count, 0),
+			COALESCE(t.error, ''),
+			t.created_at
+		FROM events e
+		LEFT JOIN event_deliveries d
+			ON d.event_id = e.event_id
+		LEFT JOIN agent_turns t
+			ON t.run_id = e.run_id
+		   AND t.trigger_event_id = e.event_id
+		   AND (
+				d.delivery_id IS NULL
+				OR (
+					COALESCE(d.subscriber_type, '') = 'agent'
+					AND COALESCE(d.subscriber_id, '') <> ''
+					AND t.agent_id = d.subscriber_id
+				)
+		   )
+		LEFT JOIN trace_sessions sess
+			ON sess.session_id = COALESCE(t.session_id, d.active_session_id)
+		   AND (
+				sess.run_id = e.run_id
+				OR sess.run_id IS NULL
+		   )
+		WHERE e.run_id = $1::uuid
+		ORDER BY
+			e.created_at ASC,
+			e.event_id ASC,
+			d.created_at ASC NULLS FIRST,
+			d.delivery_id ASC NULLS FIRST,
+			t.created_at ASC NULLS FIRST,
+			t.turn_id ASC NULLS FIRST
+		LIMIT $2
+	`, sessionSources), runID, opts.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("load run debug trace: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]RunDebugTraceRow, 0, opts.Limit)
+	for rows.Next() {
+		var (
+			item                RunDebugTraceRow
+			deliveryCreatedAt   sql.NullTime
+			deliveryStartedAt   sql.NullTime
+			deliveryDeliveredAt sql.NullTime
+			sessionUpdatedAt    sql.NullTime
+			turnCreatedAt       sql.NullTime
+		)
+		if err := rows.Scan(
+			&item.EventID,
+			&item.EventName,
+			&item.SourceEventID,
+			&item.EntityID,
+			&item.EventSource,
+			&item.EventSourceType,
+			&item.EventCreatedAt,
+			&item.DeliveryID,
+			&item.SubscriberType,
+			&item.SubscriberID,
+			&item.DeliveryStatus,
+			&item.DeliveryReasonCode,
+			&item.ActiveSessionID,
+			&deliveryCreatedAt,
+			&deliveryStartedAt,
+			&deliveryDeliveredAt,
+			&item.SessionID,
+			&item.SessionKind,
+			&item.SessionRuntimeMode,
+			&item.SessionStatus,
+			&sessionUpdatedAt,
+			&item.TurnID,
+			&item.TurnTriggerEventID,
+			&item.TurnTriggerEventType,
+			&item.TurnRuntimeMode,
+			&item.TurnScopeKey,
+			&item.TurnEntityID,
+			&item.TurnTaskID,
+			&item.TurnParseOK,
+			&item.TurnRetryCount,
+			&item.TurnError,
+			&turnCreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan run debug trace: %w", err)
+		}
+		item.DeliveryCreatedAt = nullableTimePtr(deliveryCreatedAt)
+		item.DeliveryStartedAt = nullableTimePtr(deliveryStartedAt)
+		item.DeliveryDeliveredAt = nullableTimePtr(deliveryDeliveredAt)
+		item.SessionUpdatedAt = nullableTimePtr(sessionUpdatedAt)
+		item.TurnCreatedAt = nullableTimePtr(turnCreatedAt)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read run debug trace: %w", err)
+	}
+	return out, nil
+}
+
+func runDebugTraceSessionSources(caps StoreSchemaCapabilities) string {
+	sources := []string{}
+	if caps.Conversations.Sessions == SchemaFlavorCanonical {
+		sources = append(sources, `
+			SELECT
+				session_id,
+				run_id,
+				'live_session' AS session_kind,
+				COALESCE(runtime_mode, '') AS runtime_mode,
+				COALESCE(status, '') AS status,
+				updated_at
+			FROM agent_sessions
+		`)
+	}
+	if caps.Conversations.Audits == SchemaFlavorCanonical {
+		sources = append(sources, `
+			SELECT
+				session_id,
+				run_id,
+				'turn_audit' AS session_kind,
+				COALESCE(runtime_mode, '') AS runtime_mode,
+				COALESCE(status, '') AS status,
+				updated_at
+			FROM agent_conversation_audits
+		`)
+	}
+	if len(sources) == 0 {
+		return `
+			SELECT
+				NULL::uuid AS session_id,
+				NULL::uuid AS run_id,
+				''::text AS session_kind,
+				''::text AS runtime_mode,
+				''::text AS status,
+				NULL::timestamptz AS updated_at
+			WHERE FALSE
+		`
+	}
+	return strings.Join(sources, "\nUNION ALL\n")
+}
+
+func nullableTimePtr(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	tm := value.Time
+	return &tm
 }
 
 func (s *PostgresStore) loadRunDebugRuntimeLogs(ctx context.Context, runID string, opts RunDebugQueryOptions, report *RunDebugReport) error {

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -727,10 +727,14 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 func runDebugTraceSessionSources(caps StoreSchemaCapabilities) string {
 	sources := []string{}
 	if caps.Conversations.Sessions == SchemaFlavorCanonical {
+		runIDExpr := "NULL::uuid"
+		if caps.Conversations.SessionRunID {
+			runIDExpr = "run_id"
+		}
 		sources = append(sources, `
 			SELECT
 				session_id,
-				run_id,
+				`+runIDExpr+`,
 				'live_session' AS session_kind,
 				COALESCE(runtime_mode, '') AS runtime_mode,
 				COALESCE(status, '') AS status,
@@ -739,10 +743,14 @@ func runDebugTraceSessionSources(caps StoreSchemaCapabilities) string {
 		`)
 	}
 	if caps.Conversations.Audits == SchemaFlavorCanonical {
+		runIDExpr := "NULL::uuid"
+		if caps.Conversations.AuditRunID {
+			runIDExpr = "run_id"
+		}
 		sources = append(sources, `
 			SELECT
 				session_id,
-				run_id,
+				`+runIDExpr+`,
 				'turn_audit' AS session_kind,
 				COALESCE(runtime_mode, '') AS runtime_mode,
 				COALESCE(status, '') AS status,

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -385,5 +386,27 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_UsesTaskAuditSessionWhenLiveSessi
 	got := rows[0]
 	if got.SessionID != sessionID || got.SessionKind != "turn_audit" || got.SessionRuntimeMode != "task" {
 		t.Fatalf("task audit trace = %#v", got)
+	}
+}
+
+func TestRunDebugTraceSessionSources_NullsMissingRunIDColumnsForCanonicalConversationVariants(t *testing.T) {
+	caps := StoreSchemaCapabilities{
+		Conversations: ConversationSchemaCapabilities{
+			Sessions:     SchemaFlavorCanonical,
+			Audits:       SchemaFlavorCanonical,
+			SessionRunID: false,
+			AuditRunID:   false,
+		},
+	}
+
+	sql := runDebugTraceSessionSources(caps)
+	if strings.Contains(sql, "SELECT\n\t\t\t\tsession_id,\n\t\t\t\trun_id,") {
+		t.Fatalf("session source sql still selects raw run_id without capability guard:\n%s", sql)
+	}
+	if strings.Count(sql, "NULL::uuid") < 2 {
+		t.Fatalf("session source sql = %q, want NULL::uuid projection for both canonical variants", sql)
+	}
+	if !strings.Contains(sql, "FROM agent_sessions") || !strings.Contains(sql, "FROM agent_conversation_audits") {
+		t.Fatalf("session source sql = %q, want both canonical conversation sources", sql)
 	}
 }

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -7,9 +7,29 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
+	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/testutil"
 )
+
+func seedRunDebugAgent(t *testing.T, pg *PostgresStore, ctx context.Context, agentID string, entityID string) {
+	t.Helper()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:       agentID,
+			Role:     agentID,
+			Mode:     "operating",
+			EntityID: entityID,
+			Config:   json.RawMessage(`{"system_prompt":"You are a trace test agent.","tools":[],"subscriptions":["trace.*"]}`),
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed agent %s: %v", agentID, err)
+	}
+}
 
 func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
@@ -190,5 +210,180 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	}
 	if len(report.Deliveries) != 1 {
 		t.Fatalf("Deliveries len = %d, want 1", len(report.Deliveries))
+	}
+}
+
+func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	sessionID := uuid.NewString()
+	turnID := uuid.NewString()
+	entityID := uuid.NewString()
+	now := time.Unix(1700000400, 0).UTC()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, now.Add(-5*time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'scan.requested', $3::uuid, 'entity', '{}'::jsonb, 'builder', 'platform', $4)
+	`, runID, eventID, entityID, now); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	seedRunDebugAgent(t, pg, ctx, "agent-source", entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-source', $3::uuid, 'flow-a', 'entity:' || $3::text, 'entity',
+			'[]'::jsonb, 1, 'session', '{}'::jsonb,
+			NULL, NULL, 'active', $4, $5
+		)
+	`, sessionID, runID, entityID, now.Add(1*time.Second), now.Add(3*time.Second)); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, active_session_id, started_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-source', 'in_progress', 'session_started',
+			$4::uuid, $5, $6
+		)
+	`, deliveryID, runID, eventID, sessionID, now.Add(1*time.Second), now.Add(500*time.Millisecond)); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+			request_payload, response_payload, parse_ok, latency_ms, retry_count, error, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-source', $3::uuid, 'session', 'entity:' || $4::text, $4::uuid,
+			$5::uuid, 'scan.requested', 'task-1', '[]'::jsonb, '[]'::jsonb,
+			'[]'::jsonb, '{}'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			'{}'::jsonb, '{}'::jsonb, true, 12, 1, '', $6
+		)
+	`, turnID, runID, sessionID, entityID, eventID, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed turn: %v", err)
+	}
+
+	rows, err := pg.LoadRunDebugTrace(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTrace: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("trace len = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.EventID != eventID || got.EventName != "scan.requested" {
+		t.Fatalf("event trace = %#v", got)
+	}
+	if got.DeliveryID != deliveryID || got.DeliveryStatus != "in_progress" || got.SubscriberID != "agent-source" {
+		t.Fatalf("delivery trace = %#v", got)
+	}
+	if got.SessionID != sessionID || got.SessionKind != "live_session" || got.SessionRuntimeMode != "session" {
+		t.Fatalf("session trace = %#v", got)
+	}
+	if got.TurnID != turnID || got.TurnTriggerEventID != eventID || got.TurnTaskID != "task-1" || got.TurnRetryCount != 1 {
+		t.Fatalf("turn trace = %#v", got)
+	}
+	if got.TurnCreatedAt == nil || got.DeliveryStartedAt == nil {
+		t.Fatalf("expected non-nil turn/delivery timestamps: %#v", got)
+	}
+}
+
+func TestRunDebugReadSurface_LoadRunDebugTrace_UsesTaskAuditSessionWhenLiveSessionDoesNotExist(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	sessionID := uuid.NewString()
+	turnID := uuid.NewString()
+	entityID := uuid.NewString()
+	now := time.Unix(1700000500, 0).UTC()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, now.Add(-5*time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'task.started', $3::uuid, 'entity', '{}'::jsonb, 'builder', 'platform', $4)
+	`, runID, eventID, entityID, now); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	seedRunDebugAgent(t, pg, ctx, "agent-task", entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, agent_id, entity_id, flow_instance, scope_key, scope, conversation,
+			turn_count, runtime_mode, runtime_state, run_id, status, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, 'agent-task', $2::uuid, 'flow-a', 'entity:' || $2::text, 'entity', '[]'::jsonb,
+			1, 'task', '{}'::jsonb, $3::uuid, 'active', $4, $5
+		)
+	`, sessionID, entityID, runID, now.Add(1*time.Second), now.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed audit session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-task', 'delivered', 'handled', $4
+		)
+	`, deliveryID, runID, eventID, now.Add(500*time.Millisecond)); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+			request_payload, response_payload, parse_ok, latency_ms, retry_count, error, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-task', $3::uuid, 'task', 'entity:' || $4::text, $4::uuid,
+			$5::uuid, 'task.started', 'task-2', '[]'::jsonb, '[]'::jsonb,
+			'[]'::jsonb, '{}'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			'{}'::jsonb, '{}'::jsonb, true, 8, 0, '', $6
+		)
+	`, turnID, runID, sessionID, entityID, eventID, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("seed turn: %v", err)
+	}
+
+	rows, err := pg.LoadRunDebugTrace(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTrace: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("trace len = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.SessionID != sessionID || got.SessionKind != "turn_audit" || got.SessionRuntimeMode != "task" {
+		t.Fatalf("task audit trace = %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- extend the canonical persisted run-debug owner with a joined run-trace projection across events, deliveries, sessions, and turns
- expose one supported operator surface at `GET /api/runs/:run_id/trace` through the existing dashboard server wiring
- add focused store and handler proofs for live-session and task-audit trace joins

## Issue
Part of #364

## Spec References
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: run_model.flight_recorder.joined_trace_surface`
  - governing rule: operator-facing run trace surfaces extend canonical persisted run-bound diagnostics instead of creating a second observability island
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: run_model.builder_api.run_trace`
  - governing rule: `GET /runs/:run_id/trace` is the supported run-centric joined trace operator surface

## Testing
- `go test ./internal/store -run 'TestRunDebugReadSurface_(LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn|LoadRunDebugTrace_UsesTaskAuditSessionWhenLiveSessionDoesNotExist|ListRunDebugRuns_UsesCanonicalRunScope|LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMutations)$' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_(RunTraceUsesCanonicalPersistedRunDebugOwner|RunEventReplayUsesCanonicalPersistedRunDebugOwner)$' -count=1`
- `go test ./internal/store ./internal/dashboard/server ./cmd/swarm -count=1`
- `go test ./... -count=1`
