### PR TITLE
[agent-d][issue #511] Add dotted save_entity_field writes

### DIFF
--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -268,24 +268,20 @@ func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metad
 }
 
 func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, error) {
-	if strings.Contains(strings.TrimSpace(fieldName), ".") {
-		field, err := ResolveLeafField(contract, fieldName)
-		if err != nil {
-			return nil, err
-		}
-		return normalizeValueForType(contract, strings.TrimSpace(fieldName), strings.TrimSpace(field.Type), value)
-	}
-	field, err := FieldDecl(contract, fieldName)
+	field, err := ResolveFieldPath(contract, fieldName)
 	if err != nil {
 		return nil, err
 	}
-	return normalizeValueForType(contract, strings.TrimSpace(fieldName), strings.TrimSpace(field.Type), value)
+	return normalizeValueForType(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), value)
 }
 
-func ResolveLeafField(contract Contract, path string) (Field, error) {
+func ResolveFieldPath(contract Contract, path string) (Field, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return Field{}, fmt.Errorf("field is required")
+	}
+	if strings.Contains(path, "[") || strings.Contains(path, "]") {
+		return Field{}, fmt.Errorf("list index writes are not supported for path %s", path)
 	}
 	segments := strings.Split(path, ".")
 	if len(segments) == 0 {
@@ -297,29 +293,34 @@ func ResolveLeafField(contract Contract, path string) (Field, error) {
 		return Field{}, err
 	}
 	currentType := strings.TrimSpace(decl.Type)
-	if len(segments) == 1 {
-		kind, err := leafKind(contract, currentType)
-		if err != nil {
-			return Field{}, err
-		}
-		return Field{Path: path, Type: currentType, LeafKind: kind, FieldDecl: decl}, nil
-	}
 	for _, segment := range segments[1:] {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return Field{}, fmt.Errorf("field is required")
+		}
 		named, ok := contract.Types.Types[typeName(contract, currentType)]
 		if !ok {
 			return Field{}, fmt.Errorf("path %s does not resolve through a named type", path)
 		}
-		spec, ok := named.Fields[strings.TrimSpace(segment)]
+		spec, ok := named.Fields[segment]
 		if !ok {
 			return Field{}, fmt.Errorf("undeclared path %s", path)
 		}
 		currentType = strings.TrimSpace(spec.Type)
 	}
-	kind, err := leafKind(contract, currentType)
+	kind := pathKind(contract, currentType)
+	return Field{Path: path, Type: currentType, LeafKind: kind, FieldDecl: decl}, nil
+}
+
+func ResolveLeafField(contract Contract, path string) (Field, error) {
+	field, err := ResolveFieldPath(contract, path)
 	if err != nil {
 		return Field{}, err
 	}
-	return Field{Path: path, Type: currentType, LeafKind: kind, FieldDecl: decl}, nil
+	if field.LeafKind != "scalar" && field.LeafKind != "enum" {
+		return Field{}, fmt.Errorf("path does not resolve to scalar or enum leaf")
+	}
+	return field, nil
 }
 
 func PathValue(value map[string]any, path string) (any, bool) {
@@ -506,23 +507,36 @@ func normalizeValueForType(contract Contract, fieldName, typeRef string, value a
 }
 
 func leafKind(contract Contract, typeRef string) (string, error) {
-	switch {
-	case isTextType(typeRef):
-		return "scalar", nil
-	case isIntegerType(contract, typeRef):
-		return "scalar", nil
-	case isNumericType(contract, typeRef):
-		return "scalar", nil
-	case isBooleanType(contract, typeRef):
-		return "scalar", nil
-	case isTimestampType(contract, typeRef):
-		return "scalar", nil
-	case isUUIDType(contract, typeRef):
-		return "scalar", nil
-	case isEnumType(contract, typeRef):
-		return "enum", nil
+	switch kind := pathKind(contract, typeRef); kind {
+	case "scalar", "enum":
+		return kind, nil
 	default:
 		return "", fmt.Errorf("path does not resolve to scalar or enum leaf")
+	}
+}
+
+func pathKind(contract Contract, typeRef string) string {
+	switch {
+	case isTextType(typeRef):
+		return "scalar"
+	case isIntegerType(contract, typeRef):
+		return "scalar"
+	case isNumericType(contract, typeRef):
+		return "scalar"
+	case isBooleanType(contract, typeRef):
+		return "scalar"
+	case isTimestampType(contract, typeRef):
+		return "scalar"
+	case isUUIDType(contract, typeRef):
+		return "scalar"
+	case isEnumType(contract, typeRef):
+		return "enum"
+	case isNamedType(contract, typeRef):
+		return "object"
+	case isListType(typeRef):
+		return "list"
+	default:
+		return ""
 	}
 }
 

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -297,11 +297,53 @@ func applyProjectionMapValue(target map[string]any, key string, value any, bucke
 		return ErrInvalidMutationLogWriter(fmt.Sprintf("%s mutation key is required", strings.TrimSpace(bucket)))
 	}
 	if value == nil {
-		delete(target, key)
+		deleteProjectionMapValue(target, strings.Split(key, "."))
 		return nil
 	}
-	target[key] = value
+	applyProjectionNestedMapValue(target, strings.Split(key, "."), value)
 	return nil
+}
+
+func applyProjectionNestedMapValue(target map[string]any, path []string, value any) {
+	if len(path) == 0 {
+		return
+	}
+	segment := strings.TrimSpace(path[0])
+	if segment == "" {
+		return
+	}
+	if len(path) == 1 {
+		target[segment] = value
+		return
+	}
+	next, _ := target[segment].(map[string]any)
+	if next == nil {
+		next = map[string]any{}
+		target[segment] = next
+	}
+	applyProjectionNestedMapValue(next, path[1:], value)
+}
+
+func deleteProjectionMapValue(target map[string]any, path []string) bool {
+	if len(path) == 0 {
+		return len(target) == 0
+	}
+	segment := strings.TrimSpace(path[0])
+	if segment == "" {
+		return len(target) == 0
+	}
+	if len(path) == 1 {
+		delete(target, segment)
+		return len(target) == 0
+	}
+	next, ok := target[segment].(map[string]any)
+	if !ok || next == nil {
+		return len(target) == 0
+	}
+	if empty := deleteProjectionMapValue(next, path[1:]); empty {
+		delete(target, segment)
+	}
+	return len(target) == 0
 }
 
 func normalizeRunID(runID string) string {

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -49,3 +49,30 @@ func TestReconstructEntityStateProjection_RoundTripsTrackedEntityState(t *testin
 		t.Fatalf("Accumulator = %#v", got.Accumulator)
 	}
 }
+
+func TestReconstructEntityStateProjection_AppliesNestedFieldMutationsOverTopLevelObjects(t *testing.T) {
+	got, err := ReconstructEntityStateProjection([]ProjectionMutation{
+		{Field: "metadata", NewValue: map[string]any{"region": "us", "score_band": "low"}},
+		{Field: "metadata.region", NewValue: "ca"},
+		{Field: "status", NewValue: "open"},
+	})
+	if err != nil {
+		t.Fatalf("ReconstructEntityStateProjection: %v", err)
+	}
+	metadata, ok := got.Fields["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("Fields = %#v", got.Fields)
+	}
+	if metadata["region"] != "ca" {
+		t.Fatalf("metadata.region = %#v, want ca", metadata["region"])
+	}
+	if metadata["score_band"] != "low" {
+		t.Fatalf("metadata.score_band = %#v, want low", metadata["score_band"])
+	}
+	if got.Fields["status"] != "open" {
+		t.Fatalf("Fields = %#v", got.Fields)
+	}
+	if _, ok := got.Fields["metadata.region"]; ok {
+		t.Fatalf("Fields contains literal dotted key: %#v", got.Fields)
+	}
+}

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -66,8 +66,17 @@ review_subject:
 	saveProps, _ := saveSchema["properties"].(map[string]any)
 	fieldEnum, _ := saveProps["field"].(map[string]any)
 	values, _ := fieldEnum["enum"].([]any)
-	if len(values) != 4 {
-		t.Fatalf("save_entity_field field enum = %#v", values)
+	if !containsAnyString(values, "status") {
+		t.Fatalf("save_entity_field field enum = %#v, want status", values)
+	}
+	if !containsAnyString(values, "metadata") {
+		t.Fatalf("save_entity_field field enum = %#v, want metadata", values)
+	}
+	if !containsAnyString(values, "metadata.region") {
+		t.Fatalf("save_entity_field field enum = %#v, want metadata.region", values)
+	}
+	if containsAnyString(values, "entity_id") {
+		t.Fatalf("save_entity_field field enum = %#v, should not include envelope field entity_id", values)
 	}
 
 	searchSchema := defByName["search_entities"]

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -65,18 +65,11 @@ func (s entityToolSchema) declaredField(name string) (entityruntime.Field, error
 	if name == "" {
 		return entityruntime.Field{}, fmt.Errorf("field is required")
 	}
-	if strings.Contains(name, ".") {
-		return entityruntime.Field{}, fmt.Errorf("%w: nested writes are not supported in Wave 1", ErrUnknownEntityField)
-	}
-	decl, err := entityruntime.FieldDecl(s.Contract, name)
+	field, err := entityruntime.ResolveFieldPath(s.Contract, name)
 	if err != nil {
 		return entityruntime.Field{}, fmt.Errorf("%w: %v", ErrUnknownEntityField, err)
 	}
-	return entityruntime.Field{
-		Path:      name,
-		Type:      strings.TrimSpace(decl.Type),
-		FieldDecl: decl,
-	}, nil
+	return field, nil
 }
 
 func normalizeEntityFieldValue(schema entityToolSchema, field entityruntime.Field, value any) (any, error) {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -305,20 +305,158 @@ func TestEntityTools_SearchEntitiesAcceptsAnnotatedJSONBFilter(t *testing.T) {
 	}
 }
 
-func TestEntityTools_SaveEntityFieldRejectsNestedWritePath(t *testing.T) {
+func TestEntityTools_SaveEntityFieldAllowsDeclaredNestedWritePath(t *testing.T) {
 	ctx, exec := newAnnotatedEntityToolExecutor(t)
-	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{"flow_instance": "validation/inst-1"})
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/inst-1",
+		"fields": map[string]any{
+			"mvp_spec": map[string]any{
+				"headline": "old",
+				"approved": false,
+			},
+		},
+	})
 
-	_, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+	out, err := exec.Execute(ctx, "save_entity_field", map[string]any{
 		"entity_id": entityID,
 		"field":     "mvp_spec.headline",
 		"value":     "launch fast",
 	})
-	if err == nil {
-		t.Fatal("expected nested write path to be rejected")
+	if err != nil {
+		t.Fatalf("save_entity_field nested path: %v", err)
 	}
-	if !strings.Contains(err.Error(), "invalid enum value mvp_spec.headline") {
-		t.Fatalf("err = %v, want delivery-boundary nested write rejection", err)
+	saved, ok := out.(map[string]any)
+	if !ok || strings.TrimSpace(asString(saved["field"])) != "mvp_spec.headline" {
+		t.Fatalf("unexpected save_entity_field output: %#v", out)
+	}
+
+	got, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity after nested save: %v", err)
+	}
+	entity, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected entity map, got %#v", got)
+	}
+	fields, ok := entity["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %#v", entity["fields"])
+	}
+	mvpSpec, ok := fields["mvp_spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mvp_spec object, got %#v", fields["mvp_spec"])
+	}
+	if got := strings.TrimSpace(asString(mvpSpec["headline"])); got != "launch fast" {
+		t.Fatalf("mvp_spec.headline = %q, want launch fast", got)
+	}
+	if approved, ok := mvpSpec["approved"].(bool); !ok || approved {
+		t.Fatalf("mvp_spec.approved = %#v, want false", mvpSpec["approved"])
+	}
+}
+
+func TestEntityTools_SaveEntityFieldAllowsNestedListWritePath(t *testing.T) {
+	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/inst-1",
+		"fields": map[string]any{
+			"validation_kit": map[string]any{
+				"checklist": []any{"ux"},
+			},
+		},
+	})
+
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "validation_kit.checklist",
+		"value":     []any{"ux", "brand"},
+	}); err != nil {
+		t.Fatalf("save_entity_field nested list path: %v", err)
+	}
+
+	got, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity after nested list save: %v", err)
+	}
+	entity, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected entity map, got %#v", got)
+	}
+	fields, ok := entity["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %#v", entity["fields"])
+	}
+	validationKit, ok := fields["validation_kit"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected validation_kit object, got %#v", fields["validation_kit"])
+	}
+	checklist, ok := validationKit["checklist"].([]any)
+	if !ok || len(checklist) != 2 {
+		t.Fatalf("validation_kit.checklist = %#v, want two items", validationKit["checklist"])
+	}
+}
+
+func TestEntityTools_SaveEntityFieldRejectsInvalidDottedPathsBeforePersistence(t *testing.T) {
+	ctx, exec, db := newEntityToolTestHarnessWithActor(t, models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
+	})
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "review/inst-1",
+		"fields": map[string]any{
+			"status":   "open",
+			"metadata": map[string]any{"region": "us"},
+		},
+	})
+
+	for _, tc := range []struct {
+		name  string
+		field string
+	}{
+		{name: "undeclared nested path", field: "metadata.regoin"},
+		{name: "envelope field", field: "entity_id"},
+		{name: "list index path", field: "validation_kit.checklist[0]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+				"entity_id": entityID,
+				"field":     tc.field,
+				"value":     "x",
+			})
+			re, ok := runtimetools.AsRuntimeError(err)
+			if err == nil || !ok || re.Code != "invalid_tool_input" {
+				t.Fatalf("expected invalid_tool_input, got %v", err)
+			}
+
+			var mutationCount int
+			if err := db.QueryRowContext(ctx, `
+				SELECT COUNT(*)
+				FROM entity_mutations
+				WHERE entity_id = $1::uuid AND field = $2
+			`, entityID, tc.field).Scan(&mutationCount); err != nil {
+				t.Fatalf("count entity mutations: %v", err)
+			}
+			if mutationCount != 0 {
+				t.Fatalf("mutation_count = %d, want 0 for %s", mutationCount, tc.field)
+			}
+
+			got, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+			if err != nil {
+				t.Fatalf("get_entity after invalid nested save: %v", err)
+			}
+			entity, ok := got.(map[string]any)
+			if !ok {
+				t.Fatalf("expected entity map, got %#v", got)
+			}
+			fields, ok := entity["fields"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected fields map, got %#v", entity["fields"])
+			}
+			metadata, ok := fields["metadata"].(map[string]any)
+			if !ok || strings.TrimSpace(asString(metadata["region"])) != "us" {
+				t.Fatalf("fields.metadata.region = %#v, want us", fields["metadata"])
+			}
+		})
 	}
 }
 
