### PR TITLE
[agent-d][issue #466] Enforce action emit schema parity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -592,6 +592,9 @@ handler_specification:
       type: string
       purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence. The platform executes
         the named action. NOT for platform actions — all behavior must be declarative.'
+      emit_interaction: If the resolved runtime action instruction emits a follow-up event, that event uses the action-originated
+        emitted-event payload rules under observation_model.emitted_events.payload_rules. The action field itself does not
+        declare emit.fields or a separate payload carrier.
       valid_values:
         create_flow_instance:
           description: Create a new dynamic flow instance.
@@ -1760,7 +1763,7 @@ compliance:
     - Message delivery checked against agent message scope permission
     - State state_changes only follow declared advances_to paths
     - Guards evaluated before state advancement — block if false
-    - Events validated against payload schema before publish
+    - Events, including action-originated emits, validated against payload schema before publish
     - Accumulation is idempotent — duplicate events do not double-count
     - Permission checks read from agent.permissions, not hardcoded policy functions
     - Product behavior read from policy configuration, not hardcoded
@@ -1791,6 +1794,7 @@ compliance:
     - 'Apply advances_to, sets_gate, and data_accumulation from the active handler/branch/rule outcome.'
     - 'If the active emit site has emit: publish the selected follow-up event.'
     - 'If handler has action that is a platform action: call registered platform action.'
+    - 'If the resolved action runtime instruction emits an event: publish it using the action-originated payload rules and fail-closed schema validation before commit.'
   product_boundary:
     description: Rules for product-specific code isolation.
     rules:
@@ -3184,6 +3188,7 @@ observation_model:
     - Events from handler on_complete emit
     - Events from handler accumulate.on_timeout emit
     - Events from handler fan_out emit
+    - Events from action-originated emits produced by runtime action instructions
     - Events from handler action side effects (e.g., auto_emit_on_create)
     excludes:
     - Agent fixture emissions (agents are independent, their emissions route through the event loop separately)
@@ -3192,20 +3197,35 @@ observation_model:
     naming: Events are recorded with their fully-qualified URI in the parent flow context. When a child flow node emits order.completed,
       the parent sees child-flow-id/order.completed. Within the same flow, events use local names (no prefix).
     payload_rules:
-      description: Rules for constructing emitted event payloads on the supported declarative system-node emit surface.
-      construction_order:
-      - 1. Start from an empty payload
-      - 2. Evaluate emit.fields for the active emit site, if present
-      - '3. Force platform fields: entity_id, trigger_event_type, current_state'
-      collision_priority: platform fields > emit.fields
-      note: This surface has no implicit entity passthrough or trigger-payload passthrough. If an emitted event needs a field
-        beyond the platform-forced fields, the producer must declare it explicitly in emit.fields at the active emit site.
-      runtime_validation:
-        description: Runtime validates the emitted payload fail-closed on this surface.
-        validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
-          that the target schema does not declare.
-        rejection_rule: If any non-runtime-owned field is absent from the target schema, or any declared field violates the schema,
-          handler execution fails. Runtime does not silently trim producer-authored business payload keys.
+      description: Rules for constructing emitted event payloads on supported system-node runtime emit surfaces.
+      declarative_system_node_emit_surface:
+        construction_order:
+        - 1. Start from an empty payload
+        - 2. Evaluate emit.fields for the active emit site, if present
+        - '3. Force platform fields: entity_id, trigger_event_type, current_state'
+        collision_priority: platform fields > emit.fields
+        note: This surface has no implicit entity passthrough or trigger-payload passthrough. If an emitted event needs a field
+          beyond the platform-forced fields, the producer must declare it explicitly in emit.fields at the active emit site.
+        runtime_validation:
+          description: Runtime validates the emitted payload fail-closed on this surface.
+          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
+            that the target schema does not declare.
+          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any declared field violates the
+            schema, handler execution fails. Runtime does not silently trim producer-authored business payload keys.
+      action_originated_emit_surface:
+        construction_order:
+        - 1. Start from the triggering event payload
+        - '2. Force platform fields: entity_id, trigger_event_type, current_state'
+        collision_priority: platform fields > triggering event payload
+        note: This surface currently inherits its business payload from the triggering event payload because the action runtime
+          instruction model has no separate emit.fields carrier. Runtime must still fail closed on the resulting payload.
+        runtime_validation:
+          description: Runtime validates the emitted payload fail-closed on this surface before publish.
+          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
+            that the target schema does not declare.
+          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any producer-authored field is
+            undeclared or violates the schema, handler execution fails. Runtime does not silently trim inherited trigger-payload keys
+            on this surface.
   entity_state:
     description: The entity document after handler execution commits.
     observable_fields:

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -102,6 +102,10 @@ active_issues:
     title: Enforce strict event-schema parity for agent emits
     maps_to:
       - strict_event_schema_cross_flow_contract_migration
+  - id: 466
+    title: Enforce strict event-schema parity for action-originated emits
+    maps_to:
+      - strict_event_schema_cross_flow_contract_migration
   - id: 181
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
@@ -332,11 +336,15 @@ nodes:
       - boot/verify proof logic and runtime emit construction still read handler-level payload_transform rather than the active emit site
       - declarative system-node emit construction still overlays explicit emit.fields onto an implicit entity/trigger context carrier and silently trims undeclared business payload keys instead of starting from an empty payload and failing closed
       - agent emit execution still silently trims undeclared payload keys before schema validation instead of failing the emit on undeclared extras
+      - action-originated emits still reuse inbound trigger payload and bypass pipeline-side fail-closed payload-contract validation via EmitSurfaceAction before late publish-boundary schema checks
       - persisted canonical-event validation strips undeclared runtime-owned context as an adjacent broader consumer, so system-node runtime closure must stay explicit about sibling emit surfaces that remain outside the child boundary
-      - action emits and auto_emit_on_create remain adjacent emit interpreters that must stay explicitly split unless the governing draft widens
+      - auto_emit_on_create remains an adjacent emit interpreter that must stay explicitly split unless the governing draft widens
     representative_issues:
       - 455
       - 457
+      - 459
+      - 464
+      - 466
     common_framing_mistakes:
       too_broad:
         - land the entire strict event-schema migration in one PR

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -227,6 +227,7 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 		}
 		if errors.Is(err, ErrEmitPersistencePrerequisite) || errors.Is(err, ErrEmitPayloadContractViolation) {
 			result.Status = OutcomeRejected
+			result.FailureClass = FailureLogic
 		}
 		if result.Status == OutcomeUnknown {
 			result.Status = OutcomeRejected

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -225,7 +225,7 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 		if result.AccumulatorCompletionDiagnostics.Relevant {
 			result.AccumulatorCompletionDiagnostics.CommitOutcome = AccumulatorCompletionCommitRolledBack
 		}
-		if errors.Is(err, ErrEmitPersistencePrerequisite) {
+		if errors.Is(err, ErrEmitPersistencePrerequisite) || errors.Is(err, ErrEmitPayloadContractViolation) {
 			result.Status = OutcomeRejected
 		}
 		if result.Status == OutcomeUnknown {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1616,7 +1616,7 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 
 func TestExecutor_ActionRegistryEmitContractViolationRejectsHandler(t *testing.T) {
 	runner := &stubActionRunner{}
-	shaper := &recordingPayloadShaper{err: ErrEmitPayloadContractViolation}
+	shaper := &recordingPayloadShaper{err: errors.Join(ErrEmitPayloadContractViolation, errors.New("wrapped payload contract failure"))}
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSource(),
 		StateRepo:  stubStateRepo{},

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -71,6 +72,8 @@ type stubPayloadShaper struct{}
 type recordingPayloadShaper struct {
 	lastReq     ExecutionRequest
 	lastPayload map[string]any
+	lastSurface EmitSurface
+	err         error
 }
 
 func (stubStateRepo) LoadState(context.Context, identity.EntityID) (StateSnapshot, bool, error) {
@@ -141,9 +144,13 @@ func (stubPayloadShaper) ShapeEmitPayload(_ context.Context, _ ExecutionRequest,
 	out["shaped_for"] = eventType
 	return out, nil
 }
-func (s *recordingPayloadShaper) ShapeEmitPayload(_ context.Context, req ExecutionRequest, eventType string, payload map[string]any) (map[string]any, error) {
+func (s *recordingPayloadShaper) ShapeEmitPayload(ctx context.Context, req ExecutionRequest, eventType string, payload map[string]any) (map[string]any, error) {
 	s.lastReq = req
 	s.lastPayload = cloneStringAnyMap(payload)
+	s.lastSurface = EmitSurfaceFromContext(ctx)
+	if s.err != nil {
+		return nil, s.err
+	}
 	out := cloneStringAnyMap(payload)
 	out["shaped_for"] = eventType
 	return out, nil
@@ -1601,6 +1608,64 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 	}
 	if got := shaper.lastPayload["score"]; got != float64(9) {
 		t.Fatalf("action emit payload score = %#v, want 9", got)
+	}
+	if shaper.lastSurface != EmitSurfaceAction {
+		t.Fatalf("action emit surface = %q, want %q", shaper.lastSurface, EmitSurfaceAction)
+	}
+}
+
+func TestExecutor_ActionRegistryEmitContractViolationRejectsHandler(t *testing.T) {
+	runner := &stubActionRunner{}
+	shaper := &recordingPayloadShaper{err: ErrEmitPayloadContractViolation}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+		ActionRegistry: stubActionRegistry{entries: map[identity.ActionKey]runtimeregistry.ActionInstruction{
+			identity.NormalizeActionKey("notify"): {
+				Key:   identity.NormalizeActionKey("notify"),
+				Emits: "action.emitted",
+			},
+		}},
+		ActionRunner:  runner,
+		PayloadShaper: shaper,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{"score":9}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Action: runtimecontracts.ActionSpec{ID: "notify"},
+		},
+		State: testStateSnapshot("", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if !errors.Is(err, ErrEmitPayloadContractViolation) {
+		t.Fatalf("Execute error = %v, want %v", err, ErrEmitPayloadContractViolation)
+	}
+	if result.Status != OutcomeRejected {
+		t.Fatalf("Status = %q, want %q", result.Status, OutcomeRejected)
+	}
+	if result.FailureClass != FailureLogic {
+		t.Fatalf("FailureClass = %q, want %q", result.FailureClass, FailureLogic)
+	}
+	if len(result.EmitIntents) != 0 {
+		t.Fatalf("EmitIntents = %#v, want none", result.EmitIntents)
+	}
+	if len(result.ActionsExecuted) != 0 {
+		t.Fatalf("ActionsExecuted = %#v, want none", result.ActionsExecuted)
+	}
+	if len(runner.called) != 0 {
+		t.Fatalf("action runner calls = %#v, want none", runner.called)
+	}
+	if shaper.lastSurface != EmitSurfaceAction {
+		t.Fatalf("action emit surface = %q, want %q", shaper.lastSurface, EmitSurfaceAction)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -695,10 +695,8 @@ func (s pipelineEnginePayloadShaper) ShapeEmitPayload(ctx context.Context, req r
 	for key, value := range envelope {
 		out[key] = value
 	}
-	if runtimeengine.EmitSurfaceFromContext(ctx) == runtimeengine.EmitSurfaceDeclarative {
-		if err := validatePipelineEmitPayload(pc.SemanticSource(), req.FlowID.String(), eventType, out); err != nil {
-			return nil, err
-		}
+	if err := validatePipelineEmitPayload(pc.SemanticSource(), req.FlowID.String(), eventType, out); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1002,7 +1002,7 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsAcrossCrossFlowOutpu
 	}
 }
 
-func TestPipelineEnginePayloadShaper_DoesNotApplyDeclarativeValidationToActionSurface(t *testing.T) {
+func TestPipelineEnginePayloadShaper_AllowsDeclaredPayloadOnActionSurface(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -1031,18 +1031,103 @@ func TestPipelineEnginePayloadShaper_DoesNotApplyDeclarativeValidationToActionSu
 
 	actionCtx := runtimeengine.WithEmitSurface(context.Background(), runtimeengine.EmitSurfaceAction)
 	payload, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.done", map[string]any{
-		"entity_id":   "ent-child",
-		"vertical_id": "ent-child",
-		"result":      "accepted",
+		"entity_id": "ent-child",
 	})
 	if err != nil {
 		t.Fatalf("ShapeEmitPayload action surface: %v", err)
 	}
-	if got := payload["vertical_id"]; got != "ent-child" {
-		t.Fatalf("action payload vertical_id = %#v, want ent-child", got)
+	if got := payload["entity_id"]; got != "ent-child" {
+		t.Fatalf("action payload entity_id = %#v, want ent-child", got)
 	}
-	if got := payload["result"]; got != "accepted" {
-		t.Fatalf("action payload result = %#v, want accepted", got)
+	if got := payload["trigger_event_type"]; got != "child/child.internal" {
+		t.Fatalf("action payload trigger_event_type = %#v, want child/child.internal", got)
+	}
+}
+
+func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml":             "name: action-emit-required\nversion: 1.0.0\ndescription: Action emit required-field proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
+		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n  outputs:\n    events: [parent.result]\n",
+		"events.yaml":              "parent.trigger:\n  payload:\n    entity_id: string\nparent.result:\n  payload:\n    entity_id: string\n",
+		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
+		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.internal]\n",
+		"flows/child/events.yaml":  "child.start:\n  payload:\n    entity_id: string\nchild.internal:\n  payload:\n    entity_id: string\n    step: string\n  required: [entity_id, step]\n",
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected workflow fixture bundle")
+	}
+	shaper := pipelineEnginePayloadShaper{
+		coordinator: &PipelineCoordinator{
+			module: &previewWorkflowModule{
+				bundle: bundle,
+			},
+		},
+	}
+
+	req := runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("ent-child"),
+		FlowID:   identity.NormalizeFlowID("child"),
+		Event: events.Event{
+			Type:    events.EventType("child/child.start"),
+			Payload: json.RawMessage(`{"entity_id":"ent-child"}`),
+		}.WithEntityID("ent-child"),
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
+		},
+	}
+
+	actionCtx := runtimeengine.WithEmitSurface(context.Background(), runtimeengine.EmitSurfaceAction)
+	_, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.internal", map[string]any{
+		"entity_id": "ent-child",
+	})
+	if err == nil {
+		t.Fatal("expected action surface missing required field to fail closed")
+	}
+	if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+		t.Fatalf("ShapeEmitPayload action surface error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
+	}
+}
+
+func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected workflow fixture bundle")
+	}
+	shaper := pipelineEnginePayloadShaper{
+		coordinator: &PipelineCoordinator{
+			module: &previewWorkflowModule{
+				bundle: bundle,
+			},
+		},
+	}
+
+	req := runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("ent-child"),
+		FlowID:   identity.NormalizeFlowID("child"),
+		Event: events.Event{
+			Type:    events.EventType("child/child.internal"),
+			Payload: json.RawMessage(`{"entity_id":"ent-child","step":"done"}`),
+		}.WithEntityID("ent-child"),
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
+		},
+	}
+
+	actionCtx := runtimeengine.WithEmitSurface(context.Background(), runtimeengine.EmitSurfaceAction)
+	_, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.done", map[string]any{
+		"entity_id":   "ent-child",
+		"vertical_id": "ent-child",
+		"result":      "accepted",
+	})
+	if err == nil {
+		t.Fatal("expected undeclared action surface fields to fail closed")
+	}
+	if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+		t.Fatalf("ShapeEmitPayload action surface error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
 	}
 }
 


