### PR TITLE
[agent-a][issue #398] Admit cross-flow inherit emitted-event proof

### DIFF
--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -2,12 +2,14 @@ package cataloge2e
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
@@ -150,6 +152,26 @@ func TestAssertCatalogRuntimeOutcome_IgnoresEntityNonSuccessPreviewProof(t *test
 	}
 
 	assertCatalogRuntimeOutcome(t, h, expected)
+}
+
+func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testing.T) {
+	h := newCatalogAssertionHarness(t)
+	entityID := "11111111-1111-1111-1111-111111111111"
+	bundle := loadFixtureBundle(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier11-flow-composition", "test-subject-id-cross-flow-inherit"))
+	h.bundle = bundle
+
+	insertCatalogAssertionEntityState(t, h, entityID, "dispatched")
+	if err := h.pg.AppendEvent(context.Background(), (events.Event{
+		ID:          uuid.NewString(),
+		Type:        "score.requested",
+		SourceAgent: "runtime",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)); err != nil {
+		t.Fatalf("append score.requested event: %v", err)
+	}
+
+	assertEmittedEvents(t, h.db, h.startedAt, h.publishedIDs, entityID, []string{"score.requested"}, "", semanticview.Wrap(bundle))
 }
 
 func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -23,6 +23,7 @@ var tier11FlowCompositionFixtures = []string{
 	"test-required-agents-child",
 	"test-child-flow-sibling-isolation",
 	"test-multi-level-policy-inherit",
+	"test-subject-id-cross-flow-inherit",
 	"test-tool-override",
 	"test-wildcard-deep-subscription",
 }
@@ -30,7 +31,6 @@ var tier11FlowCompositionFixtures = []string{
 var tier11ExcludedFixtures = map[string]catalogExcludedFixture{
 	"test-dynamic-flow-instance":              {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
 	"test-sibling-both-instantiated-isolated": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-	"test-subject-id-cross-flow-inherit":      {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 	"test-subject-id-first-flow-seeds":        {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 }
 

--- a/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/expected.yaml
+++ b/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/expected.yaml
@@ -7,6 +7,8 @@ trigger:
 expected:
   handler_outcome: success
   entity_state: dispatched
+  emitted_events:
+    - score.requested
   flow_entities:
     scoring:
       entity_state: scored


### PR DESCRIPTION
Closes #398

## Governing Context
- No exact external spec section governs this child directly.
- Binding context for this PR:
  - `#398`
  - split record in `#388`
  - fixture contract in `tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/expected.yaml`
  - canonical emitted-event proof owner in `internal/runtime/cataloge2e/assertions.go`
  - tier11 execution-set owner in `internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go`

## What Changed
- made the fixture's emitted-event contract explicit by declaring `score.requested`
- admitted `test-subject-id-cross-flow-inherit` into the normal tier11 runtime execution set
- added a focused owner-level regression proving the shared emitted-event assertion seam accepts the dispatcher emission for this fixture

## Canonical Owner After This Change
- `internal/runtime/cataloge2e/assertions.go:assertEmittedEvents(...)`
- supporting owner helpers on the same seam:
  - `catalogSubjectEntityIDs(...)`
  - `normalizeCatalogObservedEventName(...)`
- execution-set owner:
  - `internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go`

## Old Path Now Invalid
- the stale fixture contract that implicitly treated omitted `expected.emitted_events` as the honest runtime result for `test-subject-id-cross-flow-inherit`
- the stale exclusion entry claiming this fixture was only "not yet wired into runtime catalog execution set"

## Production Paths Checked For Surviving Old Behavior
- the shared `cataloge2e` emitted-event proof owner through the focused assertion regression
- tier11 real-runtime execution through:
  - `TestTier11FlowCompositionCatalogFixtures_RealRuntime`
  - `TestTier11FlowCompositionCatalogFixtures_AreExplicitlyClassified`
- full `internal/runtime/cataloge2e` package execution after admission

## Migration Status
- complete for the chosen child class on current head
- no broader subject-id migration, sibling fixture work, or generic harness cleanup in this PR

## Tests
- `go test ./internal/runtime/cataloge2e -run 'TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_(RealRuntime|AreExplicitlyClassified)$' -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
