### PR TITLE
[agent-e][issue #409] Preserve persisted turn tool-call truth on CLI path

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -45,6 +45,10 @@ active_issues:
     title: Make run_id canonical across replay, diagnostics, API/dashboard scoping, and operator surfaces
     maps_to:
       - run_scoped_operator_identity
+  - id: 409
+    title: Persisted agent_turns can omit real tool calls visible in provider session transcripts
+    maps_to:
+      - shared_observability_contract
   - id: 224
     title: Remove implicit canonical schema defaults from dashboard readers and require explicit capability ownership
     maps_to:
@@ -59,10 +63,6 @@ active_issues:
       - run_scoped_operator_identity
   - id: 345
     title: Move builder run event streams onto canonical run-bound diagnostics
-    maps_to:
-      - run_scoped_operator_identity
-  - id: 364
-    title: Add run-centric trace view across run, event, delivery, session, and turn
     maps_to:
       - run_scoped_operator_identity
 nodes:
@@ -94,10 +94,12 @@ nodes:
       - CLI, dashboard, and builder observe different canonical facts
       - native capability visibility/recording diverges from the operator contract
       - first-line investigation surfaces remain too weak, pushing operators to transcript/container spelunking
+      - persisted turn tool_calls can under-report provider-observed tool activity on supported CLI turns
     representative_issues:
       - 131
       - 138
       - 363
+      - 409
     common_framing_mistakes:
       too_broad:
         - observability is inconsistent

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -66,7 +66,7 @@ func parseCLIResponse(raw []byte) *Response {
 		Message: Message{Role: "assistant"},
 	}
 	if len(raw) == 0 {
-		return resp
+		return finalizeCLIResponse(resp)
 	}
 
 	var obj map[string]any
@@ -137,14 +137,23 @@ func parseCLIResponse(raw []byte) *Response {
 		}
 		if len(texts) > 0 {
 			resp.Message.Content = strings.TrimSpace(strings.Join(texts, "\n"))
-			return resp
+			return finalizeCLIResponse(resp)
 		}
 		if len(resp.ToolCalls) > 0 {
-			return resp
+			return finalizeCLIResponse(resp)
 		}
 	}
 
 	resp.Message.Content = strings.TrimSpace(string(raw))
+	return finalizeCLIResponse(resp)
+}
+
+func finalizeCLIResponse(resp *Response) *Response {
+	if resp == nil {
+		return &Response{}
+	}
+	resp.ToolCalls = dedupeToolCalls(resp.ToolCalls)
+	resp.ObservedToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
 	return resp
 }
 

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -152,7 +152,6 @@ func finalizeCLIResponse(resp *Response) *Response {
 	if resp == nil {
 		return &Response{}
 	}
-	resp.ToolCalls = dedupeToolCalls(resp.ToolCalls)
 	resp.ObservedToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
 	return resp
 }

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -10,17 +10,18 @@ import (
 )
 
 type cliStreamAccumulator struct {
-	raw              bytes.Buffer
-	message          Message
-	toolCalls        []ToolCall
-	streamedCalls    []cliRecordedToolCall
-	sessionID        string
-	resultText       string
-	pending          map[int]*cliPendingToolCall
-	completedToolIDs map[string]struct{}
-	mcpServers       map[string]string
-	visibleTools     []string
-	mcpVisibleTools  []string
+	raw               bytes.Buffer
+	message           Message
+	toolCalls         []ToolCall
+	observedToolCalls []ToolCall
+	streamedCalls     []cliRecordedToolCall
+	sessionID         string
+	resultText        string
+	pending           map[int]*cliPendingToolCall
+	completedToolIDs  map[string]struct{}
+	mcpServers        map[string]string
+	visibleTools      []string
+	mcpVisibleTools   []string
 }
 
 type cliPendingToolCall struct {
@@ -104,6 +105,9 @@ func (a *cliStreamAccumulator) mergeAssistantObject(obj map[string]any) {
 	}
 	if len(resp.ToolCalls) > 0 && !a.hasConnectedRuntimeMCP() {
 		a.toolCalls = dedupeToolCalls(append(a.toolCalls, resp.ToolCalls...))
+	}
+	if len(resp.ObservedToolCalls) > 0 {
+		a.observedToolCalls = dedupeToolCalls(append(a.observedToolCalls, resp.ObservedToolCalls...))
 	}
 }
 
