### PR TITLE
[agent-d][issue #470] Retire legacy emit compatibility tail

### DIFF
--- a/docs/specs/swarm-platform/IMPLEMENTER-HANDOFF.md
+++ b/docs/specs/swarm-platform/IMPLEMENTER-HANDOFF.md
@@ -25,8 +25,8 @@ guard
                  └→ advances_to ─┐
                     sets_gate ────┤  (independent — any order)
                     data_accumulation ┘
-                         └→ payload_transform
-                              └→ emits
+                         └→ emit.fields
+                              └→ emit.event
                                    └→ action
 ```
 
@@ -38,11 +38,11 @@ Same answer. `data_accumulation` is independent of `advances_to`. Your "data fir
 
 ### 3. Side-effect emit equivalence
 
-`emits` is a normative handler step. The event is **persisted** within the atomic boundary and **delivered** after commit. `brand.requested`, `spec.revision_requested`, `vertical.killed` — these are handler outputs, not runtime side effects. Move them into handler-first execution.
+`emit` is a normative handler step. The event is **persisted** within the atomic boundary and **delivered** after commit. `brand.requested`, `spec.revision_requested`, `vertical.killed` — these are handler outputs, not runtime side effects. Move them into handler-first execution.
 
 ### 4. Packaging/finalization for `vertical.ready_for_review`
 
-The handler declares the complete packaging: `data_accumulation` writes (brand, research brief, spec, CTO notes) + `advances_to: ready_for_review` + `emits: mailbox event`. If your runtime does additional packaging not in the handler, the handler declaration is incomplete — tell us what's missing and we'll add it.
+The handler declares the complete packaging: `data_accumulation` writes (brand, research brief, spec, CTO notes) + `advances_to: ready_for_review` + `emit: mailbox event`. If your runtime does additional packaging not in the handler, the handler declaration is incomplete — tell us what's missing and we'll add it.
 
 ---
 ---
@@ -59,7 +59,7 @@ No. Treat the YAML contracts as the spec. The handoff explains the delta from v2
 
 ### Q3: Is `action` strictly platform-only?
 
-**Yes.** All legacy product actions (`set_gate`, `kill_vertical`, `finalize_validation`, `emit_spinup`, `accumulate_signal`, etc.) have been removed from the contracts. The only valid `action` values are `create_flow_instance` and `record_evidence`. Every other handler uses declarative fields: `advances_to`, `sets_gate`, `data_accumulation`, `emits`, `guard`, `rules`, `fan_out`, `accumulate`, `compute`, `query`, `clear`, `clear_gates`, `payload_transform`.
+**Yes.** All legacy product actions (`set_gate`, `kill_vertical`, `finalize_validation`, `emit_spinup`, `accumulate_signal`, etc.) have been removed from the contracts. The only valid `action` values are `create_flow_instance` and `record_evidence`. Every other handler uses declarative fields: `advances_to`, `sets_gate`, `data_accumulation`, `emit`, `guard`, `rules`, `fan_out`, `accumulate`, `compute`, `query`, `clear`, `clear_gates`.
 
 ### Q4: Is `platform-spec.yaml` authoritative over prose and scripts?
 
@@ -168,7 +168,7 @@ These are the handlers your runtime still runs flat-transition. Here's exactly w
 ```yaml
 vertical.shortlisted:
   advances_to: researching
-  emits: validation.started
+  emit: validation.started
 ```
 
 Cross-flow handoff: scoring emits, validation consumes. State goes to `researching` (first validation gate), not `shortlisted`.
@@ -182,7 +182,7 @@ research.completed:
     writes: [business_brief, research_context]
     source_event: research.completed
   advances_to: mvp_speccing
-  emits: spec.requested
+  emit: spec.requested
 ```
 
 Four independent writes in one atomic transaction. Order is cosmetic.
@@ -198,7 +198,7 @@ cto.spec_approved:
         target_field: cto_feasibility
     source_event: cto.spec_approved
   advances_to: branding
-  emits: brand.requested
+  emit: brand.requested
 ```
 
 Gate, data write, state advance, emit — all independent, all atomic.
@@ -208,7 +208,7 @@ Gate, data write, state advance, emit — all independent, all atomic.
 ```yaml
 vertical.ready_for_review:
   advances_to: ready_for_review
-  emits: mailbox.review_requested
+  emit: mailbox.review_requested
 ```
 
 All gates passed. Packaging happens via data_accumulation on the preceding gate handlers (research.completed, spec.approved, cto.spec_approved, brand.candidates_ready). This handler just advances state and notifies the mailbox.
@@ -218,7 +218,7 @@ All gates passed. Packaging happens via data_accumulation on the preceding gate 
 ```yaml
 vertical.approved:
   advances_to: approved
-  emits: opco.spinup_requested
+  emit: opco.spinup_requested
 ```
 
 Lifecycle handoff. The `opco.spinup_requested` event triggers `create_flow_instance` on portfolio-node.
@@ -229,7 +229,7 @@ Lifecycle handoff. The `opco.spinup_requested` event triggers `create_flow_insta
 vertical.needs_more_data:
   clear_gates: true
   advances_to: researching
-  emits: research.additional_requested
+  emit: research.additional_requested
 ```
 
 Human reset path. Gates are cleared, state goes back to `researching`, agent gets new research task.

--- a/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
+++ b/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
@@ -95,7 +95,7 @@ ticket-orchestrator:
             target_field: priority
         source_event: ticket.classified
       advances_to: assigned
-      emits: ticket.assigned
+      emit: ticket.assigned
 
     ticket.resolved:
       description: Agent resolved the ticket.
@@ -103,7 +103,7 @@ ticket-orchestrator:
         writes: [resolution, resolved_by]
         source_event: ticket.resolved
       advances_to: resolved
-      emits: ticket.resolution_confirmed
+      emit: ticket.resolution_confirmed
 
     ticket.escalated:
       description: Agent couldn't resolve. Escalate to human.
@@ -112,7 +112,7 @@ ticket-orchestrator:
         check: "entity.escalation_count < policy.max_escalations"
         on_fail: kill
       advances_to: assigned
-      emits: ticket.assigned
+      emit: ticket.assigned
 
     ticket.abandoned:
       description: Ticket abandoned (customer left, duplicate, etc.)
@@ -120,7 +120,7 @@ ticket-orchestrator:
 
     timer.ticket_sla:
       description: SLA timer expired. Breach notification.
-      emits: ticket.sla_breached
+      emit: ticket.sla_breached
 
   timers:
     - id: ticket_sla
@@ -295,7 +295,7 @@ python3 verify.py
 # Should output: 0 errors, 0 warnings
 ```
 
-**Note on emitted event payloads:** By default, emitted events carry entity fields as a base, overlaid with the triggering event payload (trigger wins on collision), plus platform fields (entity_id, trigger_event_type, current_state). Use `payload_transform` when you need to construct a custom payload from entity state, policy, or computed values instead of forwarding the trigger payload.
+**Note on emitted event payloads:** On the supported declarative system-node emit surface, payload construction starts from an empty payload, evaluates `emit.fields` for the active emit site if present, then forces platform fields. There is no implicit entity or trigger-payload passthrough on this surface.
 
 That's it. The platform loads your contracts, boots the state machine, starts the agents, and processes tickets.
 
@@ -352,7 +352,7 @@ ticket.classified:
     writes: [category, priority]
     source_event: ticket.classified
   advances_to: assigned
-  emits: ticket.assigned
+  emit: ticket.assigned
 ```
 
 **One system node per event.** No two nodes may handle the same event. This ensures unambiguous state authority.
@@ -364,7 +364,7 @@ Handler fields execute in causal order:
 ```
 guard → accumulate → compute → on_complete/rules
   → {advances_to, sets_gate, data_accumulation}   ← independent, atomic commit
-    → payload_transform → emits → action
+    → emit.fields → emit.event → action
 ```
 
 - Guard failure → handler stops (reject/discard/kill/escalate)
@@ -412,10 +412,10 @@ guard:
 rules:
   billing:
     condition: "payload.category == 'billing'"
-    emits: ticket.billing_assigned
+    emit: ticket.billing_assigned
   technical:
     condition: "payload.category == 'technical'"
-    emits: ticket.tech_assigned
+    emit: ticket.tech_assigned
 ```
 
 Available context variables:
@@ -449,7 +449,7 @@ Guard on_fail actions: `reject` (default), `discard` (silent), `kill` (terminal)
 review.completed:
   sets_gate: g_reviewed
   advances_to: approved
-  emits: approval.requested
+  emit: approval.requested
 
 # Gate 2
 approval.granted:
@@ -483,10 +483,10 @@ score.received:
   on_complete:
     - condition: "entity.composite_score >= policy.threshold"
       advances_to: approved
-      emits: candidate.approved
+      emit: candidate.approved
     - condition: "entity.composite_score < policy.threshold"
       advances_to: rejected
-      emits: candidate.rejected
+      emit: candidate.rejected
 ```
 
 `on_complete` MUST be a YAML list (ordered). First matching condition wins.
@@ -500,7 +500,8 @@ batch.requested:
   fan_out:
     items_from: payload.items
     target: worker-agent
-    emit_per_item: item.assigned
+    emit:
+      event: item.assigned
   data_accumulation:
     writes: [batch_expected_count]
     source_event: fan_out.count
@@ -515,15 +516,15 @@ request.received:
   rules:
     billing:
       condition: "payload.category == 'billing'"
-      emits: billing.request
+      emit: billing.request
       advances_to: billing_review
     technical:
       condition: "payload.category == 'technical'"
-      emits: tech.request
+      emit: tech.request
       advances_to: tech_review
     unknown:
       condition: "else"
-      emits: manual.review_needed
+      emit: manual.review_needed
 ```
 
 `rules` and `on_complete` are mutually exclusive. Never use both in the same handler.
@@ -575,7 +576,7 @@ timers:
 # Handler for timer expiry
 timer.payment_deadline:
   advances_to: payment_overdue
-  emits: payment.overdue_notification
+  emit: payment.overdue_notification
 ```
 
 ### Pattern 8: Cross-Entity Queries
@@ -592,7 +593,7 @@ timer.daily_report:
       filter: "priority == 'critical' && state != 'resolved'"
       select: [ticket_id, subject, assigned_to]
       store_as: report.open_critical
-  emits: report.daily_compiled
+  emit: report.daily_compiled
 ```
 
 ### Pattern 9: Payload Transform
@@ -601,13 +602,13 @@ Construct output event payload from multiple sources:
 
 ```yaml
 order.finalized:
-  payload_transform:
+  emit:
+    event: invoice.generation_requested
     fields:
       order_id: entity.order_id
       total: entity.computed_total
       customer: entity.customer_name
       items_count: entity.items.size()
-  emits: invoice.generation_requested
 ```
 
 CEL expressions evaluate against entity state, payload, and policy.
@@ -819,7 +820,7 @@ Your YAML must follow the platform spec exactly:
 3. **Conditions** — always prefixed: `payload.X`, `entity.X`, or `policy.X`
 4. **on_complete vs rules** — mutually exclusive, never both in one handler
 5. **advances_to** — single string, never a list
-6. **emits** — string or list of strings
+6. **emit** — string or `{event, fields}` object
 7. **data_accumulation.writes** — list of strings (direct) or `{source_field, target_field}` objects (mapped)
 8. **dedup_by** — set on accumulate when tracking by content (e.g., `payload.dimension`), not sender
 9. **clear_gates: true** — clears ALL entity gates, not selective
@@ -848,9 +849,9 @@ Your YAML must follow the platform spec exactly:
 
 ```
 guard, accumulate, compute, on_complete, rules, advances_to,
-sets_gate, clear_gates, data_accumulation, emits, fan_out,
+sets_gate, clear_gates, data_accumulation, emit, fan_out,
 filter, reduce, count, group_by, query, clear,
-payload_transform, action, from, description
+action, from, description
 ```
 
 ### Platform Actions

--- a/docs/specs/swarm-platform/SWARM-PLATFORM-BRIEF.md
+++ b/docs/specs/swarm-platform/SWARM-PLATFORM-BRIEF.md
@@ -37,7 +37,7 @@ ticket.validated:
   data_accumulation:
     writes: [order_summary, validation_context]
   advances_to: processing
-  emits: work.assigned
+  emit: work.assigned
 ```
 
 The engine reads this and executes: set the gate, write data, advance state, emit the next event. All in one atomic transaction. If anything fails, everything rolls back.
@@ -49,7 +49,7 @@ Handler fields execute in causal order:
 ```
 guard → accumulate → compute → on_complete/rules
   → {advances_to, sets_gate, data_accumulation}    ← independent, atomic
-    → payload_transform → emits → action
+    → emit.fields → emit.event → action
 ```
 
 Independent steps can run in any order. Everything commits atomically. Guards see pre-handler state. The next handler sees post-commit state.
@@ -90,7 +90,7 @@ When an order gets approved, the platform creates a new fulfillment flow instanc
 ## Platform Capabilities
 
 ### Handler primitives
-guard, advances_to, sets_gate, clear_gates, data_accumulation, emits, rules, on_complete, accumulate, compute, fan_out, filter, reduce, count, group_by, query, clear, payload_transform, record_evidence, action (create_flow_instance)
+guard, advances_to, sets_gate, clear_gates, data_accumulation, emit, rules, on_complete, accumulate, compute, fan_out, filter, reduce, count, group_by, query, clear, record_evidence, action (create_flow_instance)
 
 ### Expression language
 CEL (Common Expression Language) for all conditions, guards, and filters. Strongly typed, non-Turing-complete, safe for policy evaluation.

--- a/docs/specs/swarm-platform/platform/PROMPT-test-writer.md
+++ b/docs/specs/swarm-platform/platform/PROMPT-test-writer.md
@@ -84,7 +84,7 @@ expected:
 
 | Tier | Category | What it tests |
 |------|----------|---------------|
-| 1 | primitives | Single handler fields: advances_to, sets_gate, data_accumulation, emits, guards, rules, on_complete, compute, payload_transform |
+| 1 | primitives | Single handler fields: advances_to, sets_gate, data_accumulation, emit, guards, rules, on_complete, compute, emit.fields |
 | 2 | accumulation | Multi-event accumulate: expected_from, dedup_by, completion, timeout, idempotency |
 | 3 | list-processing | fan_out, filter, reduce, count, group_by, weighted_average |
 | 4 | cross-entity | create_entity, query, clear |

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -615,7 +615,7 @@ handler_specification:
       - "`emits` — retired; use `emit`"
       - "`payload_transform` — retired; move payload ownership into `emit.fields` at the active emit site"
       - "`fan_out.emit_per_item` — retired; use `fan_out.emit`"
-      - "`fan_out.emit_mapping` — retired; use `fan_out.emit.fields`"
+      - "`fan_out.emit_mapping` — retired; no direct replacement in the current fan_out model. Use a single `fan_out.emit` and route before or after fan-out if per-item event-name branching is required."
     clear_gates:
       field: clear_gates
       type: boolean

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -594,7 +594,7 @@ handler_specification:
         the named action. NOT for platform actions — all behavior must be declarative.'
       emit_interaction: If the resolved runtime action instruction emits a follow-up event, that event uses the action-originated
         emitted-event payload rules under observation_model.emitted_events.payload_rules. The action field itself does not
-        declare emit.fields or a separate payload carrier.
+        declare authored payload fields; runtime-owned action instructions construct and validate any follow-up payload.
       valid_values:
         create_flow_instance:
           description: Create a new dynamic flow instance.
@@ -610,6 +610,7 @@ handler_specification:
           required_sibling_fields: {}
     retired_fields:
       description: Legacy declarative emit carriers retired by the structured emit grammar.
+      rule: These fields are retired compatibility syntax, not alternate current-contract forms.
       entries:
       - "`emits` — retired; use `emit`"
       - "`payload_transform` — retired; move payload ownership into `emit.fields` at the active emit site"

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -294,7 +294,7 @@ hello-node:
   event_handlers:
     hello.requested:
       advances_to: done
-      emits: hello.completed
+      emit: hello.completed
 ```
 
 **events.yaml:**
@@ -335,8 +335,8 @@ query (optional — pre-fetch cross-entity data into handler context)
                                           └→ advances_to ─┐
                                              sets_gate ────┤ (independent of each other)
                                              data_accumulation ┘
-                                                  └→ payload_transform
-                                                       └→ emits
+                                                  └→ emit.fields
+                                                       └→ emit.event
                                                             └→ action
                                                                  └→ clear (optional — reset accumulator/state buckets)
 ```
@@ -360,19 +360,19 @@ Handlers can stop early in two important ways:
 
 These are mutually exclusive — a handler uses one or the other, never both.
 
-**`on_complete`** is an ordered list of `{condition, advances_to, emits}` objects. Conditions are evaluated top to bottom; the first match wins. This is used after accumulation or computation when you need conditional branching based on computed results.
+**`on_complete`** is an ordered list of `{condition, advances_to, emit}` objects. Conditions are evaluated top to bottom; the first match wins. This is used after accumulation or computation when you need conditional branching based on computed results.
 
-**`rules`** is a map of named rules used for payload-based routing. Each rule has a condition evaluated against the payload, plus optional `emits`, `advances_to`, and `data_accumulation`. This is used for type-dispatching — routing different kinds of incoming events to different outcomes.
+**`rules`** is a map of named rules used for payload-based routing. Each rule has a condition evaluated against the payload, plus optional `emit`, `advances_to`, and `data_accumulation`. This is used for type-dispatching — routing different kinds of incoming events to different outcomes.
 
 ### Core Fields vs. Extension Fields
 
 Most handlers use a small core subset. The spec draws this distinction explicitly.
 
 **Core fields** (used by 90%+ of handlers — learn these first):
-`guard`, `advances_to`, `sets_gate`, `data_accumulation`, `emits`, `rules`, `on_complete`
+`guard`, `advances_to`, `sets_gate`, `data_accumulation`, `emit`, `rules`, `on_complete`
 
 **Extension fields** (used by specialized handlers — learn when needed):
-`accumulate`, `compute`, `fan_out`, `filter`, `reduce`, `count`, `query`, `clear`, `payload_transform`, `clear_gates`, `action`
+`accumulate`, `compute`, `fan_out`, `filter`, `reduce`, `count`, `query`, `clear`, `clear_gates`, `action`
 
 ### Handler Fields At A Glance
 
@@ -386,7 +386,7 @@ Most handlers use a small core subset. The spec draws this distinction explicitl
 | `advances_to` | Set `entity.state` to a target state. |
 | `sets_gate` | Set `entity.gates.{name} = true`. |
 | `data_accumulation` | Write payload-derived values into entity state. |
-| `emits` | Publish follow-up event(s). |
+| `emit` | Publish the follow-up event for the active emit site. |
 | `rules` | Payload-based routing with per-rule side effects. |
 | `fan_out` | Emit one event per item in a list. |
 | `query` | Pre-fetch cross-entity data into handler context. |
@@ -395,7 +395,6 @@ Most handlers use a small core subset. The spec draws this distinction explicitl
 | `count` | Count items matching a condition. |
 | `clear` | Reset accumulator or state buckets after everything else. |
 | `action` | Invoke a platform action (`create_flow_instance` or `record_evidence`). |
-| `payload_transform` | Construct emitted payloads explicitly from multiple sources. |
 | `clear_gates` | Reset all entity gates to `false`. |
 | `evidence_target` | Required when `action` is `record_evidence`. |
 
@@ -429,14 +428,14 @@ data_accumulation:
       expression: "entity.counter + 1"    # CEL expression → entity.target_key
 ```
 
-### Rules And Handler-Level Defaults
+### Rules And Active Emit Sites
 
-When a handler has both `rules` and handler-level fields, the interaction is:
+When a handler has `rules`, the selected rule owns the active emit site:
 
 1. The matching rule fires first with its condition-specific side effects.
 2. Handler-level `data_accumulation` executes after rules — it *supplements* rule-level writes, it does not replace them.
-3. Handler-level `emits` fires after rules — both rule-level emits and handler-level emits fire (handler-level is unconditional).
-4. For fields like `advances_to` and `sets_gate`, the rule value *overrides* the handler-level value if present. Fields not specified in the rule fall through to handler-level.
+3. The selected rule's `emit` is the only emit site on that branch. There is no retired handler-level `emits` fallthrough.
+4. For fields like `advances_to` and `sets_gate`, the rule value overrides the handler-level value if present. Fields not specified in the rule fall through to handler-level.
 
 ---
 
@@ -786,11 +785,11 @@ The observation model defines what a test, audit, or flight recorder can see aft
 
 ### Emitted Events
 
-The `emitted_events` view includes events from handler `emits`, `rules`, `on_complete`, `fan_out`, and handler action side effects like `auto_emit_on_create`. It excludes agent fixture emissions, dead-lettered events, and child flow `auto_emit` events from the parent emission log.
+The `emitted_events` view includes events from handler top-level `emit`, `rules`, `on_complete`, `fan_out.emit`, and handler action side effects like `auto_emit_on_create`. It excludes agent fixture emissions, dead-lettered events, and child flow `auto_emit` events from the parent emission log.
 
 ### Payload Construction
 
-When `payload_transform` is absent, emitted payloads are constructed from entity fields, then overlaid with trigger payload fields, then forced platform fields. The collision priority (highest to lowest) is: platform fields > `payload_transform` > trigger payload > entity fields.
+On the supported declarative system-node emit surface, payload construction starts from an empty payload, evaluates `emit.fields` for the active emit site if present, then forces platform-owned fields. There is no implicit entity or trigger-payload passthrough on this surface.
 
 ### Entity State Observation
 
@@ -893,8 +892,8 @@ contracts on disk
                                                               │                                       └─ compute
                                                               │                                            └─ on_complete / rules
                                                               │                                                 └─ advances_to + sets_gate + data_accumulation
-                                                              │                                                      └─ payload_transform
-                                                              │                                                           └─ emits
+                                                              │                                                      └─ emit.fields
+                                                              │                                                           └─ emit.event
                                                               │                                                                └─ action
                                                               │                                                                     └─ clear
                                                               └─ agent delivery

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -382,7 +382,7 @@ query (optional — pre-fetch cross-entity data into handler context)
 ### retired_emit_carriers
 
 - `retired_fields`: `emits`, `payload_transform`, `fan_out.emit_per_item`, `fan_out.emit_mapping`
-- `replacement`: Use `emit` / `emit.fields` at the active emit site.
+- `replacement`: Use `emit` / `emit.fields` at the active emit site. `fan_out.emit_mapping` has no direct replacement in the current fan_out model because `fan_out` now owns one `emit.event`; per-item event-name branching must happen before or after fan-out.
 - `note`: These are retired compatibility forms, not alternate current-contract spellings.
 
 - `_note`: MUST be a YAML list (ordered), not a map (unordered). Each entry has a condition evaluated as CEL. First matching condition executes.

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -379,6 +379,12 @@ query (optional — pre-fetch cross-entity data into handler context)
   - `advances_to`: string — target state
   - `emit`: string or object — branch-local event to emit
 
+### retired_emit_carriers
+
+- `retired_fields`: `emits`, `payload_transform`, `fan_out.emit_per_item`, `fan_out.emit_mapping`
+- `replacement`: Use `emit` / `emit.fields` at the active emit site.
+- `note`: These are retired compatibility forms, not alternate current-contract spellings.
+
 - `_note`: MUST be a YAML list (ordered), not a map (unordered). Each entry has a condition evaluated as CEL. First matching condition executes.
 ### advances_to
 

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -98,6 +98,10 @@ active_issues:
     title: Remove implicit passthrough from declarative system-node emits and fail closed on undeclared payloads
     maps_to:
       - strict_event_schema_cross_flow_contract_migration
+  - id: 461
+    title: Harden verify/boot proof for the strict declarative emit payload contract
+    maps_to:
+      - strict_event_schema_cross_flow_contract_migration
   - id: 464
     title: Enforce strict event-schema parity for agent emits
     maps_to:
@@ -108,6 +112,10 @@ active_issues:
       - strict_event_schema_cross_flow_contract_migration
   - id: 468
     title: Enforce strict event-schema parity for auto_emit_on_create
+    maps_to:
+      - strict_event_schema_cross_flow_contract_migration
+  - id: 470
+    title: Retire legacy payload_transform compatibility and stale emit-contract reference surfaces
     maps_to:
       - strict_event_schema_cross_flow_contract_migration
   - id: 181
@@ -335,20 +343,27 @@ nodes:
       - emit grammar, loader, semantic-view, runtime selection, and boot/verify consumers that must interpret the same emit-site ownership model
     why_this_node_exists: the platform cannot make event schema the strict cross-flow contract while different emit sites still share one ambiguous handler-level payload model or while supported consumers interpret emit authorship differently.
     known_manifestations:
-      - multi-emit handlers cannot honestly satisfy distinct event schemas while payload_transform remains handler-scoped
-      - handler-top-level emits, on_complete branches, rules entries, accumulate.on_timeout, and fan_out per-item emits still use inconsistent or legacy event/payload ownership carriers
-      - boot/verify proof logic and runtime emit construction still read handler-level payload_transform rather than the active emit site
-      - declarative system-node emit construction still overlays explicit emit.fields onto an implicit entity/trigger context carrier and silently trims undeclared business payload keys instead of starting from an empty payload and failing closed
-      - agent emit execution still silently trims undeclared payload keys before schema validation instead of failing the emit on undeclared extras
-      - action-originated emits still reuse inbound trigger payload and bypass pipeline-side fail-closed payload-contract validation via EmitSurfaceAction before late publish-boundary schema checks
-      - persisted canonical-event validation strips undeclared runtime-owned context as an adjacent broader consumer, so system-node runtime closure must stay explicit about sibling emit surfaces that remain outside the child boundary
-      - auto_emit_on_create activation still constructs payloads from lifecycle/config state outside the canonical emit shaper and can downgrade schema violations to warning-only runtime logs on the queued post-commit publish path
+      - closed child seams under this node:
+        - structured emit ownership across handler top level, rules, on_complete, accumulate.on_timeout, and fan_out
+        - strict declarative runtime emit construction and verify/boot proof parity
+        - strict agent emit parity
+        - strict action-originated emit parity
+        - strict auto_emit_on_create parity
+      - remaining compatibility-reference tail addressed by #470:
+        - dead contract/type residue for PayloadTransformSpec after retired authored surfaces stopped being accepted on supported handler/rule/fan_out paths
+        - stale verify/report wording and dead-event audit text that still described payload_transform-era proof surfaces
+        - supported proof-harness allowlists and active prose/reference surfaces that still described payload_transform, fan_out.emit_per_item, or implicit passthrough as current behavior
+      - adjacent split retained after this node:
+        - generic post-publish canonical-event validation cleanup remains outside this migration class unless later promoted
     representative_issues:
       - 455
       - 457
       - 459
+      - 461
       - 464
       - 466
+      - 468
+      - 470
     common_framing_mistakes:
       too_broad:
         - land the entire strict event-schema migration in one PR

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -132,8 +132,8 @@ type checkerContext struct {
 	dataAccumulationExprLoaded   bool
 	dataAccumulationExprFindings []Finding
 
-	payloadTransformExprLoaded   bool
-	payloadTransformExprFindings []Finding
+	emitFieldExprLoaded   bool
+	emitFieldExprFindings []Finding
 
 	entityRefLoaded   bool
 	entityRefFindings []Finding
@@ -198,7 +198,7 @@ var bootCheckRegistry = []Check{
 	{ID: "transition_reference_validation", Severity: "error", Run: checkTransitionReferenceValidation},
 	{ID: "condition_expression_validation", Severity: "error", Run: checkConditionExpressionValidation},
 	{ID: "data_accumulation_expression_validation", Severity: "error", Run: checkDataAccumulationExpressionValidation},
-	{ID: "emit_field_expression_validation", Severity: "error", Run: checkPayloadTransformExpressionValidation},
+	{ID: "emit_field_expression_validation", Severity: "error", Run: checkEmitFieldExpressionValidation},
 	{ID: "expression_field_reference_validation", Severity: "warning", Run: checkExpressionFieldReferenceValidation},
 	{ID: "transition_ownership_validation", Severity: "error", Run: checkTransitionOwnershipValidation},
 	{ID: "event_runtime_wiring_validation", Severity: "error", Run: checkEventRuntimeWiringValidation},

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -19,7 +19,7 @@ type deadEventSchemaUsage struct {
 	agentEmitEvents    int
 	agentSubscriptions int
 	timerReferences    int
-	fanOutEmitPerItem  int
+	fanOutEmit         int
 	autoEmitOnCreate   bool
 	externalSource     bool
 	externalConsumer   bool
@@ -31,7 +31,7 @@ func (u deadEventSchemaUsage) hasAny() bool {
 		u.agentEmitEvents > 0 ||
 		u.agentSubscriptions > 0 ||
 		u.timerReferences > 0 ||
-		u.fanOutEmitPerItem > 0 ||
+		u.fanOutEmit > 0 ||
 		u.autoEmitOnCreate ||
 		u.externalSource ||
 		u.externalConsumer
@@ -58,7 +58,7 @@ func (c *checkerContext) deadEventSchema() []Finding {
 			CheckID:  "semantic_drift_dead_event_schema",
 			Severity: "warning",
 			Message: fmt.Sprintf(
-				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source annotation (_source): %s\n- External consumer annotation (_consumer): %s\n- Fan-out emit_per_item: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add _source: external (...) or _consumer: ... to document the external role.",
+				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source annotation (_source): %s\n- External consumer annotation (_consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add _source: external (...) or _consumer: ... to document the external role.",
 				decl.Canonical,
 				fileLabel,
 				usage.handlerEmits,
@@ -68,7 +68,7 @@ func (c *checkerContext) deadEventSchema() []Finding {
 				usage.timerReferences,
 				yesNoLocal(usage.externalSource),
 				yesNoLocal(usage.externalConsumer),
-				usage.fanOutEmitPerItem,
+				usage.fanOutEmit,
 				yesNoLocal(usage.autoEmitOnCreate),
 				fileLabel,
 			),
@@ -200,7 +200,7 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 				}
 				for _, emitted := range deadEventHandlerFanOutEmits(handler) {
 					if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(c.source, decl, flowID, emitted) {
-						usage.fanOutEmitPerItem++
+						usage.fanOutEmit++
 					}
 				}
 			}
@@ -246,7 +246,7 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 			}
 			for _, emitted := range deadEventHandlerFanOutEmits(handler) {
 				if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(c.source, decl, flowID, emitted) {
-					usage.fanOutEmitPerItem++
+					usage.fanOutEmit++
 				}
 			}
 		}

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -15,7 +15,7 @@ func checkConditionExpressionValidation(c *checkerContext) []Finding { return c.
 func checkDataAccumulationExpressionValidation(c *checkerContext) []Finding {
 	return c.dataAccumulationExpressions()
 }
-func checkPayloadTransformExpressionValidation(c *checkerContext) []Finding {
+func checkEmitFieldExpressionValidation(c *checkerContext) []Finding {
 	return c.emitFieldExpressions()
 }
 func checkExpressionFieldReferenceValidation(c *checkerContext) []Finding {
@@ -93,10 +93,10 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 }
 
 func (c *checkerContext) emitFieldExpressions() []Finding {
-	if c.payloadTransformExprLoaded {
-		return c.payloadTransformExprFindings
+	if c.emitFieldExprLoaded {
+		return c.emitFieldExprFindings
 	}
-	c.payloadTransformExprLoaded = true
+	c.emitFieldExprLoaded = true
 	for nodeID, node := range c.source.NodeEntries() {
 		nodeID = strings.TrimSpace(nodeID)
 		for eventType, handler := range node.EventHandlers {
@@ -106,7 +106,7 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 					continue
 				}
 				if err := workflowexpr.ValidateValueExpression(expr.Expression); err != nil {
-					c.payloadTransformExprFindings = append(c.payloadTransformExprFindings, Finding{
+					c.emitFieldExprFindings = append(c.emitFieldExprFindings, Finding{
 						CheckID:  "emit_field_expression_validation",
 						Severity: "error",
 						Message:  fmt.Sprintf("node %s handler %s %s %q is invalid for emit.fields: %v", nodeID, eventType, expr.Kind, expr.Expression, err),
@@ -116,7 +116,7 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 			}
 		}
 	}
-	return c.payloadTransformExprFindings
+	return c.emitFieldExprFindings
 }
 
 func (c *checkerContext) expressionFieldReferences() []Finding {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -220,51 +220,6 @@ type ClearSpec struct {
 	Target  string   `yaml:"target"`
 	Targets []string `yaml:"targets"`
 }
-type PayloadTransformSpec struct {
-	Mappings map[string]string `yaml:"mappings"`
-	Fields   map[string]string `yaml:"fields"`
-	Entries  []TransformSpec   `yaml:"entries,omitempty"`
-}
-type TransformSpec struct {
-	Target     string
-	TargetPath paths.Path
-	Value      ExpressionValue `yaml:"value,omitempty"`
-}
-type TransformBinding = TransformSpec
-
-func (p PayloadTransformSpec) TransformEntries() []TransformSpec {
-	mappings := p.Mappings
-	if len(mappings) == 0 && len(p.Fields) > 0 {
-		mappings = p.Fields
-	}
-	out := make([]TransformSpec, 0, len(mappings)+len(p.Entries))
-	for target, source := range mappings {
-		cleanTarget := strings.TrimSpace(target)
-		cleanSource := strings.TrimSpace(source)
-		if cleanTarget == "" || cleanSource == "" {
-			continue
-		}
-		out = append(out, TransformSpec{
-			Target:     cleanTarget,
-			TargetPath: paths.Parse(cleanTarget),
-			Value:      CELExpression(cleanSource),
-		})
-	}
-	for _, entry := range p.Entries {
-		if strings.TrimSpace(entry.Target) == "" {
-			continue
-		}
-		clone := entry
-		clone.Target = strings.TrimSpace(clone.Target)
-		clone.TargetPath = paths.Parse(clone.Target)
-		clone.Value.hydrate()
-		out = append(out, clone)
-	}
-	return out
-}
-func (p PayloadTransformSpec) TransformBindings() []TransformBinding {
-	return p.TransformEntries()
-}
 
 type ConfigFromSpec struct {
 	PolicyKeys []string          `yaml:"policy_keys"`

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -140,53 +140,6 @@ func (g *GroupBySpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (p *PayloadTransformSpec) UnmarshalYAML(node *yaml.Node) error {
-	if p == nil {
-		return nil
-	}
-	if node == nil || node.Kind == 0 {
-		*p = PayloadTransformSpec{}
-		return nil
-	}
-	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("unsupported payload transform yaml node kind %d", node.Kind)
-	}
-	type shadow struct {
-		Mappings map[string]string `yaml:"mappings"`
-		Fields   map[string]string `yaml:"fields"`
-		Entries  []TransformSpec   `yaml:"entries"`
-	}
-	var aux shadow
-	if err := node.Decode(&aux); err != nil {
-		return err
-	}
-	spec := PayloadTransformSpec{
-		Mappings: cloneStringMap(aux.Mappings),
-		Fields:   cloneStringMap(aux.Fields),
-		Entries:  append([]TransformSpec(nil), aux.Entries...),
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := strings.TrimSpace(node.Content[i].Value)
-		switch key {
-		case "", "mappings", "fields", "entries":
-			continue
-		}
-		entry, err := decodePayloadTransformShorthandEntry(key, node.Content[i+1])
-		if err != nil {
-			return err
-		}
-		spec.Entries = append(spec.Entries, entry)
-	}
-	spec.Entries = spec.TransformEntries()
-	for i := range spec.Entries {
-		if err := hydrateTransformSpec(&spec.Entries[i]); err != nil {
-			return err
-		}
-	}
-	*p = spec
-	return nil
-}
-
 func (g *GateSpec) UnmarshalYAML(node *yaml.Node) error {
 	if g == nil {
 		return nil
@@ -479,31 +432,6 @@ func (e *ExpressionValue) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
-func (t *TransformSpec) UnmarshalYAML(node *yaml.Node) error {
-	if t == nil {
-		return nil
-	}
-	if node == nil || node.Kind == 0 {
-		*t = TransformSpec{}
-		return nil
-	}
-	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("unsupported payload transform entry yaml node kind %d", node.Kind)
-	}
-	var aux struct {
-		Target     string `yaml:"target"`
-		Expression string `yaml:"expression"`
-	}
-	if err := node.Decode(&aux); err != nil {
-		return err
-	}
-	*t = TransformSpec{Target: strings.TrimSpace(aux.Target)}
-	if strings.TrimSpace(aux.Expression) != "" {
-		t.Value = CELExpression(aux.Expression)
-	}
-	return hydrateTransformSpec(t)
-}
-
 func decodeLiteralExpressionNode(node *yaml.Node) (ExpressionValue, error) {
 	var literal any
 	if err := node.Decode(&literal); err != nil {
@@ -583,35 +511,6 @@ func hydrateWorkflowDataWrite(w *WorkflowDataWrite) error {
 	w.SourcePath = paths.Parse(w.Source())
 	w.TargetPath = paths.Parse(w.Target())
 	return nil
-}
-
-func hydrateTransformSpec(t *TransformSpec) error {
-	if t == nil {
-		return nil
-	}
-	t.Target = strings.TrimSpace(t.Target)
-	t.TargetPath = paths.Parse(t.Target)
-	t.Value.hydrate()
-	if err := validateExpressionValue(t.Value); err != nil {
-		return err
-	}
-	if !t.Value.HasCELValue() {
-		return fmt.Errorf("payload transform target %q must use a CEL expression", t.Target)
-	}
-	return nil
-}
-
-func decodePayloadTransformShorthandEntry(target string, node *yaml.Node) (TransformSpec, error) {
-	entry := TransformSpec{Target: strings.TrimSpace(target)}
-	if node == nil || node.Kind == 0 {
-		entry.TargetPath = paths.Parse(entry.Target)
-		return entry, nil
-	}
-	if node.Kind == yaml.ScalarNode {
-		entry.Value = CELExpression(strings.TrimSpace(node.Value))
-		return entry, hydrateTransformSpec(&entry)
-	}
-	return TransformSpec{}, fmt.Errorf("payload transform target %q must be a CEL expression string", target)
 }
 
 func decodeWorkflowDataWriteValueNode(node *yaml.Node) (ExpressionValue, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -61,6 +61,19 @@ rules:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_RejectsRetiredPayloadTransform(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+payload_transform:
+  fields:
+    score: payload.score
+emit: score.ready
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") {
+		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED payload_transform rejection", err)
+	}
+}
+
 func TestHandlerRuleEntryDecode_AcceptsSpecComputeMetadataFields(t *testing.T) {
 	var rule HandlerRuleEntry
 	if err := yaml.Unmarshal([]byte(`
@@ -276,6 +289,17 @@ emit_mapping:
 `), &spec)
 	if err == nil || !strings.Contains(err.Error(), "RETIRED") {
 		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED legacy fan_out emit mapping rejection", err)
+	}
+}
+
+func TestFanOutSpecDecode_RejectsLegacyEmitPerItem(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+emit_per_item: routed.item
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") {
+		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED legacy fan_out emit_per_item rejection", err)
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -231,28 +231,6 @@ func normalizedCELInputMap(source map[string]any) map[string]any {
 	return workflowexpr.NormalizeCELInputMap(source)
 }
 
-func payloadTransform(base BaseContext, state ExecutionState, spec *runtimecontracts.PayloadTransformSpec) (map[string]any, error) {
-	if spec == nil {
-		return nil, nil
-	}
-	entries := spec.TransformEntries()
-	if len(entries) == 0 {
-		return nil, nil
-	}
-	payload := map[string]any{}
-	for _, entry := range entries {
-		if !entry.Value.HasCELValue() {
-			continue
-		}
-		value, err := evalWorkflowValueExpression(base, state, entry.Value.CEL)
-		if err != nil {
-			return nil, fmt.Errorf("payload transform target %s: %w", entry.Target, err)
-		}
-		setParsedValuePath(payload, entry.TargetPath, value)
-	}
-	return payload, nil
-}
-
 func emitFieldsPayload(base BaseContext, state ExecutionState, spec runtimecontracts.EmitSpec) (map[string]any, error) {
 	if len(spec.Fields) == 0 {
 		return nil, nil

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -100,21 +100,21 @@ func TestResolveRefRequiresExplicitScope(t *testing.T) {
 	}
 }
 
-func TestSetValuePathAndPayloadTransform(t *testing.T) {
+func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 	base := BaseContext{
 		Entity:  values.Wrap(map[string]any{"current_state": "researching"}),
 		Payload: values.Wrap(map[string]any{"score": 9}),
 	}
 	state := ExecutionState{}
-	transformed, err := payloadTransform(base, state, &runtimecontracts.PayloadTransformSpec{
-		Mappings: map[string]string{
-			"nested.score":   "payload.score",
-			"nested.state":   "entity.current_state",
-			"literal.string": `"hello"`,
+	transformed, err := emitFieldsPayload(base, state, runtimecontracts.EmitSpec{
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"nested.score":   runtimecontracts.CELExpression("payload.score"),
+			"nested.state":   runtimecontracts.CELExpression("entity.current_state"),
+			"literal.string": runtimecontracts.CELExpression(`"hello"`),
 		},
 	})
 	if err != nil {
-		t.Fatalf("payloadTransform(...) error = %v", err)
+		t.Fatalf("emitFieldsPayload(...) error = %v", err)
 	}
 	nested, ok := transformed["nested"].(map[string]any)
 	if !ok {
@@ -132,18 +132,17 @@ func TestSetValuePathAndPayloadTransform(t *testing.T) {
 	}
 }
 
-func TestPayloadTransform_NormalizesWholeNumberJSONInputs(t *testing.T) {
+func TestEmitFieldsPayload_NormalizesWholeNumberJSONInputs(t *testing.T) {
 	base := BaseContext{
 		Payload: values.Wrap(map[string]any{"raw_score": 25.0}),
 	}
-	transformed, err := payloadTransform(base, ExecutionState{}, &runtimecontracts.PayloadTransformSpec{
-		Entries: []runtimecontracts.TransformSpec{{
-			Target: "score",
-			Value:  runtimecontracts.CELExpression("payload.raw_score * 2"),
-		}},
+	transformed, err := emitFieldsPayload(base, ExecutionState{}, runtimecontracts.EmitSpec{
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"score": runtimecontracts.CELExpression("payload.raw_score * 2"),
+		},
 	})
 	if err != nil {
-		t.Fatalf("payloadTransform(...) error = %v", err)
+		t.Fatalf("emitFieldsPayload(...) error = %v", err)
 	}
 	if got := transformed["score"]; got != 50 {
 		t.Fatalf("score = %#v, want 50", got)

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1782,14 +1782,22 @@ func catalogConditionHasPrefix(condition string) bool {
 func catalogDefinedHandlerField(field string) bool {
 	switch strings.TrimSpace(field) {
 	case "description", "_note", "guard", "accumulate", "compute", "on_complete",
-		"advances_to", "sets_gate", "data_accumulation", "emit", "emits", "rules",
+		"advances_to", "sets_gate", "data_accumulation", "emit", "rules",
 		"fan_out", "query", "reduce", "filter", "count", "clear", "action",
-		"template", "instance_id_from", "config_from", "from", "payload_transform",
+		"template", "instance_id_from", "config_from", "from",
 		"clear_gates", "dedup_by", "subscriptions_bootstrap", "logic", "on_below_threshold",
 		"on_dedup", "on_pass":
 		return true
 	default:
 		return false
+	}
+}
+
+func TestCatalogDefinedHandlerField_RejectsRetiredEmitCarriers(t *testing.T) {
+	for _, field := range []string{"payload_transform", "emits"} {
+		if catalogDefinedHandlerField(field) {
+			t.Fatalf("catalogDefinedHandlerField(%q) = true, want false", field)
+		}
 	}
 }
 

--- a/tests/tier1-primitives/test-emits-payload-transform/package.yaml
+++ b/tests/tier1-primitives/test-emits-payload-transform/package.yaml
@@ -1,5 +1,5 @@
 name: test-emits-payload-transform
 version: 1.0.0
-description: Handler applies payload_transform before emitting event.
+description: Handler applies emit.fields before publishing the configured event.
 platform_version: ">=1.1.0"
 flows: []

--- a/tests/tier1-primitives/test-payload-transform-multi-source/package.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/package.yaml
@@ -1,6 +1,6 @@
 name: test-payload-transform-multi-source
 version: 1.0.0
-description: payload_transform constructs output from multiple sources including entity and payload.
+description: emit.fields constructs output from multiple sources including entity and payload.
 platform_version: ">=1.1.0"
 flows: []
 entity_schema:

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/package.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/package.yaml
@@ -1,5 +1,5 @@
 name: test-fan-out-emit-mapping
 version: 1.0.0
-description: fan_out with emit_mapping routes items to different events by type.
+description: fan_out.emit.fields routes items to different events by type.
 platform_version: ">=1.1.0"
 flows: []

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/package.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/package.yaml
@@ -1,5 +1,5 @@
 name: test-fan-out-emit-mapping
 version: 1.0.0
-description: fan_out.emit.fields routes items to different events by type.
+description: fan_out.emit.fields shapes per-item payload under the current single-event fan_out emit model.
 platform_version: ">=1.1.0"
 flows: []


### PR DESCRIPTION
Closes #470
Part of #455

## Governing context

Authoritative spec:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `handler_specification.action.emit_interaction`
  - `handler_specification.retired_fields`
  - `observation_model.emitted_events.payload_rules`
  - `static_analyzer.slice_2_emitted_event_payload_completeness`

Reviewed draft context:
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.event-schema-cross-flow-contract.yaml`
  - `handler_specification.handler_fields.payload_transform`
  - `payload_rules_changes.construction_order_rewrite`

## What changed

This PR removes the remaining repo-owned compatibility/reference tail for the retired `payload_transform` emit model after the strict `emit.fields` migration landed.

It:
- deletes dead contract/runtime helpers for `PayloadTransformSpec`
- removes the orphan runtime `payloadTransform(...)` helper
- renames stale bootverify internals from payload-transform terminology to emit-field terminology
- updates dead-event wording and the supported proof harness allowlist to reject retired handler emit carriers
- updates the authoritative/reference docs and fixture metadata so active prose no longer teaches `payload_transform`, `fan_out.emit_per_item`, or implicit passthrough as current contract behavior

## Migration accounting

New canonical owner:
- `emit` / `emit.fields` at the active emit site, as defined by `platform-spec.yaml`

Old producer / reader / writer paths now invalid:
- `internal/runtime/contracts/workflow_contract_types.go` `PayloadTransformSpec`
- `internal/runtime/contracts/workflow_contract_yaml_rules.go` `PayloadTransformSpec.UnmarshalYAML(...)`
- `internal/runtime/engine/helpers.go` `payloadTransform(...)`
- stale bootverify/report wording around payload-transform-era proof semantics
- supported proof-harness allowlist entry for retired handler `payload_transform`
- active prose/reference surfaces teaching the retired model

Production paths checked for surviving old behavior:
- contract loader rejection of retired authored fields
- bootverify emitted-payload proof surfaces
- supported proof harness in `internal/runtime/swarmflowtest`
- authoritative spec and active prose/reference docs

Migration status:
- complete for the chosen `#470` class
- adjacent split remains outside this PR: post-publish canonical-event validation cleanup
