### PR TITLE
[agent-d][issue #468] Enforce auto emit schema parity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3226,6 +3226,23 @@ observation_model:
           rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any producer-authored field is
             undeclared or violates the schema, handler execution fails. Runtime does not silently trim inherited trigger-payload keys
             on this surface.
+      auto_emit_on_create_surface:
+        construction_order:
+        - 1. Start from lifecycle-owned activation fields: instance_id, template_id, flow_path, subject_id, parent_entity_id
+        - 2. Overlay create_flow_instance config entries only for keys not already owned by the lifecycle surface
+        - '3. Force runtime-owned canonical context: entity_id'
+        collision_priority: runtime-owned canonical context > lifecycle-owned fields > create_flow_instance config
+        note: This surface is authored only as `auto_emit_on_create.event`, so runtime owns the payload construction. It still
+          must satisfy the active event schema fail-closed. Lifecycle-owned fields are explicit runtime payload on this surface;
+          create_flow_instance config does not silently widen the event contract.
+        runtime_validation:
+          description: Runtime validates the constructed auto-emit payload fail-closed before either immediate publish or queued
+            post-commit publish.
+          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
+            that the target schema does not declare.
+          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any lifecycle/config-authored field
+            is undeclared or violates the schema, flow activation fails. Runtime does not downgrade auto_emit_on_create schema violations
+            into warning-only success on the queued post-commit branch.
   entity_state:
     description: The entity document after handler execution commits.
     observable_fields:

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -106,6 +106,10 @@ active_issues:
     title: Enforce strict event-schema parity for action-originated emits
     maps_to:
       - strict_event_schema_cross_flow_contract_migration
+  - id: 468
+    title: Enforce strict event-schema parity for auto_emit_on_create
+    maps_to:
+      - strict_event_schema_cross_flow_contract_migration
   - id: 181
     title: Expose accumulator completion and on_complete transaction outcomes together
     maps_to:
@@ -338,7 +342,7 @@ nodes:
       - agent emit execution still silently trims undeclared payload keys before schema validation instead of failing the emit on undeclared extras
       - action-originated emits still reuse inbound trigger payload and bypass pipeline-side fail-closed payload-contract validation via EmitSurfaceAction before late publish-boundary schema checks
       - persisted canonical-event validation strips undeclared runtime-owned context as an adjacent broader consumer, so system-node runtime closure must stay explicit about sibling emit surfaces that remain outside the child boundary
-      - auto_emit_on_create remains an adjacent emit interpreter that must stay explicitly split unless the governing draft widens
+      - auto_emit_on_create activation still constructs payloads from lifecycle/config state outside the canonical emit shaper and can downgrade schema violations to warning-only runtime logs on the queued post-commit publish path
     representative_issues:
       - 455
       - 457

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -74,6 +74,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if initialState == "" {
 		initialState = "pending"
 	}
+	autoEmitEvent, autoEmitName, err := buildAutoEmitOnCreateEvent(req.ContractBundle, schema, templateID, flowPath, instanceID, flowEntityID, sourceEntityID, strings.TrimSpace(instance.ParentEntityID), req.Config)
+	if err != nil {
+		return err
+	}
 	if err := am.workflowInstances.Upsert(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      instanceID,
 		SubjectID:       strings.TrimSpace(sourceEntityID),
@@ -127,39 +131,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	} else {
 		return fmt.Errorf("event bus does not support derived flow-instance routing for %s", flowPath)
 	}
-	if autoEmit := strings.TrimSpace(schema.AutoEmitOnCreate.Event); autoEmit != "" {
-		eventType := eventidentity.ExternalizeForFlow(flowPath, []string{autoEmit}, autoEmit)
-		payload := map[string]any{
-			"entity_id":        flowEntityID,
-			"instance_id":      instanceID,
-			"template_id":      templateID,
-			"flow_path":        flowPath,
-			"subject_id":       strings.TrimSpace(sourceEntityID),
-			"parent_entity_id": strings.TrimSpace(instance.ParentEntityID),
-		}
-		for key, value := range req.Config {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				continue
-			}
-			if _, exists := payload[key]; !exists {
-				payload[key] = value
-			}
-		}
-		if err := validateAutoEmitPayload(req.ContractBundle, templateID, autoEmit, payload); err != nil {
-			return fmt.Errorf("auto-emit %s: %w", autoEmit, err)
-		}
-		encoded, err := json.Marshal(payload)
-		if err != nil {
-			return fmt.Errorf("encode auto-emit payload %s: %w", autoEmit, err)
-		}
-		autoEmitEvent := (events.Event{
-			ID:          uuid.NewString(),
-			Type:        events.EventType(eventType),
-			SourceAgent: "flow-instance-activator",
-			Payload:     encoded,
-			CreatedAt:   time.Now().UTC(),
-		}).WithEntityID(flowEntityID).WithFlowInstance(flowPath)
+	if strings.TrimSpace(autoEmitName) != "" {
 		publishAutoEmit := func() {
 			if err := am.bus.Publish(context.Background(), autoEmitEvent); err != nil {
 				am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{
@@ -167,7 +139,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 					Message:   "Auto-emitting the flow activation event failed",
 					Component: "flow_activation",
 					Action:    "auto_emit_failed",
-					EventType: autoEmit,
+					EventType: autoEmitName,
 					EntityID:  flowEntityID,
 					Detail: map[string]any{
 						"flow_path": flowPath,
@@ -178,11 +150,50 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		}
 		if !runtimepipeline.QueuePipelinePostCommitAction(ctx, publishAutoEmit) {
 			if err := am.bus.Publish(ctx, autoEmitEvent); err != nil {
-				return fmt.Errorf("auto-emit %s: %w", autoEmit, err)
+				return fmt.Errorf("auto-emit %s: %w", autoEmitName, err)
 			}
 		}
 	}
 	return nil
+}
+
+func buildAutoEmitOnCreateEvent(source semanticview.Source, schema runtimecontracts.FlowSchemaDocument, templateID, flowPath, instanceID, flowEntityID, sourceEntityID, parentEntityID string, config map[string]any) (events.Event, string, error) {
+	autoEmit := strings.TrimSpace(schema.AutoEmitOnCreate.Event)
+	if autoEmit == "" {
+		return events.Event{}, "", nil
+	}
+	eventType := eventidentity.ExternalizeForFlow(flowPath, []string{autoEmit}, autoEmit)
+	payload := map[string]any{
+		"entity_id":        flowEntityID,
+		"instance_id":      instanceID,
+		"template_id":      templateID,
+		"flow_path":        flowPath,
+		"subject_id":       strings.TrimSpace(sourceEntityID),
+		"parent_entity_id": strings.TrimSpace(parentEntityID),
+	}
+	for key, value := range config {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, exists := payload[key]; !exists {
+			payload[key] = value
+		}
+	}
+	if err := validateAutoEmitPayload(source, templateID, autoEmit, payload); err != nil {
+		return events.Event{}, autoEmit, fmt.Errorf("auto-emit %s: %w", autoEmit, err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return events.Event{}, autoEmit, fmt.Errorf("encode auto-emit payload %s: %w", autoEmit, err)
+	}
+	return (events.Event{
+		ID:          uuid.NewString(),
+		Type:        events.EventType(eventType),
+		SourceAgent: "flow-instance-activator",
+		Payload:     encoded,
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(flowEntityID).WithFlowInstance(flowPath), autoEmit, nil
 }
 
 func validateAutoEmitPayload(source semanticview.Source, flowID, eventType string, payload map[string]any) error {

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -10,12 +10,16 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimeeventpayload "swarm/internal/runtime/eventpayload"
+	runtimeeventschema "swarm/internal/runtime/eventschema"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	runtimesharedjson "swarm/internal/runtime/sharedjson"
 	runtimetools "swarm/internal/runtime/tools"
 )
 
@@ -142,6 +146,9 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 				payload[key] = value
 			}
 		}
+		if err := validateAutoEmitPayload(req.ContractBundle, templateID, autoEmit, payload); err != nil {
+			return fmt.Errorf("auto-emit %s: %w", autoEmit, err)
+		}
 		encoded, err := json.Marshal(payload)
 		if err != nil {
 			return fmt.Errorf("encode auto-emit payload %s: %w", autoEmit, err)
@@ -176,6 +183,43 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		}
 	}
 	return nil
+}
+
+func validateAutoEmitPayload(source semanticview.Source, flowID, eventType string, payload map[string]any) error {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	if source == nil || flowID == "" || eventType == "" {
+		return nil
+	}
+	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
+	if !proof.HasSchema {
+		return nil
+	}
+	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
+		proof.CatalogKey: proof.Entry,
+	})
+	schema, ok := registry[proof.CatalogKey]
+	if !ok {
+		return nil
+	}
+	validationPayload := runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(payload, autoEmitSchemaPropertyNames(schema.Schema))
+	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, validationPayload); err != nil {
+		return fmt.Errorf("%w for %s: %v", runtimebus.ErrPayloadValidation, proof.EventKey(), err)
+	}
+	return nil
+}
+
+func autoEmitSchemaPropertyNames(schema map[string]any) map[string]struct{} {
+	props := runtimesharedjson.SchemaProperties(schema["properties"])
+	out := make(map[string]struct{}, len(props))
+	for key := range props {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = struct{}{}
+	}
+	return out
 }
 
 func (am *AgentManager) EnsureStaticFlowRequiredAgents(ctx context.Context, source semanticview.Source) error {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -28,6 +28,7 @@ type flowActivationTestBus struct {
 	addedPaths   []string
 	removedPairs []string
 	published    []events.Event
+	runtimeLogs  []runtimepipeline.RuntimeLogEntry
 	routeStore   flowActivationRouteStore
 }
 
@@ -139,7 +140,8 @@ func (*flowActivationTestBus) Subscribe(string, ...events.EventType) <-chan even
 func (*flowActivationTestBus) Unsubscribe(string)           {}
 func (*flowActivationTestBus) Store() runtimebus.EventStore { return nil }
 func (*flowActivationTestBus) ResetInMemoryState() error    { return nil }
-func (*flowActivationTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
+func (b *flowActivationTestBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.runtimeLogs = append(b.runtimeLogs, entry)
 	return nil
 }
 
@@ -177,6 +179,20 @@ func (flowActivationStubAgent) OnEvent(context.Context, events.Event) ([]events.
 func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
 	reviewFlow := &runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "review"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.started": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"instance_id":      {Type: "string"},
+						"template_id":      {Type: "string"},
+						"flow_path":        {Type: "string"},
+						"subject_id":       {Type: "string"},
+						"parent_entity_id": {Type: "string"},
+					},
+				},
+				Required: []string{"instance_id", "template_id", "flow_path", "subject_id", "parent_entity_id"},
+			},
+		},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"reviewer": {
 				ID:            "reviewer-{instance_id}",
@@ -206,6 +222,19 @@ func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
 		},
 		Semantics: runtimecontracts.WorkflowSemanticView{Version: "v-test"},
 	}
