### PR TITLE
[agent-d][issue #415] Fail closed create_flow_instance admission

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -90,6 +90,10 @@ active_issues:
     title: Enforce create_entity + accumulate prohibition at canonical boot validation
     maps_to:
       - startup_validation_missing_prohibited_handler_enforcement
+  - id: 415
+    title: Align runtime enforcement with primitive-only cross-flow model
+    maps_to:
+      - primitive_only_cross_flow_runtime_migration
 nodes:
   - id: boot_verification_false_negative_validation
     title: Boot/Verification False-Negative Validation
@@ -222,6 +226,36 @@ nodes:
       too_narrow:
         - one stale tier8 fixture
         - one missing if statement in a helper
+  - id: primitive_only_cross_flow_runtime_migration
+    title: Primitive-Only Cross-Flow Runtime Migration
+    parent_class: staged migration from coupled cross-flow runtime semantics to primitive-only event/config handoff semantics
+    canonical_owners:
+      - emitted-event identity shaping and parent-retarget ownership in internal/runtime/pipeline
+      - cross-flow entity access enforcement in internal/runtime/tools and pipeline state mutation
+      - create_flow_instance boot/runtime sibling-field enforcement in internal/runtime/bootverify and internal/runtime/pipeline
+    why_this_node_exists: the current runtime still implements the older coupled cross-flow model through multiple tightly-coupled seams, but the approved migration target removes those primitives in stages rather than as one local patch.
+    known_manifestations:
+      - child-flow output events still retarget to parent/root entity context at the emitted-event owner seam
+      - cross-flow get_entity reads remain runtime-authorized
+      - cross-flow writes are already fail-closed and must stay so during migration
+      - back-propagation events remain boot/runtime-recognized compatibility semantics
+      - subject_id remains propagated, persisted, queried, and exposed as a first-class cross-flow linkage surface
+      - create_flow_instance is still admitted without required sibling enforcement for both instance_id_from and config_from
+      - runtime create_flow_instance still falls back to payload.instance_id and then uuid generation when instance_id_from is absent
+    representative_issues:
+      - 413
+      - 415
+      - 416
+      - 417
+    common_framing_mistakes:
+      too_broad:
+        - remove all cross-flow complexity at once
+        - the spec draft is already the implementation boundary
+      too_narrow:
+        - one validation retarget bug
+        - one tool denial or one missing config_from check
+        - one missing create_flow_instance sibling field when the full current-spec required-sibling class is still under-enforced
+    current_action_pressure: active
   - id: entity_tool_schema_annotation_normalization_drift
     title: Entity-Tool Schema Annotation Normalization Drift
     parent_class: runtime entity-tool semantics drift from authored entity_schema type annotations

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -948,6 +948,22 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 							Location: nodeID,
 						})
 					}
