### PR TITLE
[agent-d][issue #501] Make query filter validation contract-aware

### DIFF
--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/entityruntime"
@@ -219,6 +220,9 @@ func filterEntityStateRowsCEL(expression string, rows []map[string]any, schema e
 	if err != nil {
 		return nil, err
 	}
+	if err := validateEntityFilterExpression(env, expression, schema); err != nil {
+		return nil, err
+	}
 	ast, issues := env.Compile(expression)
 	if issues != nil && issues.Err() != nil {
 		return nil, issues.Err()
@@ -262,6 +266,247 @@ func newEntityFilterEnv(schema entityToolSchema) (*cel.Env, error) {
 		decls = append(decls, cel.Variable(key, cel.DynType))
 	}
 	return cel.NewEnv(decls...)
+}
+
+type entityFilterSelectorReference struct {
+	Path         string
+	EntityScoped bool
+}
+
+func (r entityFilterSelectorReference) display() string {
+	path := strings.TrimSpace(r.Path)
+	if path == "" {
+		return ""
+	}
+	if r.EntityScoped {
+		return "entity." + path
+	}
+	return path
+}
+
+func validateEntityFilterExpression(env *cel.Env, expression string, schema entityToolSchema) error {
+	if env == nil {
+		return fmt.Errorf("entity filter environment is not configured")
+	}
+	parsed, issues := env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return issues.Err()
+	}
+	for _, ref := range entityFilterSelectorReferences(parsed) {
+		if err := validateEntityFilterSelectorReference(schema, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func entityFilterSelectorReferences(parsed *cel.Ast) []entityFilterSelectorReference {
+	if parsed == nil || parsed.NativeRep() == nil {
+		return nil
+	}
+	root := celast.NavigateAST(parsed.NativeRep())
+	seen := map[string]struct{}{}
+	refs := make([]entityFilterSelectorReference, 0)
+	var visit func(expr celast.NavigableExpr)
+	visit = func(expr celast.NavigableExpr) {
+		if expr.Kind() == celast.SelectKind && !entityFilterSelectorHasParent(expr) {
+			if ref, ok := entityFilterSelectorReferenceFromExpr(expr); ok {
+				key := fmt.Sprintf("%t:%s", ref.EntityScoped, ref.Path)
+				if _, exists := seen[key]; !exists {
+					seen[key] = struct{}{}
+					refs = append(refs, ref)
+				}
+			}
+		}
+		for _, child := range expr.Children() {
+			visit(child)
+		}
+	}
+	visit(root)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].EntityScoped != refs[j].EntityScoped {
+			return !refs[i].EntityScoped && refs[j].EntityScoped
+		}
+		return refs[i].Path < refs[j].Path
+	})
+	return refs
+}
+
+func entityFilterSelectorHasParent(expr celast.NavigableExpr) bool {
+	parent, ok := expr.Parent()
+	if !ok || parent.Kind() != celast.SelectKind {
+		return false
+	}
+	return parent.AsSelect().Operand().ID() == expr.ID()
+}
+
+func entityFilterSelectorReferenceFromExpr(expr celast.Expr) (entityFilterSelectorReference, bool) {
+	if expr == nil || expr.Kind() != celast.SelectKind {
+		return entityFilterSelectorReference{}, false
+	}
+	selector := expr.AsSelect()
+	base, ok := entityFilterSelectorBase(selector.Operand())
+	if !ok {
+		return entityFilterSelectorReference{}, false
+	}
+	path := strings.TrimSpace(base.Path)
+	field := strings.TrimSpace(selector.FieldName())
+	if path == "" {
+		path = field
+	} else {
+		path = path + "." + field
+	}
+	return entityFilterSelectorReference{Path: path, EntityScoped: base.EntityScoped}, true
+}
+
+func entityFilterSelectorBase(expr celast.Expr) (entityFilterSelectorReference, bool) {
+	if expr == nil {
+		return entityFilterSelectorReference{}, false
+	}
+	switch expr.Kind() {
+	case celast.IdentKind:
+		name := strings.TrimSpace(expr.AsIdent())
+		if name == "" {
+			return entityFilterSelectorReference{}, false
+		}
+		if name == "entity" {
+			return entityFilterSelectorReference{EntityScoped: true}, true
+		}
+		return entityFilterSelectorReference{Path: name}, true
+	case celast.SelectKind:
+		return entityFilterSelectorReferenceFromExpr(expr)
+	default:
+		return entityFilterSelectorReference{}, false
+	}
+}
+
+func validateEntityFilterSelectorReference(schema entityToolSchema, ref entityFilterSelectorReference) error {
+	if err := validateEntitySelector(schema, ref.Path); err != nil {
+		return decorateEntityFilterSelectorError(schema, ref, err)
+	}
+	return nil
+}
+
+func decorateEntityFilterSelectorError(schema entityToolSchema, ref entityFilterSelectorReference, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !entityFilterUndeclaredPathError(err) {
+		return err
+	}
+	display := ref.display()
+	if display == "" {
+		return err
+	}
+	if suggestion := nearestEntityFilterSelector(schema, ref); suggestion != "" {
+		return fmt.Errorf("%w: undeclared field %s (did you mean %s?)", ErrUnknownEntityField, display, suggestion)
+	}
+	return fmt.Errorf("%w: undeclared field %s", ErrUnknownEntityField, display)
+}
+
+func entityFilterUndeclaredPathError(err error) bool {
+	text := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(text, "undeclared field") || strings.Contains(text, "undeclared path")
+}
+
+func nearestEntityFilterSelector(schema entityToolSchema, ref entityFilterSelectorReference) string {
+	candidates := entityToolSelectableFieldNames(schema.Contract)
+	if len(candidates) == 0 {
+		return ""
+	}
+	path := strings.TrimSpace(ref.Path)
+	if path == "" {
+		return ""
+	}
+	best := ""
+	bestScore := -1
+	inputParent, inputLeaf := entityFilterPathParentAndLeaf(path)
+	for _, candidate := range candidates {
+		score := levenshteinDistance(strings.ToLower(path), strings.ToLower(candidate))
+		candidateParent, candidateLeaf := entityFilterPathParentAndLeaf(candidate)
+		if inputParent != "" && candidateParent == inputParent {
+			if leafScore := levenshteinDistance(strings.ToLower(inputLeaf), strings.ToLower(candidateLeaf)); leafScore < score {
+				score = leafScore
+			}
+		}
+		if bestScore == -1 || score < bestScore || (score == bestScore && candidate < best) {
+			best = candidate
+			bestScore = score
+		}
+	}
+	if best == "" || bestScore > entityFilterSuggestionThreshold(path) {
+		return ""
+	}
+	if ref.EntityScoped {
+		return "entity." + best
+	}
+	return best
+}
+
+func entityFilterPathParentAndLeaf(path string) (string, string) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", ""
+	}
+	idx := strings.LastIndex(path, ".")
+	if idx < 0 {
+		return "", path
+	}
+	return strings.TrimSpace(path[:idx]), strings.TrimSpace(path[idx+1:])
+}
+
+func entityFilterSuggestionThreshold(path string) int {
+	path = strings.TrimSpace(path)
+	switch {
+	case len(path) <= 6:
+		return 2
+	case len(path) <= 16:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func levenshteinDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := 0; j <= len(b); j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			insert := curr[j-1] + 1
+			delete := prev[j] + 1
+			replace := prev[j-1] + cost
+			curr[j] = minEntityFilterDistance(insert, delete, replace)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func minEntityFilterDistance(values ...int) int {
+	best := values[0]
+	for _, value := range values[1:] {
+		if value < best {
+			best = value
+		}
+	}
+	return best
 }
 
 func entityCELActivation(row map[string]any, schema entityToolSchema) map[string]any {

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -381,6 +381,13 @@ func entityFilterSelectorBase(expr celast.Expr) (entityFilterSelectorReference, 
 }
 
 func validateEntityFilterSelectorReference(schema entityToolSchema, ref entityFilterSelectorReference) error {
+	if ref.EntityScoped {
+		path := strings.TrimSpace(ref.Path)
+		if path == "" {
+			return fmt.Errorf("%w: query filter selectors must not use the entity root", ErrUnknownEntityField)
+		}
+		return fmt.Errorf("%w: query filter selectors must not use entity.%s; use %s instead", ErrUnknownEntityField, path, path)
+	}
 	if err := validateEntitySelector(schema, ref.Path); err != nil {
 		return decorateEntityFilterSelectorError(schema, ref, err)
 	}

--- a/internal/runtime/tools/executor_entity_query_internal_test.go
+++ b/internal/runtime/tools/executor_entity_query_internal_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/entityruntime"
+)
+
+func TestValidateEntityFilterExpression_AllowsDeclaredNestedLeaf(t *testing.T) {
+	schema := testEntityFilterSchema()
+	env, err := newEntityFilterEnv(schema)
+	if err != nil {
+		t.Fatalf("newEntityFilterEnv: %v", err)
+	}
+	if err := validateEntityFilterExpression(env, `entity.metadata.region == "us"`, schema); err != nil {
+		t.Fatalf("validateEntityFilterExpression: %v", err)
+	}
+}
+
+func TestValidateEntityFilterExpression_SurfacesNearestMatchForUndeclaredLeaf(t *testing.T) {
+	schema := testEntityFilterSchema()
+	env, err := newEntityFilterEnv(schema)
+	if err != nil {
+		t.Fatalf("newEntityFilterEnv: %v", err)
+	}
+	err = validateEntityFilterExpression(env, `entity.metadata.regoin == "us"`, schema)
+	if err == nil {
+		t.Fatal("expected undeclared filter field to fail")
+	}
+	if !strings.Contains(err.Error(), "entity.metadata.regoin") {
+		t.Fatalf("expected undeclared field in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "did you mean entity.metadata.region?") {
+		t.Fatalf("expected nearest-match guidance, got %v", err)
+	}
+}
+
+func TestFilterEntityStateRowsCEL_RejectsUndeclaredFieldBeforeEvalOnEmptyRows(t *testing.T) {
+	schema := testEntityFilterSchema()
+	_, err := filterEntityStateRowsCEL(`metadata.regoin == "us"`, nil, schema)
+	if err == nil {
+		t.Fatal("expected undeclared filter field to fail before CEL evaluation")
+	}
+	if !strings.Contains(err.Error(), "metadata.regoin") {
+		t.Fatalf("expected undeclared field in error, got %v", err)
+	}
+}
+
+func testEntityFilterSchema() entityToolSchema {
+	return entityToolSchema{
+		Defined: true,
+		Contract: entityruntime.Contract{
+			FlowID:     "review",
+			EntityType: "accounts",
+			Entity: runtimecontracts.EntityContract{
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"status":   {Type: "text"},
+					"score":    {Type: "numeric"},
+					"metadata": {Type: "Metadata"},
+				},
+			},
+			Types: runtimecontracts.TypeCatalogDocument{
+				Types: map[string]runtimecontracts.NamedTypeDecl{
+					"Metadata": {
+						Fields: map[string]runtimecontracts.TypeFieldSpec{
+							"region": {Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/runtime/tools/executor_entity_query_internal_test.go
+++ b/internal/runtime/tools/executor_entity_query_internal_test.go
@@ -14,7 +14,7 @@ func TestValidateEntityFilterExpression_AllowsDeclaredNestedLeaf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newEntityFilterEnv: %v", err)
 	}
-	if err := validateEntityFilterExpression(env, `entity.metadata.region == "us"`, schema); err != nil {
+	if err := validateEntityFilterExpression(env, `metadata.region == "us"`, schema); err != nil {
 		t.Fatalf("validateEntityFilterExpression: %v", err)
 	}
 }
@@ -25,15 +25,33 @@ func TestValidateEntityFilterExpression_SurfacesNearestMatchForUndeclaredLeaf(t 
 	if err != nil {
 		t.Fatalf("newEntityFilterEnv: %v", err)
 	}
-	err = validateEntityFilterExpression(env, `entity.metadata.regoin == "us"`, schema)
+	err = validateEntityFilterExpression(env, `metadata.regoin == "us"`, schema)
 	if err == nil {
 		t.Fatal("expected undeclared filter field to fail")
 	}
-	if !strings.Contains(err.Error(), "entity.metadata.regoin") {
+	if !strings.Contains(err.Error(), "metadata.regoin") {
 		t.Fatalf("expected undeclared field in error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "did you mean entity.metadata.region?") {
+	if !strings.Contains(err.Error(), "did you mean metadata.region?") {
 		t.Fatalf("expected nearest-match guidance, got %v", err)
+	}
+}
+
+func TestValidateEntityFilterExpression_RejectsEntityScopedSelectors(t *testing.T) {
+	schema := testEntityFilterSchema()
+	env, err := newEntityFilterEnv(schema)
+	if err != nil {
+		t.Fatalf("newEntityFilterEnv: %v", err)
+	}
+	err = validateEntityFilterExpression(env, `entity.metadata.region == "us"`, schema)
+	if err == nil {
+		t.Fatal("expected entity-scoped selector to fail")
+	}
+	if !strings.Contains(err.Error(), "must not use entity.metadata.region") {
+		t.Fatalf("expected entity-scoped selector rejection, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "use metadata.region instead") {
+		t.Fatalf("expected direct selector guidance, got %v", err)
 	}
 }
 

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -668,6 +668,75 @@ terminal_states: [killed]
 	}
 }
 
+func TestEntityTools_QueryEntitiesFilterAllowsDeclaredNestedLeaf(t *testing.T) {
+	ctx, exec := newEntityToolTestExecutor(t)
+	_ = mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "review/inst-1",
+		"fields": map[string]any{
+			"status":   "open",
+			"metadata": map[string]any{"region": "us"},
+		},
+	})
+
+	out, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `entity.metadata.region == "us"`,
+		"select": []string{"status", "metadata.region"},
+		"limit":  10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities with declared nested leaf: %v", err)
+	}
+	result, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected query result map, got %#v", out)
+	}
+	rows, ok := result["results"].([]map[string]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("unexpected query results: %#v", result["results"])
+	}
+	if got := strings.TrimSpace(asString(rows[0]["status"])); got != "open" {
+		t.Fatalf("status = %q, want open", got)
+	}
+	if got := strings.TrimSpace(asString(rows[0]["metadata.region"])); got != "us" {
+		t.Fatalf("metadata.region = %q, want us", got)
+	}
+}
+
+func TestEntityTools_QueryEntitiesFilterRejectsUndeclaredFieldBeforeEvalWithNearestMatch(t *testing.T) {
+	ctx, exec := newEntityToolTestExecutor(t)
+
+	_, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `entity.metadata.regoin == "us"`,
+		"limit":  10,
+	})
+	re, ok := runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "entity.metadata.regoin") {
+		t.Fatalf("expected undeclared filter field in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "did you mean entity.metadata.region?") {
+		t.Fatalf("expected nearest-match guidance, got %v", err)
+	}
+}
+
+func TestEntityTools_QueryMetricsFilterRejectsUndeclaredFieldBeforeEval(t *testing.T) {
+	ctx, exec := newEntityToolTestExecutor(t)
+
+	_, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"metric": "count",
+		"filter": `metadata.regoin == "us"`,
+	})
+	re, ok := runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "metadata.regoin") {
+		t.Fatalf("expected undeclared metric filter field in error, got %v", err)
+	}
+}
+
 func TestEntityTools_GetSubjectStatusReturnsEmptyForUnknownSubject(t *testing.T) {
 	ctx, exec := newEntityToolTestExecutor(t)
 	subjectID := uuid.NewString()

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -679,7 +679,7 @@ func TestEntityTools_QueryEntitiesFilterAllowsDeclaredNestedLeaf(t *testing.T) {
 	})
 
 	out, err := exec.Execute(ctx, "query_entities", map[string]any{
-		"filter": `entity.metadata.region == "us"`,
+		"filter": `metadata.region == "us"`,
 		"select": []string{"status", "metadata.region"},
 		"limit":  10,
 	})
@@ -706,18 +706,37 @@ func TestEntityTools_QueryEntitiesFilterRejectsUndeclaredFieldBeforeEvalWithNear
 	ctx, exec := newEntityToolTestExecutor(t)
 
 	_, err := exec.Execute(ctx, "query_entities", map[string]any{
-		"filter": `entity.metadata.regoin == "us"`,
+		"filter": `metadata.regoin == "us"`,
 		"limit":  10,
 	})
 	re, ok := runtimetools.AsRuntimeError(err)
 	if err == nil || !ok || re.Code != "invalid_tool_input" {
 		t.Fatalf("expected invalid_tool_input, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "entity.metadata.regoin") {
+	if !strings.Contains(err.Error(), "metadata.regoin") {
 		t.Fatalf("expected undeclared filter field in error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "did you mean entity.metadata.region?") {
+	if !strings.Contains(err.Error(), "did you mean metadata.region?") {
 		t.Fatalf("expected nearest-match guidance, got %v", err)
+	}
+}
+
+func TestEntityTools_QueryEntitiesFilterRejectsEntityScopedSelectors(t *testing.T) {
+	ctx, exec := newEntityToolTestExecutor(t)
+
+	_, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `entity.metadata.region == "us"`,
+		"limit":  10,
+	})
+	re, ok := runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "must not use entity.metadata.region") {
+		t.Fatalf("expected entity-scoped selector rejection, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "use metadata.region instead") {
+		t.Fatalf("expected direct selector guidance, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #501

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:443-451`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml:703-708`
- Gate approval on `#501`: `https://github.com/yazzaoui/Swarm/issues/501#issuecomment-4283492156`

## Summary
- validate `query_entities` / `query_metrics` CEL selector paths against the inferred entity contract before generic CEL compilation/evaluation
- fail undeclared selector paths as `invalid_tool_input` with nearest-match guidance where available
- keep the change inside the approved read-side semantic executor seam in `internal/runtime/tools/executor_entity_query.go`

## Canonical owner and migration note
- New canonical owner: pre-CEL declared-field filter validation in `internal/runtime/tools/executor_entity_query.go`
- Old non-authoritative path now invalid: relying on weak `cel.DynType` selector evaluation to discover undeclared nested fields only during generic CEL eval (or not at all on empty result sets)
- Production paths checked for surviving old behavior: `query_entities`, `query_metrics`
- Migration complete for the approved first-slice read-side filter-validation class: yes

## Proof
- Passed locally:
  - `go test ./internal/runtime/tools -run '^(TestValidateEntityFilterExpression_AllowsDeclaredNestedLeaf|TestValidateEntityFilterExpression_SurfacesNearestMatchForUndeclaredLeaf|TestFilterEntityStateRowsCEL_RejectsUndeclaredFieldBeforeEvalOnEmptyRows)$' -count=1`
  - `go test ./internal/runtime/tools -run '^$' -count=1`
- Local environment blocker on the heavier executor-path proof:
  - `internal/testutil.StartPostgres` starts the Docker container successfully, but the published host port never answers from this workstation even after container readiness logs report healthy Postgres.
  - The committed executor-path tests are included in this PR and should run in CI:
    - `TestEntityTools_QueryEntitiesFilterAllowsDeclaredNestedLeaf`
    - `TestEntityTools_QueryEntitiesFilterRejectsUndeclaredFieldBeforeEvalWithNearestMatch`
    - `TestEntityTools_QueryMetricsFilterRejectsUndeclaredFieldBeforeEval`
