### PR TITLE
[agent-d][issue #464] Enforce strict agent emit schema parity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1133,9 +1133,10 @@ engine:
     - 8. Session state is persisted for audit/debug.
     tool_execution: Tools execute within the agent session context. Platform validates tool input against schema. Platform
       checks agent permissions before execution. Tool results are returned to the agent for continued reasoning.
-    event_emission: When an agent emits an event, the platform validates the payload against events.yaml schema. The event
-      enters the event loop at step 1. Agent emission is NOT within a node handler atomic boundary — it is a standalone event
-      publication.
+    event_emission: When an agent emits an event, the platform validates the payload against events.yaml schema before publish.
+      Missing required payload fields fail the emit. Undeclared agent-authored payload fields fail the emit and are not silently
+      stripped. The event enters the event loop at step 1 only after that validation passes. Agent emission is NOT within a
+      node handler atomic boundary — it is a standalone event publication.
     turn_budget: Each agent session has a max_turns_per_task (from agents.yaml). If the agent exceeds this budget, the session
       is terminated. The platform may emit a timeout or budget_exceeded event.
     agent_invocation: 'Agents are invoked via claude -p (CLI) or equivalent LLM API call. The platform constructs the invocation:

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -98,6 +98,10 @@ active_issues:
     title: Remove implicit passthrough from declarative system-node emits and fail closed on undeclared payloads
     maps_to:
       - strict_event_schema_cross_flow_contract_migration
+  - id: 464
+    title: Enforce strict event-schema parity for agent emits
+    maps_to:
+      - strict_event_schema_cross_flow_contract_migration
   - id: 181
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
@@ -327,6 +331,7 @@ nodes:
       - handler-top-level emits, on_complete branches, rules entries, accumulate.on_timeout, and fan_out per-item emits still use inconsistent or legacy event/payload ownership carriers
       - boot/verify proof logic and runtime emit construction still read handler-level payload_transform rather than the active emit site
       - declarative system-node emit construction still overlays explicit emit.fields onto an implicit entity/trigger context carrier and silently trims undeclared business payload keys instead of starting from an empty payload and failing closed
+      - agent emit execution still silently trims undeclared payload keys before schema validation instead of failing the emit on undeclared extras
       - persisted canonical-event validation strips undeclared runtime-owned context as an adjacent broader consumer, so system-node runtime closure must stay explicit about sibling emit surfaces that remain outside the child boundary
       - action emits and auto_emit_on_create remain adjacent emit interpreters that must stay explicitly split unless the governing draft widens
     representative_issues:

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -58,7 +58,6 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 
 	inbound, _ := runtimebus.InboundEventFromContext(ctx)
 	payloadMap = e.enrichEmitPayloadContext(actor, inbound, schemaEventType, payloadMap)
-	payloadMap = e.trimEmitPayloadToSchema(schemaEventType, payloadMap)
 	postEnrichmentPayload := diagnosticPayloadMap(payloadMap)
 	if err := e.emitRegistry.ValidateEventPayloadAgainstSchema(schemaEventType, payloadMap); err != nil {
 		wrapped := WrapRuntimeError(

--- a/internal/runtime/tools/executor_emit_context.go
+++ b/internal/runtime/tools/executor_emit_context.go
@@ -45,32 +45,3 @@ func (e *Executor) emitSchemaAllowsProperty(eventType, property string) bool {
 	_, ok = props[property]
 	return ok
 }
-
-func (e *Executor) trimEmitPayloadToSchema(eventType string, payload map[string]any) map[string]any {
-	if payload == nil {
-		return map[string]any{}
-	}
-	eventType = strings.TrimSpace(eventType)
-	if eventType == "" {
-		return payload
-	}
-	if e == nil || e.emitRegistry == nil {
-		return payload
-	}
-	schema := e.emitRegistry.SchemaForEventType(eventType).Schema
-	if schemaAdditionalProps(schema["additionalProperties"]) {
-		return payload
-	}
-	props := schemaProperties(schema["properties"])
-	if len(props) == 0 {
-		return payload
-	}
-	out := make(map[string]any, len(payload))
-	for k, v := range payload {
-		if _, ok := props[strings.TrimSpace(k)]; !ok {
-			continue
-		}
-		out[k] = v
-	}
-	return out
-}

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"swarm/internal/events"
@@ -14,15 +15,18 @@ import (
 
 type publishBusCapture struct {
 	event events.Event
+	count int
 }
 
 func (b *publishBusCapture) Publish(_ context.Context, evt events.Event) error {
 	b.event = evt
+	b.count++
 	return nil
 }
 
 func (b *publishBusCapture) PublishDirect(_ context.Context, evt events.Event, _ []string) error {
 	b.event = evt
+	b.count++
 	return nil
 }
 
@@ -93,6 +97,9 @@ func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
 	if got, want := payload["signal_id"], "sig-1"; got != want {
 		t.Fatalf("payload signal_id = %#v, want %q", got, want)
 	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
 }
 
 func TestHandleEmitTool_KeepsFlowOutputPinAtParentScope(t *testing.T) {
@@ -152,5 +159,48 @@ func TestHandleEmitTool_KeepsFlowOutputPinAtParentScope(t *testing.T) {
 
 	if got, want := string(bus.event.Type), "discovery/vertical.discovered"; got != want {
 		t.Fatalf("published event type = %q, want %q", got, want)
+	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
+}
+
+func TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "string"},
+					},
+					Required: []string{"category"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		EmitEvents: []string{"category.assessed"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_category_assessed", map[string]any{
+		"category":   "AP automation",
+		"unexpected": true,
+	})
+	if err == nil {
+		t.Fatal("expected undeclared payload field failure")
+	}
+	if !strings.Contains(err.Error(), "$.unexpected is not allowed") {
+		t.Fatalf("error = %v, want undeclared-field validation detail", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
 	}
 }

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -304,6 +304,77 @@ func TestExecutorTelemetry_EmitToolLogsSchemaValidationFailureSeparatelyFromPubl
 	}
 }
 
+func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t *testing.T) {
+	bus := &telemetryBusStub{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category":  {Type: "string"},
+						"entity_id": {Type: "string"},
+						"task_id":   {Type: "string"},
+					},
+				},
+				Required: []string{"category"},
+			},
+		},
+	})
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:       "agent-emit-undeclared",
+		EntityID: "entity-actor",
+		EmitEvents: []string{
+			"category.assessed",
+		},
+	})
+	ctx = runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:        "evt-inbound",
+		Type:      events.EventType("trigger.input"),
+		TaskID:    "task-inbound",
+		Payload:   []byte(`{"entity_id":"entity-inbound"}`),
+		CreatedAt: testTime(),
+	}.WithEntityID("entity-inbound"))
+
+	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{
+		"category":   "AP automation",
+		"unexpected": true,
+	}); err == nil {
+		t.Fatal("expected schema validation failure for undeclared payload field")
+	}
+	if len(bus.logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
+	}
+	detail, _ := bus.logs[0].Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "schema_validation_failed" {
+		t.Fatalf("outcome = %#v, want schema_validation_failed", detail["outcome"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_class"])); got != "validation" {
+		t.Fatalf("failure_class = %#v, want validation", detail["failure_class"])
+	}
+	if got := strings.TrimSpace(asString(detail["failure_stage"])); got != "validate_schema" {
+		t.Fatalf("failure_stage = %#v, want validate_schema", detail["failure_stage"])
+	}
+	pre, _ := detail["pre_validation_payload"].(map[string]any)
+	post, _ := detail["post_enrichment_payload"].(map[string]any)
+	if got, ok := pre["unexpected"].(bool); !ok || !got {
+		t.Fatalf("pre_validation unexpected = %#v, want true", pre["unexpected"])
+	}
+	if got, ok := post["unexpected"].(bool); !ok || !got {
+		t.Fatalf("post_enrichment unexpected = %#v, want true", post["unexpected"])
+	}
+	if got := strings.TrimSpace(asString(post["entity_id"])); got != "entity-actor" {
+		t.Fatalf("post_enrichment entity_id = %#v, want entity-actor", post["entity_id"])
+	}
+	if got := strings.TrimSpace(asString(post["task_id"])); got != "task-inbound" {
+		t.Fatalf("post_enrichment task_id = %#v, want task-inbound", post["task_id"])
+	}
+	if _, ok := detail["emitted_event_id"]; ok {
+		t.Fatalf("unexpected emitted_event_id on schema validation failure: %#v", detail["emitted_event_id"])
+	}
+}
+
 func TestExecutorTelemetry_EmitToolLogsPublishFailureWithCanonicalEventIdentity(t *testing.T) {
 	bus := &telemetryBusStub{publishErr: errors.New("publish down")}
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
@@ -429,7 +500,7 @@ func TestExecutorTelemetry_EmitToolLogsInvalidEmitToolNameOutcome(t *testing.T) 
 	}
 }
 
