### PR TITLE
[agent-d][issue #496] Enforce event envelope ownership

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -770,7 +770,8 @@ handler_specification:
       sub_fields:
         event: string — event to emit
         fields: map of output_field_name → CEL expression evaluated against handler context. Optional. If omitted, the emitted
-          payload contains only platform-forced fields.
+          payload contains no business fields. Runtime-owned envelope context is attached on the event carrier and is accessed
+          through event.* rather than payload.*.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
         If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
         Payload ownership must move to the active emit site.'
@@ -1293,11 +1294,11 @@ engine:
         event_handlers, boot fails. This ensures unambiguous state authority — one event, one state transition, one owner.
       agents: Not constrained. Multiple agents may subscribe to the same event freely.
       enforcement: Boot validation rejects duplicate node handlers for the same event.
-    emit_payload_default: 'For supported declarative system-node emit sites, the platform constructs the payload by: 1. Start
-      from an empty payload. 2. Evaluate emit.fields, if present, into the payload. 3. Force platform fields: entity_id,
-      trigger_event_type, current_state (always present, always from platform). There is no implicit entity or trigger-payload
-      passthrough on this surface. Collision order: platform fields > emit.fields. Runtime validates this surface fail-closed:
-      undeclared producer-authored payload fields are rejected, not silently trimmed.'
+    emit_payload_default: 'For supported declarative system-node emit sites, the platform constructs the business payload by:
+      1. Start from an empty payload. 2. Evaluate emit.fields, if present, into the payload. 3. Attach runtime-owned envelope
+      context on the emitted event carrier rather than copying it into payload. There is no implicit entity or trigger-payload
+      passthrough on this surface. Runtime rejects authored envelope-owned keys in emit.fields fail-closed. Runtime also validates
+      the resulting payload fail-closed: undeclared producer-authored payload fields are rejected, not silently trimmed.'
     dual_path_events: An event can be both an input pin (arriving from outside the flow) and internally generated (emitted
       by a handler within the flow). The system node handler processes it identically regardless of source. No priority or
       deduplication between paths — if the same event fires from both, it runs twice (idempotency_key in the events table
@@ -3470,49 +3471,53 @@ observation_model:
       description: Rules for constructing emitted event payloads on supported system-node runtime emit surfaces.
       declarative_system_node_emit_surface:
         construction_order:
-        - 1. Start from an empty payload
+        - 1. Start from an empty business payload
         - 2. Evaluate emit.fields for the active emit site, if present
-        - '3. Force platform fields: entity_id, trigger_event_type, current_state'
-        collision_priority: platform fields > emit.fields
+        - 3. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
+        ownership_rule: Runtime-owned envelope fields belong to the event carrier, not to emit.fields or payload.*
         note: This surface has no implicit entity passthrough or trigger-payload passthrough. If an emitted event needs a field
-          beyond the platform-forced fields, the producer must declare it explicitly in emit.fields at the active emit site.
+          beyond the runtime-owned envelope context, the producer must declare it explicitly in emit.fields at the active emit
+          site. Consumers read envelope fields through event.*.
         runtime_validation:
           description: Runtime validates the emitted payload fail-closed on this surface.
-          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
-            that the target schema does not declare.
-          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any declared field violates the
-            schema, handler execution fails. Runtime does not silently trim producer-authored business payload keys.
+          validation_view: Validate the producer-authored payload carrier against the target event schema. Runtime-owned envelope
+            fields are not synthesized into payload for validation.
+          rejection_rule: If any producer-authored field is absent from the target event schema, if any declared field violates
+            the schema, or if emit.fields authors an envelope-owned key, handler execution fails. Runtime does not silently trim
+            producer-authored business payload keys.
       action_originated_emit_surface:
         construction_order:
-        - 1. Start from the triggering event payload
-        - '2. Force platform fields: entity_id, trigger_event_type, current_state'
-        collision_priority: platform fields > triggering event payload
+        - 1. Start from the triggering event payload business carrier
+        - 2. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
+        collision_priority: triggering event payload business fields are preserved unless a future action runtime revision introduces
+          an explicit payload-construction carrier
         note: This surface currently inherits its business payload from the triggering event payload because the action runtime
-          instruction model has no separate emit.fields carrier. Runtime must still fail closed on the resulting payload.
+          instruction model has no separate emit.fields carrier. Runtime must still fail closed on the resulting payload. Consumers
+          read envelope fields through event.* rather than payload.*.
         runtime_validation:
           description: Runtime validates the emitted payload fail-closed on this surface before publish.
-          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
-            that the target schema does not declare.
-          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any producer-authored field is
-            undeclared or violates the schema, handler execution fails. Runtime does not silently trim inherited trigger-payload keys
-            on this surface.
+          validation_view: Validate the emitted payload carrier that will actually be published. Runtime-owned envelope fields are
+            not synthesized into payload for validation.
+          rejection_rule: If any inherited or producer-authored business field is undeclared or violates the schema, handler execution
+            fails. Runtime does not silently trim inherited trigger-payload keys and does not clear the failure by projecting
+            envelope-owned fields back into payload.
       auto_emit_on_create_surface:
         construction_order:
         - 1. Start from lifecycle-owned activation fields: instance_id, template_id, flow_path, subject_id, parent_entity_id
         - 2. Overlay create_flow_instance config entries only for keys not already owned by the lifecycle surface
-        - '3. Force runtime-owned canonical context: entity_id'
-        collision_priority: runtime-owned canonical context > lifecycle-owned fields > create_flow_instance config
+        - 3. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
+        collision_priority: lifecycle-owned payload fields > create_flow_instance config; runtime-owned envelope context is separate
+          from payload
         note: This surface is authored only as `auto_emit_on_create.event`, so runtime owns the payload construction. It still
           must satisfy the active event schema fail-closed. Lifecycle-owned fields are explicit runtime payload on this surface;
-          create_flow_instance config does not silently widen the event contract.
+          create_flow_instance config does not silently widen the event contract; envelope fields remain accessible through event.*.
         runtime_validation:
           description: Runtime validates the constructed auto-emit payload fail-closed before either immediate publish or queued
             post-commit publish.
-          validation_view: Validate the emitted payload against the target event schema after removing runtime-owned envelope fields
-            that the target schema does not declare.
-          rejection_rule: If any non-runtime-owned field is absent from the target event schema, or any lifecycle/config-authored field
-            is undeclared or violates the schema, flow activation fails. Runtime does not downgrade auto_emit_on_create schema violations
-            into warning-only success on the queued post-commit branch.
+          validation_view: Validate the constructed payload carrier against the target event schema. Runtime-owned envelope fields are
+            not synthesized into payload for validation.
+          rejection_rule: If any lifecycle/config-authored field is undeclared or violates the schema, flow activation fails. Runtime
+            does not downgrade auto_emit_on_create schema violations into warning-only success on the queued post-commit branch.
   entity_state:
     description: The entity document after handler execution commits.
     observable_fields:
@@ -3530,7 +3535,8 @@ observation_model:
       kill: 'Guard failed with on_fail: kill. Entity advanced to terminal state.'
       escalate: 'Guard failed with on_fail: escalate:{event}. Escalation event emitted instead, using the same emit payload
         construction rules as a declarative system-node emit with no business fields: no implicit trigger/entity passthrough,
-        platform-forced envelope only, and fail-closed contract validation.'
+        payload stays empty unless authored fields exist, runtime-owned envelope remains on the event carrier, and fail-closed
+        contract validation still applies.'
       dead_letter: Handler failed after retry exhaustion OR chain depth exceeded. Event moved to dead_letters.
       terminal_reject: Event targeted an entity in terminal state. Rejected before handler execution.
       waiting: Accumulation incomplete. Handler recorded the arrival but completion condition not yet met. No further steps
@@ -3708,17 +3714,15 @@ static_analyzer:
       - lower-authority heuristic checks
       - agent write proof via save_entity_field
     proof_carriers:
-      platform_forced_fields:
-        valid_fields:
-        - entity_id
-        - trigger_event_type
-        - current_state
       explicit_emit_fields:
-        valid_for: keys explicitly declared in emit.fields at the active emit site
+        valid_for: producer-authored payload keys explicitly declared in emit.fields at the active emit site
+      non_payload_envelope_context:
+        valid_for: runtime-owned envelope fields accessed through event.* rather than payload completeness proof
     no_emit_fields_rule:
-      description: When emit.fields is absent, only platform-forced fields are provable in this slice.
-    rule: For each required emitted-event field, emit hard-invalidity unless the field is platform-forced or explicitly covered
-      by emit.fields at the active emit site. The finding message must say the field is not statically provable.
+      description: When emit.fields is absent, no producer-authored payload fields are statically provable in this slice.
+    rule: For each required emitted-event payload field, emit hard-invalidity unless the field is explicitly covered by emit.fields
+      at the active emit site. Envelope-owned fields do not clear this proof because they are not payload carriers. The finding
+      message must say the field is not statically provable in the emitted payload.
   slice_3_input_pin_producer_path_satisfaction:
     id: input_pin_wiring
     domain: semantic_drift

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -54,7 +54,6 @@ func (e Event) WithEntityID(entityID string) Event {
 	envelope.EntityID = entityID
 	envelope.Scope = inferEventScope(envelope.EntityID, envelope.FlowInstance)
 	e.Envelope = envelope
-	e.Payload = withEntityIDPayload(e.Payload, entityID)
 	return e
 }
 
@@ -67,8 +66,44 @@ func (e Event) WithFlowInstance(flowInstance string) Event {
 	envelope.FlowInstance = flowInstance
 	envelope.Scope = inferEventScope(envelope.EntityID, envelope.FlowInstance)
 	e.Envelope = envelope
-	e.Payload = withPayloadString(e.Payload, "flow_instance", flowInstance)
 	return e
+}
+
+func (e Event) ContextMap(currentState string) map[string]any {
+	out := map[string]any{}
+	if id := strings.TrimSpace(e.ID); id != "" {
+		out["id"] = id
+	}
+	if eventType := strings.TrimSpace(string(e.Type)); eventType != "" {
+		out["type"] = eventType
+		out["trigger_event_type"] = eventType
+	}
+	if sourceAgent := strings.TrimSpace(e.SourceAgent); sourceAgent != "" {
+		out["source_agent"] = sourceAgent
+	}
+	if taskID := strings.TrimSpace(e.TaskID); taskID != "" {
+		out["task_id"] = taskID
+	}
+	envelope := e.NormalizedEnvelope()
+	if envelope.EntityID != "" {
+		out["entity_id"] = envelope.EntityID
+	}
+	if envelope.FlowInstance != "" {
+		out["flow_instance"] = envelope.FlowInstance
+	}
+	if envelope.Scope != "" {
+		out["scope"] = string(envelope.Scope)
+	}
+	if currentState = strings.TrimSpace(currentState); currentState != "" {
+		out["current_state"] = currentState
+	}
+	if parentEventID := strings.TrimSpace(e.ParentEventID); parentEventID != "" {
+		out["source_event_id"] = parentEventID
+	}
+	if !e.CreatedAt.IsZero() {
+		out["emitted_at"] = e.CreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return out
 }
 
 func (e Event) EntityID() string {
@@ -123,30 +158,6 @@ func normalizeEventScope(scope EventScope) EventScope {
 	default:
 		return ""
 	}
-}
-
-func withEntityIDPayload(raw json.RawMessage, entityID string) json.RawMessage {
-	return withPayloadString(raw, "entity_id", entityID)
-}
-
-func withPayloadString(raw json.RawMessage, key, value string) json.RawMessage {
-	key = strings.TrimSpace(key)
-	value = strings.TrimSpace(value)
-	if key == "" || value == "" {
-		return raw
-	}
-	payload := map[string]any{}
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &payload); err != nil || payload == nil {
-			return raw
-		}
-	}
-	payload[key] = value
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		return raw
-	}
-	return encoded
 }
 
 func asString(v any) string {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -638,7 +638,7 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 			{
 				Message: llm.Message{Role: "assistant", Content: "Dispatching workflow now."},
 				ToolCalls: []llm.ToolCall{
-					{Name: "emit_scan_requested", Arguments: map[string]any{"entity_id": "corpus-1"}},
+					{Name: "emit_scan_requested", Arguments: map[string]any{}},
 				},
 			},
 			{Message: llm.Message{Role: "assistant", Content: "scan_requested emitted"}},
@@ -660,13 +660,7 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"scan.requested": {
-				Payload: runtimecontracts.EventPayloadSpec{
-					Type: "object",
-					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"entity_id": {Type: "string"},
-					},
-					Required: []string{"entity_id"},
-				},
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
 			},
 		},
 	})
