### PR TITLE
[agent-e][issue #427] Converge standalone runtime platform runs

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -77,7 +77,10 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
 	}()
 	if txStore, ok := eb.store.(TransactionalEventStore); ok {
-		return eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore)
+		if err := eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore); err != nil {
+			return err
+		}
+		return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
 	}
 
 	persisted := false
@@ -119,7 +122,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 			return err
 		}
 	}
-	return nil
+	return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
 }
 
 func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, error) {
@@ -130,6 +133,17 @@ func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, 
 		return provider.CanonicalEventReceiptsCapability
 	}
 	return nil
+}
+
+func (eb *EventBus) convergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error {
+	if eb == nil || eb.store == nil {
+		return nil
+	}
+	converger, ok := eb.store.(StandaloneRuntimePlatformRunConvergencePersistence)
+	if !ok || converger == nil {
+		return nil
+	}
+	return converger.ConvergeStandaloneRuntimePlatformRun(ctx, evt)
 }
 
 func (eb *EventBus) publishTransactional(

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -2,6 +2,7 @@ package bus_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"slices"
@@ -14,11 +15,13 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/flowmodel"
+	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/runtime/semanticview"
@@ -275,6 +278,73 @@ func assertSortedStringsEqual(t *testing.T, got, want []string) {
 			t.Fatalf("strings = %v, want %v", got, want)
 		}
 	}