@@ -461,6 +599,64 @@ func TestEntityTools_SaveEntityField_LogsMutationRow(t *testing.T) {
 	}
 	if newValue != `"closed"` {
 		t.Fatalf("mutation new_value = %s, want \"closed\"", newValue)
+	}
+	if writerType != "agent" {
+		t.Fatalf("mutation writer_type = %q, want agent", writerType)
+	}
+	if step != "save_entity_field" {
+		t.Fatalf("mutation handler_step = %q, want save_entity_field", step)
+	}
+}
+
+func TestEntityTools_SaveEntityField_LogsNestedMutationRow(t *testing.T) {
+	ctx, exec, db := newEntityToolTestHarnessWithActor(t, models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
+	})
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "review/inst-1",
+		"fields": map[string]any{
+			"metadata": map[string]any{"region": "us"},
+		},
+	})
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "metadata.region",
+		"value":     "ca",
+	}); err != nil {
+		t.Fatalf("save_entity_field nested mutation: %v", err)
+	}
+
+	var (
+		field      string
+		oldValue   string
+		newValue   string
+		writerType string
+		step       string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(field, ''),
+			COALESCE(old_value::text, ''),
+			COALESCE(new_value::text, ''),
+			COALESCE(writer_type, ''),
+			COALESCE(handler_step, '')
+		FROM entity_mutations
+		WHERE entity_id = $1::uuid AND field = 'metadata.region'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, entityID).Scan(&field, &oldValue, &newValue, &writerType, &step); err != nil {
+		t.Fatalf("load nested entity mutation: %v", err)
+	}
+	if field != "metadata.region" {
+		t.Fatalf("mutation field = %q, want metadata.region", field)
+	}
+	if oldValue != `"us"` {
+		t.Fatalf("mutation old_value = %s, want \"us\"", oldValue)
+	}
+	if newValue != `"ca"` {
+		t.Fatalf("mutation new_value = %s, want \"ca\"", newValue)
 	}
 	if writerType != "agent" {
 		t.Fatalf("mutation writer_type = %q, want agent", writerType)

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/entityruntime"
@@ -52,9 +54,6 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, err, "validate field")
 	}