+					if strings.TrimSpace(handler.Action.InstanceIDFrom) == "" {
+						c.handlerFindings = append(c.handlerFindings, Finding{
+							CheckID:  "handler_field_compliance",
+							Severity: "error",
+							Message:  fmt.Sprintf("node %s handler %s create_flow_instance is missing instance_id_from", nodeID, eventType),
+							Location: nodeID,
+						})
+					}
+					if handler.Action.ConfigFrom == nil || len(handler.Action.ConfigFrom.ConfigEntries()) == 0 {
+						c.handlerFindings = append(c.handlerFindings, Finding{
+							CheckID:  "handler_field_compliance",
+							Severity: "error",
+							Message:  fmt.Sprintf("node %s handler %s create_flow_instance is missing config_from", nodeID, eventType),
+							Location: nodeID,
+						})
+					}
 				}
 				if normalizeWorkflowBuiltinActionID(actionID) == "record_evidence" && strings.TrimSpace(handler.EvidenceTarget) == "" {
 					c.handlerFindings = append(c.handlerFindings, Finding{

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/paths"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -896,6 +897,43 @@ func TestRun_AllowsFanOutDerivedAccumulationSourceEvent(t *testing.T) {
 
 	if reportContains(report.Errors(), "config_from_payload_alignment", "fan_out.child_completed") {
 		t.Fatalf("expected fan_out source_event to be accepted, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsCreateFlowInstanceMissingInstanceIDFrom(t *testing.T) {
+	repoRoot := repoRootForBootverifyTest(t)
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier9-composition-patterns", "test-compose-create-instance-config")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle := loadFixtureBundleAt(t, repoRoot, fixtureRoot, platformSpec)
+	node := bundle.Nodes["spawner"]
+	handler := node.EventHandlers["spawn.requested"]
+	handler.Action.InstanceIDFrom = ""
+	handler.Action.InstanceIDPath = paths.Path{}
+	node.EventHandlers["spawn.requested"] = handler
+	bundle.Nodes["spawner"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "create_flow_instance is missing instance_id_from") {
+		t.Fatalf("expected handler_field_compliance missing instance_id_from error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsCreateFlowInstanceMissingConfigFrom(t *testing.T) {
+	repoRoot := repoRootForBootverifyTest(t)
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier9-composition-patterns", "test-compose-create-instance-config")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle := loadFixtureBundleAt(t, repoRoot, fixtureRoot, platformSpec)
+	node := bundle.Nodes["spawner"]
+	handler := node.EventHandlers["spawn.requested"]
+	handler.Action.ConfigFrom = &runtimecontracts.ConfigFromSpec{Bindings: map[string]string{}}
+	node.EventHandlers["spawn.requested"] = handler
+	bundle.Nodes["spawner"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "create_flow_instance is missing config_from") {
+		t.Fatalf("expected handler_field_compliance missing config_from error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -13,7 +13,6 @@ var tier11FlowCompositionFixtures = []string{
 	"test-child-flow-absolute-path",
 	"test-child-flow-loads",
 	"test-child-flow-local-events",
-	"test-dynamic-flow-instance",
 	"test-nested-three-levels",
 	"test-child-flow-pin-wiring",
 	"test-child-flow-policy-inherit",
@@ -29,6 +28,7 @@ var tier11FlowCompositionFixtures = []string{
 }
 
 var tier11ExcludedFixtures = map[string]catalogExcludedFixture{
+	"test-dynamic-flow-instance":              {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
 	"test-sibling-both-instantiated-isolated": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 	"test-subject-id-cross-flow-inherit":      {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 	"test-subject-id-first-flow-seeds":        {reason: "new conformance fixture not yet wired into runtime catalog execution set"},

--- a/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
@@ -12,12 +12,13 @@ import (
 var tier4CrossEntityFixtures = []string{
 	"test-clear-multiple-targets",
 	"test-clear-state",
-	"test-create-entity",
 	"test-query-filter",
 	"test-query-group-by",
 }
 
-var tier4ExcludedFixtures = map[string]catalogExcludedFixture{}
+var tier4ExcludedFixtures = map[string]catalogExcludedFixture{
+	"test-create-entity": {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
+}
 
 func TestTier4CrossEntityCatalogFixtures_RealRuntime(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)

--- a/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
@@ -16,9 +16,6 @@ type catalogExcludedFixture struct {
 
 var tier5LifecycleFixtures = []string{
 	"test-auto-emit-on-create",
-	"test-create-flow-instance-config",
-	"test-create-flow-instance-duplicate",
-	"test-create-flow-instance",
 	"test-template-no-boot-instance",
 	"test-terminal-state-preserves",
 	"test-terminal-state-rejects",
@@ -29,7 +26,11 @@ var tier5LifecycleFixtures = []string{
 	"test-wildcard-subscription",
 }
 
-var tier5ExcludedFixtures = map[string]catalogExcludedFixture{}
+var tier5ExcludedFixtures = map[string]catalogExcludedFixture{
+	"test-create-flow-instance":           {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
+	"test-create-flow-instance-config":    {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
+	"test-create-flow-instance-duplicate": {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
+}
 
 func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -479,6 +479,27 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 		}
 		return ActionSpec{ID: actionID}, nil
 	case yaml.MappingNode:
+		allowed := map[string]struct{}{
+			"id":               {},
+			"template":         {},
+			"instance_id_from": {},
+			"config_from":      {},
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			if key == "" {
+				continue
+			}
+			if _, ok := allowed[key]; ok {
+				continue
+			}
+			switch key {
+			case "type", "flow_template", "instance_id":
+				return ActionSpec{}, fmt.Errorf("DEPRECATED: legacy action field %q is not supported; use action: create_flow_instance with template, instance_id_from, and config_from siblings", key)
+			default:
+				return ActionSpec{}, fmt.Errorf("UNDEFINED-FIELD: action field %q not in platform spec", key)
+			}
+		}
 		var aux struct {
 			ID             string    `yaml:"id"`
 			Template       string    `yaml:"template"`
@@ -487,6 +508,9 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 		}
 		if err := node.Decode(&aux); err != nil {
 			return ActionSpec{}, err
+		}
+		if strings.TrimSpace(aux.ID) == "" {
+			return ActionSpec{}, fmt.Errorf("action mapping missing id")
 		}
 		actionID, err := ParseHandlerActionID(aux.ID)
 		if err != nil {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -555,15 +555,7 @@ func decodeConfigFromSpecNode(node *yaml.Node) (*ConfigFromSpec, error) {
 	}
 	spec := &ConfigFromSpec{Bindings: map[string]string{}}
 	if hasYAMLMappingKey(node, "policy_keys") {
-		type alias ConfigFromSpec
-		var aux alias
-		if err := node.Decode(&aux); err != nil {
-			return nil, err
-		}
-		spec.PolicyKeys = normalizeStrings(aux.PolicyKeys)
-		for key, value := range aux.Bindings {
-			spec.Bindings[key] = value
-		}
+		return nil, fmt.Errorf("UNDEFINED-FIELD: config_from field %q not in platform spec", "policy_keys")
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -530,6 +530,20 @@ config_from:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_RejectsConfigFromPolicyKeys(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action: create_flow_instance
+template: worker
+instance_id_from: payload.worker_id
+config_from:
+  policy_keys: [priority_profile]
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_PreservesEvidenceTarget(t *testing.T) {
 	var handler SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -20,6 +20,33 @@ compute:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_RejectsLegacyCreateFlowInstanceActionShape(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action:
+  type: create_flow_instance
+  flow_template: worker-flow
+  instance_id: "{{payload.instance_id}}"
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "DEPRECATED: legacy action field") {
+		t.Fatalf("yaml.Unmarshal error = %v, want legacy action field rejection", err)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsActionMappingMissingID(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action:
+  template: worker
+  instance_id_from: payload.instance_id
+  config_from:
+    owner: payload.owner
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "action mapping missing id") {
+		t.Fatalf("yaml.Unmarshal error = %v, want action mapping missing id", err)
+	}
+}
+
 func TestHandlerRuleEntryDecode_AcceptsSpecComputeMetadataFields(t *testing.T) {
 	var rule HandlerRuleEntry
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
@@ -50,12 +49,12 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 	entity := map[string]any{
 		"entity_id": entityID,
 	}
-	instanceID := strings.TrimSpace(firstNonEmptyString(
-		asString(payload["instance_id"]),
-		resolveFlowInstanceID(plan.InstanceIDPath, plan.InstanceIDFrom, payload, entity),
-	))
+	if !hasRequiredCreateFlowInstanceSiblings(plan) {
+		return fmt.Errorf("create_flow_instance requires non-empty instance_id_from and config_from")
+	}
+	instanceID := strings.TrimSpace(resolveFlowInstanceID(plan.InstanceIDPath, plan.InstanceIDFrom, payload, entity))
 	if instanceID == "" {
-		instanceID = uuid.NewString()
+		return fmt.Errorf("create_flow_instance instance_id_from resolved empty")
 	}
 	sourceEntityID := strings.TrimSpace(entityID)
 	instance := runtimeflowidentity.Derive(pc.SemanticSource(), templateID, instanceID)
@@ -74,13 +73,24 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 		Config:         map[string]any{},
 		TriggerEvent:   triggerCtx.Event,
 	}
-	if plan.ConfigFrom != nil {
-		req.Config = resolveFlowInstanceConfig(plan.ConfigFrom, payload, entity)
+	req.Config = resolveFlowInstanceConfig(plan.ConfigFrom, payload, entity)
+	if len(req.Config) == 0 {
+		return fmt.Errorf("create_flow_instance config_from resolved empty")
 	}
 	if err := pc.instanceActivator(ctx, req); err != nil {
 		return err
 	}
 	return nil
+}
+
+func hasRequiredCreateFlowInstanceSiblings(plan handlerExecutionPlan) bool {
+	if strings.TrimSpace(plan.InstanceIDFrom) == "" && !plan.InstanceIDPath.HasExplicitRoot() {
+		return false
+	}
+	if plan.ConfigFrom == nil {
+		return false
+	}
+	return len(plan.ConfigFrom.ConfigEntries()) > 0
 }
 
 func resolveFlowInstanceConfig(spec *runtimecontracts.ConfigFromSpec, payload, entity map[string]any) map[string]any {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"swarm/internal/events"
@@ -22,13 +23,18 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 	}
 	trigger := (events.Event{
 		Type:    events.EventType("custom.triggered"),
-		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
+		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`),
 	}).WithEntityID("ent-1")
 
 	ok := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
 		Template:       "review",
 		InstanceIDFrom: "payload.desired_instance_id",
 		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"name": "payload.name",
+			},
+		},
 	})
 	if ok != nil {
 		t.Fatalf("expected createFlowInstance to succeed: %v", ok)
@@ -79,6 +85,103 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 	}
 	if captured.Instance.SubjectID != "ent-1" {
 		t.Fatalf("subject id = %q, want ent-1", captured.Instance.SubjectID)
+	}
+}
+
+func TestCreateFlowInstanceRejectsMissingRequiredSiblingFields(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+	}).WithEntityID("ent-1")
+
+	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+		Template: "review",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
+		t.Fatalf("createFlowInstance error = %v, want missing required siblings", err)
+	}
+}
+
+func TestCreateFlowInstanceRejectsGeneratedFallbackWithoutInstanceIDFrom(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+	}).WithEntityID("ent-1")
+
+	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+		Template: "review",
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"name": "payload.name",
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
+		t.Fatalf("createFlowInstance error = %v, want missing instance_id_from failure", err)
+	}
+}
+
+func TestCreateFlowInstanceRejectsEmptyConfigFromBindings(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
+	}).WithEntityID("ent-1")
+
+	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.desired_instance_id",
+		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
+		t.Fatalf("createFlowInstance error = %v, want missing config_from failure", err)
+	}
+}
+
+func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
+	}).WithEntityID("ent-1")
+
+	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.desired_instance_id",
+		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"name": "payload.missing_name",
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "config_from resolved empty") {
+		t.Fatalf("createFlowInstance error = %v, want empty resolved config failure", err)
 	}
 }
 


### PR DESCRIPTION
Part of #415

## Summary
- fail closed on the full current-spec `create_flow_instance` required-sibling class
- absorb the legacy action-shape decode seam so legacy `action: { type, flow_template, instance_id }` no longer collapses to empty `ActionSpec`
- reject runtime `create_flow_instance` activation when `instance_id_from` or `config_from` is missing/empty, including the old generated logical instance id fallback
- reclassify invalid legacy/missing-sibling catalog fixtures as excluded pending authored fixture migration in `#416`

## Governing spec refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `action.valid_values.create_flow_instance.required_sibling_fields`

## Proof
- real verify now fails closed on legacy-shaped fixtures
- canonical-shaped `create_flow_instance` fixture still verifies
- full affected runtime package tests passed
- `go test ./... -count=1` passed

## Out of scope
- authored contract / fixture migration in `#416`
- parent retarget removal
- cross-flow `get_entity` rejection
- backprop removal
- subject cleanup
