### PR TITLE
[agent-d][issue #490] Harden state-schema pseudo-types

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1061,6 +1061,95 @@ Use save_entity_field for `+"`business_brief`"+`.
 	}
 }
 
+func TestRunVerifyCommand_FailsForPseudoStateSchemaTypes(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-state-schema-pseudo-types
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: verify-state-schema-pseudo-types`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+accumulator:
+  id: accumulator
+  execution_type: system_node
+  state_schema:
+    fields:
+      dimensions_received: dimension score receipts keyed by dimension name
+`)
+
+	var buf bytes.Buffer
+	code := runVerifyCommand(context.Background(), repoRoot(), []string{
+		"-contracts", root,
+	}, &buf)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
+	}
+	if out := buf.String(); !strings.Contains(out, "verify failed: load Swarm contracts:") || !strings.Contains(out, "state_schema field type") {
+		t.Fatalf("unexpected output = %q", out)
+	}
+}
+
+func TestRunVerifyCommand_AllowsCanonicalStateSchemaFloat(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-state-schema-float
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: verify-state-schema-float`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+task.assigned:
+  _source: external (state schema float verify test)
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
+accumulator:
+  id: accumulator
+  execution_type: system_node
+  subscribes_to: [task.assigned]
+  event_handlers:
+    task.assigned:
+      create_entity: true
+      advances_to: done
+  state_schema:
+    fields:
+      composite: float
+`)
+
+	var buf bytes.Buffer
+	code := runVerifyCommand(context.Background(), repoRoot(), []string{
+		"-contracts", root,
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
+	}
+	if out := buf.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify output missing success marker:\n%s", out)
+	}
+}
+
 func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
 	bundle := &runtimecontracts.WorkflowContractBundle{}
 	bundle.Platform.Platform.Name = "swarm"