+}
+
+func testFlowBundleWithAutoEmitEntry(autoEmit string, entry runtimecontracts.EventCatalogEntry) *runtimecontracts.WorkflowContractBundle {
+	bundle := testFlowBundle(autoEmit)
+	reviewFlow := bundle.FlowTree.ByID["review"]
+	if reviewFlow == nil {
+		return bundle
+	}
+	if reviewFlow.Events == nil {
+		reviewFlow.Events = map[string]runtimecontracts.EventCatalogEntry{}
+	}
+	reviewFlow.Events[strings.TrimSpace(autoEmit)] = entry
+	return bundle
 }
 
 func testNestedFlowBundle() *runtimecontracts.WorkflowContractBundle {
@@ -395,6 +424,57 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	}
 }
 
+func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"instance_id": {Type: "string"},
+				"reason":      {Type: "string"},
+			},
+		},
+		Required: []string{"instance_id", "reason"},
+	})
+
+	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
+	if err == nil || !strings.Contains(err.Error(), "auto-emit task.started") || !strings.Contains(err.Error(), "reason is required") {
+		t.Fatalf("ActivateFlowInstance error = %v, want missing required auto-emit schema failure", err)
+	}
+	if len(bus.published) != 0 {
+		t.Fatalf("published events = %#v, want none", bus.published)
+	}
+	if len(bus.runtimeLogs) != 0 {
+		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
+	}
+}
+
+func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundle("task.started")
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"unexpected": "value",
+	}
+
+	err := am.ActivateFlowInstance(ctx, req)
+	if err == nil || !strings.Contains(err.Error(), "auto-emit task.started") || !strings.Contains(err.Error(), "unexpected is not allowed") {
+		t.Fatalf("ActivateFlowInstance error = %v, want undeclared auto-emit schema failure", err)
+	}
+	if len(postCommit) != 0 {
+		t.Fatalf("post-commit actions = %d, want 0", len(postCommit))
+	}
+	if len(bus.published) != 0 {
+		t.Fatalf("published events = %#v, want none", bus.published)
+	}
+	if len(bus.runtimeLogs) != 0 {
+		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
+	}
+}
+
 func TestNormalizedStaticFlowEmitEvents_ExternalizesLocalEvents(t *testing.T) {
 	got := normalizedStaticFlowEmitEvents(
 		[]string{"analysis.done", "shared.event"},
@@ -425,7 +505,20 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	instances := &flowActivationTestInstanceStore{}
 	am := newFlowActivationManager(bus, instances)
-	bundle := testFlowBundle("task.started")
+	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"instance_id":      {Type: "string"},
+				"template_id":      {Type: "string"},
+				"flow_path":        {Type: "string"},
+				"subject_id":       {Type: "string"},
+				"parent_entity_id": {Type: "string"},
+				"name":             {Type: "string"},
+				"priority":         {Type: "integer"},
+			},
+		},
+		Required: []string{"instance_id", "template_id", "flow_path", "subject_id", "parent_entity_id"},
+	})
 
 	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
 	req.Config = map[string]any{

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -426,7 +426,8 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 
 func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
 	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
 		Payload: runtimecontracts.EventPayloadSpec{
 			Properties: map[string]runtimecontracts.EventFieldSpec{
@@ -447,11 +448,21 @@ func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testin
 	if len(bus.runtimeLogs) != 0 {
 		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
 	}
+	if len(instances.upserts) != 0 {
+		t.Fatalf("instance upserts = %#v, want none", instances.upserts)
+	}
+	if len(bus.addedPaths) != 0 {
+		t.Fatalf("added paths = %#v, want none", bus.addedPaths)
+	}
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("unexpected activated agent config after auto-emit schema failure")
+	}
 }
 
 func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t *testing.T) {
 	bus := &flowActivationTestBus{}
-	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
 	bundle := testFlowBundle("task.started")
 	postCommit := make([]func(), 0, 1)
 	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
@@ -472,6 +483,15 @@ func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t 
 	}
 	if len(bus.runtimeLogs) != 0 {
 		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
+	}
+	if len(instances.upserts) != 0 {
+		t.Fatalf("instance upserts = %#v, want none", instances.upserts)
+	}
+	if len(bus.addedPaths) != 0 {
+		t.Fatalf("added paths = %#v, want none", bus.addedPaths)
+	}
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("unexpected activated agent config after queued auto-emit schema failure")
 	}
 }
 


