### PR TITLE
[agent-d][issue #491] Enforce prompt writer coverage on verify

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -992,6 +992,75 @@ reader:
 	}
 }
 
+func TestRunVerifyCommand_FailsForPromptDeclaredSaveWithoutEntityWrites(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-prompt-writer-coverage
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: verify-prompt-writer-coverage`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "entities.yaml"), `
+case:
+  business_brief:
+    type: text
+    _unused_reason: verify prompt writer proof field
+  research_context:
+    type: text
+    _unused_reason: verify prompt writer proof field
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), `
+writer:
+  id: writer
+  type: factory
+  role: writer
+  prompt_ref: writer
+  model_tier: sonnet
+  conversation_mode: task
+  subscriptions: []
+  entity_writes:
+    case:
+      save:
+      - research_context
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "prompts", "writer.md"), `
+Use save_entity_field for `+"`business_brief`"+`.
+`)
+
+	var buf bytes.Buffer
+	code := runVerifyCommand(context.Background(), repoRoot(), []string{
+		"-contracts", root,
+	}, &buf)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "entity_writer_coverage") {
+		t.Fatalf("verify output missing entity_writer_coverage:\n%s", out)
+	}
+	if !strings.Contains(out, "business_brief") {
+		t.Fatalf("verify output missing offending field:\n%s", out)
+	}
+}
+
 func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
 	bundle := &runtimecontracts.WorkflowContractBundle{}
 	bundle.Platform.Platform.Name = "swarm"

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2249,6 +2249,88 @@ func TestRun_AttributesReaderCoverageToResolvedRootContractOwner(t *testing.T) {
 	}
 }
 
+func TestRun_EntityWriterCoverageCountsExplicitAgentEntityWritesList(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - business_brief
+`, `
+case:
+  business_brief:
+    type: text
+  untouched:
+    type: text
+    _unused_reason: prompt coverage proof
+`, "")
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "entity_writer_coverage", "business_brief") {
+		t.Fatalf("unexpected entity_writer_coverage error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptCreateEntityWithoutEntityWritesAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+`, `
+case:
+  business_brief:
+    type: text
+    initial: seeded
+`, "Call create_entity using the delivered schema.\n")
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "prompt declares create_entity") {
+		t.Fatalf("expected prompt create_entity authorization error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptSaveEntityFieldWithoutMatchingEntityWritesAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - research_context
+`, `
+case:
+  business_brief:
+    type: text
+    _unused_reason: prompt save auth proof
+  research_context:
+    type: text
+    _unused_reason: prompt save auth proof
+`, "Use save_entity_field for `business_brief`.\n")
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "business_brief") {
+		t.Fatalf("expected prompt save_entity_field authorization error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsExpressionFieldReferenceForDeclaredFieldWrittenBySiblingStep(t *testing.T) {
 	bundle := loadWave1ExpressionFixtureBundle(t)
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
@@ -3615,6 +3697,42 @@ func loadWave1RootReaderCoverageFixtureBundle(t *testing.T) *runtimecontracts.Wo
 	t.Helper()
 	root := writeWave1RootReaderCoverageFixture(t)
 	return loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+}
+
+func writePromptWriterCoverageFixture(t *testing.T, agentsYAML, entitiesYAML, promptText string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: prompt-writer-coverage
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: prompt-writer-coverage\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "entities.yaml"), entitiesYAML)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), agentsYAML)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), "{}\n")
+	if strings.TrimSpace(promptText) != "" {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "prompts", "writer.md"), promptText)
+	}
+	return root
 }
 
 func loadTier8Fixture(t *testing.T, fixture string) semanticview.Source {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2366,6 +2366,65 @@ case:
 	}
 }
 