@@ -696,7 +690,7 @@ func TestBoardStep_FactoryCreatedDirectiveRemediationPreservesFlowScopedEmitTool
 			{
 				Message: llm.Message{Role: "assistant", Content: "Dispatching workflow now."},
 				ToolCalls: []llm.ToolCall{
-					{Name: "emit_scan_requested", Arguments: map[string]any{"entity_id": "corpus-1"}},
+					{Name: "emit_scan_requested", Arguments: map[string]any{}},
 				},
 			},
 			{Message: llm.Message{Role: "assistant", Content: "scan_requested emitted"}},
@@ -714,13 +708,7 @@ func TestBoardStep_FactoryCreatedDirectiveRemediationPreservesFlowScopedEmitTool
 	}, rt, &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"scan.requested": {
-				Payload: runtimecontracts.EventPayloadSpec{
-					Type: "object",
-					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"entity_id": {Type: "string"},
-					},
-					Required: []string{"entity_id"},
-				},
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
 			},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1671,7 +1671,7 @@ func TestRun_ErrorsWithoutEmitFieldsEvenWhenContextSuggestsPassthrough(t *testin
 	}
 }
 
-func TestRun_DoesNotWarnWhenEmitFieldsAndPlatformForcedFieldsCoverRequiredPayload(t *testing.T) {
+func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayload(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	node := bundle.Nodes["dispatcher"]
 	handler := node.EventHandlers["scan.corpus_dispatch"]
@@ -1742,7 +1742,7 @@ func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayloadAcrossExpressionKinds(
 	}
 }
 
-func TestRun_DoesNotWarnWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
+func TestRun_ErrorsWhenRequiredPayloadContainsEnvelopeOwnedFields(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	entry := bundle.Events["market_research.scan_assigned"]
 	entry.Required = []string{"entity_id", "current_state"}
@@ -1750,8 +1750,35 @@ func TestRun_DoesNotWarnWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "not statically provable") {
-		t.Fatalf("unexpected payload completeness error for platform-forced-only schema, got %#v", report.Errors())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "entity_id is not statically provable") {
+		t.Fatalf("expected payload completeness error for envelope-owned required field entity_id, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "current_state is not statically provable") {
+		t.Fatalf("expected payload completeness error for envelope-owned required field current_state, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsWhenEmitFieldsAuthorEnvelopeOwnedFieldWithoutRequiredPayload(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = nil
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"entity_id": runtimecontracts.RefExpression("payload.scan_id"),
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "authors envelope-owned field entity_id in emit.fields") {
+		t.Fatalf("expected authored envelope field error even without required payload fields, got %#v", report.Errors())
 	}
 }
 
@@ -1915,13 +1942,19 @@ func TestRun_ErrorsForGuardEscalatePayloadDrift(t *testing.T) {
 	}
 }
 
-func TestRun_DoesNotErrorForGuardEscalateWhenOnlyPlatformForcedFieldsAreRequired(t *testing.T) {
+func TestRun_ErrorsForGuardEscalateWhenRequiredPayloadContainsEnvelopeOwnedFields(t *testing.T) {
 	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+	entry := bundle.Events["check.escalated"]
+	entry.Required = []string{"entity_id"}
+	bundle.Events["check.escalated"] = entry
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
-		t.Fatalf("unexpected payload completeness error for platform-forced-only guard escalation, got %#v", report.Errors())
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("expected payload completeness error for guard escalation event schema that still requires envelope-owned payload fields, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "entity_id is not statically provable") {
+		t.Fatalf("expected envelope-owned entity_id drift for guard escalation, got %#v", report.Errors())
 	}
 }
 
@@ -3994,14 +4027,11 @@ func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBun
 				ConsumerType: []string{"dashboard"},
 				Payload: runtimecontracts.EventPayloadSpec{
 					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"entity_id":          {Type: "string"},
-						"current_state":      {Type: "string"},
-						"trigger_event_type": {Type: "string"},
-						"scan_id":            {Type: "string"},
-						"geography":          {Type: "string"},
+						"scan_id":   {Type: "string"},
+						"geography": {Type: "string"},
 					},
 				},
-				Required: []string{"entity_id", "scan_id"},
+				Required: []string{"scan_id"},
 			},
 		},
 	}

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -20,8 +20,6 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 	}
 	c.payloadCompletenessLoaded = true
 