-func TestExecutorTelemetry_EmitToolCapsOversizedPayloadSnapshots(t *testing.T) {
+func TestExecutorTelemetry_EmitToolCapsOversizedPayloadSnapshotsOnSchemaValidationFailure(t *testing.T) {
 	bus := &telemetryBusStub{}
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
@@ -455,13 +526,19 @@ func TestExecutorTelemetry_EmitToolCapsOversizedPayloadSnapshots(t *testing.T) {
 		oversizedPayload[fmt.Sprintf("extra_%02d", i)] = strings.Repeat("x", 40)
 	}
 
-	if _, err := exec.Execute(ctx, "emit_category_assessed", oversizedPayload); err != nil {
-		t.Fatalf("Execute(emit oversized): %v", err)
+	if _, err := exec.Execute(ctx, "emit_category_assessed", oversizedPayload); err == nil {
+		t.Fatal("expected schema validation failure for oversized undeclared payload")
 	}
 	if len(bus.logs) != 1 {
 		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))
 	}
 	detail, _ := bus.logs[0].Detail.(map[string]any)
+	if got := strings.TrimSpace(asString(detail["outcome"])); got != "schema_validation_failed" {
+		t.Fatalf("outcome = %#v, want schema_validation_failed", detail["outcome"])
+	}
+	if _, ok := detail["emitted_event_id"]; ok {
+		t.Fatalf("unexpected emitted_event_id on schema validation failure: %#v", detail["emitted_event_id"])
+	}
 	pre, _ := detail["pre_validation_payload"].(map[string]any)
 	if truncated, _ := pre["truncated"].(bool); !truncated {
 		t.Fatalf("pre_validation_payload.truncated = %#v, want true", pre["truncated"])
@@ -472,6 +549,10 @@ func TestExecutorTelemetry_EmitToolCapsOversizedPayloadSnapshots(t *testing.T) {
 	}
 	if len(summary) > maxToolTelemetryChars+3 {
 		t.Fatalf("summary length = %d, want <= %d", len(summary), maxToolTelemetryChars+3)
+	}
+	post, _ := detail["post_enrichment_payload"].(map[string]any)
+	if truncated, _ := post["truncated"].(bool); !truncated {
+		t.Fatalf("post_enrichment_payload.truncated = %#v, want true", post["truncated"])
 	}
 }
 


### PR DESCRIPTION
Closes #464

## Summary

Make the supported agent emit runtime path fail closed on undeclared payload keys instead of silently trimming them before schema validation.

## Governing refs / context

Authoritative spec:
- `engine.agent_session_management.event_emission`
- adjacent declarative cross-flow rule in `engine.state_machine.execution_model.emit_payload_default`

Reviewed draft context:
- `core_rule.agent_emissions_obey_same_contract`
- `agent_emission_runtime.validation_point`
- `agent_emission_runtime.no_silent_strip`

## Canonical owner after this change

- `internal/runtime/tools/executor_emit.go`
- `internal/runtime/tools/executor_emit_context.go`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Semantic migration

- old non-authoritative compatibility seam now invalid:
  - `internal/runtime/tools/executor_emit_context.go::trimEmitPayloadToSchema`
- new/remaining authoritative behavior:
  - agent emit payloads are enriched only with runtime-owned context that the schema explicitly allows
  - undeclared agent-authored payload keys fail schema validation rather than being silently removed
- production paths checked for surviving old behavior:
  - supported agent emit executor path in `internal/runtime/tools/executor_emit.go`
  - same-path telemetry/logging proofs in `internal/runtime/tools/executor_telemetry_test.go`
- migration complete for this child:
  - yes, for the supported agent emit runtime path
  - no claim for `action:` emits, `auto_emit_on_create`, or post-publish canonical-event validation
