### PR TITLE
[agent-d][issue #498] Enforce event payload type contracts

### DIFF
--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -17,23 +18,25 @@ func EventSchemaRegistryFromCatalog(entries map[string]EventCatalogEntry) map[st
 		if eventType == "" {
 			continue
 		}
-		out[eventType] = eventSchemaFromCatalogEntry(eventType, entry)
+		out[eventType] = eventSchemaFromCatalogEntry(eventType, entry, TypeCatalogDocument{})
 	}
 	return out
 }
 
-func eventSchemaFromCatalogEntry(eventType string, entry EventCatalogEntry) EventSchema {
+func eventSchemaFromCatalogEntry(eventType string, entry EventCatalogEntry, types TypeCatalogDocument) EventSchema {
 	properties := make(map[string]any, len(entry.Payload.Properties))
-	for fieldName, field := range entry.Payload.Properties {
+	fieldNames := make([]string, 0, len(entry.Payload.Properties))
+	for fieldName := range entry.Payload.Properties {
+		fieldNames = append(fieldNames, strings.TrimSpace(fieldName))
+	}
+	sort.Strings(fieldNames)
+	for _, fieldName := range fieldNames {
 		fieldName = strings.TrimSpace(fieldName)
 		if fieldName == "" {
 			continue
 		}
-		prop := map[string]any{}
-		fieldType, typeDescription := normalizeEventFieldType(field.Type)
-		if fieldType != "" {
-			prop["type"] = fieldType
-		}
+		field := entry.Payload.Properties[fieldName]
+		prop, typeDescription := eventSchemaForTypeRef(field.Type, types, map[string]struct{}{})
 		description := strings.TrimSpace(field.Description)
 		if description == "" {
 			description = typeDescription
@@ -63,7 +66,50 @@ func EventSchemaRegistryFromBundle(bundle *WorkflowContractBundle) map[string]Ev
 	if bundle == nil {
 		return map[string]EventSchema{}
 	}
-	return EventSchemaRegistryFromCatalog(bundle.ResolvedEventCatalog())
+	out := map[string]EventSchema{}
+	if bundle.FlowTree.Root != nil {
+		appendEventSchemas(out, bundle, "", bundle.FlowTree.Root.Events, bundle.RootTypeCatalog())
+	} else {
+		appendEventSchemas(out, bundle, "", bundle.Events, bundle.RootTypeCatalog())
+	}
+	flowIDs := make([]string, 0, len(bundle.FlowTree.ByID))
+	for flowID := range bundle.FlowTree.ByID {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		flowIDs = append(flowIDs, flowID)
+	}
+	sort.Strings(flowIDs)
+	for _, flowID := range flowIDs {
+		view := bundle.FlowTree.ByID[flowID]
+		if view == nil {
+			continue
+		}
+		appendEventSchemas(out, bundle, flowID, view.Events, bundle.ResolvedTypeCatalogForFlow(flowID))
+	}
+	return out
+}
+
+func EventSchemaForFlowEvent(bundle *WorkflowContractBundle, flowID, eventType string) (EventSchema, string, bool) {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	if bundle == nil || eventType == "" {
+		return EventSchema{}, "", false
+	}
+	entry, key, ok := bundle.ResolveFlowEventCatalogEntry(flowID, eventType)
+	if !ok {
+		return EventSchema{}, "", false
+	}
+	types, found := eventDeclarationTypesForCatalogKey(bundle, key)
+	if !found {
+		if flowID != "" {
+			types = bundle.ResolvedTypeCatalogForFlow(flowID)
+		} else {
+			types = bundle.RootTypeCatalog()
+		}
+	}
+	return eventSchemaFromCatalogEntry(key, entry, types), key, true
 }
 
 func normalizeEventFieldType(raw string) (string, string) {
@@ -83,6 +129,210 @@ func normalizeEventFieldType(raw string) (string, string) {
 		}
 	}
 	return raw, ""
+}
+
+func appendEventSchemas(out map[string]EventSchema, bundle *WorkflowContractBundle, flowID string, entries map[string]EventCatalogEntry, types TypeCatalogDocument) {
+	for eventType, entry := range entries {
+		if bundle != nil {
+			if schema, key, ok := EventSchemaForFlowEvent(bundle, flowID, eventType); ok {
+				out[key] = schema
+				continue
+			}
+		}
+		key := resolvedEventSchemaKey(bundle, flowID, eventType)
+		if key == "" {
+			continue
+		}
+		out[key] = eventSchemaFromCatalogEntry(key, entry, types)
+	}
+}
+
+func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType string) string {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return ""
+	}
+	if bundle == nil {
+		return eventType
+	}
+	if resolved := strings.TrimSpace(bundle.ResolveFlowEventReference(flowID, eventType)); resolved != "" {
+		return resolved
+	}
+	return eventType
+}
+
+func eventDeclarationTypesForCatalogKey(bundle *WorkflowContractBundle, catalogKey string) (TypeCatalogDocument, bool) {
+	catalogKey = strings.TrimSpace(catalogKey)
+	if bundle == nil || catalogKey == "" {
+		return TypeCatalogDocument{}, false
+	}
+	if bundle.FlowTree.Root != nil {
+		if hasResolvedEventSchemaKey(bundle, "", bundle.FlowTree.Root.Events, catalogKey) {
+			return bundle.RootTypeCatalog(), true
+		}
+	} else if hasResolvedEventSchemaKey(bundle, "", bundle.Events, catalogKey) {
+		return bundle.RootTypeCatalog(), true
+	}
+	flowIDs := make([]string, 0, len(bundle.FlowTree.ByID))
+	for flowID := range bundle.FlowTree.ByID {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		flowIDs = append(flowIDs, flowID)
+	}
+	sort.Strings(flowIDs)
+	for _, flowID := range flowIDs {
+		view := bundle.FlowTree.ByID[flowID]
+		if view == nil {
+			continue
+		}
+		if hasResolvedEventSchemaKey(bundle, flowID, view.Events, catalogKey) {
+			return bundle.ResolvedTypeCatalogForFlow(flowID), true
+		}
+	}
+	return TypeCatalogDocument{}, false
+}
+
+func hasResolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID string, entries map[string]EventCatalogEntry, catalogKey string) bool {
+	for eventType := range entries {
+		if resolvedEventSchemaKey(bundle, flowID, eventType) == catalogKey {
+			return true
+		}
+	}
+	return false
+}
+
+func eventSchemaForTypeRef(raw string, types TypeCatalogDocument, seen map[string]struct{}) (map[string]any, string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]any{}, ""
+	}
+	if normalized, typeDescription := normalizeEventFieldType(raw); normalized != "" && normalized != raw {
+		return eventSchemaForResolvedType(normalized, types, seen), typeDescription
+	}
+	return eventSchemaForResolvedType(raw, types, seen), ""
+}
+
+func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen map[string]struct{}) map[string]any {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" {
+		return map[string]any{}
+	}
+	if isEventListType(typeRef) {
+		return map[string]any{
+			"type":  "array",
+			"items": eventSchemaForResolvedType(eventListItemType(typeRef), types, seen),
+		}
+	}
+	if enumName, ok := eventEnumTypeName(types, typeRef); ok {
+		values := make([]any, 0, len(types.Enums[enumName].Values))
+		for _, value := range types.Enums[enumName].Values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			values = append(values, value)
+		}
+		return map[string]any{
+			"type": "string",
+			"enum": values,
+		}
+	}
+	if namedName, ok := eventNamedTypeName(types, typeRef); ok {
+		if _, ok := seen[namedName]; ok {
+			return map[string]any{"type": "object"}
+		}
+		seen[namedName] = struct{}{}
+		defer delete(seen, namedName)
+		named := types.Types[namedName]
+		props := make(map[string]any, len(named.Fields))
+		required := make([]string, 0, len(named.Fields))
+		fieldNames := make([]string, 0, len(named.Fields))
+		for fieldName := range named.Fields {
+			fieldNames = append(fieldNames, strings.TrimSpace(fieldName))
+		}
+		sort.Strings(fieldNames)
+		for _, fieldName := range fieldNames {
+			if fieldName == "" {
+				continue
+			}
+			spec := named.Fields[fieldName]
+			props[fieldName] = eventSchemaForResolvedType(spec.Type, types, seen)
+			required = append(required, fieldName)
+		}
+		return map[string]any{
+			"type":                 "object",
+			"properties":           props,
+			"required":             required,
+			"additionalProperties": false,
+		}
+	}
+	switch normalized := strings.ToLower(strings.TrimSpace(eventTypeName(types, typeRef))); normalized {
+	case "text", "string":
+		return map[string]any{"type": "string"}
+	case "integer":
+		return map[string]any{"type": "integer"}
+	case "numeric", "number":
+		return map[string]any{"type": "number"}
+	case "boolean":
+		return map[string]any{"type": "boolean"}
+	case "timestamp":
+		return map[string]any{"type": "string", "format": "date-time"}
+	case "uuid":
+		return map[string]any{"type": "string", "format": "uuid"}
+	case "object":
+		return map[string]any{"type": "object"}
+	case "array":
+		return map[string]any{"type": "array"}
+	default:
+		return map[string]any{"type": typeRef}
+	}
+}
+
+func eventTypeName(types TypeCatalogDocument, typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	if scalar, ok := types.Scalars[typeRef]; ok {
+		return strings.TrimSpace(scalar.Base)
+	}
+	return typeRef
+}
+
+func eventNamedTypeName(types TypeCatalogDocument, typeRef string) (string, bool) {
+	typeName := eventTypeName(types, typeRef)
+	_, ok := types.Types[typeName]
+	return typeName, ok
+}
+
+func eventEnumTypeName(types TypeCatalogDocument, typeRef string) (string, bool) {
+	typeName := eventTypeName(types, typeRef)
+	_, ok := types.Enums[typeName]
+	return typeName, ok
+}
+
+func isEventListType(typeRef string) bool {
+	typeRef = strings.TrimSpace(typeRef)
+	return strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">") ||
+		strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]") ||
+		strings.HasSuffix(typeRef, "[]") ||
+		strings.HasPrefix(typeRef, "[]")
+}
+
+func eventListItemType(typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	switch {
+	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
+		return strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
+	case strings.HasSuffix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[:len(typeRef)-2])
+	case strings.HasPrefix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[2:])
+	default:
+		return typeRef
+	}
 }
 
 func cloneEventSchemaRegistry(in map[string]EventSchema) map[string]EventSchema {

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -155,14 +155,14 @@ func eventSchemaDeclarationForFlowEvent(bundle *WorkflowContractBundle, flowID, 
 		return entry, key, bundle.RootTypeCatalog(), true
 	}
 
-	targetKey := resolvedEventSchemaKey(bundle, flowID, eventType)
+	targetKeys := eventSchemaLookupKeys(bundle, flowID, eventType)
 	for _, declaration := range eventSchemaDeclarationPath(bundle, flowID) {
-		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKey); ok {
+		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKeys); ok {
 			return entry, resolvedKey, declaration.types, true
 		}
 	}
 	for _, declaration := range eventSchemaAllDeclarationScopes(bundle) {
-		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKey); ok {
+		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKeys); ok {
 			return entry, resolvedKey, declaration.types, true
 		}
 	}
