### PR TITLE
[agent-a][issue #399] Canonicalize first-flow subject self-seeding

### DIFF
--- a/internal/runtime/cataloge2e/assertions.go
+++ b/internal/runtime/cataloge2e/assertions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -64,9 +65,10 @@ func assertSubjectFlowEntities(t testing.TB, workflow *runtimepipeline.WorkflowI
 	if len(want) == 0 {
 		return
 	}
+	source := semanticview.Wrap(bundle)
 	for flowID, expected := range want {
 		flowID = strings.TrimSpace(flowID)
-		got, found, err := catalogFlowInstanceForSubject(workflow, semanticview.Wrap(bundle), strings.TrimSpace(subjectID), flowID)
+		got, found, err := catalogFlowInstanceForExpectedSubject(workflow, source, strings.TrimSpace(subjectID), flowID, expected)
 		if err != nil {
 			t.Fatalf("load subject flow instance %s/%s: %v", subjectID, flowID, err)
 		}
@@ -86,7 +88,7 @@ func assertSubjectFlowEntities(t testing.TB, workflow *runtimepipeline.WorkflowI
 		}
 		if expected.SubjectIDIsSelf != nil {
 			gotSubjectID := strings.TrimSpace(got.SubjectID)
-			gotEntityID := strings.TrimSpace(got.InstanceID)
+			gotEntityID := catalogFlowEntityID(got)
 			if *expected.SubjectIDIsSelf && gotSubjectID != gotEntityID {
 				t.Fatalf("subject flow instance %s/%s subject_id = %q, want self entity_id %q", subjectID, flowID, gotSubjectID, gotEntityID)
 			}
@@ -177,7 +179,7 @@ func assertEntitySubjectIDSelf(t testing.TB, workflow *runtimepipeline.WorkflowI
 		t.Fatalf("workflow instance %s not found for subject self assertion", entityID)
 	}
 	gotSubjectID := strings.TrimSpace(instance.SubjectID)
-	gotEntityID := strings.TrimSpace(instance.InstanceID)
+	gotEntityID := catalogFlowEntityID(instance)
 	if *wantSelf && gotSubjectID != gotEntityID {
 		t.Fatalf("entity %s subject_id = %q, want self entity_id %q", entityID, gotSubjectID, gotEntityID)
 	}
@@ -324,50 +326,109 @@ func catalogFlowInstanceForSubject(workflow *runtimepipeline.WorkflowInstanceSto
 	}
 	subjectID = strings.TrimSpace(subjectID)
 	flowID = strings.TrimSpace(flowID)
-	candidates := map[string]struct{}{}
-	if flowID != "" {
-		candidates[flowID] = struct{}{}
-		if source != nil {
-			for _, scope := range source.FlowScopes() {
-				if strings.TrimSpace(scope.ID) == flowID || strings.Trim(strings.TrimSpace(scope.Path), "/") == flowID {
-					if id := strings.TrimSpace(scope.ID); id != "" {
-						candidates[id] = struct{}{}
-					}
-					if path := strings.Trim(strings.TrimSpace(scope.Path), "/"); path != "" {
-						candidates[path] = struct{}{}
-					}
-				}
-			}
-		}
-	}
+	candidates := catalogFlowCandidates(source, flowID)
 	for _, row := range rows {
 		if strings.TrimSpace(row.SubjectID) != subjectID {
 			continue
 		}
-		if len(candidates) > 0 {
-			rowWorkflow := strings.TrimSpace(row.WorkflowName)
-			rowStorage := strings.Trim(strings.TrimSpace(row.StorageRef), "/")
-			matched := false
-			for candidate := range candidates {
-				candidate = strings.Trim(candidate, "/")
-				switch {
-				case candidate == "":
-				case rowWorkflow == candidate:
-					matched = true
-				case rowStorage == candidate:
-					matched = true
-				}
-				if matched {
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
+		if !catalogFlowMatches(row, candidates) {
+			continue
 		}
 		return row, true, nil
 	}
 	return runtimepipeline.WorkflowInstance{}, false, nil
+}
+
+func catalogFlowInstanceForExpectedSubject(workflow *runtimepipeline.WorkflowInstanceStore, source semanticview.Source, subjectID, flowID string, expected catalogEntityExpected) (runtimepipeline.WorkflowInstance, bool, error) {
+	row, found, err := catalogFlowInstanceForSubject(workflow, source, subjectID, flowID)
+	if err != nil || found {
+		return row, found, err
+	}
+	if expected.SubjectIDIsSelf == nil || !*expected.SubjectIDIsSelf || strings.TrimSpace(expected.SubjectID) != "" {
+		return runtimepipeline.WorkflowInstance{}, false, nil
+	}
+	return catalogSelfSeededFlowInstance(workflow, source, flowID)
+}
+
+func catalogSelfSeededFlowInstance(workflow *runtimepipeline.WorkflowInstanceStore, source semanticview.Source, flowID string) (runtimepipeline.WorkflowInstance, bool, error) {
+	if workflow == nil {
+		return runtimepipeline.WorkflowInstance{}, false, nil
+	}
+	rows, err := workflow.List(context.Background())
+	if err != nil {
+		return runtimepipeline.WorkflowInstance{}, false, err
+	}
+	candidates := catalogFlowCandidates(source, flowID)
+	var match runtimepipeline.WorkflowInstance
+	found := false
+	for _, row := range rows {
+		if !catalogFlowMatches(row, candidates) {
+			continue
+		}
+		rowEntityID := catalogFlowEntityID(row)
+		rowSubjectID := strings.TrimSpace(row.SubjectID)
+		if rowEntityID == "" || rowSubjectID != rowEntityID {
+			continue
+		}
+		if found {
+			return runtimepipeline.WorkflowInstance{}, false, fmt.Errorf("ambiguous self-seeded flow instance for %s", strings.TrimSpace(flowID))
+		}
+		match = row
+		found = true
+	}
+	return match, found, nil
+}
+
+func catalogFlowCandidates(source semanticview.Source, flowID string) map[string]struct{} {
+	flowID = strings.TrimSpace(flowID)
+	candidates := map[string]struct{}{}
+	if flowID == "" {
+		return candidates
+	}
+	candidates[flowID] = struct{}{}
+	if source == nil {
+		return candidates
+	}
+	for _, scope := range source.FlowScopes() {
+		if strings.TrimSpace(scope.ID) == flowID || strings.Trim(strings.TrimSpace(scope.Path), "/") == flowID {
+			if id := strings.TrimSpace(scope.ID); id != "" {
+				candidates[id] = struct{}{}
+			}
+			if path := strings.Trim(strings.TrimSpace(scope.Path), "/"); path != "" {
+				candidates[path] = struct{}{}
+			}
+		}
+	}
+	return candidates
+}
+
+func catalogFlowMatches(row runtimepipeline.WorkflowInstance, candidates map[string]struct{}) bool {
+	if len(candidates) == 0 {
+		return true
+	}
+	rowWorkflow := strings.TrimSpace(row.WorkflowName)
+	rowStorage := strings.Trim(strings.TrimSpace(row.StorageRef), "/")
+	rowScope := strings.Trim(strings.TrimSpace(runtimeflowidentity.SemanticScope(rowStorage)), "/")
+	for candidate := range candidates {
+		candidate = strings.Trim(candidate, "/")
+		switch {
+		case candidate == "":
+		case rowWorkflow == candidate:
+			return true
+		case rowStorage == candidate:
+			return true
+		case rowScope == candidate:
+			return true
+		}
+	}
+	return false
+}
+
+func catalogFlowEntityID(row runtimepipeline.WorkflowInstance) string {
+	if entityID := strings.TrimSpace(asString(row.Metadata["entity_id"])); entityID != "" {
+		return entityID
+	}
+	return strings.TrimSpace(row.InstanceID)
 }
 
 func catalogPayloadMap(v any) map[string]any {

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -174,6 +174,45 @@ func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testin
 	assertEmittedEvents(t, h.db, h.startedAt, h.publishedIDs, entityID, []string{"score.requested"}, "", semanticview.Wrap(bundle))
 }
 
+func TestCatalogFlowInstanceForExpectedSubject_FallsBackToSelfSeededFlowEntity(t *testing.T) {
+	h := newCatalogAssertionHarness(t)
+	bundle := loadFixtureBundle(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier11-flow-composition", "test-subject-id-first-flow-seeds"))
+	rootEntityID := "11111111-1111-1111-1111-111111111111"
+	childEntityID := uuid.NewString()
+	if err := h.workflow.Upsert(context.Background(), runtimepipeline.WorkflowInstance{
+		InstanceID:      childEntityID,
+		SubjectID:       childEntityID,
+		StorageRef:      "intake/inst-1",
+		WorkflowName:    "intake",
+		WorkflowVersion: bundle.WorkflowVersion(),
+		CurrentState:    "processed",
+		Metadata: map[string]any{
+			"entity_id":        childEntityID,
+			"instance_id":      "inst-1",
+			"flow_path":        "intake/inst-1",
+			"storage_ref":      "intake/inst-1",
+			"subject_id":       childEntityID,
+			"parent_entity_id": rootEntityID,
+		},
+	}); err != nil {
+		t.Fatalf("seed self-seeded flow instance: %v", err)
+	}
+
+	wantSelf := true
+	got, found, err := catalogFlowInstanceForExpectedSubject(h.workflow, semanticview.Wrap(bundle), rootEntityID, "intake", catalogEntityExpected{
+		SubjectIDIsSelf: &wantSelf,
+	})
+	if err != nil {
+		t.Fatalf("catalogFlowInstanceForExpectedSubject: %v", err)
+	}
+	if !found {
+		t.Fatal("expected self-seeded flow instance fallback to find intake entity")
+	}
+	if gotEntityID := catalogFlowEntityID(got); gotEntityID != childEntityID {
+		t.Fatalf("entity_id = %q, want %q", gotEntityID, childEntityID)
+	}
+}
+
 func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {
 	t.Helper()
 	_, db, cleanup := testutil.StartPostgres(t)

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -24,6 +24,7 @@ var tier11FlowCompositionFixtures = []string{
 	"test-child-flow-sibling-isolation",
 	"test-multi-level-policy-inherit",
 	"test-subject-id-cross-flow-inherit",
+	"test-subject-id-first-flow-seeds",
 	"test-tool-override",
 	"test-wildcard-deep-subscription",
 }
@@ -31,7 +32,6 @@ var tier11FlowCompositionFixtures = []string{
 var tier11ExcludedFixtures = map[string]catalogExcludedFixture{
 	"test-dynamic-flow-instance":              {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
 	"test-sibling-both-instantiated-isolated": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-	"test-subject-id-first-flow-seeds":        {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 }
 
 var tier11StartedRuntimeFixtures = map[string]struct{}{

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -275,10 +275,11 @@ func resolveHandlerEntityIDForFlow(
 		instanceID := uuid.NewString()
 		instance := deriveFlowInstanceIdentity(source, flowID, instanceID)
 		instance.ParentEntityID = sourceEntityID
+		sourceEntityKnown := workflowStateCarriesPersistedSourceEntity(source, state)
 		if state != nil && state.Metadata != nil {
 			instance.SubjectID = strings.TrimSpace(asString(state.Metadata["subject_id"]))
 		}
-		if instance.SubjectID == "" {
+		if instance.SubjectID == "" && sourceEntityKnown {
 			instance.SubjectID = sourceEntityID
 		}
 		if instance.SubjectID == "" {
@@ -305,6 +306,13 @@ func resolveHandlerEntityIDForFlow(
 		state.EntityID = entityID
 	}
 	return entityID, evt
+}
+
+func workflowStateCarriesPersistedSourceEntity(source semanticview.Source, state *WorkflowState) bool {
+	if state == nil {
+		return false
+	}
+	return workflowStateIdentity(source, "", *state).HasStoredPath
 }
 
 func workflowCreateEntityMetadata(source semanticview.Source, flowID string, instance FlowInstanceIdentity) map[string]any {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1065,7 +1065,7 @@ func TestResolveHandlerEntityIDForFlowDoesNotRetargetSameFlowInstancePath(t *tes
 	}
 }
 
-func TestResolveHandlerEntityIDForFlowCreateEntitySeedsInitialStateAndSchemaDefaults(t *testing.T) {
+func TestResolveHandlerEntityIDForFlowCreateEntityInheritsPersistedSourceEntityWhenSubjectMissing(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			InitialStage: "queued",
@@ -1087,7 +1087,11 @@ func TestResolveHandlerEntityIDForFlowCreateEntitySeedsInitialStateAndSchemaDefa
 		EntityID: inboundEntityID,
 		Stage:    WorkflowStateID("queued"),
 		Status:   "active",
-		Metadata: map[string]any{"name": "Parent"},
+		Metadata: map[string]any{
+			"name":        "Parent",
+			"instance_id": "root-inst-1",
+			"flow_path":   "root-inst-1",
+		},
 	}
 	inbound := events.Event{
 		Type:    events.EventType("vertical.discovered"),
@@ -1213,6 +1217,42 @@ func TestResolveHandlerEntityIDForFlowCreateEntitySeedsFirstFlowSubjectID(t *tes
 	}
 	if got := strings.TrimSpace(asString(state.Metadata["subject_id"])); got != gotID {
 		t.Fatalf("state subject_id = %q, want %q", got, gotID)
+	}
+}
+
+func TestResolveHandlerEntityIDForFlowCreateEntitySeedsFirstChildFlowSubjectIDFromFreshEntity(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "queued",
+			FlowInitial:  map[string]string{"intake": "queued"},
+		},
+	})
+	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
+	const inboundEntityID = "11111111-1111-1111-1111-111111111111"
+	state := WorkflowState{}
+	inbound := events.Event{
+		Type: events.EventType("work.assigned"),
+	}.WithEnvelope(events.EventEnvelope{EntityID: inboundEntityID})
+
+	gotID, _ := resolveHandlerEntityIDForFlow(source, "intake", handler, inboundEntityID, inbound, &state)
+
+	if gotID == "" || gotID == inboundEntityID {
+		t.Fatalf("entityID = %q, want fresh child flow entity id", gotID)
+	}
+	if state.EntityID != gotID {
+		t.Fatalf("state entity_id = %q, want %q", state.EntityID, gotID)
+	}
+	if state.Stage != "queued" {
+		t.Fatalf("state stage = %q, want queued", state.Stage)
+	}
+	if state.Metadata == nil {
+		t.Fatal("state metadata = nil, want canonical subject metadata")
+	}
+	if got := strings.TrimSpace(asString(state.Metadata["subject_id"])); got != gotID {
+		t.Fatalf("state subject_id = %q, want self-seeded %q", got, gotID)
+	}
+	if got := strings.TrimSpace(asString(state.Metadata["parent_entity_id"])); got != inboundEntityID {
+		t.Fatalf("state parent_entity_id = %q, want inbound root entity %q", got, inboundEntityID)
 	}
 }
 


### PR DESCRIPTION
Closes #399

## Summary
- canonicalize first-flow child `create_entity` subject seeding on the workflow-handler runtime path
- admit `test-subject-id-first-flow-seeds` into the normal tier11 `cataloge2e` runtime set
- align the supported `subject_id_is_self` proof reader with self-seeded flow entities on the admitted runtime surface

## Governing Refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `ownership_semantics.subject_id.propagation_rules.first_flow`
  - `ownership_semantics.subject_id.propagation_rules.subsequent_flows`
  - `ownership_semantics.subject_id.propagation_rules.immutable`
- `docs/specs/swarm-platform/platform/TEST-PLAN-flow-scoped-entities.md`
  - `A1. First flow seeds subject_id = entity_id`
- binding issue / classification context:
  - `#399`
  - `#388`

## Scope Boundary
- in scope:
  - workflow-handler `create_entity` first-flow subject seeding
  - direct persistence/proof consumers needed to make `test-subject-id-first-flow-seeds` honest on the supported runtime surface
- out of scope:
  - reopening `#398`
  - broader `#125` redesign
  - generic catalog harness cleanup

## Semantic Migration
- new canonical owner:
  - `internal/runtime/pipeline/engine_bridge.go:resolveHandlerEntityIDForFlow(...)`
  - proof-side admission/read path:
    - `internal/runtime/cataloge2e/assertions.go`
    - `internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go`
- old invalid producer / reader path now invalid:
  - workflow-handler `create_entity` treating any inbound root `entity_id` as authoritative subject inheritance even when no persisted source flow entity exists
  - `flow_entities` proof anchoring `subject_id_is_self` only through the root trigger subject lookup
- production paths checked for surviving old behavior:
  - workflow-handler `create_entity` with no persisted source flow entity
  - workflow-handler `create_entity` with a persisted source flow entity whose `subject_id` is absent
  - admitted tier11 runtime proof for `test-subject-id-first-flow-seeds`
- migration complete:
  - yes for the chosen `#399` child class

## Proof
- `go test ./internal/runtime/pipeline -run 'TestResolveHandlerEntityIDForFlowCreateEntity(SeedsFirstChildFlowSubjectIDFromFreshEntity|SeedsFirstFlowSubjectID|InheritsPersistedSourceEntityWhenSubjectMissing)$' -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestCatalogFlowInstanceForExpectedSubject_FallsBackToSelfSeededFlowEntity$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_(RealRuntime/test-subject-id-first-flow-seeds|AreExplicitlyClassified)$' -count=1`

## Notes
- `go test ./internal/runtime/cataloge2e -count=1` is still red on current `master` because of unrelated pre-existing tier11 fixture failures outside `#399`; this PR uses the fixture-specific supported proof instead of claiming package-wide closure.
