### PR TITLE
[agent-a][issue #429] Restrict platform.reset to explicit admin sources

### DIFF
--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimediaglog "swarm/internal/runtime/diaglog"
 	runtimellm "swarm/internal/runtime/llm"
@@ -1007,6 +1009,45 @@ func (conformanceTimerRecoveryEventStore) ListEventDeliveryRecipients(context.Co
 
 func (conformanceTimerRecoveryEventStore) SupportsPersistedReplay() bool { return false }
 
+type conformanceRecoveryFailureEventStore struct {
+	store    *store.PostgresStore
+	missing  []events.PersistedReplayEvent
+	claimErr error
+}
+
+func (s conformanceRecoveryFailureEventStore) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (s conformanceRecoveryFailureEventStore) AppendEvent(ctx context.Context, evt events.Event) error {
+	return s.store.AppendEvent(ctx, evt)
+}
+
+func (s conformanceRecoveryFailureEventStore) InsertEventDeliveries(ctx context.Context, eventID string, recipients []string) error {
+	return s.store.InsertEventDeliveries(ctx, eventID, recipients)
+}
+
+func (s conformanceRecoveryFailureEventStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {
+	return s.store.ListEventDeliveryRecipients(ctx, eventID)
+}
+
+func (conformanceRecoveryFailureEventStore) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
+	return nil
+}
+
+func (s conformanceRecoveryFailureEventStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	return append([]events.PersistedReplayEvent(nil), s.missing...), nil
+}
+
+func (s conformanceRecoveryFailureEventStore) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
+	if s.claimErr != nil {
+		return nil, false, s.claimErr
+	}
+	return conformanceRecoveryReplayLease{}, true, nil
+}
+
+func (conformanceRecoveryFailureEventStore) SupportsPersistedReplay() bool { return true }
+
 type conformanceManagerReplayStore struct {
 	agents   []runtimemanager.PersistedAgent
 	pending  map[string][]events.Event
@@ -1178,6 +1219,85 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 	classes, _ := detail["recoverable_work_classes"].([]any)
 	if len(classes) != 1 || readString(classes[0]) != "active schedules" {
 		t.Fatalf("detail.recoverable_work_classes = %#v, want [active schedules]", detail["recoverable_work_classes"])
+	}
+}
+
+func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWithoutPlatformReset(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &store.PostgresStore{DB: db}
+
+	requireCanonicalRuntimeLogSurface(t, ctx, pg)
+	module := loadConformanceRuntimeWorkflowModule(t)
+	eventStore := conformanceRecoveryFailureEventStore{
+		store: pg,
+		missing: []events.PersistedReplayEvent{{
+			Event: events.Event{
+				ID:        uuid.NewString(),
+				Type:      events.EventType("support.item_created"),
+				CreatedAt: time.Now().Add(-time.Minute).UTC(),
+			},
+		}},
+		claimErr: errors.New("claim failed"),
+	}
+
+	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+		Runtime: config.RuntimeConfig{
+			RecoveryOnStartup: true,
+		},
+		LLM: config.LLMConfig{
+			RuntimeMode: "api",
+		},
+	}, runtimepkg.Stores{
+		SQLDB:        db,
+		EventStore:   eventStore,
+		ManagerStore: &conformanceManagerReplayStore{},
+	}, runtimepkg.RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     conformanceNoopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
+
+	var resetCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.reset'
+	`).Scan(&resetCount); err != nil {
+		t.Fatalf("count platform.reset events: %v", err)
+	}
+	if resetCount != 0 {
+		t.Fatalf("platform.reset event count = %d, want 0", resetCount)
+	}
+
+	var recoveryFailedPayloadRaw []byte
+	if err := db.QueryRowContext(ctx, `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.recovery_failed'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&recoveryFailedPayloadRaw); err != nil {
+		t.Fatalf("load platform.recovery_failed event: %v", err)
+	}
+	var recoveryFailedPayload map[string]any
+	if err := json.Unmarshal(recoveryFailedPayloadRaw, &recoveryFailedPayload); err != nil {
+		t.Fatalf("unmarshal platform.recovery_failed payload: %v", err)
+	}
+	if got := readString(recoveryFailedPayload["error"]); !strings.Contains(got, "claim replay event") || !strings.Contains(got, "claim failed") {
+		t.Fatalf("platform.recovery_failed payload.error = %q, want replay claim failure", got)
 	}
 }
 