-	if strings.TrimSpace(field.Path) != fieldName {
-		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, "nested writes are not supported in Wave 1")
-	}
 	currentFields := entityRowFieldMap(row)
 	value, err := normalizeEntityFieldValue(schema, field, payload["value"])
 	if err != nil {
@@ -65,7 +64,7 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 		if currentErr != nil {
 			return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, currentErr, "resolve immutable current value")
 		}
-		if currentValue, exists := materializedCurrent[fieldName]; exists && !valuesEqual(currentValue, value) {
+		if currentValue, exists := entityruntime.PathValue(materializedCurrent, field.Path); exists && !valuesEqual(currentValue, value) {
 			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, "immutable field %s cannot be changed after create", fieldName)
 		}
 	}
@@ -83,14 +82,19 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 			_ = tx.Rollback()
 		}
 	}()
+	pathSegments, err := entityJSONPathSegments(field.Path)
+	if err != nil {
+		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, err.Error())
+	}
+	pathArray := pq.Array(pathSegments)
 
 	var oldValue []byte
 	if err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(fields -> $2, 'null'::jsonb)
+		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $2::text[], 'null'::jsonb)
 		FROM entity_state
 		WHERE entity_id = $1::uuid
 		FOR UPDATE
-	`, entityID, fieldName).Scan(&oldValue); err != nil {
+	`, entityID, pathArray).Scan(&oldValue); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, NewRuntimeError("not_found", "tool-executor", "exec_save_entity_field.lookup", false, "entity %s not found", entityID)
 		}
