### PR TITLE
[agent-d][issue #431] Migrate nested descendant fixture boundary

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -249,6 +249,7 @@ nodes:
     representative_issues:
       - 413
       - 415
+      - 426
       - 416
       - 417
     common_framing_mistakes:
@@ -293,6 +294,7 @@ nodes:
       - broader authored migration pressure still exists for subject_id, back-propagation, and other cross-flow coupling assumptions, but those are a separate authored class unless local evidence proves they belong to the same narrow migration slice
     representative_issues:
       - 416
+      - 431
     common_framing_mistakes:
       too_broad:
         - migrate every cross-flow authored assumption in one PR

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1409,8 +1409,8 @@ func TestEventBusPublish_NestedDescendantCompletionFlushesDeferredParentEvents(t
 	if !found {
 		t.Fatal("expected child instance")
 	}
-	if got := strings.TrimSpace(child.CurrentState); got != "completed" {
-		t.Fatalf("child current_state = %q, want completed", got)
+	if got := strings.TrimSpace(child.CurrentState); got != "waiting" {
+		t.Fatalf("child current_state = %q, want waiting", got)
 	}
 
 	root, found, err := store.Load(context.Background(), rootEntityID)
@@ -1439,9 +1439,6 @@ func TestEventBusPublish_NestedDescendantCompletionFlushesDeferredParentEvents(t
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate events: %v", err)
-	}
-	if !contains(emitted, "child/step.result") {
-		t.Fatalf("events = %v, want child/step.result", emitted)
 	}
 	if !contains(emitted, "pipeline.complete") {
 		t.Fatalf("events = %v, want pipeline.complete", emitted)

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1647,7 +1647,7 @@ func TestExecuteNodeContractHandlerPayloadTransformEntityPresenceCheckMintsEntit
 	}
 }
 
-func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionAdvancesParentFlow(t *testing.T) {
+func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionEmitsRootCompletion(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -1729,14 +1729,14 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionAdvancesParentFl
 	if !found {
 		t.Fatal("expected child instance")
 	}
-	if got := strings.TrimSpace(child.CurrentState); got != "completed" {
-		t.Fatalf("child current_state = %q, want completed", got)
+	if got := strings.TrimSpace(child.CurrentState); got != "waiting" {
+		t.Fatalf("child current_state = %q, want waiting", got)
 	}
 	if got := bus.publishedCount(); got != 1 {
 		t.Fatalf("published count = %d, want 1", got)
 	}
-	if got := string(bus.publishedEvent(0).Type); got != "child/step.result" {
-		t.Fatalf("published type = %q, want child/step.result", got)
+	if got := string(bus.publishedEvent(0).Type); got != "pipeline.complete" {
+		t.Fatalf("published type = %q, want pipeline.complete", got)
 	}
 	if got := bus.publishedEvent(0).EntityID(); got != rootEntityID {
 		t.Fatalf("published entity_id = %q, want %q", got, rootEntityID)

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -609,7 +609,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsParentFlowResult(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsRootCompletion(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -680,8 +680,8 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsParentFlowR
 	if !passThrough {
 		t.Fatal("expected nested descendant completion to remain visible downstream")
 	}
-	if len(emitted) != 1 || string(emitted[0].Type) != "child/step.result" {
-		t.Fatalf("emitted = %#v, want [child/step.result]", emitted)
+	if len(emitted) != 1 || string(emitted[0].Type) != "pipeline.complete" {
+		t.Fatalf("emitted = %#v, want [pipeline.complete]", emitted)
 	}
 	if got := emitted[0].EntityID(); got != rootEntityID {
 		t.Fatalf("emitted entity_id = %q, want %q", got, rootEntityID)
@@ -694,12 +694,12 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsParentFlowR
 	if !found {
 		t.Fatal("expected child instance")
 	}
-	if got := strings.TrimSpace(child.CurrentState); got != "completed" {
-		t.Fatalf("child current_state = %q, want completed", got)
+	if got := strings.TrimSpace(child.CurrentState); got != "waiting" {
+		t.Fatalf("child current_state = %q, want waiting", got)
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedToParentStillEmitsRootResult(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedToParentStillEmitsRootCompletion(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -769,15 +769,15 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	if !passThrough {
 		t.Fatal("expected nested descendant completion to remain visible downstream")
 	}
-	if len(emitted) != 1 || string(emitted[0].Type) != "child/step.result" {
-		t.Fatalf("emitted = %#v, want [child/step.result]", emitted)
+	if len(emitted) != 1 || string(emitted[0].Type) != "pipeline.complete" {
+		t.Fatalf("emitted = %#v, want [pipeline.complete]", emitted)
 	}
 	if got := emitted[0].EntityID(); got != rootEntityID {
 		t.Fatalf("emitted entity_id = %q, want %q", got, rootEntityID)
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTxStillEmitsRootResult(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTxStillEmitsRootCompletion(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -848,8 +848,8 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	if !passThrough {
 		t.Fatal("expected nested descendant completion to remain visible downstream")
 	}
-	if len(emitted) != 1 || string(emitted[0].Type) != "child/step.result" {
-		t.Fatalf("emitted = %#v, want [child/step.result]", emitted)
+	if len(emitted) != 1 || string(emitted[0].Type) != "pipeline.complete" {
+		t.Fatalf("emitted = %#v, want [pipeline.complete]", emitted)
 	}
 	if got := emitted[0].EntityID(); got != rootEntityID {
 		t.Fatalf("emitted entity_id = %q, want %q", got, rootEntityID)

--- a/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
@@ -7,6 +7,6 @@ pipeline.complete:
 child/step.begin:
   payload:
     entity_id: string
-child/step.result:
+child/grandchild/micro.done:
   payload:
     entity_id: string

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
@@ -1,9 +1,6 @@
 step.begin:
   payload:
     entity_id: string
-step.result:
-  payload:
-    entity_id: string
 grandchild/micro.done:
   payload:
     entity_id: string

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/nodes.yaml
@@ -6,14 +6,5 @@ child-relay:
   event_handlers:
     step.begin:
       create_entity: true
-      emits: grandchild/micro.start
-
-child-aggregator:
-  id: child-aggregator
-  execution_type: system_node
-  subscribes_to: [grandchild/micro.done]
-  produces: [step.result]
-  event_handlers:
-    grandchild/micro.done:
       advances_to: completed
-      emits: step.result
+      emits: grandchild/micro.start

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/schema.yaml
@@ -5,5 +5,3 @@ states: [waiting, completed]
 pins:
   inputs:
     events: [step.begin]
-  outputs:
-    events: [step.result]

--- a/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
@@ -10,9 +10,9 @@ root-dispatcher:
 root-collector:
   id: root-collector
   execution_type: system_node
-  subscribes_to: [child/step.result]
+  subscribes_to: [child/grandchild/micro.done]
   produces: [pipeline.complete]
   event_handlers:
-    child/step.result:
+    child/grandchild/micro.done:
       advances_to: done
       emits: pipeline.complete


### PR DESCRIPTION
## Summary
Migrate the `test-nested-three-levels` authored fixture off the nested descendant cross-flow continuation behavior that `#426` removes.

Closes #431

## Governing Context
No exact canonical `platform-spec.yaml` section governs this local authored fixture migration directly.

Binding governing context for this PR:
- approved `#431` pre-audit and gate
- `#426` implementation proof stop that extracted `#431` as the exact authored blocker
- adjacent runtime contract context under `#415` / `#426`: primitive-only flow-boundary semantics with no existing-entity cross-flow continuation

## What Changed
- removed the child-level `step.result` continuation from `tests/tier11-flow-composition/test-nested-three-levels`
- made the root collector consume `child/grandchild/micro.done` directly and emit `pipeline.complete`
- updated direct proof-bearing consumers to match the migrated authored contract:
  - `internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go`
  - `internal/runtime/bus/eventbus_publish_test.go`
  - `internal/runtime/pipeline/handler_engine_transaction_test.go`
  - `internal/runtime/pipeline/workflow_timer_lifecycle_test.go`
- refined the semantic correctness watchlist entry for the authored migration child

## Why
`test-nested-three-levels` was the exact local authored dependency still relying on the cross-flow continuation behavior that `#426` removes:
- descendant completion continuing through `child/step.result`
- upward/root completion depending on that continuation shape

This PR removes that authored dependency instead of preserving the old runtime behavior.

## Scope Boundaries
In scope:
- the `test-nested-three-levels` authored fixture bundle
- its direct proof-bearing consumer expectations

Out of scope:
- runtime boundary removal in `#426`
- subject-linked residual family under `#415`
- broad authored migration under `#416`
- schema/tool cleanup under `#417`
- canonical spec rewrite under `#414`

## Semantic Migration
New canonical authored owner:
- `tests/tier11-flow-composition/test-nested-three-levels`

Old invalid authored path after this PR:
- child-local aggregator emitting `child/step.result`
- proof consumers expecting nested descendant completion to surface as `child/step.result`

Production/proof paths checked for surviving old behavior:
- `internal/runtime/cataloge2e` supported `test-nested-three-levels` path
- `internal/runtime/bus` nested descendant publish proofs
- `internal/runtime/pipeline` nested descendant intercept/transaction proofs
- full repo test suite

Migration complete:
- complete for the `#431` authored child
- `#426` runtime child remains open and can resume after this blocker removal

## Tests Run
- `go test ./internal/runtime/pipeline -run 'Test(ExecuteNodeHandlerPlanResult_NestedDescendantCompletion.*|PipelineCoordinatorIntercept_NestedDescendantCompletion.*)$' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusPublish_(NestedDescendantCompletionFlushesDeferredParentEvents|NestedThreeLevelChain_FromRootStartCompletesPipeline)$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-nested-three-levels$' -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`

## Residual Risk / Follow-up
- `#426` runtime boundary removal is still open and remains the next dependent runtime child
- later subject-linked residual work under `#415` remains separate and untouched here