@@ -1438,6 +1558,24 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	}
 	if terminationDetail != "builder_api" {
 		t.Fatalf("termination_detail = %q, want builder_api", terminationDetail)
+	}
+
+	var resetPayloadRaw []byte
+	if err := db.QueryRowContext(ctx, `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.reset'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&resetPayloadRaw); err != nil {
+		t.Fatalf("load platform.reset event: %v", err)
+	}
+	var resetPayload map[string]any
+	if err := json.Unmarshal(resetPayloadRaw, &resetPayload); err != nil {
+		t.Fatalf("unmarshal platform.reset payload: %v", err)
+	}
+	if got := readString(resetPayload["source"]); got != "builder_api" {
+		t.Fatalf("platform.reset payload.source = %q, want builder_api", got)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -804,6 +804,15 @@ func (am *AgentManager) ResetRuntimeStateWithSource(source string) error {
 	return am.resetRuntimeState(source)
 }
 
+func platformResetSourceAuthorized(source string) bool {
+	switch strings.TrimSpace(source) {
+	case "admin_cli", "builder_api":
+		return true
+	default:
+		return false
+	}
+}
+
 func (am *AgentManager) resetRuntimeState(source string) error {
 	if err := am.Shutdown(); err != nil {
 		return err
@@ -867,7 +876,7 @@ func (am *AgentManager) resetRuntimeState(source string) error {
 		}
 	}
 	source = strings.TrimSpace(source)
-	if source != "" && am.bus != nil {
+	if platformResetSourceAuthorized(source) && am.bus != nil {
 		payload, err := json.Marshal(map[string]any{
 			"source":    source,
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),

--- a/internal/runtime/manager/runtime_reset_test.go
+++ b/internal/runtime/manager/runtime_reset_test.go
@@ -14,10 +14,14 @@ import (
 )
 
 type resetTestBus struct {
-	entries []runtimepipeline.RuntimeLogEntry
+	entries   []runtimepipeline.RuntimeLogEntry
+	publishes []events.Event
 }
 
-func (b *resetTestBus) Publish(context.Context, events.Event) error { return nil }
+func (b *resetTestBus) Publish(_ context.Context, evt events.Event) error {
+	b.publishes = append(b.publishes, evt)
+	return nil
+}
 func (b *resetTestBus) PublishDirect(context.Context, events.Event, []string) error {
 	return nil
 }
@@ -142,4 +146,33 @@ func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
 	if got := records[0]["termination_reason"]; got != "orphaned" {
 		t.Fatalf("detail.orphaned_sessions[0].termination_reason = %#v, want orphaned", got)
 	}
+}
+
+func TestResetRuntimeStateWithSource_PublishesPlatformResetOnlyForExplicitAdminSources(t *testing.T) {
+	t.Run("builder_api", func(t *testing.T) {
+		bus := &resetTestBus{}
+		am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{})
+
+		if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+			t.Fatalf("ResetRuntimeStateWithSource(builder_api): %v", err)
+		}
+		if len(bus.publishes) != 1 {
+			t.Fatalf("published event count = %d, want 1", len(bus.publishes))
+		}
+		if got := string(bus.publishes[0].Type); got != "platform.reset" {
+			t.Fatalf("published event type = %q, want platform.reset", got)
+		}
+	})
+
+	t.Run("startup recovery fallback", func(t *testing.T) {
+		bus := &resetTestBus{}
+		am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{})
+
+		if err := am.ResetRuntimeStateWithSource("startup_recovery_failed"); err != nil {
+			t.Fatalf("ResetRuntimeStateWithSource(startup_recovery_failed): %v", err)
+		}
+		if len(bus.publishes) != 0 {
+			t.Fatalf("published event count = %d, want 0", len(bus.publishes))
+		}
+	})
 }


### PR DESCRIPTION
Closes #429

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `platform_events.catalog.platform.reset`
  - `platform_events.catalog.platform.recovery_failed`
  - `platform_events.routing_rules.routable_events`
- Binding issue/gate context:
  - `#429` pre-audit and approved gate
  - split from `#427` / `#410` as the separate spec-drift sibling

## What changed
- restrict the canonical `platform.reset` publisher so only explicit admin reset sources can emit it
- preserve automatic startup recovery failure signaling through `platform.recovery_failed`
- preserve the explicit builder-admin reset path

## Canonical owner after this change
- `internal/runtime/manager/runtime.go:resetRuntimeState(...)`
  - `platform.reset` publication is now keyed by explicit admin-authorized sources only

## Old path now invalid
- the old implicit rule that any non-empty source string could publish `platform.reset`
- specifically, automatic startup recovery fallback using `startup_recovery_failed` no longer authorizes `platform.reset`

## Production paths checked
- startup recovery fallback in `internal/runtime/runtime.go`
- builder-admin reset in `cmd/swarm/builder_project_supervisor.go`

## Migration status
- complete for the chosen class on current head
- no other live non-admin runtime caller of `platform.reset` was found in the pre-audit or implementation sweep

## Tests
- `go test ./internal/runtime/manager -run 'Test(ResetRuntimeState_LogsCanonicalOrphanedSessionAftermath|ResetRuntimeStateWithSource_PublishesPlatformResetOnlyForExplicitAdminSources)$' -count=1`
- `go test ./internal/runtime -run 'TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary$' -count=1`
- `go test ./internal/runtime/conformance -run 'Test(ResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader|StartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWithoutPlatformReset)$' -count=1`
- `go test ./internal/runtime/manager ./internal/runtime ./internal/runtime/conformance -count=1`
- `go test ./... -count=1`