@@ -101,21 +105,21 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err := tx.QueryRowContext(ctx, `
 		UPDATE entity_state
 		SET
-			fields = jsonb_set(COALESCE(fields, '{}'::jsonb), ARRAY[$2], $3::jsonb, true),
+			fields = jsonb_set(COALESCE(fields, '{}'::jsonb), $2::text[], $3::jsonb, true),
 			revision = revision + 1,
 			updated_at = now()
 		WHERE entity_id = $1::uuid
 		RETURNING revision
-	`, entityID, fieldName, string(valueJSON)).Scan(&revision); err != nil {
+	`, entityID, pathArray, string(valueJSON)).Scan(&revision); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.update", true, err, "save entity field %s", fieldName)
 	}
 	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
 		Fields: map[string]any{
-			fieldName: nullableJSONBytes(oldValue),
+			field.Path: nullableJSONBytes(oldValue),
 		},
 	}, runtimemutationlog.EntityStateProjection{
 		Fields: map[string]any{
-			fieldName: json.RawMessage(valueJSON),
+			field.Path: json.RawMessage(valueJSON),
 		},
 	}, runtimemutationlog.Writer{
 		Type:        "agent",
@@ -130,9 +134,29 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	committed = true
 	return map[string]any{
 		"entity_id": entityID,
-		"field":     fieldName,
+		"field":     field.Path,
 		"revision":  revision,
 	}, nil
+}
+
+func entityJSONPathSegments(path string) ([]string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("field is required")
+	}
+	if strings.Contains(path, "[") || strings.Contains(path, "]") {
+		return nil, fmt.Errorf("list index writes are not supported for path %s", path)
+	}
+	rawSegments := strings.Split(path, ".")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return nil, fmt.Errorf("field is required")
+		}
+		segments = append(segments, segment)
+	}
+	return segments, nil
 }
 
 func nullableJSONBytes(raw []byte) any {

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -59,7 +59,7 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 		},
 		"save_entity_field": {
 			Category:    "entity_persistence",
-			Description: "Write a single declared top-level field on an entity.",
+			Description: "Write a single declared field or dotted subfield path on an entity.",
 			InputSchema: ObjectSchema(map[string]any{
 				"flow_instance": map[string]any{"type": "string"},
 				"entity_id":     map[string]any{"type": "string"},
@@ -138,6 +138,7 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 
 func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[string]ContractSchemaEntry {
 	topLevelFields := entityruntime.FieldNames(contract)
+	writablePaths := entityToolWritablePathNames(contract)
 	filterSelectors := entityToolLeafSelectorNames(contract)
 	selectableSelectors := entityToolSelectableFieldNames(contract)
 	filterProperties := make(map[string]any, len(filterSelectors))
@@ -160,8 +161,8 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 	for _, name := range selectableSelectors {
 		selectorEnum = append(selectorEnum, name)
 	}
-	fieldEnum := make([]any, 0, len(topLevelFields))
-	for _, name := range topLevelFields {
+	fieldEnum := make([]any, 0, len(writablePaths))
+	for _, name := range writablePaths {
 		fieldEnum = append(fieldEnum, name)
 	}
 	return map[string]ContractSchemaEntry{
@@ -190,7 +191,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 		},
 		"save_entity_field": {
 			Category:    "entity_persistence",
-			Description: "Write a single declared top-level field on an entity.",
+			Description: "Write a single declared field or dotted subfield path on an entity.",
 			InputSchema: ObjectSchema(map[string]any{
 				"flow_instance": map[string]any{"type": "string"},
 				"entity_id":     map[string]any{"type": "string"},
@@ -301,6 +302,49 @@ func entityToolLeafSelectorNames(contract entityruntime.Contract) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func entityToolWritablePathNames(contract entityruntime.Contract) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, name := range entityruntime.FieldNames(contract) {
+		decl, err := entityruntime.FieldDecl(contract, name)
+		if err != nil {
+			continue
+		}
+		collectEntityToolWritablePaths(contract, strings.TrimSpace(name), strings.TrimSpace(decl.Type), seen, map[string]struct{}{}, &out)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectEntityToolWritablePaths(contract entityruntime.Contract, path, typeRef string, seen map[string]struct{}, visiting map[string]struct{}, out *[]string) {
+	path = strings.TrimSpace(path)
+	typeRef = strings.TrimSpace(typeRef)
+	if path == "" || typeRef == "" {
+		return
+	}
+	if _, ok := seen[path]; !ok {
+		seen[path] = struct{}{}
+		*out = append(*out, path)
+	}
+	if !deliveryNamedType(contract, typeRef) {
+		return
+	}
+	typeName := deliveryTypeName(contract, typeRef)
+	if _, ok := visiting[typeName]; ok {
+		return
+	}
+	visiting[typeName] = struct{}{}
+	named := contract.Types.Types[typeName]
+	for fieldName, spec := range named.Fields {
+		fieldName = strings.TrimSpace(fieldName)
+		if fieldName == "" {
+			continue
+		}
+		collectEntityToolWritablePaths(contract, path+"."+fieldName, strings.TrimSpace(spec.Type), seen, visiting, out)
+	}
+	delete(visiting, typeName)
 }
 
 func collectEntityToolLeafSelectors(contract entityruntime.Contract, path, typeRef string, seen map[string]struct{}, visiting map[string]struct{}, out *[]string) {


### PR DESCRIPTION
Closes #511

## Summary
- add contract-aware dotted-path support for `save_entity_field` on the supported tool path
- align contract-derived delivery, validator-consumed tool definitions, executor validation, JSONB persistence, and mutation logging for declared dotted write targets
- keep the change inside the approved `#511` first-slice boundary; no handler-side nested writes or authored migration changes

## Governing refs / context
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`
  - `child_3_nested_writes`
  - section 18 decision 3
  - section 18 decision 4
  - section 18 `requirement_2_semantic_executor_validation`
- binding issue / gate context:
  - `#507`
  - `#510`
  - `#511` pre-audit and approved first-slice gate
- adjacent current platform spec context:
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` still carries the older top-level-only `save_entity_field` wording; this PR follows the reopened tracker/gated review-draft direction already approved for this child

## Canonical owner after change
- `internal/runtime/tools/platform_builtin_catalog.go`
- `internal/runtime/tools/entity_schema.go`
- `internal/runtime/tools/executor_entity_write.go`
- shared path/type resolution in `internal/runtime/entityruntime/contracts.go`

## Semantic migration
- new canonical owner behavior:
  - contract-derived `save_entity_field.field` schemas now enumerate declared dotted write targets, not just top-level fields
  - semantic executor resolves write targets through the declared type chain and applies shallow replace at the target path
  - persisted writes and mutation diagnostics now use the dotted target path
- old producer / reader / writer paths now invalid:
  - top-level-only `save_entity_field` field enum/description
  - `entityToolSchema.declaredField` top-level-only interpretation
  - executor Wave 1 nested-write guard
  - single-segment JSONB write path assumption
  - top-level-only mutation-log keying for nested writes
- production paths checked for surviving old behavior:
  - actor-scoped tool delivery
  - `ContractDefinitionsForSource`
  - `LoadContractSchemasForSource`
  - `ToolInputValidator`
  - `execSaveEntityField`
- migration complete for this child: yes, for the supported `save_entity_field` tool path only

## Proof
- `go test ./internal/runtime/tools -run '^(TestToolDefinitionsForActor_DeriveWave1EntitySchemasFromActorContract|TestEntityTools_SaveEntityFieldAllowsDeclaredNestedWritePath|TestEntityTools_SaveEntityFieldAllowsNestedListWritePath|TestEntityTools_SaveEntityFieldRejectsInvalidDottedPathsBeforePersistence|TestEntityTools_SaveEntityField_LogsNestedMutationRow)$' -count=1`
- `go test ./internal/runtime/tools ./internal/runtime/entityruntime -count=1`