### PR TITLE
[agent-d][issue #461] Harden verify emitted payload proof

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1272,10 +1272,10 @@ func TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface(t *testing
 
 	err := verifyBundle(context.Background(), semanticview.Wrap(bundle))
 	if err == nil {
-		t.Fatal("verifyBundle error = nil, want warning-only failure from emitted payload completeness")
+		t.Fatal("verifyBundle error = nil, want emitted payload completeness invalidity")
 	}
 	if !strings.Contains(err.Error(), "scan_id is not statically provable") {
-		t.Fatalf("verifyBundle error = %v, want emitted payload completeness warning", err)
+		t.Fatalf("verifyBundle error = %v, want emitted payload completeness invalidity", err)
 	}
 	if strings.Contains(err.Error(), "definitely missing") {
 		t.Fatalf("verifyBundle error = %v, want approved warning wording only", err)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3372,8 +3372,8 @@ static_analyzer:
   slice_2_emitted_event_payload_completeness:
     id: semantic_drift_payload_completeness
     domain: semantic_drift
-    authority: semantic_drift_warning
-    severity: warning
+    authority: hard_invalidity
+    severity: error
     canonical_owner: internal/runtime/bootverify
     supported_surface: cmd/swarm verify
     spec_basis:
@@ -3384,7 +3384,12 @@ static_analyzer:
       description: For every event emitted by a system node handler, verify that the emitted payload statically covers all required
         event-schema fields using only the accepted slice-2 proof carriers.
       applies_to:
-      - all system-node emitted events
+      - handler top-level single-emit
+      - rules entries
+      - on_complete branches
+      - accumulate.on_timeout
+      - fan_out per-item emit
+      - guard on_fail: escalate
       excludes:
       - cross-handler reaching-definitions
       - prompt lint / provenance / handoff audit work
@@ -3400,7 +3405,7 @@ static_analyzer:
         valid_for: keys explicitly declared in emit.fields at the active emit site
     no_emit_fields_rule:
       description: When emit.fields is absent, only platform-forced fields are provable in this slice.
-    rule: For each required emitted-event field, emit semantic_drift_warning unless the field is platform-forced or explicitly covered
+    rule: For each required emitted-event field, emit hard-invalidity unless the field is platform-forced or explicitly covered
       by emit.fields at the active emit site. The finding message must say the field is not statically provable.
   slice_3_input_pin_producer_path_satisfaction:
     id: input_pin_wiring

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -172,7 +172,7 @@ var bootCheckRegistry = []Check{
 	{ID: "event_producer_exists", Severity: "warning", Run: checkEventProducerExists},
 	{ID: "semantic_drift_dead_event_schema", Severity: "warning", Run: checkSemanticDriftDeadEventSchema},
 	{ID: "payload_field_coverage", Severity: "error", Run: checkPayloadFieldCoverage},
-	{ID: "semantic_drift_payload_completeness", Severity: "warning", Run: checkSemanticDriftPayloadCompleteness},
+	{ID: "semantic_drift_payload_completeness", Severity: "error", Run: checkSemanticDriftPayloadCompleteness},
 	{ID: "condition_payload_alignment", Severity: "error", Run: checkConditionPayloadAlignment},
 	{ID: "condition_policy_alignment", Severity: "warning", Run: checkConditionPolicyAlignment},
 	{ID: "state_machine_coherence", Severity: "error", Run: checkStateMachineCoherence},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1627,7 +1627,7 @@ func TestRun_DoesNotWarnForPhantomProducesWhenDeclaredEventsMatchEmits(t *testin
 	}
 }
 
-func TestRun_WarnsWhenEmitFieldsOmitRequiredEmittedField(t *testing.T) {
+func TestRun_ErrorsWhenEmitFieldsOmitRequiredEmittedField(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	node := bundle.Nodes["dispatcher"]
 	handler := node.EventHandlers["scan.corpus_dispatch"]
@@ -1644,18 +1644,15 @@ func TestRun_WarnsWhenEmitFieldsOmitRequiredEmittedField(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if report.HasErrors() {
-		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected payload completeness error for scan_id, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
-		t.Fatalf("expected payload completeness warning for scan_id, got %#v", report.Warnings())
-	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "emit.fields covers: geography, mode") {
-		t.Fatalf("expected payload completeness warning to mention emit.fields coverage, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "emit.fields covers: geography, mode") {
+		t.Fatalf("expected payload completeness error to mention emit.fields coverage, got %#v", report.Errors())
 	}
 }
 
-func TestRun_WarnsWithoutEmitFieldsEvenWhenContextSuggestsPassthrough(t *testing.T) {
+func TestRun_ErrorsWithoutEmitFieldsEvenWhenContextSuggestsPassthrough(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	entry := bundle.Events["market_research.scan_assigned"]
 	entry.Required = []string{"entity_id", "scan_id"}
@@ -1663,20 +1660,17 @@ func TestRun_WarnsWithoutEmitFieldsEvenWhenContextSuggestsPassthrough(t *testing
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if report.HasErrors() {
-		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected payload completeness error for scan_id, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
-		t.Fatalf("expected payload completeness warning for scan_id, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "emit.fields: absent") {
+		t.Fatalf("expected payload completeness error to mention missing emit.fields, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "emit.fields: absent") {
-		t.Fatalf("expected payload completeness warning to mention missing emit.fields, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "trigger schema declares scan_id: yes (required)") {
+		t.Fatalf("expected payload completeness error to mention trigger schema context, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "trigger schema declares scan_id: yes (required)") {
-		t.Fatalf("expected payload completeness warning to mention trigger schema context, got %#v", report.Warnings())
-	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "entity schema declares scan_id: yes") {
-		t.Fatalf("expected payload completeness warning to mention entity schema context, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "entity schema declares scan_id: yes") {
+		t.Fatalf("expected payload completeness error to mention entity schema context, got %#v", report.Errors())
 	}
 }
 
@@ -1697,8 +1691,8 @@ func TestRun_DoesNotWarnWhenEmitFieldsAndPlatformForcedFieldsCoverRequiredPayloa
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
-		t.Fatalf("unexpected payload completeness warning when transform covers required fields, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("unexpected payload completeness error when transform covers required fields, got %#v", report.Errors())
 	}
 }
 
@@ -1744,8 +1738,8 @@ func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayloadAcrossExpressionKinds(
 
 			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-			if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
-				t.Fatalf("unexpected payload completeness warning for %s transform form, got %#v", tc.name, report.Warnings())
+			if reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+				t.Fatalf("unexpected payload completeness error for %s transform form, got %#v", tc.name, report.Errors())
 			}
 		})
 	}
@@ -1759,12 +1753,12 @@ func TestRun_DoesNotWarnWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "not statically provable") {
-		t.Fatalf("unexpected payload completeness warning for platform-forced-only schema, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "not statically provable") {
+		t.Fatalf("unexpected payload completeness error for platform-forced-only schema, got %#v", report.Errors())
 	}
 }
 
-func TestRun_WarnsPerEmitSiteWhenSameEventIsUnderspecifiedOnOneRuleOnly(t *testing.T) {
+func TestRun_ErrorsPerEmitSiteWhenSameEventIsUnderspecifiedOnOneRuleOnly(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	node := bundle.Nodes["dispatcher"]
 	handler := node.EventHandlers["scan.corpus_dispatch"]
@@ -1797,17 +1791,140 @@ func TestRun_WarnsPerEmitSiteWhenSameEventIsUnderspecifiedOnOneRuleOnly(t *testi
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if report.HasErrors() {
-		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "rules[partial].emit") {
+		t.Fatalf("expected site-specific payload completeness error for partial rule, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "rules[partial].emit") {
-		t.Fatalf("expected site-specific payload completeness warning for partial rule, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected missing scan_id error for underspecified rule, got %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
-		t.Fatalf("expected missing scan_id warning for underspecified rule, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "rules[complete].emit") {
+		t.Fatalf("unexpected payload completeness error for fully specified rule, got %#v", report.Errors())
 	}
-	if reportContains(report.Warnings(), "semantic_drift_payload_completeness", "rules[complete].emit") {
-		t.Fatalf("unexpected payload completeness warning for fully specified rule, got %#v", report.Warnings())
+}
+
+func TestRun_ErrorsForOnCompleteEmitSitePayloadDrift(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{}
+	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{
+		{
+			ID: "complete",
+			Emit: runtimecontracts.EmitSpec{
+				Event: "market_research.scan_assigned",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+				},
+			},
+		},
+		{
+			ID: "partial",
+			Emit: runtimecontracts.EmitSpec{
+				Event: "market_research.scan_assigned",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"geography": runtimecontracts.RefExpression("payload.geography"),
+				},
+			},
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "on_complete[partial].emit") {
+		t.Fatalf("expected on_complete payload completeness error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected missing scan_id error for underspecified on_complete branch, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "on_complete[complete].emit") {
+		t.Fatalf("unexpected payload completeness error for fully specified on_complete branch, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsForAccumulateOnTimeoutEmitSitePayloadDrift(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{}
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{
+		OnTimeout: &runtimecontracts.HandlerRuleEntry{
+			ID: "timeout",
+			Emit: runtimecontracts.EmitSpec{
+				Event: "market_research.scan_assigned",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"geography": runtimecontracts.RefExpression("payload.geography"),
+				},
+			},
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "accumulate.on_timeout[timeout].emit") {
+		t.Fatalf("expected accumulate.on_timeout payload completeness error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected missing scan_id error for accumulate.on_timeout emit, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsForFanOutEmitSitePayloadDrift(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{}
+	handler.FanOut = &runtimecontracts.FanOutSpec{
+		Emit: runtimecontracts.EmitSpec{
+			Event: "market_research.scan_assigned",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"geography": runtimecontracts.RefExpression("payload.geography"),
+			},
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "handler.fan_out.emit") {
+		t.Fatalf("expected fan_out payload completeness error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") {
+		t.Fatalf("expected missing scan_id error for fan_out emit, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsForGuardEscalatePayloadDrift(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+	entry := bundle.Events["check.escalated"]
+	entry.Payload.Properties["reason"] = runtimecontracts.EventFieldSpec{Type: "string"}
+	entry.Required = []string{"entity_id", "reason"}
+	bundle.Events["check.escalated"] = entry
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("expected guard escalation payload completeness error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "reason is not statically provable") {
+		t.Fatalf("expected missing reason error for guard escalation emit, got %#v", report.Errors())
+	}
+}
+
+func TestRun_DoesNotErrorForGuardEscalateWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("unexpected payload completeness error for platform-forced-only guard escalation, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -54,7 +55,7 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 
 					c.payloadCompletenessFindings = append(c.payloadCompletenessFindings, Finding{
 						CheckID:  "semantic_drift_payload_completeness",
-						Severity: "warning",
+						Severity: "error",
 						Message: payloadCompletenessMessage(
 							nodeID,
 							triggerEventType,
@@ -148,6 +149,14 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 			add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "emit"), handler.Accumulate.OnTimeout.Emit)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
 				add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "fan_out.emit"), handler.Accumulate.OnTimeout.FanOut.Emit)
+			}
+		}
+	}
+	if handler.Guard != nil {
+		onFail := strings.TrimSpace(handler.Guard.OnFail)
+		if onFail != "" {
+			if parsed, err := runtimeengine.ParseGuardFailure(onFail); err == nil && parsed.Action == runtimeengine.GuardFailureEscalate {
+				add("guard.on_fail.escalate", runtimecontracts.EmitSpec{Event: strings.TrimSpace(parsed.EventType)})
 			}
 		}
 	}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -182,12 +182,26 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if len(turns.records) == 0 {
 		t.Fatal("expected persisted turn records")
 	}
-	first := turns.records[0]
+	first := AgentTurnRecord{}
+	found := false
+	for _, rec := range turns.records {
+		if got := rec.MCPServers["runtime-tools"]; got == "connected" {
+			first = rec
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no provider-observed first-turn record found in %#v", turns.records)
+	}
 	if !slices.Equal(first.AvailableTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
 		t.Fatalf("first turn available_tools = %#v", first.AvailableTools)
 	}
-	if !slices.Equal(first.MCPToolsListed, []string{"mcp__runtime-tools__emit_category_assessed"}) {
-		t.Fatalf("first turn mcp_tools_listed = %#v", first.MCPToolsListed)
+	if !slices.Equal(first.MCPToolsVisible, []string{"mcp__runtime-tools__emit_category_assessed"}) {
+		t.Fatalf("first turn mcp_tools_visible = %#v", first.MCPToolsVisible)
+	}
+	if got := first.MCPServers["runtime-tools"]; got != "connected" {
+		t.Fatalf("first turn mcp_servers = %#v", first.MCPServers)
 	}
 	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
 		t.Fatalf("emitted events = %#v", recorder.Snapshot())

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -182,26 +182,12 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if len(turns.records) == 0 {
 		t.Fatal("expected persisted turn records")
 	}
-	first := AgentTurnRecord{}
-	found := false
-	for _, rec := range turns.records {
-		if got := rec.MCPServers["runtime-tools"]; got == "connected" {
-			first = rec
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("no provider-observed first-turn record found in %#v", turns.records)
-	}
+	first := turns.records[0]
 	if !slices.Equal(first.AvailableTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
 		t.Fatalf("first turn available_tools = %#v", first.AvailableTools)
 	}
-	if !slices.Equal(first.MCPToolsVisible, []string{"mcp__runtime-tools__emit_category_assessed"}) {
-		t.Fatalf("first turn mcp_tools_visible = %#v", first.MCPToolsVisible)
-	}
-	if got := first.MCPServers["runtime-tools"]; got != "connected" {
-		t.Fatalf("first turn mcp_servers = %#v", first.MCPServers)
+	if !slices.Equal(first.MCPToolsListed, []string{"mcp__runtime-tools__emit_category_assessed"}) {
+		t.Fatalf("first turn mcp_tools_listed = %#v", first.MCPToolsListed)
 	}
 	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
 		t.Fatalf("emitted events = %#v", recorder.Snapshot())


### PR DESCRIPTION
Closes #461

## Summary
- elevate declarative system-node emitted-payload completeness from warning-grade drift to hard invalidity on the authoritative `cmd/swarm verify` surface
- extend payload-completeness proof to the supported guard `on_fail: escalate` emit outcome
- update the authoritative spec to match the landed verify behavior for the supported declarative emit sites

## Governing Refs / Context
- Authoritative spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `static_analyzer.slice_2_emitted_event_payload_completeness`
  - `observation_model.handler_outcome.escalate`
  - `observation_model.emitted_events.payload_rules`
- Binding issue / pre-audit context: `#461`, parent stream `#455`
- Reviewed draft context used during implementation: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.event-schema-cross-flow-contract.yaml`
  - `verify_enforcement.slice_2_elevation`
  - `emit_grammar_changes.where_emit_can_appear`

## Semantic Migration
- New canonical owner for this child:
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `internal/runtime/bootverify/workflow_payload_completeness_checks.go`
  - `internal/runtime/bootverify/checks.go`
- Old non-authoritative behavior now invalid:
  - warning-grade `semantic_drift_payload_completeness` on the supported declarative system-node emit surface
  - omission of guard `on_fail: escalate` from payload-completeness proof enumeration
- Production paths checked for surviving old behavior:
  - handler top-level single-emit
  - `rules`
  - `on_complete`
  - `accumulate.on_timeout`
  - `fan_out`
  - guard `on_fail: escalate`
- Migration completeness for this child:
  - complete for the supported declarative system-node verify surface only
  - explicitly not widened to agent emits, `action:` emits, `auto_emit_on_create`, or runtime construction
