### PR TITLE
[agent-a][issue #400] Allow empty canonical runtime log messages

### DIFF
--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -202,25 +202,63 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 	}
 }
 
-func TestRuntimeLogger_Log_FailsClosedOnMissingCanonicalMessage(t *testing.T) {
+func TestRuntimeLogger_Log_AllowsEmptyCanonicalMessageWhenDetailsExist(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	defer db.Close()
 
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs("", runtimeLogPayloadArg{
+			level:     "info",
+			message:   "",
+			component: "agent-manager",
+			action:    "delivery_lifecycle_transition",
+			eventID:   "evt-1",
+			agentID:   "agent-a",
+			detail: map[string]any{
+				"delivery_state":          "launching",
+				"delivery_transition":     "launching",
+				"delivery_previous_state": "queued",
+				"delivery_reason":         "agent_processing",
+				"subscriber_type":         "agent",
+				"subscriber_id":           "agent-a",
+			},
+		}, "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
 	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
-	err = logger.Log(context.Background(), RuntimeLogEntry{
-		Level:     "error",
+	if err := logger.Log(context.Background(), RuntimeLogEntry{
+		Level:     "debug",
 		Message:   "",
-		Component: "diagnostics",
-		Action:    "missing_message",
-	})
-	if err == nil || !strings.Contains(err.Error(), "runtime log message is required") {
-		t.Fatalf("logger.Log() error = %v, want missing canonical message failure", err)
+		Component: "agent-manager",
+		Action:    "delivery_lifecycle_transition",
+		EventID:   "evt-1",
+		AgentID:   "agent-a",
+		Detail: map[string]any{
+			"delivery_state":          "launching",
+			"delivery_transition":     "launching",
+			"delivery_previous_state": "queued",
+			"delivery_reason":         "agent_processing",
+			"subscriber_type":         "agent",
+			"subscriber_id":           "agent-a",
+		},
+	}); err != nil {
+		t.Fatalf("logger.Log() error = %v, want nil", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestDecodeCanonicalRuntimeLogPayload_FailsClosedOnMissingMessageField(t *testing.T) {
+	_, err := DecodeCanonicalRuntimeLogPayload([]byte(`{
+		"log_level":"debug",
+		"details":{"component":"agent-manager","action":"delivery_lifecycle_transition"}
+	}`))
+	if err == nil || !strings.Contains(err.Error(), "runtime log message is required") {
+		t.Fatalf("DecodeCanonicalRuntimeLogPayload() error = %v, want missing message failure", err)
 	}
 }
 

--- a/internal/runtime/runtime_log_payload.go
+++ b/internal/runtime/runtime_log_payload.go
@@ -51,7 +51,7 @@ func DecodeCanonicalRuntimeLogPayload(raw []byte) (CanonicalRuntimeLogPayload, e
 	if err != nil {
 		return CanonicalRuntimeLogPayload{}, err
 	}
-	message, err := requiredRuntimeLogString(payload, "message")
+	message, err := requiredRuntimeLogPresentString(payload, "message")
 	if err != nil {
 		return CanonicalRuntimeLogPayload{}, err
 	}
@@ -199,6 +199,18 @@ func requiredRuntimeLogString(raw map[string]any, key string) (string, error) {
 		return "", fmt.Errorf("runtime log %s is required", key)
 	}
 	return text, nil
+}
+
+func requiredRuntimeLogPresentString(raw map[string]any, key string) (string, error) {
+	value, ok := raw[key]
+	if !ok {
+		return "", fmt.Errorf("runtime log %s is required", key)
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("runtime log %s must be a string", key)
+	}
+	return strings.TrimSpace(text), nil
 }
 
 func optionalRuntimeLogString(raw map[string]any, key string) (string, error) {


### PR DESCRIPTION
Closes #400

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `diagnostics_encoding.runtime_log_encoding`
- `docs/specs/swarm-platform/platform/platform-spec.md`
  - `diagnostics_encoding.runtime_log_encoding`
- Binding issue context:
  - `#400`
  - delivery-lifecycle transition runtime logs on the supported helper path

## What changed
- allow canonical runtime-log payloads to persist when `message` is present but empty
- keep the validator fail-closed for missing `message`, non-string `message`, and malformed `details`

## Canonical owner after this change
- `internal/runtime/runtime_log_payload.go:DecodeCanonicalRuntimeLogPayload(...)`
  - canonical validation owner for persisted runtime-log payload shape

## Old path now invalid
- the old validator rule that required `message` to be non-empty for every canonical runtime log payload

## Production paths checked
- delivery-lifecycle transition diagnostics on the supported runtime path
- adjacent canonical runtime-log persistence through `RuntimeLogger.Log(...)`

## Migration status
- complete for the chosen class on current head
- no broader runtime logging redesign in this PR

## Tests
- `go test ./internal/runtime -run 'Test(RuntimeLogger_Log_(AllowsEmptyCanonicalMessageWhenDetailsExist|PersistsRuntimeLogPayloadViaCapabilityOwner|EnsuresRunRowBeforePersistingRunScopedEntry|ReturnsPersistenceFailure|FailsClosedWithoutCanonicalCapability)|DecodeCanonicalRuntimeLogPayload_FailsClosedOnMissingMessageField)$' -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./... -count=1`