-	forced := payloadCompletenessForcedFields()
-
 	for nodeID := range c.source.NodeEntries() {
 		nodeID = strings.TrimSpace(nodeID)
 		nodeSource, _ := c.source.NodeContractSource(nodeID)
@@ -45,6 +43,19 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 					continue
 				}
 				emittedProof := semanticview.ResolveFlowEventProof(c.source, flowID, emitted)
+				emittedDisplayName := strings.TrimSpace(emittedProof.DisplayName())
+				if emittedDisplayName == "" {
+					emittedDisplayName = emitted
+				}
+
+				for _, authoredEnvelopeField := range payloadCompletenessEnvelopeFields(emitSite.Fields) {
+					c.payloadCompletenessFindings = append(c.payloadCompletenessFindings, Finding{
+						CheckID:  "semantic_drift_payload_completeness",
+						Severity: "error",
+						Message:  fmt.Sprintf("event %s emitted by node %s handler %s at %s authors envelope-owned field %s in emit.fields; envelope fields are platform-managed and must be accessed via event.*", emittedDisplayName, nodeID, triggerEventType, emitSite.Label, authoredEnvelopeField),
+						Location: nodeID,
+					})
+				}
 				if !emittedProof.HasSchema {
 					continue
 				}
@@ -54,9 +65,6 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 				}
 
 				for _, field := range required {
-					if _, ok := forced[field]; ok {
-						continue
-					}
 					if _, ok := emitSite.Fields[field]; ok {
 						continue
 					}
@@ -67,7 +75,7 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 						Message: payloadCompletenessMessage(
 							nodeID,
 							triggerEventType,
-							emittedProof.DisplayName(),
+							emittedDisplayName,
 							field,
 							emitSite.Label,
 							emitSite.Fields,
@@ -99,14 +107,6 @@ type payloadCompletenessEmitSite struct {
 
 func payloadCompletenessRequiredFields(entry runtimecontracts.EventCatalogEntry) []string {
 	return uniquePayloadCompletenessStrings(entry.Required...)
-}
-
-func payloadCompletenessForcedFields() map[string]struct{} {
-	return map[string]struct{}{
-		"entity_id":          {},
-		"trigger_event_type": {},
-		"current_state":      {},
-	}
 }
 
 func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandler) []payloadCompletenessEmitSite {
@@ -171,6 +171,31 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 	return out
 }
 
+func payloadCompletenessEnvelopeFields(fields map[string]struct{}) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" || !isRuntimeOwnedCanonicalContextField(field) {
+			continue
+		}
+		out = append(out, field)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isRuntimeOwnedCanonicalContextField(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle", "source_event_id", "emitted_at":
+		return true
+	default:
+		return false
+	}
+}
+
 func payloadCompletenessRuleLabel(scope string, index int, id, suffix string) string {
 	scope = strings.TrimSpace(scope)
 	id = strings.TrimSpace(id)
@@ -231,7 +256,7 @@ func payloadCompletenessMessage(nodeID, triggerEventType, emittedEventType, fiel
 		}
 	}
 	return fmt.Sprintf(
-		"event %s emitted by node %s handler %s at %s: required field %s is not statically provable in the emitted payload. Payload construction: emit.fields: %s; emit.fields covers: %s; platform-forced: entity_id, trigger_event_type, current_state. Context (does not clear finding): trigger schema declares %s: %s; entity schema declares %s: %s.",
+		"event %s emitted by node %s handler %s at %s: required field %s is not statically provable in the emitted payload. Payload construction: emit.fields: %s; emit.fields covers: %s. Context (does not clear finding): trigger schema declares %s: %s; entity schema declares %s: %s.",
 		strings.TrimSpace(emittedEventType),
 		strings.TrimSpace(nodeID),
 		strings.TrimSpace(triggerEventType),

--- a/internal/runtime/cataloge2e/scripted_llm.go
+++ b/internal/runtime/cataloge2e/scripted_llm.go
@@ -134,7 +134,7 @@ func defaultScriptedResponseForTools(session *llm.Session, content string) (llm.
 	if session == nil {
 		return llm.Response{}, false
 	}
-	eventType, entityID := parseAgentEventMessage(content)
+	eventType, _ := parseAgentEventMessage(content)
 	if strings.TrimSpace(eventType) == "" {
 		return llm.Response{}, false
 	}
@@ -148,15 +148,11 @@ func defaultScriptedResponseForTools(session *llm.Session, content string) (llm.
 	if len(emitTools) != 1 {
 		return llm.Response{}, false
 	}
-	args := map[string]any{}
-	if strings.TrimSpace(entityID) != "" {
-		args["entity_id"] = strings.TrimSpace(entityID)
-	}
 	return llm.Response{
 		Message: llm.Message{Role: "assistant", Content: ""},
 		ToolCalls: []llm.ToolCall{{
 			Name:      emitTools[0],
-			Arguments: args,
+			Arguments: map[string]any{},
 		}},
 	}, true
 }

--- a/internal/runtime/core/paths/path.go
+++ b/internal/runtime/core/paths/path.go
@@ -7,6 +7,7 @@ type PathRoot uint8
 const (
 	RootUnknown PathRoot = iota
 	RootPayload
+	RootEvent
 	RootEntity
 	RootPolicy
 	RootMetadata
@@ -20,6 +21,8 @@ func (r PathRoot) String() string {
 	switch r {
 	case RootPayload:
 		return "payload"
+	case RootEvent:
+		return "event"
 	case RootEntity:
 		return "entity"
 	case RootPolicy:
@@ -73,6 +76,8 @@ func parseRoot(text string) PathRoot {
 	switch strings.ToLower(strings.TrimSpace(text)) {
 	case "payload":
 		return RootPayload
+	case "event":
+		return RootEvent
 	case "entity":
 		return RootEntity
 	case "policy":

--- a/internal/runtime/core/values/context.go
+++ b/internal/runtime/core/values/context.go
@@ -4,6 +4,7 @@ import "swarm/internal/runtime/core/paths"
 
 type Context struct {
 	Entity      Bucket
+	Event       Bucket
 	Policy      Bucket
 	Metadata    Bucket
 	Gates       Bucket
@@ -16,6 +17,7 @@ type Context struct {
 func NewContext() Context {
 	return Context{
 		Entity:      Wrap(map[string]any{}),
+		Event:       Wrap(map[string]any{}),
 		Policy:      Wrap(map[string]any{}),
 		Metadata:    Wrap(map[string]any{}),
 		Gates:       Wrap(map[string]any{}),
@@ -29,6 +31,7 @@ func NewContext() Context {
 func (c Context) Clone() Context {
 	return Context{
 		Entity:      c.Entity.Clone(),
+		Event:       c.Event.Clone(),
 		Policy:      c.Policy.Clone(),
 		Metadata:    c.Metadata.Clone(),
 		Gates:       c.Gates.Clone(),
@@ -41,6 +44,11 @@ func (c Context) Clone() Context {
 
 func (c Context) WithPayload(payload map[string]any) Context {
 	c.Payload = Wrap(payload).Clone()
+	return c
+}
+
+func (c Context) WithEvent(event map[string]any) Context {
+	c.Event = Wrap(event).Clone()
 	return c
 }
 
@@ -58,6 +66,8 @@ func (c Context) Bucket(root paths.PathRoot) Bucket {
 	switch root {
 	case paths.RootEntity:
 		return c.Entity
+	case paths.RootEvent:
+		return c.Event
 	case paths.RootPolicy:
 		return c.Policy
 	case paths.RootMetadata:

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/entityruntime"
@@ -19,6 +20,7 @@ type ContextBuilderInput struct {
 	Source  semanticview.Source
 	FlowID  string
 	State   StateSnapshot
+	Event   events.Event
 	Payload map[string]any
 }
 
@@ -30,6 +32,7 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 	base.Entity = values.Wrap(materializedState.EntityContext())
 	base.Metadata = values.Wrap(cloneStringAnyMap(input.State.StateCarrier.Metadata))
 	base.Gates = values.Wrap(boolMapToAnyMap(input.State.StateCarrier.Gates))
+	base.Event = values.Wrap(input.Event.ContextMap(input.State.CurrentState))
 	base.Payload = values.Wrap(cloneStringAnyMap(input.Payload))
 	if input.Source != nil {
 		base.Policy = values.Wrap(policyDocumentToMap(input.Source.ResolvedPolicyForFlow(input.FlowID)))
@@ -39,6 +42,11 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 
 func WithPayload(base BaseContext, payload map[string]any) BaseContext {
 	base.Payload = values.Wrap(cloneStringAnyMap(payload))
+	return base
+}
+
+func WithEvent(base BaseContext, event map[string]any) BaseContext {
+	base.Event = values.Wrap(cloneStringAnyMap(event))
 	return base
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -385,7 +385,7 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 		}
 		filtered := make([]any, 0, len(items))
 		for _, item := range items {
-			scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
 			passed, err := compiled.Eval(scope)
 			if err != nil {
 				return err
@@ -401,7 +401,7 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 	case strings.TrimSpace(spec.GroupBy) != "":
 		grouped := map[string]any{}
 		for _, item := range items {
-			scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
 			resolved, err := scope.resolveOperand(strings.TrimSpace(spec.GroupBy), executionOperandDefaultItem)
 			if err != nil {
 				return err
@@ -576,7 +576,7 @@ func (e *Executor) stepFilter(frame *executionFrame) error {
 	}
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
-		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
 		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
@@ -620,7 +620,7 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 			count++
 			continue
 		}
-		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
 		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
@@ -712,7 +712,7 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 	current := e.currentContext(frame)
 	grouped := make(map[string]any)
 	for _, item := range items {
-		scope := newExecutionScope(item, frame.payload, frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
 		resolved, err := scope.resolveOperand(strings.TrimSpace(spec.Key), executionOperandDefaultItem)
 		if err != nil {
 			return err

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -280,6 +280,7 @@ func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame
 		Source:  e.deps.Source,
 		FlowID:  req.FlowID.String(),
 		State:   state,
+		Event:   req.Event,
 		Payload: payload,
 	})
 	req.State = state
@@ -1159,6 +1160,7 @@ func mergeStateSnapshots(base, loaded StateSnapshot) StateSnapshot {
 
 func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx := WithPayload(frame.base, frame.payload)
+	ctx = WithEvent(ctx, frame.req.Event.ContextMap(frame.state.State.CurrentState))
 	ctx = WithAccumulated(ctx, frame.state.Accumulated)
 	ctx = WithFanOutItem(ctx, frame.state.FanOut)
 	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
@@ -1390,7 +1392,6 @@ func (e *Executor) newEmitIntent(frame *executionFrame, eventType string, payloa
 		}
 	}
 	entityID := strings.TrimSpace(firstNonEmpty(
-		asString(payload["entity_id"]),
 		frame.req.EntityID.String(),
 	))
 	evt := events.Event{
@@ -1401,6 +1402,17 @@ func (e *Executor) newEmitIntent(frame *executionFrame, eventType string, payloa
 	}
 	if entityID != "" {
 		evt = evt.WithEntityID(entityID)
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(firstNonEmpty(
+		frame.req.Event.FlowInstance(),
+		asString(frame.req.State.StateCarrier.Metadata["flow_path"]),
+	)), "/")
+	if flowInstance != "" {
+		evt = evt.WithFlowInstance(flowInstance)
+	}
+	evt.ParentEventID = strings.TrimSpace(frame.req.Event.ID)
+	if evt.TaskID == "" {
+		evt.TaskID = strings.TrimSpace(frame.req.Event.TaskID)
 	}
 	return EmitIntent{
 		Event:         evt,

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -227,6 +227,47 @@ func TestExecutor_ValidateRequestRejectsConflictingCompletionDialect(t *testing.
 	}
 }
 
+func TestExecutionScopeResolveOperand_AllowsEventRoot(t *testing.T) {
+	scope := newExecutionScope(
+		nil,
+		map[string]any{"entity_id": "payload-entity"},
+		map[string]any{"entity_id": "event-entity"},
+		nil,
+		nil,
+	)
+
+	got, err := scope.resolveOperand("event.entity_id", executionOperandDefaultNone)
+	if err != nil {
+		t.Fatalf("resolveOperand(event.entity_id) error: %v", err)
+	}
+	if got != "event-entity" {
+		t.Fatalf("resolveOperand(event.entity_id) = %#v, want event-entity", got)
+	}
+}
+
+func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
+	compiled, err := compileExecutionCondition(`event.entity_id == "event-entity"`)
+	if err != nil {
+		t.Fatalf("compileExecutionCondition error: %v", err)
+	}
+
+	scope := newExecutionScope(
+		nil,
+		map[string]any{"entity_id": "payload-entity"},
+		map[string]any{"entity_id": "event-entity"},
+		nil,
+		nil,
+	)
+
+	ok, err := compiled.Eval(scope)
+	if err != nil {
+		t.Fatalf("compiled condition Eval error: %v", err)
+	}
+	if !ok {
+		t.Fatal("compiled condition evaluated false, want true")
+	}
+}
+
 func TestExecutor_ValidateRequestRejectsCreateEntityWithAccumulate(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSource(),

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -217,6 +217,7 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string) (any, error) {
 	return workflowexpr.EvalValueExpression(expression, workflowexpr.ValueContext{
 		Entity:  base.Entity.Raw(),
+		Event:   base.Event.Raw(),
 		Payload: base.Payload.Raw(),
 		Policy:  base.Policy.Raw(),
 		FanOut:  state.FanOut,

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -481,6 +481,7 @@ func executionItems(value any) []any {
 type executionScope struct {
 	Item    any
 	Payload map[string]any
+	Event   map[string]any
 	Entity  map[string]any
 	Policy  map[string]any
 }
@@ -497,10 +498,11 @@ type compiledExecutionCondition struct {
 	program    cel.Program
 }
 
-func newExecutionScope(item any, payload, entity, policy map[string]any) executionScope {
+func newExecutionScope(item any, payload, event, entity, policy map[string]any) executionScope {
 	return executionScope{
 		Item:    normalizeCELValue(item),
 		Payload: normalizedCELInputMap(payload),
+		Event:   normalizedCELInputMap(event),
 		Entity:  normalizedCELInputMap(entity),
 		Policy:  normalizedCELInputMap(policy),
 	}
@@ -510,6 +512,7 @@ func (s executionScope) activation() map[string]any {
 	return map[string]any{
 		"item":    s.Item,
 		"payload": s.Payload,
+		"event":   s.Event,
 		"entity":  s.Entity,
 		"policy":  s.Policy,
 	}
@@ -520,6 +523,7 @@ func executionConditionEnv() (*cel.Env, error) {
 		executionConditionEnvRef, executionConditionEnvErr = cel.NewEnv(
 			cel.Variable("item", cel.DynType),
 			cel.Variable("payload", cel.DynType),
+			cel.Variable("event", cel.DynType),
 			cel.Variable("entity", cel.DynType),
 			cel.Variable("policy", cel.DynType),
 		)
@@ -629,6 +633,8 @@ func (s executionScope) lookupExplicitRoot(root paths.PathRoot, segments []strin
 	switch root {
 	case paths.RootPayload:
 		return lookupExecutionOperandPath(s.Payload, segments)
+	case paths.RootEvent:
+		return lookupExecutionOperandPath(s.Event, segments)
 	case paths.RootEntity:
 		return lookupExecutionOperandPath(s.Entity, segments)
 	case paths.RootPolicy:

--- a/internal/runtime/eventpayload/context.go
+++ b/internal/runtime/eventpayload/context.go
@@ -4,7 +4,7 @@ import "strings"
 
 func IsRuntimeOwnedCanonicalContextField(key string) bool {
 	switch strings.TrimSpace(key) {
-	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle":
+	case "entity_id", "flow_instance", "trigger_event_type", "current_state", "task_id", "timer_handle", "source_event_id", "emitted_at":
 		return true
 	default:
 		return false
@@ -42,6 +42,24 @@ func StripRuntimeOwnedCanonicalContext(payload map[string]any) map[string]any {
 			continue
 		}
 		out[key] = value
+	}
+	return out
+}
+
+func RuntimeOwnedCanonicalContextFields(payload map[string]any) []string {
+	if len(payload) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(payload))
+	for key := range payload {
+		key = strings.TrimSpace(key)
+		if key == "" || !IsRuntimeOwnedCanonicalContextField(key) {
+			continue
+		}
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -164,7 +164,6 @@ func buildAutoEmitOnCreateEvent(source semanticview.Source, schema runtimecontra
 	}
 	eventType := eventidentity.ExternalizeForFlow(flowPath, []string{autoEmit}, autoEmit)
 	payload := map[string]any{
-		"entity_id":        flowEntityID,
 		"instance_id":      instanceID,
 		"template_id":      templateID,
 		"flow_path":        flowPath,

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -810,9 +810,6 @@ func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType s
 	allowed := eventPayloadProperties(proof.Entry)
 	validationPayload := cloneStringAnyMap(payload)
 	if surface != runtimeengine.EmitSurfaceDeclarative {
-		for key, value := range envelope {
-			validationPayload[key] = value
-		}
 		validationPayload = runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(validationPayload, allowed)
 	}
 	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, validationPayload); err != nil {

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 	}
 	queryCtx := workflowExpressionContext{
 		Entity:      cloneStringAnyMap(ctx.Entity.Raw()),
+		Event:       cloneStringAnyMap(ctx.Event.Raw()),
 		Payload:     cloneStringAnyMap(ctx.Payload.Raw()),
 		Policy:      cloneStringAnyMap(ctx.Policy.Raw()),
 		Accumulated: accumulatedItemsForCEL(ctx.Accumulated.Raw()),
@@ -782,32 +784,18 @@ func (s pipelineEnginePayloadShaper) ShapeEmitPayload(ctx context.Context, req r
 		out = map[string]any{}
 	}
 	envelope := pc.handlerEmitEnvelope(ctx, engineTriggerContext(req), strings.TrimSpace(eventType))
-	state := workflowStateFromEngine(req.State)
-	entityID := resolveEmittedEntityID(
-		pc.SemanticSource(),
-		req.FlowID.String(),
-		eventType,
-		*state,
-		req.Event,
-		req.EntityID.String(),
-		asString(envelope["entity_id"]),
-	)
-	if entityID == "" && !req.EntityID.IsZero() {
-		entityID = strings.TrimSpace(req.EntityID.String())
+	if emitSurface := runtimeengine.EmitSurfaceFromContext(ctx); emitSurface == runtimeengine.EmitSurfaceDeclarative {
+		if err := rejectAuthoredEnvelopeFields(out); err != nil {
+			return nil, err
+		}
 	}
-	if entityID != "" {
-		envelope["entity_id"] = entityID
-	}
-	for key, value := range envelope {
-		out[key] = value
-	}
-	if err := validatePipelineEmitPayload(pc.SemanticSource(), req.FlowID.String(), eventType, out); err != nil {
+	if err := validatePipelineEmitPayload(pc.SemanticSource(), req.FlowID.String(), eventType, out, envelope, runtimeengine.EmitSurfaceFromContext(ctx)); err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType string, payload map[string]any) error {
+func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType string, payload, envelope map[string]any, surface runtimeengine.EmitSurface) error {
 	proof := semanticview.ResolveFlowEventProof(source, strings.TrimSpace(flowID), strings.TrimSpace(eventType))
 	if !proof.HasSchema {
 		return nil
@@ -820,11 +808,26 @@ func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType s
 		return nil
 	}
 	allowed := eventPayloadProperties(proof.Entry)
-	validationPayload := runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(payload, allowed)
+	validationPayload := cloneStringAnyMap(payload)
+	if surface != runtimeengine.EmitSurfaceDeclarative {
+		for key, value := range envelope {
+			validationPayload[key] = value
+		}
+		validationPayload = runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(validationPayload, allowed)
+	}
 	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, validationPayload); err != nil {
 		return fmt.Errorf("%w: event %s payload violates schema: %v", runtimeengine.ErrEmitPayloadContractViolation, proof.EventKey(), err)
 	}
 	return nil
+}
+
+func rejectAuthoredEnvelopeFields(payload map[string]any) error {
+	fields := runtimeeventpayload.RuntimeOwnedCanonicalContextFields(payload)
+	if len(fields) == 0 {
+		return nil
+	}
+	sort.Strings(fields)
+	return fmt.Errorf("%w: authored emit payload must not include platform-owned envelope field(s): %s", runtimeengine.ErrEmitPayloadContractViolation, strings.Join(fields, ", "))
 }
 
 func pipelineEmitPayloadProperties(source semanticview.Source, flowID, eventType string) map[string]struct{} {
@@ -1116,16 +1119,6 @@ func workflowBoolGatesAsMap(gates map[string]bool) map[string]any {
 }
 
 func engineTriggerContext(req runtimeengine.ExecutionRequest) workflowTriggerContext {
-	payload := parsePayloadMap(req.Event.Payload)
-	if len(payload) == 0 {
-		payload = map[string]any{}
-		if !req.EntityID.IsZero() {
-			payload["entity_id"] = req.EntityID.String()
-			if encoded, err := json.Marshal(payload); err == nil {
-				req.Event.Payload = encoded
-			}
-		}
-	}
 	return workflowTriggerContext{
 		Event: req.Event,
 		State: WorkflowState{

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -944,18 +944,18 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 		},
 	}
 
-	internal, err := shaper.ShapeEmitPayload(context.Background(), req, "child/child.internal", map[string]any{"entity_id": "ent-child", "step": "done"})
+	internal, err := shaper.ShapeEmitPayload(context.Background(), req, "child/child.internal", map[string]any{"step": "done"})
 	if err != nil {
 		t.Fatalf("ShapeEmitPayload internal: %v", err)
 	}
-	if got := internal["entity_id"]; got != "ent-child" {
-		t.Fatalf("internal emit entity_id = %#v, want ent-child", got)
+	if _, ok := internal["entity_id"]; ok {
+		t.Fatalf("internal emit payload must not carry envelope entity_id: %#v", internal["entity_id"])
 	}
 	if got := internal["step"]; got != "done" {
 		t.Fatalf("internal emit step = %#v, want done", got)
 	}
 
-	if _, err := shaper.ShapeEmitPayload(context.Background(), req, "child/child.done", map[string]any{"entity_id": "ent-child", "step": "done"}); err == nil {
+	if _, err := shaper.ShapeEmitPayload(context.Background(), req, "child/child.done", map[string]any{"step": "done"}); err == nil {
 		t.Fatal("expected cross-flow undeclared field to fail closed")
 	} else if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
 		t.Fatalf("ShapeEmitPayload output error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
@@ -990,7 +990,6 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsAcrossCrossFlowOutpu
 	}
 
 	_, err := shaper.ShapeEmitPayload(context.Background(), req, "child/child.done", map[string]any{
-		"entity_id":   "ent-child",
 		"vertical_id": "ent-child",
 		"result":      "accepted",
 	})
@@ -1030,17 +1029,12 @@ func TestPipelineEnginePayloadShaper_AllowsDeclaredPayloadOnActionSurface(t *tes
 	}
 
 	actionCtx := runtimeengine.WithEmitSurface(context.Background(), runtimeengine.EmitSurfaceAction)
-	payload, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.done", map[string]any{
-		"entity_id": "ent-child",
-	})
+	payload, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.done", map[string]any{})
 	if err != nil {
 		t.Fatalf("ShapeEmitPayload action surface: %v", err)
 	}
-	if got := payload["entity_id"]; got != "ent-child" {
-		t.Fatalf("action payload entity_id = %#v, want ent-child", got)
-	}
-	if got := payload["trigger_event_type"]; got != "child/child.internal" {
-		t.Fatalf("action payload trigger_event_type = %#v, want child/child.internal", got)
+	if len(payload) != 0 {
+		t.Fatalf("action payload = %#v, want declared business payload only", payload)
 	}
 }
 
@@ -1146,11 +1140,11 @@ func TestPipelineEmitPayloadProperties_UsesCanonicalFlowEventProofForLocalAndCan
 	if !reflect.DeepEqual(canonical, local) {
 		t.Fatalf("local/canonical payload properties drifted: canonical=%#v local=%#v", canonical, local)
 	}
-	if _, ok := canonical["entity_id"]; !ok {
-		t.Fatalf("expected entity_id in canonical payload properties: %#v", canonical)
-	}
 	if _, ok := canonical["step"]; !ok {
 		t.Fatalf("expected step in canonical payload properties: %#v", canonical)
+	}
+	if _, ok := canonical["entity_id"]; ok {
+		t.Fatalf("payload properties must not expose envelope entity_id: %#v", canonical)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1084,6 +1084,50 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface
 	}
 }
 
+func TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSurface(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml":             "name: action-emit-envelope-required\nversion: 1.0.0\ndescription: Action emit envelope-required proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
+		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n  outputs:\n    events: [parent.result]\n",
+		"events.yaml":              "parent.trigger:\n  entity_id: string\nparent.result:\n  entity_id: string\n",
+		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
+		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.internal]\n",
+		"flows/child/events.yaml":  "child.start:\n  entity_id: string\nchild.internal:\n  entity_id: string\n  required: [entity_id]\n",
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected workflow fixture bundle")
+	}
+	shaper := pipelineEnginePayloadShaper{
+		coordinator: &PipelineCoordinator{
+			module: &previewWorkflowModule{
+				bundle: bundle,
+			},
+		},
+	}
+
+	req := runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("ent-child"),
+		FlowID:   identity.NormalizeFlowID("child"),
+		Event: events.Event{
+			Type:    events.EventType("child/child.start"),
+			Payload: json.RawMessage(`{"entity_id":"ent-child"}`),
+		}.WithEntityID("ent-child"),
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
+		},
+	}
+
+	actionCtx := runtimeengine.WithEmitSurface(context.Background(), runtimeengine.EmitSurfaceAction)
+	_, err := shaper.ShapeEmitPayload(actionCtx, req, "child/child.internal", map[string]any{})
+	if err == nil {
+		t.Fatal("expected action surface envelope-only required field to fail closed")
+	}
+	if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+		t.Fatalf("ShapeEmitPayload action surface error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
+	}
+}
+
 func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -197,8 +197,8 @@ func TestExecuteNodeContractHandlerUsesTypedEnvelopeIdentityOverPayload(t *testi
 	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
 		t.Fatalf("unmarshal emitted payload: %v", err)
 	}
-	if got := payload["entity_id"]; got != "env-ent" {
-		t.Fatalf("emitted payload entity_id = %#v, want env-ent", got)
+	if _, ok := payload["entity_id"]; ok {
+		t.Fatalf("emitted payload must not carry envelope entity_id: %#v", payload["entity_id"])
 	}
 }
 
@@ -1619,10 +1619,10 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
-				"entity_id":     runtimecontracts.CELExpression("payload.entity_id"),
-				"summary.stage": runtimecontracts.CELExpression("entity.current_state"),
-				"flags.ready":   runtimecontracts.CELExpression("true"),
-				"label":         runtimecontracts.CELExpression(`"done"`),
+				"summary.entity_id": runtimecontracts.CELExpression("event.entity_id"),
+				"summary.stage":     runtimecontracts.CELExpression("entity.current_state"),
+				"flags.ready":       runtimecontracts.CELExpression("true"),
+				"label":             runtimecontracts.CELExpression(`"done"`),
 			},
 		},
 	}, workflowTriggerContext{
@@ -1642,10 +1642,10 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
 		t.Fatalf("decode payload: %v", err)
 	}
-	if got := payload["entity_id"]; got != "ent-1" {
-		t.Fatalf("payload.entity_id = %#v, want ent-1", got)
-	}
 	summary, _ := payload["summary"].(map[string]any)
+	if got := summary["entity_id"]; got != "ent-1" {
+		t.Fatalf("payload.summary.entity_id = %#v, want ent-1", got)
+	}
 	if got := summary["stage"]; got != "queued" {
 		t.Fatalf("payload.summary.stage = %#v, want queued", got)
 	}
@@ -1655,6 +1655,9 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 	}
 	if got := payload["label"]; got != "done" {
 		t.Fatalf("payload.label = %#v, want done", got)
+	}
+	if _, ok := payload["entity_id"]; ok {
+		t.Fatalf("payload must not carry envelope entity_id: %#v", payload["entity_id"])
 	}
 }
 
@@ -2049,20 +2052,26 @@ func TestExecuteNodeContractHandler_UsesEmitFieldsAsOnlyBusinessPayloadSource(t 
 	if got := payload["label"]; got != "done" {
 		t.Fatalf("payload.label = %#v, want done", got)
 	}
-	if got := payload["entity_id"]; got != "ent-1" {
-		t.Fatalf("payload.entity_id = %#v, want ent-1", got)
+	if _, ok := payload["entity_id"]; ok {
+		t.Fatalf("payload must not carry envelope entity_id: %#v", payload["entity_id"])
 	}
-	if got := payload["trigger_event_type"]; got != "custom.trigger" {
-		t.Fatalf("payload.trigger_event_type = %#v, want custom.trigger", got)
+	if _, ok := payload["trigger_event_type"]; ok {
+		t.Fatalf("payload must not carry envelope trigger_event_type: %#v", payload["trigger_event_type"])
 	}
-	if got := payload["current_state"]; got != "queued" {
-		t.Fatalf("payload.current_state = %#v, want queued", got)
+	if _, ok := payload["current_state"]; ok {
+		t.Fatalf("payload must not carry envelope current_state: %#v", payload["current_state"])
 	}
 	if _, ok := payload["legacy"]; ok {
 		t.Fatalf("legacy trigger payload leaked into emitted payload: %#v", payload["legacy"])
 	}
 	if _, ok := payload["legacy_entity"]; ok {
 		t.Fatalf("entity metadata leaked into emitted payload: %#v", payload["legacy_entity"])
+	}
+	if got := bus.publishedEvent(0).EntityID(); got != "ent-1" {
+		t.Fatalf("emitted event entity_id = %q, want ent-1", got)
+	}
+	if got := string(bus.publishedEvent(0).Type); got != "custom.emitted" {
+		t.Fatalf("emitted event type = %q, want custom.emitted", got)
 	}
 }
 
@@ -2093,20 +2102,23 @@ func TestExecuteNodeContractHandler_GuardEscalateUsesOnlyRuntimeOwnedEnvelope(t 
 	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
 		t.Fatalf("decode payload: %v", err)
 	}
-	if got := payload["entity_id"]; got != "ent-1" {
-		t.Fatalf("payload.entity_id = %#v, want ent-1", got)
+	if _, ok := payload["entity_id"]; ok {
+		t.Fatalf("payload must not carry envelope entity_id: %#v", payload["entity_id"])
 	}
-	if got := payload["trigger_event_type"]; got != "custom.trigger" {
-		t.Fatalf("payload.trigger_event_type = %#v, want custom.trigger", got)
+	if _, ok := payload["trigger_event_type"]; ok {
+		t.Fatalf("payload must not carry envelope trigger_event_type: %#v", payload["trigger_event_type"])
 	}
-	if got := payload["current_state"]; got != "queued" {
-		t.Fatalf("payload.current_state = %#v, want queued", got)
+	if _, ok := payload["current_state"]; ok {
+		t.Fatalf("payload must not carry envelope current_state: %#v", payload["current_state"])
 	}
 	if _, ok := payload["score"]; ok {
 		t.Fatalf("guard escalation leaked trigger payload into emitted payload: %#v", payload["score"])
 	}
 	if _, ok := payload["legacy"]; ok {
 		t.Fatalf("guard escalation leaked legacy trigger payload into emitted payload: %#v", payload["legacy"])
+	}
+	if got := bus.publishedEvent(0).EntityID(); got != "ent-1" {
+		t.Fatalf("guard escalation event entity_id = %q, want ent-1", got)
 	}
 	if _, ok := payload["legacy_entity"]; ok {
 		t.Fatalf("guard escalation leaked entity metadata into emitted payload: %#v", payload["legacy_entity"])

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -43,6 +43,7 @@ func ValidateConditionCEL(expression string, context WorkflowConditionContext) e
 func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {
 	options := []cel.EnvOption{
 		cel.Variable("entity", cel.DynType),
+		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
 		cel.Function("count_ge",
@@ -86,6 +87,7 @@ func WorkflowConditionMissingRecognizedPrefix(expression string, context Workflo
 func workflowConditionRecognizedPrefixes(context WorkflowConditionContext) []string {
 	prefixes := []string{
 		"payload.",
+		"event.",
 		"entity.",
 		"policy.",
 		"query_entities(",

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -23,6 +23,7 @@ var workflowExpressionQueryPredicatePattern = regexp.MustCompile(`^\s*([a-zA-Z_]
 
 type workflowExpressionContext struct {
 	Entity           map[string]any
+	Event            map[string]any
 	Payload          map[string]any
 	Policy           map[string]any
 	Accumulated      any
@@ -39,6 +40,7 @@ type workflowExpressionEvaluator struct {
 func newWorkflowExpressionEvaluator() *workflowExpressionEvaluator {
 	env, err := cel.NewEnv(
 		cel.Variable("entity", cel.DynType),
+		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
 		cel.Variable("accumulated", cel.DynType),
@@ -78,6 +80,7 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 	}
 	out, _, err := program.Eval(map[string]any{
 		"entity":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Entity)),
+		"event":       workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Event)),
 		"payload":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Payload)),
 		"policy":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Policy)),
 		"accumulated": normalizedCtx.Accumulated,
@@ -144,6 +147,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	if expression == "" {
 		return "", workflowExpressionContext{
 			Entity:           cloneStringAnyMap(ctx.Entity),
+			Event:            cloneStringAnyMap(ctx.Event),
 			Payload:          cloneStringAnyMap(ctx.Payload),
 			Policy:           cloneStringAnyMap(ctx.Policy),
 			Accumulated:      cloneAccumulatedItems(ctx.Accumulated),
@@ -174,6 +178,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	normalized = rewriteWorkflowExpressionEntityNullPresenceChecks(normalized)
 	normalizedCtx := workflowExpressionContext{
 		Entity:           cloneStringAnyMap(ctx.Entity),
+		Event:            cloneStringAnyMap(ctx.Event),
 		Payload:          cloneStringAnyMap(ctx.Payload),
 		Policy:           cloneStringAnyMap(ctx.Policy),
 		Accumulated:      cloneAccumulatedItems(ctx.Accumulated),
@@ -291,6 +296,8 @@ func workflowExpressionLookupContextValue(ref string, ctx workflowExpressionCont
 	switch {
 	case strings.HasPrefix(ref, "entity."):
 		return workflowExpressionLookupPath(ctx.Entity, strings.TrimPrefix(ref, "entity."))
+	case strings.HasPrefix(ref, "event."):
+		return workflowExpressionLookupPath(ctx.Event, strings.TrimPrefix(ref, "event."))
 	case strings.HasPrefix(ref, "payload."):
 		return workflowExpressionLookupPath(ctx.Payload, strings.TrimPrefix(ref, "payload."))
 	case strings.HasPrefix(ref, "policy."):

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -58,6 +58,10 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 
 	inbound, _ := runtimebus.InboundEventFromContext(ctx)
 	payloadMap = e.enrichEmitPayloadContext(actor, inbound, schemaEventType, payloadMap)
+	if err := rejectEmitEnvelopeFields(payloadMap); err != nil {
+		e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, diagnosticPayloadMap(payloadMap), events.Event{}, "payload_shape_failed", "payload_shape", "envelope_field", err)
+		return nil, err
+	}
 	postEnrichmentPayload := diagnosticPayloadMap(payloadMap)
 	if err := e.emitRegistry.ValidateEventPayloadAgainstSchema(schemaEventType, payloadMap); err != nil {
 		wrapped := WrapRuntimeError(
@@ -76,27 +80,26 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		ID:          uuid.NewString(),
 		Type:        events.EventType(eventType),
 		SourceAgent: actor.ID,
-		TaskID:      strings.TrimSpace(asString(payloadMap["task_id"])),
 		Payload:     mustJSON(payloadMap),
 		CreatedAt:   time.Now(),
-	}).WithEntityID(strings.TrimSpace(asString(payloadMap["entity_id"])))
-	if flowInstance := strings.Trim(strings.TrimSpace(asString(payloadMap["flow_instance"])), "/"); flowInstance != "" {
+	})
+	entityID := strings.TrimSpace(actor.EffectiveEntityID())
+	if entityID == "" {
+		entityID = strings.TrimSpace(inbound.EntityID())
+	}
+	if entityID != "" {
+		emitted = emitted.WithEntityID(entityID)
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(actor.CanonicalFlowPath()), "/")
+	if flowInstance == "" {
+		flowInstance = strings.Trim(strings.TrimSpace(inbound.FlowInstance()), "/")
+	}
+	if flowInstance != "" {
 		emitted = emitted.WithFlowInstance(flowInstance)
 	}
-	if emitted.EntityID() == "" {
-		emitted = emitted.WithEntityID(strings.TrimSpace(actor.EffectiveEntityID()))
-	}
+	emitted.TaskID = strings.TrimSpace(inbound.TaskID)
 	if emitted.TaskID == "" {
-		emitted.TaskID = strings.TrimSpace(inbound.TaskID)
-	}
-	if emitted.EntityID() == "" {
-		emitted = emitted.WithEntityID(strings.TrimSpace(inbound.EntityID()))
-	}
-	if emitted.EntityID() != "" {
-		if strings.TrimSpace(asString(payloadMap["entity_id"])) == "" {
-			payloadMap["entity_id"] = emitted.EntityID()
-		}
-		emitted.Payload = mustJSON(payloadMap)
+		emitted.TaskID = strings.TrimSpace(asString(payloadMap["task_id"]))
 	}
 	if err := e.bus.Publish(ctx, emitted); err != nil {
 		wrapped := WrapRuntimeError(

--- a/internal/runtime/tools/executor_emit_context.go
+++ b/internal/runtime/tools/executor_emit_context.go
@@ -2,8 +2,8 @@ package tools
 
 import (
 	"swarm/internal/events"
-	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	models "swarm/internal/runtime/core/actors"
+	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 )
 
 func (e *Executor) enrichEmitPayloadContext(actor models.AgentConfig, inbound events.Event, eventType string, payload map[string]any) map[string]any {

--- a/internal/runtime/tools/executor_emit_context.go
+++ b/internal/runtime/tools/executor_emit_context.go
@@ -1,9 +1,8 @@
 package tools
 
 import (
-	"strings"
-
 	"swarm/internal/events"
+	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	models "swarm/internal/runtime/core/actors"
 )
 
@@ -11,37 +10,23 @@ func (e *Executor) enrichEmitPayloadContext(actor models.AgentConfig, inbound ev
 	if payload == nil {
 		payload = map[string]any{}
 	}
-	out := make(map[string]any, len(payload)+2)
+	out := make(map[string]any, len(payload))
 	for k, v := range payload {
 		out[k] = v
-	}
-	if e.emitSchemaAllowsProperty(eventType, "task_id") && strings.TrimSpace(asString(out["task_id"])) == "" {
-		out["task_id"] = strings.TrimSpace(inbound.TaskID)
-	}
-	entityID := actor.EffectiveEntityID()
-	if entityID == "" {
-		entityID = strings.TrimSpace(inbound.EntityID())
-	}
-	if e.emitSchemaAllowsProperty(eventType, "entity_id") && strings.TrimSpace(asString(out["entity_id"])) == "" {
-		out["entity_id"] = entityID
 	}
 	return out
 }
 
-func (e *Executor) emitSchemaAllowsProperty(eventType, property string) bool {
-	eventType = strings.TrimSpace(eventType)
-	property = strings.TrimSpace(property)
-	if eventType == "" || property == "" {
-		return false
+func rejectEmitEnvelopeFields(payload map[string]any) error {
+	for _, field := range runtimeeventpayload.RuntimeOwnedCanonicalContextFields(payload) {
+		return NewRuntimeError(
+			"invalid_tool_input",
+			"tool-executor",
+			"handle_emit_tool.envelope_field",
+			false,
+			"%s is platform-owned event envelope context and must not be authored in emit payload",
+			field,
+		)
 	}
-	if e == nil || e.emitRegistry == nil {
-		return false
-	}
-	schema := e.emitRegistry.SchemaForEventType(eventType).Schema
-	props, ok := schema["properties"].(map[string]any)
-	if !ok || len(props) == 0 {
-		return false
-	}
-	_, ok = props[property]
-	return ok
+	return nil
 }

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -201,9 +201,7 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 				Payload: runtimecontracts.EventPayloadSpec{
 					Type: "object",
 					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"category":  {Type: "string"},
-						"entity_id": {Type: "string"},
-						"task_id":   {Type: "string"},
+						"category": {Type: "string"},
 					},
 				},
 				Required: []string{"category"},
@@ -251,14 +249,23 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 	if got := strings.TrimSpace(asString(pre["entity_id"])); got != "" {
 		t.Fatalf("pre_validation entity_id = %#v, want empty", pre["entity_id"])
 	}
-	if got := strings.TrimSpace(asString(post["entity_id"])); got != "entity-actor" {
-		t.Fatalf("post_enrichment entity_id = %#v, want entity-actor", post["entity_id"])
+	if _, ok := post["entity_id"]; ok {
+		t.Fatalf("post_enrichment payload must not carry envelope entity_id: %#v", post["entity_id"])
 	}
-	if got := strings.TrimSpace(asString(post["task_id"])); got != "task-inbound" {
-		t.Fatalf("post_enrichment task_id = %#v, want task-inbound", post["task_id"])
+	if _, ok := post["task_id"]; ok {
+		t.Fatalf("post_enrichment payload must not carry envelope task_id: %#v", post["task_id"])
 	}
 	if got := strings.TrimSpace(asString(detail["emitted_event_id"])); got == "" {
 		t.Fatal("expected emitted_event_id")
+	}
+	if len(bus.published) != 1 {
+		t.Fatalf("published event count = %d, want 1", len(bus.published))
+	}
+	if got := bus.published[0].EntityID(); got != "entity-actor" {
+		t.Fatalf("published event entity_id = %q, want entity-actor", got)
+	}
+	if got := bus.published[0].TaskID; got != "task-inbound" {
+		t.Fatalf("published event task_id = %q, want task-inbound", got)
 	}
 }
 
@@ -312,9 +319,7 @@ func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t 
 				Payload: runtimecontracts.EventPayloadSpec{
 					Type: "object",
 					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"category":  {Type: "string"},
-						"entity_id": {Type: "string"},
-						"task_id":   {Type: "string"},
+						"category": {Type: "string"},
 					},
 				},
 				Required: []string{"category"},
@@ -364,11 +369,11 @@ func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t 
 	if got, ok := post["unexpected"].(bool); !ok || !got {
 		t.Fatalf("post_enrichment unexpected = %#v, want true", post["unexpected"])
 	}
-	if got := strings.TrimSpace(asString(post["entity_id"])); got != "entity-actor" {
-		t.Fatalf("post_enrichment entity_id = %#v, want entity-actor", post["entity_id"])
+	if _, ok := post["entity_id"]; ok {
+		t.Fatalf("post_enrichment payload must not carry envelope entity_id: %#v", post["entity_id"])
 	}
-	if got := strings.TrimSpace(asString(post["task_id"])); got != "task-inbound" {
-		t.Fatalf("post_enrichment task_id = %#v, want task-inbound", post["task_id"])
+	if _, ok := post["task_id"]; ok {
+		t.Fatalf("post_enrichment payload must not carry envelope task_id: %#v", post["task_id"])
 	}
 	if _, ok := detail["emitted_event_id"]; ok {
 		t.Fatalf("unexpected emitted_event_id on schema validation failure: %#v", detail["emitted_event_id"])

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -32,6 +32,7 @@ var (
 
 type ValueContext struct {
 	Entity  map[string]any
+	Event   map[string]any
 	Payload map[string]any
 	Policy  map[string]any
 	FanOut  map[string]any
@@ -75,6 +76,7 @@ func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 	}
 	out, _, err := program.Eval(map[string]any{
 		"entity":  NormalizeCELInputMap(ctx.Entity),
+		"event":   NormalizeCELInputMap(ctx.Event),
 		"payload": NormalizeCELInputMap(ctx.Payload),
 		"policy":  NormalizeCELInputMap(ctx.Policy),
 		"fan_out": NormalizeCELInputMap(ctx.FanOut),
@@ -303,6 +305,7 @@ func dataExpressionEnvForContext() (*cel.Env, error) {
 	dataExpressionEnvOnce.Do(func() {
 		dataExpressionEnv, dataExpressionEnvErr = cel.NewEnv(
 			cel.Variable("entity", cel.DynType),
+			cel.Variable("event", cel.DynType),
 			cel.Variable("payload", cel.DynType),
 			cel.Variable("policy", cel.DynType),
 			cel.Variable("fan_out", cel.DynType),

--- a/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
@@ -9,7 +9,7 @@ test-node:
       emit:
         event: item.exported
         fields:
-          id: payload.entity_id
+          id: event.entity_id
           name: entity.name
           status: entity.current_state
   state_schema:

--- a/tests/tier11-flow-composition/test-child-flow-local-events/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-local-events/flows/child/events.yaml
@@ -1,7 +1,5 @@
 child.start:
   entity_id: string
 child.internal:
-  entity_id: string
   step: string
-child.done:
-  entity_id: string
+child.done: {}

--- a/tests/tier11-flow-composition/test-required-agents-child/events.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/events.yaml
@@ -1,8 +1,5 @@
 request.start:
   entity_id: string
-request.complete:
-  entity_id: string
-analyzer-flow/analysis.requested:
-  entity_id: string
-analyzer-flow/analysis.done:
-  entity_id: string
+request.complete: {}
+analyzer-flow/analysis.requested: {}
+analyzer-flow/analysis.done: {}

--- a/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/events.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/events.yaml
@@ -1,4 +1,2 @@
-analysis.requested:
-  entity_id: string
-analysis.done:
-  entity_id: string
+analysis.requested: {}
+analysis.done: {}

--- a/tests/tier7-composition/test-agent-emits-to-node/events.yaml
+++ b/tests/tier7-composition/test-agent-emits-to-node/events.yaml
@@ -1,8 +1,5 @@
 task.assigned:
   entity_id: string
-task.acknowledged:
-  entity_id: string
-task.completed:
-  entity_id: string
-task.finalized:
-  entity_id: string
+task.acknowledged: {}
+task.completed: {}
+task.finalized: {}

--- a/tests/tier7-composition/test-agent-emits-to-node/fixtures.yaml
+++ b/tests/tier7-composition/test-agent-emits-to-node/fixtures.yaml
@@ -3,4 +3,4 @@ agent_fixtures:
     - on: task.assigned
       emits:
         - event: task.completed
-          payload: { entity_id: "{{entity_id}}" }
+          payload: {}


### PR DESCRIPTION
Part of #496

Governing refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#strict_payload_contract.envelope_split`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#event_payload_migration.rules.envelope_payload_split`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#engine.runtime_contract.emit_payload_default`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.declarative_system_node_emit_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.action_originated_emit_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.auto_emit_on_create_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#static_analyzer.slice_2_emit_field_coverage`

What changed:
- removed payload mutation from shared event carriers and emit shapers
- added `event.*` to supported runtime/CEL expression surfaces
- made declarative emits and emit tools reject authored envelope-owned fields in `emit.fields`
- aligned bootverify to fail when authored emit payloads try to carry envelope fields, even without required payload fields
- updated the authoritative spec sections above so runtime procedure text matches the implemented event-envelope model
- updated first-party Swarm proof fixtures and catalog harnesses that still injected payload `entity_id`

Canonical owners after this change:
- `internal/events/types.go`
- `internal/runtime/pipeline/engine_adapter.go`
- `internal/runtime/tools/executor_emit_context.go`
- `internal/runtime/tools/executor_emit.go`
- `internal/runtime/pipeline/workflow_expression_evaluator.go`
- `internal/runtime/workflowexpr/data_expression.go`
- `internal/runtime/bootverify/workflow_payload_completeness_checks.go`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

Old non-authoritative paths now invalid:
- payload mutation in `Event.WithEntityID` / `Event.WithFlowInstance`
- declarative emit payload overlay of envelope fields
- emit-tool payload enrichment of `entity_id` / `task_id`
- handler/CEL access that relied on payload-carried envelope fields instead of `event.*`
- spec text that described platform-forced envelope fields as payload carriers

Production paths checked for surviving old behavior:
- declarative emits
- action-originated emits
- agent emit tools
- auto-emit on flow activation
- supported `cmd/swarm verify`
- catalog/e2e harnesses and first-party Swarm fixtures
- companion Empire contracts on paired PR `yazzaoui/empire#6`

Migration status:
- complete for the approved Swarm-side `#496` owner cluster
- not merge-ready alone: full issue closure still depends on paired Empire PR `yazzaoui/empire#6`
- sibling issue `#498` remains separate

Validation:
- `go test ./...`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `python3 /Users/youmew/swarm/empire/scripts/prompt-lint.py`
- `rg -n 'payload\.(entity_id|flow_instance|trigger_event_type|current_state)' /Users/youmew/swarm/empire/contracts`