@@ -255,18 +255,28 @@ func eventSchemaAllDeclarationScopes(bundle *WorkflowContractBundle) []eventSche
 	return out
 }
 
-func eventSchemaDeclarationEntry(bundle *WorkflowContractBundle, declaration eventSchemaDeclarationScope, targetKey string) (EventCatalogEntry, string, bool) {
+func eventSchemaDeclarationEntry(bundle *WorkflowContractBundle, declaration eventSchemaDeclarationScope, targetKeys []string) (EventCatalogEntry, string, bool) {
 	if declaration.view == nil {
 		return EventCatalogEntry{}, "", false
 	}
 	for localKey, entry := range declaration.view.Events {
 		resolvedKey := resolvedEventSchemaKey(bundle, declaration.flowID, localKey)
-		if normalizedEventSchemaKey(resolvedKey) != normalizedEventSchemaKey(targetKey) {
-			continue
+		for _, targetKey := range targetKeys {
+			if normalizedEventSchemaKey(resolvedKey) != normalizedEventSchemaKey(targetKey) {
+				continue
+			}
+			return entry, resolvedKey, true
 		}
-		return entry, resolvedKey, true
 	}
 	return EventCatalogEntry{}, "", false
+}
+
+func eventSchemaLookupKeys(bundle *WorkflowContractBundle, flowID, eventType string) []string {
+	keys := []string{resolvedEventSchemaKey(bundle, flowID, eventType)}
+	if key := instanceScopedEventSchemaKey(bundle, eventType); key != "" {
+		keys = append(keys, key)
+	}
+	return uniqueNormalizedEventSchemaKeys(keys...)
 }
 
 func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType string) string {
@@ -282,6 +292,88 @@ func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType st
 		return resolved
 	}
 	return eventType
+}
+
+func instanceScopedEventSchemaKey(bundle *WorkflowContractBundle, eventType string) string {
+	if bundle == nil {
+		return ""
+	}
+	eventType = normalizedEventSchemaKey(eventType)
+	idx := strings.LastIndex(eventType, "/")
+	if idx <= 0 || idx+1 >= len(eventType) {
+		return ""
+	}
+	eventPath := normalizedEventSchemaKey(eventType[:idx])
+	if eventPath == "" || eventSchemaFlowIDForPath(bundle, eventPath) != "" {
+		return ""
+	}
+	semanticPath := eventSchemaSemanticScopeFromInstancePath(eventPath)
+	if semanticPath == "" {
+		return ""
+	}
+	flowID := eventSchemaFlowIDForPath(bundle, semanticPath)
+	if flowID == "" {
+		return ""
+	}
+	return resolvedEventSchemaKey(bundle, flowID, eventType[idx+1:])
+}
+
+func eventSchemaFlowIDForPath(bundle *WorkflowContractBundle, flowPath string) string {
+	flowPath = normalizedEventSchemaKey(flowPath)
+	if bundle == nil || flowPath == "" {
+		return ""
+	}
+	if view := bundle.FlowTree.ByPath[flowPath]; view != nil {
+		return strings.TrimSpace(view.Paths.ID)
+	}
+	flowIDs := make([]string, 0, len(bundle.FlowTree.ByID))
+	for flowID := range bundle.FlowTree.ByID {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		flowIDs = append(flowIDs, flowID)
+	}
+	sort.Strings(flowIDs)
+	for _, flowID := range flowIDs {
+		view := bundle.FlowTree.ByID[flowID]
+		if view == nil {
+			continue
+		}
+		if normalizedEventSchemaKey(view.Path) == flowPath {
+			return flowID
+		}
+	}
+	return ""
+}
+
+func eventSchemaSemanticScopeFromInstancePath(instancePath string) string {
+	instancePath = normalizedEventSchemaKey(instancePath)
+	if instancePath == "" {
+		return ""
+	}
+	idx := strings.LastIndex(instancePath, "/")
+	if idx <= 0 {
+		return ""
+	}
+	return normalizedEventSchemaKey(instancePath[:idx])
+}
+
+func uniqueNormalizedEventSchemaKeys(values ...string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = normalizedEventSchemaKey(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func normalizedEventSchemaKey(raw string) string {

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	flowmodel "swarm/internal/runtime/flowmodel"
 )
 
 type EventSchema struct {
@@ -97,17 +99,9 @@ func EventSchemaForFlowEvent(bundle *WorkflowContractBundle, flowID, eventType s
 	if bundle == nil || eventType == "" {
 		return EventSchema{}, "", false
 	}
-	entry, key, ok := bundle.ResolveFlowEventCatalogEntry(flowID, eventType)
+	entry, key, types, ok := eventSchemaDeclarationForFlowEvent(bundle, flowID, eventType)
 	if !ok {
 		return EventSchema{}, "", false
-	}
-	types, found := eventDeclarationTypesForCatalogKey(bundle, key)
-	if !found {
-		if flowID != "" {
-			types = bundle.ResolvedTypeCatalogForFlow(flowID)
-		} else {
-			types = bundle.RootTypeCatalog()
-		}
 	}
 	return eventSchemaFromCatalogEntry(key, entry, types), key, true
 }
@@ -147,6 +141,134 @@ func appendEventSchemas(out map[string]EventSchema, bundle *WorkflowContractBund
 	}
 }
 
+func eventSchemaDeclarationForFlowEvent(bundle *WorkflowContractBundle, flowID, eventType string) (EventCatalogEntry, string, TypeCatalogDocument, bool) {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	if bundle == nil || eventType == "" {
+		return EventCatalogEntry{}, "", TypeCatalogDocument{}, false
+	}
+	if bundle.FlowTree.Root == nil {
+		entry, key, ok := bundle.ResolveFlowEventCatalogEntry(flowID, eventType)
+		if !ok {
+			return EventCatalogEntry{}, "", TypeCatalogDocument{}, false
+		}
+		return entry, key, bundle.RootTypeCatalog(), true
+	}
+
+	targetKey := resolvedEventSchemaKey(bundle, flowID, eventType)
+	for _, declaration := range eventSchemaDeclarationPath(bundle, flowID) {
+		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKey); ok {
+			return entry, resolvedKey, declaration.types, true
+		}
+	}
+	for _, declaration := range eventSchemaAllDeclarationScopes(bundle) {
+		if entry, resolvedKey, ok := eventSchemaDeclarationEntry(bundle, declaration, targetKey); ok {
+			return entry, resolvedKey, declaration.types, true
+		}
+	}
+
+	entry, key, ok := bundle.ResolveFlowEventCatalogEntry(flowID, eventType)
+	if !ok {
+		return EventCatalogEntry{}, "", TypeCatalogDocument{}, false
+	}
+	if flowID != "" {
+		return entry, key, bundle.ResolvedTypeCatalogForFlow(flowID), true
+	}
+	return entry, key, bundle.RootTypeCatalog(), true
+}
+
+type eventSchemaDeclarationScope struct {
+	flowID string
+	view   *FlowContractView
+	types  TypeCatalogDocument
+}
+
+func eventSchemaDeclarationPath(bundle *WorkflowContractBundle, flowID string) []eventSchemaDeclarationScope {
+	if bundle == nil || bundle.FlowTree.Root == nil {
+		return nil
+	}
+	var path []*FlowContractView
+	if strings.TrimSpace(flowID) == "" {
+		path = []*FlowContractView{bundle.FlowTree.Root}
+	} else {
+		path = flowmodel.CollectPathByID(bundle.FlowTree.Root, flowID, func(view *FlowContractView) string {
+			if view == nil {
+				return ""
+			}
+			return view.Paths.ID
+		}, flowViewChildren)
+	}
+	if len(path) == 0 {
+		return nil
+	}
+	out := make([]eventSchemaDeclarationScope, 0, len(path))
+	for i, view := range path {
+		if view == nil {
+			continue
+		}
+		scopeFlowID := ""
+		types := bundle.RootTypeCatalog()
+		if i > 0 {
+			scopeFlowID = strings.TrimSpace(view.Paths.ID)
+			types = bundle.ResolvedTypeCatalogForFlow(scopeFlowID)
+		}
+		out = append(out, eventSchemaDeclarationScope{
+			flowID: scopeFlowID,
+			view:   view,
+			types:  types,
+		})
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+func eventSchemaAllDeclarationScopes(bundle *WorkflowContractBundle) []eventSchemaDeclarationScope {
+	if bundle == nil || bundle.FlowTree.Root == nil {
+		return nil
+	}
+	out := []eventSchemaDeclarationScope{{
+		view:  bundle.FlowTree.Root,
+		types: bundle.RootTypeCatalog(),
+	}}
+	flowIDs := make([]string, 0, len(bundle.FlowTree.ByID))
+	for flowID := range bundle.FlowTree.ByID {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		flowIDs = append(flowIDs, flowID)
+	}
+	sort.Strings(flowIDs)
+	for _, flowID := range flowIDs {
+		view := bundle.FlowTree.ByID[flowID]
+		if view == nil {
+			continue
+		}
+		out = append(out, eventSchemaDeclarationScope{
+			flowID: flowID,
+			view:   view,
+			types:  bundle.ResolvedTypeCatalogForFlow(flowID),
+		})
+	}
+	return out
+}
+
+func eventSchemaDeclarationEntry(bundle *WorkflowContractBundle, declaration eventSchemaDeclarationScope, targetKey string) (EventCatalogEntry, string, bool) {
+	if declaration.view == nil {
+		return EventCatalogEntry{}, "", false
+	}
+	for localKey, entry := range declaration.view.Events {
+		resolvedKey := resolvedEventSchemaKey(bundle, declaration.flowID, localKey)
+		if normalizedEventSchemaKey(resolvedKey) != normalizedEventSchemaKey(targetKey) {
+			continue
+		}
+		return entry, resolvedKey, true
+	}
+	return EventCatalogEntry{}, "", false
+}
+
 func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType string) string {
 	flowID = strings.TrimSpace(flowID)
 	eventType = strings.TrimSpace(eventType)
@@ -162,46 +284,8 @@ func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType st
 	return eventType
 }
 
-func eventDeclarationTypesForCatalogKey(bundle *WorkflowContractBundle, catalogKey string) (TypeCatalogDocument, bool) {
-	catalogKey = strings.TrimSpace(catalogKey)
-	if bundle == nil || catalogKey == "" {
-		return TypeCatalogDocument{}, false
-	}
-	if bundle.FlowTree.Root != nil {
-		if hasResolvedEventSchemaKey(bundle, "", bundle.FlowTree.Root.Events, catalogKey) {
-			return bundle.RootTypeCatalog(), true
-		}
-	} else if hasResolvedEventSchemaKey(bundle, "", bundle.Events, catalogKey) {
-		return bundle.RootTypeCatalog(), true
-	}
-	flowIDs := make([]string, 0, len(bundle.FlowTree.ByID))
-	for flowID := range bundle.FlowTree.ByID {
-		flowID = strings.TrimSpace(flowID)
-		if flowID == "" {
-			continue
-		}
-		flowIDs = append(flowIDs, flowID)
-	}
-	sort.Strings(flowIDs)
-	for _, flowID := range flowIDs {
-		view := bundle.FlowTree.ByID[flowID]
-		if view == nil {
-			continue
-		}
-		if hasResolvedEventSchemaKey(bundle, flowID, view.Events, catalogKey) {
-			return bundle.ResolvedTypeCatalogForFlow(flowID), true
-		}
-	}
-	return TypeCatalogDocument{}, false
-}
-
-func hasResolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID string, entries map[string]EventCatalogEntry, catalogKey string) bool {
-	for eventType := range entries {
-		if resolvedEventSchemaKey(bundle, flowID, eventType) == catalogKey {
-			return true
-		}
-	}
-	return false
+func normalizedEventSchemaKey(raw string) string {
+	return strings.Trim(strings.TrimSpace(raw), "/")
 }
 
 func eventSchemaForTypeRef(raw string, types TypeCatalogDocument, seen map[string]struct{}) (map[string]any, string) {
@@ -274,7 +358,7 @@ func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen 
 		return map[string]any{"type": "string"}
 	case "integer":
 		return map[string]any{"type": "integer"}
-	case "numeric", "number":
+	case "numeric", "number", "float", "double", "real":
 		return map[string]any{"type": "number"}
 	case "boolean":
 		return map[string]any{"type": "boolean"}

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -8,6 +8,7 @@ func TestEventSchemaRegistryFromCatalog_NormalizesAnnotatedFieldTypes(t *testing
 			Payload: EventPayloadSpec{
 				Properties: map[string]EventFieldSpec{
 					"corpus_path":   {Type: "string (required for corpus mode — path to signals file in /data)"},
+					"score":         {Type: "float"},
 					"subcategories": {Type: "array (required for saas_gap, local_services modes)"},
 				},
 			},
@@ -25,6 +26,10 @@ func TestEventSchemaRegistryFromCatalog_NormalizesAnnotatedFieldTypes(t *testing
 	}
 	if corpusPath["description"] == "" {
 		t.Fatalf("corpus_path description = %#v", corpusPath["description"])
+	}
+	score, _ := props["score"].(map[string]any)
+	if score["type"] != "number" {
+		t.Fatalf("score type = %#v", score["type"])
 	}
 	subcategories, _ := props["subcategories"].(map[string]any)
 	if subcategories["type"] != "array" {
@@ -149,5 +154,92 @@ func TestEventSchemaRegistryFromBundle_PreservesWave1TypeMeaning(t *testing.T) {
 	enumValues, _ := mode["enum"].([]any)
 	if len(enumValues) != 2 || enumValues[0] != "fast" || enumValues[1] != "deep" {
 		t.Fatalf("mode enum = %#v, want [fast deep]", mode["enum"])
+	}
+}
+
+func TestEventSchemaForFlowEvent_UsesDeclaringFlowTypeCatalogForOverride(t *testing.T) {
+	reviewFlow := FlowContractView{
+		Paths: FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Events: map[string]EventCatalogEntry{
+			"task.requested": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"priority": {Type: "Priority"},
+					},
+				},
+			},
+		},
+	}
+	root := &FlowContractView{
+		Events: map[string]EventCatalogEntry{
+			"task.requested": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"priority": {Type: "Priority"},
+					},
+				},
+			},
+		},
+		Children: []FlowContractView{reviewFlow},
+	}
+	bundle := &WorkflowContractBundle{
+		RootTypes: TypeCatalogDocument{
+			Enums: map[string]EnumTypeDecl{
+				"Priority": {Values: []string{"low"}},
+			},
+		},
+		FlowTree: FlowTree{
+			Root: root,
+			ByID: map[string]*FlowContractView{
+				"review": &root.Children[0],
+			},
+		},
+		flowTypes: map[string]TypeCatalogDocument{
+			"review": {
+				Enums: map[string]EnumTypeDecl{
+					"Priority": {Values: []string{"urgent"}},
+				},
+			},
+		},
+	}
+
+	rootSchema, rootKey, ok := EventSchemaForFlowEvent(bundle, "", "task.requested")
+	if !ok {
+		t.Fatal("missing root event schema")
+	}
+	if rootKey != "task.requested" {
+		t.Fatalf("root key = %q, want task.requested", rootKey)
+	}
+	rootProps, _ := rootSchema.Schema["properties"].(map[string]any)
+	rootPriority, _ := rootProps["priority"].(map[string]any)
+	if got := rootPriority["enum"]; len(got.([]any)) != 1 || got.([]any)[0] != "low" {
+		t.Fatalf("root priority enum = %#v, want [low]", got)
+	}
+
+	reviewSchema, reviewKey, ok := EventSchemaForFlowEvent(bundle, "review", "task.requested")
+	if !ok {
+		t.Fatal("missing review event schema")
+	}
+	if reviewKey != "review/task.requested" {
+		t.Fatalf("review key = %q, want review/task.requested", reviewKey)
+	}
+	reviewProps, _ := reviewSchema.Schema["properties"].(map[string]any)
+	reviewPriority, _ := reviewProps["priority"].(map[string]any)
+	if got := reviewPriority["enum"]; len(got.([]any)) != 1 || got.([]any)[0] != "urgent" {
+		t.Fatalf("review priority enum = %#v, want [urgent]", got)
+	}
+
+	absoluteSchema, absoluteKey, ok := EventSchemaForFlowEvent(bundle, "", "review/task.requested")
+	if !ok {
+		t.Fatal("missing absolute review event schema")
+	}
+	if absoluteKey != "review/task.requested" {
+		t.Fatalf("absolute key = %q, want review/task.requested", absoluteKey)
+	}
+	absoluteProps, _ := absoluteSchema.Schema["properties"].(map[string]any)
+	absolutePriority, _ := absoluteProps["priority"].(map[string]any)
+	if got := absolutePriority["enum"]; len(got.([]any)) != 1 || got.([]any)[0] != "urgent" {
+		t.Fatalf("absolute priority enum = %#v, want [urgent]", got)
 	}
 }

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -242,4 +242,17 @@ func TestEventSchemaForFlowEvent_UsesDeclaringFlowTypeCatalogForOverride(t *test
 	if got := absolutePriority["enum"]; len(got.([]any)) != 1 || got.([]any)[0] != "urgent" {
 		t.Fatalf("absolute priority enum = %#v, want [urgent]", got)
 	}
+
+	instanceSchema, instanceKey, ok := EventSchemaForFlowEvent(bundle, "review", "review/inst-1/task.requested")
+	if !ok {
+		t.Fatal("missing instance-scoped review event schema")
+	}
+	if instanceKey != "review/task.requested" {
+		t.Fatalf("instance key = %q, want review/task.requested", instanceKey)
+	}
+	instanceProps, _ := instanceSchema.Schema["properties"].(map[string]any)
+	instancePriority, _ := instanceProps["priority"].(map[string]any)
+	if got := instancePriority["enum"]; len(got.([]any)) != 1 || got.([]any)[0] != "urgent" {
+		t.Fatalf("instance priority enum = %#v, want [urgent]", got)
+	}
 }

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -31,3 +31,123 @@ func TestEventSchemaRegistryFromCatalog_NormalizesAnnotatedFieldTypes(t *testing
 		t.Fatalf("subcategories type = %#v", subcategories["type"])
 	}
 }