+}
+
+func seedActiveRuntimeBusAgent(t *testing.T, ctx context.Context, pg *store.PostgresStore, agentID string) {
+	t.Helper()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:     agentID,
+			Role:   "observer",
+			Mode:   "global",
+			Type:   "stub",
+			Config: []byte(`{}`),
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
+}
+
+func loadRunStateForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) (string, string, string) {
+	t.Helper()
+	var runID, runStatus, triggerEventType string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(r.run_id::text, ''),
+			COALESCE(r.status, ''),
+			COALESCE(r.trigger_event_type, '')
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = $1::uuid
+	`, eventID).Scan(&runID, &runStatus, &triggerEventType); err != nil {
+		t.Fatalf("load run state for %s: %v", eventID, err)
+	}
+	return runID, runStatus, triggerEventType
+}
+
+func countEventDeliveriesForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count event deliveries for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func loadAgentDeliveryForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID, agentID string) (string, string) {
+	t.Helper()
+	var status, runStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.status, ''),
+			COALESCE(r.status, '')
+		FROM event_deliveries d
+		INNER JOIN runs r ON r.run_id = d.run_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $2
+	`, eventID, agentID).Scan(&status, &runStatus); err != nil {
+		t.Fatalf("load delivery state for %s/%s: %v", eventID, agentID, err)
+	}
+	return status, runStatus
 }
 
 func TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition(t *testing.T) {
@@ -884,6 +954,157 @@ func TestEventBusPublish_RuntimeLogBypassesContradictionRouting(t *testing.T) {
 	got := store.eventTypes()
 	if len(got) != 1 || got[0] != "platform.runtime_log" {
 		t.Fatalf("persisted event types = %v, want [platform.runtime_log]", got)
+	}
+}
+
+func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersistedDeliveries(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		eventID   string
+		eventType events.EventType
+	}{
+		{
+			name:      "platform.boot",
+			eventID:   "10000000-0000-0000-0000-000000000001",
+			eventType: events.EventType("platform.boot"),
+		},
+		{
+			name:      "platform.recovery_failed",
+			eventID:   "10000000-0000-0000-0000-000000000002",
+			eventType: events.EventType("platform.recovery_failed"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			internal := eb.SubscribeInternal("internal-"+string(tc.eventType), tc.eventType)
+			defer eb.Unsubscribe("internal-" + string(tc.eventType))
+
+			if err := eb.Publish(ctx, events.Event{
+				ID:          tc.eventID,
+				Type:        tc.eventType,
+				SourceAgent: "runtime",
+				Payload:     []byte(`{}`),
+				CreatedAt:   time.Now().UTC(),
+			}); err != nil {
+				t.Fatalf("Publish(%s): %v", tc.eventType, err)
+			}
+
+			select {
+			case got := <-internal:
+				if got.ID != tc.eventID {
+					t.Fatalf("internal delivery event_id = %q, want %q", got.ID, tc.eventID)
+				}
+			case <-time.After(250 * time.Millisecond):
+				t.Fatalf("timed out waiting for internal %s delivery", tc.eventType)
+			}
+
+			runID, runStatus, triggerEventType := loadRunStateForEvent(t, ctx, db, tc.eventID)
+			if strings.TrimSpace(runID) == "" {
+				t.Fatalf("run_id missing for %s", tc.eventType)
+			}
+			if runStatus != "completed" {
+				t.Fatalf("run status for %s = %q, want completed", tc.eventType, runStatus)
+			}
+			if triggerEventType != string(tc.eventType) {
+				t.Fatalf("trigger_event_type for %s = %q, want %q", tc.eventType, triggerEventType, tc.eventType)
+			}
+			if got := countEventDeliveriesForEvent(t, ctx, db, tc.eventID); got != 0 {
+				t.Fatalf("event_deliveries for %s = %d, want 0", tc.eventType, got)
+			}
+		})
+	}
+}
+
+func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalReceipt(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	agentID := "agent-runtime-owned-platform"
+	seedActiveRuntimeBusAgent(t, ctx, pg, agentID)
+
+	testCases := []struct {
+		name      string
+		eventID   string
+		eventType events.EventType
+	}{
+		{
+			name:      "manager platform.agent_failed",
+			eventID:   "20000000-0000-0000-0000-000000000001",
+			eventType: events.EventType("platform.agent_failed"),
+		},
+		{
+			name:      "receipts platform.paused",
+			eventID:   "20000000-0000-0000-0000-000000000002",
+			eventType: events.EventType("platform.paused"),
+		},
+		{
+			name:      "budget platform.budget_threshold_crossed",
+			eventID:   "20000000-0000-0000-0000-000000000003",
+			eventType: events.EventType("platform.budget_threshold_crossed"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subscription := eb.Subscribe(agentID, tc.eventType)
+			defer eb.Unsubscribe(agentID)
+
+			if err := eb.Publish(ctx, events.Event{
+				ID:          tc.eventID,
+				Type:        tc.eventType,
+				SourceAgent: "runtime",
+				Payload:     []byte(`{}`),
+				CreatedAt:   time.Now().UTC(),
+			}); err != nil {
+				t.Fatalf("Publish(%s): %v", tc.eventType, err)
+			}
+
+			select {
+			case got := <-subscription:
+				if got.ID != tc.eventID {
+					t.Fatalf("delivered event_id = %q, want %q", got.ID, tc.eventID)
+				}
+			case <-time.After(250 * time.Millisecond):
+				t.Fatalf("timed out waiting for agent delivery of %s", tc.eventType)
+			}
+
+			if got := countEventDeliveriesForEvent(t, ctx, db, tc.eventID); got != 1 {
+				t.Fatalf("event_deliveries for %s = %d, want 1", tc.eventType, got)
+			}
+			if deliveryStatus, runStatus := loadAgentDeliveryForEvent(t, ctx, db, tc.eventID, agentID); deliveryStatus != "pending" || runStatus != "running" {
+				t.Fatalf("pre-receipt state for %s = delivery:%q run:%q, want pending/running", tc.eventType, deliveryStatus, runStatus)
+			}
+
+			if err := pg.UpsertEventReceipt(ctx, tc.eventID, agentID, runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+				t.Fatalf("UpsertEventReceipt(%s): %v", tc.eventType, err)
+			}
+
+			deliveryStatus, runStatus := loadAgentDeliveryForEvent(t, ctx, db, tc.eventID, agentID)
+			if deliveryStatus != "delivered" {
+				t.Fatalf("delivery status for %s = %q, want delivered", tc.eventType, deliveryStatus)
+			}
+			if runStatus != "completed" {
+				t.Fatalf("run status for %s = %q, want completed", tc.eventType, runStatus)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -67,6 +67,10 @@ type RunLifecyclePersistence interface {
 	MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error
 }
 
+type StandaloneRuntimePlatformRunConvergencePersistence interface {
+	ConvergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error
+}
+
 type RunLifecycleSnapshot struct {
 	RunID        string
 	Status       string

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -47,7 +47,7 @@ func (s *PostgresStore) UpsertEventReceipt(ctx context.Context, eventID, agentID
 	}
 	switch caps.Events.Receipts {
 	case SchemaFlavorCanonical:
-		return s.upsertAgentReceiptSpec(ctx, eventID, agentID, status, errText)
+		return s.upsertAgentReceiptSpec(ctx, caps, eventID, agentID, status, errText)
 	default:
 		return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
 	}
@@ -142,7 +142,7 @@ type deliveryBackedTerminalTransitionRequest struct {
 
 // Receipts are outcome-only for an existing agent delivery. This write path must
 // never mint or repair delivery ownership from receipt state.
-func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSchemaCapabilities, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
 	return withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
@@ -173,6 +173,9 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, eventID, age
 			if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
 				return err
 			}
+		}
+		if err := s.convergeStandaloneRuntimePlatformRunByEventID(ctx, tx, caps, eventID); err != nil {
+			return err
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("commit event receipt tx: %w", err)

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -143,7 +143,7 @@ type deliveryBackedTerminalTransitionRequest struct {
 // Receipts are outcome-only for an existing agent delivery. This write path must
 // never mint or repair delivery ownership from receipt state.
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSchemaCapabilities, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
-	return withEventStoreRetry(ctx, nil, func() error {
+	if err := withEventStoreRetry(ctx, nil, func() error {
 		tx, err := s.DB.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("begin event receipt tx: %w", err)
@@ -174,14 +174,14 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSc
 				return err
 			}
 		}
-		if err := s.convergeStandaloneRuntimePlatformRunByEventID(ctx, tx, caps, eventID); err != nil {
-			return err
-		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("commit event receipt tx: %w", err)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	return s.convergeStandaloneRuntimePlatformRunByEventID(ctx, s.DB, caps, eventID)
 }
 
 func buildAgentReceiptWriteState(baseRetryCount int, status runtimemanager.ReceiptStatus, errText string) agentReceiptWriteState {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -857,6 +857,14 @@ func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status, erro
 	return err
 }
 
+func (s *PostgresStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	return s.convergeStandaloneRuntimePlatformRunByEventID(ctx, s.DB, caps, strings.TrimSpace(evt.ID))
+}
+
 func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {
 	return storerunlifecycle.EnsureActiveOptions{
 		HasStartedAtCol: caps.Events.RunStartedAt,
@@ -864,6 +872,137 @@ func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureA
 		HasCounterCols:  caps.Events.RunCounterColumns,
 		HasTerminalCols: caps.Events.RunTerminalFields,
 	}
+}
+
+type standaloneRuntimePlatformRunRecord struct {
+	RunID            string
+	RunStatus        string
+	EventID          string
+	EventType        string
+	ProducedBy       string
+	ProducedByType   string
+	SourceEventID    string
+	TriggerEventID   string
+	TriggerEventType string
+}
+
+func isStandaloneRuntimePlatformEventType(eventType string) bool {
+	switch strings.TrimSpace(eventType) {
+	case "platform.boot",
+		"platform.recovery_failed",
+		"platform.event_quarantined",
+		"platform.agent_panic",
+		"platform.agent_failed",
+		"platform.auth_required",
+		"platform.paused",
+		"platform.dead_letter_escalation",
+		"platform.budget_threshold_crossed":
+		return true
+	default:
+		return false
+	}
+}
+
+func loadStandaloneRuntimePlatformRunRecord(ctx context.Context, db storerunlifecycle.DBTX, eventID string) (standaloneRuntimePlatformRunRecord, bool, error) {
+	eventID = sanitizeOptionalUUID(eventID)
+	if db == nil || eventID == "" {
+		return standaloneRuntimePlatformRunRecord{}, false, nil
+	}
+	var rec standaloneRuntimePlatformRunRecord
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(r.run_id::text, ''),
+			COALESCE(r.status, ''),
+			COALESCE(e.event_id::text, ''),
+			COALESCE(e.event_name, ''),
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.produced_by_type, ''),
+			COALESCE(e.source_event_id::text, ''),
+			COALESCE(r.trigger_event_id::text, ''),
+			COALESCE(r.trigger_event_type, '')
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = $1::uuid
+		LIMIT 1
+	`, eventID).Scan(
+		&rec.RunID,
+		&rec.RunStatus,
+		&rec.EventID,
+		&rec.EventType,
+		&rec.ProducedBy,
+		&rec.ProducedByType,
+		&rec.SourceEventID,
+		&rec.TriggerEventID,
+		&rec.TriggerEventType,
+	)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return standaloneRuntimePlatformRunRecord{}, false, nil
+	case err != nil:
+		return standaloneRuntimePlatformRunRecord{}, false, fmt.Errorf("load standalone runtime platform run candidate: %w", err)
+	default:
+		return rec, true, nil
+	}
+}
+
+func isStandaloneRuntimePlatformRunRecord(rec standaloneRuntimePlatformRunRecord) bool {
+	if strings.TrimSpace(rec.RunID) == "" {
+		return false
+	}
+	if !isStandaloneRuntimePlatformEventType(rec.EventType) {
+		return false
+	}
+	if strings.TrimSpace(rec.ProducedByType) != "platform" {
+		return false
+	}
+	producedBy := strings.TrimSpace(rec.ProducedBy)
+	if producedBy != "" && producedBy != "runtime" {
+		return false
+	}
+	if strings.TrimSpace(rec.SourceEventID) != "" {
+		return false
+	}
+	if strings.TrimSpace(rec.TriggerEventID) != strings.TrimSpace(rec.EventID) {
+		return false
+	}
+	if strings.TrimSpace(rec.TriggerEventType) != strings.TrimSpace(rec.EventType) {
+		return false
+	}
+	return true
+}
+
+func (s *PostgresStore) convergeStandaloneRuntimePlatformRunByEventID(
+	ctx context.Context,
+	db storerunlifecycle.DBTX,
+	caps StoreSchemaCapabilities,
+	eventID string,
+) error {
+	eventID = sanitizeOptionalUUID(eventID)
+	if db == nil || eventID == "" || !caps.Events.HasRuns || caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID {
+		return nil
+	}
+	rec, found, err := loadStandaloneRuntimePlatformRunRecord(ctx, db, eventID)
+	if err != nil || !found || !isStandaloneRuntimePlatformRunRecord(rec) {
+		return err
+	}
+	switch strings.TrimSpace(rec.RunStatus) {
+	case "completed":
+		return nil
+	case "failed", "cancelled", "forked":
+		return fmt.Errorf("standalone runtime platform run %s already terminal with status %s", rec.RunID, strings.TrimSpace(rec.RunStatus))
+	}
+	active, err := storerunlifecycle.HasActiveDeliveries(ctx, db, rec.RunID)
+	if err != nil {
+		return err
+	}
+	if active {
+		return nil
+	}
+	_, err = storerunlifecycle.MarkTerminal(ctx, db, rec.RunID, "completed", "", time.Now().UTC(), runLifecycleOptions(caps))
+	if err != nil {
+		return fmt.Errorf("converge standalone runtime platform run: %w", err)
+	}
+	return nil
 }
 
 func runIDOrEventID(runID, eventID string) string {

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -317,6 +317,115 @@ func TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2(t *testin
 	}
 }
 
+func TestUpsertEventReceipt_ConcurrentTerminalReceiptsConvergeStandaloneRuntimeRun_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentA := seedEntityAndAgent(t, ctx, pg)
+	agentB := "agent-" + uuid.NewString()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:       agentB,
+			Type:     "test",
+			Role:     "test",
+			Mode:     "worker",
+			EntityID: entityID,
+			Config:   []byte(`{"system_prompt":"x"}`),
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed second agent: %v", err)
+	}
+	payload, _ := json.Marshal(map[string]any{"k": "v"})
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		RunID:       "",
+		Type:        events.EventType("platform.paused"),
+		SourceAgent: "runtime",
+		Payload:     payload,
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+	}).WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentA, agentB}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+
+	if _, err := pg.DB.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION slow_receipt_delivery_sync()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			PERFORM pg_sleep(0.2);
+			RETURN NEW;
+		END;
+		$$;
+	`); err != nil {
+		t.Fatalf("create slow trigger function: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		CREATE TRIGGER event_deliveries_slow_terminal_sync
+		BEFORE UPDATE ON event_deliveries
+		FOR EACH ROW
+		EXECUTE FUNCTION slow_receipt_delivery_sync()
+	`); err != nil {
+		t.Fatalf("create slow trigger: %v", err)
+	}
+
+	errCh := make(chan error, 2)
+	for _, agentID := range []string{agentA, agentB} {
+		agentID := agentID
+		go func() {
+			errCh <- pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusProcessed, "")
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("concurrent processed receipt #%d: %v", i+1, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for concurrent processed receipts")
+		}
+	}
+
+	var (
+		runStatus      string
+		pendingCount   int
+		deliveredCount int
+	)
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(r.status, '')
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = $1::uuid
+	`, evt.ID).Scan(&runStatus); err != nil {
+		t.Fatalf("load run status: %v", err)
+	}
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE status IN ('pending', 'in_progress')),
+			COUNT(*) FILTER (WHERE status = 'delivered')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+	`, evt.ID).Scan(&pendingCount, &deliveredCount); err != nil {
+		t.Fatalf("load delivery counts: %v", err)
+	}
+	if runStatus != "completed" {
+		t.Fatalf("run status = %q, want completed", runStatus)
+	}
+	if pendingCount != 0 || deliveredCount != 2 {
+		t.Fatalf("delivery counts = pending:%d delivered:%d, want pending:0 delivered:2", pendingCount, deliveredCount)
+	}
+}
+
 func TestUpsertEventReceipt_RollsBackReceiptWhenDeliverySyncFails_V2(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()


### PR DESCRIPTION
Part of #427
Related to #410

## Summary
Converge standalone runs for the approved runtime-owned top-level routable platform-event family once canonical delivery work becomes idle.

## Governing Context
Exact governing spec sections:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `runs` lifecycle / `run_id_propagation`
  - `routing_rules.routable_events`
  - `platform.boot`
  - `platform.recovery_failed`
  - adjacent runtime-owned routable platform event catalog entries for the approved family

Binding issue/gate context:
- `#427` approved first-slice boundary
- `#429` remains split and is not absorbed here

## What Changed
- added a canonical store-side convergence helper for standalone runtime-owned platform runs in `internal/store/events.go`
- wired `EventBus.Publish(...)` to invoke that helper after successful publish completion so zero-delivery / internal-only standalone platform runs converge terminally
- wired `UpsertEventReceipt(...)` to invoke the same helper after delivery rows transition terminally so receipt-backed standalone platform runs close when the last persisted delivery drains
- added focused postgres-backed bus proof for:
  - `platform.boot`
  - `platform.recovery_failed`
  - representative manager / receipts / budget publisher-family event types

## Canonical Owner Migration
New canonical owner:
- run activation: `internal/store/events.go`
- run terminality: `internal/store/runlifecycle/owner.go`
- family-level convergence hook now attached in `internal/store/events.go` and consumed from publish completion plus receipt-backed delivery completion

Old invalid path now removed:
- activation-only behavior for standalone runtime-owned platform events, where `ensureRunRow(...)` could create a canonical standalone run but no matching write-side owner closed it after the delivery frontier drained

Production paths checked for surviving old behavior:
- runtime startup publishers: `platform.boot`, `platform.recovery_failed`
- manager runtime publishers: `platform.event_quarantined`, `platform.agent_panic`, `platform.agent_failed`
- receipts publishers: `platform.auth_required`, `platform.paused`, `platform.dead_letter_escalation`
- budget publisher: `platform.budget_threshold_crossed`

Migration completeness:
- complete for the approved `#427` family
- `platform.reset` remains explicitly split to `#429`

## Scope Boundaries
In scope:
- standalone run terminal-state convergence for the approved runtime-owned top-level routable platform-event family

Out of scope:
- `platform.reset` / `#429`
- `#424` session-lineage reconciliation
- local `cmd/swarm status` / trace projection cleanup under `#410`

## Tests
- `go test ./internal/runtime/bus -run 'TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConverge(WithoutPersistedDeliveries|AfterFinalReceipt)$' -count=1`\n- `go test ./internal/store -run 'TestPostgresStore_MarkRunTerminal_(UsesCanonicalCountersAndRejectsActiveDeliveries|PersistsCanonicalLifecycle)$' -count=1`\n- `go test ./internal/runtime/bus ./internal/store -count=1`\n- `go test ./... -count=1`\n\n## Residual Risk\n- the family-level convergence rule is still implicit policy over a concrete event-type allowlist; no new same-concept interpreter appeared during implementation, but broader lifecycle modeling remains tracked under the parent/watchlist lane\n