### PR TITLE
[agent-d][issue #426] Remove cross-flow continuation semantics from flow boundaries

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -330,11 +330,6 @@ func (c *checkerContext) gateSchemaValidation() []Finding {
 	return c.gateSchemaFindings
 }
 
-func isBackpropEvent(eventType string) bool {
-	eventType = strings.TrimSpace(eventType)
-	return eventType != "" && strings.HasSuffix(eventType, "_backprop")
-}
-
 func platformVersionAtLeast(raw string, major, minor, patch int) bool {
 	raw = strings.TrimSpace(raw)
 	for _, prefix := range []string{">=", ">", "=", "~", "^"} {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2662,7 +2662,7 @@ func TestRun_AllowsStatelessFlowInputPinHandlersWithoutCreateEntity(t *testing.T
 	}
 }
 
-func TestRun_AllowsBackpropInputPinHandlersWithoutCreateEntity(t *testing.T) {
+func TestRun_RequiresCreateEntityForBackpropInputPinHandlers(t *testing.T) {
 	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-pin-wiring"))
 	flowID := "child"
 	flowView, ok := bundle.FlowViewByID(flowID)
@@ -2696,8 +2696,8 @@ func TestRun_AllowsBackpropInputPinHandlersWithoutCreateEntity(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "flow_boundary_create_entity_validation", "must declare create_entity: true") {
-		t.Fatalf("unexpected flow_boundary_create_entity_validation error, got %#v", report.Errors())
+	if !reportContains(report.Errors(), "flow_boundary_create_entity_validation", "must declare create_entity: true") {
+		t.Fatalf("expected flow_boundary_create_entity_validation error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -456,9 +456,6 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 				if _, ok := inputs[eventType]; !ok {
 					continue
 				}
-				if isBackpropEvent(eventType) {
-					continue
-				}
 				if handler.CreateEntity {
 					continue
 				}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1305,7 +1305,7 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 	}
 }
 
-func TestEventBusPublish_NestedDescendantCompletionFlushesDeferredParentEvents(t *testing.T) {
+func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -1440,6 +1440,9 @@ func TestEventBusPublish_NestedDescendantCompletionFlushesDeferredParentEvents(t
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate events: %v", err)
 	}
+	if contains(emitted, "child/step.result") {
+		t.Fatalf("events = %v, do not want child/step.result", emitted)
+	}
 	if !contains(emitted, "pipeline.complete") {
 		t.Fatalf("events = %v, want pipeline.complete", emitted)
 	}
@@ -1454,7 +1457,7 @@ func contains(items []string, want string) bool {
 	return false
 }
 
-func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesPipeline(t *testing.T) {
+func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChildContinuation(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -1531,6 +1534,51 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesPipeline(t 
 		}
 		instances, _ := runtimepipeline.NewWorkflowInstanceStore(db).List(context.Background())
 		t.Fatalf("root current_state = %q, want done; events=%v instances=%#v", got, dump, instances)
+	}
+
+	instances, err := runtimepipeline.NewWorkflowInstanceStore(db).List(context.Background())
+	if err != nil {
+		t.Fatalf("list workflow instances: %v", err)
+	}
+	var (
+		childState      string
+		grandchildState string
+	)
+	var emitted []string
+	rows, err := db.QueryContext(context.Background(), `SELECT event_name FROM events ORDER BY created_at ASC, event_id ASC`)
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan event: %v", err)
+		}
+		emitted = append(emitted, strings.TrimSpace(name))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate events: %v", err)
+	}
+	for _, instance := range instances {
+		switch strings.TrimSpace(instance.WorkflowName) {
+		case "child":
+			childState = strings.TrimSpace(instance.CurrentState)
+		case "grandchild":
+			grandchildState = strings.TrimSpace(instance.CurrentState)
+		}
+	}
+	if childState != "completed" {
+		t.Fatalf("child current_state = %q, want completed", childState)
+	}
+	if grandchildState != "finished" {
+		t.Fatalf("grandchild current_state = %q, want finished", grandchildState)
+	}
+	if contains(emitted, "child/step.result") {
+		t.Fatalf("events = %v, do not want child/step.result", emitted)
+	}
+	if !contains(emitted, "pipeline.complete") {
+		t.Fatalf("events = %v, want pipeline.complete", emitted)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -958,15 +958,15 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 	if err != nil {
 		t.Fatalf("ShapeEmitPayload output: %v", err)
 	}
-	if got := output["entity_id"]; got != "ent-parent" {
-		t.Fatalf("output emit entity_id = %#v, want ent-parent", got)
+	if got := output["entity_id"]; got != "ent-child" {
+		t.Fatalf("output emit entity_id = %#v, want ent-child", got)
 	}
 	if _, ok := output["step"]; ok {
 		t.Fatalf("output emit step should be trimmed to the target event schema: %#v", output["step"])
 	}
 }
 
-func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputRetarget(t *testing.T) {
+func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputBoundary(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -1001,8 +1001,8 @@ func TestPipelineEnginePayloadShaper_TrimsUndeclaredFieldsAcrossCrossFlowOutputR
 	if err != nil {
 		t.Fatalf("ShapeEmitPayload output: %v", err)
 	}
-	if got := output["entity_id"]; got != "ent-parent" {
-		t.Fatalf("output emit entity_id = %#v, want ent-parent", got)
+	if got := output["entity_id"]; got != "ent-child" {
+		t.Fatalf("output emit entity_id = %#v, want ent-child", got)
 	}
 	if _, ok := output["vertical_id"]; ok {
 		t.Fatalf("output emit vertical_id should be trimmed to the target event schema: %#v", output["vertical_id"])

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -294,16 +294,6 @@ func resolveHandlerEntityIDForFlow(
 		return entityID, evt
 	}
 	entityID, evt = ensureHandlerEntityID(source, handler, entityID, evt)
-	if flowID != "" && state != nil {
-		inboundInstance := workflowStateIdentity(source, flowID, *state)
-		currentScopeKey := strings.TrimSpace(workflowScopeKey(source, flowID))
-		if isDescendantFlowInstance(currentScopeKey, inboundInstance.InstancePath) {
-			if parentEntityID := strings.TrimSpace(inboundInstance.ParentEntityID); parentEntityID != "" {
-				entityID = parentEntityID
-				state.EntityID = parentEntityID
-			}
-		}
-	}
 	if strings.TrimSpace(flowID) == "" && state != nil {
 		subjectID := strings.TrimSpace(workflowStateIdentity(source, "", *state).SubjectID)
 		if subjectID != "" && subjectID != entityID {

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -103,15 +103,5 @@ func resolveEmittedEntityID(
 		workflowEventEntityID(trigger),
 		trigger.EntityID(),
 	))
-	if !workflowEmitTargetsParentEntity(source, flowID, eventType) {
-		return entityID
-	}
-	if !instance.HasStoredPath {
-		return entityID
-	}
-	return strings.TrimSpace(firstNonEmptyString(
-		instance.ParentEntityID,
-		trigger.EntityID(),
-		entityID,
-	))
+	return entityID
 }

--- a/internal/runtime/pipeline/flow_instance_identity_test.go
+++ b/internal/runtime/pipeline/flow_instance_identity_test.go
@@ -108,8 +108,8 @@ func TestFlowInstanceIdentity_ResolveEmittedEntityID(t *testing.T) {
 	if got := resolveEmittedEntityID(source, "child", "child/child.internal", childState, trigger, "ent-child", "ent-child"); got != "ent-child" {
 		t.Fatalf("internal emitted entity_id = %q, want ent-child", got)
 	}
-	if got := resolveEmittedEntityID(source, "child", "child/child.done", childState, trigger, "ent-child", "ent-child"); got != "ent-parent" {
-		t.Fatalf("output emitted entity_id = %q, want ent-parent", got)
+	if got := resolveEmittedEntityID(source, "child", "child/child.done", childState, trigger, "ent-child", "ent-child"); got != "ent-child" {
+		t.Fatalf("output emitted entity_id = %q, want ent-child", got)
 	}
 
 	rootState := WorkflowState{

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1003,7 +1003,7 @@ func TestResolveHandlerEntityIDForRootUsesSubjectEntityForFlowScopedInbound(t *t
 	}
 }
 
-func TestResolveHandlerEntityIDForFlowUsesParentEntityForDescendantScopedInbound(t *testing.T) {
+func TestResolveHandlerEntityIDForFlowKeepsInboundEntityForDescendantScopedInbound(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Emits: runtimecontracts.EventEmission{Single: "step.result"},
 	}
@@ -1022,14 +1022,14 @@ func TestResolveHandlerEntityIDForFlowUsesParentEntityForDescendantScopedInbound
 		Type: events.EventType("child/grandchild/micro.done"),
 	}.WithEntityID(inboundEntityID), &state)
 
-	if gotID != parentEntityID {
-		t.Fatalf("entityID = %q, want parent %q", gotID, parentEntityID)
+	if gotID != inboundEntityID {
+		t.Fatalf("entityID = %q, want inbound %q", gotID, inboundEntityID)
 	}
 	if got := gotEvt.EntityID(); got != inboundEntityID {
 		t.Fatalf("inbound event entity_id = %q, want preserved %q", got, inboundEntityID)
 	}
-	if state.EntityID != parentEntityID {
-		t.Fatalf("state entity_id = %q, want %q", state.EntityID, parentEntityID)
+	if state.EntityID != inboundEntityID {
+		t.Fatalf("state entity_id = %q, want %q", state.EntityID, inboundEntityID)
 	}
 }
 
@@ -1647,7 +1647,7 @@ func TestExecuteNodeContractHandlerPayloadTransformEntityPresenceCheckMintsEntit
 	}
 }
 
-func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionEmitsRootCompletion(t *testing.T) {
+func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotEmitChildContinuation(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -210,14 +210,6 @@ func (pc *PipelineCoordinator) handlerEmitPayload(ctx context.Context, triggerCt
 	return out
 }
 
-func workflowEmitTargetsParentEntity(source semanticview.Source, flowID, eventType string) bool {
-	flowID = strings.TrimSpace(flowID)
-	if source == nil || flowID == "" {
-		return false
-	}
-	return semanticview.ResolveFlowEventProof(source, flowID, eventType).CrossesDeclaredOutputBoundary(source)
-}
-
 func workflowEntityMetadataPayload(source semanticview.Source, metadata map[string]any) map[string]any {
 	if len(metadata) == 0 {
 		return nil

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -185,41 +185,7 @@ func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
 	}
 }
 
-func TestWorkflowEmitTargetsParentEntity_OutputPin(t *testing.T) {
-	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
-	if !workflowEmitTargetsParentEntity(source, "child", "child/child.done") {
-		t.Fatal("expected child/child.done to target the parent entity")
-	}
-	if !workflowEmitTargetsParentEntity(source, "child", "child.done") {
-		t.Fatal("expected local child.done to target the parent entity through the same canonical proof")
-	}
-	if workflowEmitTargetsParentEntity(source, "child", "child/child.internal") {
-		t.Fatal("did not expect child/child.internal to target the parent entity")
-	}
-	if workflowEmitTargetsParentEntity(source, "child", "child.internal") {
-		t.Fatal("did not expect local child.internal to target the parent entity")
-	}
-
-	pinSource := loadWorkflowFixtureSource(t, "test-child-flow-pin-wiring")
-	if !workflowEmitTargetsParentEntity(pinSource, "child", "child/work.completed") {
-		t.Fatal("expected child/work.completed to target the parent entity")
-	}
-	if !workflowEmitTargetsParentEntity(pinSource, "child", "work.completed") {
-		t.Fatal("expected local work.completed to target the parent entity through the same canonical proof")
-	}
-}
-
-func TestWorkflowEmitTargetsParentEntity_DoesNotScanOtherFlows(t *testing.T) {
-	source := loadWorkflowFixtureSource(t, "test-child-flow-sibling-isolation")
-	if workflowEmitTargetsParentEntity(source, "flow-a", "flow-b/work.done") {
-		t.Fatal("did not expect flow-b output event to retarget when executing inside flow-a")
-	}
-	if workflowEmitTargetsParentEntity(source, "", "flow-a/work.done") {
-		t.Fatal("did not expect root/no-flow context to retarget from a child flow output declaration")
-	}
-}
-
-func TestHandlerEmitPayload_UsesParentEntityForOutputPinsAndLocalEntityForInternalEvents(t *testing.T) {
+func TestHandlerEmitPayload_KeepsLocalEntityAcrossOutputBoundaries(t *testing.T) {
 	bundle := loadWorkflowFixtureBundle(t, "test-child-flow-local-events")
 	module, err := newPipelineFixtureWorkflowModule(bundle)
 	if err != nil {
@@ -247,8 +213,8 @@ func TestHandlerEmitPayload_UsesParentEntityForOutputPinsAndLocalEntityForIntern
 	}
 
 	outputPayload := pc.handlerEmitPayload(withPipelineFlowScope(context.Background(), "child"), trigger, "child/child.done")
-	if got := asString(outputPayload["entity_id"]); got != "ent-parent" {
-		t.Fatalf("output payload entity_id = %q, want ent-parent", got)
+	if got := asString(outputPayload["entity_id"]); got != "ent-child" {
+		t.Fatalf("output payload entity_id = %q, want ent-child", got)
 	}
 
 	pinBundle := loadWorkflowFixtureBundle(t, "test-child-flow-pin-wiring")
@@ -258,8 +224,8 @@ func TestHandlerEmitPayload_UsesParentEntityForOutputPinsAndLocalEntityForIntern
 	}
 	pinPC := &PipelineCoordinator{module: pinModule}
 	pinPayload := pinPC.handlerEmitPayload(withPipelineFlowScope(context.Background(), "child"), trigger, "child/work.completed")
-	if got := asString(pinPayload["entity_id"]); got != "ent-parent" {
-		t.Fatalf("pin output payload entity_id = %q, want ent-parent", got)
+	if got := asString(pinPayload["entity_id"]); got != "ent-child" {
+		t.Fatalf("pin output payload entity_id = %q, want ent-child", got)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -609,7 +609,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsRootCompletion(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChildContinuation(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -699,7 +699,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionEmitsRootComplet
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedToParentStillEmitsRootCompletion(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedToParentStillEmitsRootResult(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
@@ -777,7 +777,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTxStillEmitsRootCompletion(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTxStillEmitsRootResult(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")


### PR DESCRIPTION
## Summary
Remove existing-entity cross-flow continuation semantics from runtime/boot flow boundaries.

Closes #426

## Governing Context
No exact current `platform-spec.yaml` section governs this migration child, because canonical spec adoption is explicitly deferred to `#414`.

Binding governing context for this PR:
- approved `#426` pre-audit and gate on the issue thread
- parent residual classification under `#415`
- reviewed migration direction recorded in the `#426` issue comments

Nearest adjacent current spec sections used only as constraint/context for the old behavior being removed:
- `parent_retarget_semantics`
- `killed_across_flows` / `_backprop` compatibility surfaces

## What Changed
- removed child-output parent retargeting from emitted identity shaping
- removed descendant/backprop parent rebinding from inbound runtime handler resolution
- removed the boot `_backprop` exemption from `create_entity: true`
- updated focused proof surfaces to reflect the new primitive-only boundary behavior while keeping the separate subject-linked residual split

## Canonical Owner Migration
New canonical owner set:
- `internal/runtime/pipeline/flow_instance_identity.go`
- `internal/runtime/pipeline/workflow_instance_activation.go`
- `internal/runtime/pipeline/engine_adapter.go`
- `internal/runtime/pipeline/engine_bridge.go`
- `internal/runtime/bootverify/workflow_flow_boundary_checks.go`
- `internal/runtime/bootverify/checks.go`

Old invalid producer/reader/writer paths after this PR:
- child-output parent retargeting through `workflowEmitTargetsParentEntity(...)`
- parent-entity rebinding in `resolveHandlerEntityIDForFlow(...)` for descendant-scoped inbound handling
- `_backprop` heuristic exemption via `isBackpropEvent(...)`

Production/proof paths checked for surviving old behavior:
- emitted payload shaping proofs in `internal/runtime/pipeline`
- inbound handler entity resolution proofs in `internal/runtime/pipeline`
- `_backprop` boot verification proofs in `internal/runtime/bootverify`
- cross-flow write fail-closed preservation in `internal/runtime/tools`
- supported tier11 runtime path for `test-nested-three-levels`
- full repo test suite

Migration complete:
- complete for the approved `#426` child
- later subject-linked residual family under `#415` remains open and explicitly split

## Scope Boundaries
In scope:
- runtime/boot removal of existing-entity continuation semantics at flow boundaries
- focused proof updates that move with the approved owner set

Out of scope:
- subject-linked residual family under `#415`
- schema/tool/operator cleanup in `#417`
- canonical spec rewrite in `#414`

## Tests Run
- `go test ./internal/runtime/pipeline -run 'Test(FlowInstanceIdentity_ResolveEmittedEntityID|HandlerEmitPayload_KeepsLocalEntityAcrossOutputBoundaries|ResolveHandlerEntityIDForFlow(KeepsInboundEntityForDescendantScopedInbound|DoesNotRetargetSameFlowInstancePath)|ExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotEmitChildContinuation|PipelineCoordinatorIntercept_NestedDescendantCompletion(DoesNotEmitChildContinuation|AlreadyTargetedToParentStillEmitsRootResult|InsideOuterSQLTxStillEmitsRootResult))$' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_(RequiresCreateEntityForBackpropInputPinHandlers|AllowsStatelessFlowInputPinHandlersWithoutCreateEntity)$' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusPublish_(NestedDescendantCompletionDoesNotEmitChildContinuation|NestedThreeLevelChain_FromRootStartCompletesWithoutChildContinuation)$' -count=1`
- `go test ./internal/runtime/tools -run 'TestEntityTools_(SaveEntityFieldRejectsCrossFlowWrite|FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity)$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-nested-three-levels$' -count=1`
- real verify canonical fixture: `SWARM_BOOT_WARNINGS_FATAL=0 go run ./cmd/swarm verify --contracts tests/tier11-flow-composition/test-child-flow-pin-wiring --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- real verify mutated `_backprop` fixture fails closed on `flow_boundary_create_entity_validation`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/bootverify ./internal/runtime/cataloge2e ./internal/runtime/tools ./internal/runtime/... -count=1`
- `go test ./... -count=1`

## Residual Risk / Follow-up
- later subject-linked `get_entity` / `subject_id` runtime family remains open under `#415`
- canonical spec adoption remains last in `#414`