--- a/internal/runtime/contracts/node_state_types.go
+++ b/internal/runtime/contracts/node_state_types.go
@@ -35,7 +35,12 @@ func NormalizeNodeStateFieldType(raw string) (string, error) {
 	normalized := strings.ToLower(raw)
 	switch normalized {
 	case "text", "string", "integer", "int", "bigint", "float", "double", "real", "numeric", "boolean", "bool", "jsonb", "json", "timestamp", "timestamptz", "uuid":
-		return normalized, nil
+		switch normalized {
+		case "bool":
+			return "boolean", nil
+		default:
+			return normalized, nil
+		}
 	}
 
 	if strings.ContainsAny(raw, " \t\r\n") {

--- a/internal/runtime/contracts/node_state_types.go
+++ b/internal/runtime/contracts/node_state_types.go
@@ -1,0 +1,45 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var nodeStateNumericTypePattern = regexp.MustCompile(`(?i)^numeric\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
+
+// NormalizeNodeStateFieldType enforces the supported canonical vocabulary for
+// node-local accumulator/state fields. Unlike the Wave 1 entity/event contract
+// surface, node state still allows jsonb and float-like primitives, but it does
+// not allow descriptive prose or inline modifiers to masquerade as a type.
+func NormalizeNodeStateFieldType(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("state_schema field type is required")
+	}
+	if strings.HasSuffix(raw, "[]") {
+		base := strings.TrimSpace(strings.TrimSuffix(raw, "[]"))
+		if base == "" {
+			return "", fmt.Errorf("state_schema list type requires an element type")
+		}
+		normalizedBase, err := NormalizeNodeStateFieldType(base)
+		if err != nil {
+			return "", err
+		}
+		return normalizedBase + "[]", nil
+	}
+	if matches := nodeStateNumericTypePattern.FindStringSubmatch(raw); len(matches) == 3 {
+		return fmt.Sprintf("numeric(%s,%s)", matches[1], matches[2]), nil
+	}
+
+	normalized := strings.ToLower(raw)
+	switch normalized {
+	case "text", "string", "integer", "int", "bigint", "float", "double", "real", "numeric", "boolean", "bool", "jsonb", "json", "timestamp", "timestamptz", "uuid":
+		return normalized, nil
+	}
+
+	if strings.ContainsAny(raw, " \t\r\n") {
+		return "", fmt.Errorf("state_schema field type %q is not canonical; descriptive notes and inline modifiers must not appear in type declarations", raw)
+	}
+	return "", fmt.Errorf("unsupported state_schema field type %q; use a canonical scalar, numeric(p,s), or [] form", raw)
+}

--- a/internal/runtime/contracts/node_state_types_test.go
+++ b/internal/runtime/contracts/node_state_types_test.go
@@ -12,6 +12,8 @@ func TestNormalizeNodeStateFieldType_AllowsCanonicalNodeStateTypes(t *testing.T)
 		"text":           "text",
 		"string":         "string",
 		"integer":        "integer",
+		"bool":           "boolean",
+		"boolean":        "boolean",
 		"float":          "float",
 		"numeric(8, 2)":  "numeric(8,2)",
 		"jsonb":          "jsonb",

--- a/internal/runtime/contracts/node_state_types_test.go
+++ b/internal/runtime/contracts/node_state_types_test.go
@@ -1,0 +1,46 @@
+package contracts
+
+import "testing"
+
+func TestNormalizeNodeStateFieldType_AllowsCanonicalNodeStateTypes(t *testing.T) {
+	cases := map[string]string{
+		"text":           "text",
+		"string":         "string",
+		"integer":        "integer",
+		"float":          "float",
+		"numeric(8, 2)":  "numeric(8,2)",
+		"jsonb":          "jsonb",
+		"timestamptz":    "timestamptz",
+		"uuid":           "uuid",
+		"text[]":         "text[]",
+		"numeric(5,2)[]": "numeric(5,2)[]",
+	}
+	for raw, want := range cases {
+		t.Run(raw, func(t *testing.T) {
+			got, err := NormalizeNodeStateFieldType(raw)
+			if err != nil {
+				t.Fatalf("NormalizeNodeStateFieldType(%q): %v", raw, err)
+			}
+			if got != want {
+				t.Fatalf("NormalizeNodeStateFieldType(%q) = %q, want %q", raw, got, want)
+			}
+		})
+	}
+}
+
+func TestNormalizeNodeStateFieldType_RejectsPseudoTypes(t *testing.T) {
+	cases := []string{
+		"uuid (primary key)",
+		"text[] (scanner types dispatched)",
+		"timestamptz (null until done)",
+		"dimension score receipts keyed by dimension name",
+		"integer default 0",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := NormalizeNodeStateFieldType(raw); err == nil {
+				t.Fatalf("expected pseudo-type rejection for %q", raw)
+			}
+		})
+	}
+}

--- a/internal/runtime/contracts/node_state_types_test.go
+++ b/internal/runtime/contracts/node_state_types_test.go
@@ -1,6 +1,11 @@
 package contracts
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 func TestNormalizeNodeStateFieldType_AllowsCanonicalNodeStateTypes(t *testing.T) {
 	cases := map[string]string{
@@ -42,5 +47,19 @@ func TestNormalizeNodeStateFieldType_RejectsPseudoTypes(t *testing.T) {
 				t.Fatalf("expected pseudo-type rejection for %q", raw)
 			}
 		})
+	}
+}
+
+func TestDecodeNodeStateFields_RejectsPseudoTypesInSequenceForm(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(`
+- name: dimensions_received
+  type: dimension score receipts keyed by dimension name
+`), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	_, err := decodeNodeStateFields(node.Content[0])
+	if err == nil || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("expected pseudo-type error, got %v", err)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -402,6 +402,14 @@ func decodeNodeStateFields(node *yaml.Node) ([]NodeStateField, error) {
 		if err := node.Decode(&fields); err != nil {
 			return nil, err
 		}
+		for i := range fields {
+			fields[i].Name = strings.TrimSpace(fields[i].Name)
+			normalizedType, err := NormalizeNodeStateFieldType(fields[i].Type)
+			if err != nil {
+				return nil, fmt.Errorf("node state field %s: %w", fields[i].Name, err)
+			}
+			fields[i].Type = normalizedType
+		}
 		return fields, nil
 	case yaml.MappingNode:
 		fields := make([]NodeStateField, 0, len(node.Content)/2)

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -426,9 +426,12 @@ func decodeNodeStateField(name string, node *yaml.Node) (NodeStateField, error) 
 	field := NodeStateField{Name: strings.TrimSpace(name)}
 	switch node.Kind {
 	case yaml.ScalarNode:
-		parsed := parseTypedFieldString(node.Value)
-		field.Type = parsed.Type
-		field.Default = parsed.Default
+		field.Type = strings.TrimSpace(node.Value)
+		normalizedType, err := NormalizeNodeStateFieldType(field.Type)
+		if err != nil {
+			return NodeStateField{}, fmt.Errorf("node state field %s: %w", field.Name, err)
+		}
+		field.Type = normalizedType
 		return field, nil
 	case yaml.MappingNode:
 		type alias NodeStateField
@@ -436,7 +439,11 @@ func decodeNodeStateField(name string, node *yaml.Node) (NodeStateField, error) 
 		if err := node.Decode(&aux); err != nil {
 			return NodeStateField{}, err
 		}
-		field.Type = aux.Type
+		normalizedType, err := NormalizeNodeStateFieldType(aux.Type)
+		if err != nil {
+			return NodeStateField{}, fmt.Errorf("node state field %s: %w", field.Name, err)
+		}
+		field.Type = normalizedType
 		field.Default = aux.Default
 		return field, nil
 	default:

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -44,6 +44,10 @@ func SchemaFieldTypeToDDL(schemaType string) (string, error) {
 		return "TEXT", nil
 	case "integer", "int", "bigint":
 		return "BIGINT", nil
+	case "float", "double", "real":
+		return "DOUBLE PRECISION", nil
+	case "numeric":
+		return "NUMERIC", nil
 	case "boolean":
 		return "BOOLEAN", nil
 	case "jsonb", "json":
@@ -232,7 +236,11 @@ func GenerateNodeStateTableDDLs(nodes map[string]runtimecontracts.SystemNodeCont
 				return nil, fmt.Errorf("node %s state table %s declares duplicate column %s", strings.TrimSpace(nodeID), tableName, columnName)
 			}
 			seenColumns[columnName] = struct{}{}
-			columnType, err := SchemaFieldTypeToDDL(field.Type)
+			normalizedType, err := runtimecontracts.NormalizeNodeStateFieldType(field.Type)
+			if err != nil {
+				return nil, fmt.Errorf("node %s state table %s field %s: %w", strings.TrimSpace(nodeID), tableName, columnName, err)
+			}
+			columnType, err := SchemaFieldTypeToDDL(normalizedType)
 			if err != nil {
 				return nil, fmt.Errorf("node %s state table %s field %s: %w", strings.TrimSpace(nodeID), tableName, columnName, err)
 			}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -29,6 +29,12 @@ func SchemaFieldTypeToDDL(schemaType string) (string, error) {
 		return "", fmt.Errorf("schema type is required")
 	}
 	normalized := strings.ToLower(schemaType)
+	if matches := schemaDDLNumericPattern.FindStringSubmatch(normalized); len(matches) == 3 {
+		return fmt.Sprintf("NUMERIC(%s,%s)", matches[1], matches[2]), nil
+	}
+	if strings.HasPrefix(normalized, "numeric ") {
+		return "", fmt.Errorf("%w %q", ErrUnknownSchemaType, schemaType)
+	}
 	if idx := strings.IndexAny(normalized, " \t\r\n"); idx >= 0 {
 		normalized = strings.TrimSpace(normalized[:idx])
 	}
@@ -56,9 +62,6 @@ func SchemaFieldTypeToDDL(schemaType string) (string, error) {
 		return "TIMESTAMPTZ", nil
 	case "uuid":
 		return "UUID", nil
-	}
-	if matches := schemaDDLNumericPattern.FindStringSubmatch(normalized); len(matches) == 3 {
-		return fmt.Sprintf("NUMERIC(%s,%s)", matches[1], matches[2]), nil
 	}
 	return "", fmt.Errorf("%w %q", ErrUnknownSchemaType, schemaType)
 }

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -42,6 +42,9 @@ func TestSchemaFieldTypeToDDLError(t *testing.T) {
 	if _, err := SchemaFieldTypeToDDL("object"); err == nil || !errors.Is(err, ErrUnknownSchemaType) {
 		t.Fatalf("expected unknown schema type error, got %v", err)
 	}
+	if _, err := SchemaFieldTypeToDDL("numeric (12,2)"); err == nil || !errors.Is(err, ErrUnknownSchemaType) {
+		t.Fatalf("expected spaced numeric type to fail fast, got %v", err)
+	}
 }
 
 func TestGeneratePlatformTableDDLs(t *testing.T) {

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -16,17 +16,14 @@ func TestSchemaFieldTypeToDDL(t *testing.T) {
 		{schemaType: "text", wantDDL: "TEXT"},
 		{schemaType: "string", wantDDL: "TEXT"},
 		{schemaType: "integer", wantDDL: "BIGINT"},
+		{schemaType: "float", wantDDL: "DOUBLE PRECISION"},
+		{schemaType: "numeric", wantDDL: "NUMERIC"},
 		{schemaType: "numeric(12,2)", wantDDL: "NUMERIC(12,2)"},
 		{schemaType: "boolean", wantDDL: "BOOLEAN"},
 		{schemaType: "jsonb", wantDDL: "JSONB"},
 		{schemaType: "timestamp", wantDDL: "TIMESTAMPTZ"},
-		{schemaType: "timestamptz (set on state change)", wantDDL: "TIMESTAMPTZ"},
 		{schemaType: "uuid", wantDDL: "UUID"},
-		{schemaType: "uuid (null for non-derived)", wantDDL: "UUID"},
-		{schemaType: "integer default 0", wantDDL: "BIGINT"},
-		{schemaType: "numeric(5,2) (computed by node weighted_average)", wantDDL: "NUMERIC(5,2)"},
 		{schemaType: "text[]", wantDDL: "TEXT[]"},
-		{schemaType: "text[] (scanner types dispatched)", wantDDL: "TEXT[]"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.schemaType, func(t *testing.T) {
@@ -223,6 +220,7 @@ func TestGenerateNodeStateTableDDLs(t *testing.T) {
 				Fields: []runtimecontracts.NodeStateField{
 					{Name: "attempts", Type: "integer"},
 					{Name: "last_error", Type: "text"},
+					{Name: "score", Type: "float"},
 				},
 			},
 		},
@@ -242,10 +240,28 @@ func TestGenerateNodeStateTableDDLs(t *testing.T) {
 	if !strings.Contains(createStmt, `"node_id" TEXT NOT NULL`) {
 		t.Fatalf("expected node_id column, got %q", createStmt)
 	}
-	if !strings.Contains(createStmt, `"attempts" BIGINT`) || !strings.Contains(createStmt, `"last_error" TEXT`) {
+	if !strings.Contains(createStmt, `"attempts" BIGINT`) || !strings.Contains(createStmt, `"last_error" TEXT`) || !strings.Contains(createStmt, `"score" DOUBLE PRECISION`) {
 		t.Fatalf("expected state_schema fields, got %q", createStmt)
 	}
 	if !strings.Contains(createStmt, `PRIMARY KEY ("entity_id", "node_id")`) {
 		t.Fatalf("expected composite primary key, got %q", createStmt)
+	}
+}
+
+func TestGenerateNodeStateTableDDLs_RejectsPseudoTypes(t *testing.T) {
+	nodes := map[string]runtimecontracts.SystemNodeContract{
+		"processing-node": {
+			StateTable: "processing_node_state",
+			StateSchema: runtimecontracts.NodeStateSchema{
+				Fields: []runtimecontracts.NodeStateField{
+					{Name: "received_items", Type: "dimension score receipts keyed by dimension name"},
+				},
+			},
+		},
+	}
+
+	_, err := GenerateNodeStateTableDDLs(nodes)
+	if err == nil || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("expected pseudo-type error, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #490

## Summary

This PR closes the supported-path `state_schema.fields.*` pseudo-type gap by making node-state field types explicit and fail-closed on the same path used by `cmd/swarm verify`.

## Governing Refs / Context

No exact dedicated governing section exists in `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml` for freeform `state_schema.fields.*` typing.

Binding governing context for this seam:
- `#490`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:901-902`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:1316`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:1354-1360`

## Canonical owner after change

- Loader acceptance / normalization: `internal/runtime/contracts/node_state_types.go`
- Loader consumer: `internal/runtime/contracts/workflow_contract_yaml_schema.go`
- Concrete boot / DDL consumer: `internal/store/schema_ddl.go`
- Supported verify carrier: `cmd/swarm/main.go`

## Old path now invalid

The old non-authoritative path was descriptive / modifier-bearing scalar strings in `nodes.yaml state_schema.fields.*`, for example:
- `uuid (primary key)`
- `timestamptz (null until done)`
- `dimension score receipts keyed by dimension name`

Those strings now fail during contract loading instead of silently surviving `cmd/swarm verify`.

## Production paths checked

- `cmd/swarm verify`
- contract bundle load through `LoadWorkflowContractBundleWithOverrides(...)`
- node-state table DDL generation through `GenerateNodeStateTableDDLs(...)`

## Migration completeness

- complete for the `#490` chosen class
- this PR does not reopen `#491` or earlier Wave 1 parser/runtime/delivery/entity slices