+func TestRun_EntityWriterCoverageCountsExplicitAgentEntityWritesForScopedDuplicateIDs(t *testing.T) {
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: duplicate-agent-writer-coverage
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: alpha
+    flow: alpha
+    mode: static
+  - id: beta
+    flow: beta
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: duplicate-agent-writer-coverage\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	for _, flowID := range []string{"alpha", "beta"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), "name: "+flowID+"\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), `
+case:
+  business_brief:
+    type: text
+`)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), `
+writer:
+  id: writer
+  type: factory
+  role: writer
+  prompt_ref: writer
+  model_tier: sonnet
+  conversation_mode: task
+  subscriptions: []
+  entity_writes:
+    case:
+      save:
+      - business_brief
+`)
+	}
+
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "entity_writer_coverage", "flow alpha entity_type case declares field business_brief") {
+		t.Fatalf("unexpected alpha entity_writer_coverage error, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "entity_writer_coverage", "flow beta entity_type case declares field business_brief") {
+		t.Fatalf("unexpected beta entity_writer_coverage error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsExpressionFieldReferenceForDeclaredFieldWrittenBySiblingStep(t *testing.T) {
 	bundle := loadWave1ExpressionFixtureBundle(t)
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2331,6 +2331,41 @@ case:
 	}
 }
 
+func TestRun_PromptEntityWritesPrefersFlowScopedAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  type: factory
+  role: writer
+  prompt_ref: writer
+  model_tier: sonnet
+  conversation_mode: task
+  subscriptions: []
+  entity_writes:
+    case:
+      save:
+      - research_context
+    child.case:
+      save:
+      - business_brief
+`, `
+case:
+  business_brief:
+    type: text
+    _unused_reason: scoped auth precedence proof
+  research_context:
+    type: text
+    _unused_reason: scoped auth precedence proof
+`, "Use `save_entity_field` for `business_brief`.\n")
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "entity_writer_coverage", "business_brief") {
+		t.Fatalf("unexpected entity_writer_coverage error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsExpressionFieldReferenceForDeclaredFieldWrittenBySiblingStep(t *testing.T) {
 	bundle := loadWave1ExpressionFixtureBundle(t)
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -21,6 +21,12 @@ type wave1WriteTarget struct {
 	Entity    bool
 }
 
+type wave1ScopedAgentRecord struct {
+	LogicalID string
+	Entry     runtimecontracts.AgentRegistryEntry
+	Source    runtimecontracts.ContractItemSource
+}
+
 func wave1SpecialClearTarget(target string) bool {
 	switch strings.TrimSpace(target) {
 	case "accumulator_state", "cycle_counters", "pending_dedup":
@@ -169,17 +175,12 @@ func wave1AgentExplicitEntityWriteCoverageByFlow(source semanticview.Source) map
 	if !ok || bundle == nil {
 		return out
 	}
-	for _, agentID := range wave1SortedAgentIDs(bundle) {
-		entry, ok := bundle.Agents[agentID]
-		if !ok || len(entry.EntityWrites) == 0 {
+	for _, record := range wave1ScopedAgentRecords(bundle) {
+		if len(record.Entry.EntityWrites) == 0 {
 			continue
 		}
-		agentSource, ok := bundle.AgentContractSource(agentID)
-		if !ok {
-			continue
-		}
-		for entityType, decl := range entry.EntityWrites {
-			contract, ok := wave1ResolveEntityWriteContract(source, agentSource, entityType)
+		for entityType, decl := range record.Entry.EntityWrites {
+			contract, ok := wave1ResolveEntityWriteContract(source, record.Source, entityType)
 			if !ok {
 				continue
 			}
@@ -310,18 +311,52 @@ func wave1AgentPromptEntityContract(source semanticview.Source, agentSource runt
 	return wave1EntityContractView{}, false
 }
 
-func wave1SortedAgentIDs(bundle *runtimecontracts.WorkflowContractBundle) []string {
+func wave1ScopedAgentRecords(bundle *runtimecontracts.WorkflowContractBundle) []wave1ScopedAgentRecord {
 	if bundle == nil {
 		return nil
 	}
-	out := make([]string, 0, len(bundle.Agents))
-	for agentID := range bundle.Agents {
-		agentID = strings.TrimSpace(agentID)
-		if agentID != "" {
-			out = append(out, agentID)
+	out := make([]wave1ScopedAgentRecord, 0)
+	for _, view := range bundle.ProjectViews() {
+		agentIDs := make([]string, 0, len(view.Agents))
+		for logicalID := range view.Agents {
+			logicalID = strings.TrimSpace(logicalID)
+			if logicalID != "" {
+				agentIDs = append(agentIDs, logicalID)
+			}
+		}
+		sort.Strings(agentIDs)
+		for _, logicalID := range agentIDs {
+			out = append(out, wave1ScopedAgentRecord{
+				LogicalID: logicalID,
+				Entry:     view.Agents[logicalID],
+				Source: runtimecontracts.ContractItemSource{
+					PackageKey: strings.TrimSpace(view.Paths.Key),
+					Layer:      "project",
+				},
+			})
 		}
 	}
-	sort.Strings(out)
+	for _, view := range bundle.FlowViews() {
+		agentIDs := make([]string, 0, len(view.Agents))
+		for logicalID := range view.Agents {
+			logicalID = strings.TrimSpace(logicalID)
+			if logicalID != "" {
+				agentIDs = append(agentIDs, logicalID)
+			}
+		}
+		sort.Strings(agentIDs)
+		for _, logicalID := range agentIDs {
+			out = append(out, wave1ScopedAgentRecord{
+				LogicalID: logicalID,
+				Entry:     view.Agents[logicalID],
+				Source: runtimecontracts.ContractItemSource{
+					PackageKey: strings.TrimSpace(view.Paths.PackageKey),
+					FlowID:     strings.TrimSpace(view.Paths.ID),
+					Layer:      "flow",
+				},
+			})
+		}
+	}
 	return out
 }
 

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -81,6 +81,7 @@ func (c *checkerContext) entityWriterCoverage() []Finding {
 			})
 		}
 	}
+	c.entityWriterCoverageFindings = append(c.entityWriterCoverageFindings, wave1PromptEntityWriteAuthorizationFindings(c.source)...)
 	return c.entityWriterCoverageFindings
 }
 
@@ -151,6 +152,185 @@ func wave1EntityWriterCoverageByFlow(source semanticview.Source) map[string]map[
 		}
 		out[contract.FlowID][target.Field] = struct{}{}
 	}
+	for flowID, fields := range wave1AgentExplicitEntityWriteCoverageByFlow(source) {
+		if out[flowID] == nil {
+			out[flowID] = map[string]struct{}{}
+		}
+		for field := range fields {
+			out[flowID][field] = struct{}{}
+		}
+	}
+	return out
+}
+
+func wave1AgentExplicitEntityWriteCoverageByFlow(source semanticview.Source) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return out
+	}
+	for _, agentID := range wave1SortedAgentIDs(bundle) {
+		entry, ok := bundle.Agents[agentID]
+		if !ok || len(entry.EntityWrites) == 0 {
+			continue
+		}
+		agentSource, ok := bundle.AgentContractSource(agentID)
+		if !ok {
+			continue
+		}
+		for entityType, decl := range entry.EntityWrites {
+			contract, ok := wave1ResolveEntityWriteContract(source, agentSource, entityType)
+			if !ok {
+				continue
+			}
+			if out[contract.FlowID] == nil {
+				out[contract.FlowID] = map[string]struct{}{}
+			}
+			for _, field := range decl.Create.Fields {
+				if _, declared := contract.Contract.Fields[field]; declared && !wave1EntityEnvelopeField(field) {
+					out[contract.FlowID][field] = struct{}{}
+				}
+			}
+			for _, field := range decl.Save.Fields {
+				if _, declared := contract.Contract.Fields[field]; declared && !wave1EntityEnvelopeField(field) {
+					out[contract.FlowID][field] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func wave1PromptEntityWriteAuthorizationFindings(source semanticview.Source) []Finding {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return nil
+	}
+	evidence, err := runtimecontracts.DerivePromptEntityWriteEvidence(bundle)
+	if err != nil {
+		return []Finding{{
+			CheckID:  "entity_writer_coverage",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("prompt entity write evidence derivation failed: %v", err),
+			Location: defaultFlowLabel(""),
+		}}
+	}
+	findings := make([]Finding, 0)
+	for _, item := range evidence {
+		entry, ok := bundle.Agents[item.AgentID]
+		if !ok {
+			continue
+		}
+		agentSource, ok := bundle.AgentContractSource(item.AgentID)
+		if !ok {
+			continue
+		}
+		contract, ok := wave1AgentPromptEntityContract(source, agentSource)
+		if !ok {
+			continue
+		}
+		writeDecl, ok := wave1PromptEntityWriteDecl(entry, contract)
+		if item.CreateEntity && (!ok || !writeDecl.Create.Declared()) {
+			findings = append(findings, Finding{
+				CheckID:  "entity_writer_coverage",
+				Severity: SeverityHardInvalidity,
+				Message:  fmt.Sprintf("agent %s prompt declares create_entity for flow %s entity_type %s without matching agents.yaml entity_writes.%s.create authorization", item.AgentID, defaultFlowLabel(contract.FlowID), contract.EntityType, contract.EntityType),
+				Location: item.PromptFile,
+			})
+		}
+		if item.SaveEntity && (!ok || !writeDecl.Save.Declared()) {
+			findings = append(findings, Finding{
+				CheckID:  "entity_writer_coverage",
+				Severity: SeverityHardInvalidity,
+				Message:  fmt.Sprintf("agent %s prompt declares save_entity_field for flow %s entity_type %s without matching agents.yaml entity_writes.%s.save authorization", item.AgentID, defaultFlowLabel(contract.FlowID), contract.EntityType, contract.EntityType),
+				Location: item.PromptFile,
+			})
+			continue
+		}
+		if !item.SaveEntity || writeDecl.Save.All {
+			continue
+		}
+		for _, field := range item.SaveFields {
+			if writeDecl.Save.AllowsField(field) {
+				continue
+			}
+			findings = append(findings, Finding{
+				CheckID:  "entity_writer_coverage",
+				Severity: SeverityHardInvalidity,
+				Message:  fmt.Sprintf("agent %s prompt declares save_entity_field for field %s on flow %s entity_type %s without matching agents.yaml entity_writes.%s.save authorization", item.AgentID, field, defaultFlowLabel(contract.FlowID), contract.EntityType, contract.EntityType),
+				Location: item.PromptFile,
+			})
+		}
+	}
+	return findings
+}
+
+func wave1PromptEntityWriteDecl(entry runtimecontracts.AgentRegistryEntry, contract wave1EntityContractView) (runtimecontracts.AgentEntityWriteDecl, bool) {
+	if len(entry.EntityWrites) == 0 {
+		return runtimecontracts.AgentEntityWriteDecl{}, false
+	}
+	for key, value := range entry.EntityWrites {
+		key = strings.TrimSpace(key)
+		if key == contract.EntityType {
+			return value, true
+		}
+		if contract.FlowID != "" && key == contract.FlowID+"."+contract.EntityType {
+			return value, true
+		}
+	}
+	return runtimecontracts.AgentEntityWriteDecl{}, false
+}
+
+func wave1ResolveEntityWriteContract(source semanticview.Source, agentSource runtimecontracts.ContractItemSource, entityType string) (wave1EntityContractView, bool) {
+	entityType = strings.TrimSpace(entityType)
+	if entityType == "" {
+		return wave1EntityContractView{}, false
+	}
+	if flowID := strings.TrimSpace(agentSource.FlowID); flowID != "" {
+		view := wave1EntityContractForFlow(source, flowID)
+		if view.Defined {
+			if entityType == view.EntityType || entityType == flowID+"."+view.EntityType {
+				return view, true
+			}
+		}
+	}
+	for _, contract := range wave1DeclaredEntityContracts(source) {
+		if entityType == contract.EntityType {
+			return contract, true
+		}
+		if contract.FlowID != "" && entityType == contract.FlowID+"."+contract.EntityType {
+			return contract, true
+		}
+	}
+	return wave1EntityContractView{}, false
+}
+
+func wave1AgentPromptEntityContract(source semanticview.Source, agentSource runtimecontracts.ContractItemSource) (wave1EntityContractView, bool) {
+	if flowID := strings.TrimSpace(agentSource.FlowID); flowID != "" {
+		view := wave1EntityContractForFlow(source, flowID)
+		if view.Defined {
+			return view, true
+		}
+	}
+	root := wave1EntityContractForFlow(source, "")
+	if root.Defined {
+		return root, true
+	}
+	return wave1EntityContractView{}, false
+}
+
+func wave1SortedAgentIDs(bundle *runtimecontracts.WorkflowContractBundle) []string {
+	if bundle == nil {
+		return nil
+	}
+	out := make([]string, 0, len(bundle.Agents))
+	for agentID := range bundle.Agents {
+		agentID = strings.TrimSpace(agentID)
+		if agentID != "" {
+			out = append(out, agentID)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -217,19 +217,11 @@ func wave1PromptEntityWriteAuthorizationFindings(source semanticview.Source) []F
 	}
 	findings := make([]Finding, 0)
 	for _, item := range evidence {
-		entry, ok := bundle.Agents[item.AgentID]
+		contract, ok := wave1AgentPromptEntityContract(source, item.Source)
 		if !ok {
 			continue
 		}
-		agentSource, ok := bundle.AgentContractSource(item.AgentID)
-		if !ok {
-			continue
-		}
-		contract, ok := wave1AgentPromptEntityContract(source, agentSource)
-		if !ok {
-			continue
-		}
-		writeDecl, ok := wave1PromptEntityWriteDecl(entry, contract)
+		writeDecl, ok := wave1PromptEntityWriteDecl(item.Entry, contract)
 		if item.CreateEntity && (!ok || !writeDecl.Create.Declared()) {
 			findings = append(findings, Finding{
 				CheckID:  "entity_writer_coverage",
@@ -269,14 +261,13 @@ func wave1PromptEntityWriteDecl(entry runtimecontracts.AgentRegistryEntry, contr
 	if len(entry.EntityWrites) == 0 {
 		return runtimecontracts.AgentEntityWriteDecl{}, false
 	}
-	for key, value := range entry.EntityWrites {
-		key = strings.TrimSpace(key)
-		if key == contract.EntityType {
+	if contract.FlowID != "" {
+		if value, ok := entry.EntityWrites[contract.FlowID+"."+contract.EntityType]; ok {
 			return value, true
 		}
-		if contract.FlowID != "" && key == contract.FlowID+"."+contract.EntityType {
-			return value, true
-		}
+	}
+	if value, ok := entry.EntityWrites[contract.EntityType]; ok {
+		return value, true
 	}
 	return runtimecontracts.AgentEntityWriteDecl{}, false
 }

--- a/internal/runtime/contracts/prompt_entity_writes.go
+++ b/internal/runtime/contracts/prompt_entity_writes.go
@@ -10,6 +10,8 @@ import (
 
 type PromptEntityWriteEvidence struct {
 	AgentID      string
+	Source       ContractItemSource
+	Entry        AgentRegistryEntry
 	PromptFile   string
 	CreateEntity bool
 	SaveEntity   bool
@@ -22,26 +24,13 @@ func DerivePromptEntityWriteEvidence(bundle *WorkflowContractBundle) ([]PromptEn
 	if bundle == nil {
 		return nil, fmt.Errorf("workflow contract bundle is required")
 	}
-	agentIDs := make([]string, 0, len(bundle.Agents))
-	for agentID := range bundle.Agents {
-		agentID = strings.TrimSpace(agentID)
-		if agentID != "" {
-			agentIDs = append(agentIDs, agentID)
-		}
-	}
-	sort.Strings(agentIDs)
-
 	out := make([]PromptEntityWriteEvidence, 0)
-	for _, agentID := range agentIDs {
-		entry, ok := bundle.Agents[agentID]
-		if !ok {
+	for _, record := range bundleAgentRecords(bundle) {
+		agentID := strings.TrimSpace(record.LogicalID)
+		if agentID == "" {
 			continue
 		}
-		source, ok := bundle.AgentContractSource(agentID)
-		if !ok {
-			continue
-		}
-		path, text, ok, err := loadPromptEntityWriteText(bundle, agentID, entry, source)
+		path, text, ok, err := loadPromptEntityWriteText(bundle, agentID, record.Entry, record.Source)
 		if err != nil {
 			return nil, err
 		}
@@ -54,17 +43,28 @@ func DerivePromptEntityWriteEvidence(bundle *WorkflowContractBundle) ([]PromptEn
 		}
 		out = append(out, PromptEntityWriteEvidence{
 			AgentID:      agentID,
+			Source:       record.Source,
+			Entry:        record.Entry,
 			PromptFile:   path,
 			CreateEntity: createEntity,
 			SaveEntity:   saveEntity,
 			SaveFields:   saveFields,
 		})
 	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AgentID == out[j].AgentID {
+			if out[i].Source.FlowID == out[j].Source.FlowID {
+				return out[i].PromptFile < out[j].PromptFile
+			}
+			return out[i].Source.FlowID < out[j].Source.FlowID
+		}
+		return out[i].AgentID < out[j].AgentID
+	})
 	return out, nil
 }
 
 func loadPromptEntityWriteText(bundle *WorkflowContractBundle, agentID string, entry AgentRegistryEntry, source ContractItemSource) (string, string, bool, error) {
-	dirs := promptDirsForBundleAgent(bundle, agentID)
+	dirs := promptEntityWritePromptDirs(bundle, source)
 	if len(dirs) == 0 {
 		return "", "", false, nil
 	}
@@ -81,6 +81,30 @@ func loadPromptEntityWriteText(bundle *WorkflowContractBundle, agentID string, e
 		}
 	}
 	return "", "", false, nil
+}
+
+func promptEntityWritePromptDirs(bundle *WorkflowContractBundle, source ContractItemSource) []string {
+	if bundle == nil {
+		return nil
+	}
+	dirs := make([]string, 0, 4)
+	if flowID := strings.TrimSpace(source.FlowID); flowID != "" {
+		if flow, ok := bundle.FlowViewByID(flowID); ok && strings.TrimSpace(flow.Paths.PromptsDir) != "" {
+			dirs = append(dirs, flow.Paths.PromptsDir)
+		}
+	}
+	if pkgKey := strings.TrimSpace(source.PackageKey); pkgKey != "" {
+		for _, pkg := range bundle.ProjectViews() {
+			if strings.TrimSpace(pkg.Paths.Key) == pkgKey && strings.TrimSpace(pkg.Paths.ProjectPromptsDir) != "" {
+				dirs = append(dirs, pkg.Paths.ProjectPromptsDir)
+				break
+			}
+		}
+	}
+	if strings.TrimSpace(bundle.Paths.ProjectPromptsDir) != "" {
+		dirs = append(dirs, bundle.Paths.ProjectPromptsDir)
+	}
+	return uniqueStrings(dirs...)
 }
 
 func extractPromptEntityWriteEvidence(promptText string) (bool, bool, []string) {
@@ -100,7 +124,11 @@ func extractPromptEntityWriteEvidence(promptText string) (bool, bool, []string) 
 			if len(match) < 2 {
 				continue
 			}
-			fields = append(fields, strings.TrimSpace(match[1]))
+			field := strings.TrimSpace(match[1])
+			if field == "" || field == "save_entity_field" {
+				continue
+			}
+			fields = append(fields, field)
 		}
 	}
 	return createEntity, true, uniquePromptStrings(fields)

--- a/internal/runtime/contracts/prompt_entity_writes.go
+++ b/internal/runtime/contracts/prompt_entity_writes.go
@@ -1,0 +1,107 @@
+package contracts
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type PromptEntityWriteEvidence struct {
+	AgentID      string
+	PromptFile   string
+	CreateEntity bool
+	SaveEntity   bool
+	SaveFields   []string
+}
+
+var promptSaveFieldPattern = regexp.MustCompile("`([a-zA-Z_][a-zA-Z0-9_]*)`")
+
+func DerivePromptEntityWriteEvidence(bundle *WorkflowContractBundle) ([]PromptEntityWriteEvidence, error) {
+	if bundle == nil {
+		return nil, fmt.Errorf("workflow contract bundle is required")
+	}
+	agentIDs := make([]string, 0, len(bundle.Agents))
+	for agentID := range bundle.Agents {
+		agentID = strings.TrimSpace(agentID)
+		if agentID != "" {
+			agentIDs = append(agentIDs, agentID)
+		}
+	}
+	sort.Strings(agentIDs)
+
+	out := make([]PromptEntityWriteEvidence, 0)
+	for _, agentID := range agentIDs {
+		entry, ok := bundle.Agents[agentID]
+		if !ok {
+			continue
+		}
+		source, ok := bundle.AgentContractSource(agentID)
+		if !ok {
+			continue
+		}
+		path, text, ok, err := loadPromptEntityWriteText(bundle, agentID, entry, source)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		createEntity, saveEntity, saveFields := extractPromptEntityWriteEvidence(text)
+		if !createEntity && !saveEntity {
+			continue
+		}
+		out = append(out, PromptEntityWriteEvidence{
+			AgentID:      agentID,
+			PromptFile:   path,
+			CreateEntity: createEntity,
+			SaveEntity:   saveEntity,
+			SaveFields:   saveFields,
+		})
+	}
+	return out, nil
+}
+
+func loadPromptEntityWriteText(bundle *WorkflowContractBundle, agentID string, entry AgentRegistryEntry, source ContractItemSource) (string, string, bool, error) {
+	dirs := promptDirsForBundleAgent(bundle, agentID)
+	if len(dirs) == 0 {
+		return "", "", false, nil
+	}
+	mode := promptFlowMode(bundle, source.FlowID)
+	for _, dir := range dirs {
+		for _, candidate := range promptPathCandidates(dir, agentID, entry, mode) {
+			raw, err := os.ReadFile(candidate)
+			if err == nil {
+				return candidate, string(raw), true, nil
+			}
+			if !os.IsNotExist(err) {
+				return "", "", false, fmt.Errorf("read %s: %w", candidate, err)
+			}
+		}
+	}
+	return "", "", false, nil
+}
+
+func extractPromptEntityWriteEvidence(promptText string) (bool, bool, []string) {
+	createEntity := promptContainsToken(promptText, "create_entity")
+	saveEntity := promptContainsToken(promptText, "save_entity_field")
+	if !saveEntity {
+		return createEntity, false, nil
+	}
+	fields := make([]string, 0)
+	for _, rawLine := range strings.Split(promptText, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || !promptContainsToken(line, "save_entity_field") {
+			continue
+		}
+		matches := promptSaveFieldPattern.FindAllStringSubmatch(line, -1)
+		for _, match := range matches {
+			if len(match) < 2 {
+				continue
+			}
+			fields = append(fields, strings.TrimSpace(match[1]))
+		}
+	}
+	return createEntity, true, uniquePromptStrings(fields)
+}

--- a/internal/runtime/contracts/prompt_entity_writes_test.go
+++ b/internal/runtime/contracts/prompt_entity_writes_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -79,5 +80,90 @@ writer:
 	}
 	if !reflect.DeepEqual(got[0].SaveFields, []string{"business_brief"}) {
 		t.Fatalf("SaveFields = %#v", got[0].SaveFields)
+	}
+}
+
+func TestExtractPromptEntityWriteEvidence_SkipsToolToken(t *testing.T) {
+	_, saveEntity, saveFields := extractPromptEntityWriteEvidence("Use `save_entity_field` for `business_brief`.\n")
+	if !saveEntity {
+		t.Fatal("expected save_entity_field evidence")
+	}
+	if !reflect.DeepEqual(saveFields, []string{"business_brief"}) {
+		t.Fatalf("SaveFields = %#v", saveFields)
+	}
+}
+
+func TestDerivePromptEntityWriteEvidence_IncludesScopedDuplicateAgentIDs(t *testing.T) {
+	repo := repoRoot(t)
+	root := t.TempDir()
+
+	writePromptWriterFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: prompt-entity-writes-duplicate
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: alpha
+    flow: alpha
+    mode: static
+  - id: beta
+    flow: beta
+    mode: static
+`)
+	writePromptWriterFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: prompt-entity-writes-duplicate\n")
+	writePromptWriterFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePromptWriterFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePromptWriterFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePromptWriterFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writePromptWriterFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	for _, flowID := range []string{"alpha", "beta"} {
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), "name: "+flowID+"\n")
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "{}\n")
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), `
+case:
+  business_brief:
+    type: text
+    _unused_reason: scoped duplicate prompt proof
+`)
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), `
+writer:
+  id: writer
+  role: writer
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+`)
+		writePromptWriterFixtureFile(t, filepath.Join(root, "flows", flowID, "prompts", "writer.md"), "Use save_entity_field for `business_brief` in "+flowID+".\n")
+	}
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	got, err := DerivePromptEntityWriteEvidence(bundle)
+	if err != nil {
+		t.Fatalf("DerivePromptEntityWriteEvidence: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Source.FlowID == got[1].Source.FlowID {
+		t.Fatalf("scoped evidence flow ids = %#v, want distinct flows", []string{got[0].Source.FlowID, got[1].Source.FlowID})
+	}
+	if strings.TrimSpace(got[0].AgentID) != "writer" || strings.TrimSpace(got[1].AgentID) != "writer" {
+		t.Fatalf("AgentIDs = %#v, want duplicate logical ids", []string{got[0].AgentID, got[1].AgentID})
+	}
+}
+
+func writePromptWriterFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/runtime/contracts/prompt_entity_writes_test.go
+++ b/internal/runtime/contracts/prompt_entity_writes_test.go
@@ -1,0 +1,83 @@
+package contracts
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAgentEntityWriteRule_UnmarshalYAML(t *testing.T) {
+	t.Run("all", func(t *testing.T) {
+		var rule AgentEntityWriteRule
+		if err := yaml.Unmarshal([]byte("all\n"), &rule); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		if !rule.All {
+			t.Fatal("expected All to be true")
+		}
+		if len(rule.Fields) != 0 {
+			t.Fatalf("Fields = %#v, want nil", rule.Fields)
+		}
+	})
+
+	t.Run("explicit list", func(t *testing.T) {
+		var rule AgentEntityWriteRule
+		if err := yaml.Unmarshal([]byte("- one\n- two\n"), &rule); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		if rule.All {
+			t.Fatal("expected All to be false")
+		}
+		if !reflect.DeepEqual(rule.Fields, []string{"one", "two"}) {
+			t.Fatalf("Fields = %#v", rule.Fields)
+		}
+	})
+}
+
+func TestDerivePromptEntityWriteEvidence(t *testing.T) {
+	repo := repoRoot(t)
+	root := writePromptTestBundle(t, repo)
+
+	agentsPath := filepath.Join(root, "agents.yaml")
+	agentsRaw, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", agentsPath, err)
+	}
+	agentsRaw = append(agentsRaw, []byte(`
+writer:
+  id: writer
+  role: writer
+  workspace_class: factory
+  manager_fallback: ops-lead
+`)...)
+	if err := os.WriteFile(agentsPath, agentsRaw, 0o644); err != nil {
+		t.Fatalf("write %s: %v", agentsPath, err)
+	}
+
+	prompt := "Call create_entity using the delivered schema.\nThen call save_entity_field for `business_brief`.\n"
+	if err := os.WriteFile(filepath.Join(root, "prompts", "writer.md"), []byte(prompt), 0o644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	got, err := DerivePromptEntityWriteEvidence(bundle)
+	if err != nil {
+		t.Fatalf("DerivePromptEntityWriteEvidence: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].AgentID != "writer" || !got[0].CreateEntity || !got[0].SaveEntity {
+		t.Fatalf("evidence = %#v", got[0])
+	}
+	if !reflect.DeepEqual(got[0].SaveFields, []string{"business_brief"}) {
+		t.Fatalf("SaveFields = %#v", got[0].SaveFields)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_agent_writes.go
+++ b/internal/runtime/contracts/workflow_contract_agent_writes.go
@@ -1,0 +1,82 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type AgentEntityWriteDecl struct {
+	Create AgentEntityWriteRule `yaml:"create"`
+	Save   AgentEntityWriteRule `yaml:"save"`
+}
+
+type AgentEntityWriteRule struct {
+	All    bool
+	Fields []string
+}
+
+func (r *AgentEntityWriteRule) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*r = AgentEntityWriteRule{}
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		value := strings.TrimSpace(node.Value)
+		if value != "all" {
+			return fmt.Errorf("entity write rule must be \"all\" or an explicit field list")
+		}
+		*r = AgentEntityWriteRule{All: true}
+		return nil
+	case yaml.SequenceNode:
+		var fields []string
+		if err := node.Decode(&fields); err != nil {
+			return err
+		}
+		out := make([]string, 0, len(fields))
+		seen := map[string]struct{}{}
+		for _, field := range fields {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			if field == "all" {
+				return fmt.Errorf("entity write rule cannot mix reserved keyword \"all\" with explicit fields")
+			}
+			if _, ok := seen[field]; ok {
+				continue
+			}
+			seen[field] = struct{}{}
+			out = append(out, field)
+		}
+		if len(out) == 0 {
+			return fmt.Errorf("entity write rule explicit field list must not be empty")
+		}
+		*r = AgentEntityWriteRule{Fields: out}
+		return nil
+	default:
+		return fmt.Errorf("entity write rule must be scalar \"all\" or sequence")
+	}
+}
+
+func (r AgentEntityWriteRule) Declared() bool {
+	return r.All || len(r.Fields) > 0
+}
+
+func (r AgentEntityWriteRule) AllowsField(field string) bool {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return false
+	}
+	if r.All {
+		return true
+	}
+	for _, candidate := range r.Fields {
+		if strings.TrimSpace(candidate) == field {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -851,27 +851,28 @@ type EventCatalogEntry struct {
 	Required          []string         `yaml:"required"`
 }
 type AgentRegistryEntry struct {
-	ID                     string         `yaml:"id"`
-	Type                   string         `yaml:"type"`
-	Role                   string         `yaml:"role"`
-	PromptRef              string         `yaml:"prompt_ref"`
-	Permissions            []string       `yaml:"permissions" json:"permissions,omitempty"`
-	PermissionsBundle      string         `yaml:"permissions_bundle" json:"permissions_bundle,omitempty"`
-	WorkspaceClass         string         `yaml:"workspace_class"`
-	ManagerFallback        string         `yaml:"manager_fallback"`
-	NodeType               string         `yaml:"node_type"`
-	ModelTier              string         `yaml:"model_tier"`
-	ConversationMode       string         `yaml:"conversation_mode"`
-	SessionScope           string         `yaml:"session_scope"`
-	MaxTurnsPerTask        int            `yaml:"max_turns_per_task"`
-	Subscriptions          []string       `yaml:"subscriptions"`
-	SubscriptionsBootstrap []string       `yaml:"subscriptions_bootstrap"`
-	SubscribesTo           []string       `yaml:"subscribes_to"`
-	Tools                  []string       `yaml:"tools"`
-	ToolsTier2             []string       `yaml:"tools_tier2"`
-	NativeTools            map[string]any `yaml:"native_tools"`
-	EmitEvents             []string       `yaml:"emit_events"`
-	Implementation         string         `yaml:"implementation"`
+	ID                     string                          `yaml:"id"`
+	Type                   string                          `yaml:"type"`
+	Role                   string                          `yaml:"role"`
+	PromptRef              string                          `yaml:"prompt_ref"`
+	EntityWrites           map[string]AgentEntityWriteDecl `yaml:"entity_writes"`
+	Permissions            []string                        `yaml:"permissions" json:"permissions,omitempty"`
+	PermissionsBundle      string                          `yaml:"permissions_bundle" json:"permissions_bundle,omitempty"`
+	WorkspaceClass         string                          `yaml:"workspace_class"`
+	ManagerFallback        string                          `yaml:"manager_fallback"`
+	NodeType               string                          `yaml:"node_type"`
+	ModelTier              string                          `yaml:"model_tier"`
+	ConversationMode       string                          `yaml:"conversation_mode"`
+	SessionScope           string                          `yaml:"session_scope"`
+	MaxTurnsPerTask        int                             `yaml:"max_turns_per_task"`
+	Subscriptions          []string                        `yaml:"subscriptions"`
+	SubscriptionsBootstrap []string                        `yaml:"subscriptions_bootstrap"`
+	SubscribesTo           []string                        `yaml:"subscribes_to"`
+	Tools                  []string                        `yaml:"tools"`
+	ToolsTier2             []string                        `yaml:"tools_tier2"`
+	NativeTools            map[string]any                  `yaml:"native_tools"`
+	EmitEvents             []string                        `yaml:"emit_events"`
+	Implementation         string                          `yaml:"implementation"`
 }
 
 func (e AgentRegistryEntry) ConfiguredTools() []string {


### PR DESCRIPTION
Closes #491

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`
  - `agent_writes_declaration`
  - `verify_enforcement.slice_e1_writer_coverage`
  - `verify_enforcement.slice_e1_writer_coverage.authorization_is_not_write_site`
  - `verify_enforcement.slice_e1_writer_coverage.verify_implementation`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `slice_6_entity_writer_coverage`

## Scope
This PR closes the supported-path verifier defect where prompt-declared `create_entity` / `save_entity_field` behavior could pass `cmd/swarm verify` without matching `agents.yaml` `entity_writes` authorization.

## Semantic migration
- New canonical owner: `internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go`
- Prompt evidence feed added in: `internal/runtime/contracts/prompt_entity_writes.go`
- Contract carrier added in: `internal/runtime/contracts/workflow_contract_types.go` and `internal/runtime/contracts/workflow_contract_agent_writes.go`
- Old non-authoritative behavior now invalid: prompt-declared entity writes that do not have matching `entity_writes.<entity>.create` / `save` authorization no longer pass verify
- Production paths checked for surviving old behavior:
  - `cmd/swarm verify`
  - `internal/runtime/workflow_validation.go`
  - `internal/runtime/bootverify/checks.go`
  - `internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go`
- Migration complete: yes for the `#491` chosen class

## Proof
- `go test ./internal/runtime/contracts -run 'Test(AgentEntityWriteRule_UnmarshalYAML|DerivePromptEntityWriteEvidence)$' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_(EntityWriterCoverageCountsExplicitAgentEntityWritesList|ReportsPromptCreateEntityWithoutEntityWritesAuthorization|ReportsPromptSaveEntityFieldWithoutMatchingEntityWritesAuthorization)$' -count=1`
- `go test ./cmd/swarm -run 'TestRunVerifyCommand_(SurfacesLintEvidence|FailsForPromptDeclaredSaveWithoutEntityWrites)$' -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./cmd/swarm -count=1`
- `go test ./... -count=1`