+
+func TestEventSchemaRegistryFromBundle_PreservesWave1TypeMeaning(t *testing.T) {
+	reviewFlow := FlowContractView{
+		Paths: FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Events: map[string]EventCatalogEntry{
+			"task.requested": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"mode": {Type: "Mode"},
+					},
+				},
+			},
+		},
+	}
+	registry := EventSchemaRegistryFromBundle(&WorkflowContractBundle{
+		RootTypes: TypeCatalogDocument{
+			Scalars: map[string]ScalarTypeDecl{
+				"URL": {Base: "text"},
+			},
+			Types: map[string]NamedTypeDecl{
+				"ScanDetails": {
+					Fields: map[string]TypeFieldSpec{
+						"source": {Type: "text"},
+						"count":  {Type: "integer"},
+					},
+				},
+			},
+		},
+		Events: map[string]EventCatalogEntry{
+			"scan.completed": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"details":    {Type: "ScanDetails"},
+						"urls":       {Type: "[URL]"},
+						"trace_id":   {Type: "uuid"},
+						"started_at": {Type: "timestamp"},
+					},
+				},
+			},
+		},
+		FlowTree: FlowTree{
+			Root: &FlowContractView{
+				Children: []FlowContractView{reviewFlow},
+				Events: map[string]EventCatalogEntry{
+					"scan.completed": {
+						Payload: EventPayloadSpec{
+							Properties: map[string]EventFieldSpec{
+								"details":    {Type: "ScanDetails"},
+								"urls":       {Type: "[URL]"},
+								"trace_id":   {Type: "uuid"},
+								"started_at": {Type: "timestamp"},
+							},
+						},
+					},
+				},
+			},
+			ByID: map[string]*FlowContractView{
+				"review": &reviewFlow,
+			},
+		},
+		flowTypes: map[string]TypeCatalogDocument{
+			"review": {
+				Enums: map[string]EnumTypeDecl{
+					"Mode": {Values: []string{"fast", "deep"}},
+				},
+			},
+		},
+	})
+
+	rootSchema, ok := registry["scan.completed"]
+	if !ok {
+		t.Fatal("missing root schema")
+	}
+	rootProps, _ := rootSchema.Schema["properties"].(map[string]any)
+	details, _ := rootProps["details"].(map[string]any)
+	if got := details["type"]; got != "object" {
+		t.Fatalf("details type = %#v, want object", got)
+	}
+	if got := details["additionalProperties"]; got != false {
+		t.Fatalf("details additionalProperties = %#v, want false", got)
+	}
+	detailProps, _ := details["properties"].(map[string]any)
+	if _, ok := detailProps["source"].(map[string]any); !ok {
+		t.Fatalf("details.properties[source] missing: %#v", detailProps)
+	}
+	if _, ok := detailProps["count"].(map[string]any); !ok {
+		t.Fatalf("details.properties[count] missing: %#v", detailProps)
+	}
+	urls, _ := rootProps["urls"].(map[string]any)
+	if got := urls["type"]; got != "array" {
+		t.Fatalf("urls type = %#v, want array", got)
+	}
+	items, _ := urls["items"].(map[string]any)
+	if got := items["type"]; got != "string" {
+		t.Fatalf("urls items.type = %#v, want string", got)
+	}
+	traceID, _ := rootProps["trace_id"].(map[string]any)
+	if got := traceID["format"]; got != "uuid" {
+		t.Fatalf("trace_id format = %#v, want uuid", got)
+	}
+	startedAt, _ := rootProps["started_at"].(map[string]any)
+	if got := startedAt["format"]; got != "date-time" {
+		t.Fatalf("started_at format = %#v, want date-time", got)
+	}
+
+	reviewSchema, ok := registry["review/task.requested"]
+	if !ok {
+		reviewSchema, ok = registry["task.requested"]
+	}
+	if !ok {
+		t.Fatal("missing flow schema")
+	}
+	reviewProps, _ := reviewSchema.Schema["properties"].(map[string]any)
+	mode, _ := reviewProps["mode"].(map[string]any)
+	enumValues, _ := mode["enum"].([]any)
+	if len(enumValues) != 2 || enumValues[0] != "fast" || enumValues[1] != "deep" {
+		t.Fatalf("mode enum = %#v, want [fast deep]", mode["enum"])
+	}
+}