@@ -352,7 +356,9 @@ func (a *cliStreamAccumulator) Response() *Response {
 		message.Content = strings.TrimSpace(a.resultText)
 	}
 	toolCalls := append([]ToolCall(nil), a.toolCalls...)
+	observedToolCalls := append([]ToolCall(nil), a.observedToolCalls...)
 	for _, call := range a.streamedCalls {
+		observedToolCalls = append(observedToolCalls, call.Call)
 		if call.ID != "" {
 			if _, completed := a.completedToolIDs[call.ID]; completed {
 				continue
@@ -367,13 +373,14 @@ func (a *cliStreamAccumulator) Response() *Response {
 		toolCalls = nil
 	}
 	return &Response{
-		Message:         message,
-		ToolCalls:       dedupeToolCalls(toolCalls),
-		SessionID:       strings.TrimSpace(a.sessionID),
-		Raw:             bytes.TrimSpace(a.raw.Bytes()),
-		VisibleTools:    append([]string(nil), a.visibleTools...),
-		MCPServers:      a.mcpServers,
-		MCPVisibleTools: append([]string(nil), a.mcpVisibleTools...),
+		Message:           message,
+		ToolCalls:         dedupeToolCalls(toolCalls),
+		ObservedToolCalls: dedupeToolCalls(observedToolCalls),
+		SessionID:         strings.TrimSpace(a.sessionID),
+		Raw:               bytes.TrimSpace(a.raw.Bytes()),
+		VisibleTools:      append([]string(nil), a.visibleTools...),
+		MCPServers:        a.mcpServers,
+		MCPVisibleTools:   append([]string(nil), a.mcpVisibleTools...),
 	}
 }
 

--- a/internal/runtime/llm/cli_stream_parser.go
+++ b/internal/runtime/llm/cli_stream_parser.go
@@ -107,7 +107,7 @@ func (a *cliStreamAccumulator) mergeAssistantObject(obj map[string]any) {
 		a.toolCalls = dedupeToolCalls(append(a.toolCalls, resp.ToolCalls...))
 	}
 	if len(resp.ObservedToolCalls) > 0 {
-		a.observedToolCalls = dedupeToolCalls(append(a.observedToolCalls, resp.ObservedToolCalls...))
+		a.observedToolCalls = append(a.observedToolCalls, resp.ObservedToolCalls...)
 	}
 }
 
@@ -375,7 +375,7 @@ func (a *cliStreamAccumulator) Response() *Response {
 	return &Response{
 		Message:           message,
 		ToolCalls:         dedupeToolCalls(toolCalls),
-		ObservedToolCalls: dedupeToolCalls(observedToolCalls),
+		ObservedToolCalls: observedToolCalls,
 		SessionID:         strings.TrimSpace(a.sessionID),
 		Raw:               bytes.TrimSpace(a.raw.Bytes()),
 		VisibleTools:      append([]string(nil), a.visibleTools...),

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -21,6 +21,9 @@ func TestCLIStreamAccumulator_Response(t *testing.T) {
 	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "sql_execute" {
 		t.Fatalf("unexpected tool calls: %+v", resp.ToolCalls)
 	}
+	if len(resp.ObservedToolCalls) != 1 || resp.ObservedToolCalls[0].Name != "sql_execute" {
+		t.Fatalf("unexpected observed tool calls: %+v", resp.ObservedToolCalls)
+	}
 	if len(resp.Raw) == 0 {
 		t.Fatal("expected raw stream payload")
 	}
@@ -98,6 +101,9 @@ func TestCLIStreamAccumulator_IgnoresAssistantToolCallsWhenMCPConnected(t *testi
 	if len(resp.ToolCalls) != 0 {
 		t.Fatalf("expected assistant-object tool calls to be ignored when MCP is connected, got %+v", resp.ToolCalls)
 	}
+	if len(resp.ObservedToolCalls) != 1 || resp.ObservedToolCalls[0].Name != "emit_scan_requested" {
+		t.Fatalf("expected observed assistant tool call to remain available for persistence, got %+v", resp.ObservedToolCalls)
+	}
 }
 
 func TestCLIStreamAccumulator_SuppressesCompletedMCPToolCalls(t *testing.T) {
@@ -112,6 +118,9 @@ func TestCLIStreamAccumulator_SuppressesCompletedMCPToolCalls(t *testing.T) {
 	if len(resp.ToolCalls) != 0 {
 		t.Fatalf("expected completed MCP tool call to be suppressed, got %+v", resp.ToolCalls)
 	}
+	if len(resp.ObservedToolCalls) != 1 || resp.ObservedToolCalls[0].Name != "emit_scan_requested" {
+		t.Fatalf("expected completed MCP tool call to remain observed for persistence, got %+v", resp.ObservedToolCalls)
+	}
 }
 
 func TestCLIStreamAccumulator_SuppressesCompletedMCPToolCalls_FromMessageWrappedUserEvent(t *testing.T) {
@@ -125,6 +134,9 @@ func TestCLIStreamAccumulator_SuppressesCompletedMCPToolCalls_FromMessageWrapped
 	resp := acc.Response()
 	if len(resp.ToolCalls) != 0 {
 		t.Fatalf("expected wrapped completed MCP tool call to be suppressed, got %+v", resp.ToolCalls)
+	}
+	if len(resp.ObservedToolCalls) != 1 || resp.ObservedToolCalls[0].Name != "emit_scan_requested" {
+		t.Fatalf("expected wrapped completed MCP tool call to remain observed for persistence, got %+v", resp.ObservedToolCalls)
 	}
 }
 

--- a/internal/runtime/llm/cli_stream_parser_test.go
+++ b/internal/runtime/llm/cli_stream_parser_test.go
@@ -164,6 +164,40 @@ func TestParseCLIResponse_NormalizesBuiltinToolCallNames(t *testing.T) {
 	}
 }
 
+func TestParseCLIResponse_PreservesDuplicateToolCalls(t *testing.T) {
+	resp := parseCLIResponse([]byte(`{"content":[{"type":"tool_use","name":"Read","input":{"path":"/tmp/a.txt"}},{"type":"tool_use","name":"Read","input":{"path":"/tmp/a.txt"}}]}`))
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %#v", resp.ToolCalls)
+	}
+	if len(resp.ObservedToolCalls) != 2 {
+		t.Fatalf("observed tool calls = %#v", resp.ObservedToolCalls)
+	}
+}
+
+func TestCLIStreamAccumulator_PreservesDuplicateObservedToolCallsForPersistence(t *testing.T) {
+	acc := newCLIStreamAccumulator()
+	acc.AddLine([]byte(`{"type":"system","subtype":"init","session_id":"sess-dup","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_scan_requested"]}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_1","name":"mcp__runtime-tools__emit_scan_requested","input":{"mode":"corpus"}}},"session_id":"sess-dup"}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_stop","index":2},"session_id":"sess-dup"}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_2","name":"mcp__runtime-tools__emit_scan_requested","input":{"mode":"corpus"}}},"session_id":"sess-dup"}`))
+	acc.AddLine([]byte(`{"type":"stream_event","event":{"type":"content_block_stop","index":3},"session_id":"sess-dup"}`))
+	acc.AddLine([]byte(`{"type":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"text","text":"{\"event_id\":\"evt-1\"}"}]},{"type":"tool_result","tool_use_id":"toolu_2","content":[{"type":"text","text":"{\"event_id\":\"evt-2\"}"}]}]}`))
+
+	resp := acc.Response()
+	if len(resp.ToolCalls) != 0 {
+		t.Fatalf("expected completed MCP tool calls to stay suppressed for execution, got %+v", resp.ToolCalls)
+	}
+	if len(resp.ObservedToolCalls) != 2 {
+		t.Fatalf("observed tool calls = %#v", resp.ObservedToolCalls)
+	}
+	if resp.ObservedToolCalls[0].Name != "emit_scan_requested" || resp.ObservedToolCalls[1].Name != "emit_scan_requested" {
+		t.Fatalf("observed tool calls = %#v", resp.ObservedToolCalls)
+	}
+}
+
 func TestCLIStreamAccumulator_IgnoresNestedToolArgumentListsForVisibility(t *testing.T) {
 	acc := newCLIStreamAccumulator()
 	acc.AddLine([]byte(`{"type":"system","subtype":"init","session_id":"sess-nested","tools":["Read"]}`))

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -67,7 +67,11 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		}
 	}
 	if resp != nil && len(rec.ToolCalls) == 0 {
-		rec.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+		if len(resp.ObservedToolCalls) > 0 {
+			rec.ToolCalls = append([]ToolCall(nil), resp.ObservedToolCalls...)
+		} else {
+			rec.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+		}
 	}
 	if resp != nil && len(rec.AvailableTools) == 0 {
 		actor, _ := runtimeactors.ActorFromContext(ctx)

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -345,6 +345,31 @@ func TestEnrichTurnRecord_UsesPlannedConfiguredSurfaceWhenObservedMetadataIsAbse
 	}
 }
 
+func TestEnrichTurnRecord_PrefersObservedToolCallsForPersistenceWhenExecutionCallsAreSuppressed(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, &Response{
+		ToolCalls: []ToolCall{},
+		ObservedToolCalls: []ToolCall{
+			{Name: "emit_category_assessed", Arguments: map[string]any{"category": "payments"}},
+		},
+	})
+
+	if len(rec.ToolCalls) != 1 || rec.ToolCalls[0].Name != "emit_category_assessed" {
+		t.Fatalf("tool_calls = %#v", rec.ToolCalls)
+	}
+}
+
 func TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble(t *testing.T) {
 	actor := runtimeactors.AgentConfig{
 		ID: "analysis-agent",

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -19,13 +19,14 @@ type ToolCall struct {
 }
 
 type Response struct {
-	Message         Message           `json:"message"`
-	ToolCalls       []ToolCall        `json:"tool_calls,omitempty"`
-	SessionID       string            `json:"session_id,omitempty"`
-	Raw             []byte            `json:"raw,omitempty"`
-	VisibleTools    []string          `json:"visible_tools,omitempty"`
-	MCPServers      map[string]string `json:"mcp_servers,omitempty"`
-	MCPVisibleTools []string          `json:"mcp_visible_tools,omitempty"`
+	Message           Message           `json:"message"`
+	ToolCalls         []ToolCall        `json:"tool_calls,omitempty"`
+	ObservedToolCalls []ToolCall        `json:"-"`
+	SessionID         string            `json:"session_id,omitempty"`
+	Raw               []byte            `json:"raw,omitempty"`
+	VisibleTools      []string          `json:"visible_tools,omitempty"`
+	MCPServers        map[string]string `json:"mcp_servers,omitempty"`
+	MCPVisibleTools   []string          `json:"mcp_visible_tools,omitempty"`
 }
 
 type Session struct {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3441,6 +3441,61 @@ func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t
 	}
 }
 
+func TestManagerStore_AppendAgentTurn_PersistsObservedToolCalls(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:     "a1",
+		RuntimeMode: "session",
+		SessionID:   sessionID,
+		ToolCalls: []runtimellm.ToolCall{
+			{Name: "query_entities", Arguments: map[string]any{"entity_type": "company"}},
+			{Name: "web_search", Arguments: map[string]any{"query": "b2b payments"}},
+		},
+		RequestPayload: []byte(`{"kind":"session"}`),
+		ResponseRaw:    []byte(`{"result":"done"}`),
+		ParseOK:        true,
+		Latency:        10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn: %v", err)
+	}
+
+	var raw string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(tool_calls::text, '[]')
+		FROM agent_turns
+		WHERE agent_id = 'a1' AND session_id = $1::uuid
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, sessionID).Scan(&raw); err != nil {
+		t.Fatalf("load tool_calls: %v", err)
+	}
+
+	var calls []map[string]any
+	if err := json.Unmarshal([]byte(raw), &calls); err != nil {
+		t.Fatalf("decode tool_calls: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("tool_calls count = %d, want 2 in %s", len(calls), raw)
+	}
+	if calls[0]["name"] != redactName("query_entities") || calls[1]["name"] != redactName("web_search") {
+		t.Fatalf("tool_calls = %#v", calls)
+	}
+	args0, ok := calls[0]["arguments"].(map[string]any)
+	if !ok || args0["entity_type"] != "company" {
+		t.Fatalf("first tool call arguments = %#v", calls[0]["arguments"])
+	}
+	args1, ok := calls[1]["arguments"].(map[string]any)
+	if !ok || args1["query"] != "b2b payments" {
+		t.Fatalf("second tool call arguments = %#v", calls[1]["arguments"])
+	}
+}
+
 func TestManagerStore_LiveConversationPersistenceRequiresCanonicalLiveSession(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #409

## Summary
Persist provider-observed CLI tool activity into `agent_turns.tool_calls` even when the connected runtime MCP path suppresses executable `Response.ToolCalls` for replay safety.

## Governing Context
No exact governing spec section was identified for this runtime bug. The binding governing context for this PR is the approved issue record on `#409`, including the `Pre-Implementation Coverage Audit` and the independent pre-audit gate that bounded this child to persisted turn-audit `tool_calls` truth on the supported CLI path.

## What Changed
- added `ObservedToolCalls` on the CLI response model as the persistence-facing provider-observed tool-call surface
- kept connected-MCP execution suppression on `Response.ToolCalls`
- taught CLI response parsing/stream accumulation to preserve observed tool calls while leaving execution calls replay-safe
- preserved duplicate tool-call multiplicity on the non-stream CLI path and for persistence-facing observed calls
- taught turn-record enrichment to persist observed tool calls when executable tool calls are intentionally empty
- added focused regression coverage for CLI parser behavior, turn enrichment, store persistence, and the watchlist mapping for this supported path bug

## Why
`agent_turns.tool_calls` is the canonical persisted turn-audit field for tool-call accounting. On the supported CLI connected-MCP path, provider transcripts could still show real tool activity while normalization suppressed `Response.ToolCalls`, leaving persisted `tool_calls` empty. This change removes that drift without reopening execution semantics.

## Scope Boundaries
- in scope: CLI provider transcript normalization into persisted turn-audit truth for `agent_turns.tool_calls`
- out of scope: `#406` tool-surface parity / follow-up-file work, broader observability work under `#363`, provider transcript retention policy changes, and API-runtime-specific extraction changes

## Tests
- `go test ./internal/runtime/llm -run 'Test(ParseCLIResponse_(NormalizesBuiltinToolCallNames|PreservesDuplicateToolCalls)|CLIStreamAccumulator_(Response|IgnoresAssistantToolCallsWhenMCPConnected|SuppressesCompletedMCPToolCalls|SuppressesCompletedMCPToolCalls_FromMessageWrappedUserEvent|PreservesDuplicateObservedToolCallsForPersistence)|EnrichTurnRecord_PrefersObservedToolCallsForPersistenceWhenExecutionCallsAreSuppressed|BuildTurnBlocks_CorrelatesToolResultsWithToolUse)$' -count=1`
- `go test ./internal/store -run 'TestManagerStore_AppendAgentTurn_PersistsObservedToolCalls$' -count=1`
- `go test ./internal/runtime/llm ./internal/store ./internal/dashboard/server -count=1`
- `go test ./... -count=1`

## Residual Risk
The change intentionally stays on the supported CLI path and does not alter execution-time tool-call validation or replay behavior. If another provider path suppresses persistence truth independently, that would be a separate child.

## Follow-up
- none for this chosen failure class
