### PR TITLE
[agent-d][issue #478] Add Wave 1 contract loader foundation

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3100,24 +3100,18 @@ func writeSessionScopeValidationFixture(t *testing.T, rootAgents, flowSchema, fl
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:`+flows+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	if strings.TrimSpace(rootAgents) == "" {
 		rootAgents = "{}\n"
@@ -3134,10 +3128,7 @@ item.created:
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), flowAgents)
 	}
@@ -3152,17 +3143,14 @@ func writePackageBackedSessionScopeValidationFixture(t *testing.T, flowSchema, p
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -3170,10 +3158,7 @@ flows:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
 name: support
@@ -3184,10 +3169,7 @@ flows: []
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), packageAgents)
 	return root
@@ -3222,16 +3204,14 @@ func writeTimerValidationFixtureWithOptions(t *testing.T, opts timerValidationFi
 name: timer-validation
 version: "1.0.0"
 platform: ">=1.6.0"
-entity_schema:
-  groups:
-    - name: ticket
-      fields:
-        - name: ticket_id
-          type: string
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+ticket:
+  ticket_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: timer-validation\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -3242,10 +3222,7 @@ flows:
 	if opts.includeTimerEvent {
 		timerEventBlock = strings.TrimSpace(`
 ` + opts.event + `:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
@@ -3257,15 +3234,9 @@ states: [waiting, active, done]
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 ticket.opened:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 ticket.closed:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `+timerEventBlock+`
 `)
 	timerBlock := `
@@ -3306,12 +3277,6 @@ func writeCrossFlowPinAmbiguityFixture(t *testing.T, scoped bool) string {
 name: pin-ambiguity
 version: "1.0.0"
 platform: ">=1.6.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
 flows:
   - id: producer_a
     flow: producer_a
@@ -3322,6 +3287,10 @@ flows:
   - id: consumer
     flow: consumer
     mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: pin-ambiguity\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -3345,10 +3314,7 @@ pins:
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), `
 ticket.ready:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	}
 
@@ -3372,15 +3338,9 @@ pins:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
 ticket.ready:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 consumer.started:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
 consumer-node:
@@ -3438,7 +3398,9 @@ pins:
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
 		entry := "ticket.ready:\n  payload:\n    entity_id: string\n"
 		if flowID == "external_consumer" {
-			entry = "ticket.ready:\n  _source: external (manual handoff)\n  payload:\n    entity_id: string\n"
+			entry = "ticket.ready:\n  _source: external (manual handoff)\n  entity_id: string\n"
+		} else {
+			entry = "ticket.ready:\n  entity_id: string\n"
 		}
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), entry)
 	}
@@ -3454,12 +3416,6 @@ func writeLocalizedEventRoutingFixture(t *testing.T) string {
 name: localized-event-routing
 version: "1.0.0"
 platform: ">=1.6.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
 flows:
   - id: producer
     flow: producer
@@ -3467,6 +3423,10 @@ flows:
   - id: consumer
     flow: consumer
     mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: localized-event-routing\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -3489,10 +3449,7 @@ pins:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
 ticket.ready:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
 producer-node:
@@ -3522,10 +3479,7 @@ pins:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
 ticket.ready:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
 consumer-node:
@@ -3550,16 +3504,14 @@ func writeStateReachabilityFixture(t *testing.T) string {
 name: state-reachability
 version: "1.0.0"
 platform: ">=1.6.0"
-entity_schema:
-  groups:
-    - name: ticket
-      fields:
-        - name: ticket_id
-          type: string
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+ticket:
+  ticket_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: state-reachability\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -3576,11 +3528,9 @@ states: [waiting, active, review, done]
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 ticket.opened:
-  payload:
-    entity_id: string
+  entity_id: string
 ticket.closed:
-  payload:
-    entity_id: string
+  entity_id: string
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
 support-node:

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -334,24 +334,18 @@ func loadSessionScopeConformanceSource(t *testing.T, tc sessionScopeConformanceC
 name: session-scope-conformance
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:`+flows+`
+`)
+	writeSessionScopeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeSessionScopeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-conformance\n")
 	writeSessionScopeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeSessionScopeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	rootAgents := "{}\n"
 	flowAgents := "{}\n"
@@ -367,10 +361,7 @@ states:
 		writeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 		writeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 		writeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), flowAgents)
 	} else {

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -27,7 +27,12 @@ func LoadWorkflowContractBundleWithOverrides(repoRoot, workflowDirOverride, plat
 func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractBundle, error) {
 	bundle := &WorkflowContractBundle{
 		Paths:                 paths,
+		Compatibility:         nil,
 		projectContracts:      map[string]ProjectContractView{},
+		projectTypes:          map[string]TypeCatalogDocument{},
+		projectEntities:       map[string]EntityContractsDocument{},
+		flowTypes:             map[string]TypeCatalogDocument{},
+		flowEntities:          map[string]EntityContractsDocument{},
 		scopedNodes:           map[string]SystemNodeContract{},
 		scopedEvents:          map[string]EventCatalogEntry{},
 		scopedAgents:          map[string]AgentRegistryEntry{},
@@ -59,6 +64,12 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 			}
 			bundle.RootSchema = &rootSchema
 		}
+		if err := loadOptionalYAMLMap(paths.RootTypesFile, &bundle.RootTypes); err != nil {
+			return nil, err
+		}
+		if err := loadOptionalYAMLMap(paths.RootEntitiesFile, &bundle.RootEntities); err != nil {
+			return nil, err
+		}
 		for i, pkgPaths := range paths.ProjectPackages {
 			var manifest ProjectPackageDocument
 			if err := loadYAMLFile(pkgPaths.PackageFile, &manifest); err != nil {
@@ -67,6 +78,14 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 			if i == 0 {
 				bundle.Package = manifest
 			}
+			if manifest.UsesLegacyEntitySchema {
+				recordContractCompatibilityUsage(bundle, ContractCompatibilityUsage{
+					Kind:   "legacy_package_entity_schema",
+					File:   pkgPaths.PackageFile,
+					Scope:  pkgPaths.Key,
+					Detail: "package.yaml entity_schema loaded through Wave 1 migration compatibility",
+				})
+			}
 			bundle.PackageTree = append(bundle.PackageTree, LoadedProjectPackage{
 				Key:       pkgPaths.Key,
 				ParentKey: pkgPaths.ParentKey,
@@ -74,11 +93,28 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 				Paths:     pkgPaths,
 				Manifest:  manifest,
 			})
+			if pkgPaths.Key != "." {
+				var projectTypes TypeCatalogDocument
+				if err := loadOptionalYAMLMap(pkgPaths.ProjectTypesFile, &projectTypes); err != nil {
+					return nil, err
+				}
+				if len(projectTypes.Scalars) > 0 || len(projectTypes.Enums) > 0 || len(projectTypes.Types) > 0 {
+					bundle.projectTypes[pkgPaths.Key] = projectTypes
+				}
+				var projectEntities EntityContractsDocument
+				if err := loadOptionalYAMLMap(pkgPaths.ProjectEntitiesFile, &projectEntities); err != nil {
+					return nil, err
+				}
+				if len(projectEntities) > 0 {
+					bundle.projectEntities[pkgPaths.Key] = projectEntities
+				}
+			}
 			projectView, err := loadProjectContractView(pkgPaths, manifest)
 			if err != nil {
 				return nil, err
 			}
 			bundle.projectContracts[pkgPaths.Key] = projectView
+			recordEventCompatibilityUsages(bundle, projectView.Events, pkgPaths.ProjectEventsFile, pkgPaths.Key)
 		}
 		if err := validateDiscoveredPackageTree(bundle.PackageTree); err != nil {
 			return nil, err
@@ -98,11 +134,29 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 				schema.Mode = strings.TrimSpace(flow.Mode)
 			}
 			bundle.FlowSchemas[flow.ID] = schema
+			var flowTypes TypeCatalogDocument
+			if err := loadOptionalYAMLMap(flow.TypesFile, &flowTypes); err != nil {
+				return nil, err
+			}
+			if len(flowTypes.Scalars) > 0 || len(flowTypes.Enums) > 0 || len(flowTypes.Types) > 0 {
+				bundle.flowTypes[flow.ID] = flowTypes
+			}
+			var flowEntities EntityContractsDocument
+			if err := loadOptionalYAMLMap(flow.EntitiesFile, &flowEntities); err != nil {
+				return nil, err
+			}
+			if len(flowEntities) > 0 {
+				bundle.flowEntities[flow.ID] = flowEntities
+			}
 			flowView, err := loadFlowContractView(flow, schema)
 			if err != nil {
 				return nil, err
 			}
 			flowViewsByID[flow.ID] = flowView
+			recordEventCompatibilityUsages(bundle, flowView.Events, flow.EventsFile, flow.ID)
+		}
+		if err := validateWave1ContractsLoadBoundary(bundle); err != nil {
+			return nil, err
 		}
 		if err := buildFlowTree(bundle, flowViewsByID); err != nil {
 			return nil, err

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -27,10 +27,7 @@ func LoadWorkflowContractBundleWithOverrides(repoRoot, workflowDirOverride, plat
 func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractBundle, error) {
 	bundle := &WorkflowContractBundle{
 		Paths:                 paths,
-		Compatibility:         nil,
 		projectContracts:      map[string]ProjectContractView{},
-		projectTypes:          map[string]TypeCatalogDocument{},
-		projectEntities:       map[string]EntityContractsDocument{},
 		flowTypes:             map[string]TypeCatalogDocument{},
 		flowEntities:          map[string]EntityContractsDocument{},
 		scopedNodes:           map[string]SystemNodeContract{},
@@ -78,14 +75,6 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 			if i == 0 {
 				bundle.Package = manifest
 			}
-			if manifest.UsesLegacyEntitySchema {
-				recordContractCompatibilityUsage(bundle, ContractCompatibilityUsage{
-					Kind:   "legacy_package_entity_schema",
-					File:   pkgPaths.PackageFile,
-					Scope:  pkgPaths.Key,
-					Detail: "package.yaml entity_schema loaded through Wave 1 migration compatibility",
-				})
-			}
 			bundle.PackageTree = append(bundle.PackageTree, LoadedProjectPackage{
 				Key:       pkgPaths.Key,
 				ParentKey: pkgPaths.ParentKey,
@@ -93,28 +82,11 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 				Paths:     pkgPaths,
 				Manifest:  manifest,
 			})
-			if pkgPaths.Key != "." {
-				var projectTypes TypeCatalogDocument
-				if err := loadOptionalYAMLMap(pkgPaths.ProjectTypesFile, &projectTypes); err != nil {
-					return nil, err
-				}
-				if len(projectTypes.Scalars) > 0 || len(projectTypes.Enums) > 0 || len(projectTypes.Types) > 0 {
-					bundle.projectTypes[pkgPaths.Key] = projectTypes
-				}
-				var projectEntities EntityContractsDocument
-				if err := loadOptionalYAMLMap(pkgPaths.ProjectEntitiesFile, &projectEntities); err != nil {
-					return nil, err
-				}
-				if len(projectEntities) > 0 {
-					bundle.projectEntities[pkgPaths.Key] = projectEntities
-				}
-			}
 			projectView, err := loadProjectContractView(pkgPaths, manifest)
 			if err != nil {
 				return nil, err
 			}
 			bundle.projectContracts[pkgPaths.Key] = projectView
-			recordEventCompatibilityUsages(bundle, projectView.Events, pkgPaths.ProjectEventsFile, pkgPaths.Key)
 		}
 		if err := validateDiscoveredPackageTree(bundle.PackageTree); err != nil {
 			return nil, err
@@ -153,7 +125,6 @@ func loadWorkflowContractBundleForPaths(paths ContractPaths) (*WorkflowContractB
 				return nil, err
 			}
 			flowViewsByID[flow.ID] = flowView
-			recordEventCompatibilityUsages(bundle, flowView.Events, flow.EventsFile, flow.ID)
 		}
 		if err := validateWave1ContractsLoadBoundary(bundle); err != nil {
 			return nil, err

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -127,8 +127,6 @@ func ContractFilesExist(repoRoot string) []string {
 		for _, pkg := range paths.ProjectPackages {
 			files = append(files,
 				pkg.PackageFile,
-				pkg.ProjectTypesFile,
-				pkg.ProjectEntitiesFile,
 				pkg.ProjectNodesFile,
 				pkg.ProjectEventsFile,
 				pkg.ProjectAgentsFile,
@@ -210,19 +208,17 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 			key = filepath.Clean(rel)
 		}
 		pkg := ProjectPackagePaths{
-			Key:                 key,
-			ParentKey:           parentKey,
-			Depth:               depth,
-			Dir:                 packageDir,
-			PackageFile:         packageFile,
-			ProjectTypesFile:    existingFile(filepath.Join(packageDir, "types.yaml")),
-			ProjectEntitiesFile: existingFile(filepath.Join(packageDir, "entities.yaml")),
-			ProjectNodesFile:    existingFile(filepath.Join(packageDir, "nodes.yaml")),
-			ProjectEventsFile:   existingFile(filepath.Join(packageDir, "events.yaml")),
-			ProjectAgentsFile:   existingFile(filepath.Join(packageDir, "agents.yaml")),
-			ProjectToolsFile:    existingFile(filepath.Join(packageDir, "tools.yaml")),
-			ProjectPolicyFile:   existingFile(filepath.Join(packageDir, "policy.yaml")),
-			ProjectPromptsDir:   existingDir(filepath.Join(packageDir, "prompts")),
+			Key:               key,
+			ParentKey:         parentKey,
+			Depth:             depth,
+			Dir:               packageDir,
+			PackageFile:       packageFile,
+			ProjectNodesFile:  existingFile(filepath.Join(packageDir, "nodes.yaml")),
+			ProjectEventsFile: existingFile(filepath.Join(packageDir, "events.yaml")),
+			ProjectAgentsFile: existingFile(filepath.Join(packageDir, "agents.yaml")),
+			ProjectToolsFile:  existingFile(filepath.Join(packageDir, "tools.yaml")),
+			ProjectPolicyFile: existingFile(filepath.Join(packageDir, "policy.yaml")),
+			ProjectPromptsDir: existingDir(filepath.Join(packageDir, "prompts")),
 		}
 		if manifestErr != nil {
 			out = append(out, pkg)

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -74,6 +74,8 @@ func ResolveWorkflowContractPathsWithOverrides(repoRoot, workflowDirOverride, pl
 		ContractsRoot:         workflowDir,
 		WorkflowDir:           workflowDir,
 		RootSchemaFile:        existingFile(filepath.Join(workflowDir, "schema.yaml")),
+		RootTypesFile:         existingFile(filepath.Join(workflowDir, "types.yaml")),
+		RootEntitiesFile:      existingFile(filepath.Join(workflowDir, "entities.yaml")),
 		ProjectPackageFile:    existingFile(filepath.Join(workflowDir, "package.yaml")),
 		ProjectNodesFile:      existingFile(filepath.Join(workflowDir, "nodes.yaml")),
 		ProjectEventsFile:     existingFile(filepath.Join(workflowDir, "events.yaml")),
@@ -116,6 +118,8 @@ func ContractFilesExist(repoRoot string) []string {
 	if paths.ProjectPackageFile != "" {
 		files = append(files,
 			paths.ProjectPackageFile,
+			paths.RootTypesFile,
+			paths.RootEntitiesFile,
 			paths.ProjectNodesFile,
 			paths.ProjectEventsFile,
 			paths.ProjectAgentsFile,
@@ -123,6 +127,8 @@ func ContractFilesExist(repoRoot string) []string {
 		for _, pkg := range paths.ProjectPackages {
 			files = append(files,
 				pkg.PackageFile,
+				pkg.ProjectTypesFile,
+				pkg.ProjectEntitiesFile,
 				pkg.ProjectNodesFile,
 				pkg.ProjectEventsFile,
 				pkg.ProjectAgentsFile,
@@ -131,7 +137,7 @@ func ContractFilesExist(repoRoot string) []string {
 			)
 		}
 		for _, flow := range paths.Flows {
-			files = append(files, flow.SchemaFile, flow.NodesFile, flow.EventsFile, flow.AgentsFile)
+			files = append(files, flow.SchemaFile, flow.TypesFile, flow.EntitiesFile, flow.NodesFile, flow.EventsFile, flow.AgentsFile)
 		}
 	}
 	missing := make([]string, 0)
@@ -196,9 +202,7 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 		visited[packageFile] = true
 
 		var manifest ProjectPackageDocument
-		if err := loadYAMLFile(packageFile, &manifest); err != nil {
-			return
-		}
+		manifestErr := loadYAMLFile(packageFile, &manifest)
 
 		packageDir := filepath.Dir(packageFile)
 		key := "."
@@ -206,17 +210,23 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 			key = filepath.Clean(rel)
 		}
 		pkg := ProjectPackagePaths{
-			Key:               key,
-			ParentKey:         parentKey,
-			Depth:             depth,
-			Dir:               packageDir,
-			PackageFile:       packageFile,
-			ProjectNodesFile:  existingFile(filepath.Join(packageDir, "nodes.yaml")),
-			ProjectEventsFile: existingFile(filepath.Join(packageDir, "events.yaml")),
-			ProjectAgentsFile: existingFile(filepath.Join(packageDir, "agents.yaml")),
-			ProjectToolsFile:  existingFile(filepath.Join(packageDir, "tools.yaml")),
-			ProjectPolicyFile: existingFile(filepath.Join(packageDir, "policy.yaml")),
-			ProjectPromptsDir: existingDir(filepath.Join(packageDir, "prompts")),
+			Key:                 key,
+			ParentKey:           parentKey,
+			Depth:               depth,
+			Dir:                 packageDir,
+			PackageFile:         packageFile,
+			ProjectTypesFile:    existingFile(filepath.Join(packageDir, "types.yaml")),
+			ProjectEntitiesFile: existingFile(filepath.Join(packageDir, "entities.yaml")),
+			ProjectNodesFile:    existingFile(filepath.Join(packageDir, "nodes.yaml")),
+			ProjectEventsFile:   existingFile(filepath.Join(packageDir, "events.yaml")),
+			ProjectAgentsFile:   existingFile(filepath.Join(packageDir, "agents.yaml")),
+			ProjectToolsFile:    existingFile(filepath.Join(packageDir, "tools.yaml")),
+			ProjectPolicyFile:   existingFile(filepath.Join(packageDir, "policy.yaml")),
+			ProjectPromptsDir:   existingDir(filepath.Join(packageDir, "prompts")),
+		}
+		if manifestErr != nil {
+			out = append(out, pkg)
+			return
 		}
 		for _, flow := range manifest.Flows {
 			flowDirName := strings.TrimSpace(flow.Flow)
@@ -225,20 +235,22 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 			}
 			dir := filepath.Join(packageDir, "flows", flowDirName)
 			pkg.Flows = append(pkg.Flows, FlowContractPaths{
-				ID:         strings.TrimSpace(flow.ID),
-				Flow:       flowDirName,
-				Mode:       strings.TrimSpace(flow.Mode),
-				Namespace:  strings.TrimSpace(flow.Namespace),
-				PackageKey: pkg.Key,
-				PackageDir: packageDir,
-				Dir:        dir,
-				SchemaFile: existingFile(filepath.Join(dir, "schema.yaml")),
-				NodesFile:  existingFile(filepath.Join(dir, "nodes.yaml")),
-				EventsFile: existingFile(filepath.Join(dir, "events.yaml")),
-				AgentsFile: existingFile(filepath.Join(dir, "agents.yaml")),
-				ToolsFile:  existingFile(filepath.Join(dir, "tools.yaml")),
-				PolicyFile: existingFile(filepath.Join(dir, "policy.yaml")),
-				PromptsDir: existingDir(filepath.Join(dir, "prompts")),
+				ID:           strings.TrimSpace(flow.ID),
+				Flow:         flowDirName,
+				Mode:         strings.TrimSpace(flow.Mode),
+				Namespace:    strings.TrimSpace(flow.Namespace),
+				PackageKey:   pkg.Key,
+				PackageDir:   packageDir,
+				Dir:          dir,
+				SchemaFile:   existingFile(filepath.Join(dir, "schema.yaml")),
+				TypesFile:    existingFile(filepath.Join(dir, "types.yaml")),
+				EntitiesFile: existingFile(filepath.Join(dir, "entities.yaml")),
+				NodesFile:    existingFile(filepath.Join(dir, "nodes.yaml")),
+				EventsFile:   existingFile(filepath.Join(dir, "events.yaml")),
+				AgentsFile:   existingFile(filepath.Join(dir, "agents.yaml")),
+				ToolsFile:    existingFile(filepath.Join(dir, "tools.yaml")),
+				PolicyFile:   existingFile(filepath.Join(dir, "policy.yaml")),
+				PromptsDir:   existingDir(filepath.Join(dir, "prompts")),
 			})
 		}
 		sort.Slice(pkg.Flows, func(i, j int) bool {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -12,7 +12,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 	}
 	name := strings.TrimSpace(bundle.Package.Name)
 	version := strings.TrimSpace(bundle.Package.Version)
-	entitySchema := bundle.Package.EntitySchema
+	entitySchema := legacyWorkflowEntitySchema(bundle)
 	semantics := WorkflowSemanticView{
 		Name:                   name,
 		Version:                version,
@@ -139,6 +139,53 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		semantics.NodeHandlers[nodeID] = handlers
 	}
 	bundle.Semantics = semantics
+}
+
+func legacyWorkflowEntitySchema(bundle *WorkflowContractBundle) EntitySchema {
+	if bundle == nil {
+		return EntitySchema{}
+	}
+	if !bundle.Package.EntitySchema.Empty() {
+		return bundle.Package.EntitySchema
+	}
+	if len(bundle.RootEntities) > 0 {
+		return entityContractsToLegacyEntitySchema(bundle.RootEntities)
+	}
+	if len(bundle.flowEntities) == 1 {
+		for _, entities := range bundle.flowEntities {
+			return entityContractsToLegacyEntitySchema(entities)
+		}
+	}
+	return EntitySchema{}
+}
+
+func entityContractsToLegacyEntitySchema(entities EntityContractsDocument) EntitySchema {
+	if len(entities) == 0 {
+		return EntitySchema{}
+	}
+	groups := make([]EntitySchemaGroup, 0, len(entities))
+	for entityType, contract := range entities {
+		group := EntitySchemaGroup{
+			Name:   strings.TrimSpace(entityType),
+			Fields: make([]EntitySchemaField, 0, len(contract.Fields)),
+		}
+		for fieldName, field := range contract.Fields {
+			group.Fields = append(group.Fields, EntitySchemaField{
+				Name:        strings.TrimSpace(fieldName),
+				Type:        strings.TrimSpace(field.Type),
+				Initial:     field.Initial,
+				Description: field.Description,
+			})
+		}
+		sort.Slice(group.Fields, func(i, j int) bool {
+			return strings.TrimSpace(group.Fields[i].Name) < strings.TrimSpace(group.Fields[j].Name)
+		})
+		groups = append(groups, group)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		return strings.TrimSpace(groups[i].Name) < strings.TrimSpace(groups[j].Name)
+	})
+	return EntitySchema{Groups: groups}
 }
 func deriveWorkflowGuardEntries(bundle *WorkflowContractBundle) []GuardActionEntry {
 	if bundle == nil {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -11,6 +11,8 @@ type ContractPaths struct {
 	ContractsRoot         string
 	WorkflowDir           string
 	RootSchemaFile        string
+	RootTypesFile         string
+	RootEntitiesFile      string
 	ProjectPackageFile    string
 	ProjectPackages       []ProjectPackagePaths
 	ProjectNodesFile      string
@@ -30,7 +32,12 @@ type WorkflowContractBundle struct {
 	Paths                 ContractPaths
 	Package               ProjectPackageDocument
 	PackageTree           []LoadedProjectPackage
+	Compatibility         []ContractCompatibilityUsage
 	projectContracts      map[string]ProjectContractView
+	projectTypes          map[string]TypeCatalogDocument
+	projectEntities       map[string]EntityContractsDocument
+	flowTypes             map[string]TypeCatalogDocument
+	flowEntities          map[string]EntityContractsDocument
 	scopedNodes           map[string]SystemNodeContract
 	scopedEvents          map[string]EventCatalogEntry
 	scopedAgents          map[string]AgentRegistryEntry
@@ -55,6 +62,8 @@ type WorkflowContractBundle struct {
 	Policy                PolicyDocument
 	Platform              PlatformSpecDocument
 	RootSchema            *FlowSchemaDocument
+	RootTypes             TypeCatalogDocument
+	RootEntities          EntityContractsDocument
 	FlowSchemas           map[string]FlowSchemaDocument
 	FlowTree              FlowTree
 	URIRegistry           ContractURIRegistry
@@ -88,6 +97,14 @@ type WorkflowSemanticView struct {
 	EventOwners            map[string][]string
 	HandlerTransitions     []HandlerTransitionSemantic
 	HandlerTransitionIndex map[string]map[string]HandlerTransitionSemantic
+}
+
+type ContractCompatibilityUsage struct {
+	Kind   string
+	File   string
+	Scope  string
+	ItemID string
+	Detail string
 }
 
 type FlowInputAutoWireResolution struct {
@@ -441,47 +458,92 @@ type ToolInputSchema struct {
 	Maximum              *float64                   `yaml:"maximum"`
 }
 type ProjectPackagePaths struct {
-	Key               string
-	ParentKey         string
-	Depth             int
-	Dir               string
-	PackageFile       string
-	ProjectNodesFile  string
-	ProjectEventsFile string
-	ProjectAgentsFile string
-	ProjectToolsFile  string
-	ProjectPolicyFile string
-	ProjectPromptsDir string
-	Flows             []FlowContractPaths
+	Key                 string
+	ParentKey           string
+	Depth               int
+	Dir                 string
+	PackageFile         string
+	ProjectTypesFile    string
+	ProjectEntitiesFile string
+	ProjectNodesFile    string
+	ProjectEventsFile   string
+	ProjectAgentsFile   string
+	ProjectToolsFile    string
+	ProjectPolicyFile   string
+	ProjectPromptsDir   string
+	Flows               []FlowContractPaths
 }
 type FlowContractPaths struct {
-	ID         string
-	Flow       string
-	Mode       string
-	Namespace  string
-	PackageKey string
-	PackageDir string
-	Dir        string
-	SchemaFile string
-	NodesFile  string
-	EventsFile string
-	AgentsFile string
-	ToolsFile  string
-	PolicyFile string
-	PromptsDir string
+	ID           string
+	Flow         string
+	Mode         string
+	Namespace    string
+	PackageKey   string
+	PackageDir   string
+	Dir          string
+	SchemaFile   string
+	TypesFile    string
+	EntitiesFile string
+	NodesFile    string
+	EventsFile   string
+	AgentsFile   string
+	ToolsFile    string
+	PolicyFile   string
+	PromptsDir   string
 }
 type ProjectPackageDocument struct {
-	Name            string              `yaml:"name"`
-	Version         string              `yaml:"version"`
-	PlatformVersion string              `yaml:"platform_version"`
-	Author          string              `yaml:"author"`
-	Description     string              `yaml:"description"`
-	Flows           []ProjectFlowRef    `yaml:"flows"`
-	Packages        []ProjectPackageRef `yaml:"packages"`
-	Children        []ProjectPackageRef `yaml:"children"`
-	Subpackages     []ProjectPackageRef `yaml:"subpackages"`
-	Handoffs        []ProjectHandoff    `yaml:"handoffs"`
-	EntitySchema    EntitySchema        `yaml:"entity_schema"`
+	Name                   string              `yaml:"name"`
+	Version                string              `yaml:"version"`
+	PlatformVersion        string              `yaml:"platform_version"`
+	Author                 string              `yaml:"author"`
+	Description            string              `yaml:"description"`
+	Flows                  []ProjectFlowRef    `yaml:"flows"`
+	Packages               []ProjectPackageRef `yaml:"packages"`
+	Children               []ProjectPackageRef `yaml:"children"`
+	Subpackages            []ProjectPackageRef `yaml:"subpackages"`
+	Handoffs               []ProjectHandoff    `yaml:"handoffs"`
+	EntitySchema           EntitySchema        `yaml:"entity_schema"`
+	UsesLegacyEntitySchema bool                `yaml:"-"`
+}
+
+type TypeCatalogDocument struct {
+	Scalars map[string]ScalarTypeDecl `yaml:"scalars"`
+	Enums   map[string]EnumTypeDecl   `yaml:"enums"`
+	Types   map[string]NamedTypeDecl  `yaml:"types"`
+}
+
+type ScalarTypeDecl struct {
+	Base string `yaml:"-"`
+}
+
+type EnumTypeDecl struct {
+	Values []string `yaml:"-"`
+}
+
+type NamedTypeDecl struct {
+	Description string                   `yaml:"-"`
+	Fields      map[string]TypeFieldSpec `yaml:"-"`
+}
+
+type TypeFieldSpec struct {
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+}
+
+type EntityContractsDocument map[string]EntityContract
+
+type EntityContract struct {
+	Description string                     `yaml:"-"`
+	Owner       string                     `yaml:"-"`
+	Fields      map[string]EntityFieldDecl `yaml:"-"`
+}
+
+type EntityFieldDecl struct {
+	Type         string `yaml:"type"`
+	Initial      any    `yaml:"initial"`
+	Immutable    bool   `yaml:"immutable"`
+	Description  string `yaml:"description"`
+	UnusedReason string `yaml:"_unused_reason"`
 }
 type ProjectPackageRef struct {
 	ID      string `yaml:"id"`
@@ -785,6 +847,7 @@ type SystemNodeEventHandler struct {
 	Branch           []BranchSpec             `yaml:"branch"`
 }
 type EventCatalogEntry struct {
+	Note              string           `yaml:"_note"`
 	Emitter           EventEmitterRef  `yaml:"emitter"`
 	EmitterType       string           `yaml:"emitter_type"`
 	Producer          []string         `yaml:"producer"`
@@ -800,6 +863,7 @@ type EventCatalogEntry struct {
 	DeliveryChannel   string           `yaml:"delivery_channel"`
 	Payload           EventPayloadSpec `yaml:"payload"`
 	Required          []string         `yaml:"required"`
+	UsesLegacyPayload bool             `yaml:"-"`
 }
 type AgentRegistryEntry struct {
 	ID                     string         `yaml:"id"`

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -32,10 +32,7 @@ type WorkflowContractBundle struct {
 	Paths                 ContractPaths
 	Package               ProjectPackageDocument
 	PackageTree           []LoadedProjectPackage
-	Compatibility         []ContractCompatibilityUsage
 	projectContracts      map[string]ProjectContractView
-	projectTypes          map[string]TypeCatalogDocument
-	projectEntities       map[string]EntityContractsDocument
 	flowTypes             map[string]TypeCatalogDocument
 	flowEntities          map[string]EntityContractsDocument
 	scopedNodes           map[string]SystemNodeContract
@@ -97,14 +94,6 @@ type WorkflowSemanticView struct {
 	EventOwners            map[string][]string
 	HandlerTransitions     []HandlerTransitionSemantic
 	HandlerTransitionIndex map[string]map[string]HandlerTransitionSemantic
-}
-
-type ContractCompatibilityUsage struct {
-	Kind   string
-	File   string
-	Scope  string
-	ItemID string
-	Detail string
 }
 
 type FlowInputAutoWireResolution struct {
@@ -458,20 +447,18 @@ type ToolInputSchema struct {
 	Maximum              *float64                   `yaml:"maximum"`
 }
 type ProjectPackagePaths struct {
-	Key                 string
-	ParentKey           string
-	Depth               int
-	Dir                 string
-	PackageFile         string
-	ProjectTypesFile    string
-	ProjectEntitiesFile string
-	ProjectNodesFile    string
-	ProjectEventsFile   string
-	ProjectAgentsFile   string
-	ProjectToolsFile    string
-	ProjectPolicyFile   string
-	ProjectPromptsDir   string
-	Flows               []FlowContractPaths
+	Key               string
+	ParentKey         string
+	Depth             int
+	Dir               string
+	PackageFile       string
+	ProjectNodesFile  string
+	ProjectEventsFile string
+	ProjectAgentsFile string
+	ProjectToolsFile  string
+	ProjectPolicyFile string
+	ProjectPromptsDir string
+	Flows             []FlowContractPaths
 }
 type FlowContractPaths struct {
 	ID           string
@@ -492,18 +479,17 @@ type FlowContractPaths struct {
 	PromptsDir   string
 }
 type ProjectPackageDocument struct {
-	Name                   string              `yaml:"name"`
-	Version                string              `yaml:"version"`
-	PlatformVersion        string              `yaml:"platform_version"`
-	Author                 string              `yaml:"author"`
-	Description            string              `yaml:"description"`
-	Flows                  []ProjectFlowRef    `yaml:"flows"`
-	Packages               []ProjectPackageRef `yaml:"packages"`
-	Children               []ProjectPackageRef `yaml:"children"`
-	Subpackages            []ProjectPackageRef `yaml:"subpackages"`
-	Handoffs               []ProjectHandoff    `yaml:"handoffs"`
-	EntitySchema           EntitySchema        `yaml:"entity_schema"`
-	UsesLegacyEntitySchema bool                `yaml:"-"`
+	Name            string              `yaml:"name"`
+	Version         string              `yaml:"version"`
+	PlatformVersion string              `yaml:"platform_version"`
+	Author          string              `yaml:"author"`
+	Description     string              `yaml:"description"`
+	Flows           []ProjectFlowRef    `yaml:"flows"`
+	Packages        []ProjectPackageRef `yaml:"packages"`
+	Children        []ProjectPackageRef `yaml:"children"`
+	Subpackages     []ProjectPackageRef `yaml:"subpackages"`
+	Handoffs        []ProjectHandoff    `yaml:"handoffs"`
+	EntitySchema    EntitySchema        `yaml:"entity_schema"`
 }
 
 type TypeCatalogDocument struct {
@@ -863,7 +849,6 @@ type EventCatalogEntry struct {
 	DeliveryChannel   string           `yaml:"delivery_channel"`
 	Payload           EventPayloadSpec `yaml:"payload"`
 	Required          []string         `yaml:"required"`
-	UsesLegacyPayload bool             `yaml:"-"`
 }
 type AgentRegistryEntry struct {
 	ID                     string         `yaml:"id"`

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -39,9 +39,14 @@ func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 	if bundle == nil {
 		return nil
 	}
-	if bundle.Package.UsesLegacyEntitySchema && (len(bundle.RootEntities) > 0 || len(bundle.projectEntities) > 0 || len(bundle.flowEntities) > 0) {
+	legacyEntitySchemaScope, hasLegacyEntitySchema := bundleLegacyEntitySchemaScope(bundle)
+	if hasLegacyEntitySchema && (len(bundle.RootEntities) > 0 || len(bundle.projectEntities) > 0 || len(bundle.flowEntities) > 0) {
+		detail := "AMBIGUOUS-CONTRACT-GRAMMAR: package.yaml entity_schema cannot coexist with Wave 1 entities.yaml declarations in the same bundle"
+		if legacyEntitySchemaScope != "" {
+			detail += " (legacy scope: " + legacyEntitySchemaScope + ")"
+		}
 		return &LoadValidationError{Items: []error{
-			errString("AMBIGUOUS-CONTRACT-GRAMMAR: package.yaml entity_schema cannot coexist with Wave 1 entities.yaml declarations in the same bundle"),
+			errString(detail),
 		}}
 	}
 	for flowID, entities := range bundle.flowEntities {
@@ -59,6 +64,26 @@ func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 		}
 	}
 	return nil
+}
+
+func bundleLegacyEntitySchemaScope(bundle *WorkflowContractBundle) (string, bool) {
+	if bundle == nil {
+		return "", false
+	}
+	if bundle.Package.UsesLegacyEntitySchema {
+		return ".", true
+	}
+	for _, pkg := range bundle.PackageTree {
+		if !pkg.Manifest.UsesLegacyEntitySchema {
+			continue
+		}
+		scope := strings.TrimSpace(pkg.Key)
+		if scope == "" {
+			scope = "."
+		}
+		return scope, true
+	}
+	return "", false
 }
 
 type errString string

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -1,0 +1,302 @@
+package contracts
+
+import "strings"
+
+func recordContractCompatibilityUsage(bundle *WorkflowContractBundle, usage ContractCompatibilityUsage) {
+	if bundle == nil {
+		return
+	}
+	usage.Kind = strings.TrimSpace(usage.Kind)
+	usage.File = strings.TrimSpace(usage.File)
+	usage.Scope = strings.TrimSpace(usage.Scope)
+	usage.ItemID = strings.TrimSpace(usage.ItemID)
+	usage.Detail = strings.TrimSpace(usage.Detail)
+	if usage.Kind == "" || usage.File == "" {
+		return
+	}
+	bundle.Compatibility = append(bundle.Compatibility, usage)
+}
+
+func recordEventCompatibilityUsages(bundle *WorkflowContractBundle, entries map[string]EventCatalogEntry, file, scope string) {
+	if bundle == nil || strings.TrimSpace(file) == "" || len(entries) == 0 {
+		return
+	}
+	for eventType, entry := range entries {
+		if !entry.UsesLegacyPayload {
+			continue
+		}
+		recordContractCompatibilityUsage(bundle, ContractCompatibilityUsage{
+			Kind:   "legacy_event_payload_block",
+			File:   file,
+			Scope:  scope,
+			ItemID: strings.TrimSpace(eventType),
+			Detail: "events.yaml payload: block loaded through Wave 1 migration compatibility",
+		})
+	}
+}
+
+func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
+	if bundle == nil {
+		return nil
+	}
+	if bundle.Package.UsesLegacyEntitySchema && (len(bundle.RootEntities) > 0 || len(bundle.projectEntities) > 0 || len(bundle.flowEntities) > 0) {
+		return &LoadValidationError{Items: []error{
+			errString("AMBIGUOUS-CONTRACT-GRAMMAR: package.yaml entity_schema cannot coexist with Wave 1 entities.yaml declarations in the same bundle"),
+		}}
+	}
+	for flowID, entities := range bundle.flowEntities {
+		if len(entities) > 1 {
+			return &LoadValidationError{Items: []error{
+				errString("INVALID-ENTITY-OWNERSHIP: flow " + strings.TrimSpace(flowID) + " declares multiple entity types; Wave 1 permits at most one entity type per flow"),
+			}}
+		}
+		for entityType, contract := range entities {
+			if strings.TrimSpace(contract.Owner) != "" {
+				return &LoadValidationError{Items: []error{
+					errString("UNDEFINED-FIELD: flow entity contract " + strings.TrimSpace(entityType) + " must not declare _owner; ownership is implied by flow location"),
+				}}
+			}
+		}
+	}
+	return nil
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func (b *WorkflowContractBundle) CompatibilityUsages() []ContractCompatibilityUsage {
+	if b == nil || len(b.Compatibility) == 0 {
+		return nil
+	}
+	out := make([]ContractCompatibilityUsage, len(b.Compatibility))
+	copy(out, b.Compatibility)
+	return out
+}
+
+func (b *WorkflowContractBundle) RootTypeCatalog() TypeCatalogDocument {
+	if b == nil {
+		return TypeCatalogDocument{}
+	}
+	return cloneTypeCatalogDocument(b.RootTypes)
+}
+
+func (b *WorkflowContractBundle) RootEntityContracts() EntityContractsDocument {
+	if b == nil {
+		return nil
+	}
+	return cloneEntityContractsDocument(b.RootEntities)
+}
+
+func (b *WorkflowContractBundle) ProjectTypeCatalogByKey(key string) (TypeCatalogDocument, bool) {
+	key = strings.TrimSpace(key)
+	if b == nil || key == "" || key == "." {
+		return TypeCatalogDocument{}, false
+	}
+	doc, ok := b.projectTypes[key]
+	return cloneTypeCatalogDocument(doc), ok
+}
+
+func (b *WorkflowContractBundle) ProjectEntityContractsByKey(key string) (EntityContractsDocument, bool) {
+	key = strings.TrimSpace(key)
+	if b == nil || key == "" || key == "." {
+		return nil, false
+	}
+	doc, ok := b.projectEntities[key]
+	return cloneEntityContractsDocument(doc), ok
+}
+
+func (b *WorkflowContractBundle) FlowTypeCatalogByID(flowID string) (TypeCatalogDocument, bool) {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil || flowID == "" {
+		return TypeCatalogDocument{}, false
+	}
+	doc, ok := b.flowTypes[flowID]
+	return cloneTypeCatalogDocument(doc), ok
+}
+
+func (b *WorkflowContractBundle) FlowEntityContractsByID(flowID string) (EntityContractsDocument, bool) {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil || flowID == "" {
+		return nil, false
+	}
+	doc, ok := b.flowEntities[flowID]
+	return cloneEntityContractsDocument(doc), ok
+}
+
+func (b *WorkflowContractBundle) FlowOwnedEntityContract(flowID string) (string, EntityContract, bool) {
+	entities, ok := b.FlowEntityContractsByID(flowID)
+	if !ok || len(entities) == 0 {
+		return "", EntityContract{}, false
+	}
+	for entityType, contract := range entities {
+		return strings.TrimSpace(entityType), cloneEntityContract(contract), true
+	}
+	return "", EntityContract{}, false
+}
+
+func (b *WorkflowContractBundle) ResolvedTypeCatalogForFlow(flowID string) TypeCatalogDocument {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil {
+		return TypeCatalogDocument{}
+	}
+	resolved := cloneTypeCatalogDocument(b.RootTypes)
+	packageKey := ""
+	if flowID != "" {
+		if view, ok := b.FlowViewByID(flowID); ok {
+			packageKey = strings.TrimSpace(view.Paths.PackageKey)
+		}
+	}
+	for _, key := range b.packageLineageKeys(packageKey) {
+		doc, ok := b.projectTypes[key]
+		if !ok {
+			continue
+		}
+		resolved = mergeTypeCatalogDocuments(resolved, doc)
+	}
+	if flowID != "" {
+		if flowDoc, ok := b.flowTypes[flowID]; ok {
+			resolved = mergeTypeCatalogDocuments(resolved, flowDoc)
+		}
+	}
+	return resolved
+}
+
+func (b *WorkflowContractBundle) ResolvedEntityContractsForFlow(flowID string) EntityContractsDocument {
+	flowID = strings.TrimSpace(flowID)
+	if b == nil {
+		return nil
+	}
+	resolved := cloneEntityContractsDocument(b.RootEntities)
+	packageKey := ""
+	if flowID != "" {
+		if view, ok := b.FlowViewByID(flowID); ok {
+			packageKey = strings.TrimSpace(view.Paths.PackageKey)
+		}
+	}
+	for _, key := range b.packageLineageKeys(packageKey) {
+		doc, ok := b.projectEntities[key]
+		if !ok {
+			continue
+		}
+		resolved = mergeEntityContractsDocuments(resolved, doc)
+	}
+	if flowID != "" {
+		if flowDoc, ok := b.flowEntities[flowID]; ok {
+			resolved = mergeEntityContractsDocuments(resolved, flowDoc)
+		}
+	}
+	return resolved
+}
+
+func (b *WorkflowContractBundle) packageLineageKeys(key string) []string {
+	key = strings.TrimSpace(key)
+	if b == nil || key == "" || key == "." {
+		return nil
+	}
+	parents := map[string]string{}
+	for _, pkg := range b.PackageTree {
+		parents[strings.TrimSpace(pkg.Key)] = strings.TrimSpace(pkg.ParentKey)
+	}
+	var lineage []string
+	for key != "" && key != "." {
+		lineage = append([]string{key}, lineage...)
+		key = parents[key]
+	}
+	return lineage
+}
+
+func mergeTypeCatalogDocuments(base, incoming TypeCatalogDocument) TypeCatalogDocument {
+	out := cloneTypeCatalogDocument(base)
+	if out.Scalars == nil {
+		out.Scalars = map[string]ScalarTypeDecl{}
+	}
+	if out.Enums == nil {
+		out.Enums = map[string]EnumTypeDecl{}
+	}
+	if out.Types == nil {
+		out.Types = map[string]NamedTypeDecl{}
+	}
+	for key, value := range incoming.Scalars {
+		out.Scalars[key] = value
+	}
+	for key, value := range incoming.Enums {
+		out.Enums[key] = value
+	}
+	for key, value := range incoming.Types {
+		out.Types[key] = value
+	}
+	return out
+}
+
+func mergeEntityContractsDocuments(base, incoming EntityContractsDocument) EntityContractsDocument {
+	out := cloneEntityContractsDocument(base)
+	if out == nil {
+		out = EntityContractsDocument{}
+	}
+	for key, value := range incoming {
+		out[key] = cloneEntityContract(value)
+	}
+	return out
+}
+
+func cloneTypeCatalogDocument(in TypeCatalogDocument) TypeCatalogDocument {
+	out := TypeCatalogDocument{}
+	if len(in.Scalars) > 0 {
+		out.Scalars = make(map[string]ScalarTypeDecl, len(in.Scalars))
+		for key, value := range in.Scalars {
+			out.Scalars[key] = value
+		}
+	}
+	if len(in.Enums) > 0 {
+		out.Enums = make(map[string]EnumTypeDecl, len(in.Enums))
+		for key, value := range in.Enums {
+			out.Enums[key] = EnumTypeDecl{Values: append([]string{}, value.Values...)}
+		}
+	}
+	if len(in.Types) > 0 {
+		out.Types = make(map[string]NamedTypeDecl, len(in.Types))
+		for key, value := range in.Types {
+			out.Types[key] = cloneNamedTypeDecl(value)
+		}
+	}
+	return out
+}
+
+func cloneNamedTypeDecl(in NamedTypeDecl) NamedTypeDecl {
+	out := NamedTypeDecl{
+		Description: in.Description,
+	}
+	if len(in.Fields) > 0 {
+		out.Fields = make(map[string]TypeFieldSpec, len(in.Fields))
+		for key, value := range in.Fields {
+			out.Fields[key] = value
+		}
+	}
+	return out
+}
+
+func cloneEntityContractsDocument(in EntityContractsDocument) EntityContractsDocument {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(EntityContractsDocument, len(in))
+	for key, value := range in {
+		out[key] = cloneEntityContract(value)
+	}
+	return out
+}
+
+func cloneEntityContract(in EntityContract) EntityContract {
+	out := EntityContract{
+		Description: in.Description,
+		Owner:       in.Owner,
+	}
+	if len(in.Fields) > 0 {
+		out.Fields = make(map[string]EntityFieldDecl, len(in.Fields))
+		for key, value := range in.Fields {
+			out.Fields[key] = value
+		}
+	}
+	return out
+}

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -1,53 +1,40 @@
 package contracts
 
-import "strings"
-
-func recordContractCompatibilityUsage(bundle *WorkflowContractBundle, usage ContractCompatibilityUsage) {
-	if bundle == nil {
-		return
-	}
-	usage.Kind = strings.TrimSpace(usage.Kind)
-	usage.File = strings.TrimSpace(usage.File)
-	usage.Scope = strings.TrimSpace(usage.Scope)
-	usage.ItemID = strings.TrimSpace(usage.ItemID)
-	usage.Detail = strings.TrimSpace(usage.Detail)
-	if usage.Kind == "" || usage.File == "" {
-		return
-	}
-	bundle.Compatibility = append(bundle.Compatibility, usage)
-}
-
-func recordEventCompatibilityUsages(bundle *WorkflowContractBundle, entries map[string]EventCatalogEntry, file, scope string) {
-	if bundle == nil || strings.TrimSpace(file) == "" || len(entries) == 0 {
-		return
-	}
-	for eventType, entry := range entries {
-		if !entry.UsesLegacyPayload {
-			continue
-		}
-		recordContractCompatibilityUsage(bundle, ContractCompatibilityUsage{
-			Kind:   "legacy_event_payload_block",
-			File:   file,
-			Scope:  scope,
-			ItemID: strings.TrimSpace(eventType),
-			Detail: "events.yaml payload: block loaded through Wave 1 migration compatibility",
-		})
-	}
-}
+import (
+	"path/filepath"
+	"strings"
+)
 
 func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 	if bundle == nil {
 		return nil
 	}
-	legacyEntitySchemaScope, hasLegacyEntitySchema := bundleLegacyEntitySchemaScope(bundle)
-	if hasLegacyEntitySchema && (len(bundle.RootEntities) > 0 || len(bundle.projectEntities) > 0 || len(bundle.flowEntities) > 0) {
-		detail := "AMBIGUOUS-CONTRACT-GRAMMAR: package.yaml entity_schema cannot coexist with Wave 1 entities.yaml declarations in the same bundle"
-		if legacyEntitySchemaScope != "" {
-			detail += " (legacy scope: " + legacyEntitySchemaScope + ")"
-		}
+	if legacyScope, ok := bundleLegacyEntitySchemaScope(bundle); ok {
 		return &LoadValidationError{Items: []error{
-			errString(detail),
+			errString("RETIRED: package.yaml entity_schema is no longer supported; migrate to entities.yaml (legacy scope: " + legacyScope + ")"),
 		}}
+	}
+	for _, pkg := range bundle.PackageTree {
+		if strings.TrimSpace(pkg.Key) == "." {
+			continue
+		}
+		if path := existingFile(filepath.Join(pkg.Paths.Dir, "types.yaml")); path != "" {
+			return &LoadValidationError{Items: []error{
+				errString("RETIRED: package-scoped types.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
+			}}
+		}
+		if path := existingFile(filepath.Join(pkg.Paths.Dir, "entities.yaml")); path != "" {
+			return &LoadValidationError{Items: []error{
+				errString("RETIRED: package-scoped entities.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
+			}}
+		}
+	}
+	for entityType, contract := range bundle.RootEntities {
+		if strings.TrimSpace(contract.Owner) != "" {
+			return &LoadValidationError{Items: []error{
+				errString("UNDEFINED-FIELD: root entity contract " + strings.TrimSpace(entityType) + " must not declare _owner; ownership is implied by root location"),
+			}}
+		}
 	}
 	for flowID, entities := range bundle.flowEntities {
 		if len(entities) > 1 {
@@ -70,11 +57,8 @@ func bundleLegacyEntitySchemaScope(bundle *WorkflowContractBundle) (string, bool
 	if bundle == nil {
 		return "", false
 	}
-	if bundle.Package.UsesLegacyEntitySchema {
-		return ".", true
-	}
 	for _, pkg := range bundle.PackageTree {
-		if !pkg.Manifest.UsesLegacyEntitySchema {
+		if pkg.Manifest.EntitySchema.Empty() {
 			continue
 		}
 		scope := strings.TrimSpace(pkg.Key)
@@ -83,21 +67,15 @@ func bundleLegacyEntitySchemaScope(bundle *WorkflowContractBundle) (string, bool
 		}
 		return scope, true
 	}
+	if !bundle.Package.EntitySchema.Empty() {
+		return ".", true
+	}
 	return "", false
 }
 
 type errString string
 
 func (e errString) Error() string { return string(e) }
-
-func (b *WorkflowContractBundle) CompatibilityUsages() []ContractCompatibilityUsage {
-	if b == nil || len(b.Compatibility) == 0 {
-		return nil
-	}
-	out := make([]ContractCompatibilityUsage, len(b.Compatibility))
-	copy(out, b.Compatibility)
-	return out
-}
 
 func (b *WorkflowContractBundle) RootTypeCatalog() TypeCatalogDocument {
 	if b == nil {
@@ -111,24 +89,6 @@ func (b *WorkflowContractBundle) RootEntityContracts() EntityContractsDocument {
 		return nil
 	}
 	return cloneEntityContractsDocument(b.RootEntities)
-}
-
-func (b *WorkflowContractBundle) ProjectTypeCatalogByKey(key string) (TypeCatalogDocument, bool) {
-	key = strings.TrimSpace(key)
-	if b == nil || key == "" || key == "." {
-		return TypeCatalogDocument{}, false
-	}
-	doc, ok := b.projectTypes[key]
-	return cloneTypeCatalogDocument(doc), ok
-}
-
-func (b *WorkflowContractBundle) ProjectEntityContractsByKey(key string) (EntityContractsDocument, bool) {
-	key = strings.TrimSpace(key)
-	if b == nil || key == "" || key == "." {
-		return nil, false
-	}
-	doc, ok := b.projectEntities[key]
-	return cloneEntityContractsDocument(doc), ok
 }
 
 func (b *WorkflowContractBundle) FlowTypeCatalogByID(flowID string) (TypeCatalogDocument, bool) {
@@ -166,19 +126,6 @@ func (b *WorkflowContractBundle) ResolvedTypeCatalogForFlow(flowID string) TypeC
 		return TypeCatalogDocument{}
 	}
 	resolved := cloneTypeCatalogDocument(b.RootTypes)
-	packageKey := ""
-	if flowID != "" {
-		if view, ok := b.FlowViewByID(flowID); ok {
-			packageKey = strings.TrimSpace(view.Paths.PackageKey)
-		}
-	}
-	for _, key := range b.packageLineageKeys(packageKey) {
-		doc, ok := b.projectTypes[key]
-		if !ok {
-			continue
-		}
-		resolved = mergeTypeCatalogDocuments(resolved, doc)
-	}
 	if flowID != "" {
 		if flowDoc, ok := b.flowTypes[flowID]; ok {
 			resolved = mergeTypeCatalogDocuments(resolved, flowDoc)
@@ -193,42 +140,12 @@ func (b *WorkflowContractBundle) ResolvedEntityContractsForFlow(flowID string) E
 		return nil
 	}
 	resolved := cloneEntityContractsDocument(b.RootEntities)
-	packageKey := ""
-	if flowID != "" {
-		if view, ok := b.FlowViewByID(flowID); ok {
-			packageKey = strings.TrimSpace(view.Paths.PackageKey)
-		}
-	}
-	for _, key := range b.packageLineageKeys(packageKey) {
-		doc, ok := b.projectEntities[key]
-		if !ok {
-			continue
-		}
-		resolved = mergeEntityContractsDocuments(resolved, doc)
-	}
 	if flowID != "" {
 		if flowDoc, ok := b.flowEntities[flowID]; ok {
 			resolved = mergeEntityContractsDocuments(resolved, flowDoc)
 		}
 	}
 	return resolved
-}
-
-func (b *WorkflowContractBundle) packageLineageKeys(key string) []string {
-	key = strings.TrimSpace(key)
-	if b == nil || key == "" || key == "." {
-		return nil
-	}
-	parents := map[string]string{}
-	for _, pkg := range b.PackageTree {
-		parents[strings.TrimSpace(pkg.Key)] = strings.TrimSpace(pkg.ParentKey)
-	}
-	var lineage []string
-	for key != "" && key != "." {
-		lineage = append([]string{key}, lineage...)
-		key = parents[key]
-	}
-	return lineage
 }
 
 func mergeTypeCatalogDocuments(base, incoming TypeCatalogDocument) TypeCatalogDocument {

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -100,12 +100,9 @@ vertical.shortlisted:
 	if _, ok := resolvedTypes.Types["ScoreBreakdown"]; !ok {
 		t.Fatal("expected resolved flow type catalog to include flow-local type")
 	}
-	if len(bundle.CompatibilityUsages()) != 0 {
-		t.Fatalf("CompatibilityUsages() = %#v, want none", bundle.CompatibilityUsages())
-	}
 }
 
-func TestLoadWorkflowContractBundle_RecordsLegacyCompatibilityUsage(t *testing.T) {
+func TestLoadWorkflowContractBundle_RejectsLegacyPackageEntitySchema(t *testing.T) {
 	repoRoot := repoRootForContractsTest(t)
 	root := t.TempDir()
 
@@ -122,41 +119,9 @@ flows:
     mode: static
 `)
 	writeFixtureFile(t, root+"/schema.yaml", "name: compat-bundle\n")
-	writeFixtureFile(t, root+"/events.yaml", `
-root.ready:
-  payload:
-    entity_id: uuid
-`)
-	writeFixtureFile(t, root+"/flows/scoring/schema.yaml", `
-name: scoring
-initial_state: pending
-states: [pending, done]
-terminal_states: [done]
-pins:
-  inputs:
-    events: [root.ready]
-  outputs:
-    events: []
-`)
-
-	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
-	}
-
-	usages := bundle.CompatibilityUsages()
-	if len(usages) != 2 {
-		t.Fatalf("len(CompatibilityUsages()) = %d, want 2 (%#v)", len(usages), usages)
-	}
-	seen := map[string]bool{}
-	for _, usage := range usages {
-		seen[usage.Kind] = true
-	}
-	if !seen["legacy_package_entity_schema"] {
-		t.Fatalf("missing legacy_package_entity_schema usage in %#v", usages)
-	}
-	if !seen["legacy_event_payload_block"] {
-		t.Fatalf("missing legacy_event_payload_block usage in %#v", usages)
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "entity_schema") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want RETIRED entity_schema rejection", err)
 	}
 }
 
@@ -181,8 +146,8 @@ bundle_item:
 `)
 
 	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
-	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-CONTRACT-GRAMMAR") {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want AMBIGUOUS-CONTRACT-GRAMMAR", err)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "entity_schema") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want RETIRED entity_schema rejection", err)
 	}
 }
 
@@ -215,11 +180,62 @@ entity_schema:
 `)
 
 	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
-	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-CONTRACT-GRAMMAR") {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want AMBIGUOUS-CONTRACT-GRAMMAR", err)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "entity_schema") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want RETIRED entity_schema rejection", err)
 	}
-	if !strings.Contains(err.Error(), "legacy scope: packages/legacy-child") {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want legacy subpackage scope", err)
+}
+
+func TestLoadWorkflowContractBundle_RejectsPackageScopedTypeCatalog(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: invalid-package-types
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: packages/child
+flows: []
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: invalid-package-types\n")
+	writeFixtureFile(t, root+"/packages/child/package.yaml", `
+name: child
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeFixtureFile(t, root+"/packages/child/types.yaml", "types:\n  Thing:\n    name: text\n")
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "package-scoped types.yaml") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want package-scoped types.yaml rejection", err)
+	}
+}
+
+func TestLoadWorkflowContractBundle_RejectsPackageScopedEntityContracts(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: invalid-package-entities
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: packages/child
+flows: []
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: invalid-package-entities\n")
+	writeFixtureFile(t, root+"/packages/child/package.yaml", `
+name: child
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeFixtureFile(t, root+"/packages/child/entities.yaml", "child:\n  name: text\n")
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "package-scoped entities.yaml") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want package-scoped entities.yaml rejection", err)
 	}
 }
 
@@ -261,9 +277,9 @@ campaign:
 	}
 }
 
-func TestProjectPackageDocumentDecode_PreservesManifestFieldsWithLegacyEntitySchemaListField(t *testing.T) {
+func TestProjectPackageDocumentDecode_RejectsLegacyEntitySchema(t *testing.T) {
 	var doc ProjectPackageDocument
-	if err := yaml.Unmarshal([]byte(`
+	err := yaml.Unmarshal([]byte(`
 name: test-accumulate-all
 version: 1.0.0
 description: Accumulate 3 items, fire on_complete when all arrive.
@@ -273,27 +289,9 @@ entity_schema:
   core:
     expected_count: integer
     received_items: [text]
-`), &doc); err != nil {
-		t.Fatalf("yaml.Unmarshal: %v", err)
-	}
-	if got := doc.Name; got != "test-accumulate-all" {
-		t.Fatalf("Name = %q", got)
-	}
-	if got := doc.Version; got != "1.0.0" {
-		t.Fatalf("Version = %q", got)
-	}
-	if got := doc.PlatformVersion; got != ">=1.1.0" {
-		t.Fatalf("PlatformVersion = %q", got)
-	}
-	if !doc.UsesLegacyEntitySchema {
-		t.Fatal("expected UsesLegacyEntitySchema to be set")
-	}
-	if got := len(doc.EntitySchema.Groups); got != 1 {
-		t.Fatalf("len(EntitySchema.Groups) = %d", got)
-	}
-	fields := doc.EntitySchema.Groups[0].Fields
-	if got := fields[1].Type; got != "list<text>" {
-		t.Fatalf("received_items type = %q", got)
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "entity_schema") {
+		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED entity_schema rejection", err)
 	}
 }
 
@@ -316,8 +314,8 @@ flows: []
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
-	if !strings.Contains(err.Error(), "parse") || !strings.Contains(err.Error(), "jsonb") {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want parse error mentioning jsonb", err)
+	if !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "entity_schema") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want RETIRED entity_schema rejection", err)
 	}
 	if strings.Contains(err.Error(), "workflow.name missing") {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want parse error instead of downstream semantics failure", err)
@@ -335,9 +333,6 @@ composite_score:
   description: final score
 `), &entry); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
-	}
-	if entry.UsesLegacyPayload {
-		t.Fatal("expected flat event grammar to avoid legacy payload compatibility flag")
 	}
 	if got := entry.Note; got != "root handoff" {
 		t.Fatalf("Note = %q", got)
@@ -357,8 +352,8 @@ payload:
   entity_id: uuid
 vertical_name: text
 `), &entry)
-	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-EVENT-GRAMMAR") {
-		t.Fatalf("yaml.Unmarshal error = %v, want AMBIGUOUS-EVENT-GRAMMAR", err)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "payload") {
+		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED nested payload rejection", err)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -1,0 +1,355 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadWorkflowContractBundle_LoadsWave1TypeAndEntityDocuments(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: wave1-bundle
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: wave1-bundle\n")
+	writeFixtureFile(t, root+"/types.yaml", `
+scalars:
+  URL: text
+types:
+  Brand:
+    name: text
+`)
+	writeFixtureFile(t, root+"/events.yaml", `
+root.ready:
+  _note: root event
+  entity_id: uuid
+`)
+	writeFixtureFile(t, root+"/flows/scoring/schema.yaml", `
+name: scoring
+initial_state: discovered
+states: [discovered, shortlisted]
+terminal_states: [shortlisted]
+pins:
+  inputs:
+    events: [root.ready]
+  outputs:
+    events: [vertical.shortlisted]
+`)
+	writeFixtureFile(t, root+"/flows/scoring/types.yaml", `
+types:
+  ScoreBreakdown:
+    total: numeric
+`)
+	writeFixtureFile(t, root+"/flows/scoring/entities.yaml", `
+vertical:
+  _description: scoring vertical
+  name: text
+  review_count:
+    type: integer
+    initial: 0
+`)
+	writeFixtureFile(t, root+"/flows/scoring/events.yaml", `
+vertical.shortlisted:
+  _note: shortlist event
+  vertical_name: text
+  composite_score: numeric
+`)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	rootTypes := bundle.RootTypeCatalog()
+	if got := rootTypes.Scalars["URL"].Base; got != "text" {
+		t.Fatalf("RootTypeCatalog().Scalars[URL] = %q", got)
+	}
+	if _, ok := rootTypes.Types["Brand"]; !ok {
+		t.Fatal("expected root Brand type")
+	}
+	flowTypes, ok := bundle.FlowTypeCatalogByID("scoring")
+	if !ok {
+		t.Fatal("expected scoring flow types")
+	}
+	if _, ok := flowTypes.Types["ScoreBreakdown"]; !ok {
+		t.Fatal("expected scoring flow-local type")
+	}
+	entityType, entity, ok := bundle.FlowOwnedEntityContract("scoring")
+	if !ok {
+		t.Fatal("expected scoring owned entity contract")
+	}
+	if entityType != "vertical" {
+		t.Fatalf("FlowOwnedEntityContract entity type = %q", entityType)
+	}
+	if got := entity.Fields["review_count"].Type; got != "integer" {
+		t.Fatalf("review_count type = %q", got)
+	}
+	resolvedTypes := bundle.ResolvedTypeCatalogForFlow("scoring")
+	if _, ok := resolvedTypes.Scalars["URL"]; !ok {
+		t.Fatal("expected resolved flow type catalog to include root scalar")
+	}
+	if _, ok := resolvedTypes.Types["ScoreBreakdown"]; !ok {
+		t.Fatal("expected resolved flow type catalog to include flow-local type")
+	}
+	if len(bundle.CompatibilityUsages()) != 0 {
+		t.Fatalf("CompatibilityUsages() = %#v, want none", bundle.CompatibilityUsages())
+	}
+}
+
+func TestLoadWorkflowContractBundle_RecordsLegacyCompatibilityUsage(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: compat-bundle
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  item:
+    item_id: text
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: compat-bundle\n")
+	writeFixtureFile(t, root+"/events.yaml", `
+root.ready:
+  payload:
+    entity_id: uuid
+`)
+	writeFixtureFile(t, root+"/flows/scoring/schema.yaml", `
+name: scoring
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [root.ready]
+  outputs:
+    events: []
+`)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	usages := bundle.CompatibilityUsages()
+	if len(usages) != 2 {
+		t.Fatalf("len(CompatibilityUsages()) = %d, want 2 (%#v)", len(usages), usages)
+	}
+	seen := map[string]bool{}
+	for _, usage := range usages {
+		seen[usage.Kind] = true
+	}
+	if !seen["legacy_package_entity_schema"] {
+		t.Fatalf("missing legacy_package_entity_schema usage in %#v", usages)
+	}
+	if !seen["legacy_event_payload_block"] {
+		t.Fatalf("missing legacy_event_payload_block usage in %#v", usages)
+	}
+}
+
+func TestLoadWorkflowContractBundle_RejectsMixedLegacyEntitySchemaAndWave1Entities(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: mixed-bundle
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  item:
+    item_id: text
+flows: []
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: mixed-bundle\n")
+	writeFixtureFile(t, root+"/entities.yaml", `
+bundle_item:
+  _owner: scoring
+  name: text
+`)
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-CONTRACT-GRAMMAR") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want AMBIGUOUS-CONTRACT-GRAMMAR", err)
+	}
+}
+
+func TestLoadWorkflowContractBundle_RejectsMultipleFlowEntityTypes(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: invalid-flow-entities
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: invalid-flow-entities\n")
+	writeFixtureFile(t, root+"/flows/scoring/schema.yaml", `
+name: scoring
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`)
+	writeFixtureFile(t, root+"/flows/scoring/entities.yaml", `
+vertical:
+  name: text
+campaign:
+  title: text
+`)
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "INVALID-ENTITY-OWNERSHIP") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want INVALID-ENTITY-OWNERSHIP", err)
+	}
+}
+
+func TestProjectPackageDocumentDecode_PreservesManifestFieldsWithLegacyEntitySchemaListField(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: test-accumulate-all
+version: 1.0.0
+description: Accumulate 3 items, fire on_complete when all arrive.
+platform_version: ">=1.1.0"
+flows: []
+entity_schema:
+  core:
+    expected_count: integer
+    received_items: [text]
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := doc.Name; got != "test-accumulate-all" {
+		t.Fatalf("Name = %q", got)
+	}
+	if got := doc.Version; got != "1.0.0" {
+		t.Fatalf("Version = %q", got)
+	}
+	if got := doc.PlatformVersion; got != ">=1.1.0" {
+		t.Fatalf("PlatformVersion = %q", got)
+	}
+	if !doc.UsesLegacyEntitySchema {
+		t.Fatal("expected UsesLegacyEntitySchema to be set")
+	}
+	if got := len(doc.EntitySchema.Groups); got != 1 {
+		t.Fatalf("len(EntitySchema.Groups) = %d", got)
+	}
+	fields := doc.EntitySchema.Groups[0].Fields
+	if got := fields[1].Type; got != "list<text>" {
+		t.Fatalf("received_items type = %q", got)
+	}
+}
+
+func TestLoadWorkflowContractBundle_InvalidLegacyPackageFieldReturnsParseError(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: invalid-legacy-bundle
+version: "1.0.0"
+platform_version: ">=1.0.0"
+entity_schema:
+  core:
+    metadata: jsonb
+flows: []
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: invalid-legacy-bundle\n")
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse") || !strings.Contains(err.Error(), "jsonb") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want parse error mentioning jsonb", err)
+	}
+	if strings.Contains(err.Error(), "workflow.name missing") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want parse error instead of downstream semantics failure", err)
+	}
+}
+
+func TestEventCatalogEntryDecode_AcceptsFlatWave1PayloadGrammar(t *testing.T) {
+	var entry EventCatalogEntry
+	if err := yaml.Unmarshal([]byte(`
+_note: root handoff
+_source: scoring
+vertical_name: text
+composite_score:
+  type: numeric
+  description: final score
+`), &entry); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if entry.UsesLegacyPayload {
+		t.Fatal("expected flat event grammar to avoid legacy payload compatibility flag")
+	}
+	if got := entry.Note; got != "root handoff" {
+		t.Fatalf("Note = %q", got)
+	}
+	if got := entry.Payload.Properties["vertical_name"].Type; got != "text" {
+		t.Fatalf("vertical_name type = %q", got)
+	}
+	if got := entry.Payload.Properties["composite_score"].Type; got != "numeric" {
+		t.Fatalf("composite_score type = %q", got)
+	}
+}
+
+func TestEventCatalogEntryDecode_RejectsMixedPayloadBlockAndFlatFields(t *testing.T) {
+	var entry EventCatalogEntry
+	err := yaml.Unmarshal([]byte(`
+payload:
+  entity_id: uuid
+vertical_name: text
+`), &entry)
+	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-EVENT-GRAMMAR") {
+		t.Fatalf("yaml.Unmarshal error = %v, want AMBIGUOUS-EVENT-GRAMMAR", err)
+	}
+}
+
+func TestEntityContractsDocumentDecode_RejectsRetiredParserLocalForms(t *testing.T) {
+	var doc EntityContractsDocument
+	err := yaml.Unmarshal([]byte(`
+vertical:
+  _state_model:
+    state_field: current_state
+  metadata:
+    type: jsonb
+`), &doc)
+	if err == nil || (!strings.Contains(err.Error(), "RETIRED") && !strings.Contains(err.Error(), "jsonb")) {
+		t.Fatalf("yaml.Unmarshal error = %v, want retired parser-local form rejection", err)
+	}
+}
+
+func TestTypeCatalogDocumentDecode_RejectsInlineObjectField(t *testing.T) {
+	var doc TypeCatalogDocument
+	err := yaml.Unmarshal([]byte(`
+types:
+  Brand:
+    palette:
+      type: object
+      properties:
+        primary: text
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED") {
+		t.Fatalf("yaml.Unmarshal error = %v, want RETIRED inline object rejection", err)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -186,6 +186,43 @@ bundle_item:
 	}
 }
 
+func TestLoadWorkflowContractBundle_RejectsLegacySubpackageEntitySchemaAlongsideWave1Entities(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, root+"/package.yaml", `
+name: mixed-subpackage-bundle
+version: "1.0.0"
+platform_version: ">=1.0.0"
+packages:
+  - path: packages/legacy-child
+flows: []
+`)
+	writeFixtureFile(t, root+"/schema.yaml", "name: mixed-subpackage-bundle\n")
+	writeFixtureFile(t, root+"/entities.yaml", `
+root_entity:
+  _owner: scoring
+  name: text
+`)
+	writeFixtureFile(t, root+"/packages/legacy-child/package.yaml", `
+name: legacy-child
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+entity_schema:
+  child:
+    legacy_id: text
+`)
+
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-CONTRACT-GRAMMAR") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want AMBIGUOUS-CONTRACT-GRAMMAR", err)
+	}
+	if !strings.Contains(err.Error(), "legacy scope: packages/legacy-child") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want legacy subpackage scope", err)
+	}
+}
+
 func TestLoadWorkflowContractBundle_RejectsMultipleFlowEntityTypes(t *testing.T) {
 	repoRoot := repoRootForContractsTest(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -213,7 +213,16 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if e == nil {
 		return nil
 	}
+	hasLegacyPayload := hasYAMLMappingKey(node, "payload")
+	flatPayload, err := buildFlatEventPayloadSpec(node)
+	if err != nil {
+		return err
+	}
+	if hasLegacyPayload && len(flatPayload.Properties) > 0 {
+		return fmt.Errorf("AMBIGUOUS-EVENT-GRAMMAR: event mixes retired payload: with flat payload fields")
+	}
 	var aux struct {
+		Note               string    `yaml:"_note"`
 		Emitter            yaml.Node `yaml:"emitter"`
 		EmitterType        string    `yaml:"emitter_type"`
 		Producer           yaml.Node `yaml:"producer"`
@@ -276,10 +285,17 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	payload, err := decodeEventPayloadSpecNode(&aux.Payload)
-	if err != nil {
-		return err
+	payload := flatPayload
+	if hasLegacyPayload {
+		payload, err = decodeEventPayloadSpecNode(&aux.Payload)
+		if err != nil {
+			return err
+		}
 	}
+	if len(payload.Required) == 0 {
+		payload.Required = normalizeStrings(aux.Required)
+	}
+	e.Note = strings.TrimSpace(aux.Note)
 	e.Emitter = emitter
 	e.EmitterType = strings.TrimSpace(aux.EmitterType)
 	e.Producer = mergeStringLists(producer, legacyProducer)
@@ -295,6 +311,7 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	e.DeliveryChannel = deliveryChannel
 	e.Payload = payload
 	e.Required = normalizeStrings(aux.Required)
+	e.UsesLegacyPayload = hasLegacyPayload
 	return nil
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -213,13 +213,12 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if e == nil {
 		return nil
 	}
-	hasLegacyPayload := hasYAMLMappingKey(node, "payload")
+	if hasYAMLMappingKey(node, "payload") {
+		return fmt.Errorf("RETIRED: nested events.yaml payload blocks are no longer supported; move payload fields to the event top level")
+	}
 	flatPayload, err := buildFlatEventPayloadSpec(node)
 	if err != nil {
 		return err
-	}
-	if hasLegacyPayload && len(flatPayload.Properties) > 0 {
-		return fmt.Errorf("AMBIGUOUS-EVENT-GRAMMAR: event mixes retired payload: with flat payload fields")
 	}
 	var aux struct {
 		Note               string    `yaml:"_note"`
@@ -286,12 +285,6 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	payload := flatPayload
-	if hasLegacyPayload {
-		payload, err = decodeEventPayloadSpecNode(&aux.Payload)
-		if err != nil {
-			return err
-		}
-	}
 	if len(payload.Required) == 0 {
 		payload.Required = normalizeStrings(aux.Required)
 	}
@@ -311,7 +304,6 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	e.DeliveryChannel = deliveryChannel
 	e.Payload = payload
 	e.Required = normalizeStrings(aux.Required)
-	e.UsesLegacyPayload = hasLegacyPayload
 	return nil
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -126,21 +126,20 @@ func (s *EventFieldSpec) UnmarshalYAML(node *yaml.Node) error {
 	if s == nil {
 		return nil
 	}
-	switch node.Kind {
-	case yaml.ScalarNode:
-		*s = EventFieldSpec{Type: strings.TrimSpace(node.Value)}
-		return nil
-	case yaml.MappingNode:
-		type alias EventFieldSpec
-		var aux alias
-		if err := node.Decode(&aux); err != nil {
-			return err
-		}
-		*s = EventFieldSpec(aux)
-		return nil
-	default:
-		return fmt.Errorf("unsupported event field yaml node kind %d", node.Kind)
+	parsed, err := decodeWave1FieldNode(node, wave1FieldNodeOptions{
+		Context:           "event payload field",
+		AllowInitial:      false,
+		AllowImmutable:    false,
+		AllowUnusedReason: false,
+	})
+	if err != nil {
+		return err
 	}
+	*s = EventFieldSpec{
+		Type:        parsed.Type,
+		Description: parsed.Description,
+	}
+	return nil
 }
 
 func (p *EventPayloadSpec) UnmarshalYAML(node *yaml.Node) error {
@@ -348,6 +347,26 @@ func decodeEntitySchemaField(name string, node *yaml.Node) (EntitySchemaField, e
 		field.Primary = parsed.Primary
 		field.Indexed = parsed.Indexed
 		field.Nullable = parsed.Nullable
+		if err := validateWave1TypeRef(field.Type, fmt.Sprintf("entity schema field %s", field.Name)); err != nil {
+			return EntitySchemaField{}, err
+		}
+		return field, nil
+	case yaml.SequenceNode:
+		var items []string
+		if err := node.Decode(&items); err != nil {
+			return EntitySchemaField{}, err
+		}
+		if len(items) != 1 {
+			return EntitySchemaField{}, fmt.Errorf("entity schema field %s: list shorthand requires exactly one item type", field.Name)
+		}
+		itemType := strings.TrimSpace(items[0])
+		if itemType == "" {
+			return EntitySchemaField{}, fmt.Errorf("entity schema field %s: list shorthand requires a non-empty item type", field.Name)
+		}
+		if err := validateWave1TypeRef(itemType, fmt.Sprintf("entity schema field %s list item", field.Name)); err != nil {
+			return EntitySchemaField{}, err
+		}
+		field.Type = fmt.Sprintf("list<%s>", itemType)
 		return field, nil
 	case yaml.MappingNode:
 		type alias EntitySchemaField
@@ -363,6 +382,9 @@ func decodeEntitySchemaField(name string, node *yaml.Node) (EntitySchemaField, e
 		field.Description = aux.Description
 		if strings.TrimSpace(field.Type) == "" {
 			return EntitySchemaField{}, fmt.Errorf("entity schema field %s: type is required", field.Name)
+		}
+		if err := validateWave1TypeRef(field.Type, fmt.Sprintf("entity schema field %s", field.Name)); err != nil {
+			return EntitySchemaField{}, err
 		}
 		return field, nil
 	default:

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -218,25 +218,22 @@ pins:
 }
 
 func TestEntitySchemaDecode_AcceptsMappingInitialValue(t *testing.T) {
-	var doc ProjectPackageDocument
+	var schema EntitySchema
 	if err := yaml.Unmarshal([]byte(`
-name: test
-version: 1.0.0
-entity_schema:
-  scoring_phase:
-    revision_count:
-      type: integer
-      initial: 0
-    is_duplicate:
-      type: boolean
-      initial: false
-`), &doc); err != nil {
+scoring_phase:
+  revision_count:
+    type: integer
+    initial: 0
+  is_duplicate:
+    type: boolean
+    initial: false
+`), &schema); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
-	if got := len(doc.EntitySchema.Groups); got != 1 {
-		t.Fatalf("len(EntitySchema.Groups) = %d", got)
+	if got := len(schema.Groups); got != 1 {
+		t.Fatalf("len(Groups) = %d", got)
 	}
-	fields := doc.EntitySchema.Groups[0].Fields
+	fields := schema.Groups[0].Fields
 	if got := fields[0].Name; got != "revision_count" {
 		t.Fatalf("Fields[0].Name = %q", got)
 	}
@@ -249,29 +246,23 @@ entity_schema:
 }
 
 func TestEntitySchemaDecode_RejectsScalarInitialSuffix(t *testing.T) {
-	var doc ProjectPackageDocument
+	var schema EntitySchema
 	err := yaml.Unmarshal([]byte(`
-name: test
-version: 1.0.0
-entity_schema:
-  scoring_phase:
-    revision_count: integer initial 0
-`), &doc)
+scoring_phase:
+  revision_count: integer initial 0
+`), &schema)
 	if err == nil || !strings.Contains(err.Error(), "scalar form cannot declare initial values") {
 		t.Fatalf("yaml.Unmarshal error = %v, want scalar initial rejection", err)
 	}
 }
 
 func TestEntitySchemaDecode_RejectsMappingWithoutType(t *testing.T) {
-	var doc ProjectPackageDocument
+	var schema EntitySchema
 	err := yaml.Unmarshal([]byte(`
-name: test
-version: 1.0.0
-entity_schema:
-  scoring_phase:
-    revision_count:
-      initial: 0
-`), &doc)
+scoring_phase:
+  revision_count:
+    initial: 0
+`), &schema)
 	if err == nil || !strings.Contains(err.Error(), "type is required") {
 		t.Fatalf("yaml.Unmarshal error = %v, want missing-type rejection", err)
 	}

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -20,6 +20,9 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 	if p == nil {
 		return nil
 	}
+	if hasYAMLMappingKey(node, "entity_schema") {
+		return fmt.Errorf("RETIRED: package.yaml entity_schema is no longer supported; migrate to entities.yaml")
+	}
 	var aux struct {
 		Name            string              `yaml:"name"`
 		Version         string              `yaml:"version"`
@@ -49,7 +52,6 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		Handoffs:        append([]ProjectHandoff(nil), aux.Handoffs...),
 		EntitySchema:    aux.EntitySchema,
 	}
-	p.UsesLegacyEntitySchema = hasYAMLMappingKey(node, "entity_schema")
 	return nil
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -1,0 +1,478 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var builtinWave1ScalarTypes = map[string]struct{}{
+	"text":      {},
+	"integer":   {},
+	"numeric":   {},
+	"boolean":   {},
+	"timestamp": {},
+	"uuid":      {},
+}
+
+func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
+	if p == nil {
+		return nil
+	}
+	var aux struct {
+		Name            string              `yaml:"name"`
+		Version         string              `yaml:"version"`
+		PlatformVersion string              `yaml:"platform_version"`
+		Author          string              `yaml:"author"`
+		Description     string              `yaml:"description"`
+		Flows           []ProjectFlowRef    `yaml:"flows"`
+		Packages        []ProjectPackageRef `yaml:"packages"`
+		Children        []ProjectPackageRef `yaml:"children"`
+		Subpackages     []ProjectPackageRef `yaml:"subpackages"`
+		Handoffs        []ProjectHandoff    `yaml:"handoffs"`
+		EntitySchema    EntitySchema        `yaml:"entity_schema"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*p = ProjectPackageDocument{
+		Name:            aux.Name,
+		Version:         aux.Version,
+		PlatformVersion: aux.PlatformVersion,
+		Author:          aux.Author,
+		Description:     aux.Description,
+		Flows:           append([]ProjectFlowRef(nil), aux.Flows...),
+		Packages:        append([]ProjectPackageRef(nil), aux.Packages...),
+		Children:        append([]ProjectPackageRef(nil), aux.Children...),
+		Subpackages:     append([]ProjectPackageRef(nil), aux.Subpackages...),
+		Handoffs:        append([]ProjectHandoff(nil), aux.Handoffs...),
+		EntitySchema:    aux.EntitySchema,
+	}
+	p.UsesLegacyEntitySchema = hasYAMLMappingKey(node, "entity_schema")
+	return nil
+}
+
+func (d *TypeCatalogDocument) UnmarshalYAML(node *yaml.Node) error {
+	if d == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*d = TypeCatalogDocument{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("type catalog must be a mapping")
+	}
+	doc := TypeCatalogDocument{
+		Scalars: map[string]ScalarTypeDecl{},
+		Enums:   map[string]EnumTypeDecl{},
+		Types:   map[string]NamedTypeDecl{},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "scalars":
+			if err := value.Decode(&doc.Scalars); err != nil {
+				return err
+			}
+		case "enums":
+			if err := value.Decode(&doc.Enums); err != nil {
+				return err
+			}
+		case "types":
+			if err := value.Decode(&doc.Types); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: type catalog field %q not in platform spec", key)
+		}
+	}
+	*d = doc
+	return nil
+}
+
+func (s *ScalarTypeDecl) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	base, err := decodeScalarStringNode(node)
+	if err != nil {
+		return err
+	}
+	if err := validateWave1TypeRef(base, "scalar alias"); err != nil {
+		return err
+	}
+	if !isBuiltinWave1Scalar(base) {
+		return fmt.Errorf("RETIRED: scalar alias %q must resolve to a built-in Wave 1 scalar", strings.TrimSpace(base))
+	}
+	s.Base = base
+	return nil
+}
+
+func (e *EnumTypeDecl) UnmarshalYAML(node *yaml.Node) error {
+	if e == nil {
+		return nil
+	}
+	values, err := decodeStringListNode(node)
+	if err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("enum declaration requires at least one value")
+	}
+	e.Values = values
+	return nil
+}
+
+func (n *NamedTypeDecl) UnmarshalYAML(node *yaml.Node) error {
+	if n == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*n = NamedTypeDecl{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("named type declaration must be a mapping")
+	}
+	decl := NamedTypeDecl{Fields: map[string]TypeFieldSpec{}}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		if key == "" {
+			continue
+		}
+		if strings.HasPrefix(key, "_") {
+			switch key {
+			case "_description":
+				text, err := decodeScalarStringNode(value)
+				if err != nil {
+					return err
+				}
+				decl.Description = text
+			default:
+				return fmt.Errorf("UNDEFINED-FIELD: type metadata field %q not in platform spec", key)
+			}
+			continue
+		}
+		var field TypeFieldSpec
+		if err := value.Decode(&field); err != nil {
+			return err
+		}
+		decl.Fields[key] = field
+	}
+	*n = decl
+	return nil
+}
+
+func (f *TypeFieldSpec) UnmarshalYAML(node *yaml.Node) error {
+	if f == nil {
+		return nil
+	}
+	parsed, err := decodeWave1FieldNode(node, wave1FieldNodeOptions{
+		Context:           "type field",
+		AllowInitial:      false,
+		AllowImmutable:    false,
+		AllowUnusedReason: false,
+	})
+	if err != nil {
+		return err
+	}
+	f.Type = parsed.Type
+	f.Description = parsed.Description
+	return nil
+}
+
+func (d *EntityContractsDocument) UnmarshalYAML(node *yaml.Node) error {
+	if d == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*d = EntityContractsDocument{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("entity contracts document must be a mapping")
+	}
+	out := make(EntityContractsDocument, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		var entity EntityContract
+		if err := node.Content[i+1].Decode(&entity); err != nil {
+			return err
+		}
+		out[key] = entity
+	}
+	*d = out
+	return nil
+}
+
+func (e *EntityContract) UnmarshalYAML(node *yaml.Node) error {
+	if e == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*e = EntityContract{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("entity contract must be a mapping")
+	}
+	decl := EntityContract{Fields: map[string]EntityFieldDecl{}}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		if key == "" {
+			continue
+		}
+		if strings.HasPrefix(key, "_") {
+			switch key {
+			case "_description":
+				text, err := decodeScalarStringNode(value)
+				if err != nil {
+					return err
+				}
+				decl.Description = text
+			case "_owner":
+				text, err := decodeScalarStringNode(value)
+				if err != nil {
+					return err
+				}
+				decl.Owner = text
+			case "_state_model":
+				return fmt.Errorf("RETIRED: entity field %q is retired; state authority is implicit from schema.yaml", key)
+			default:
+				return fmt.Errorf("UNDEFINED-FIELD: entity metadata field %q not in platform spec", key)
+			}
+			continue
+		}
+		if key == "state_field" {
+			return fmt.Errorf("RETIRED: entity field %q is retired; state authority is implicit from schema.yaml", key)
+		}
+		var field EntityFieldDecl
+		if err := value.Decode(&field); err != nil {
+			return err
+		}
+		decl.Fields[key] = field
+	}
+	*e = decl
+	return nil
+}
+
+func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
+	if f == nil {
+		return nil
+	}
+	parsed, err := decodeWave1FieldNode(node, wave1FieldNodeOptions{
+		Context:           "entity field",
+		AllowInitial:      true,
+		AllowImmutable:    true,
+		AllowUnusedReason: true,
+	})
+	if err != nil {
+		return err
+	}
+	f.Type = parsed.Type
+	f.Initial = parsed.Initial
+	f.Immutable = parsed.Immutable
+	f.Description = parsed.Description
+	f.UnusedReason = parsed.UnusedReason
+	return nil
+}
+
+func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1ParsedFieldNode, error) {
+	if node == nil || node.Kind == 0 {
+		return wave1ParsedFieldNode{}, fmt.Errorf("%s type is required", opts.Context)
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		typ, err := decodeScalarStringNode(node)
+		if err != nil {
+			return wave1ParsedFieldNode{}, err
+		}
+		if err := validateWave1TypeRef(typ, opts.Context); err != nil {
+			return wave1ParsedFieldNode{}, err
+		}
+		return wave1ParsedFieldNode{Type: typ}, nil
+	case yaml.SequenceNode:
+		values, err := decodeStringListNode(node)
+		if err != nil {
+			return wave1ParsedFieldNode{}, err
+		}
+		if len(values) != 1 {
+			return wave1ParsedFieldNode{}, fmt.Errorf("%s list shorthand requires exactly one element type", opts.Context)
+		}
+		typ := "[" + strings.TrimSpace(values[0]) + "]"
+		if err := validateWave1TypeRef(typ, opts.Context); err != nil {
+			return wave1ParsedFieldNode{}, err
+		}
+		return wave1ParsedFieldNode{Type: typ}, nil
+	case yaml.MappingNode:
+	default:
+		return wave1ParsedFieldNode{}, fmt.Errorf("unsupported %s yaml node kind %d", opts.Context, node.Kind)
+	}
+
+	allowed := map[string]struct{}{
+		"type":        {},
+		"description": {},
+	}
+	if opts.AllowInitial {
+		allowed["initial"] = struct{}{}
+	}
+	if opts.AllowImmutable {
+		allowed["immutable"] = struct{}{}
+	}
+	if opts.AllowUnusedReason {
+		allowed["_unused_reason"] = struct{}{}
+	}
+
+	var field wave1ParsedFieldNode
+	var listOf string
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			switch key {
+			case "properties", "fields", "shape":
+				return wave1ParsedFieldNode{}, fmt.Errorf("RETIRED: %s inline object declarations are retired; declare a named type in types.yaml", opts.Context)
+			case "of":
+				listValue, err := decodeScalarStringNode(value)
+				if err != nil {
+					return wave1ParsedFieldNode{}, err
+				}
+				listOf = listValue
+				continue
+			case "initial", "immutable", "_unused_reason":
+				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
+			default:
+				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
+			}
+		}
+		switch key {
+		case "type":
+			typ, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Type = typ
+		case "description":
+			text, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Description = text
+		case "initial":
+			var initial any
+			if err := value.Decode(&initial); err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Initial = initial
+		case "immutable":
+			immutable, err := decodeBoolNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Immutable = immutable
+		case "_unused_reason":
+			text, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.UnusedReason = text
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(field.Type), "list") {
+		if strings.TrimSpace(listOf) == "" {
+			return wave1ParsedFieldNode{}, fmt.Errorf("RETIRED: %s list declarations require an of: element type", opts.Context)
+		}
+		if err := validateWave1TypeRef(listOf, opts.Context); err != nil {
+			return wave1ParsedFieldNode{}, err
+		}
+		field.Type = fmt.Sprintf("[%s]", strings.TrimSpace(listOf))
+	}
+	if err := validateWave1TypeRef(field.Type, opts.Context); err != nil {
+		return wave1ParsedFieldNode{}, err
+	}
+	if opts.AllowUnusedReason && strings.TrimSpace(field.UnusedReason) != "" && len(strings.TrimSpace(field.UnusedReason)) < 10 {
+		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reason must be at least 10 characters", opts.Context)
+	}
+	return field, nil
+}
+
+func validateWave1TypeRef(raw, context string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("%s type is required", context)
+	}
+	switch strings.ToLower(raw) {
+	case "jsonb":
+		return fmt.Errorf("RETIRED: %s type %q is retired; declare a named type in types.yaml", context, raw)
+	case "object":
+		return fmt.Errorf("RETIRED: %s type %q is retired; declare a named type in types.yaml", context, raw)
+	}
+	if strings.HasPrefix(raw, "Optional<") {
+		return fmt.Errorf("RETIRED: %s type %q is not part of the Wave 1 type system", context, raw)
+	}
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]"))
+		if inner == "" {
+			return fmt.Errorf("%s list type requires an element type", context)
+		}
+		if strings.EqualFold(inner, "object") || strings.EqualFold(inner, "jsonb") {
+			return fmt.Errorf("RETIRED: %s type %q is retired; declare a named type in types.yaml", context, raw)
+		}
+		return nil
+	}
+	return nil
+}
+
+func isBuiltinWave1Scalar(raw string) bool {
+	_, ok := builtinWave1ScalarTypes[strings.TrimSpace(raw)]
+	return ok
+}
+
+func buildFlatEventPayloadSpec(node *yaml.Node) (EventPayloadSpec, error) {
+	spec := EventPayloadSpec{Properties: map[string]EventFieldSpec{}}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		if key == "" || strings.HasPrefix(key, "_") {
+			continue
+		}
+		switch key {
+		case "description", "emitter", "emitter_type", "producer", "_producer", "alternate_emitters", "consumer", "_consumer", "consumer_type", "_consumer_type", "_source", "_status", "_note", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "payload", "required":
+			continue
+		}
+		var field EventFieldSpec
+		if err := value.Decode(&field); err != nil {
+			return EventPayloadSpec{}, err
+		}
+		spec.Properties[key] = field
+	}
+	return spec, nil
+}
+
+type wave1FieldNodeOptions struct {
+	Context           string
+	AllowInitial      bool
+	AllowImmutable    bool
+	AllowUnusedReason bool
+}
+
+type wave1ParsedFieldNode struct {
+	Type         string
+	Initial      any
+	Immutable    bool
+	Description  string
+	UnusedReason string
+}

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -109,12 +109,6 @@ func TestNodeEventHandler_LocalizesCrossFlowQualifiedInputEventToLocalHandler(t 
 name: cross-flow-localization
 version: "1.0.0"
 platform_version: ">=1.6.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
 flows:
   - id: scoring
     flow: scoring
@@ -122,6 +116,10 @@ flows:
   - id: validation
     flow: validation
     mode: static
+`)
+	writeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: cross-flow-localization\n")
 	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -144,10 +142,7 @@ pins:
 	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "policy.yaml"), "{}\n")
 	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "events.yaml"), `
 vertical.shortlisted:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "nodes.yaml"), `
 scoring-node:
@@ -178,10 +173,7 @@ pins:
 	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "policy.yaml"), "{}\n")
 	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "events.yaml"), `
 validation.started:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "nodes.yaml"), `
 validation-orchestrator:
@@ -225,16 +217,12 @@ func currentWorkflowContractsDirForTest(t *testing.T) string {
 name: contract-test-bundle
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
-        - name: status
-          type: string
 flows: []
+`)
+	writeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
+  status: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), `
 initial_state: idle
@@ -262,24 +250,11 @@ control-plane:
 `)
 	writeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
-      item_id:
-        type: string
-    required:
-      - entity_id
-      - item_id
+  entity_id: string
+  item_id: string
 evidence.recorded:
-  payload:
-    properties:
-      entity_id:
-        type: string
-      note:
-        type: string
-    required:
-      - entity_id
+  entity_id: string
+  note: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
 audit-node:
@@ -332,8 +307,7 @@ parent-node:
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "events.yaml"), `
 parent.started:
-  payload:
-    entity_id: string
+  entity_id: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "agents.yaml"), `
 parent-agent:
@@ -365,8 +339,7 @@ child-node:
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "flows", "child", "events.yaml"), `
 child.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 `)
 	writeFixtureFile(t, filepath.Join(root, "flows", "parent", "flows", "child", "agents.yaml"), `
 child-agent:
@@ -476,8 +449,7 @@ _source: external (human board interface)
 _producer: mailbox_human
 _consumer: mailbox_system (external UI, not agent-subscribed)
 _consumer_type: external_ui
-payload:
-  entity_id: string
+entity_id: string
 `), &entry); err != nil {
 		t.Fatalf("load event catalog entry: %v", err)
 	}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -182,26 +182,12 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if len(turns.records) == 0 {
 		t.Fatal("expected persisted turn records")
 	}
-	first := AgentTurnRecord{}
-	found := false
-	for _, rec := range turns.records {
-		if got := rec.MCPServers["runtime-tools"]; got == "connected" {
-			first = rec
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("no provider-observed first-turn record found in %#v", turns.records)
-	}
+	first := turns.records[0]
 	if !slices.Equal(first.AvailableTools, []string{"emit_category_assessed", "read_file", "write_file"}) {
 		t.Fatalf("first turn available_tools = %#v", first.AvailableTools)
 	}
-	if !slices.Equal(first.MCPToolsVisible, []string{"mcp__runtime-tools__emit_category_assessed"}) {
-		t.Fatalf("first turn mcp_tools_visible = %#v", first.MCPToolsVisible)
-	}
-	if got := first.MCPServers["runtime-tools"]; got != "connected" {
-		t.Fatalf("first turn mcp_servers = %#v", first.MCPServers)
+	if !slices.Equal(first.MCPToolsListed, []string{"mcp__runtime-tools__emit_category_assessed"}) {
+		t.Fatalf("first turn mcp_tools_listed = %#v", first.MCPToolsListed)
 	}
 	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
 		t.Fatalf("emitted events = %#v", recorder.Snapshot())

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -924,17 +924,14 @@ func loadPackageBackedStaticAgentSource(t *testing.T) semanticview.Source {
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -942,10 +939,7 @@ flows:
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
 name: support
@@ -962,10 +956,7 @@ states:
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 backend:
@@ -997,17 +988,14 @@ version: "1.0.0"
 platform_version: ">=1.0.0"
 packages:
   - path: extras
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -1015,10 +1003,7 @@ flows:
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
 name: support
@@ -1030,10 +1015,7 @@ states:
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
 name: extras

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1048,10 +1048,10 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface
 	source := loadWorkflowTempSource(t, map[string]string{
 		"package.yaml":             "name: action-emit-required\nversion: 1.0.0\ndescription: Action emit required-field proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
 		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n  outputs:\n    events: [parent.result]\n",
-		"events.yaml":              "parent.trigger:\n  payload:\n    entity_id: string\nparent.result:\n  payload:\n    entity_id: string\n",
+		"events.yaml":              "parent.trigger:\n  entity_id: string\nparent.result:\n  entity_id: string\n",
 		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
 		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.internal]\n",
-		"flows/child/events.yaml":  "child.start:\n  payload:\n    entity_id: string\nchild.internal:\n  payload:\n    entity_id: string\n    step: string\n  required: [entity_id, step]\n",
+		"flows/child/events.yaml":  "child.start:\n  entity_id: string\nchild.internal:\n  entity_id: string\n  step: string\n  required: [entity_id, step]\n",
 	})
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -62,17 +62,14 @@ func loadPackageBackedRuntimeSessionScopeSource(t *testing.T) semanticview.Sourc
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -81,10 +78,7 @@ flows:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
   _source: external (bootstrap fixture)
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
 name: support
@@ -101,10 +95,7 @@ states:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "prompts", "backend.md"), "Handle support events.\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 backend:
@@ -138,17 +129,14 @@ version: "1.0.0"
 platform_version: ">=1.0.0"
 packages:
   - path: extras
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -157,10 +145,7 @@ flows:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
   _source: external (bootstrap fixture)
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
 name: support
@@ -171,10 +156,7 @@ states:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 support/item.created:
-  payload:
-    properties:
-      entity_id:
-        type: string
+  entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "extras", "prompts", "backend.md"), "Handle support events.\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -17,7 +17,7 @@ func TestProjectScopes_PackageBackedScopeCarriesOwningFlowID(t *testing.T) {
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
@@ -90,7 +90,7 @@ func TestProjectScopes_SoleParentFlowCarriesOwningFlowIDOutsideFlowDir(t *testin
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
@@ -166,7 +166,7 @@ func TestResolveAgentSessionScopeProof_PackageBackedAgentCarriesFlowPath(t *test
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
@@ -234,7 +234,7 @@ func TestResolveAgentSessionScopeProof_FlowScopedAgentCarriesFlowPath(t *testing
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -17,21 +17,18 @@ func TestProjectScopes_PackageBackedScopeCarriesOwningFlowID(t *testing.T) {
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -93,23 +90,20 @@ func TestProjectScopes_SoleParentFlowCarriesOwningFlowIDOutsideFlowDir(t *testin
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
 packages:
   - path: extras
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -172,21 +166,18 @@ func TestResolveAgentSessionScopeProof_PackageBackedAgentCarriesFlowPath(t *test
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
@@ -243,21 +234,18 @@ func TestResolveAgentSessionScopeProof_FlowScopedAgentCarriesFlowPath(t *testing
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
 
-	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=1.0.0"
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
 flows:
   - id: support
     flow: support
     mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: session-scope-validation\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1179,10 +1179,10 @@ func catalogCollectBootIssues(bundle catalogBootBundle) []catalogBootIssue {
 				if condition := catalogGuardCheckString(handler["guard"]); condition != "" && !catalogConditionHasPrefix(condition) {
 					issues = append(issues, catalogBootIssue{Severity: "error", Category: "DIALECT-BARE-COND", Message: fmt.Sprintf("%s: condition '%s' missing prefix", loc, condition)})
 				}
-				payloadFields := catalogFlattenPayloadFields(catalogMap(catalogMap(bundle.AllEvents[eventType])["payload"]))
+				payloadFields := catalogEventPayloadFields(catalogMap(bundle.AllEvents[eventType]))
 				if dataAccumulation := catalogMap(handler["data_accumulation"]); len(dataAccumulation) > 0 {
 					sourceEvent := catalogFirstNonEmptyString(catalogBootText(dataAccumulation["source_event"]), eventType)
-					sourceFields := catalogFlattenPayloadFields(catalogMap(catalogMap(bundle.AllEvents[sourceEvent])["payload"]))
+					sourceFields := catalogEventPayloadFields(catalogMap(bundle.AllEvents[sourceEvent]))
 					for _, rawWrite := range catalogAnySlice(dataAccumulation["writes"]) {
 						switch typed := rawWrite.(type) {
 						case string:
@@ -1665,6 +1665,27 @@ func catalogFlattenPayloadFields(payload map[string]any) map[string]struct{} {
 	}
 	walk("", payload)
 	return fields
+}
+
+func catalogEventPayloadFields(entry map[string]any) map[string]struct{} {
+	if len(entry) == 0 {
+		return map[string]struct{}{}
+	}
+	if payload := catalogMap(entry["payload"]); len(payload) > 0 {
+		return catalogFlattenPayloadFields(payload)
+	}
+	flat := map[string]any{}
+	for _, key := range catalogSortedKeys(entry) {
+		if key == "" || strings.HasPrefix(key, "_") {
+			continue
+		}
+		switch key {
+		case "description", "emitter", "emitter_type", "producer", "alternate_emitters", "consumer", "consumer_type", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "required":
+			continue
+		}
+		flat[key] = entry[key]
+	}
+	return catalogFlattenPayloadFields(flat)
 }
 
 func catalogSchemaLeaf(node map[string]any) bool {

--- a/internal/runtime/testdata/generic-swarm-bundle/entities.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/entities.yaml
@@ -1,0 +1,6 @@
+item:
+  item_id: string
+  status: string
+  priority: string
+  score: number
+  gates: GateState

--- a/internal/runtime/testdata/generic-swarm-bundle/package.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/package.yaml
@@ -18,7 +18,7 @@ entity_schema:
           type: number
           nullable: true
         - name: gates
-          type: object
+          type: GateState
           nullable: true
 flows:
   - id: intake

--- a/internal/runtime/testdata/generic-swarm-bundle/package.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/package.yaml
@@ -2,24 +2,6 @@ name: test-platform
 version: "1.0.0"
 platform_version: ">=1.0.0"
 description: Generic Swarm bundle for contract-driven runtime tests.
-entity_schema:
-  groups:
-    - name: item
-      fields:
-        - name: item_id
-          type: string
-          primary: true
-        - name: status
-          type: string
-          indexed: true
-        - name: priority
-          type: string
-        - name: score
-          type: number
-          nullable: true
-        - name: gates
-          type: GateState
-          nullable: true
 flows:
   - id: intake
     flow: intake

--- a/internal/runtime/testdata/generic-swarm-bundle/types.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/types.yaml
@@ -1,0 +1,3 @@
+types:
+  GateState:
+    open_gates: [text]

--- a/tests/tier1-primitives/test-advances-to-terminal/events.yaml
+++ b/tests/tier1-primitives/test-advances-to-terminal/events.yaml
@@ -1,6 +1,4 @@
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.finished:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-advances-to/events.yaml
+++ b/tests/tier1-primitives/test-advances-to/events.yaml
@@ -1,6 +1,4 @@
 task.started:
-  payload:
-    entity_id: string
+  entity_id: string
 task.progressed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-clear-gates/events.yaml
+++ b/tests/tier1-primitives/test-clear-gates/events.yaml
@@ -1,6 +1,4 @@
 gates.clear_requested:
-  payload:
-    entity_id: string
+  entity_id: string
 gates.cleared:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-compute-standalone/entities.yaml
+++ b/tests/tier1-primitives/test-compute-standalone/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  composite: numeric(5,2)

--- a/tests/tier1-primitives/test-compute-standalone/events.yaml
+++ b/tests/tier1-primitives/test-compute-standalone/events.yaml
@@ -1,7 +1,5 @@
 scores.ready:
-  payload:
-    entity_id: string
-    scores: array
+  entity_id: string
+  scores: array
 scores.computed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-compute-standalone/package.yaml
+++ b/tests/tier1-primitives/test-compute-standalone/package.yaml
@@ -1,8 +1,5 @@
 name: test-compute-standalone
 version: 1.0.0
 description: Compute as a standalone handler field with weighted_average operation.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    composite: numeric(5,2)

--- a/tests/tier1-primitives/test-data-accumulation-direct/entities.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-direct/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  name: text
+  score: integer

--- a/tests/tier1-primitives/test-data-accumulation-direct/events.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-direct/events.yaml
@@ -1,8 +1,6 @@
 item.received:
-  payload:
-    entity_id: string
-    name: string
-    score: integer
+  entity_id: string
+  name: string
+  score: integer
 item.stored:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-data-accumulation-direct/package.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-direct/package.yaml
@@ -1,9 +1,6 @@
 name: test-data-accumulation-direct
 version: 1.0.0
-description: data_accumulation writes payload fields directly to entity with matching field names.
-platform_version: ">=1.1.0"
+description: data_accumulation writes payload fields directly to entity with matching
+  field names.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    name: text
-    score: integer

--- a/tests/tier1-primitives/test-data-accumulation-literal/entities.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-literal/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  category: text

--- a/tests/tier1-primitives/test-data-accumulation-literal/events.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-literal/events.yaml
@@ -1,6 +1,4 @@
 item.received:
-  payload:
-    entity_id: string
+  entity_id: string
 item.categorized:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-data-accumulation-literal/package.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-literal/package.yaml
@@ -1,8 +1,5 @@
 name: test-data-accumulation-literal
 version: 1.0.0
 description: data_accumulation with value literal writes fixed value to entity field.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    category: text

--- a/tests/tier1-primitives/test-data-accumulation-mapped/entities.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-mapped/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  name: text

--- a/tests/tier1-primitives/test-data-accumulation-mapped/events.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-mapped/events.yaml
@@ -1,7 +1,5 @@
 item.received:
-  payload:
-    entity_id: string
-    src_name: string
+  entity_id: string
+  src_name: string
 item.stored:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-data-accumulation-mapped/package.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-mapped/package.yaml
@@ -1,8 +1,5 @@
 name: test-data-accumulation-mapped
 version: 1.0.0
 description: data_accumulation with source_field to target_field mapping.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    name: text

--- a/tests/tier1-primitives/test-emits-multiple/events.yaml
+++ b/tests/tier1-primitives/test-emits-multiple/events.yaml
@@ -1,9 +1,6 @@
 item.received:
-  payload:
-    entity_id: string
+  entity_id: string
 item.processed:
-  payload:
-    entity_id: string
+  entity_id: string
 item.logged:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-emits-payload-transform/events.yaml
+++ b/tests/tier1-primitives/test-emits-payload-transform/events.yaml
@@ -1,8 +1,6 @@
 item.received:
-  payload:
-    entity_id: string
-    raw_score: integer
+  entity_id: string
+  raw_score: integer
 item.scored:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer

--- a/tests/tier1-primitives/test-emits-single/events.yaml
+++ b/tests/tier1-primitives/test-emits-single/events.yaml
@@ -1,6 +1,4 @@
 item.received:
-  payload:
-    entity_id: string
+  entity_id: string
 item.processed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-from-filter/events.yaml
+++ b/tests/tier1-primitives/test-from-filter/events.yaml
@@ -1,6 +1,4 @@
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.acknowledged:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-compound-condition/events.yaml
+++ b/tests/tier1-primitives/test-guard-compound-condition/events.yaml
@@ -1,8 +1,6 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
-    override: boolean
+  entity_id: string
+  score: integer
+  override: boolean
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-discard/events.yaml
+++ b/tests/tier1-primitives/test-guard-discard/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-entity-ref/events.yaml
+++ b/tests/tier1-primitives/test-guard-entity-ref/events.yaml
@@ -1,6 +1,4 @@
 check.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-escalate/events.yaml
+++ b/tests/tier1-primitives/test-guard-escalate/events.yaml
@@ -1,10 +1,7 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string
 check.escalated:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-kill/events.yaml
+++ b/tests/tier1-primitives/test-guard-kill/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-multi-fail/events.yaml
+++ b/tests/tier1-primitives/test-guard-multi-fail/events.yaml
@@ -1,8 +1,6 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
-    level: integer
+  entity_id: string
+  score: integer
+  level: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-multi/events.yaml
+++ b/tests/tier1-primitives/test-guard-multi/events.yaml
@@ -1,8 +1,6 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
-    level: integer
+  entity_id: string
+  score: integer
+  level: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-pass/events.yaml
+++ b/tests/tier1-primitives/test-guard-pass/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-policy-ref/events.yaml
+++ b/tests/tier1-primitives/test-guard-policy-ref/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    region: string
+  entity_id: string
+  region: string
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-guard-reject/events.yaml
+++ b/tests/tier1-primitives/test-guard-reject/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-on-complete-first-match/events.yaml
+++ b/tests/tier1-primitives/test-on-complete-first-match/events.yaml
@@ -1,10 +1,7 @@
 item.evaluated:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 item.passed:
-  payload:
-    entity_id: string
+  entity_id: string
 item.failed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-on-complete-second-match/events.yaml
+++ b/tests/tier1-primitives/test-on-complete-second-match/events.yaml
@@ -1,10 +1,7 @@
 item.evaluated:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 item.passed:
-  payload:
-    entity_id: string
+  entity_id: string
 item.failed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-on-complete-with-state/entities.yaml
+++ b/tests/tier1-primitives/test-on-complete-with-state/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  priority: text

--- a/tests/tier1-primitives/test-on-complete-with-state/events.yaml
+++ b/tests/tier1-primitives/test-on-complete-with-state/events.yaml
@@ -1,6 +1,4 @@
 item.evaluated:
-  payload:
-    entity_id: string
+  entity_id: string
 item.expedited:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-on-complete-with-state/package.yaml
+++ b/tests/tier1-primitives/test-on-complete-with-state/package.yaml
@@ -1,8 +1,5 @@
 name: test-on-complete-with-state
 version: 1.0.0
 description: on_complete condition reads entity state to determine branch.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    priority: text

--- a/tests/tier1-primitives/test-payload-transform-multi-source/entities.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  name: text

--- a/tests/tier1-primitives/test-payload-transform-multi-source/events.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/events.yaml
@@ -1,9 +1,7 @@
 export.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 item.exported:
-  payload:
-    entity_id: string
-    id: string
-    name: string
-    status: string
+  entity_id: string
+  id: string
+  name: string
+  status: string

--- a/tests/tier1-primitives/test-payload-transform-multi-source/package.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/package.yaml
@@ -1,8 +1,6 @@
 name: test-payload-transform-multi-source
 version: 1.0.0
-description: emit.fields constructs output from multiple sources including entity and payload.
-platform_version: ">=1.1.0"
+description: emit.fields constructs output from multiple sources including entity
+  and payload.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    name: text

--- a/tests/tier1-primitives/test-record-evidence/events.yaml
+++ b/tests/tier1-primitives/test-record-evidence/events.yaml
@@ -1,8 +1,6 @@
 evidence.submitted:
-  payload:
-    entity_id: string
-    finding: string
-    severity: string
+  entity_id: string
+  finding: string
+  severity: string
 evidence.recorded:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-rules-advances-to/events.yaml
+++ b/tests/tier1-primitives/test-rules-advances-to/events.yaml
@@ -1,7 +1,5 @@
 item.reviewed:
-  payload:
-    entity_id: string
-    decision: string
+  entity_id: string
+  decision: string
 item.approved:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-rules-data-accumulation/entities.yaml
+++ b/tests/tier1-primitives/test-rules-data-accumulation/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  value: integer

--- a/tests/tier1-primitives/test-rules-data-accumulation/events.yaml
+++ b/tests/tier1-primitives/test-rules-data-accumulation/events.yaml
@@ -1,8 +1,6 @@
 item.received:
-  payload:
-    entity_id: string
-    kind: string
-    value: integer
+  entity_id: string
+  kind: string
+  value: integer
 item.accumulated:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-rules-data-accumulation/package.yaml
+++ b/tests/tier1-primitives/test-rules-data-accumulation/package.yaml
@@ -1,8 +1,5 @@
 name: test-rules-data-accumulation
 version: 1.0.0
 description: Rules branch with data_accumulation writes payload value to entity field.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    value: integer

--- a/tests/tier1-primitives/test-rules-else/events.yaml
+++ b/tests/tier1-primitives/test-rules-else/events.yaml
@@ -1,10 +1,7 @@
 item.received:
-  payload:
-    entity_id: string
-    kind: string
+  entity_id: string
+  kind: string
 routed.a:
-  payload:
-    entity_id: string
+  entity_id: string
 routed.unknown:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-rules-match/events.yaml
+++ b/tests/tier1-primitives/test-rules-match/events.yaml
@@ -1,10 +1,7 @@
 item.received:
-  payload:
-    entity_id: string
-    kind: string
+  entity_id: string
+  kind: string
 routed.a:
-  payload:
-    entity_id: string
+  entity_id: string
 routed.b:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-rules-no-match/events.yaml
+++ b/tests/tier1-primitives/test-rules-no-match/events.yaml
@@ -1,10 +1,7 @@
 item.received:
-  payload:
-    entity_id: string
-    kind: string
+  entity_id: string
+  kind: string
 routed.a:
-  payload:
-    entity_id: string
+  entity_id: string
 routed.b:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier1-primitives/test-sets-gate/events.yaml
+++ b/tests/tier1-primitives/test-sets-gate/events.yaml
@@ -1,6 +1,4 @@
 gate.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 gate.set:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-capacity-query/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-capacity-query/events.yaml
@@ -1,6 +1,4 @@
 slot.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 slot.granted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-counter-escalate/entities.yaml
+++ b/tests/tier10-policy-patterns/test-policy-counter-escalate/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  attempt_count: integer

--- a/tests/tier10-policy-patterns/test-policy-counter-escalate/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-counter-escalate/events.yaml
@@ -1,9 +1,6 @@
 attempt.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 attempt.processed:
-  payload:
-    entity_id: string
+  entity_id: string
 attempt.limit_hit:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-counter-escalate/package.yaml
+++ b/tests/tier10-policy-patterns/test-policy-counter-escalate/package.yaml
@@ -1,10 +1,8 @@
 name: test-policy-counter-escalate
 version: 1.0.0
-description: >
-  Policy: guard checks entity counter against policy limit.
-  Counter at limit triggers escalation event.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    attempt_count: integer
+description: 'Policy: guard checks entity counter against policy limit. Counter at
+  limit triggers escalation event.
+
+  '
+platform_version: '>=1.1.0'
 flows: []

--- a/tests/tier10-policy-patterns/test-policy-hard-gate-override/entities.yaml
+++ b/tests/tier10-policy-patterns/test-policy-hard-gate-override/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  main_score: number
+  secondary_score: number

--- a/tests/tier10-policy-patterns/test-policy-hard-gate-override/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-hard-gate-override/events.yaml
@@ -1,14 +1,10 @@
 score.final:
-  payload:
-    entity_id: string
-    main_score: number
-    secondary_score: number
+  entity_id: string
+  main_score: number
+  secondary_score: number
 result.promoted:
-  payload:
-    entity_id: string
+  entity_id: string
 result.demoted:
-  payload:
-    entity_id: string
+  entity_id: string
 result.rejected:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-hard-gate-override/package.yaml
+++ b/tests/tier10-policy-patterns/test-policy-hard-gate-override/package.yaml
@@ -1,11 +1,6 @@
 name: test-policy-hard-gate-override
 version: 1.0.0
-description: >
-  Policy: main score passes policy.high_mark but a secondary field
-  fails policy.hard_floor — hard gate overrides the main threshold.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    main_score: number
-    secondary_score: number
+description: "Policy: main score passes policy.high_mark but a secondary field fails\
+  \ policy.hard_floor \u2014 hard gate overrides the main threshold.\n"
+platform_version: '>=1.1.0'
 flows: []

--- a/tests/tier10-policy-patterns/test-policy-multi-guard-partial/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-multi-guard-partial/events.yaml
@@ -1,8 +1,6 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: number
-    confidence: number
+  entity_id: string
+  score: number
+  confidence: number
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-threshold-three-way/entities.yaml
+++ b/tests/tier10-policy-patterns/test-policy-threshold-three-way/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  score: number

--- a/tests/tier10-policy-patterns/test-policy-threshold-three-way/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-threshold-three-way/events.yaml
@@ -1,13 +1,9 @@
 eval.submitted:
-  payload:
-    entity_id: string
-    score: number
+  entity_id: string
+  score: number
 eval.tier_a:
-  payload:
-    entity_id: string
+  entity_id: string
 eval.tier_b:
-  payload:
-    entity_id: string
+  entity_id: string
 eval.tier_c:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier10-policy-patterns/test-policy-threshold-three-way/package.yaml
+++ b/tests/tier10-policy-patterns/test-policy-threshold-three-way/package.yaml
@@ -1,10 +1,6 @@
 name: test-policy-threshold-three-way
 version: 1.0.0
-description: >
-  Policy: on_complete branches reference policy thresholds for 3-way
-  routing — high/mid/low based on policy.high_mark and policy.low_mark.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    score: number
+description: "Policy: on_complete branches reference policy thresholds for 3-way routing\
+  \ \u2014 high/mid/low based on policy.high_mark and policy.low_mark.\n"
+platform_version: '>=1.1.0'
 flows: []

--- a/tests/tier10-policy-patterns/test-policy-timeout-elapsed/events.yaml
+++ b/tests/tier10-policy-patterns/test-policy-timeout-elapsed/events.yaml
@@ -1,13 +1,9 @@
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.check:
-  payload:
-    entity_id: string
-    elapsed_hours: number
+  entity_id: string
+  elapsed_hours: number
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.timed_out:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/events.yaml
@@ -1,12 +1,8 @@
 work.start:
-  payload:
-    entity_id: string
+  entity_id: string
 work.finished:
-  payload:
-    entity_id: string
+  entity_id: string
 child/task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 child/task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-loads/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-loads/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-loads/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-loads/flows/child/events.yaml
@@ -1,6 +1,4 @@
 child.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-local-events/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-local-events/events.yaml
@@ -1,6 +1,4 @@
 parent.trigger:
-  payload:
-    entity_id: string
+  entity_id: string
 parent.result:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-local-events/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-local-events/flows/child/events.yaml
@@ -1,10 +1,7 @@
 child.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child.internal:
-  payload:
-    entity_id: string
-    step: string
+  entity_id: string
+  step: string
 child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/events.yaml
@@ -1,13 +1,9 @@
 job.submit:
-  payload:
-    entity_id: string
+  entity_id: string
 work.requested:
-  payload:
-    entity_id: string
-    task_type: string
+  entity_id: string
+  task_type: string
 job.done:
-  payload:
-    entity_id: string
+  entity_id: string
 child/work.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/events.yaml
@@ -1,7 +1,5 @@
 work.requested:
-  payload:
-    entity_id: string
-    task_type: string
+  entity_id: string
+  task_type: string
 work.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-policy-inherit/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-policy-inherit/events.yaml
@@ -1,7 +1,5 @@
 review.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 review.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-policy-inherit/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-policy-inherit/flows/child/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-sibling-isolation/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-sibling-isolation/events.yaml
@@ -1,21 +1,14 @@
 run.start:
-  payload:
-    entity_id: string
+  entity_id: string
 run.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/alpha.start:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/internal.done:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/alpha.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/beta.start:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/beta.complete:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-sibling-isolation/flows/flow-a/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-sibling-isolation/flows/flow-a/events.yaml
@@ -1,9 +1,6 @@
 alpha.start:
-  payload:
-    entity_id: string
+  entity_id: string
 internal.done:
-  payload:
-    entity_id: string
+  entity_id: string
 alpha.complete:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-sibling-isolation/flows/flow-b/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-sibling-isolation/flows/flow-b/events.yaml
@@ -1,6 +1,4 @@
 beta.start:
-  payload:
-    entity_id: string
+  entity_id: string
 beta.complete:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-tool-inherit/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-tool-inherit/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-child-flow-tool-inherit/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-tool-inherit/flows/child/events.yaml
@@ -1,6 +1,4 @@
 child.task:
-  payload:
-    entity_id: string
+  entity_id: string
 child.result:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-wiring/entities.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  task_config: json
+  result: json

--- a/tests/tier11-flow-composition/test-data-pin-wiring/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/events.yaml
@@ -1,14 +1,10 @@
 job.start:
-  payload:
-    entity_id: string
-    mode: string
-    threshold: string
+  entity_id: string
+  mode: string
+  threshold: string
 job.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 processor/process.run:
-  payload:
-    entity_id: string
+  entity_id: string
 processor/process.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/events.yaml
@@ -1,6 +1,4 @@
 process.run:
-  payload:
-    entity_id: string
+  entity_id: string
 process.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/package.yaml
@@ -1,9 +1,5 @@
 name: processor
 version: 1.0.0
 description: Child flow that reads task_config and writes result.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    task_config: json
-    result: json

--- a/tests/tier11-flow-composition/test-data-pin-wiring/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/package.yaml
@@ -1,12 +1,8 @@
 name: test-data-pin-wiring
 version: 1.0.0
 description: Parent writes data pin, child reads it and writes result back.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows:
 - id: processor
   flow: processor
   mode: static
-entity_schema:
-  core:
-    task_config: json
-    result: json

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/entities.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  shared_field: text

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/events.yaml
@@ -1,18 +1,12 @@
 start:
-  payload:
-    entity_id: string
+  entity_id: string
 complete:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/a.start:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/a.done:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/b.start:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/b.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/events.yaml
@@ -1,6 +1,4 @@
 a.start:
-  payload:
-    entity_id: string
+  entity_id: string
 a.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/package.yaml
@@ -1,8 +1,5 @@
 name: flow-a
 version: 1.0.0
 description: Sibling flow A that writes shared_field.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    shared_field: text

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/events.yaml
@@ -1,6 +1,4 @@
 b.start:
-  payload:
-    entity_id: string
+  entity_id: string
 b.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/package.yaml
@@ -1,8 +1,5 @@
 name: flow-b
 version: 1.0.0
 description: Sibling flow B that also writes shared_field, causing conflict.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    shared_field: text

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/package.yaml
@@ -1,7 +1,8 @@
 name: test-data-pin-write-conflict
 version: 1.0.0
-description: Two sibling child flows declare the same writes data pin. Boot should fail.
-platform_version: ">=1.1.0"
+description: Two sibling child flows declare the same writes data pin. Boot should
+  fail.
+platform_version: '>=1.1.0'
 flows:
 - id: flow-a
   flow: flow-a
@@ -9,6 +10,3 @@ flows:
 - id: flow-b
   flow: flow-b
   mode: static
-entity_schema:
-  core:
-    shared_field: text

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/events.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/events.yaml
@@ -1,16 +1,11 @@
 spawn.requested:
-  payload:
-    entity_id: string
-    worker_id: string
+  entity_id: string
+  worker_id: string
 spawn.confirmed:
-  payload:
-    entity_id: string
+  entity_id: string
 worker/worker.ready:
-  payload:
-    entity_id: string
+  entity_id: string
 worker/work.assign:
-  payload:
-    entity_id: string
+  entity_id: string
 worker/work.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/events.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/events.yaml
@@ -1,9 +1,6 @@
 worker.ready:
-  payload:
-    entity_id: string
+  entity_id: string
 work.assign:
-  payload:
-    entity_id: string
+  entity_id: string
 work.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/events.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/events.yaml
@@ -1,12 +1,8 @@
 validate.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 validate.passed:
-  payload:
-    entity_id: string
+  entity_id: string
 child/validate.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child/validation.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/events.yaml
@@ -1,6 +1,4 @@
 validate.start:
-  payload:
-    entity_id: string
+  entity_id: string
 validation.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/events.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/events.yaml
@@ -1,7 +1,5 @@
 root.check:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 root.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/events.yaml
@@ -1,7 +1,5 @@
 child.check:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/flows/grandchild/events.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/flows/grandchild/events.yaml
@@ -1,7 +1,5 @@
 grandchild.check:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 grandchild.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
@@ -1,12 +1,8 @@
 pipeline.start:
-  payload:
-    entity_id: string
+  entity_id: string
 pipeline.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 child/step.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 child/grandchild/micro.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
@@ -1,6 +1,4 @@
 step.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 grandchild/micro.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/events.yaml
@@ -1,6 +1,4 @@
 micro.start:
-  payload:
-    entity_id: string
+  entity_id: string
 micro.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-required-agents-child/events.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/events.yaml
@@ -1,12 +1,8 @@
 request.start:
-  payload:
-    entity_id: string
+  entity_id: string
 request.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 analyzer-flow/analysis.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 analyzer-flow/analysis.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/events.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/events.yaml
@@ -1,6 +1,4 @@
 analysis.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 analysis.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/events.yaml
+++ b/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/events.yaml
@@ -1,24 +1,16 @@
 start.all:
-  payload:
-    entity_id: string
+  entity_id: string
 work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 all.done:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/internal.step2:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-a/alpha.done:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/beta.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/flows/flow-a/events.yaml
+++ b/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/flows/flow-a/events.yaml
@@ -1,9 +1,6 @@
 work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 internal.step2:
-  payload:
-    entity_id: string
+  entity_id: string
 alpha.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/flows/flow-b/events.yaml
+++ b/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/flows/flow-b/events.yaml
@@ -1,6 +1,4 @@
 work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 beta.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/events.yaml
+++ b/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/events.yaml
@@ -1,16 +1,11 @@
 item.discovered:
-  payload:
-    entity_id: string
-    name: string
+  entity_id: string
+  name: string
 score.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 item.dispatched:
-  payload:
-    entity_id: string
+  entity_id: string
 scoring/score.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 scoring/score.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/flows/scoring/events.yaml
+++ b/tests/tier11-flow-composition/test-subject-id-cross-flow-inherit/flows/scoring/events.yaml
@@ -1,6 +1,4 @@
 score.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 score.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-subject-id-first-flow-seeds/events.yaml
+++ b/tests/tier11-flow-composition/test-subject-id-first-flow-seeds/events.yaml
@@ -1,15 +1,10 @@
 job.created:
-  payload:
-    entity_id: string
+  entity_id: string
 work.assigned:
-  payload:
-    entity_id: string
+  entity_id: string
 job.done:
-  payload:
-    entity_id: string
+  entity_id: string
 intake/work.assigned:
-  payload:
-    entity_id: string
+  entity_id: string
 intake/item.processed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-subject-id-first-flow-seeds/flows/intake/events.yaml
+++ b/tests/tier11-flow-composition/test-subject-id-first-flow-seeds/flows/intake/events.yaml
@@ -1,6 +1,4 @@
 work.assigned:
-  payload:
-    entity_id: string
+  entity_id: string
 item.processed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-tool-override/events.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/events.yaml
@@ -1,12 +1,8 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string
 child/child.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child/child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/events.yaml
@@ -1,6 +1,4 @@
 child.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/events.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/events.yaml
@@ -1,18 +1,12 @@
 pipeline.start:
-  payload:
-    entity_id: string
+  entity_id: string
 pipeline.complete:
-  payload:
-    entity_id: string
+  entity_id: string
 child/work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 child/work.finished:
-  payload:
-    entity_id: string
+  entity_id: string
 child/grandchild/task.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child/grandchild/task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/events.yaml
@@ -1,12 +1,8 @@
 work.begin:
-  payload:
-    entity_id: string
+  entity_id: string
 work.finished:
-  payload:
-    entity_id: string
+  entity_id: string
 grandchild/task.start:
-  payload:
-    entity_id: string
+  entity_id: string
 grandchild/task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/events.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/events.yaml
@@ -1,6 +1,4 @@
 task.start:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-all/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-all/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-all/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-all/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-all
 version: 1.0.0
 description: Accumulate 3 items, fire on_complete when all arrive.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/package.yaml
@@ -1,9 +1,6 @@
 name: test-accumulate-crash-recovery
 version: 1.0.0
-description: Accumulate persists state across sequential item arrivals, proving crash recovery.
-platform_version: ">=1.1.0"
+description: Accumulate persists state across sequential item arrivals, proving crash
+  recovery.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  item_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     item_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-expected-from-entity
 version: 1.0.0
 description: Expected count read from entity field item_count. Send 2 items to complete.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    item_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-from-filter/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-from-filter/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/events.yaml
@@ -1,7 +1,5 @@
 score.received:
-  payload:
-    entity_id: string
-    score: float
+  entity_id: string
+  score: float
 scores.collected:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-from-filter/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/package.yaml
@@ -1,9 +1,6 @@
 name: test-accumulate-from-filter
 version: 1.0.0
-description: Accumulate with from sender path filter only accepts items from matching sender.
-platform_version: ">=1.1.0"
+description: Accumulate with from sender path filter only accepts items from matching
+  sender.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-from-filter/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-idempotent/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-idempotent/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-idempotent/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-idempotent
 version: 1.0.0
 description: Duplicate item_id is deduplicated; only unique items count.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-idempotent/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  expected_count: integer

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/events.yaml
@@ -1,10 +1,7 @@
 score.received:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 batch.scored:
-  payload:
-    entity_id: string
+  entity_id: string
 scores.verified:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/package.yaml
@@ -1,11 +1,9 @@
 name: test-accumulate-on-complete-rollback
 version: 1.0.0
-description: >
-  Accumulator completion is atomic with on_complete. When the final item
-  completes accumulation, advances_to and emits from on_complete must all
-  commit together. A second handler verifies the state transition persisted.
-platform_version: ">=1.1.0"
+description: 'Accumulator completion is atomic with on_complete. When the final item
+  completes accumulation, advances_to and emits from on_complete must all commit together.
+  A second handler verifies the state transition persisted.
+
+  '
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/events.yaml
@@ -1,13 +1,9 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 accumulate.timeout:
-  payload:
-    entity_id: string
+  entity_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string
 collection.partial:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/package.yaml
@@ -1,9 +1,6 @@
 name: test-accumulate-on-timeout
 version: 1.0.0
-description: Accumulate with on_timeout branch fires when timer expires before all items arrive.
-platform_version: ">=1.1.0"
+description: Accumulate with on_timeout branch fires when timer expires before all
+  items arrive.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-partial/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-partial/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-partial/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-partial
 version: 1.0.0
 description: Expect 3 items but send only 2. Accumulate stays incomplete.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-partial/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-threshold/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-threshold/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/events.yaml
@@ -1,7 +1,5 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-threshold/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-threshold
 version: 1.0.0
 description: Accumulate with threshold completion fires after 2 of 3 items.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-threshold/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-timeout/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/entities.yaml
@@ -1,0 +1,4 @@
+core:
+  expected_count: integer
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-timeout/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/events.yaml
@@ -1,10 +1,7 @@
 item.arrived:
-  payload:
-    entity_id: string
-    item_id: string
+  entity_id: string
+  item_id: string
 accumulate.timeout:
-  payload:
-    entity_id: string
+  entity_id: string
 collection.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier2-accumulation/test-accumulate-timeout/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/package.yaml
@@ -1,9 +1,5 @@
 name: test-accumulate-timeout
 version: 1.0.0
 description: Accumulate with timeout completion fires handler with partial results.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-timeout/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/package.yaml
@@ -6,4 +6,4 @@ flows: []
 entity_schema:
   core:
     expected_count: integer
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-with-compute/entities.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/entities.yaml
@@ -1,0 +1,5 @@
+core:
+  expected_count: integer
+  composite: numeric(5,2)
+  received_items:
+  - text

--- a/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
@@ -1,9 +1,7 @@
 score.received:
-  payload:
-    entity_id: string
-    dimension: string
-    score: float
+  entity_id: string
+  dimension: string
+  score: float
 scores.aggregated:
-  payload:
-    entity_id: string
-    composite: float
+  entity_id: string
+  composite: float

--- a/tests/tier2-accumulation/test-accumulate-with-compute/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/package.yaml
@@ -1,10 +1,5 @@
 name: test-accumulate-with-compute
 version: 1.0.0
 description: Accumulate all items then compute weighted_average via on_complete.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer
-    composite: numeric(5,2)
-    received_items: [text]

--- a/tests/tier2-accumulation/test-accumulate-with-compute/package.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/package.yaml
@@ -7,4 +7,4 @@ entity_schema:
   core:
     expected_count: integer
     composite: numeric(5,2)
-    received_items: jsonb
+    received_items: [text]

--- a/tests/tier3-list-processing/test-fan-out-basic/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/events.yaml
@@ -5,4 +5,4 @@ batch.submitted:
 item.assigned:
   payload:
     entity_id: string
-    item: object
+    item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-basic/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/events.yaml
@@ -1,8 +1,6 @@
 batch.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 item.assigned:
-  payload:
-    entity_id: string
-    item: FanOutItem
+  entity_id: string
+  item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-basic/types.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/types.yaml
@@ -1,0 +1,3 @@
+types:
+  FanOutItem:
+    id: text

--- a/tests/tier3-list-processing/test-fan-out-count/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/events.yaml
@@ -5,4 +5,4 @@ batch.received:
 task.dispatched:
   payload:
     entity_id: string
-    item: object
+    item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-count/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/events.yaml
@@ -1,8 +1,6 @@
 batch.received:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 task.dispatched:
-  payload:
-    entity_id: string
-    item: FanOutItem
+  entity_id: string
+  item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-count/types.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/types.yaml
@@ -1,0 +1,3 @@
+types:
+  FanOutItem:
+    id: text

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
@@ -1,12 +1,9 @@
 batch.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 routed.a:
-  payload:
-    entity_id: string
-    item: FanOutItem
+  entity_id: string
+  item: FanOutItem
 routed.b:
-  payload:
-    entity_id: string
-    item: FanOutItem
+  entity_id: string
+  item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
@@ -5,8 +5,8 @@ batch.submitted:
 routed.a:
   payload:
     entity_id: string
-    item: object
+    item: FanOutItem
 routed.b:
   payload:
     entity_id: string
-    item: object
+    item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/types.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/types.yaml
@@ -1,0 +1,4 @@
+types:
+  FanOutItem:
+    id: text
+    kind: text

--- a/tests/tier3-list-processing/test-fan-out-empty/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/events.yaml
@@ -5,4 +5,4 @@ batch.submitted:
 item.assigned:
   payload:
     entity_id: string
-    item: object
+    item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-empty/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/events.yaml
@@ -1,8 +1,6 @@
 batch.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 item.assigned:
-  payload:
-    entity_id: string
-    item: FanOutItem
+  entity_id: string
+  item: FanOutItem

--- a/tests/tier3-list-processing/test-fan-out-empty/types.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/types.yaml
@@ -1,0 +1,3 @@
+types:
+  FanOutItem:
+    id: text

--- a/tests/tier3-list-processing/test-filter-basic/entities.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  filtered:
+  - FilteredItem

--- a/tests/tier3-list-processing/test-filter-basic/events.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/events.yaml
@@ -1,7 +1,5 @@
 items.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 items.filtered:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-filter-basic/package.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/package.yaml
@@ -5,4 +5,4 @@ platform_version: ">=1.1.0"
 flows: []
 entity_schema:
   core:
-    filtered: jsonb
+    filtered: [FilteredItem]

--- a/tests/tier3-list-processing/test-filter-basic/package.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/package.yaml
@@ -1,8 +1,5 @@
 name: test-filter-basic
 version: 1.0.0
 description: filter keeps only items where score > 50.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    filtered: [FilteredItem]

--- a/tests/tier3-list-processing/test-filter-basic/types.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/types.yaml
@@ -1,0 +1,4 @@
+types:
+  FilteredItem:
+    id: text
+    score: integer

--- a/tests/tier3-list-processing/test-filter-empty/entities.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  filtered:
+  - FilteredItem

--- a/tests/tier3-list-processing/test-filter-empty/events.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/events.yaml
@@ -1,7 +1,5 @@
 items.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 items.filtered:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-filter-empty/package.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/package.yaml
@@ -5,4 +5,4 @@ platform_version: ">=1.1.0"
 flows: []
 entity_schema:
   core:
-    filtered: jsonb
+    filtered: [FilteredItem]

--- a/tests/tier3-list-processing/test-filter-empty/package.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/package.yaml
@@ -1,8 +1,5 @@
 name: test-filter-empty
 version: 1.0.0
 description: filter where no items match returns an empty list.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    filtered: [FilteredItem]

--- a/tests/tier3-list-processing/test-filter-empty/types.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/types.yaml
@@ -1,0 +1,4 @@
+types:
+  FilteredItem:
+    id: text
+    score: integer

--- a/tests/tier3-list-processing/test-group-by-standalone/entities.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  grouped:
+  - GroupBucket

--- a/tests/tier3-list-processing/test-group-by-standalone/events.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/events.yaml
@@ -1,7 +1,5 @@
 items.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 items.grouped:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-group-by-standalone/package.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/package.yaml
@@ -1,8 +1,5 @@
 name: test-group-by-standalone
 version: 1.0.0
 description: Standalone group_by groups items by key into entity field.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    grouped: [GroupBucket]

--- a/tests/tier3-list-processing/test-group-by-standalone/package.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/package.yaml
@@ -5,4 +5,4 @@ platform_version: ">=1.1.0"
 flows: []
 entity_schema:
   core:
-    grouped: jsonb
+    grouped: [GroupBucket]

--- a/tests/tier3-list-processing/test-group-by-standalone/types.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/types.yaml
@@ -1,0 +1,4 @@
+types:
+  GroupBucket:
+    category: text
+    count: integer

--- a/tests/tier3-list-processing/test-reduce-count/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-count/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  active_count: integer

--- a/tests/tier3-list-processing/test-reduce-count/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-count/events.yaml
@@ -1,7 +1,5 @@
 items.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 items.counted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-count/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-count/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-count
 version: 1.0.0
 description: count operation counts items matching a condition.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    active_count: integer

--- a/tests/tier3-list-processing/test-reduce-max/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-max/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  maximum: integer

--- a/tests/tier3-list-processing/test-reduce-max/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-max/events.yaml
@@ -1,7 +1,5 @@
 values.submitted:
-  payload:
-    entity_id: string
-    values: array
+  entity_id: string
+  values: array
 values.reduced:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-max/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-max/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-max
 version: 1.0.0
 description: reduce with max operation finds the maximum value.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    maximum: integer

--- a/tests/tier3-list-processing/test-reduce-min/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-min/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  minimum: integer

--- a/tests/tier3-list-processing/test-reduce-min/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-min/events.yaml
@@ -1,7 +1,5 @@
 values.submitted:
-  payload:
-    entity_id: string
-    values: array
+  entity_id: string
+  values: array
 values.reduced:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-min/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-min/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-min
 version: 1.0.0
 description: reduce with min operation finds the minimum value.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    minimum: integer

--- a/tests/tier3-list-processing/test-reduce-operation-count/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-operation-count/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  item_count: integer

--- a/tests/tier3-list-processing/test-reduce-operation-count/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-operation-count/events.yaml
@@ -1,7 +1,5 @@
 batch.submitted:
-  payload:
-    entity_id: string
-    items: array
+  entity_id: string
+  items: array
 batch.counted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-operation-count/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-operation-count/package.yaml
@@ -1,8 +1,6 @@
 name: test-reduce-operation-count
 version: 1.0.0
-description: Reduce with operation count counts all items in list without condition filter.
-platform_version: ">=1.1.0"
+description: Reduce with operation count counts all items in list without condition
+  filter.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    item_count: integer

--- a/tests/tier3-list-processing/test-reduce-pick-or-average/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-pick-or-average/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  result: numeric(5,2)

--- a/tests/tier3-list-processing/test-reduce-pick-or-average/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-pick-or-average/events.yaml
@@ -1,6 +1,4 @@
 scores.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 scores.resolved:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-pick-or-average/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-pick-or-average/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-pick-or-average
 version: 1.0.0
 description: reduce with pick_or_average picks higher score when spread exceeds threshold.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    result: numeric(5,2)

--- a/tests/tier3-list-processing/test-reduce-sum/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-sum/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  total: integer

--- a/tests/tier3-list-processing/test-reduce-sum/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-sum/events.yaml
@@ -1,6 +1,4 @@
 values.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 values.totaled:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-sum/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-sum/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-sum
 version: 1.0.0
 description: reduce with sum operation totals numeric values.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    total: integer

--- a/tests/tier3-list-processing/test-reduce-weighted-average/entities.yaml
+++ b/tests/tier3-list-processing/test-reduce-weighted-average/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  composite: numeric(5,2)

--- a/tests/tier3-list-processing/test-reduce-weighted-average/events.yaml
+++ b/tests/tier3-list-processing/test-reduce-weighted-average/events.yaml
@@ -1,6 +1,4 @@
 scores.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 scores.aggregated:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier3-list-processing/test-reduce-weighted-average/package.yaml
+++ b/tests/tier3-list-processing/test-reduce-weighted-average/package.yaml
@@ -1,8 +1,5 @@
 name: test-reduce-weighted-average
 version: 1.0.0
 description: reduce with weighted_average computes weighted average of scored items.
-platform_version: ">=1.1.0"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    composite: numeric(5,2)

--- a/tests/tier4-cross-entity/test-clear-multiple-targets/events.yaml
+++ b/tests/tier4-cross-entity/test-clear-multiple-targets/events.yaml
@@ -1,6 +1,4 @@
 state.reset_requested:
-  payload:
-    entity_id: string
+  entity_id: string
 state.reset_completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier4-cross-entity/test-clear-state/events.yaml
+++ b/tests/tier4-cross-entity/test-clear-state/events.yaml
@@ -1,6 +1,4 @@
 state.clear_requested:
-  payload:
-    entity_id: string
+  entity_id: string
 state.cleared:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier4-cross-entity/test-create-entity/events.yaml
+++ b/tests/tier4-cross-entity/test-create-entity/events.yaml
@@ -1,7 +1,5 @@
 entity.create_requested:
-  payload:
-    entity_id: string
-    child_id: string
+  entity_id: string
+  child_id: string
 entity.created:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier4-cross-entity/test-create-entity/flows/child-flow/events.yaml
+++ b/tests/tier4-cross-entity/test-create-entity/flows/child-flow/events.yaml
@@ -1,6 +1,4 @@
 child.start:
-  payload:
-    entity_id: string
+  entity_id: string
 child.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier4-cross-entity/test-query-filter/events.yaml
+++ b/tests/tier4-cross-entity/test-query-filter/events.yaml
@@ -1,7 +1,6 @@
 filter.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 filter.completed:
-  payload:
-    entity_id: string
-    results: [FilterResult]
+  entity_id: string
+  results:
+  - FilterResult

--- a/tests/tier4-cross-entity/test-query-filter/events.yaml
+++ b/tests/tier4-cross-entity/test-query-filter/events.yaml
@@ -4,4 +4,4 @@ filter.requested:
 filter.completed:
   payload:
     entity_id: string
-    results: object
+    results: [FilterResult]

--- a/tests/tier4-cross-entity/test-query-filter/types.yaml
+++ b/tests/tier4-cross-entity/test-query-filter/types.yaml
@@ -1,0 +1,3 @@
+types:
+  FilterResult:
+    entity_id: text

--- a/tests/tier4-cross-entity/test-query-group-by/events.yaml
+++ b/tests/tier4-cross-entity/test-query-group-by/events.yaml
@@ -1,7 +1,6 @@
 digest.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 digest.compiled:
-  payload:
-    entity_id: string
-    groups: [GroupedDigest]
+  entity_id: string
+  groups:
+  - GroupedDigest

--- a/tests/tier4-cross-entity/test-query-group-by/events.yaml
+++ b/tests/tier4-cross-entity/test-query-group-by/events.yaml
@@ -4,4 +4,4 @@ digest.requested:
 digest.compiled:
   payload:
     entity_id: string
-    groups: object
+    groups: [GroupedDigest]

--- a/tests/tier4-cross-entity/test-query-group-by/types.yaml
+++ b/tests/tier4-cross-entity/test-query-group-by/types.yaml
@@ -1,0 +1,4 @@
+types:
+  GroupedDigest:
+    key: text
+    count: integer

--- a/tests/tier5-flow-lifecycle/test-auto-emit-on-create/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-auto-emit-on-create/events.yaml
@@ -1,9 +1,6 @@
 flow.created:
-  payload:
-    entity_id: string
+  entity_id: string
 auto.started:
-  payload:
-    entity_id: string
+  entity_id: string
 auto.processed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/events.yaml
@@ -1,8 +1,6 @@
 flow.spawn_with_config:
-  payload:
-    entity_id: string
-    instance_id: string
-    config: WorkerConfig
+  entity_id: string
+  instance_id: string
+  config: WorkerConfig
 flow.spawned:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/events.yaml
@@ -2,7 +2,7 @@ flow.spawn_with_config:
   payload:
     entity_id: string
     instance_id: string
-    config: object
+    config: WorkerConfig
 flow.spawned:
   payload:
     entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/events.yaml
@@ -1,3 +1,2 @@
 worker.ready:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/types.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/types.yaml
@@ -1,0 +1,4 @@
+types:
+  WorkerConfig:
+    max_retries: integer
+    timeout_ms: integer

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/events.yaml
@@ -1,7 +1,5 @@
 flow.spawn_requested:
-  payload:
-    entity_id: string
-    instance_id: string
+  entity_id: string
+  instance_id: string
 flow.spawned:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/events.yaml
@@ -1,3 +1,2 @@
 worker.ready:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/events.yaml
@@ -1,7 +1,5 @@
 flow.spawn_requested:
-  payload:
-    entity_id: string
-    instance_id: string
+  entity_id: string
+  instance_id: string
 flow.spawned:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/events.yaml
@@ -1,3 +1,2 @@
 worker.ready:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-template-no-boot-instance/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-template-no-boot-instance/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-terminal-state-preserves/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-preserves/events.yaml
@@ -1,13 +1,9 @@
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.updated:
-  payload:
-    entity_id: string
-    data: string
+  entity_id: string
+  data: string
 task.finished:
-  payload:
-    entity_id: string
+  entity_id: string
 state.updated:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-terminal-state-rejects/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-rejects/events.yaml
@@ -1,12 +1,8 @@
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.reopen_requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.finished:
-  payload:
-    entity_id: string
+  entity_id: string
 state.reopened:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-cancel/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-cancel/events.yaml
@@ -1,12 +1,8 @@
 timer.scheduled:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.cancel_requested:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.check:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.cancelled:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-fire/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-fire/events.yaml
@@ -1,6 +1,4 @@
 timer.scheduled:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.check:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-recurring/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-recurring/events.yaml
@@ -1,6 +1,4 @@
 monitor.started:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.tick:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-start-on/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-start-on/events.yaml
@@ -1,9 +1,6 @@
 task.started:
-  payload:
-    entity_id: string
+  entity_id: string
 timer.task_timeout:
-  payload:
-    entity_id: string
+  entity_id: string
 task.timed_out:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier5-flow-lifecycle/test-wildcard-subscription/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-wildcard-subscription/events.yaml
@@ -1,9 +1,6 @@
-"*.completed":
-  payload:
-    entity_id: string
+'*.completed':
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 match.found:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-atomicity-commit/events.yaml
+++ b/tests/tier6-event-loop/test-atomicity-commit/events.yaml
@@ -1,6 +1,4 @@
 task.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/entities.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  status: text
+  counter: integer

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/events.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/events.yaml
@@ -1,6 +1,4 @@
 process.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 process.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/package.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/package.yaml
@@ -1,11 +1,8 @@
 name: test-atomicity-guard-rollback
 version: 1.0.0
-description: >
-  When a guard rejects, ALL handler side effects are rolled back atomically.
+description: 'When a guard rejects, ALL handler side effects are rolled back atomically.
   No data change, no gate change, no emitted events.
-platform_version: ">=1.1.0"
+
+  '
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    status: text
-    counter: integer

--- a/tests/tier6-event-loop/test-atomicity-rollback/events.yaml
+++ b/tests/tier6-event-loop/test-atomicity-rollback/events.yaml
@@ -1,6 +1,4 @@
 task.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-chain-depth-limit/events.yaml
+++ b/tests/tier6-event-loop/test-chain-depth-limit/events.yaml
@@ -1,24 +1,16 @@
 chain.start:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e1:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e2:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e3:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e4:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e5:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e6:
-  payload:
-    entity_id: string
+  entity_id: string
 chain.e7:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-cross-entity-concurrent/events.yaml
+++ b/tests/tier6-event-loop/test-cross-entity-concurrent/events.yaml
@@ -1,6 +1,4 @@
 task.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-dead-letter/events.yaml
+++ b/tests/tier6-event-loop/test-dead-letter/events.yaml
@@ -1,7 +1,5 @@
 task.submitted:
-  payload:
-    entity_id: string
-    score: number
+  entity_id: string
+  score: number
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-entity-serialization/events.yaml
+++ b/tests/tier6-event-loop/test-entity-serialization/events.yaml
@@ -1,12 +1,8 @@
 step.first:
-  payload:
-    entity_id: string
+  entity_id: string
 step.second:
-  payload:
-    entity_id: string
+  entity_id: string
 step.first_done:
-  payload:
-    entity_id: string
+  entity_id: string
 step.second_done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-event-persisted-before-delivery/events.yaml
+++ b/tests/tier6-event-loop/test-event-persisted-before-delivery/events.yaml
@@ -1,6 +1,4 @@
 task.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-event-validation/events.yaml
+++ b/tests/tier6-event-loop/test-event-validation/events.yaml
@@ -1,8 +1,8 @@
 task.submitted:
-  payload:
-    entity_id: string
-    priority: integer
-  required: [entity_id, priority]
+  required:
+  - entity_id
+  - priority
+  entity_id: string
+  priority: integer
 task.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-guards-pre-handler-state/entities.yaml
+++ b/tests/tier6-event-loop/test-guards-pre-handler-state/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  counter: integer

--- a/tests/tier6-event-loop/test-guards-pre-handler-state/events.yaml
+++ b/tests/tier6-event-loop/test-guards-pre-handler-state/events.yaml
@@ -1,6 +1,4 @@
 process.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 process.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier6-event-loop/test-guards-pre-handler-state/package.yaml
+++ b/tests/tier6-event-loop/test-guards-pre-handler-state/package.yaml
@@ -1,8 +1,6 @@
 name: test-guards-pre-handler-state
 version: 1.0.0
-description: Guard evaluates entity state BEFORE handler modifies it. Counter=5 fails guard check < 3.
-platform_version: ">=1.1.0"
+description: Guard evaluates entity state BEFORE handler modifies it. Counter=5 fails
+  guard check < 3.
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    counter: integer

--- a/tests/tier6-event-loop/test-on-complete-atomicity-chain/events.yaml
+++ b/tests/tier6-event-loop/test-on-complete-atomicity-chain/events.yaml
@@ -1,11 +1,8 @@
 task.started:
-  payload:
-    entity_id: string
-    ready: boolean
-    batch_id: string
+  entity_id: string
+  ready: boolean
+  batch_id: string
 phase.advanced:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-agent-emits-to-node/events.yaml
+++ b/tests/tier7-composition/test-agent-emits-to-node/events.yaml
@@ -1,12 +1,8 @@
 task.assigned:
-  payload:
-    entity_id: string
+  entity_id: string
 task.acknowledged:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.finalized:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-cross-flow-subscription/events.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/events.yaml
@@ -1,10 +1,7 @@
 flow-b/order.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-b/order.completed:
-  description: "Cross-flow event from flow-b indicating an order has been completed"
-  payload:
-    entity_id: string
+  description: Cross-flow event from flow-b indicating an order has been completed
+  entity_id: string
 flow-a/invoice.created:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-cross-flow-subscription/flows/flow-a/events.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/flows/flow-a/events.yaml
@@ -1,3 +1,2 @@
 invoice.created:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/events.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/events.yaml
@@ -1,6 +1,4 @@
 order.submitted:
-  payload:
-    entity_id: string
+  entity_id: string
 order.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-dual-delivery/events.yaml
+++ b/tests/tier7-composition/test-dual-delivery/events.yaml
@@ -1,10 +1,7 @@
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.finalized:
-  payload:
-    entity_id: string
+  entity_id: string
 task.audited:
-  description: "Event emitted by audit-agent after auditing a completed task"
-  payload:
-    entity_id: string
+  description: Event emitted by audit-agent after auditing a completed task
+  entity_id: string

--- a/tests/tier7-composition/test-full-lifecycle/events.yaml
+++ b/tests/tier7-composition/test-full-lifecycle/events.yaml
@@ -1,10 +1,7 @@
 order.submitted:
-  payload:
-    entity_id: string
-    amount: integer
+  entity_id: string
+  amount: integer
 order.validated:
-  payload:
-    entity_id: string
+  entity_id: string
 order.finalized:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-multi-gate-pipeline/events.yaml
+++ b/tests/tier7-composition/test-multi-gate-pipeline/events.yaml
@@ -1,18 +1,12 @@
 gate.g1_set:
-  payload:
-    entity_id: string
+  entity_id: string
 gate.g2_set:
-  payload:
-    entity_id: string
+  entity_id: string
 gate.g3_set:
-  payload:
-    entity_id: string
+  entity_id: string
 approval.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 approval.granted:
-  payload:
-    entity_id: string
+  entity_id: string
 gate.set:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-two-node-chain/events.yaml
+++ b/tests/tier7-composition/test-two-node-chain/events.yaml
@@ -1,9 +1,6 @@
 task.started:
-  payload:
-    entity_id: string
+  entity_id: string
 task.progressed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.finished:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-wildcard-cross-flow/events.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/events.yaml
@@ -1,14 +1,10 @@
 audit.logged:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-alpha/trigger.alpha:
-  payload:
-    entity_id: string
+  entity_id: string
 flow-alpha/job.alpha_done:
-  description: "Cross-flow event from flow-alpha indicating alpha job completion"
-  payload:
-    entity_id: string
+  description: Cross-flow event from flow-alpha indicating alpha job completion
+  entity_id: string
 flow-beta/job.beta_done:
-  description: "Cross-flow event from flow-beta indicating beta job completion"
-  payload:
-    entity_id: string
+  description: Cross-flow event from flow-beta indicating beta job completion
+  entity_id: string

--- a/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-alpha/events.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-alpha/events.yaml
@@ -1,6 +1,4 @@
 trigger.alpha:
-  payload:
-    entity_id: string
+  entity_id: string
 job.alpha_done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-beta/events.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-beta/events.yaml
@@ -1,6 +1,4 @@
 trigger.beta:
-  payload:
-    entity_id: string
+  entity_id: string
 job.beta_done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-advances-to-list/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-advances-to-list/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-bare-condition/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-bare-condition/events.yaml
@@ -1,7 +1,5 @@
 intake.requested:
-  payload:
-    entity_id: string
-    type: string
+  entity_id: string
+  type: string
 intake.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-cel-parse-error/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-cel-parse-error/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-condition-payload-mismatch/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-condition-payload-mismatch/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-condition-policy/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-condition-policy/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/entities.yaml
+++ b/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  expected_count: integer

--- a/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/events.yaml
@@ -1,6 +1,4 @@
 task.started:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/package.yaml
+++ b/tests/tier8-boot-verification/test-boot-create-entity-plus-accumulate/package.yaml
@@ -1,11 +1,7 @@
 name: test-boot-create-entity-plus-accumulate
 version: 1.0.0
-description: >
-  Boot verification: handler declares both create_entity and accumulate.
-  This is prohibited — create_entity mints a new entity_id on every
-  invocation, but accumulate needs the same entity across events.
-platform_version: ">=1.5.0"
+description: "Boot verification: handler declares both create_entity and accumulate.\
+  \ This is prohibited \u2014 create_entity mints a new entity_id on every invocation,\
+  \ but accumulate needs the same entity across events.\n"
+platform_version: '>=1.5.0'
 flows: []
-entity_schema:
-  core:
-    expected_count: integer

--- a/tests/tier8-boot-verification/test-boot-deprecated-field/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-deprecated-field/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-dialect-dual/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-dialect-dual/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-dialect-guard/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-dialect-guard/events.yaml
@@ -1,7 +1,5 @@
 check.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 check.passed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-emit-mismatch/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-emit-mismatch/events.yaml
@@ -1,8 +1,6 @@
 task.requested:
-  payload:
-    entity_id: string
-    task_type: string
+  entity_id: string
+  task_type: string
 task.completed:
-  payload:
-    entity_id: string
-    result: string
+  entity_id: string
+  result: string

--- a/tests/tier8-boot-verification/test-boot-event-cycle/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-cycle/events.yaml
@@ -1,6 +1,4 @@
 cycle.ping:
-  payload:
-    entity_id: string
+  entity_id: string
 cycle.pong:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-event-no-consumer/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-no-consumer/events.yaml
@@ -1,7 +1,5 @@
 task.requested:
   _source: external
-  payload:
-    entity_id: string
+  entity_id: string
 orphan.unconsumed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-event-no-producer/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-no-producer/events.yaml
@@ -1,12 +1,8 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 ghost.event:
-  payload:
-    entity_id: string
+  entity_id: string
 ghost.ack:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-event-no-schema/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-no-schema/events.yaml
@@ -1,3 +1,2 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-handler-field-undefined/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-handler-field-undefined/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-missing-pin/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/events.yaml
@@ -1,14 +1,10 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 child/task.assigned:
-  description: "Cross-flow event dispatching a task assignment to the child flow"
-  payload:
-    entity_id: string
+  description: Cross-flow event dispatching a task assignment to the child flow
+  entity_id: string
 child/task.result:
-  description: "Cross-flow event returning a task result from the child flow"
-  payload:
-    entity_id: string
+  description: Cross-flow event returning a task result from the child flow
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/events.yaml
@@ -1,10 +1,7 @@
 task.assigned:
-  payload:
-    entity_id: string
+  entity_id: string
 task.feedback:
-  payload:
-    entity_id: string
-    comment: string
+  entity_id: string
+  comment: string
 task.result:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-on-complete-and-rules-mutual-exclusion/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-on-complete-and-rules-mutual-exclusion/events.yaml
@@ -1,11 +1,8 @@
 task.submitted:
-  payload:
-    entity_id: string
-    score: integer
-    type: string
+  entity_id: string
+  score: integer
+  type: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string
 task.routed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-on-complete-dict/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-on-complete-dict/events.yaml
@@ -1,7 +1,5 @@
 task.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-on-complete-state-invalid/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-on-complete-state-invalid/events.yaml
@@ -1,7 +1,5 @@
 task.requested:
-  payload:
-    entity_id: string
-    score: integer
+  entity_id: string
+  score: integer
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-payload-mismatch/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-payload-mismatch/events.yaml
@@ -1,7 +1,5 @@
 item.received:
-  payload:
-    entity_id: string
-    name: string
+  entity_id: string
+  name: string
 item.stored:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/events.yaml
@@ -1,7 +1,5 @@
 task.requested:
   _source: external
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-policy-conflict/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-policy-conflict/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-policy-conflict/flows/sub-flow/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-policy-conflict/flows/sub-flow/events.yaml
@@ -1,6 +1,4 @@
 sub.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 sub.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-produces-drift/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-produces-drift/events.yaml
@@ -1,9 +1,6 @@
 item.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 item.done:
-  payload:
-    entity_id: string
+  entity_id: string
 item.surprise:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-prompt-missing/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-missing/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/events.yaml
@@ -1,8 +1,6 @@
 task.requested:
-  payload:
-    entity_id: string
-    task_type: string
+  entity_id: string
+  task_type: string
 task.completed:
-  payload:
-    entity_id: string
-    result: string
+  entity_id: string
+  result: string

--- a/tests/tier8-boot-verification/test-boot-required-agent-missing/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-required-agent-missing/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-self-emit/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-self-emit/events.yaml
@@ -1,3 +1,2 @@
 loop.event:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-state-machine-invalid/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-state-machine-invalid/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-state-machine-unreachable/entities.yaml
+++ b/tests/tier8-boot-verification/test-boot-state-machine-unreachable/entities.yaml
@@ -1,0 +1,2 @@
+ticket:
+  ticket_id: string

--- a/tests/tier8-boot-verification/test-boot-state-machine-unreachable/flows/support/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-state-machine-unreachable/flows/support/events.yaml
@@ -1,6 +1,4 @@
 ticket.opened:
-  payload:
-    entity_id: string
+  entity_id: string
 ticket.closed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-state-machine-unreachable/package.yaml
+++ b/tests/tier8-boot-verification/test-boot-state-machine-unreachable/package.yaml
@@ -1,17 +1,12 @@
 name: test-boot-state-machine-unreachable
 version: 1.0.0
-description: >
-  Boot verification: declared workflow state is unreachable from the authored
-  initial state and transition carriers. Platform must surface a warning-grade
-  semantic drift finding on the supported verify path.
-platform_version: ">=1.1.0"
-entity_schema:
-  groups:
-    - name: ticket
-      fields:
-        - name: ticket_id
-          type: string
+description: 'Boot verification: declared workflow state is unreachable from the authored
+  initial state and transition carriers. Platform must surface a warning-grade semantic
+  drift finding on the supported verify path.
+
+  '
+platform_version: '>=1.1.0'
 flows:
-  - id: support
-    flow: support
-    mode: static
+- id: support
+  flow: support
+  mode: static

--- a/tests/tier8-boot-verification/test-boot-success/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-success/events.yaml
@@ -1,9 +1,6 @@
 task.requested:
   _source: external
-  payload:
-    entity_id: string
-
+  entity_id: string
 task.completed:
   _source: external
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier8-boot-verification/test-boot-tool-missing/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-tool-missing/events.yaml
@@ -1,6 +1,4 @@
 task.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 task.completed:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  score: integer

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/events.yaml
@@ -1,13 +1,9 @@
 score.submitted:
-  payload:
-    entity_id: string
-    value: number
+  entity_id: string
+  value: number
 result.high:
-  payload:
-    entity_id: string
+  entity_id: string
 result.mid:
-  payload:
-    entity_id: string
+  entity_id: string
 result.low:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/package.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/package.yaml
@@ -1,10 +1,6 @@
 name: test-compose-accumulate-compute-branch
 version: 1.0.0
-description: >
-  Composition: accumulate score via data_accumulation →
-  on_complete with 3 conditional branches based on score value.
-platform_version: ">=1.1.0"
+description: "Composition: accumulate score via data_accumulation \u2192 on_complete\
+  \ with 3 conditional branches based on score value.\n"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    score: integer

--- a/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/events.yaml
@@ -1,12 +1,8 @@
 review.done:
-  payload:
-    entity_id: string
+  entity_id: string
 review.insufficient:
-  payload:
-    entity_id: string
+  entity_id: string
 review.approved:
-  payload:
-    entity_id: string
+  entity_id: string
 review.restarted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/events.yaml
@@ -1,10 +1,8 @@
 spawn.requested:
-  payload:
-    entity_id: string
-    instance_id: string
-    name: string
-    priority: integer
-    owner: string
+  entity_id: string
+  instance_id: string
+  name: string
+  priority: integer
+  owner: string
 spawn.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/events.yaml
@@ -1,6 +1,4 @@
 task.assign:
-  payload:
-    entity_id: string
+  entity_id: string
 task.done:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-gate-chain-three/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-chain-three/events.yaml
@@ -1,12 +1,8 @@
 step.a_done:
-  payload:
-    entity_id: string
+  entity_id: string
 step.b_done:
-  payload:
-    entity_id: string
+  entity_id: string
 step.c_done:
-  payload:
-    entity_id: string
+  entity_id: string
 release.ready:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/entities.yaml
@@ -1,0 +1,3 @@
+core:
+  stage_one_result: text
+  stage_two_result: text

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/events.yaml
@@ -1,14 +1,10 @@
 stage.one_done:
-  payload:
-    entity_id: string
-    result: string
+  entity_id: string
+  result: string
 stage.two_done:
-  payload:
-    entity_id: string
-    result: string
+  entity_id: string
+  result: string
 stage.two_start:
-  payload:
-    entity_id: string
+  entity_id: string
 stage.complete:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/package.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/package.yaml
@@ -1,11 +1,6 @@
 name: test-compose-gate-data-advance-emit
 version: 1.0.0
-description: >
-  Composition: single handler combines sets_gate, data_accumulation,
-  advances_to, and emits — the four-field validation stage pattern.
-platform_version: ">=1.1.0"
+description: "Composition: single handler combines sets_gate, data_accumulation, advances_to,\
+  \ and emits \u2014 the four-field validation stage pattern.\n"
+platform_version: '>=1.1.0'
 flows: []
-entity_schema:
-  core:
-    stage_one_result: text
-    stage_two_result: text

--- a/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  retry_count: integer

--- a/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/events.yaml
@@ -1,9 +1,6 @@
 retry.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 retry.dispatched:
-  payload:
-    entity_id: string
+  entity_id: string
 limit.reached:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/package.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/package.yaml
@@ -1,10 +1,8 @@
 name: test-compose-guard-counter-escalate
 version: 1.0.0
-description: >
-  Composition: guard checks entity counter against policy limit.
-  When counter reaches limit, on_fail escalates to a named event.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    retry_count: integer
+description: 'Composition: guard checks entity counter against policy limit. When
+  counter reaches limit, on_fail escalates to a named event.
+
+  '
+platform_version: '>=1.1.0'
 flows: []

--- a/tests/tier9-composition-patterns/test-compose-guard-multi-source/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-multi-source/events.yaml
@@ -1,8 +1,6 @@
 candidate.submitted:
-  payload:
-    entity_id: string
-    name: string
-    score: integer
+  entity_id: string
+  name: string
+  score: integer
 candidate.accepted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-guard-query-capacity/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-query-capacity/events.yaml
@@ -1,6 +1,4 @@
 admission.requested:
-  payload:
-    entity_id: string
+  entity_id: string
 admission.granted:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/events.yaml
@@ -1,21 +1,14 @@
 phase.init:
-  payload:
-    entity_id: string
+  entity_id: string
 phase.activate:
-  payload:
-    entity_id: string
+  entity_id: string
 phase.start:
-  payload:
-    entity_id: string
+  entity_id: string
 phase.stabilize:
-  payload:
-    entity_id: string
+  entity_id: string
 phase.wind_down:
-  payload:
-    entity_id: string
+  entity_id: string
 phase.close:
-  payload:
-    entity_id: string
+  entity_id: string
 lifecycle.complete:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/events.yaml
@@ -1,10 +1,7 @@
 task.completed:
-  payload:
-    entity_id: string
-    status: string
+  entity_id: string
+  status: string
 task.logged:
-  payload:
-    entity_id: string
+  entity_id: string
 tracker/task.record:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/flows/tracker/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/flows/tracker/events.yaml
@@ -1,6 +1,4 @@
 task.record:
-  payload:
-    entity_id: string
+  entity_id: string
 task.recorded:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-rules-fanout-data/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-fanout-data/entities.yaml
@@ -1,0 +1,2 @@
+core:
+  dispatch_count: integer

--- a/tests/tier9-composition-patterns/test-compose-rules-fanout-data/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-fanout-data/events.yaml
@@ -1,8 +1,6 @@
 batch.requested:
-  payload:
-    entity_id: string
-    mode: string
-    items: array
+  entity_id: string
+  mode: string
+  items: array
 batch.dispatched:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-rules-fanout-data/package.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-fanout-data/package.yaml
@@ -1,10 +1,8 @@
 name: test-compose-rules-fanout-data
 version: 1.0.0
-description: >
-  Composition: rules with 3 branches, winning branch triggers fan_out
+description: 'Composition: rules with 3 branches, winning branch triggers fan_out
   over payload items, data_accumulation stores the fan_out count.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    dispatch_count: integer
+
+  '
+platform_version: '>=1.1.0'
 flows: []

--- a/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/entities.yaml
@@ -1,0 +1,5 @@
+core:
+  resolved_value: string
+  resolved_value_a: string
+  resolved_value_b: string
+  resolution_method: string

--- a/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/events.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/events.yaml
@@ -1,9 +1,7 @@
 conflict.submitted:
-  payload:
-    entity_id: string
-    strategy: string
-    value_a: string
-    value_b: string
+  entity_id: string
+  strategy: string
+  value_a: string
+  value_b: string
 conflict.resolved:
-  payload:
-    entity_id: string
+  entity_id: string

--- a/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/package.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/package.yaml
@@ -1,13 +1,6 @@
 name: test-compose-rules-per-rule-data
 version: 1.0.0
-description: >
-  Composition: rules with 3 branches where each rule writes different
-  entity fields via data_accumulation — the per-rule field mapping pattern.
-platform_version: ">=1.1.0"
-entity_schema:
-  core:
-    resolved_value: string
-    resolved_value_a: string
-    resolved_value_b: string
-    resolution_method: string
+description: "Composition: rules with 3 branches where each rule writes different\
+  \ entity fields via data_accumulation \u2014 the per-rule field mapping pattern.\n"
+platform_version: '>=1.1.0'
 flows: []


### PR DESCRIPTION
Closes #478

## Summary
- add Wave 1 contracts-layer discovery, parsing, and materialization for `types.yaml` and `entities.yaml` at bundle root and flow scope, plus the rare bundle-root `entities.yaml` case already authorized by the governing draft
- keep `#478` inside the approved first-slice boundary by adding new contracts-layer accessors instead of migrating downstream `WorkflowEntitySchema()` consumers
- fail closed on retired parser-owned grammar on the normal load path, including `package.yaml entity_schema` and nested `events.yaml.payload`
- migrate first-party parser-loaded proof-surface fixtures/testdata so the approved `#478` proof rings stay green under the strict boundary

## Governing Refs
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`
  - `type_system`
  - `entity_contracts`
  - `event_payload_migration`
  - `state_machine_authority`
  - `migration`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

## Scope Boundary
This PR implements the repaired `#478` parser / loader / materialization slice only.

Explicitly split out:
- `#479` runtime entity semantics
- `#480` verify / boot enforcement
- `#481` delivery / tool surfaces

## Canonical Owner After This PR
- `internal/runtime/contracts` is the canonical owner for Wave 1 contract discovery, parsing, strict retired-form rejection on the normal load path, contracts-layer materialization, and additive contracts-layer accessors

## Retired Grammar
Rejected now in the contracts layer on the normal load path:
- `package.yaml entity_schema`
- nested `events.yaml.payload`
- package-scoped `types.yaml`
- package-scoped `entities.yaml`
- `jsonb`
- inline object-ish declarations / `type: object`
- retired state aliases / mixed old-new ambiguous declarations

## Old Paths / Migration Notes
- old single-schema materialization remains available through `WorkflowEntitySchema()` only for already-split downstream consumers
- new additive contracts-layer accessors expose Wave 1 root/per-flow type and entity documents without forcing downstream semantic migration in this PR
- production paths checked for surviving old behavior: contract path discovery, bundle loading, project/flow event loading, semantic-view wrapping tests, parser-backed proof fixtures in `tests/**`, and the `swarmflowtest` catalog harness
- migration is complete for the approved `#478` slice: strict parser/loader/materialization plus the first-party proof-surface fixture migration needed to keep that slice green; downstream semantic consumer migration remains intentionally incomplete and is tracked by `#479`, `#480`, and `#481`

## Proof
- `go test ./internal/runtime/contracts -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./cmd/swarm -count=1`
- `go test ./internal/runtime/cataloge2e ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/conformance ./internal/runtime/manager ./internal/runtime/swarmflowtest -count=1`
- `go test ./... -count=1`
- `rg -n "entity_schema:|^[[:space:]]*payload:" tests --glob 'package.yaml' --glob 'events.yaml' internal/runtime/testdata/generic-swarm-bundle internal/runtime/semanticview/scopes_test.go internal/runtime/runtime_session_scope_startup_test.go internal/runtime/bootverify/report_test.go internal/runtime/conformance/session_scope_conformance_test.go internal/runtime/manager/flow_activation_test.go internal/runtime/pipeline/engine_adapter_test.go`
- `find tests -path '*/flows/*/entities.yaml' -o -path '*/packages/*/entities.yaml' | sort`
