### PR TITLE
[agent-e][issue #368] Align first-turn file tool surface and relay

### DIFF
--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -561,6 +561,11 @@ func observedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []Too
 	return filterCanonicalVisibleToolsForActor(actor, tools, observed)
 }
 
+func cliTurnContextAllowedToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	return append([]string(nil), surface.RuntimeToolNames...)
+}
+
 func plannedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	return append([]string(nil), surface.CanonicalVisibleTools...)
@@ -569,6 +574,17 @@ func plannedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []Tool
 func cliLocalFallbackVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	return append([]string(nil), surface.LocalFallbackTools...)
+}
+
+func resolvedCLIUsableToolsForTurn(actor models.AgentConfig, tools []ToolDefinition, resp *Response) []string {
+	usable := appendCanonicalToolNames(nil, cliLocalFallbackVisibleToolsForActor(actor, tools))
+	if observed := observedCanonicalVisibleToolsForActor(actor, tools, resp); len(observed) > 0 {
+		return appendCanonicalToolNames(usable, observed)
+	}
+	if hasObservedCLIExecutionSurface(resp) {
+		return usable
+	}
+	return appendCanonicalToolNames(usable, plannedCanonicalVisibleToolsForActor(actor, tools))
 }
 
 func hasObservedCLIExecutionSurface(resp *Response) bool {
@@ -583,25 +599,39 @@ func cliToolCallAllowedForTurn(actor models.AgentConfig, tools []ToolDefinition,
 	if name == "" {
 		return false
 	}
-	for _, allowed := range cliLocalFallbackVisibleToolsForActor(actor, tools) {
-		if allowed == name {
-			return true
-		}
-	}
-	for _, visible := range observedCanonicalVisibleToolsForActor(actor, tools, resp) {
-		if visible == name {
-			return true
-		}
-	}
-	if hasObservedCLIExecutionSurface(resp) {
-		return false
-	}
-	for _, visible := range plannedCanonicalVisibleToolsForActor(actor, tools) {
+	for _, visible := range resolvedCLIUsableToolsForTurn(actor, tools, resp) {
 		if visible == name {
 			return true
 		}
 	}
 	return false
+}
+
+func appendCanonicalToolNames(dst []string, names []string) []string {
+	if len(names) == 0 {
+		return dst
+	}
+	seen := make(map[string]struct{}, len(dst)+len(names))
+	for _, existing := range dst {
+		existing = toolidentity.CanonicalName(existing)
+		if existing == "" {
+			continue
+		}
+		seen[existing] = struct{}{}
+	}
+	for _, name := range names {
+		name = toolidentity.CanonicalName(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		dst = append(dst, name)
+	}
+	slices.Sort(dst)
+	return dst
 }
 
 func hasToolPrefix(names []string, prefix string) bool {

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -182,7 +182,18 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if len(turns.records) == 0 {
 		t.Fatal("expected persisted turn records")
 	}
-	first := turns.records[0]
+	first := AgentTurnRecord{}
+	found := false
+	for _, rec := range turns.records {
+		if got := rec.MCPServers["runtime-tools"]; got == "connected" {
+			first = rec
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no provider-observed first-turn record found in %#v", turns.records)
+	}
 	if !slices.Equal(first.AvailableTools, []string{"emit_category_assessed", "read_file"}) {
 		t.Fatalf("first turn available_tools = %#v", first.AvailableTools)
 	}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -1,0 +1,234 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
+	"swarm/internal/runtime/sessions"
+	workspace "swarm/internal/runtime/workspace"
+)
+
+type firstTurnWorkflowToolExec struct {
+	readPayload any
+	calls       []string
+}
+
+func (e *firstTurnWorkflowToolExec) Execute(ctx context.Context, name string, input any) (any, error) {
+	e.calls = append(e.calls, strings.TrimSpace(name))
+	switch strings.TrimSpace(name) {
+	case "read_file":
+		return e.readPayload, nil
+	case "emit_category_assessed":
+		if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok {
+			recorder.Append(events.Event{Type: events.EventType("discovery/category.assessed")})
+		}
+		return map[string]any{"emitted": true, "input": input}, nil
+	default:
+		return map[string]any{"name": name, "input": input}, nil
+	}
+}
+
+func (e *firstTurnWorkflowToolExec) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, name := range names {
+		kind := toolcapabilities.KindStandard
+		if strings.HasPrefix(strings.TrimSpace(name), "emit_") {
+			kind = toolcapabilities.KindEmit
+		}
+		caps = append(caps, toolcapabilities.Capability{
+			Name:     name,
+			Kind:     kind,
+			Visible:  true,
+			Callable: true,
+		})
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t *testing.T) {
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	tempDir := t.TempDir()
+	stateFile := filepath.Join(tempDir, "docker-state")
+	captureDir := filepath.Join(tempDir, "captures")
+	if err := os.MkdirAll(captureDir, 0o755); err != nil {
+		t.Fatalf("mkdir capture dir: %v", err)
+	}
+	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
+	script := `#!/bin/sh
+set -eu
+state_file="${FAKE_DOCKER_STATE_FILE}"
+capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
+count=0
+if [ -f "$state_file" ]; then
+  count=$(cat "$state_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$state_file"
+cat > "$capture_dir/$count.stdin"
+if [ "$count" -eq 1 ]; then
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","mcp__runtime-tools__read_file"]}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"mcp__runtime-tools__read_file","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"provider-sess-1"}'
+  exit 0
+fi
+printf '%s\n' '{"type":"result","result":"done"}'
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker script: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+	t.Setenv("FAKE_DOCKER_STATE_FILE", stateFile)
+	t.Setenv("FAKE_DOCKER_CAPTURE_DIR", captureDir)
+
+	cfg := &config.Config{}
+	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
+	cfg.LLM.ClaudeCLI.Command = "claude"
+
+	var allowedTools []string
+	turns := &turnCapture{}
+	runtime := NewClaudeCLIRuntimeWithOptions(
+		cfg,
+		sessions.NewInMemoryRegistry(0),
+		"worker-1",
+		turns,
+		nil,
+		workspaceResolverStub{target: &workspace.Target{Container: "swarm-agent-market-research", Workdir: "/workspace"}},
+		nil,
+		nil,
+		ClaudeCLIRuntimeOptions{
+			MCPTurnContextStore: mcpTurnContextStoreStub{
+				register: func(_ context.Context, _ time.Duration, got []string) string {
+					allowedTools = append([]string(nil), got...)
+					return "ctx-token-368"
+				},
+				unregister: func(string) {},
+			},
+		},
+	)
+	relayWrites := 0
+	runtime.execWorkspaceFn = func(context.Context, *workspace.Target, string, ...string) ([]byte, []byte, int, error) {
+		relayWrites++
+		return nil, nil, 0, nil
+	}
+
+	huge := strings.Repeat("x", maxToolResultBytes+1024)
+	exec := &firstTurnWorkflowToolExec{
+		readPayload: map[string]any{
+			"content":    huge,
+			"size_bytes": len(huge),
+		},
+	}
+	conv := NewConversation(
+		"market-research-agent",
+		"task-1",
+		"system prompt",
+		[]ToolDefinition{
+			{Name: "emit_category_assessed"},
+			{Name: "read_file"},
+		},
+		SessionScoped,
+		4,
+		runtime,
+	)
+	conv.SetToolExecutor(exec)
+
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(
+		sessions.WithScope(
+			runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+				ID: "market-research-agent",
+				NativeTools: runtimeactors.NativeToolConfig{
+					FileIO: true,
+				},
+				SessionScope: sessions.SessionScopeGlobal.String(),
+			}),
+			sessions.RuntimeModeSession.String(),
+			sessions.SessionScopeGlobal.String(),
+			"global",
+		),
+		recorder,
+	)
+
+	resp, err := conv.Step(ctx, "scan the file")
+	if err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected final response")
+	}
+	if relayWrites != 0 {
+		t.Fatalf("relay writes = %d, want 0 on supported read_file turn", relayWrites)
+	}
+	if !slices.Equal(allowedTools, []string{"emit_category_assessed", "read_file"}) {
+		t.Fatalf("allowed tools = %#v", allowedTools)
+	}
+	if len(turns.records) == 0 {
+		t.Fatal("expected persisted turn records")
+	}
+	first := turns.records[0]
+	if !slices.Equal(first.AvailableTools, []string{"emit_category_assessed", "read_file"}) {
+		t.Fatalf("first turn available_tools = %#v", first.AvailableTools)
+	}
+	if !slices.Equal(first.MCPToolsVisible, []string{
+		"mcp__runtime-tools__emit_category_assessed",
+		"mcp__runtime-tools__read_file",
+	}) {
+		t.Fatalf("first turn mcp_tools_visible = %#v", first.MCPToolsVisible)
+	}
+	if got := first.MCPServers["runtime-tools"]; got != "connected" {
+		t.Fatalf("first turn mcp_servers = %#v", first.MCPServers)
+	}
+	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
+		t.Fatalf("emitted events = %#v", recorder.Snapshot())
+	}
+	if !slices.Equal(exec.calls, []string{"read_file", "emit_category_assessed"}) {
+		t.Fatalf("tool exec calls = %#v", exec.calls)
+	}
+
+	secondInput, err := os.ReadFile(filepath.Join(captureDir, "2.stdin"))
+	if err != nil {
+		t.Fatalf("read second stdin: %v", err)
+	}
+	var payload []map[string]any
+	if err := json.Unmarshal(secondInput, &payload); err != nil {
+		t.Fatalf("unmarshal second stdin: %v", err)
+	}
+	if len(payload) != 2 {
+		t.Fatalf("tool payload entries = %d, want 2 (%#v)", len(payload), payload)
+	}
+	readEntry := payload[0]
+	if readEntry["name"] != "read_file" || readEntry["ok"] != true {
+		t.Fatalf("read entry = %#v", readEntry)
+	}
+	readResult, _ := readEntry["result"].(map[string]any)
+	if readResult == nil {
+		t.Fatalf("read result = %#v", readEntry["result"])
+	}
+	if _, ok := readResult["follow_up"]; ok {
+		t.Fatalf("read result follow_up = %#v, want absent on supported turn", readResult["follow_up"])
+	}
+	if truncated, _ := readResult["truncated"].(bool); truncated {
+		t.Fatalf("read result = %#v, want full inline content", readResult)
+	}
+	content, _ := readResult["content"].(string)
+	if len(content) != len(huge) {
+		t.Fatalf("read result content len = %d, want %d", len(content), len(huge))
+	}
+}

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -55,8 +55,7 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 	if token := strings.TrimSpace(gatewayToken); token != "" {
 		headers["Authorization"] = "Bearer " + token
 	}
-	surface := cliExecutionToolSurfaceForActor(actor, s.Tools)
-	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), surface.RuntimeToolNames)
+	contextToken := turns.RegisterTurnContextWithAllowedTools(ctx, mcpContextTokenTTLForConfig(ctx, cfg), cliTurnContextAllowedToolsForActor(actor, s.Tools))
 	if contextToken != "" {
 		headers[mcpContextTokenHeader] = contextToken
 	}

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -30,12 +30,13 @@ const (
 const defaultMaxToolRounds = 8
 
 const (
-	maxToolResultBytes        = 16 * 1024
-	maxToolMessageBytes       = 64 * 1024
-	maxReadFileResultBytes    = 256 * 1024
-	maxReadFileMessageBytes   = 256 * 1024
-	maxToolErrorTextRunes     = 600
-	maxToolResultPreviewRunes = 1200
+	maxToolResultBytes              = 16 * 1024
+	maxToolMessageBytes             = 64 * 1024
+	maxReadFileResultBytes          = 256 * 1024
+	maxReadFileEnvelopeReserveBytes = 8 * 1024
+	maxReadFileMessageBytes         = maxReadFileResultBytes + maxToolResultBytes + maxReadFileEnvelopeReserveBytes
+	maxToolErrorTextRunes           = 600
+	maxToolResultPreviewRunes       = 1200
 )
 
 type ToolResult struct {

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -13,6 +13,12 @@ import (
 	"swarm/internal/runtime/sessions"
 )
 
+type cliUsableToolsContextKey struct{}
+
+type cliUsableToolsContextValue struct {
+	tools []string
+}
+
 type ConversationMode int
 
 const (
@@ -194,6 +200,7 @@ func (c *Conversation) resolveToolCalls(ctx context.Context, initial *Response) 
 		if len(resp.ToolCalls) == 0 {
 			return resp, nil
 		}
+		ctx = withCLIUsableToolsForTurn(ctx, c.turnToolDefinitions(), resp)
 		toolPayload, executed := c.executeToolCalls(ctx, resp.ToolCalls)
 		if shouldTerminateAfterToolCalls(executed) {
 			terminal := *resp
@@ -273,7 +280,7 @@ func (c *Conversation) projectToolResult(ctx context.Context, name string, input
 			"error":     "marshal tool result",
 		}, nil
 	}
-	limit := toolRelayResultLimitForRuntime(c.runtime, name, input)
+	limit := toolRelayResultLimitForRuntime(ctx, c.runtime, c.turnToolDefinitions(), name, input)
 	if len(b) <= limit {
 		return result, nil
 	}
@@ -387,6 +394,14 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 }
 
 func runtimeReadFileFollowUpAllowedForTurn(ctx context.Context, tools []ToolDefinition) bool {
+	if usable, ok := cliUsableToolsForTurnFromContext(ctx); ok {
+		for _, name := range usable {
+			if name == "read_file" {
+				return true
+			}
+		}
+		return false
+	}
 	actor, _ := models.ActorFromContext(ctx)
 	for _, name := range plannedCanonicalVisibleToolsForActor(actor, tools) {
 		if name == "read_file" {
@@ -427,19 +442,22 @@ func relayOversizedToolResult(ctx context.Context, runtime Runtime, session *Ses
 	return relay, true, err
 }
 
-func toolRelayResultLimitForRuntime(runtime Runtime, name string, input any) int {
+func toolRelayResultLimitForRuntime(ctx context.Context, runtime Runtime, tools []ToolDefinition, name string, input any) int {
 	limit := toolRelayResultLimit(name)
-	if _, ok := runtime.(oversizedToolResultRelayWriter); ok && helperReadFileShouldUseGenericRelayLimit(name, input) {
+	if _, ok := runtime.(oversizedToolResultRelayWriter); ok && helperReadFileShouldUseGenericRelayLimit(ctx, tools, name, input) {
 		return maxToolResultBytes
 	}
 	return limit
 }
 
-func helperReadFileShouldUseGenericRelayLimit(name string, input any) bool {
+func helperReadFileShouldUseGenericRelayLimit(ctx context.Context, tools []ToolDefinition, name string, input any) bool {
 	if !toolIsLargeRelayFileRead(name) {
 		return false
 	}
-	return !toolInputTargetsRuntimeRelayPath(input)
+	if toolInputTargetsRuntimeRelayPath(input) {
+		return false
+	}
+	return !runtimeReadFileFollowUpAllowedForTurn(ctx, tools)
 }
 
 func toolRelayResultLimit(name string) int {
@@ -494,6 +512,23 @@ func toolInputPath(input any) string {
 		return ""
 	}
 	return strings.TrimSpace(pathCarrier.Path)
+}
+
+func withCLIUsableToolsForTurn(ctx context.Context, tools []ToolDefinition, resp *Response) context.Context {
+	actor, _ := models.ActorFromContext(ctx)
+	usable := resolvedCLIUsableToolsForTurn(actor, tools, resp)
+	return context.WithValue(ctx, cliUsableToolsContextKey{}, cliUsableToolsContextValue{tools: append([]string(nil), usable...)})
+}
+
+func cliUsableToolsForTurnFromContext(ctx context.Context) ([]string, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	v, ok := ctx.Value(cliUsableToolsContextKey{}).(cliUsableToolsContextValue)
+	if !ok {
+		return nil, false
+	}
+	return append([]string(nil), v.tools...), true
 }
 
 func clampRunes(s string, maxRunes int) string {

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -487,6 +487,59 @@ func TestConversation_ExecuteToolCalls_RelaysOversizedReadFileResultsForHelperRu
 	}
 }
 
+func TestConversation_ExecuteToolCalls_PreservesNearLimitReadFileResultWithCompanionEmitCall(t *testing.T) {
+	huge := strings.Repeat("x", maxReadFileResultBytes-1024)
+	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/read-file-1.json"}
+	tools := []ToolDefinition{{Name: "read_file"}, {Name: "emit_category_assessed"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
+	c.SetToolExecutor(&selectiveToolExec{
+		results: map[string]any{
+			"read_file": map[string]any{
+				"content":    huge,
+				"size_bytes": len(huge),
+			},
+			"emit_category_assessed": map[string]any{
+				"event_id": "evt-1",
+				"status":   "published",
+			},
+		},
+	})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	ctx = withCLIUsableToolsForTurn(ctx, tools, &Response{
+		MCPServers:      map[string]string{"runtime-tools": "connected"},
+		MCPVisibleTools: []string{"mcp__runtime-tools__read_file", "mcp__runtime-tools__emit_category_assessed"},
+	})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{
+		{Name: "read_file", Arguments: map[string]any{"path": "/data/test-signals-25.jsonl"}},
+		{Name: "emit_category_assessed", Arguments: map[string]any{"category": "payments"}},
+	})
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("tool payload entries = %d, want 2 (%#v)", len(arr), arr)
+	}
+	readResult, _ := arr[0]["result"].(map[string]any)
+	if readResult == nil {
+		t.Fatalf("read result = %#v", arr[0]["result"])
+	}
+	if truncated, _ := readResult["truncated"].(bool); truncated {
+		t.Fatalf("expected near-limit inline read_file result to survive envelope wrapping, got %#v", readResult)
+	}
+	if _, ok := readResult["follow_up"]; ok {
+		t.Fatalf("follow_up = %#v, want absent for supported inline read_file result", readResult["follow_up"])
+	}
+	if content, _ := readResult["content"].(string); len(content) != len(huge) {
+		t.Fatalf("content length = %d, want %d", len(content), len(huge))
+	}
+	if rt.toolName != "" {
+		t.Fatalf("relay tool name = %q, want no helper relay write", rt.toolName)
+	}
+}
+
 func TestConversation_ExecuteToolCalls_PreservesRelayReadFileResultsForHelperRuntime(t *testing.T) {
 	huge := strings.Repeat("x", maxToolResultBytes+1024)
 	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/read-file-1.json"}

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -457,6 +457,10 @@ func TestConversation_ExecuteToolCalls_RelaysOversizedReadFileResultsForHelperRu
 	}})
 
 	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	ctx = withCLIUsableToolsForTurn(ctx, tools, &Response{
+		MCPServers:      map[string]string{"runtime-tools": "connected"},
+		MCPVisibleTools: []string{"mcp__runtime-tools__read_file"},
+	})
 	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_file", Arguments: map[string]any{"path": "/data/test-signals-25.jsonl"}}})
 	var arr []map[string]any
 	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
@@ -469,15 +473,17 @@ func TestConversation_ExecuteToolCalls_RelaysOversizedReadFileResultsForHelperRu
 	if resultMap == nil {
 		t.Fatalf("expected result map, got %#v", arr[0]["result"])
 	}
-	if rt.toolName != "read_file" {
-		t.Fatalf("relay tool name = %q, want read_file", rt.toolName)
+	if rt.toolName != "" {
+		t.Fatalf("relay tool name = %q, want no helper relay write on supported read_file turn", rt.toolName)
 	}
-	if resultMap["truncated"] != true {
-		t.Fatalf("expected relayed read_file metadata, got %#v", resultMap)
+	if resultMap["truncated"] == true {
+		t.Fatalf("expected supported read_file turn to preserve full content, got %#v", resultMap)
 	}
-	followUp, _ := resultMap["follow_up"].(map[string]any)
-	if followUp == nil || followUp["path"] != rt.relayPath || followUp["tool"] != "read_file" {
-		t.Fatalf("follow_up = %#v, want relay path/tool", followUp)
+	if _, ok := resultMap["follow_up"]; ok {
+		t.Fatalf("follow_up = %#v, want absent when read_file is supported on this turn", resultMap["follow_up"])
+	}
+	if content, _ := resultMap["content"].(string); len(content) != len(huge) {
+		t.Fatalf("content length = %d, want %d", len(content), len(huge))
 	}
 }
 
@@ -511,6 +517,41 @@ func TestConversation_ExecuteToolCalls_PreservesRelayReadFileResultsForHelperRun
 	}
 	if len(rt.raw) != 0 {
 		t.Fatalf("did not expect relay writer to run for runtime relay path read, got raw=%q", string(rt.raw))
+	}
+}
+
+func TestConversation_ExecuteToolCalls_SuppressesReadFileRelayWhenObservedSurfaceFailed(t *testing.T) {
+	huge := strings.Repeat("x", maxToolResultBytes+1024)
+	rt := &relayRuntime{relayPath: "/workspace/.swarm/tool-results/sess-relay/read-file-1.json"}
+	tools := []ToolDefinition{{Name: "read_file"}}
+	c := NewConversation("a1", "t1", "sys", tools, SessionScoped, 4, rt)
+	c.Session = &Session{ID: "sess-relay", AgentID: "a1", RuntimeMode: "cli_test", Tools: tools}
+	c.SetToolExecutor(largeToolExec{payload: map[string]any{
+		"content":    huge,
+		"size_bytes": len(huge),
+	}})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	ctx = withCLIUsableToolsForTurn(ctx, tools, &Response{
+		MCPServers: map[string]string{"runtime-tools": "failed"},
+	})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_file", Arguments: map[string]any{"path": "/data/test-signals-25.jsonl"}}})
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != true {
+		t.Fatalf("expected successful tool payload, got %#v", arr)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	if resultMap == nil || resultMap["truncated"] != true {
+		t.Fatalf("expected observed failed surface to clamp helper read_file output, got %#v", arr[0]["result"])
+	}
+	if _, ok := resultMap["follow_up"]; ok {
+		t.Fatalf("follow_up = %#v, want absent when read_file is not usable on the observed turn", resultMap["follow_up"])
+	}
+	if rt.toolName != "" {
+		t.Fatalf("relay tool name = %q, want no relay write when observed turn surface failed", rt.toolName)
 	}
 }
 

--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -75,11 +75,7 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 	}
 	if resp != nil && len(rec.AvailableTools) == 0 {
 		actor, _ := runtimeactors.ActorFromContext(ctx)
-		if observed := observedCanonicalVisibleToolsForActor(actor, sessionTools(s), resp); len(observed) > 0 {
-			rec.AvailableTools = append([]string(nil), observed...)
-		} else if hasObservedCLIExecutionSurface(resp) {
-			rec.AvailableTools = append([]string(nil), cliLocalFallbackVisibleToolsForActor(actor, s.Tools)...)
-		}
+		rec.AvailableTools = append([]string(nil), resolvedCLIUsableToolsForTurn(actor, sessionTools(s), resp)...)
 	}
 	if resp != nil && len(rec.MCPToolsVisible) == 0 {
 		rec.MCPToolsVisible = append([]string(nil), resp.MCPVisibleTools...)

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -322,6 +322,33 @@ func TestEnrichTurnRecord_UsesEmitFallbackWhenObservedCLISurfaceExistsWithoutVis
 	}
 }
 
+func TestEnrichTurnRecord_PreservesEmitFallbackAlongsideObservedSupportedReadFileSurface(t *testing.T) {
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID: "analysis-agent",
+		NativeTools: runtimeactors.NativeToolConfig{
+			FileIO: true,
+		},
+	})
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+		Tools: []ToolDefinition{
+			{Name: "emit_category_assessed"},
+			{Name: "read_file"},
+		},
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, &Response{
+		MCPServers:      map[string]string{"runtime-tools": "connected"},
+		MCPVisibleTools: []string{"mcp__runtime-tools__read_file"},
+	})
+
+	if !slices.Equal(rec.AvailableTools, []string{"emit_category_assessed", "read_file"}) {
+		t.Fatalf("available_tools = %#v", rec.AvailableTools)
+	}
+}
+
 func TestEnrichTurnRecord_UsesPlannedConfiguredSurfaceWhenObservedMetadataIsAbsent(t *testing.T) {
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
 		ID: "analysis-agent",


### PR DESCRIPTION
Closes #368

## What changed
- align the supported first-turn Claude CLI usable tool truth behind one resolved surface across helper validation, MCP turn-context registration, persisted `available_tools`, and same-turn relay/clamp behavior
- preserve local emit fallback alongside observed provider-visible `read_file` on supported turns
- stop helper-runtime `read_file` from degrading into preview-only relay/follow-up metadata when that same turn can actually call `read_file`
- add a supported-path Claude CLI first-turn proof plus focused regressions for relay and persisted turn shaping

## Why
Current head could still let the same supported first turn tell different truths:
- helper/validation knew the turn could use `read_file`
- persisted turn shaping could diverge from that usable truth
- helper relay/clamp still treated non-relay-path `read_file` as generic oversized output and converted it into preview/follow-up metadata on the same turn

That degraded legitimate file-backed first-turn work even when the turn genuinely exposed `read_file` and still emitted a workflow event on the same turn.

## Governing context
No exact governing spec section exists for this seam.

Binding context:
- issue #368 pre-audit and approved gate comments
- split downstream boundary in #373
- broader architecture tracker #374

Adjacent contract context used:
- `internal/runtime/llm/cli_runtime_helpers.go`
- `internal/runtime/llm/cli_runtime_transport.go`
- `internal/runtime/llm/persistence.go`
- `internal/runtime/llm/conversation.go`

## Semantic migration
- new canonical owner for same-turn usable tool truth: the resolved CLI usable surface derived from observed provider visibility plus local fallback emit tools
- old non-authoritative path now invalid: helper relay/clamp deciding supported `read_file` fallback behavior from planned surface alone
- production paths checked for surviving old behavior:
  - helper-side canonical visible / prompt / allowed-tool projection
  - MCP turn-context binding
  - persisted `available_tools` / MCP-visible turn shaping
  - same-turn helper relay / clamp behavior
- migration is complete for the approved `#368` first-turn child; downstream propagation remains split to #373 and typed architecture unification remains tracked in #374

## Validation
- `go test ./internal/runtime/llm -run 'Test(Conversation_ExecuteToolCalls_(RelaysOversizedReadFileResultsForHelperRuntime|SuppressesReadFileRelayWhenObservedSurfaceFailed|SuppressesRuntimeReadFileFollowUpWithoutReadFileSurface)|EnrichTurnRecord_(UsesEmitFallbackWhenObservedCLISurfaceExistsWithoutVisibleNonEmitTools|PreservesEmitFallbackAlongsideObservedSupportedReadFileSurface)|BuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation|ValidateCLIResponseToolCallsForTurn_(FailsClosedForNonEmitToolOutsideObservedSurface|AllowsObservedMCPToolAndEmitFallback)|ConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface)$' -count=1`
- `go test ./internal/runtime/llm -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./... -count=1`
