### PR TITLE
[agent-d][issue #512] Canonicalize handler nested writes

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -567,23 +567,25 @@ func (c *checkerContext) payloadFieldCoverage() []Finding {
 		}
 		seen[key] = struct{}{}
 
-		if target.Nested {
+		if target.Kind == "handler.clear" && wave1SpecialClearTarget(target.Field) {
+			continue
+		}
+		resolved, ownerFlowID, rootField, err := wave1ResolveWriteTargetPath(c.source, target)
+		if err != nil {
 			c.payloadCoverageFindings = append(c.payloadCoverageFindings, Finding{
 				CheckID:  "payload_field_coverage",
 				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("flow %s node %s handler %s %s target %q is a nested entity write; Wave 1 permits top-level entity fields only", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, target.Target),
+				Message:  fmt.Sprintf("flow %s node %s handler %s %s target %q is invalid: %v", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, target.Target, err),
 				Location: target.NodeID,
 			})
 			continue
 		}
-		if target.Kind == "handler.clear" && wave1SpecialClearTarget(target.Field) {
-			continue
-		}
-		if wave1EntityEnvelopeField(target.Field) {
+		_ = resolved
+		if wave1EntityEnvelopeField(rootField) {
 			c.payloadCoverageFindings = append(c.payloadCoverageFindings, Finding{
 				CheckID:  "payload_field_coverage",
 				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("flow %s node %s handler %s %s targets envelope field %q; envelope fields are platform-owned", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, target.Field),
+				Message:  fmt.Sprintf("flow %s node %s handler %s %s targets envelope field %q; envelope fields are platform-owned", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, rootField),
 				Location: target.NodeID,
 			})
 			continue
@@ -598,11 +600,14 @@ func (c *checkerContext) payloadFieldCoverage() []Finding {
 			})
 			continue
 		}
-		if _, ok := contract.Contract.Fields[target.Field]; !ok {
+		if ownerFlowID != "" {
+			contract.FlowID = ownerFlowID
+		}
+		if _, ok := contract.Contract.Fields[rootField]; !ok {
 			c.payloadCoverageFindings = append(c.payloadCoverageFindings, Finding{
 				CheckID:  "payload_field_coverage",
 				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("flow %s node %s handler %s %s writes undeclared entity field %q on entity_type %s", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, target.Field, contract.EntityType),
+				Message:  fmt.Sprintf("flow %s node %s handler %s %s writes undeclared entity field %q on entity_type %s", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, rootField, contract.EntityType),
 				Location: target.NodeID,
 			})
 		}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -857,8 +857,51 @@ func TestRun_MapsPayloadCoverageMismatchToNamedError(t *testing.T) {
 	if !report.HasErrors() {
 		t.Fatalf("expected error report, got %#v", report.Findings)
 	}
-	if !reportContains(report.Errors(), "payload_field_coverage", `writes "foo"`) {
+	if !reportContains(report.Errors(), "payload_field_coverage", `target "foo" is invalid`) {
 		t.Fatalf("expected payload_field_coverage error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_MapsUndeclaredNestedEntityWriteTargetToPayloadCoverageError(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Analysis": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"summary": {Type: "text"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"subject": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"analysis": {Type: "Analysis"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-1": {
+				ID: "node-1",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.completed": {
+						Compute: &runtimecontracts.ComputeSpec{
+							Operation: runtimecontracts.ComputeOpCount,
+							StoreAs:   "entity.analysis.missing",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !report.HasErrors() {
+		t.Fatalf("expected error report, got %#v", report.Findings)
+	}
+	if !reportContains(report.Errors(), "payload_field_coverage", `entity.analysis.missing`) {
+		t.Fatalf("expected nested payload_field_coverage error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -857,7 +857,7 @@ func TestRun_MapsPayloadCoverageMismatchToNamedError(t *testing.T) {
 	if !report.HasErrors() {
 		t.Fatalf("expected error report, got %#v", report.Findings)
 	}
-	if !reportContains(report.Errors(), "payload_field_coverage", `target "foo" is invalid`) {
+	if !reportContains(report.Errors(), "payload_field_coverage", `writes "foo" missing`) {
 		t.Fatalf("expected payload_field_coverage error, got %#v", report.Errors())
 	}
 }

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -556,6 +556,19 @@ func wave1ResolveWriteTargetPath(source semanticview.Source, target wave1WriteTa
 		return wave1ResolvedType{}, "", "", fmt.Errorf("target %q is not an entity write target", target.Target)
 	}
 	rootField, _, _ := strings.Cut(path, ".")
+	if !strings.Contains(path, ".") {
+		if view := wave1EntityContractForFlow(source, target.FlowID); view.Defined {
+			if _, ok := view.Contract.Fields[strings.TrimSpace(rootField)]; ok {
+				return wave1ResolvedType{}, strings.TrimSpace(view.FlowID), strings.TrimSpace(rootField), nil
+			}
+		}
+		if target.FlowID != "" && wave1FlowWritesRootField(source, target.FlowID, rootField) {
+			if root, ok := wave1RootFieldContract(source, rootField); ok {
+				return wave1ResolvedType{}, strings.TrimSpace(root.FlowID), strings.TrimSpace(rootField), nil
+			}
+		}
+		return wave1ResolvedType{}, strings.TrimSpace(target.FlowID), strings.TrimSpace(rootField), nil
+	}
 	leaf, ownerFlowID, err := wave1ResolveEntityPathWithOwner(source, target.FlowID, "entity."+path)
 	if err != nil {
 		return wave1ResolvedType{}, "", "", err

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/entityruntime"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -37,8 +38,14 @@ func wave1SpecialClearTarget(target string) bool {
 }
 
 func wave1WriteTargetContract(source semanticview.Source, target wave1WriteTarget) (wave1EntityContractView, bool) {
-	if !target.Entity || target.Nested || wave1EntityEnvelopeField(target.Field) {
+	if !target.Entity || wave1EntityEnvelopeField(target.Field) {
 		return wave1EntityContractView{}, false
+	}
+	if _, ownerFlowID, _, err := wave1ResolveWriteTargetPath(source, target); err == nil {
+		view := wave1EntityContractForFlow(source, ownerFlowID)
+		if view.Defined {
+			return view, true
+		}
 	}
 	view := wave1EntityContractForFlow(source, target.FlowID)
 	if view.Defined {
@@ -146,17 +153,17 @@ func wave1DeclaredEntityContracts(source semanticview.Source) []wave1EntityContr
 func wave1EntityWriterCoverageByFlow(source semanticview.Source) map[string]map[string]struct{} {
 	out := map[string]map[string]struct{}{}
 	for _, target := range wave1AllEntityWriteTargets(source) {
-		if !target.Entity || target.Nested || wave1EntityEnvelopeField(target.Field) || wave1SpecialClearTarget(target.Field) {
+		if !target.Entity || wave1EntityEnvelopeField(target.Field) || wave1SpecialClearTarget(target.Field) {
 			continue
 		}
-		contract, ok := wave1WriteTargetContract(source, target)
-		if !ok {
+		_, ownerFlowID, rootField, err := wave1ResolveWriteTargetPath(source, target)
+		if err != nil {
 			continue
 		}
-		if out[contract.FlowID] == nil {
-			out[contract.FlowID] = map[string]struct{}{}
+		if out[ownerFlowID] == nil {
+			out[ownerFlowID] = map[string]struct{}{}
 		}
-		out[contract.FlowID][target.Field] = struct{}{}
+		out[ownerFlowID][rootField] = struct{}{}
 	}
 	for flowID, fields := range wave1AgentExplicitEntityWriteCoverageByFlow(source) {
 		if out[flowID] == nil {
@@ -538,6 +545,22 @@ func wave1ParseWriteTarget(flowID, nodeID, eventType, kind, target string) wave1
 	}
 	write.Field = strings.TrimSpace(target)
 	return write
+}
+
+func wave1ResolveWriteTargetPath(source semanticview.Source, target wave1WriteTarget) (wave1ResolvedType, string, string, error) {
+	path, entityTarget, err := entityruntime.EntityWritePath(target.Target)
+	if err != nil {
+		return wave1ResolvedType{}, "", "", err
+	}
+	if !entityTarget {
+		return wave1ResolvedType{}, "", "", fmt.Errorf("target %q is not an entity write target", target.Target)
+	}
+	rootField, _, _ := strings.Cut(path, ".")
+	leaf, ownerFlowID, err := wave1ResolveEntityPathWithOwner(source, target.FlowID, "entity."+path)
+	if err != nil {
+		return wave1ResolvedType{}, "", "", err
+	}
+	return leaf, ownerFlowID, strings.TrimSpace(rootField), nil
 }
 
 type wave1ResolvedExpressionRef struct {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -638,12 +638,13 @@ type WorkflowDataAccumulation struct {
 	SourceEvent string              `yaml:"source_event"`
 }
 type WorkflowDataWrite struct {
-	Field       string          `yaml:"-" json:"field,omitempty"`
-	SourceField string          `yaml:"source_field,omitempty" json:"source_field,omitempty"`
-	SourcePath  paths.Path      `yaml:"-" json:"-"`
-	TargetField string          `yaml:"target_field,omitempty" json:"target_field,omitempty"`
-	TargetPath  paths.Path      `yaml:"-" json:"-"`
-	Value       ExpressionValue `yaml:"value,omitempty" json:"value,omitempty"`
+	Field         string          `yaml:"-" json:"field,omitempty"`
+	SourceField   string          `yaml:"source_field,omitempty" json:"source_field,omitempty"`
+	SourcePath    paths.Path      `yaml:"-" json:"-"`
+	TargetField   string          `yaml:"target_field,omitempty" json:"target_field,omitempty"`
+	TargetPathRef string          `yaml:"target_path,omitempty" json:"target_path,omitempty"`
+	TargetPath    paths.Path      `yaml:"-" json:"-"`
+	Value         ExpressionValue `yaml:"value,omitempty" json:"value,omitempty"`
 }
 
 func (w WorkflowDataWrite) Source() string {
@@ -658,6 +659,8 @@ func (w WorkflowDataWrite) Source() string {
 }
 func (w WorkflowDataWrite) Target() string {
 	switch {
+	case strings.TrimSpace(w.TargetPathRef) != "":
+		return strings.TrimSpace(w.TargetPathRef)
 	case strings.TrimSpace(w.TargetField) != "":
 		return strings.TrimSpace(w.TargetField)
 	case strings.TrimSpace(w.Field) != "":

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -185,7 +185,7 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		switch strings.TrimSpace(node.Content[i].Value) {
-		case "", "field", "source_field", "target_field", "expression", "value":
+		case "", "field", "source_field", "target_field", "target_path", "expression", "value":
 		default:
 			return fmt.Errorf("unsupported workflow data write field %q", strings.TrimSpace(node.Content[i].Value))
 		}
@@ -194,6 +194,7 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 		Field       string    `yaml:"field"`
 		SourceField string    `yaml:"source_field"`
 		TargetField string    `yaml:"target_field"`
+		TargetPath  string    `yaml:"target_path"`
 		Expression  string    `yaml:"expression"`
 		Value       yaml.Node `yaml:"value"`
 	}
@@ -201,9 +202,10 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*w = WorkflowDataWrite{
-		Field:       strings.TrimSpace(aux.Field),
-		SourceField: strings.TrimSpace(aux.SourceField),
-		TargetField: strings.TrimSpace(aux.TargetField),
+		Field:         strings.TrimSpace(aux.Field),
+		SourceField:   strings.TrimSpace(aux.SourceField),
+		TargetField:   strings.TrimSpace(aux.TargetField),
+		TargetPathRef: strings.TrimSpace(aux.TargetPath),
 	}
 	switch aux.Value.Kind {
 	case 0:
@@ -482,28 +484,32 @@ func hydrateWorkflowDataWrite(w *WorkflowDataWrite) error {
 	w.Field = strings.TrimSpace(w.Field)
 	w.SourceField = strings.TrimSpace(w.SourceField)
 	w.TargetField = strings.TrimSpace(w.TargetField)
+	w.TargetPathRef = strings.TrimSpace(w.TargetPathRef)
 	w.Value.hydrate()
 	if err := validateExpressionValue(w.Value); err != nil {
 		return err
 	}
+	if w.TargetField != "" && w.TargetPathRef != "" {
+		return fmt.Errorf("workflow data write must not declare both target_field and target_path")
+	}
 	switch {
 	case w.Field != "":
-		if w.SourceField != "" || w.TargetField != "" || !w.Value.IsZero() {
+		if w.SourceField != "" || w.TargetField != "" || w.TargetPathRef != "" || !w.Value.IsZero() {
 			return fmt.Errorf("workflow data write %q must use bare direct form only", w.Field)
 		}
 	case w.SourceField != "":
-		if w.TargetField == "" || !w.Value.IsZero() {
-			return fmt.Errorf("workflow data write with source_field %q must also declare target_field and no value/expression", w.SourceField)
+		if (w.TargetField == "" && w.TargetPathRef == "") || !w.Value.IsZero() {
+			return fmt.Errorf("workflow data write with source_field %q must also declare target_field or target_path and no value/expression", w.SourceField)
 		}
 		if paths.Parse(w.SourceField).HasExplicitRoot() {
 			return fmt.Errorf("workflow data source_field %q must be payload-local, not scoped", w.SourceField)
 		}
 	case !w.Value.IsZero():
-		if w.TargetField == "" {
-			return fmt.Errorf("workflow data write with value/expression must declare target_field")
+		if w.TargetField == "" && w.TargetPathRef == "" {
+			return fmt.Errorf("workflow data write with value/expression must declare target_field or target_path")
 		}
 		if w.Value.HasRefValue() {
-			return fmt.Errorf("workflow data write %q cannot use ref expressions", w.TargetField)
+			return fmt.Errorf("workflow data write %q cannot use ref expressions", w.Target())
 		}
 	default:
 		return fmt.Errorf("workflow data write must use one canonical form")

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -375,6 +375,40 @@ writes:
 	}
 }
 
+func TestWorkflowDataWriteDecode_PreservesTargetPathAuthoring(t *testing.T) {
+	var write WorkflowDataWrite
+	if err := yaml.Unmarshal([]byte(`
+source_field: summary
+target_path: entity.analysis.summary
+`), &write); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := write.Source(); got != "summary" {
+		t.Fatalf("Source() = %q", got)
+	}
+	if got := write.Target(); got != "entity.analysis.summary" {
+		t.Fatalf("Target() = %q", got)
+	}
+	if got := write.TargetPath.String(); got != "entity.analysis.summary" {
+		t.Fatalf("TargetPath = %q", got)
+	}
+}
+
+func TestWorkflowDataWriteDecode_RejectsConflictingTargetFieldAndTargetPath(t *testing.T) {
+	var write WorkflowDataWrite
+	err := yaml.Unmarshal([]byte(`
+source_field: summary
+target_field: analysis
+target_path: entity.analysis.summary
+`), &write)
+	if err == nil {
+		t.Fatal("expected conflicting target_field/target_path error")
+	}
+	if !strings.Contains(err.Error(), "target_field and target_path") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestWorkflowDataAccumulationDecode_RejectsLegacySourceAlias(t *testing.T) {
 	var spec WorkflowDataAccumulation
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -15,6 +15,8 @@ import (
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/core/values"
+	"swarm/internal/runtime/entityruntime"
+	"swarm/internal/runtime/semanticview"
 )
 
 type Step string
@@ -132,7 +134,171 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	if err := validateHandlerComputeSpecs(req.Handler); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
+	if err := validateHandlerEntityWriteTargets(e.deps.Source, req.FlowID.String(), req.Handler); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
 	return nil
+}
+
+func validateHandlerEntityWriteTargets(source semanticview.Source, flowID string, handler runtimecontracts.SystemNodeEventHandler) error {
+	validateTarget := func(kind, target string) error {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			return nil
+		}
+		contract, resolved, entityTarget, err := resolveHandlerEntityWriteTarget(source, flowID, target)
+		if err != nil {
+			return fmt.Errorf("%s target %q: %w", kind, target, err)
+		}
+		if !entityTarget {
+			return nil
+		}
+		if strings.Contains(resolved.Path, "[") || strings.Contains(resolved.Path, "]") {
+			return fmt.Errorf("%s target %q: list index writes are not supported", kind, target)
+		}
+		if resolved.Nested && contract.Entity.Fields == nil {
+			return fmt.Errorf("%s target %q: entity contract is unavailable", kind, target)
+		}
+		return nil
+	}
+	validateWrites := func(kind string, writes []runtimecontracts.WorkflowDataWrite) error {
+		for _, write := range writes {
+			if err := validateTarget(kind, write.Target()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	validateRule := func(kind string, rule runtimecontracts.HandlerRuleEntry) error {
+		if err := validateWrites(kind+".data_accumulation", rule.DataAccumulation.Writes); err != nil {
+			return err
+		}
+		if rule.Compute != nil {
+			if err := validateTarget(kind+".compute", rule.Compute.StoreAs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	var validateQuery func(kind string, query *runtimecontracts.QuerySpec) error
+	validateQuery = func(kind string, query *runtimecontracts.QuerySpec) error {
+		if query == nil {
+			return nil
+		}
+		if err := validateTarget(kind+".query", query.StoreAs); err != nil {
+			return err
+		}
+		for i := range query.Queries {
+			if err := validateQuery(kind+".query", &query.Queries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := validateQuery("handler", handler.Query); err != nil {
+		return err
+	}
+	if err := validateWrites("handler.data_accumulation", handler.DataAccumulation.Writes); err != nil {
+		return err
+	}
+	if handler.Compute != nil {
+		if err := validateTarget("handler.compute", handler.Compute.StoreAs); err != nil {
+			return err
+		}
+	}
+	if handler.Filter != nil {
+		if err := validateTarget("handler.filter", handler.Filter.StoreAs); err != nil {
+			return err
+		}
+	}
+	if handler.GroupBy != nil {
+		if err := validateTarget("handler.group_by", handler.GroupBy.StoreAs); err != nil {
+			return err
+		}
+	}
+	if handler.Reduce != nil {
+		if err := validateTarget("handler.reduce", handler.Reduce.StoreAs); err != nil {
+			return err
+		}
+	}
+	if handler.Count != nil {
+		if err := validateTarget("handler.count", handler.Count.StoreAs); err != nil {
+			return err
+		}
+	}
+	if handler.Clear != nil {
+		if err := validateTarget("handler.clear", handler.Clear.Target); err != nil {
+			return err
+		}
+		for _, target := range handler.Clear.Targets {
+			if err := validateTarget("handler.clear", target); err != nil {
+				return err
+			}
+		}
+	}
+	for _, rule := range handler.Rules {
+		if err := validateRule("handler.rule", rule); err != nil {
+			return err
+		}
+	}
+	for _, rule := range handler.OnComplete {
+		if err := validateRule("handler.on_complete", rule); err != nil {
+			return err
+		}
+	}
+	if handler.Accumulate != nil {
+		for _, rule := range handler.Accumulate.OnComplete {
+			if err := validateRule("handler.accumulate.on_complete", rule); err != nil {
+				return err
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			if err := validateRule("handler.accumulate.on_timeout", *handler.Accumulate.OnTimeout); err != nil {
+				return err
+			}
+		}
+	}
+	for _, branch := range handler.Branch {
+		if branch.Then != nil {
+			if err := validateRule("handler.branch.then", *branch.Then); err != nil {
+				return err
+			}
+		}
+		if branch.Else != nil {
+			if err := validateRule("handler.branch.else", *branch.Else); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func resolveHandlerEntityWriteTarget(source semanticview.Source, flowID, target string) (entityruntime.Contract, entityruntime.WriteTarget, bool, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return entityruntime.Contract{}, entityruntime.WriteTarget{}, false, fmt.Errorf("field is required")
+	}
+	path, entityTarget, err := entityruntime.EntityWritePath(target)
+	if err != nil || !entityTarget {
+		return entityruntime.Contract{}, entityruntime.WriteTarget{Raw: target}, entityTarget, err
+	}
+	rootField, _, _ := strings.Cut(path, ".")
+	unvalidated := entityruntime.WriteTarget{
+		Raw:       target,
+		Path:      path,
+		RootField: strings.TrimSpace(rootField),
+		Nested:    strings.Contains(path, "."),
+	}
+	contract, ok := entityruntime.ResolveForFlow(source, flowID)
+	if !ok {
+		if !strings.Contains(path, ".") {
+			return entityruntime.Contract{}, unvalidated, true, nil
+		}
+		return entityruntime.Contract{}, unvalidated, true, fmt.Errorf("flow %s has no declared entity contract", strings.TrimSpace(flowID))
+	}
+	resolved, _, err := entityruntime.ResolveEntityWriteTarget(contract, target)
+	return contract, resolved, true, err
 }
 
 func validateHandlerComputeSpecs(handler runtimecontracts.SystemNodeEventHandler) error {
@@ -436,7 +602,9 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 		}
 		value = selected
 	}
-	e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.query"), value)
+	if err := e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.query"), value); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -585,7 +753,9 @@ func (e *Executor) stepFilter(frame *executionFrame) error {
 			filtered = append(filtered, item)
 		}
 	}
-	e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.filter"), filtered)
+	if err := e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.filter"), filtered); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -598,7 +768,9 @@ func (e *Executor) stepReduce(frame *executionFrame) error {
 	sourceValue, _ := resolveContractPath(current, frame.state, spec.ItemsPath, firstNonEmpty(spec.ItemsFrom, spec.Source))
 	items := executionItems(sourceValue)
 	value := executionReduceValue(items, strings.TrimSpace(spec.Operation))
-	e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.reduce"), value)
+	if err := e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.reduce"), value); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -629,7 +801,9 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 			count++
 		}
 	}
-	e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.count"), count)
+	if err := e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.count"), count); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -643,15 +817,17 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 	if err != nil {
 		return err
 	}
-	field := normalizeStateField(spec.StoreAs)
-	if field == "" {
-		field = "computed"
+	if storeAs := strings.TrimSpace(spec.StoreAs); storeAs != "" {
+		if err := e.writeStepValue(frame, storeAs, value); err != nil {
+			return err
+		}
+		return nil
 	}
-	frame.state.SetComputed(field, value)
-	frame.result.SetComputed(field, value)
-	frame.state.State.SetMetadata(field, value)
+	frame.state.SetComputed("computed", value)
+	frame.result.SetComputed("computed", value)
+	frame.state.State.SetMetadata("computed", value)
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
-	frame.result.StateMutation.SetMetadata(field, value)
+	frame.result.StateMutation.SetMetadata("computed", value)
 	return nil
 }
 
@@ -666,7 +842,9 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	frame.state.FanOut = map[string]any{}
 	frame.state.SetFanOut("target", spec.Target)
 	frame.state.SetFanOut("count", len(items))
-	e.writeStepValue(frame, "entity.fan_out_count", len(items))
+	if err := e.writeStepValue(frame, "entity.fan_out_count", len(items)); err != nil {
+		return false, err
+	}
 	if len(items) == 0 {
 		return false, nil
 	}
@@ -724,7 +902,9 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 		existing, _ := grouped[key].([]any)
 		grouped[key] = append(existing, item)
 	}
-	e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.group_by"), grouped)
+	if err := e.writeStepValue(frame, firstNonEmpty(strings.TrimSpace(spec.StoreAs), "computed.group_by"), grouped); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -959,7 +1139,9 @@ func (e *Executor) stepClear(frame *executionFrame) error {
 		case "pending_dedup":
 			delete(frame.state.State.StateCarrier.Metadata, "dedup_key")
 		default:
-			e.clearStepValue(frame, target)
+			if err := e.clearStepValue(frame, target); err != nil {
+				return err
+			}
 		}
 	}
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
@@ -1170,45 +1352,66 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	return ctx
 }
 
-func (e *Executor) writeStepValue(frame *executionFrame, target string, value any) {
+func (e *Executor) writeStepValue(frame *executionFrame, target string, value any) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		return
+		return nil
 	}
 	parsed := paths.Parse(target)
 	switch parsed.Root {
 	case paths.RootComputed:
 		frame.state.SetComputed(strings.Join(parsed.Segments, "."), value)
 		frame.result.SetComputed(strings.Join(parsed.Segments, "."), value)
+		return nil
 	case paths.RootAccumulated:
 		frame.state.SetAccumulated(strings.Join(parsed.Segments, "."), value)
+		return nil
 	case paths.RootFanOut:
 		frame.state.SetFanOut(strings.Join(parsed.Segments, "."), value)
-	default:
-		if frame.state.State.StateCarrier.Metadata == nil {
-			frame.state.State.StateCarrier.Metadata = map[string]any{}
-		}
-		switch {
-		case parsed.Root == paths.RootEntity || parsed.Root == paths.RootMetadata:
-			setParsedValuePath(frame.state.State.StateCarrier.Metadata, paths.Path{Segments: parsed.Segments}, value)
-		case parsed.HasExplicitRoot():
-			setParsedValuePath(frame.state.State.StateCarrier.Metadata, paths.Path{Segments: parsed.Segments}, value)
-		default:
-			setParsedValuePath(frame.state.State.StateCarrier.Metadata, parsed, value)
-		}
-		frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
+		return nil
 	}
+	if frame.state.State.StateCarrier.Metadata == nil {
+		frame.state.State.StateCarrier.Metadata = map[string]any{}
+	}
+	storagePath := parsed
+	if _, resolved, entityTarget, err := resolveHandlerEntityWriteTarget(e.deps.Source, frame.req.FlowID.String(), target); err != nil {
+		return err
+	} else if entityTarget {
+		storagePath = paths.Parse(resolved.Path)
+		if value != nil && len(resolved.Field.Path) != 0 {
+			contract, ok := entityruntime.ResolveForFlow(e.deps.Source, frame.req.FlowID.String())
+			if !ok {
+				return fmt.Errorf("flow %s has no declared entity contract", strings.TrimSpace(frame.req.FlowID.String()))
+			}
+			normalized, normalizeErr := entityruntime.NormalizeFieldValue(contract, resolved.Path, value)
+			if normalizeErr != nil {
+				return normalizeErr
+			}
+			value = normalized
+		}
+	} else if parsed.HasExplicitRoot() {
+		storagePath = paths.Path{Segments: parsed.Segments}
+	}
+	setParsedValuePath(frame.state.State.StateCarrier.Metadata, storagePath, value)
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
+	return nil
 }
 
-func (e *Executor) clearStepValue(frame *executionFrame, target string) {
+func (e *Executor) clearStepValue(frame *executionFrame, target string) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		return
+		return nil
 	}
 	parsed := paths.Parse(target)
 	if !parsed.HasExplicitRoot() {
+		if _, resolved, entityTarget, err := resolveHandlerEntityWriteTarget(e.deps.Source, frame.req.FlowID.String(), target); err != nil {
+			return err
+		} else if entityTarget {
+			executionDeletePath(frame.state.State.StateCarrier.Metadata, strings.Split(resolved.Path, "."))
+			return nil
+		}
 		executionDeletePath(frame.state.State.StateCarrier.Metadata, strings.Split(target, "."))
-		return
+		return nil
 	}
 	switch parsed.Root {
 	case paths.RootComputed:
@@ -1219,10 +1422,19 @@ func (e *Executor) clearStepValue(frame *executionFrame, target string) {
 	case paths.RootFanOut:
 		delete(frame.state.FanOut, strings.Join(parsed.Segments, "."))
 	case paths.RootEntity, paths.RootMetadata:
+		if parsed.Root == paths.RootEntity {
+			if _, resolved, _, err := resolveHandlerEntityWriteTarget(e.deps.Source, frame.req.FlowID.String(), target); err != nil {
+				return err
+			} else {
+				executionDeletePath(frame.state.State.StateCarrier.Metadata, strings.Split(resolved.Path, "."))
+			}
+			return nil
+		}
 		executionDeletePath(frame.state.State.StateCarrier.Metadata, parsed.Segments)
 	default:
 		delete(frame.state.State.StateCarrier.Metadata, target)
 	}
+	return nil
 }
 
 func (e *Executor) executionContext(frame *executionFrame, step Step) ExecutionContext {
@@ -1335,8 +1547,41 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 }
 
 func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) error {
-	if err := applyDataAccumulationToState(e.currentContext(frame), frame.state, &frame.state.State, spec); err != nil {
-		return err
+	current := e.currentContext(frame)
+	for _, write := range spec.Writes {
+		target := strings.TrimSpace(write.Target())
+		if target == "" {
+			continue
+		}
+		switch parsed := paths.Parse(target); parsed.Root {
+		case paths.RootComputed, paths.RootAccumulated, paths.RootFanOut, paths.RootGates, paths.RootEvent, paths.RootPayload, paths.RootPolicy:
+			return fmt.Errorf("data_accumulation target %s: unsupported target scope", target)
+		}
+		if write.Value.HasLiteralValue() {
+			if err := e.writeStepValue(frame, target, write.Value.Literal); err != nil {
+				return fmt.Errorf("data_accumulation target %s: %w", target, err)
+			}
+			continue
+		}
+		if write.Value.HasCELValue() {
+			value, err := evalWorkflowValueExpression(current, frame.state, write.Value.CEL)
+			if err != nil {
+				return fmt.Errorf("data_accumulation target %s: %w", target, err)
+			}
+			if err := e.writeStepValue(frame, target, value); err != nil {
+				return fmt.Errorf("data_accumulation target %s: %w", target, err)
+			}
+			continue
+		}
+		source := strings.TrimSpace(write.Source())
+		if source == "" {
+			continue
+		}
+		if value, ok := lookupPath(cloneStringAnyMap(current.Payload.Raw()), source); ok {
+			if err := e.writeStepValue(frame, target, value); err != nil {
+				return fmt.Errorf("data_accumulation target %s: %w", target, err)
+			}
+		}
 	}
 	frame.state.State.SetMetadata("last_data_accumulation_event", strings.TrimSpace(string(frame.req.Event.Type)))
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -228,11 +228,11 @@ func validateHandlerEntityWriteTargets(source semanticview.Source, flowID string
 		}
 	}
 	if handler.Clear != nil {
-		if err := validateTarget("handler.clear", handler.Clear.Target); err != nil {
+		if err := validateHandlerClearTarget(source, flowID, handler.Clear.Target); err != nil {
 			return err
 		}
 		for _, target := range handler.Clear.Targets {
-			if err := validateTarget("handler.clear", target); err != nil {
+			if err := validateHandlerClearTarget(source, flowID, target); err != nil {
 				return err
 			}
 		}
@@ -274,6 +274,18 @@ func validateHandlerEntityWriteTargets(source semanticview.Source, flowID string
 	return nil
 }
 
+func validateHandlerClearTarget(source semanticview.Source, flowID, target string) error {
+	target = strings.TrimSpace(target)
+	if target == "" || specialHandlerClearTarget(target) {
+		return nil
+	}
+	_, _, _, err := resolveHandlerEntityWriteTarget(source, flowID, target)
+	if err != nil {
+		return fmt.Errorf("handler.clear target %q is invalid: %w", target, err)
+	}
+	return nil
+}
+
 func resolveHandlerEntityWriteTarget(source semanticview.Source, flowID, target string) (entityruntime.Contract, entityruntime.WriteTarget, bool, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
@@ -289,6 +301,11 @@ func resolveHandlerEntityWriteTarget(source semanticview.Source, flowID, target 
 		Path:      path,
 		RootField: strings.TrimSpace(rootField),
 		Nested:    strings.Contains(path, "."),
+	}
+	// #512 is the nested-write slice. Preserve legacy top-level handler targets
+	// while enforcing declared-path resolution only for dotted writes.
+	if !unvalidated.Nested {
+		return entityruntime.Contract{}, unvalidated, true, nil
 	}
 	contract, ok := entityruntime.ResolveForFlow(source, flowID)
 	if !ok {
@@ -818,9 +835,21 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 		return err
 	}
 	if storeAs := strings.TrimSpace(spec.StoreAs); storeAs != "" {
-		if err := e.writeStepValue(frame, storeAs, value); err != nil {
-			return err
+		if handlerTargetRequiresCanonicalWrite(storeAs) {
+			if err := e.writeStepValue(frame, storeAs, value); err != nil {
+				return err
+			}
+			return nil
 		}
+		field := normalizeStateField(storeAs)
+		if field == "" {
+			field = "computed"
+		}
+		frame.state.SetComputed(field, value)
+		frame.result.SetComputed(field, value)
+		frame.state.State.SetMetadata(field, value)
+		frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
+		frame.result.StateMutation.SetMetadata(field, value)
 		return nil
 	}
 	frame.state.SetComputed("computed", value)
@@ -829,6 +858,31 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.result.StateMutation.SetMetadata("computed", value)
 	return nil
+}
+
+func handlerTargetRequiresCanonicalWrite(target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	parsed := paths.Parse(target)
+	if parsed.HasExplicitRoot() {
+		return true
+	}
+	path, entityTarget, err := entityruntime.EntityWritePath(target)
+	if err != nil || !entityTarget {
+		return false
+	}
+	return strings.Contains(path, ".")
+}
+
+func specialHandlerClearTarget(target string) bool {
+	switch strings.TrimSpace(target) {
+	case "accumulator_state", "cycle_counters", "pending_dedup":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
@@ -842,9 +896,10 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	frame.state.FanOut = map[string]any{}
 	frame.state.SetFanOut("target", spec.Target)
 	frame.state.SetFanOut("count", len(items))
-	if err := e.writeStepValue(frame, "entity.fan_out_count", len(items)); err != nil {
-		return false, err
-	}
+	// fan_out_count is platform-populated runtime bookkeeping, not an authored
+	// entity write target.
+	frame.state.State.SetMetadata("fan_out_count", len(items))
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	if len(items) == 0 {
 		return false, nil
 	}

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -28,6 +28,28 @@ func sourceWithPolicy(values map[string]any) semanticview.Source {
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Policy: policy})
 }
 
+func stubSourceWithRootEntityContract() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Analysis": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"summary":      {Type: "text"},
+						"report_count": {Type: "integer"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"subject": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"analysis": {Type: "Analysis"},
+				},
+			},
+		},
+	})
+}
+
 func sourceWithKilledState() semanticview.Source {
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
@@ -1268,6 +1290,128 @@ func TestExecutor_PayloadTransformSeesDataAccumulationWrites(t *testing.T) {
 	ctx, ok := payload["discovery_context"].(map[string]any)
 	if !ok || ctx["source"] != "corpus" {
 		t.Fatalf("discovery_context = %#v", payload["discovery_context"])
+	}
+}
+
+func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{"summary":"ready"}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					SourceField:   "summary",
+					TargetPathRef: "entity.analysis.summary",
+				}},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"analysis": map[string]any{
+				"summary":      "stale",
+				"report_count": 2,
+			},
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	analysis, ok := result.StateMutation.Metadata["analysis"].(map[string]any)
+	if !ok {
+		t.Fatalf("analysis = %#v", result.StateMutation.Metadata["analysis"])
+	}
+	if got := analysis["summary"]; got != "ready" {
+		t.Fatalf("analysis.summary = %#v, want ready", got)
+	}
+	if got := analysis["report_count"]; got != 2 {
+		t.Fatalf("analysis.report_count = %#v, want 2", got)
+	}
+}
+
+func TestExecutor_RejectsUndeclaredNestedEntityWriteBeforeExecution(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpCount,
+				StoreAs:   "entity.analysis.missing",
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil {
+		t.Fatal("expected invalid config error")
+	}
+	if !strings.Contains(err.Error(), "invalid config") {
+		t.Fatalf("error = %v, want invalid config", err)
+	}
+	if !strings.Contains(err.Error(), "entity.analysis.missing") {
+		t.Fatalf("error = %v, want target path context", err)
+	}
+}
+
+func TestExecutor_ClearRemovesNestedEntityLeaf(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Clear: &runtimecontracts.ClearSpec{Target: "entity.analysis.summary"},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"analysis": map[string]any{
+				"summary":      "stale",
+				"report_count": 2,
+			},
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	analysis, ok := result.StateMutation.Metadata["analysis"].(map[string]any)
+	if !ok {
+		t.Fatalf("analysis = %#v", result.StateMutation.Metadata["analysis"])
+	}
+	if _, exists := analysis["summary"]; exists {
+		t.Fatalf("analysis.summary unexpectedly present: %#v", analysis)
+	}
+	if got := analysis["report_count"]; got != 2 {
+		t.Fatalf("analysis.report_count = %#v, want 2", got)
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1415,6 +1415,53 @@ func TestExecutor_ClearRemovesNestedEntityLeaf(t *testing.T) {
 	}
 }
 
+func TestExecutor_ClearSpecialTargetsBypassContractValidation(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	initial := testStateSnapshot("pending", map[string]any{
+		"dedup_key":         "dup-1",
+		"accumulated_total": 5,
+		"received_items":    []any{"a"},
+	}, nil, map[string]map[string]any{
+		"node-1": {
+			handlerAccumulatorBucketKey: map[string]any{"items": []any{"a"}},
+		},
+	})
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "root",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Clear: &runtimecontracts.ClearSpec{Targets: []string{"pending_dedup", "accumulator_state"}},
+		},
+		State: initial,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if _, ok := result.StateMutation.Metadata["dedup_key"]; ok {
+		t.Fatalf("expected dedup_key to be cleared, metadata=%#v", result.StateMutation.Metadata)
+	}
+	if _, ok := result.StateMutation.Metadata["received_items"]; ok {
+		t.Fatalf("expected received_items to be cleared, metadata=%#v", result.StateMutation.Metadata)
+	}
+	if nodeBucket, ok := result.StateMutation.StateBuckets["node-1"]; ok {
+		if _, ok := nodeBucket[handlerAccumulatorBucketKey]; ok {
+			t.Fatalf("expected accumulator bucket to be cleared, state_buckets=%#v", result.StateMutation.StateBuckets)
+		}
+	}
+}
+
 func TestExecutor_EmitFieldsCELFailureReturnsError(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSource(),
@@ -1485,6 +1532,40 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 	}
 	if result.NextState != "scanning" {
 		t.Fatalf("NextState = %q", result.NextState)
+	}
+	if got := result.StateMutation.Metadata["fan_out_count"]; got != 0 {
+		t.Fatalf("fan_out_count metadata = %#v", got)
+	}
+}
+
+func TestExecutor_FanOutInternalCountBypassesEntityContractValidation(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "root",
+		Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{"items":[]}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			FanOut: &runtimecontracts.FanOutSpec{
+				ItemsFrom: "payload.items",
+				Emit:      runtimecontracts.EmitSpec{Event: "item.process"},
+			},
+			AdvancesTo: "scanning",
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
 	}
 	if got := result.StateMutation.Metadata["fan_out_count"]; got != 0 {
 		t.Fatalf("fan_out_count metadata = %#v", got)

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -168,43 +168,42 @@ func setParsedValuePath(target map[string]any, path paths.Path, value any) {
 	values.Wrap(target).SetPath(path, value)
 }
 
-func normalizeStateField(field string) string {
-	field = strings.TrimSpace(field)
-	switch {
-	case strings.HasPrefix(field, "entity."):
-		return strings.TrimSpace(strings.TrimPrefix(field, "entity."))
-	case strings.HasPrefix(field, "metadata."):
-		return strings.TrimSpace(strings.TrimPrefix(field, "metadata."))
-	default:
-		return field
-	}
-}
-
 func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapshot *StateSnapshot, spec runtimecontracts.WorkflowDataAccumulation) error {
 	if snapshot == nil || len(spec.Writes) == 0 {
 		return nil
 	}
+	if snapshot.StateCarrier.Metadata == nil {
+		snapshot.StateCarrier.Metadata = map[string]any{}
+	}
 	for _, write := range spec.Writes {
-		target := normalizeStateField(write.Target())
+		target := strings.TrimSpace(write.Target())
 		if target == "" {
 			continue
 		}
+		parsed := paths.Parse(target)
+		switch parsed.Root {
+		case paths.RootEntity, paths.RootMetadata:
+			parsed = paths.Path{Segments: parsed.Segments}
+		case paths.RootUnknown:
+		default:
+			return fmt.Errorf("data_accumulation target %s: unsupported target scope", strings.TrimSpace(write.Target()))
+		}
 		switch {
 		case write.Value.HasLiteralValue():
-			snapshot.SetMetadata(target, write.Value.Literal)
+			setParsedValuePath(snapshot.StateCarrier.Metadata, parsed, write.Value.Literal)
 		case write.Value.HasCELValue():
 			value, err := evalWorkflowValueExpression(base, state, write.Value.CEL)
 			if err != nil {
 				return fmt.Errorf("data_accumulation target %s: %w", strings.TrimSpace(write.Target()), err)
 			}
-			snapshot.SetMetadata(target, value)
+			setParsedValuePath(snapshot.StateCarrier.Metadata, parsed, value)
 		default:
 			source := strings.TrimSpace(write.Source())
 			if source == "" {
 				continue
 			}
 			if value, ok := lookupPath(cloneStringAnyMap(base.Payload.Raw()), source); ok {
-				snapshot.SetMetadata(target, value)
+				setParsedValuePath(snapshot.StateCarrier.Metadata, parsed, value)
 			}
 		}
 	}

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -168,6 +168,18 @@ func setParsedValuePath(target map[string]any, path paths.Path, value any) {
 	values.Wrap(target).SetPath(path, value)
 }
 
+func normalizeStateField(field string) string {
+	field = strings.TrimSpace(field)
+	switch {
+	case strings.HasPrefix(field, "entity."):
+		return strings.TrimSpace(strings.TrimPrefix(field, "entity."))
+	case strings.HasPrefix(field, "metadata."):
+		return strings.TrimSpace(strings.TrimPrefix(field, "metadata."))
+	default:
+		return field
+	}
+}
+
 func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapshot *StateSnapshot, spec runtimecontracts.WorkflowDataAccumulation) error {
 	if snapshot == nil || len(spec.Writes) == 0 {
 		return nil

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -284,6 +284,41 @@ func TestApplyDataAccumulationToState_EvaluatesArithmeticCELExpressions(t *testi
 	}
 }
 
+func TestApplyDataAccumulationToState_WritesNestedTargetPath(t *testing.T) {
+	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{
+		"analysis": map[string]any{
+			"summary":      "stale",
+			"report_count": 2,
+		},
+	}, nil, nil)}
+	base := BaseContext{
+		Payload: values.Wrap(map[string]any{
+			"summary": "ready",
+		}),
+	}
+	spec := runtimecontracts.WorkflowDataAccumulation{
+		Writes: []runtimecontracts.WorkflowDataWrite{{
+			SourceField:   "summary",
+			TargetPathRef: "entity.analysis.summary",
+		}},
+	}
+
+	if err := applyDataAccumulationToState(base, ExecutionState{}, state, spec); err != nil {
+		t.Fatalf("applyDataAccumulationToState(...) error = %v", err)
+	}
+
+	analysis, ok := state.StateCarrier.Metadata["analysis"].(map[string]any)
+	if !ok {
+		t.Fatalf("analysis = %#v", state.StateCarrier.Metadata["analysis"])
+	}
+	if got := analysis["summary"]; got != "ready" {
+		t.Fatalf("analysis.summary = %#v, want ready", got)
+	}
+	if got := analysis["report_count"]; got != 2 {
+		t.Fatalf("analysis.report_count = %#v, want 2", got)
+	}
+}
+
 func TestApplyDataAccumulationToState_FailsClosedOnCELRuntimeError(t *testing.T) {
 	state := &StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, nil)}
 	base := BaseContext{

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -416,6 +416,10 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 		return false, nil
 	case isTimestampType(contract, typeRef), isUUIDType(contract, typeRef):
 		return nil, nil
+	case isJSONObjectType(contract, typeRef):
+		return map[string]any{}, nil
+	case isJSONArrayType(contract, typeRef):
+		return []any{}, nil
 	case isEnumType(contract, typeRef):
 		enum := contract.Types.Enums[typeName(contract, typeRef)]
 		if len(enum.Values) == 0 {
@@ -491,6 +495,18 @@ func normalizeValueForType(contract Contract, fieldName, typeRef string, value a
 			return nil, fieldTypeError(fieldName, "must be boolean")
 		}
 		return boolean, nil
+	case isJSONObjectType(contract, typeRef):
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be object")
+		}
+		return cloneMap(object), nil
+	case isJSONArrayType(contract, typeRef):
+		items, ok := listValues(value)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be array")
+		}
+		return cloneValue(items), nil
 	case isTimestampType(contract, typeRef):
 		switch typed := value.(type) {
 		case time.Time:
@@ -581,6 +597,10 @@ func pathKind(contract Contract, typeRef string) string {
 		return "scalar"
 	case isBooleanType(contract, typeRef):
 		return "scalar"
+	case isJSONObjectType(contract, typeRef):
+		return "object"
+	case isJSONArrayType(contract, typeRef):
+		return "list"
 	case isTimestampType(contract, typeRef):
 		return "scalar"
 	case isUUIDType(contract, typeRef):
@@ -645,11 +665,20 @@ func isIntegerType(contract Contract, typeRef string) bool {
 
 func isNumericType(contract Contract, typeRef string) bool {
 	raw := strings.ToLower(strings.TrimSpace(typeName(contract, typeRef)))
-	return raw == "numeric" || strings.HasPrefix(raw, "numeric(")
+	return raw == "numeric" || raw == "number" || raw == "float" || raw == "double" || raw == "real" || strings.HasPrefix(raw, "numeric(")
 }
 
 func isBooleanType(contract Contract, typeRef string) bool {
 	return strings.EqualFold(typeName(contract, typeRef), "boolean")
+}
+
+func isJSONObjectType(contract Contract, typeRef string) bool {
+	raw := strings.ToLower(strings.TrimSpace(typeName(contract, typeRef)))
+	return raw == "json" || raw == "object"
+}
+
+func isJSONArrayType(contract Contract, typeRef string) bool {
+	return strings.EqualFold(typeName(contract, typeRef), "array")
 }
 
 func isTimestampType(contract Contract, typeRef string) bool {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/semanticview"
 	runtimesharedjson "swarm/internal/runtime/sharedjson"
 )
@@ -25,6 +26,14 @@ type Field struct {
 	Type      string
 	LeafKind  string
 	FieldDecl runtimecontracts.EntityFieldDecl
+}
+
+type WriteTarget struct {
+	Raw       string
+	Path      string
+	RootField string
+	Field     Field
+	Nested    bool
 }
 
 func ResolveForActor(source semanticview.Source, actorID string) (Contract, bool) {
@@ -273,6 +282,53 @@ func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, e
 		return nil, err
 	}
 	return normalizeValueForType(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), value)
+}
+
+func EntityWritePath(target string) (string, bool, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", false, fmt.Errorf("field is required")
+	}
+	parsed := paths.Parse(target)
+	if parsed.IsZero() {
+		return "", false, fmt.Errorf("field is required")
+	}
+	if parsed.HasExplicitRoot() {
+		switch parsed.Root {
+		case paths.RootEntity:
+			if len(parsed.Segments) == 0 {
+				return "", true, fmt.Errorf("field is required")
+			}
+			return strings.Join(parsed.Segments, "."), true, nil
+		case paths.RootMetadata:
+			return "", false, nil
+		default:
+			return "", false, nil
+		}
+	}
+	if len(parsed.Segments) == 0 {
+		return "", false, fmt.Errorf("field is required")
+	}
+	return strings.Join(parsed.Segments, "."), true, nil
+}
+
+func ResolveEntityWriteTarget(contract Contract, target string) (WriteTarget, bool, error) {
+	path, entityTarget, err := EntityWritePath(target)
+	if err != nil || !entityTarget {
+		return WriteTarget{Raw: strings.TrimSpace(target)}, entityTarget, err
+	}
+	field, err := ResolveFieldPath(contract, path)
+	if err != nil {
+		return WriteTarget{Raw: strings.TrimSpace(target), Path: path}, true, err
+	}
+	rootField, _, _ := strings.Cut(path, ".")
+	return WriteTarget{
+		Raw:       strings.TrimSpace(target),
+		Path:      path,
+		RootField: strings.TrimSpace(rootField),
+		Field:     field,
+		Nested:    strings.Contains(path, "."),
+	}, true, nil
 }
 
 func ResolveFieldPath(contract Contract, path string) (Field, error) {

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -1,0 +1,35 @@
+package entityruntime
+
+import (
+	"reflect"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestNormalizeFieldValue_AcceptsBuiltInNumberAndJSONTypes(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"score":   {Type: "number"},
+				"details": {Type: "json"},
+			},
+		},
+	}
+
+	score, err := NormalizeFieldValue(contract, "score", 91.5)
+	if err != nil {
+		t.Fatalf("NormalizeFieldValue(score): %v", err)
+	}
+	if score != 91.5 {
+		t.Fatalf("score = %#v, want 91.5", score)
+	}
+
+	details, err := NormalizeFieldValue(contract, "details", map[string]any{"summary": "ok"})
+	if err != nil {
+		t.Fatalf("NormalizeFieldValue(details): %v", err)
+	}
+	if !reflect.DeepEqual(details, map[string]any{"summary": "ok"}) {
+		t.Fatalf("details = %#v", details)
+	}
+}

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -12,6 +12,7 @@ import (
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/timeridentity"
 	runtimeengine "swarm/internal/runtime/engine"
+	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/workflowexpr"
 )
@@ -511,13 +512,10 @@ func accumulateReferencesEntity(spec *runtimecontracts.AccumulateSpec) bool {
 }
 
 func normalizeEntityWriteTarget(target string) string {
-	target = strings.TrimSpace(target)
-	switch {
-	case strings.HasPrefix(target, "entity."):
-		return strings.TrimSpace(strings.TrimPrefix(target, "entity."))
-	case strings.HasPrefix(target, "metadata."):
-		return strings.TrimSpace(strings.TrimPrefix(target, "metadata."))
-	default:
-		return target
+	path, entityTarget, err := entityruntime.EntityWritePath(target)
+	if err != nil || !entityTarget {
+		return ""
 	}
+	field, _, _ := strings.Cut(path, ".")
+	return strings.TrimSpace(field)
 }

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/workflowexpr"
 )
 
@@ -230,26 +231,16 @@ func workflowBuiltinEntityFields() map[string]struct{} {
 }
 
 func workflowEntityFieldNameFromTarget(target string) (string, bool) {
-	target = strings.TrimSpace(target)
-	if target == "" {
+	path, entityTarget, err := entityruntime.EntityWritePath(target)
+	if err != nil || !entityTarget {
 		return "", false
 	}
-	if strings.HasPrefix(target, "entity.") {
-		target = strings.TrimSpace(strings.TrimPrefix(target, "entity."))
-	} else if strings.HasPrefix(target, "metadata.") {
-		target = strings.TrimSpace(strings.TrimPrefix(target, "metadata."))
-	}
-	if target == "" {
+	field, _, _ := strings.Cut(path, ".")
+	field = strings.TrimSpace(field)
+	if field == "" {
 		return "", false
 	}
-	if idx := strings.IndexByte(target, '.'); idx >= 0 {
-		target = target[:idx]
-	}
-	target = strings.TrimSpace(target)
-	if target == "" {
-		return "", false
-	}
-	return target, true
+	return field, true
 }
 
 func phaseAfter(current, threshold WorkflowEntityFieldLifecyclePhase) bool {

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -57,6 +57,20 @@ func TestWorkflowEntityFieldsAvailableBeforeDataAccumulation_IncludesEarlierComp
 	}
 }
 
+func TestWorkflowEntityFieldsAvailableBeforeDataAccumulation_IncludesEarlierNestedComputeRootField(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.analysis.report_count",
+		},
+	}
+
+	available := WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
+	if _, ok := available["analysis"]; !ok {
+		t.Fatalf("analysis missing from data_accumulation availability: %#v", available)
+	}
+}
+
 func TestWorkflowEntityFieldsAvailableBeforeEmitFields_IncludesCreateEntityTopLevelWrites(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		CreateEntity: true,


### PR DESCRIPTION
Closes #512

## Summary
- add `target_path` authoring for declarative `data_accumulation.writes`
- canonicalize nested entity-target validation across declarative handler write targets before execution
- make `data_accumulation`, handler `store_as`, and `clear.target` / `clear.targets` share one dotted-path entity target discipline
- align bootverify and lifecycle accounting with the same nested target model

## Governing refs / context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`
  - `child_3_nested_writes`
  - section 18 `decision_3_path_syntax_for_nested_writes`
  - section 18 `decision_4_list_index_in_paths`
- current authoritative spec has not yet promoted this child; binding implementation context is `#512` under `#507` / `#510` plus the approved gate on `#512`

## Canonical owners after change
- `internal/runtime/contracts/workflow_contract_types.go`
- `internal/runtime/contracts/workflow_contract_yaml_rules.go`
- `internal/runtime/engine/helpers.go`
- `internal/runtime/engine/executor.go`
- `internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go`
- `internal/runtime/bootverify/checks.go`
- `internal/runtime/pipeline/workflow_entity_field_lifecycle.go`
- `internal/runtime/pipeline/node_declarative.go`

## Old paths now invalid / non-authoritative
- top-level-only `data_accumulation` target handling that flattened dotted targets through metadata keys
- handler nested entity writes that reached generic runtime mutation without declared-path validation
- boot / lifecycle accounting that treated nested handler write targets as first-segment-only without validating the full path

## Production paths checked
- parser / hydration for `WorkflowDataWrite`
- runtime executor nested writes for `data_accumulation`, `store_as`, and `clear`
- bootverify payload coverage / writer accounting
- lifecycle entity field availability accounting

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/engine ./internal/runtime/bootverify ./internal/runtime/pipeline -count=1`

## Migration status
- declarative handler-side nested writes are canonicalized for this child slice
- tool-path nested writes remain closed separately in `#511`
- first-party authored migration remains separate in `#513`