### PR DESCRIPTION
Closes #466
Related to #455

## Governing context

Authoritative spec references:
- `handler_specification.node_handler_fields.action`
- `observation_model.emitted_events.payload_rules`
- `compliance.runtime_enforcement.required_checks`
- `compliance.handler_execution.rules`

Adjacent reviewed-draft context:
- `explicitly_not_an_emit_site.actions`
- `runtime_enforcement.paths_covered`
- `synchronous_create_flow_instance_followup`

The reviewed draft still excludes action emit sites today, so this PR closes runtime parity on the live action-originated emit path and updates the authoritative spec to describe that path explicitly.

## Summary

This PR removes the action-surface schema-validation bypass so action-originated emits now fail closed on missing required fields and undeclared producer-authored payload keys before publish.

It also fixes executor outcome classification so action-surface emit contract violations reject the handler instead of surfacing with a completed outcome, and updates the authoritative spec to describe the live action-originated payload contract.

## Semantic migration

New canonical owner set for this child:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `internal/runtime/engine/executor.go`
- `internal/runtime/engine/interfaces.go`
- `internal/runtime/pipeline/engine_adapter.go`

Old non-authoritative path now invalid:
- `EmitSurfaceAction` bypass in `pipelineEnginePayloadShaper.ShapeEmitPayload(...)` that skipped fail-closed payload-contract validation for action-originated emits
- relying on late generic publish validation alone for action-emitted payload drift

Production/runtime paths checked for surviving old behavior:
- `Executor.stepAction(...)` action-originated emit intent construction
- `pipelineEnginePayloadShaper.ShapeEmitPayload(...)` action-surface payload shaping and validation
- executor rejection classification on emit contract violation

Migration completeness for this slice:
- complete for the supported action-originated runtime emit surface
- not claiming closure for `auto_emit_on_create`, verify-side action payload parity, or post-publish canonical-event cleanup