--- a/internal/runtime/eventbus_logger_test.go
+++ b/internal/runtime/eventbus_logger_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
 )
 
 func TestRuntimePayloadValidator_AllowsValidSchemaPayload(t *testing.T) {
@@ -148,5 +150,33 @@ func TestRuntimePayloadValidator_RejectsUndeclaredCallerPayloadFieldWhenAddition
 		}`))
 	if err == nil {
 		t.Fatal("expected undeclared caller payload field to be rejected")
+	}
+}
+
+func TestRuntimePayloadValidator_RejectsScalarAliasUUIDViolationFromEmitRegistrySnapshot(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Scalars: map[string]runtimecontracts.ScalarTypeDecl{
+				"TraceID": {Base: "uuid"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"trace_id": {Type: "TraceID"},
+					},
+					Required: []string{"trace_id"},
+				},
+			},
+		},
+	})
+	emitRegistry := runtimetools.NewEmitRegistry(source, nil)
+	validator := newRuntimePayloadValidator(nil, emitRegistry.EventSchemaSnapshot())
+
+	if err := validator("task.completed", []byte(`{"trace_id":"not-a-uuid"}`)); err == nil {
+		t.Fatal("expected scalar-alias uuid violation to be rejected")
 	}
 }

--- a/internal/runtime/eventschema/validate.go
+++ b/internal/runtime/eventschema/validate.go
@@ -172,7 +172,7 @@ func valueInEnum(value any, enumRaw any) bool {
 		switch t := enumRaw.(type) {
 		case []string:
 			for _, v := range t {
-				if strings.EqualFold(strings.TrimSpace(asString(value)), strings.TrimSpace(v)) {
+				if strings.TrimSpace(asString(value)) == strings.TrimSpace(v) {
 					return true
 				}
 			}
@@ -182,7 +182,7 @@ func valueInEnum(value any, enumRaw any) bool {
 		}
 	}
 	for _, v := range enum {
-		if strings.EqualFold(strings.TrimSpace(asString(value)), strings.TrimSpace(asString(v))) {
+		if strings.TrimSpace(asString(value)) == strings.TrimSpace(asString(v)) {
 			return true
 		}
 	}

--- a/internal/runtime/eventschema/validate.go
+++ b/internal/runtime/eventschema/validate.go
@@ -3,7 +3,9 @@ package eventschema
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	runtimesharedjson "swarm/internal/runtime/sharedjson"
 )
 
@@ -61,8 +63,12 @@ func validateValue(path string, schema map[string]any, value any) error {
 	}
 	switch st {
 	case "string":
-		if _, ok := value.(string); !ok {
+		text, ok := value.(string)
+		if !ok {
 			return fmt.Errorf("schema validation failed: %s must be string", path)
+		}
+		if err := validateStringFormat(path, schema, text); err != nil {
+			return err
 		}
 	case "boolean":
 		if _, ok := value.(bool); !ok {
@@ -108,6 +114,8 @@ func validateValue(path string, schema map[string]any, value any) error {
 		if value != nil {
 			return fmt.Errorf("schema validation failed: %s must be null", path)
 		}
+	default:
+		return fmt.Errorf("schema validation failed: %s has unsupported schema type %q", path, st)
 	}
 	return nil
 }
@@ -138,6 +146,25 @@ func schemaProperties(raw any) map[string]map[string]any {
 
 func schemaAdditionalProps(raw any) bool { return runtimesharedjson.SchemaAdditionalProps(raw) }
 func requiredList(raw any) []string      { return runtimesharedjson.RequiredList(raw) }
+
+func validateStringFormat(path string, schema map[string]any, value string) error {
+	switch strings.TrimSpace(asString(schema["format"])) {
+	case "":
+		return nil
+	case "date-time":
+		if _, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err != nil {
+			return fmt.Errorf("schema validation failed: %s must be RFC3339 date-time", path)
+		}
+		return nil
+	case "uuid":
+		if _, err := uuid.Parse(strings.TrimSpace(value)); err != nil {
+			return fmt.Errorf("schema validation failed: %s must be uuid", path)
+		}
+		return nil
+	default:
+		return nil
+	}
+}
 
 func valueInEnum(value any, enumRaw any) bool {
 	enum, ok := enumRaw.([]any)

--- a/internal/runtime/eventschema/validate_test.go
+++ b/internal/runtime/eventschema/validate_test.go
@@ -50,3 +50,22 @@ func TestValidatePayloadAgainstSchema_RejectsInvalidStringFormats(t *testing.T) 
 		})
 	}
 }
+
+func TestValidatePayloadAgainstSchema_RejectsCaseVariantEnumValue(t *testing.T) {
+	t.Parallel()
+
+	err := ValidatePayloadAgainstSchema(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"mode": map[string]any{
+				"type": "string",
+				"enum": []any{"fast"},
+			},
+		},
+		"required":             []any{"mode"},
+		"additionalProperties": false,
+	}, map[string]any{"mode": "FAST"})
+	if err == nil {
+		t.Fatal("expected case-variant enum value to fail")
+	}
+}

--- a/internal/runtime/eventschema/validate_test.go
+++ b/internal/runtime/eventschema/validate_test.go
@@ -1,0 +1,52 @@
+package eventschema
+
+import "testing"
+
+func TestValidatePayloadAgainstSchema_RejectsUnsupportedSchemaType(t *testing.T) {
+	t.Parallel()
+
+	err := ValidatePayloadAgainstSchema(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"mode": map[string]any{"type": "Mode"},
+		},
+		"additionalProperties": false,
+	}, map[string]any{"mode": "fast"})
+	if err == nil {
+		t.Fatal("expected unsupported schema type failure")
+	}
+}
+
+func TestValidatePayloadAgainstSchema_RejectsInvalidStringFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format string
+		value  any
+	}{
+		{name: "uuid", format: "uuid", value: "not-a-uuid"},
+		{name: "date-time", format: "date-time", value: "not-a-timestamp"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidatePayloadAgainstSchema(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"type":   "string",
+						"format": tc.format,
+					},
+				},
+				"required":             []any{"value"},
+				"additionalProperties": false,
+			}, map[string]any{"value": tc.value})
+			if err == nil {
+				t.Fatalf("expected %s format failure", tc.format)
+			}
+		})
+	}
+}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -189,11 +189,13 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if !slices.Equal(first.MCPToolsListed, []string{"mcp__runtime-tools__emit_category_assessed"}) {
 		t.Fatalf("first turn mcp_tools_listed = %#v", first.MCPToolsListed)
 	}
-	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
-		t.Fatalf("emitted events = %#v", recorder.Snapshot())
-	}
 	if !slices.Equal(exec.calls, []string{"read_file", "emit_category_assessed"}) {
 		t.Fatalf("tool exec calls = %#v", exec.calls)
+	}
+	if emitted := recorder.Snapshot(); len(emitted) > 0 {
+		if len(emitted) != 1 || emitted[0].Type != events.EventType("discovery/category.assessed") {
+			t.Fatalf("emitted events = %#v", emitted)
+		}
 	}
 
 	secondInput, err := os.ReadFile(filepath.Join(captureDir, "2.stdin"))

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -192,10 +192,8 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if !slices.Equal(exec.calls, []string{"read_file", "emit_category_assessed"}) {
 		t.Fatalf("tool exec calls = %#v", exec.calls)
 	}
-	if emitted := recorder.Snapshot(); len(emitted) > 0 {
-		if len(emitted) != 1 || emitted[0].Type != events.EventType("discovery/category.assessed") {
-			t.Fatalf("emitted events = %#v", emitted)
-		}
+	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
+		t.Fatalf("emitted events = %#v", recorder.Snapshot())
 	}
 
 	secondInput, err := os.ReadFile(filepath.Join(captureDir, "2.stdin"))

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -209,6 +209,12 @@ func validateAutoEmitPayload(source semanticview.Source, flowID, eventType strin
 		proof.CatalogKey: proof.Entry,
 	})
 	schema, ok := registry[proof.CatalogKey]
+	if bundle, okBundle := semanticview.Bundle(source); okBundle && bundle != nil {
+		if resolved, _, okResolved := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); okResolved {
+			schema = resolved
+			ok = true
+		}
+	}
 	if !ok {
 		return nil
 	}

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -495,6 +495,42 @@ func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t 
 	}
 }
 
+func TestValidateAutoEmitPayload_RejectsListTypeViolation(t *testing.T) {
+	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"instance_id":      {Type: "string"},
+				"template_id":      {Type: "string"},
+				"flow_path":        {Type: "string"},
+				"subject_id":       {Type: "string"},
+				"parent_entity_id": {Type: "string"},
+				"sources":          {Type: "[SourceID]"},
+			},
+		},
+		Required: []string{"instance_id", "template_id", "flow_path", "subject_id", "parent_entity_id", "sources"},
+	})
+	bundle.RootTypes = runtimecontracts.TypeCatalogDocument{
+		Scalars: map[string]runtimecontracts.ScalarTypeDecl{
+			"SourceID": {Base: "text"},
+		},
+	}
+
+	err := validateAutoEmitPayload(semanticview.Wrap(bundle), "review", "task.started", map[string]any{
+		"instance_id":      "inst-1",
+		"template_id":      "review",
+		"flow_path":        "review/inst-1",
+		"subject_id":       "ent-1",
+		"parent_entity_id": "ent-parent",
+		"sources":          "not-a-list",
+	})
+	if err == nil {
+		t.Fatal("expected list-type auto-emit failure")
+	}
+	if !strings.Contains(err.Error(), "$.sources must be array") {
+		t.Fatalf("validateAutoEmitPayload error = %v, want list-type detail", err)
+	}
+}
+
 func TestNormalizedStaticFlowEmitEvents_ExternalizesLocalEvents(t *testing.T) {
 	got := normalizedStaticFlowEmitEvents(
 		[]string{"analysis.done", "shared.event"},

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -804,6 +804,12 @@ func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType s
 		proof.CatalogKey: proof.Entry,
 	})
 	schema, ok := registry[proof.CatalogKey]
+	if bundle, okBundle := semanticview.Bundle(source); okBundle && bundle != nil {
+		if resolved, _, okResolved := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); okResolved {
+			schema = resolved
+			ok = true
+		}
+	}
 	if !ok {
 		return nil
 	}

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1128,6 +1128,31 @@ func TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSur
 	}
 }
 
+func TestValidatePipelineEmitPayload_RejectsEnumViolationOnActionSurface(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml":             "name: action-emit-enum\nversion: 1.0.0\ndescription: Action emit enum proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
+		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n  outputs:\n    events: [parent.result]\n",
+		"events.yaml":              "parent.trigger:\n  entity_id: string\nparent.result:\n  entity_id: string\n",
+		"types.yaml":               "enums:\n  Mode: [fast, deep]\n",
+		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
+		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.internal]\n",
+		"flows/child/events.yaml":  "child.start:\n  entity_id: string\nchild.internal:\n  mode: Mode\n  required: [mode]\n",
+	})
+
+	err := validatePipelineEmitPayload(source, "child", "child.internal", map[string]any{
+		"mode": "invalid",
+	}, nil, runtimeengine.EmitSurfaceAction)
+	if err == nil {
+		t.Fatal("expected enum violation to fail closed on the action surface")
+	}
+	if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+		t.Fatalf("validatePipelineEmitPayload error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
+	}
+	if !strings.Contains(err.Error(), "invalid enum value") {
+		t.Fatalf("validatePipelineEmitPayload error = %v, want enum detail", err)
+	}
+}
+
 func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -103,10 +103,24 @@ func (r *EmitRegistry) GenerateEmitToolsForEvents(eventTypes []string, warn func
 	if len(allowed) == 0 {
 		return nil
 	}
+	collisions := duplicateEmitToolNames(allowed)
 	tools := make([]llm.ToolDefinition, 0, len(allowed))
 	for _, eventType := range allowed {
 		eventType = strings.TrimSpace(eventType)
 		if eventType == "" {
+			continue
+		}
+		toolName := EmitToolName(eventType)
+		if collisions[toolName] > 1 {
+			if warn != nil {
+				warn(
+					"emit-tool-ambiguous-name-"+toolName,
+					"event-schema-registry",
+					"skipping emit tool generation for %q because emit tool name %q is ambiguous across configured events",
+					eventType,
+					toolName,
+				)
+			}
 			continue
 		}
 		schema, ok := emitSchemaForEventType(r.activeSchemas, eventType)
@@ -122,7 +136,7 @@ func (r *EmitRegistry) GenerateEmitToolsForEvents(eventTypes []string, warn func
 			continue
 		}
 		tools = append(tools, llm.ToolDefinition{
-			Name:        EmitToolName(eventType),
+			Name:        toolName,
 			Description: schema.Description,
 			Schema:      schema.Schema,
 		})
@@ -136,10 +150,24 @@ func (r *EmitRegistry) GenerateEmitToolsForActor(actor models.AgentConfig, warn 
 		return nil
 	}
 	if configured := UniqueNonEmpty(actor.EmitEvents); len(configured) > 0 {
+		collisions := duplicateEmitToolNames(configured)
 		tools := make([]llm.ToolDefinition, 0, len(configured))
 		for _, eventType := range configured {
 			eventType = strings.TrimSpace(eventType)
 			if eventType == "" {
+				continue
+			}
+			toolName := EmitToolName(eventType)
+			if collisions[toolName] > 1 {
+				if warn != nil {
+					warn(
+						"emit-tool-ambiguous-name-"+toolName,
+						"event-schema-registry",
+						"skipping emit tool generation for %q because emit tool name %q is ambiguous across actor-configured events",
+						eventType,
+						toolName,
+					)
+				}
 				continue
 			}
 			schema, ok := r.schemaForActorEvent(actor, eventType)
@@ -155,7 +183,7 @@ func (r *EmitRegistry) GenerateEmitToolsForActor(actor models.AgentConfig, warn 
 				continue
 			}
 			tools = append(tools, llm.ToolDefinition{
-				Name:        EmitToolName(eventType),
+				Name:        toolName,
 				Description: schema.Description,
 				Schema:      schema.Schema,
 			})
@@ -331,6 +359,18 @@ func emitEventTypesEquivalent(left, right string) bool {
 		return true
 	}
 	return localEmitEventType(left) == localEmitEventType(right)
+}
+
+func duplicateEmitToolNames(eventTypes []string) map[string]int {
+	counts := make(map[string]int, len(eventTypes))
+	for _, eventType := range eventTypes {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			continue
+		}
+		counts[EmitToolName(eventType)]++
+	}
+	return counts
 }
 
 func emitSchemaForEventType(activeSchemas map[string]EmitSchema, eventType string) (EmitSchema, bool) {

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -224,6 +224,49 @@ func (r *EmitRegistry) ValidateEventPayloadAgainstSchema(eventType string, paylo
 	return ValidatePayloadAgainstSchema(r.SchemaForEventType(eventType).Schema, payload)
 }
 
+func (r *EmitRegistry) EventSchemaForActorTool(actor models.AgentConfig, toolName string) (string, EmitSchema, bool) {
+	if r == nil {
+		return "", EmitSchema{}, false
+	}
+	toolName = normalizeNativeToolName(toolName)
+	if toolName == "" {
+		return "", EmitSchema{}, false
+	}
+	if configured := UniqueNonEmpty(actor.EmitEvents); len(configured) > 0 {
+		var matchedEventType string
+		var matchedSchema EmitSchema
+		matchCount := 0
+		for _, eventType := range configured {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" || EmitToolName(eventType) != toolName {
+				continue
+			}
+			schema, ok := r.schemaForActorEvent(actor, eventType)
+			if !ok {
+				continue
+			}
+			matchedEventType = eventType
+			matchedSchema = schema
+			matchCount++
+		}
+		if matchCount == 1 {
+			return matchedEventType, matchedSchema, true
+		}
+		if matchCount > 1 {
+			return "", EmitSchema{}, false
+		}
+	}
+	eventType, ok := r.EventTypeFromToolName(toolName)
+	if !ok {
+		return "", EmitSchema{}, false
+	}
+	schema, ok := emitSchemaForEventType(r.activeSchemas, eventType)
+	if !ok {
+		return "", EmitSchema{}, false
+	}
+	return eventType, schema, true
+}
+
 func (r *EmitRegistry) IsEmitToolAllowedForRole(role, toolName string) bool {
 	if r == nil {
 		return false
@@ -244,7 +287,7 @@ func (r *EmitRegistry) IsEmitToolAllowedForActor(actor models.AgentConfig, toolN
 	if r == nil {
 		return false
 	}
-	eventType, ok := r.EventTypeFromToolName(toolName)
+	eventType, _, ok := r.EventSchemaForActorTool(actor, toolName)
 	if !ok {
 		return false
 	}

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -303,7 +303,25 @@ func emitSchemaForEventType(activeSchemas map[string]EmitSchema, eventType strin
 		return EmitSchema{}, false
 	}
 	schema, ok := activeSchemas[local]
-	return schema, ok
+	if ok {
+		return schema, true
+	}
+	var matched EmitSchema
+	matchCount := 0
+	for schemaEventType, schema := range activeSchemas {
+		if localEmitEventType(schemaEventType) != local {
+			continue
+		}
+		matched = schema
+		matchCount++
+		if matchCount > 1 {
+			return EmitSchema{}, false
+		}
+	}
+	if matchCount == 1 {
+		return matched, true
+	}
+	return EmitSchema{}, false
 }
 
 func missingProducerEventSchemas(producerRoles func() []string, producerEvents func(string) []string, registry map[string]EmitSchema) []string {

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -299,12 +299,14 @@ func emitSchemaForEventType(activeSchemas map[string]EmitSchema, eventType strin
 		return schema, true
 	}
 	local := localEmitEventType(eventType)
-	if local == "" || local == eventType {
+	if local == "" {
 		return EmitSchema{}, false
 	}
-	schema, ok := activeSchemas[local]
-	if ok {
-		return schema, true
+	if local != eventType {
+		schema, ok := activeSchemas[local]
+		if ok {
+			return schema, true
+		}
 	}
 	var matched EmitSchema
 	matchCount := 0

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -22,10 +22,16 @@ type EmitRegistry struct {
 func NewEmitRegistry(source semanticview.Source, provider runtimeauthority.Provider) *EmitRegistry {
 	provider = runtimeauthority.ProviderOrNoop(provider)
 	catalog := map[string]runtimecontracts.EventCatalogEntry{}
+	activeSchemas := map[string]EmitSchema{}
 	if source != nil {
 		catalog = source.ResolvedEventCatalog()
+		if bundle, ok := semanticview.Bundle(source); ok && bundle != nil {
+			activeSchemas = runtimecontracts.EventSchemaRegistryFromBundle(bundle)
+		}
 	}
-	activeSchemas := runtimecontracts.EventSchemaRegistryFromCatalog(catalog)
+	if len(activeSchemas) == 0 {
+		activeSchemas = runtimecontracts.EventSchemaRegistryFromCatalog(catalog)
+	}
 	generatedSchemas := make(map[string]struct{})
 	if source != nil {
 		for _, entry := range source.AgentEntries() {
@@ -178,6 +184,11 @@ func (r *EmitRegistry) schemaForActorEvent(actor models.AgentConfig, eventType s
 	proof := semanticview.ResolveFlowEventProof(r.source, flowID, eventType)
 	if !proof.HasSchema {
 		return EmitSchema{}, false
+	}
+	if bundle, ok := semanticview.Bundle(r.source); ok && bundle != nil {
+		if schema, _, ok := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); ok {
+			return schema, true
+		}
 	}
 	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
 		proof.CatalogKey: proof.Entry,

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -104,6 +104,26 @@ func TestEmitRegistry_KeepsRuntimeSourcesIsolated(t *testing.T) {
 	}
 }
 
+func TestEmitSchemaForEventType_UsesOnlyUniqueScopedLocalMatch(t *testing.T) {
+	scanSchema := EmitSchema{Description: "scan"}
+	reviewSchema := EmitSchema{Description: "review"}
+
+	schema, ok := emitSchemaForEventType(map[string]EmitSchema{
+		"review/scan.requested": scanSchema,
+	}, "review/inst-1/scan.requested")
+	if !ok || schema.Description != "scan" {
+		t.Fatalf("unique scoped schema = %#v, %v; want scan,true", schema, ok)
+	}
+
+	_, ok = emitSchemaForEventType(map[string]EmitSchema{
+		"review/scan.requested":     scanSchema,
+		"validation/scan.requested": reviewSchema,
+	}, "scan.requested")
+	if ok {
+		t.Fatal("ambiguous scoped local match should not resolve")
+	}
+}
+
 func TestGenerateEmitToolsForActor_ResolvesInstanceScopedFlowEmitEventsThroughOwningFlowProof(t *testing.T) {
 	reviewFlow := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 
 	runtimeauthority "swarm/internal/runtime/authority"
@@ -122,6 +123,73 @@ func TestEmitSchemaForEventType_UsesOnlyUniqueScopedLocalMatch(t *testing.T) {
 	}, "scan.requested")
 	if ok {
 		t.Fatal("ambiguous scoped local match should not resolve")
+	}
+}
+
+func TestGenerateEmitToolsForActor_FailsClosedOnDuplicateLocalToolNames(t *testing.T) {
+	reviewFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"priority": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	validationFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "validation", Flow: "validation"},
+		Path:  "validation",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"priority": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	root := &runtimecontracts.FlowContractView{
+		Children: []runtimecontracts.FlowContractView{reviewFlow, validationFlow},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+		},
+	}
+	registry := NewEmitRegistry(semanticview.Wrap(bundle), nil)
+	actor := models.AgentConfig{
+		ID:         "dual-scope-agent",
+		Role:       "reviewer",
+		Mode:       "review",
+		FlowPath:   "review",
+		EmitEvents: []string{"review/task.requested", "validation/task.requested"},
+	}
+
+	var warnings []string
+	tools := registry.GenerateEmitToolsForActor(actor, func(code, component, format string, args ...any) {
+		warnings = append(warnings, code)
+	})
+	if len(tools) != 0 {
+		t.Fatalf("tools = %#v, want none on duplicate local tool name collision", tools)
+	}
+	if !slices.Contains(warnings, "emit-tool-ambiguous-name-emit_task_requested") {
+		t.Fatalf("warnings = %#v, want duplicate-name warning", warnings)
+	}
+	if registry.IsEmitToolAllowedForActor(actor, "emit_task_requested") {
+		t.Fatal("expected duplicate local tool name collision to deny actor emit tool authorization")
 	}
 }
 

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"path/filepath"
 	"testing"
 
 	runtimeauthority "swarm/internal/runtime/authority"
@@ -168,5 +169,23 @@ func TestGenerateEmitToolsForActor_ResolvesInstanceScopedFlowEmitEventsThroughOw
 	}
 	if tools[0].Name != "emit_scan_requested" {
 		t.Fatalf("tool name = %q, want emit_scan_requested", tools[0].Name)
+	}
+}
+
+func TestEmitRegistry_DoesNotGenerateMissingSchemaForChildLocalAgentEmitFixture(t *testing.T) {
+	repoRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-required-agents-child")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := semanticview.Wrap(bundle)
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+
+	if missing := registry.GeneratedEmitSchemasForAgentRoles(); len(missing) != 0 {
+		t.Fatalf("generated missing schemas = %v, active schemas = %#v", missing, registry.activeSchemas)
 	}
 }

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig, toolName string, input any) (any, error) {
-	eventType, ok := e.emitRegistry.EventTypeFromToolName(toolName)
+	eventType, eventSchema, ok := e.emitRegistry.EventSchemaForActorTool(actor, toolName)
 	if !ok {
 		err := NewRuntimeError(
 			"invalid_emit_tool_name",
@@ -63,7 +63,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		return nil, err
 	}
 	postEnrichmentPayload := diagnosticPayloadMap(payloadMap)
-	if err := e.emitRegistry.ValidateEventPayloadAgainstSchema(schemaEventType, payloadMap); err != nil {
+	if err := ValidatePayloadAgainstSchema(eventSchema.Schema, payloadMap); err != nil {
 		wrapped := WrapRuntimeError(
 			"schema_validation_failed",
 			"tool-executor",

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -377,6 +377,78 @@ func TestHandleEmitTool_ResolvesDuplicateLeafScopedSchemasThroughActor(t *testin
 	}
 }
 
+func TestHandleEmitTool_FailsClosedOnSameActorDuplicateLeafScopedSchemas(t *testing.T) {
+	reviewFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"priority": {Type: "string"},
+					},
+					Required: []string{"priority"},
+				},
+			},
+		},
+	}
+	validationFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "validation", Flow: "validation"},
+		Path:  "validation",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"priority": {Type: "string"},
+					},
+					Required: []string{"priority"},
+				},
+			},
+		},
+	}
+	root := &runtimecontracts.FlowContractView{
+		Children: []runtimecontracts.FlowContractView{reviewFlow, validationFlow},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "dual-scope-agent",
+		Role:       "reviewer",
+		Mode:       "review",
+		FlowPath:   "review",
+		EmitEvents: []string{"review/task.requested", "validation/task.requested"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_task_requested", map[string]any{
+		"priority": "urgent",
+	})
+	if err == nil {
+		t.Fatal("expected same-actor duplicate local tool name collision to fail closed")
+	}
+	if !strings.Contains(err.Error(), "invalid emit tool name") {
+		t.Fatalf("error = %v, want invalid emit tool name", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
+	}
+}
+
 func TestHandleEmitTool_FailsClosedOnNamedTypeViolation(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -266,6 +266,117 @@ func TestHandleEmitTool_AllowsValidWave1EventPayloadTypes(t *testing.T) {
 	}
 }
 
+func TestHandleEmitTool_ResolvesDuplicateLeafScopedSchemasThroughActor(t *testing.T) {
+	reviewFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"details": {Type: "ReviewRequest"},
+					},
+					Required: []string{"details"},
+				},
+			},
+		},
+	}
+	validationFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "validation", Flow: "validation"},
+		Path:  "validation",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"details": {Type: "ValidationRequest"},
+					},
+					Required: []string{"details"},
+				},
+			},
+		},
+	}
+	root := &runtimecontracts.FlowContractView{
+		Children: []runtimecontracts.FlowContractView{reviewFlow, validationFlow},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Enums: map[string]runtimecontracts.EnumTypeDecl{
+				"ReviewPriority":     {Values: []string{"urgent"}},
+				"ValidationPriority": {Values: []string{"low"}},
+			},
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"ReviewRequest": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"priority": {Type: "ReviewPriority"},
+					},
+				},
+				"ValidationRequest": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"priority": {Type: "ValidationPriority"},
+					},
+				},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"review":     &root.Children[0],
+				"validation": &root.Children[1],
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+
+	reviewActor := models.AgentConfig{
+		ID:         "review-agent",
+		Role:       "reviewer",
+		Mode:       "review",
+		FlowPath:   "review",
+		EmitEvents: []string{"review/task.requested"},
+	}
+	_, err := exec.handleEmitTool(context.Background(), reviewActor, "emit_task_requested", map[string]any{
+		"details": map[string]any{
+			"priority": "urgent",
+		},
+	})
+	if err != nil {
+		t.Fatalf("review handleEmitTool: %v", err)
+	}
+	if got, want := string(bus.event.Type), "review/task.requested"; got != want {
+		t.Fatalf("review published event type = %q, want %q", got, want)
+	}
+
+	validationActor := models.AgentConfig{
+		ID:         "validation-agent",
+		Role:       "validator",
+		Mode:       "validation",
+		FlowPath:   "validation",
+		EmitEvents: []string{"validation/task.requested"},
+	}
+	_, err = exec.handleEmitTool(context.Background(), validationActor, "emit_task_requested", map[string]any{
+		"details": map[string]any{
+			"priority": "low",
+		},
+	})
+	if err != nil {
+		t.Fatalf("validation handleEmitTool: %v", err)
+	}
+	if got, want := string(bus.event.Type), "validation/task.requested"; got != want {
+		t.Fatalf("validation published event type = %q, want %q", got, want)
+	}
+	if bus.count != 2 {
+		t.Fatalf("publish count = %d, want 2", bus.count)
+	}
+}
+
 func TestHandleEmitTool_FailsClosedOnNamedTypeViolation(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -204,3 +204,112 @@ func TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField(t *testing.T) {
 		t.Fatalf("publish count = %d, want 0", bus.count)
 	}
 }
+
+func TestHandleEmitTool_AllowsValidWave1EventPayloadTypes(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Scalars: map[string]runtimecontracts.ScalarTypeDecl{
+				"TraceID": {Base: "uuid"},
+				"Label":   {Base: "text"},
+			},
+			Enums: map[string]runtimecontracts.EnumTypeDecl{
+				"Mode": {Values: []string{"fast", "deep"}},
+			},
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"ScanDetails": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"source": {Type: "text"},
+						"count":  {Type: "integer"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"mode":     {Type: "Mode"},
+						"details":  {Type: "ScanDetails"},
+						"labels":   {Type: "[Label]"},
+						"trace_id": {Type: "TraceID"},
+					},
+					Required: []string{"mode", "details", "labels", "trace_id"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		EmitEvents: []string{"scan.completed"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_scan_completed", map[string]any{
+		"mode": "fast",
+		"details": map[string]any{
+			"source": "scanner-a",
+			"count":  2,
+		},
+		"labels":   []any{"a", "b"},
+		"trace_id": "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
+}
+
+func TestHandleEmitTool_FailsClosedOnNamedTypeViolation(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"ScanDetails": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"source": {Type: "text"},
+						"count":  {Type: "integer"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"details": {Type: "ScanDetails"},
+					},
+					Required: []string{"details"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		EmitEvents: []string{"scan.completed"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_scan_completed", map[string]any{
+		"details": "not-an-object",
+	})
+	if err == nil {
+		t.Fatal("expected named-type payload violation")
+	}
+	if !strings.Contains(err.Error(), "$.details must be object") {
+		t.Fatalf("handleEmitTool error = %v, want named-type detail", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
+	}
+}


### PR DESCRIPTION
Closes #498

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:283-320`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:398-414`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:3470-3504`
- Approved `#498` pre-audit/gate: issue comments `4299801959` and `4299803077`

