### PR TITLE
[agent-a][issue #424] Reconcile session lineage with delivery frontier

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -85,6 +85,14 @@ active_issues:
     title: Expose recovery and restart decisions through canonical diagnostics
     maps_to:
       - recovery_restart_diagnostics
+  - id: 410
+    title: Reconcile run, session, and delivery lifecycle truth on the supported path
+    maps_to:
+      - runtime_lifecycle_observability
+  - id: 424
+    title: Reconcile stale active agent sessions against the delivery frontier on the supported path
+    maps_to:
+      - runtime_lifecycle_observability
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -247,8 +255,11 @@ nodes:
       - launch lifecycle is not exposed clearly enough
       - stalled runs and healthy running state look too similar
       - long-running or no-output sessions require log archaeology instead of first-class visibility
+      - persisted agent_sessions can remain active after the canonical same-run delivery frontier has narrowed
     representative_issues:
       - 175
+      - 410
+      - 424
     common_framing_mistakes:
       too_broad:
         - observability is weak

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -297,11 +297,11 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 	}
 
 	var (
-		deliveryStatus    string
-		activeSessionID   string
-		sessionStatus     string
-		sessionScopeKey   string
-		liveSessionCount  int
+		deliveryStatus   string
+		activeSessionID  string
+		sessionStatus    string
+		sessionScopeKey  string
+		liveSessionCount int
 	)
 	if err := db.QueryRowContext(ctx, `
 		SELECT COALESCE(status, ''), COALESCE(active_session_id::text, '')

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,9 +31,22 @@ import (
 	runtimesemanticview "swarm/internal/runtime/semanticview"
 	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
+	runtimeworkspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
+
+type staticWorkspaceResolver struct {
+	target *runtimeworkspace.Target
+	err    error
+}
+
+func (s staticWorkspaceResolver) ResolveWorkspace(context.Context, runtimeactors.AgentConfig) (*runtimeworkspace.Target, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.target, nil
+}
 
 func acquireLiveConversationSession(t *testing.T, ctx context.Context, db *sql.DB, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, scopeKey string) string {
 	t.Helper()
@@ -356,6 +370,159 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 	}
 	if got := facts["agent-1"].BlockingLayer; got != "session_execution" {
 		t.Fatalf("lifecycle blocking_layer = %q, want session_execution", got)
+	}
+}
+
+func TestRotatedLiveSessionRebindsDeliveryFrontierToSuccessorSession(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	requireCanonicalDeliveryLifecycleSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	eventID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("review.requested"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"turn":1}`),
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{"agent-1"}); err != nil {
+		t.Fatalf("InsertEventDeliveries: %v", err)
+	}
+
+	dockerState := filepath.Join(t.TempDir(), "fake-docker-count")
+	fakeDocker := filepath.Join(t.TempDir(), "docker")
+	script := `#!/bin/sh
+state="$SWARM_FAKE_DOCKER_STATE"
+count=0
+if [ -f "$state" ]; then
+  count=$(cat "$state")
+fi
+count=$((count + 1))
+printf "%s" "$count" > "$state"
+if [ "$count" -eq 1 ]; then
+  printf "session not found" >&2
+  exit 1
+fi
+printf '{"result":"ok"}'
+`
+	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", fakeDocker)
+	t.Setenv("SWARM_FAKE_DOCKER_STATE", dockerState)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	runtime := runtimellm.NewClaudeCLIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeCLI: config.ClaudeCLIConfig{
+				Command:      "claude",
+				OutputFormat: "json",
+			},
+		},
+	}, registry, "worker-1", nil, nil, staticWorkspaceResolver{
+		target: &runtimeworkspace.Target{
+			Container: "swarm-agent-1",
+			Workdir:   "/workspace",
+		},
+	}, pg, bus)
+
+	newTurnContext := func(evt events.Event) context.Context {
+		base := runtimesessions.WithScope(context.Background(), runtimesessions.RuntimeModeSession.String(), runtimesessions.SessionScopeGlobal.String(), "global")
+		base = runtimecorrelation.WithRunID(base, runID)
+		base = runtimebus.WithInboundEvent(base, evt)
+		return runtimeactors.WithActor(base, runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Type:             "stub",
+			SessionScope:     runtimesessions.SessionScopeGlobal.String(),
+			ConversationMode: runtimesessions.RuntimeModeSession.String(),
+		})
+	}
+
+	session, err := runtime.StartSession(newTurnContext(evt), "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	originalSessionID := session.ID
+	if err := pg.MarkEventDeliveryInProgress(newTurnContext(evt), evt.ID, "agent-1", ""); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress(prelaunch): %v", err)
+	}
+	resp, err := runtime.ContinueSession(newTurnContext(evt), session, runtimellm.Message{Role: "user", Content: "rotate me"})
+	if err != nil {
+		t.Fatalf("ContinueSession: %v", err)
+	}
+	if resp == nil || strings.TrimSpace(resp.Message.Content) != "ok" {
+		t.Fatalf("response = %#v, want assistant ok", resp)
+	}
+	if session.ID == originalSessionID {
+		t.Fatalf("session ID did not rotate; got %q", session.ID)
+	}
+
+	var (
+		deliveryStatus         string
+		activeSessionID        string
+		predecessorStatus      string
+		successorStatus        string
+		successorRetriesFromID string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(active_session_id::text, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-1'
+	`, evt.ID).Scan(&deliveryStatus, &activeSessionID); err != nil {
+		t.Fatalf("load delivery: %v", err)
+	}
+	if deliveryStatus != "in_progress" {
+		t.Fatalf("delivery status = %q, want in_progress", deliveryStatus)
+	}
+	if activeSessionID != session.ID {
+		t.Fatalf("delivery active_session_id = %q, want %q", activeSessionID, session.ID)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, originalSessionID).Scan(&predecessorStatus); err != nil {
+		t.Fatalf("load predecessor session: %v", err)
+	}
+	if predecessorStatus != "terminated" {
+		t.Fatalf("predecessor status = %q, want terminated", predecessorStatus)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(status, ''),
+			COALESCE(runtime_state->>'retries_from_session_id', '')
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, session.ID).Scan(&successorStatus, &successorRetriesFromID); err != nil {
+		t.Fatalf("load successor session: %v", err)
+	}
+	if successorStatus != "active" {
+		t.Fatalf("successor status = %q, want active", successorStatus)
+	}
+	if successorRetriesFromID != originalSessionID {
+		t.Fatalf("successor retries_from_session_id = %q, want %q", successorRetriesFromID, originalSessionID)
 	}
 }
 

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimediaglog "swarm/internal/runtime/diaglog"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -188,6 +191,178 @@ func TestCanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader(t *
 	if items[0].Metadata.Watchdog.Outcome != "warning_emitted" {
 		t.Fatalf("list watchdog outcome = %q, want warning_emitted", items[0].Metadata.Watchdog.Outcome)
 	}
+}
+
+func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalConversationSurface(t, ctx, pg)
+	requireCanonicalDeliveryLifecycleSurface(t, ctx, pg)
+	seedConformanceAgent(t, ctx, pg, "agent-1")
+
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	event1 := events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("review.requested"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"turn":1}`),
+		CreatedAt:   time.Now().Add(-2 * time.Minute).UTC(),
+	}
+	event2 := events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("review.requested"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"turn":2}`),
+		CreatedAt:   time.Now().Add(-1 * time.Minute).UTC(),
+	}
+	for _, evt := range []events.Event{event1, event2} {
+		if err := pg.AppendEvent(ctx, evt); err != nil {
+			t.Fatalf("AppendEvent(%s): %v", evt.ID, err)
+		}
+		if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{"agent-1"}); err != nil {
+			t.Fatalf("InsertEventDeliveries(%s): %v", evt.ID, err)
+		}
+	}
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			Body: io.NopCloser(strings.NewReader(`{
+				"model":"claude-test",
+				"usage":{"input_tokens":1,"output_tokens":1},
+				"content":[{"type":"text","text":"ok"}]
+			}`)),
+			Request: req,
+		}, nil
+	})
+	defer func() {
+		http.DefaultTransport = previousTransport
+	}()
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
+	runtime := runtimellm.NewAnthropicAPIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeAPI: config.ClaudeAPIConfig{
+				DefaultModel: "claude-test",
+			},
+		},
+	}, registry, "worker-1", nil, pg, nil, bus)
+
+	newTurnContext := func(evt events.Event) context.Context {
+		base := runtimesessions.WithScope(context.Background(), runtimesessions.RuntimeModeSession.String(), runtimesessions.SessionScopeGlobal.String(), "global")
+		base = runtimecorrelation.WithRunID(base, runID)
+		base = runtimebus.WithInboundEvent(base, evt)
+		return runtimeactors.WithActor(base, runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Type:             "stub",
+			SessionScope:     runtimesessions.SessionScopeGlobal.String(),
+			ConversationMode: runtimesessions.RuntimeModeSession.String(),
+		})
+	}
+
+	session, err := runtime.StartSession(newTurnContext(event1), "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if _, err := runtime.ContinueSession(newTurnContext(event1), session, runtimellm.Message{Role: "user", Content: "first"}); err != nil {
+		t.Fatalf("ContinueSession(first): %v", err)
+	}
+	if err := pg.UpsertEventReceipt(newTurnContext(event1), event1.ID, "agent-1", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("UpsertEventReceipt(first): %v", err)
+	}
+
+	if err := pg.MarkEventDeliveryInProgress(newTurnContext(event2), event2.ID, "agent-1", ""); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress(second prelaunch): %v", err)
+	}
+	if _, err := runtime.ContinueSession(newTurnContext(event2), session, runtimellm.Message{Role: "user", Content: "second"}); err != nil {
+		t.Fatalf("ContinueSession(second): %v", err)
+	}
+
+	var (
+		deliveryStatus    string
+		activeSessionID   string
+		sessionStatus     string
+		sessionScopeKey   string
+		liveSessionCount  int
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(active_session_id::text, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-1'
+	`, event2.ID).Scan(&deliveryStatus, &activeSessionID); err != nil {
+		t.Fatalf("load second delivery: %v", err)
+	}
+	if deliveryStatus != "in_progress" {
+		t.Fatalf("second delivery status = %q, want in_progress", deliveryStatus)
+	}
+	if activeSessionID != session.ID {
+		t.Fatalf("second delivery active_session_id = %q, want %q", activeSessionID, session.ID)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(status, ''),
+			COALESCE(scope_key, '')
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, session.ID).Scan(&sessionStatus, &sessionScopeKey); err != nil {
+		t.Fatalf("load live session row: %v", err)
+	}
+	if sessionStatus != "active" {
+		t.Fatalf("session status = %q, want active", sessionStatus)
+	}
+	if sessionScopeKey != "global" {
+		t.Fatalf("session scope_key = %q, want global", sessionScopeKey)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_sessions
+		WHERE agent_id = 'agent-1'
+		  AND scope_key = 'global'
+		  AND runtime_mode = 'session'
+		  AND status = 'active'
+	`).Scan(&liveSessionCount); err != nil {
+		t.Fatalf("count live session lineage: %v", err)
+	}
+	if liveSessionCount != 1 {
+		t.Fatalf("live session lineage count = %d, want 1", liveSessionCount)
+	}
+
+	facts, err := pg.ListAgentLifecycleFacts(ctx, []string{"agent-1"})
+	if err != nil {
+		t.Fatalf("ListAgentLifecycleFacts: %v", err)
+	}
+	if got := facts["agent-1"].CurrentState; got != "active" {
+		t.Fatalf("lifecycle current_state = %q, want active", got)
+	}
+	if got := facts["agent-1"].BlockingLayer; got != "session_execution" {
+		t.Fatalf("lifecycle blocking_layer = %q, want session_execution", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func TestConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions(t *testing.T) {

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -188,11 +188,11 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 			s.ID = lease.SessionID
 		}
 	}
-	if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
-		logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the reused agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
-			"runtime_mode": resolved.RuntimeMode.String(),
-			"scope_key":    resolved.ScopeKey,
-		}, err)
+	if err := requireInboundDeliveryActiveForSession(ctx, r.events, s, "error", "Marking the reused agent delivery in progress failed", map[string]any{
+		"runtime_mode": resolved.RuntimeMode.String(),
+		"scope_key":    resolved.ScopeKey,
+	}, entityID); err != nil {
+		return nil, fmt.Errorf("mark inbound delivery active for reused api session: %w", err)
 	}
 
 	if strings.TrimSpace(r.apiKey) == "" {

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -188,6 +188,12 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 			s.ID = lease.SessionID
 		}
 	}
+	if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the reused agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
+			"runtime_mode": resolved.RuntimeMode.String(),
+			"scope_key":    resolved.ScopeKey,
+		}, err)
+	}
 
 	if strings.TrimSpace(r.apiKey) == "" {
 		return nil, errors.New("ANTHROPIC_API_KEY is required for api runtime mode")

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -232,11 +232,11 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 			s.ProviderSessionID = sid
 		}
 	}
-	if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
-		logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the reused agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
-			"runtime_mode": resolved.RuntimeMode.String(),
-			"scope_key":    resolved.ScopeKey,
-		}, err)
+	if err := requireInboundDeliveryActiveForSession(ctx, r.events, s, "error", "Marking the reused agent delivery in progress failed", map[string]any{
+		"runtime_mode": resolved.RuntimeMode.String(),
+		"scope_key":    resolved.ScopeKey,
+	}, entityID); err != nil {
+		return nil, fmt.Errorf("mark inbound delivery active for reused cli session: %w", err)
 	}
 	target, err := r.resolveWorkspace(ctx)
 	if err != nil {
@@ -369,11 +369,11 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					s.Messages = []Message{{Role: "system", Content: "Session rotated due to CLI runtime recovery."}}
 				}
 				LogSessionRotatedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), oldSessionID, rotated.SessionID, resolved.ScopeKey, rotateReason, oldTurnCount, oldParseFailures)
-				if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
-					logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the rotated agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
-						"runtime_mode": resolved.RuntimeMode.String(),
-						"scope_key":    resolved.ScopeKey,
-					}, err)
+				if err := requireInboundDeliveryActiveForSession(ctx, r.events, s, "error", "Marking the rotated agent delivery in progress failed", map[string]any{
+					"runtime_mode": resolved.RuntimeMode.String(),
+					"scope_key":    resolved.ScopeKey,
+				}, entityID); err != nil {
+					return nil, fmt.Errorf("mark inbound delivery active for rotated cli session: %w", err)
 				}
 				args = []string{
 					"-p",

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -232,6 +232,12 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 			s.ProviderSessionID = sid
 		}
 	}
+	if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the reused agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
+			"runtime_mode": resolved.RuntimeMode.String(),
+			"scope_key":    resolved.ScopeKey,
+		}, err)
+	}
 	target, err := r.resolveWorkspace(ctx)
 	if err != nil {
 		return nil, err
@@ -363,6 +369,12 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					s.Messages = []Message{{Role: "system", Content: "Session rotated due to CLI runtime recovery."}}
 				}
 				LogSessionRotatedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), oldSessionID, rotated.SessionID, resolved.ScopeKey, rotateReason, oldTurnCount, oldParseFailures)
+				if _, err := markInboundDeliveryActiveForSession(ctx, r.events, s); err != nil {
+					logPublisherRuntime(ctx, r.events, "error", "mark_delivery_in_progress_failed", "Marking the rotated agent delivery in progress failed", s.AgentID, s.ID, entityID, map[string]any{
+						"runtime_mode": resolved.RuntimeMode.String(),
+						"scope_key":    resolved.ScopeKey,
+					}, err)
+				}
 				args = []string{
 					"-p",
 					"--session-id", sessionToken(s),

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -17,7 +17,7 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 	if publisher == nil || session == nil || strings.TrimSpace(session.AgentID) == "" {
 		return
 	}
-	marked, err := publisher.MarkDeliveryInProgress(ctx, session.AgentID, session.ID)
+	marked, err := markInboundDeliveryActiveForSession(ctx, publisher, session)
 	if err != nil {
 		logPublisherRuntime(ctx, publisher, "error", "mark_delivery_in_progress_failed", "Marking the agent delivery in progress failed", session.AgentID, session.ID, "", nil, err)
 	} else if marked {
@@ -70,6 +70,18 @@ func publishAgentStarted(ctx context.Context, publisher EventPublisher, session 
 			"event_type": strings.TrimSpace(string(eventType)),
 		}, err)
 	}
+}
+
+func markInboundDeliveryActiveForSession(ctx context.Context, publisher EventPublisher, session *Session) (bool, error) {
+	if publisher == nil || session == nil {
+		return false, nil
+	}
+	agentID := strings.TrimSpace(session.AgentID)
+	sessionID := strings.TrimSpace(session.ID)
+	if agentID == "" || sessionID == "" {
+		return false, nil
+	}
+	return publisher.MarkDeliveryInProgress(ctx, agentID, sessionID)
 }
 
 func sessionModelTier(actor runtimeactors.AgentConfig) string {

--- a/internal/runtime/llm/session_events.go
+++ b/internal/runtime/llm/session_events.go
@@ -10,6 +10,7 @@ import (
 	"swarm/internal/events"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
+	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/sessions"
 )
 
@@ -82,6 +83,18 @@ func markInboundDeliveryActiveForSession(ctx context.Context, publisher EventPub
 		return false, nil
 	}
 	return publisher.MarkDeliveryInProgress(ctx, agentID, sessionID)
+}
+
+func requireInboundDeliveryActiveForSession(ctx context.Context, publisher EventPublisher, session *Session, level diaglog.Level, message string, detail map[string]any, entityID string) error {
+	if publisher == nil || session == nil {
+		return nil
+	}
+	_, err := markInboundDeliveryActiveForSession(ctx, publisher, session)
+	if err == nil {
+		return nil
+	}
+	logPublisherRuntime(ctx, publisher, level, "mark_delivery_in_progress_failed", message, session.AgentID, session.ID, entityID, detail, err)
+	return err
 }
 
 func sessionModelTier(actor runtimeactors.AgentConfig) string {

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -605,6 +607,61 @@ func TestClaudeCLIRuntime_StartSessionLoadsRetryLineage(t *testing.T) {
 	}
 	if s.TurnCount != 2 || len(s.Messages) != 1 {
 		t.Fatalf("unexpected restored session: %+v", s)
+	}
+}
+
+func TestAnthropicAPIRuntime_ContinueSessionReMarksInboundDeliveryForReusedSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model":"claude-test",
+			"usage":{"input_tokens":1,"output_tokens":1},
+			"content":[{"type":"text","text":"ok"}]
+		}`))
+	}))
+	defer server.Close()
+
+	publisher := &eventPublisherStub{}
+	runtime := NewAnthropicAPIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeAPI: config.ClaudeAPIConfig{
+				DefaultModel: "claude-test",
+			},
+		},
+	}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, publisher)
+	runtime.apiURL = server.URL
+	runtime.apiKey = "test-key"
+	runtime.httpClient = server.Client()
+
+	ctx := runtimeactors.WithActor(
+		runtimebus.WithInboundEvent(
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeGlobal.String(), "global"),
+			events.Event{ID: "evt-1"},
+		),
+		runtimeactors.AgentConfig{
+			ID:           "agent-1",
+			Type:         "sonnet",
+			SessionScope: sessions.SessionScopeGlobal.String(),
+		},
+	)
+
+	s, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if len(publisher.marks) != 1 {
+		t.Fatalf("start-session marks = %d, want 1", len(publisher.marks))
+	}
+	publisher.marks = nil
+
+	if _, err := runtime.ContinueSession(ctx, s, Message{Role: "user", Content: "hello"}); err != nil {
+		t.Fatalf("ContinueSession: %v", err)
+	}
+	if len(publisher.marks) != 1 {
+		t.Fatalf("continue-session marks = %d, want 1", len(publisher.marks))
+	}
+	if got := publisher.marks[0]; got != "agent-1|"+s.ID {
+		t.Fatalf("continue-session mark = %q, want %q", got, "agent-1|"+s.ID)
 	}
 }
 

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -665,6 +665,80 @@ func TestAnthropicAPIRuntime_ContinueSessionReMarksInboundDeliveryForReusedSessi
 	}
 }
 