### PR DESCRIPTION
Closes #468

## Summary

Enforce strict event-schema parity for `auto_emit_on_create` on the live runtime activation path.

This change moves the contract boundary into `AgentManager.ActivateFlowInstance(...)` so both lifecycle branches fail closed on schema violations:
- immediate publish
- queued post-commit publish

## Governing refs

Authoritative spec refs updated in this PR:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `dynamic_instance_lifecycle.creation.auto_emit`
  - `observation_model.emitted_events.payload_rules.auto_emit_on_create_surface`

Reviewed draft context used as binding adjacent design direction:
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.event-schema-cross-flow-contract.yaml`
  - important context: this draft explicitly leaves `auto_emit_on_create` outside the structured authored emit rewrite, so this PR closes runtime parity for the lifecycle surface rather than widening into grammar work.

## Canonical owner and migration note

New canonical owner for strict schema enforcement on this surface:
- `internal/runtime/manager/flow_activation.go`

Old non-authoritative behavior now invalid:
- queued `auto_emit_on_create` post-commit publish could log `auto_emit_failed` and still let activation succeed after a schema rejection
- this surface depended on late generic bus validation rather than a lifecycle-owned fail-closed boundary

Production paths checked for surviving old behavior:
- `ActivateFlowInstance(...)` immediate publish branch
- `ActivateFlowInstance(...)` queued post-commit branch
- supported tier5 real-runtime success path `test-auto-emit-on-create`

Migration completeness for this child:
- complete for the `auto_emit_on_create` runtime surface only
- broader parent `#455` remains open for the remaining tracked tail