## Semantic migration
- New canonical owner: `internal/runtime/contracts/schema_registry.go` lowers event payload contracts with Wave 1 type-system meaning preserved for runtime validation.
- New canonical validator behavior: `internal/runtime/eventschema/validate.go` fails closed for unsupported lowered schema types and validates string formats for `uuid` and `timestamp`/`date-time`.
- Old invalid path: event payload refs were lowered to shallow/opaque `type` strings; unknown runtime schema types silently passed validation.
- Production paths checked for surviving old behavior: declarative/action emits, auto-emits, agent emit tools, event-bus canonical validation, and registry/validator call sweeps.
- Migration completeness: complete for the approved `#498` runtime event-schema enforcement class after payload reaches validation.

## Proof run
- `go test ./internal/runtime/contracts ./internal/runtime/eventschema -count=1`
- `go test ./internal/runtime/pipeline -run 'TestValidatePipelineEmitPayload_RejectsEnumViolationOnActionSurface|TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSurface|TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface' -count=1`
- `go test ./internal/runtime/manager -run 'TestValidateAutoEmitPayload_RejectsListTypeViolation|TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField|TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField' -count=1`
- `go test ./internal/runtime/tools -run 'TestHandleEmitTool_AllowsValidWave1EventPayloadTypes|TestHandleEmitTool_FailsClosedOnNamedTypeViolation|TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField|TestHandleEmitTool_PreservesPayloadForFlowScopedEmit|TestGenerateEmitToolsForActor|TestEmitRegistry|TestRuntimeAndValidatorNormalizationStayAligned|TestToolDefinitionsForActor' -count=1`
- `go test ./internal/runtime -run 'TestRuntimePayloadValidator_RejectsScalarAliasUUIDViolationFromEmitRegistrySnapshot|TestRuntimePayloadValidator_RejectsSchemaMismatch|TestRuntimePayloadValidator_RejectsUndeclaredCallerPayloadFieldWhenAdditionalPropertiesFalse' -count=1`
- `go test ./cmd/swarm -run 'TestRunVerifyCommand' -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`

Broad package run note:
- `go test ./internal/runtime/contracts ./internal/runtime/eventschema ./internal/runtime/tools ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime ./cmd/swarm -count=1 -timeout=120s` was attempted and timed out in existing Postgres-backed tests waiting for local Postgres startup, not in the `#498` assertions.
