### PR TITLE
[agent-e][issue #432] Canonicalize swarm status lifecycle projection

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -257,12 +257,6 @@ type runStatusReport struct {
 	RuntimeLogs       []runStatusRuntimeLog     `json:"runtime_logs,omitempty"`
 }
 
-type runOperationalProjection struct {
-	State          string
-	BlockingLayer  string
-	BlockingReason string
-}
-
 type runStatusEventCount struct {
 	EventName string `json:"event_name"`
 	Count     int    `json:"count"`
@@ -430,11 +424,11 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 		return runStatusReport{}, err
 	}
 	report := runStatusReportFromStore(detail)
-	operational := projectRunOperationalStatus(report)
+	operational := store.ProjectRunOperationalStatus(detail)
 	report.OperationalState = operational.State
 	report.BlockingLayer = operational.BlockingLayer
 	report.BlockingReason = operational.BlockingReason
-	report.Heuristics = deriveRunStatusHeuristics(report)
+	report.Heuristics = append([]string(nil), operational.Heuristics...)
 
 	return report, nil
 }
@@ -444,52 +438,6 @@ func logLimitForStatus(opts runStatusOptions) int {
 		return 100
 	}
 	return 20
-}
-
-func deriveRunStatusHeuristics(report runStatusReport) []string {
-	heuristics := make([]string, 0, 4)
-	if len(report.DeadLetters) > 0 {
-		heuristics = append(heuristics, "dead letters exist for this run")
-	}
-	return heuristics
-}
-
-func projectRunOperationalStatus(report runStatusReport) runOperationalProjection {
-	status := strings.ToLower(strings.TrimSpace(report.RunTableStatus))
-	if status == "" {
-		return runOperationalProjection{}
-	}
-	if status != "running" {
-		return runOperationalProjection{State: status}
-	}
-
-	eventCounts := map[string]int{}
-	for _, item := range report.EventCounts {
-		eventCounts[strings.TrimSpace(item.EventName)] = item.Count
-	}
-	activeDeliveries := 0
-	for _, item := range report.Deliveries {
-		switch strings.ToLower(strings.TrimSpace(item.Status)) {
-		case "pending", "in_progress":
-			activeDeliveries += item.Count
-		}
-	}
-	terminalScoring := eventCounts["scoring/vertical.marginal"] + eventCounts["scoring/vertical.rejected"] + eventCounts["scoring/vertical.shortlisted"]
-	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
-		return runOperationalProjection{
-			State:          "stalled",
-			BlockingLayer:  "scoring_terminal_outcome",
-			BlockingReason: "terminal_scoring_outcome_missing",
-		}
-	}
-	if activeDeliveries == 0 && !report.LastEventAt.IsZero() {
-		return runOperationalProjection{
-			State:          "stalled",
-			BlockingLayer:  "delivery_lifecycle",
-			BlockingReason: "no_active_deliveries",
-		}
-	}
-	return runOperationalProjection{State: "running"}
 }
 
 func printRunStatusReport(w io.Writer, report runStatusReport) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -138,16 +138,16 @@ func TestPrintRunStatusReport(t *testing.T) {
 }
 
 func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationallyStalled(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 2},
 			{SubscriberID: "agent-2", Status: "failed", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -160,18 +160,18 @@ func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationally
 }
 
 func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		EventCounts: []runStatusEventCount{
+		EventCounts: []store.RunDebugEventCount{
 			{EventName: "scoring/scoring.requested", Count: 1},
 		},
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -184,19 +184,19 @@ func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.
 }
 
 func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutcome(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		EventCounts: []runStatusEventCount{
+		EventCounts: []store.RunDebugEventCount{
 			{EventName: "scoring/scoring.requested", Count: 1},
 			{EventName: "scoring/vertical.shortlisted", Count: 1},
 		},
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -209,16 +209,16 @@ func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutco
 }
 
 func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
 			{SubscriberID: "agent-2", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "running" {
 		t.Fatalf("state = %q, want running", got.State)
 	}

--- a/internal/store/run_operational_status_read_surface.go
+++ b/internal/store/run_operational_status_read_surface.go
@@ -1,0 +1,66 @@
+package store
+
+import "strings"
+
+type RunOperationalStatus struct {
+	State          string
+	BlockingLayer  string
+	BlockingReason string
+	Heuristics     []string
+}
+
+// ProjectRunOperationalStatus owns supported run-status semantics above the
+// canonical persisted run-debug evidence surface.
+func ProjectRunOperationalStatus(report RunDebugReport) RunOperationalStatus {
+	out := RunOperationalStatus{
+		Heuristics: runOperationalStatusHeuristics(report),
+	}
+
+	status := strings.ToLower(strings.TrimSpace(report.RunTableStatus))
+	if status == "" {
+		return out
+	}
+	if status != "running" {
+		out.State = status
+		return out
+	}
+
+	eventCounts := map[string]int{}
+	for _, item := range report.EventCounts {
+		eventCounts[strings.TrimSpace(item.EventName)] = item.Count
+	}
+
+	activeDeliveries := 0
+	for _, item := range report.Deliveries {
+		switch strings.ToLower(strings.TrimSpace(item.Status)) {
+		case "pending", "in_progress":
+			activeDeliveries += item.Count
+		}
+	}
+
+	terminalScoring := eventCounts["scoring/vertical.marginal"] +
+		eventCounts["scoring/vertical.rejected"] +
+		eventCounts["scoring/vertical.shortlisted"]
+	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
+		out.State = "stalled"
+		out.BlockingLayer = "scoring_terminal_outcome"
+		out.BlockingReason = "terminal_scoring_outcome_missing"
+		return out
+	}
+	if activeDeliveries == 0 && !report.LastEventAt.IsZero() {
+		out.State = "stalled"
+		out.BlockingLayer = "delivery_lifecycle"
+		out.BlockingReason = "no_active_deliveries"
+		return out
+	}
+
+	out.State = "running"
+	return out
+}
+
+func runOperationalStatusHeuristics(report RunDebugReport) []string {
+	if len(report.DeadLetters) == 0 {
+		return nil
+	}
+	return []string{"dead letters exist for this run"}
+}

--- a/internal/store/run_operational_status_read_surface_test.go
+++ b/internal/store/run_operational_status_read_surface_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationallyStalled(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 2},
+			{SubscriberID: "agent-2", Status: "failed", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []RunDebugEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+		},
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "scoring_terminal_outcome" {
+		t.Fatalf("blocking_layer = %q, want scoring_terminal_outcome", got.BlockingLayer)
+	}
+	if got.BlockingReason != "terminal_scoring_outcome_missing" {
+		t.Fatalf("blocking_reason = %q, want terminal_scoring_outcome_missing", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutcome(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []RunDebugEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+			{EventName: "scoring/vertical.shortlisted", Count: 1},
+		},
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
+			{SubscriberID: "agent-2", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "running" {
+		t.Fatalf("state = %q, want running", got.State)
+	}
+	if got.BlockingLayer != "" || got.BlockingReason != "" {
+		t.Fatalf("unexpected blocking projection: %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
Move supported `swarm status` stalled/blocking semantics onto one store-owned projection above canonical persisted run-debug evidence, and remove the CLI-local lifecycle interpreter.

Closes #432
Part of #410

## What Changed
- added `internal/store.ProjectRunOperationalStatus(...)` as the canonical run operational status owner above `RunDebugReport`
- moved `cmd/swarm` status loading onto that store-owned projection
- removed the old CLI-local semantic owner in `cmd/swarm/main.go`:
  - `projectRunOperationalStatus(...)`
  - `deriveRunStatusHeuristics(...)`
- added direct store-owner proofs and kept the supported `swarm status` proofs on the CLI surface

## Why
After `#424` and `#427`, the remaining live `#410` residual was reader-side: `swarm status` still invented `operational_state`, `blocking_layer`, and `blocking_reason` locally over mixed persisted lifecycle rows. This PR closes that child by moving those semantics into one canonical store-owned projection instead of preserving CLI-local ownership.

## Scope
- in scope:
  - supported `swarm status` operational-state / blocking projection
- out of scope:
  - `#429`
  - builder run-debug transport/replay work
  - broader `#169` lifecycle observability redesign
  - reopening `#424` or `#427`

## Governing Context
No exact governing spec section currently defines `swarm status` stalled/blocking semantics.

Binding context for this PR:
- `#410` residual split history
- `#432` approved child boundary and gate

Adjacent contract sections used to constrain the seam:
- `joined_trace_surface`
- `runs_list`
- `run_trace`
  from `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Semantic Migration
- new canonical owner:
  - `internal/store.ProjectRunOperationalStatus(...)`
- old non-authoritative path now invalid:
  - `cmd/swarm/main.go:projectRunOperationalStatus(...)`
  - `cmd/swarm/main.go:deriveRunStatusHeuristics(...)`
- production paths checked for surviving old behavior:
  - `go run ./cmd/swarm status` path in `cmd/swarm/main.go`
  - dashboard run trace consumer of `LoadRunDebugTrace(...)`
  - builder run-debug replay consumer of `RunTableStatus`
  - generic dashboard observability readers
- migration complete for the chosen child:
  - yes

## Tests
- `go test ./internal/store -run 'TestProjectRunOperationalStatus_(UsesDeliveryLifecycleWhenRunIsOperationallyStalled|UsesScoringOutcomeBlockingLayer|TreatsScopedShortlistAsTerminalScoringOutcome|PreservesHealthyRunningWhenActiveDeliveriesRemain)$' -count=1`
- `go test ./cmd/swarm -run 'TestLoadRunStatusReport_(UsesDurableCompletedRunState|KeepsSupportedRunRunningUntilManagerWorkSettles|PreservesRunningTruthAcrossBuilderQuiescenceTimeout|ProjectsExplicitStalledRunState|ProjectsScoringOutcomeStall)$' -count=1`
- `go test ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`