+func TestAnthropicAPIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *testing.T) {
+	publisher := &eventPublisherStub{}
+	runtime := NewAnthropicAPIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeAPI: config.ClaudeAPIConfig{
+				DefaultModel: "claude-test",
+			},
+		},
+	}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, publisher)
+	ctx := runtimeactors.WithActor(
+		runtimebus.WithInboundEvent(
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeGlobal.String(), "global"),
+			events.Event{ID: "evt-1"},
+		),
+		runtimeactors.AgentConfig{
+			ID:           "agent-1",
+			Type:         "sonnet",
+			SessionScope: sessions.SessionScopeGlobal.String(),
+		},
+	)
+
+	s, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	publisher.marks = nil
+	publisher.markErr = errors.New("mark boom")
+
+	_, err = runtime.ContinueSession(ctx, s, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "mark inbound delivery active for reused api session: mark boom") {
+		t.Fatalf("ContinueSession err = %v, want mark failure", err)
+	}
+	if len(publisher.runtimeLogs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(publisher.runtimeLogs))
+	}
+	if publisher.runtimeLogs[0].Action != "mark_delivery_in_progress_failed" {
+		t.Fatalf("runtime log action = %q, want mark_delivery_in_progress_failed", publisher.runtimeLogs[0].Action)
+	}
+}
+
+func TestClaudeCLIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *testing.T) {
+	publisher := &eventPublisherStub{}
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, publisher)
+	ctx := runtimeactors.WithActor(
+		runtimebus.WithInboundEvent(
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeGlobal.String(), "global"),
+			events.Event{ID: "evt-1"},
+		),
+		runtimeactors.AgentConfig{
+			ID:           "agent-1",
+			Type:         "sonnet",
+			SessionScope: sessions.SessionScopeGlobal.String(),
+		},
+	)
+
+	s, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	publisher.marks = nil
+	publisher.markErr = errors.New("mark boom")
+
+	_, err = runtime.ContinueSession(ctx, s, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "mark inbound delivery active for reused cli session: mark boom") {
+		t.Fatalf("ContinueSession err = %v, want mark failure", err)
+	}
+	if len(publisher.runtimeLogs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(publisher.runtimeLogs))
+	}
+	if publisher.runtimeLogs[0].Action != "mark_delivery_in_progress_failed" {
+		t.Fatalf("runtime log action = %q, want mark_delivery_in_progress_failed", publisher.runtimeLogs[0].Action)
+	}
+}
+
 func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), "run-123")
 	ctx = runtimebus.WithInboundEvent(ctx, (events.Event{


### PR DESCRIPTION
Closes #424

## Summary
- re-mark inbound deliveries with the canonical session ID when API and CLI runtimes continue an existing session
- re-mark the inbound delivery again when the CLI runtime rotates to a successor session mid-turn
- add focused runtime and supported persisted-surface proofs for reused-session frontier/session reconciliation

## Governing Context
- No exact governing spec section exists for this reconciliation seam.
- Binding authority for this PR is the approved `#424` pre-audit and gate record, extracted from parent `#410`.
- Adjacent contract context used to constrain the seam:
  - `session_termination_metadata`
  - `agent_sessions`
  - `event_deliveries`
  - all in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Scope Boundary
- This PR stays inside the approved child: write-side session termination/successor/stale-active-session reconciliation against the delivery frontier.
- It does not widen into bootstrap run terminal convergence.
- It does not widen into `cmd/swarm status` or other reader/projection cleanup.

## Semantic Migration
- New canonical owner: the runtime session execution paths now stamp the active inbound delivery with the authoritative session ID at session start, reuse, and CLI rotation.
- Old non-authoritative path: the manager launch-time `MarkEventDeliveryInProgress(..., "")` prelaunch write is no longer sufficient to represent reused-session activity by itself.
- Production paths checked for surviving old behavior:
  - API `ContinueSession(...)` on reused sessions
  - CLI `ContinueSession(...)` on reused sessions
  - CLI rotate-and-retry successor session path
  - reset/orphan cleanup preservation
  - successor-session lineage preservation
- Migration completeness: complete for the approved `#424` child class.

## Validation
- `go test ./internal/runtime/llm -run 'TestAnthropicAPIRuntime_ContinueSessionReMarksInboundDeliveryForReusedSession$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(ReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession|ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader)$' -count=1`
- `go test ./internal/store -run 'TestManagerStore_LoadActiveConversationIncludesRetryLineage$' -count=1`
- `go test ./internal/runtime/sessions -run 'Test(PostgresSessionRegistry_Rotate_And_IncrementTurn|PostgresSessionRegistry_ResetAll)$' -count=1`
- `go test ./internal/runtime/llm ./internal/runtime/conformance ./internal/store -count=1`
- `go test ./... -count=1`