### PR TITLE
[agent-e][issue #406] Suppress no-read_file follow-up artifacts

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -257,12 +257,6 @@ type runStatusReport struct {
 	RuntimeLogs       []runStatusRuntimeLog     `json:"runtime_logs,omitempty"`
 }
 
-type runOperationalProjection struct {
-	State          string
-	BlockingLayer  string
-	BlockingReason string
-}
-
 type runStatusEventCount struct {
 	EventName string `json:"event_name"`
 	Count     int    `json:"count"`
@@ -430,11 +424,11 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 		return runStatusReport{}, err
 	}
 	report := runStatusReportFromStore(detail)
-	operational := projectRunOperationalStatus(report)
+	operational := store.ProjectRunOperationalStatus(detail)
 	report.OperationalState = operational.State
 	report.BlockingLayer = operational.BlockingLayer
 	report.BlockingReason = operational.BlockingReason
-	report.Heuristics = deriveRunStatusHeuristics(report)
+	report.Heuristics = append([]string(nil), operational.Heuristics...)
 
 	return report, nil
 }
@@ -444,52 +438,6 @@ func logLimitForStatus(opts runStatusOptions) int {
 		return 100
 	}
 	return 20
-}
-
-func deriveRunStatusHeuristics(report runStatusReport) []string {
-	heuristics := make([]string, 0, 4)
-	if len(report.DeadLetters) > 0 {
-		heuristics = append(heuristics, "dead letters exist for this run")
-	}
-	return heuristics
-}
-
-func projectRunOperationalStatus(report runStatusReport) runOperationalProjection {
-	status := strings.ToLower(strings.TrimSpace(report.RunTableStatus))
-	if status == "" {
-		return runOperationalProjection{}
-	}
-	if status != "running" {
-		return runOperationalProjection{State: status}
-	}
-
-	eventCounts := map[string]int{}
-	for _, item := range report.EventCounts {
-		eventCounts[strings.TrimSpace(item.EventName)] = item.Count
-	}
-	activeDeliveries := 0
-	for _, item := range report.Deliveries {
-		switch strings.ToLower(strings.TrimSpace(item.Status)) {
-		case "pending", "in_progress":
-			activeDeliveries += item.Count
-		}
-	}
-	terminalScoring := eventCounts["scoring/vertical.marginal"] + eventCounts["scoring/vertical.rejected"] + eventCounts["scoring/vertical.shortlisted"]
-	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
-		return runOperationalProjection{
-			State:          "stalled",
-			BlockingLayer:  "scoring_terminal_outcome",
-			BlockingReason: "terminal_scoring_outcome_missing",
-		}
-	}
-	if activeDeliveries == 0 && !report.LastEventAt.IsZero() {
-		return runOperationalProjection{
-			State:          "stalled",
-			BlockingLayer:  "delivery_lifecycle",
-			BlockingReason: "no_active_deliveries",
-		}
-	}
-	return runOperationalProjection{State: "running"}
 }
 
 func printRunStatusReport(w io.Writer, report runStatusReport) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -138,16 +138,16 @@ func TestPrintRunStatusReport(t *testing.T) {
 }
 
 func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationallyStalled(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 2},
 			{SubscriberID: "agent-2", Status: "failed", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -160,18 +160,18 @@ func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationally
 }
 
 func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		EventCounts: []runStatusEventCount{
+		EventCounts: []store.RunDebugEventCount{
 			{EventName: "scoring/scoring.requested", Count: 1},
 		},
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -184,19 +184,19 @@ func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.
 }
 
 func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutcome(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		EventCounts: []runStatusEventCount{
+		EventCounts: []store.RunDebugEventCount{
 			{EventName: "scoring/scoring.requested", Count: 1},
 			{EventName: "scoring/vertical.shortlisted", Count: 1},
 		},
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "stalled" {
 		t.Fatalf("state = %q, want stalled", got.State)
 	}
@@ -209,16 +209,16 @@ func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutco
 }
 
 func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
-	report := runStatusReport{
+	report := store.RunDebugReport{
 		RunTableStatus: "running",
 		LastEventAt:    time.Unix(1700000000, 0).UTC(),
-		Deliveries: []runStatusDeliveryCount{
+		Deliveries: []store.RunDebugDeliveryCount{
 			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
 			{SubscriberID: "agent-2", Status: "delivered", Count: 1},
 		},
 	}
 
-	got := projectRunOperationalStatus(report)
+	got := store.ProjectRunOperationalStatus(report)
 	if got.State != "running" {
 		t.Fatalf("state = %q, want running", got.State)
 	}

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -89,6 +89,10 @@ active_issues:
     title: Reconcile run, session, and delivery lifecycle truth on the supported path
     maps_to:
       - runtime_lifecycle_observability
+  - id: 406
+    title: truncated tool-result follow-up files can be advertised on turns that lack a callable read_file tool
+    maps_to:
+      - transport_policy_and_surface_parity
   - id: 424
     title: Reconcile stale active agent sessions against the delivery frontier on the supported path
     maps_to:
@@ -106,12 +110,14 @@ nodes:
       - agent-visible tool availability differs between prompt and transport
       - supported agent turns can persist a canonical visible tool surface that is broader than the provider-callable surface actually available on that turn
       - fallback relay on a supported turn can degrade file-backed work by clamping large relayed tool results to preview-only text
+      - supported no-read_file turns can emit runtime_read_file follow-up artifacts for oversized tool results even though the same turn surface cannot call read_file
       - oversized file-backed tool results on supported Claude helper turns can leak provider scratch paths back into later runtime read_file calls
     representative_issues:
       - 111
       - 136
       - 137
       - 368
+      - 406
       - 381
     common_framing_mistakes:
       too_broad:

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -277,6 +277,13 @@ func (c *Conversation) projectToolResult(ctx context.Context, name string, input
 	if len(b) <= limit {
 		return result, nil
 	}
+	if !runtimeReadFileFollowUpAllowedForTurn(ctx, c.turnToolDefinitions()) {
+		return map[string]any{
+			"truncated": true,
+			"bytes":     len(b),
+			"preview":   clampRunes(string(b), maxToolResultPreviewRunes),
+		}, nil
+	}
 	if relay, ok, err := relayOversizedToolResult(ctx, c.runtime, c.Session, name, b); ok {
 		if err != nil {
 			return nil, fmt.Errorf("persist oversized tool result relay for %s: %w", strings.TrimSpace(name), err)
@@ -307,6 +314,16 @@ func (c *Conversation) projectToolResult(ctx context.Context, name string, input
 		"bytes":     len(b),
 		"preview":   clampRunes(string(b), maxToolResultPreviewRunes),
 	}, nil
+}
+
+func (c *Conversation) turnToolDefinitions() []ToolDefinition {
+	if c == nil {
+		return nil
+	}
+	if c.Session != nil && len(c.Session.Tools) > 0 {
+		return c.Session.Tools
+	}
+	return c.Tools
 }
 
 func shouldTerminateAfterToolCalls(calls []executedToolCall) bool {
@@ -367,6 +384,16 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 		return ctx
 	}
 	return toolcapabilities.WithContext(ctx, c.toolExecutor.ToolCapabilitiesForActor(actor, names, nil))
+}
+
+func runtimeReadFileFollowUpAllowedForTurn(ctx context.Context, tools []ToolDefinition) bool {
+	actor, _ := models.ActorFromContext(ctx)
+	for _, name := range plannedCanonicalVisibleToolsForActor(actor, tools) {
+		if name == "read_file" {
+			return true
+		}
+	}
+	return false
 }
 
 func clampToolResult(name string, result any) any {

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -380,11 +380,13 @@ func TestConversation_ExecuteToolCalls_PreservesLargeReadFileResultOnSupportedRe
 func TestConversation_ExecuteToolCalls_RelaysOversizedResultsForHelperRuntime(t *testing.T) {
 	huge := strings.Repeat("x", maxToolResultBytes+1024)
 	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/sql-execute-1.json"}
-	c := NewConversation("a1", "t1", "sys", nil, SessionScoped, 4, rt)
-	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test"}
+	tools := []ToolDefinition{{Name: "sql_execute"}, {Name: "read_file"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
 	c.SetToolExecutor(largeToolExec{payload: map[string]any{"blob": huge}})
 
-	raw, _ := c.executeToolCalls(context.Background(), []ToolCall{{Name: "sql_execute", Arguments: map[string]any{"query": "select 1"}}})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "sql_execute", Arguments: map[string]any{"query": "select 1"}}})
 	var arr []map[string]any
 	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
 		t.Fatalf("unmarshal tool payload: %v", err)
@@ -411,17 +413,51 @@ func TestConversation_ExecuteToolCalls_RelaysOversizedResultsForHelperRuntime(t 
 	}
 }
 
+func TestConversation_ExecuteToolCalls_SuppressesRuntimeReadFileFollowUpWithoutReadFileSurface(t *testing.T) {
+	huge := strings.Repeat("x", maxToolResultBytes+1024)
+	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/query-entities-1.json"}
+	tools := []ToolDefinition{{Name: "query_entities"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
+	c.SetToolExecutor(largeToolExec{payload: map[string]any{"blob": huge}})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "query_entities", Arguments: map[string]any{"entity_type": "company"}}})
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != true {
+		t.Fatalf("expected successful tool payload, got %#v", arr)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	if resultMap == nil || resultMap["truncated"] != true {
+		t.Fatalf("expected truncated oversized result metadata, got %#v", arr[0]["result"])
+	}
+	if _, ok := resultMap["follow_up"]; ok {
+		t.Fatalf("follow_up = %#v, want absent on no-read_file turn", resultMap["follow_up"])
+	}
+	if rt.toolName != "" {
+		t.Fatalf("relay tool name = %q, want no relay write", rt.toolName)
+	}
+	if len(rt.raw) != 0 {
+		t.Fatalf("relay raw = %q, want no relay payload write", string(rt.raw))
+	}
+}
+
 func TestConversation_ExecuteToolCalls_RelaysOversizedReadFileResultsForHelperRuntime(t *testing.T) {
 	huge := strings.Repeat("x", maxToolResultBytes+1024)
 	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/read-file-1.json"}
-	c := NewConversation("a1", "t1", "sys", nil, SessionScoped, 4, rt)
-	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test"}
+	tools := []ToolDefinition{{Name: "read_file"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
 	c.SetToolExecutor(largeToolExec{payload: map[string]any{
 		"content":    huge,
 		"size_bytes": len(huge),
 	}})
 
-	raw, _ := c.executeToolCalls(context.Background(), []ToolCall{{Name: "read_file", Arguments: map[string]any{"path": "/data/test-signals-25.jsonl"}}})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_file", Arguments: map[string]any{"path": "/data/test-signals-25.jsonl"}}})
 	var arr []map[string]any
 	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
 		t.Fatalf("unmarshal tool payload: %v", err)
@@ -481,11 +517,13 @@ func TestConversation_ExecuteToolCalls_PreservesRelayReadFileResultsForHelperRun
 func TestConversation_ExecuteToolCalls_FailsClosedWhenHelperRelayWriteFails(t *testing.T) {
 	huge := strings.Repeat("x", maxToolResultBytes+1024)
 	rt := &relayRuntime{relayErr: errors.New("workspace boom")}
-	c := NewConversation("a1", "t1", "sys", nil, SessionScoped, 4, rt)
-	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test"}
+	tools := []ToolDefinition{{Name: "sql_execute"}, {Name: "read_file"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
 	c.SetToolExecutor(largeToolExec{payload: map[string]any{"blob": huge}})
 
-	raw, executed := c.executeToolCalls(context.Background(), []ToolCall{{Name: "sql_execute", Arguments: map[string]any{"query": "select 1"}}})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, executed := c.executeToolCalls(ctx, []ToolCall{{Name: "sql_execute", Arguments: map[string]any{"query": "select 1"}}})
 	var arr []map[string]any
 	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
 		t.Fatalf("unmarshal tool payload: %v", err)

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -359,6 +359,13 @@ func projectToolCallSuccessText(ctx context.Context, executor runtimeGatewayExec
 	if len(raw) <= toolCallRelayResultLimit(toolName, input) {
 		return ToolResultText(out), nil
 	}
+	if !runtimeReadFileFollowUpAllowedInContext(ctx) {
+		return ToolResultText(map[string]any{
+			"truncated": true,
+			"bytes":     len(raw),
+			"preview":   clampRunes(string(raw), maxToolResultPreviewRunes),
+		}), nil
+	}
 	writer, ok := executor.(OversizedToolResultRelayWriter)
 	if !ok {
 		return ToolResultText(out), nil
@@ -486,6 +493,14 @@ func toolAllowedInContext(ctx context.Context, toolName string) bool {
 		return false
 	}
 	return cap.Callable
+}
+
+func runtimeReadFileFollowUpAllowedInContext(ctx context.Context) bool {
+	cap, ok := toolCapabilityInContext(ctx, "read_file")
+	if !ok {
+		return false
+	}
+	return cap.Visible && cap.Callable
 }
 
 func toolIsKindInContext(ctx context.Context, toolName string, kind toolcapabilities.ToolKind) bool {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -1042,6 +1042,84 @@ func TestGatewayHandleMCP_ToolsCallRelaysOversizedReadFileResultsForHelperPath(t
 	}
 }
 
+func TestGatewayHandleMCP_ToolsCallSuppressesRuntimeReadFileFollowUpWithoutReadFileSurface(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	exec := &relayAwareToolExecutorStub{
+		execFn: func(_ context.Context, _ string, _ any) (any, error) {
+			return map[string]any{
+				"content":    strings.Repeat("q", maxToolResultBytes+512),
+				"size_bytes": maxToolResultBytes + 512,
+			}, nil
+		},
+		relayRef: ToolResultRelayRef{
+			Path:       "/workspace/.swarm/tool-results/agent/query-entities-1.json",
+			ReadTool:   "read_file",
+			Format:     "json",
+			Visibility: "workspace_mount",
+		},
+	}
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-query-only", TurnContext{
+		Actor:     models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
+		Allowed:   map[string]struct{}{"query_entities": {}},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "query_entities",
+			"arguments": map[string]any{"entity_type": "company"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-query-only")
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	resp := mustRPCResponse(t, rec)
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v, want single text entry", result["content"])
+	}
+	entry, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content[0] = %#v, want map", content[0])
+	}
+	text, _ := entry["text"].(string)
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(text), &projected); err != nil {
+		t.Fatalf("unmarshal projected text: %v", err)
+	}
+	if truncated, _ := projected["truncated"].(bool); !truncated {
+		t.Fatalf("truncated = %#v, want true", projected["truncated"])
+	}
+	if _, ok := projected["follow_up"]; ok {
+		t.Fatalf("follow_up = %#v, want absent on no-read_file turn", projected["follow_up"])
+	}
+	if exec.relayTool != "" {
+		t.Fatalf("relay tool = %q, want no relay write", exec.relayTool)
+	}
+	if len(exec.relayRaw) != 0 {
+		t.Fatalf("relay raw = %q, want no relay payload write", string(exec.relayRaw))
+	}
+}
+
 func TestGatewayHandleMCP_ToolsCallPreservesLargeRelayPathReadInline(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	exec := &relayAwareToolExecutorStub{

--- a/internal/store/run_operational_status_read_surface.go
+++ b/internal/store/run_operational_status_read_surface.go
@@ -1,0 +1,66 @@
+package store
+
+import "strings"
+
+type RunOperationalStatus struct {
+	State          string
+	BlockingLayer  string
+	BlockingReason string
+	Heuristics     []string
+}
+
+// ProjectRunOperationalStatus owns supported run-status semantics above the
+// canonical persisted run-debug evidence surface.
+func ProjectRunOperationalStatus(report RunDebugReport) RunOperationalStatus {
+	out := RunOperationalStatus{
+		Heuristics: runOperationalStatusHeuristics(report),
+	}
+
+	status := strings.ToLower(strings.TrimSpace(report.RunTableStatus))
+	if status == "" {
+		return out
+	}
+	if status != "running" {
+		out.State = status
+		return out
+	}
+
+	eventCounts := map[string]int{}
+	for _, item := range report.EventCounts {
+		eventCounts[strings.TrimSpace(item.EventName)] = item.Count
+	}
+
+	activeDeliveries := 0
+	for _, item := range report.Deliveries {
+		switch strings.ToLower(strings.TrimSpace(item.Status)) {
+		case "pending", "in_progress":
+			activeDeliveries += item.Count
+		}
+	}
+
+	terminalScoring := eventCounts["scoring/vertical.marginal"] +
+		eventCounts["scoring/vertical.rejected"] +
+		eventCounts["scoring/vertical.shortlisted"]
+	if activeDeliveries == 0 && eventCounts["scoring/scoring.requested"] > 0 && terminalScoring == 0 {
+		out.State = "stalled"
+		out.BlockingLayer = "scoring_terminal_outcome"
+		out.BlockingReason = "terminal_scoring_outcome_missing"
+		return out
+	}
+	if activeDeliveries == 0 && !report.LastEventAt.IsZero() {
+		out.State = "stalled"
+		out.BlockingLayer = "delivery_lifecycle"
+		out.BlockingReason = "no_active_deliveries"
+		return out
+	}
+
+	out.State = "running"
+	return out
+}
+
+func runOperationalStatusHeuristics(report RunDebugReport) []string {
+	if len(report.DeadLetters) == 0 {
+		return nil
+	}
+	return []string{"dead letters exist for this run"}
+}

--- a/internal/store/run_operational_status_read_surface_test.go
+++ b/internal/store/run_operational_status_read_surface_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProjectRunOperationalStatus_UsesDeliveryLifecycleWhenRunIsOperationallyStalled(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 2},
+			{SubscriberID: "agent-2", Status: "failed", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_UsesScoringOutcomeBlockingLayer(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []RunDebugEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+		},
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "scoring_terminal_outcome" {
+		t.Fatalf("blocking_layer = %q, want scoring_terminal_outcome", got.BlockingLayer)
+	}
+	if got.BlockingReason != "terminal_scoring_outcome_missing" {
+		t.Fatalf("blocking_reason = %q, want terminal_scoring_outcome_missing", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_TreatsScopedShortlistAsTerminalScoringOutcome(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		EventCounts: []RunDebugEventCount{
+			{EventName: "scoring/scoring.requested", Count: 1},
+			{EventName: "scoring/vertical.shortlisted", Count: 1},
+		},
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", got.State)
+	}
+	if got.BlockingLayer != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %q, want delivery_lifecycle", got.BlockingLayer)
+	}
+	if got.BlockingReason != "no_active_deliveries" {
+		t.Fatalf("blocking_reason = %q, want no_active_deliveries", got.BlockingReason)
+	}
+}
+
+func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveriesRemain(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
+			{SubscriberID: "agent-2", Status: "delivered", Count: 1},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if got.State != "running" {
+		t.Fatalf("state = %q, want running", got.State)
+	}
+	if got.BlockingLayer != "" || got.BlockingReason != "" {
+		t.Fatalf("unexpected blocking projection: %#v", got)
+	}
+}


### PR DESCRIPTION
Closes #406
Related to #374
Related to #368

## Summary

This PR closes the later-turn no-`read_file` follow-up parity child under `#406`.

Supported no-`read_file` turns were able to emit `runtime_read_file` oversized-result follow-up artifacts even though the same turn surface could not call `read_file`. The fix keeps oversized-result projection behind the canonical turn-usable tool-surface truth and fails closed when `read_file` is not part of that turn surface.

## Governing context

There is no exact governing spec section for `runtime_read_file` follow-up artifacts.

Binding context for this change:
- issue/thread: `#406`
- broader family tracker: `#374`
- split sibling child: `#368`

Adjacent constraining spec refs used:
- `platform.native_tools`
- `platform.native_tools.file_io`
- `platform.native_tools.tool_names.file_io`
- `platform.native_tools.runtime_resolution`

## Canonical owner migration

New canonical owner set:
- helper/local oversized-result follow-up admissibility now consumes the canonical turn-visible tool surface via `plannedCanonicalVisibleToolsForActor(...)`
- MCP/runtime oversized-result follow-up admissibility now consumes the resolved turn capability surface from the transport context

Old non-authoritative paths now invalid:
- `internal/runtime/llm/conversation.go:projectToolResult(...)` no longer advertises `runtime_read_file` blindly
- `internal/runtime/mcp/gateway.go:projectToolCallSuccessText(...)` no longer advertises `runtime_read_file` blindly

Production paths checked for surviving old behavior:
- helper/local oversized-result projection in `Conversation.executeToolCalls(...)`
- MCP/runtime oversized-result projection in `Gateway` tool-call success responses
- persisted no-`read_file` available-tool shaping already consumed by `enrichTurnRecord(...)`

Migration completeness:
- complete for the approved `#406` child boundary
- broader typed turn-surface architecture work remains tracked by `#374`

## Proof

Focused proof:
- `go test ./internal/runtime/llm -run 'Test(Conversation_ExecuteToolCalls_(RelaysOversizedResultsForHelperRuntime|SuppressesRuntimeReadFileFollowUpWithoutReadFileSurface|RelaysOversizedReadFileResultsForHelperRuntime)|EnrichTurnRecord_UsesEmitFallbackWhenObservedCLISurfaceExistsWithoutVisibleNonEmitTools|EnrichTurnRecord_UsesPlannedConfiguredSurfaceWhenObservedMetadataIsAbsent|ValidateCLIResponseToolCallsForTurn_FailsClosedForNonEmitToolOutsideObservedSurface)$' -count=1`
- `go test ./internal/runtime/mcp -run 'TestGatewayHandleMCP_ToolsCall(RelaysOversizedReadFileResultsForHelperPath|SuppressesRuntimeReadFileFollowUpWithoutReadFileSurface|PreservesLargeRelayPathReadInline)$' -count=1`
- `go test ./internal/runtime/llm ./internal/runtime/mcp -count=1`
- `go test ./... -count=1`
