### PR TITLE
[agent-d][issue #497] Surface writable paths in session primer

### DIFF
--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -42,9 +42,22 @@ func TestFormatEventForAgent_UsesPostCompositionToolSurface(t *testing.T) {
 		{Name: "get_entity"},
 		{Name: "emit_example"},
 		{Name: "read_file"},
+		{
+			Name: "save_entity_field",
+			Schema: map[string]any{
+				"properties": map[string]any{
+					"field": map[string]any{
+						"enum": []any{"metadata", "metadata.region", "status"},
+					},
+				},
+			},
+		},
 	})
-	if !strings.Contains(formatted, "Available non-emit tools in this turn: get_entity, read_file") {
+	if !strings.Contains(formatted, "Available non-emit tools in this turn: get_entity, read_file, save_entity_field") {
 		t.Fatalf("expected post-composition non-emit summary, got %q", formatted)
+	}
+	if !strings.Contains(formatted, "Writable entity paths for save_entity_field in this turn: metadata, metadata.region, status") {
+		t.Fatalf("expected writable path summary, got %q", formatted)
 	}
 	if strings.Contains(formatted, "schedule") {
 		t.Fatalf("expected raw contract-only tool to stay out of event summary, got %q", formatted)

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -239,10 +239,11 @@ var claudeProviderBuiltinToolNames = []string{
 }
 
 type AgentVisibleToolSurface struct {
-	RuntimeToolNames   []string
-	EmitToolNames      []string
-	NonEmitToolNames   []string
-	NativeBuiltinTools []string
+	RuntimeToolNames    []string
+	EmitToolNames       []string
+	NonEmitToolNames    []string
+	NativeBuiltinTools  []string
+	WritableEntityPaths []string
 }
 
 type CLIExecutionToolSurface struct {
@@ -380,11 +381,56 @@ func AgentVisibleToolSurfaceForActor(actor models.AgentConfig, tools []ToolDefin
 	}
 
 	return AgentVisibleToolSurface{
-		RuntimeToolNames:   runtimeNames,
-		EmitToolNames:      emitNames,
-		NonEmitToolNames:   nonEmitNames,
-		NativeBuiltinTools: append([]string(nil), surface.ProviderBuiltinTools...),
+		RuntimeToolNames:    runtimeNames,
+		EmitToolNames:       emitNames,
+		NonEmitToolNames:    nonEmitNames,
+		NativeBuiltinTools:  append([]string(nil), surface.ProviderBuiltinTools...),
+		WritableEntityPaths: saveEntityFieldWritablePaths(tools),
 	}
+}
+
+func saveEntityFieldWritablePaths(tools []ToolDefinition) []string {
+	for _, tool := range tools {
+		if toolidentity.CanonicalName(tool.Name) != "save_entity_field" {
+			continue
+		}
+		schema, ok := tool.Schema.(map[string]any)
+		if !ok {
+			return nil
+		}
+		properties, ok := schema["properties"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		fieldSchema, ok := properties["field"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		enumValues, ok := fieldSchema["enum"].([]any)
+		if !ok {
+			return nil
+		}
+		out := make([]string, 0, len(enumValues))
+		seen := make(map[string]struct{}, len(enumValues))
+		for _, value := range enumValues {
+			path, ok := value.(string)
+			if !ok {
+				continue
+			}
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			out = append(out, path)
+		}
+		slices.Sort(out)
+		return out
+	}
+	return nil
 }
 
 func claudeControlToolNames() []string {
@@ -497,7 +543,7 @@ const deliveryToolSurfaceMarker = "## Swarm Tool Surface"
 
 func AgentVisibleToolSummaryLinesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := AgentVisibleToolSurfaceForActor(actor, tools)
-	lines := make([]string, 0, 3)
+	lines := make([]string, 0, 4)
 	emitLine := "(none declared)"
 	if len(surface.EmitToolNames) > 0 {
 		emitLine = strings.Join(surface.EmitToolNames, ", ")
@@ -508,6 +554,9 @@ func AgentVisibleToolSummaryLinesForActor(actor models.AgentConfig, tools []Tool
 	}
 	if len(surface.NativeBuiltinTools) > 0 {
 		lines = append(lines, "Available native CLI tools in this turn: "+strings.Join(surface.NativeBuiltinTools, ", "))
+	}
+	if len(surface.WritableEntityPaths) > 0 {
+		lines = append(lines, "Writable entity paths for save_entity_field in this turn: "+strings.Join(surface.WritableEntityPaths, ", "))
 	}
 	return lines
 }

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -231,6 +231,16 @@ func TestAnthropicAPIRuntime_StartSessionAugmentsSystemPromptWithDerivedToolSurf
 	s, err := runtime.StartSession(ctx, "agent-3", "base prompt", []ToolDefinition{
 		{Name: "emit_market_research_scan_complete"},
 		{Name: "query_entities"},
+		{
+			Name: "save_entity_field",
+			Schema: map[string]any{
+				"properties": map[string]any{
+					"field": map[string]any{
+						"enum": []any{"metadata", "metadata.region", "status"},
+					},
+				},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
@@ -246,6 +256,9 @@ func TestAnthropicAPIRuntime_StartSessionAugmentsSystemPromptWithDerivedToolSurf
 	}
 	if !strings.Contains(s.SystemPrompt, "Available non-emit tools in this turn: query_entities") {
 		t.Fatalf("expected non-emit tool summary in system prompt, got %q", s.SystemPrompt)
+	}
+	if !strings.Contains(s.SystemPrompt, "Writable entity paths for save_entity_field in this turn: metadata, metadata.region, status") {
+		t.Fatalf("expected writable path summary in system prompt, got %q", s.SystemPrompt)
 	}
 	if !strings.Contains(s.SystemPrompt, "Available native CLI tools in this turn: Edit, Read, Write") {
 		t.Fatalf("expected native tool summary in system prompt, got %q", s.SystemPrompt)
@@ -500,6 +513,26 @@ func TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble(
 	}
 	if strings.Contains(prompt, "Claude CLI native tools available in this turn") {
 		t.Fatalf("did not expect native builtin prompt section, got %q", prompt)
+	}
+}
+
+func TestClaudeCLIRuntimePrompt_IncludesWritableEntityPathSummary(t *testing.T) {
+	actor := runtimeactors.AgentConfig{
+		ID:   "analysis-agent",
+		Role: "analysis",
+	}
+	prompt := augmentCLISystemPrompt("base prompt", actor, []ToolDefinition{
+		{Name: "save_entity_field", Schema: map[string]any{
+			"properties": map[string]any{
+				"field": map[string]any{
+					"enum": []any{"status", "metadata.region", "metadata"},
+				},
+			},
+		}},
+	})
+
+	if !strings.Contains(prompt, "Writable entity paths for save_entity_field in this turn: metadata, metadata.region, status") {
+		t.Fatalf("expected writable path summary in prompt, got %q", prompt)
 	}
 }
 

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -1,9 +1,11 @@
 package tools_test
 
 import (
+	"strings"
 	"testing"
 
 	models "swarm/internal/runtime/core/actors"
+	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 )
@@ -78,6 +80,11 @@ review_subject:
 	if containsAnyString(values, "entity_id") {
 		t.Fatalf("save_entity_field field enum = %#v, should not include envelope field entity_id", values)
 	}
+	summaryLines := llm.AgentVisibleToolSummaryLinesForActor(actor, defs)
+	wantWritablePathLine := "Writable entity paths for save_entity_field in this turn: " + strings.Join(anyStrings(values), ", ")
+	if !containsString(summaryLines, wantWritablePathLine) {
+		t.Fatalf("agent-visible writable path summary = %#v, want %q", summaryLines, wantWritablePathLine)
+	}
 
 	searchSchema := defByName["search_entities"]
 	searchProps, _ := searchSchema["properties"].(map[string]any)
@@ -118,6 +125,25 @@ review_subject:
 }
 
 func containsAnyString(values []any, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func anyStrings(values []any) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if got, ok := value.(string); ok {
+			out = append(out, got)
+		}
+	}
+	return out
+}
+
+func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
 			return true


### PR DESCRIPTION
## Summary

Closes #497.

This PR closes the approved first-slice primer/parity class for contract-derived nested writable paths:

- agent-visible startup/session summaries now render the `save_entity_field` writable path set from the delivered tool schema
- API startup, CLI startup, CLI startup-probe, and `formatEventForAgent(...)` move together because they already consume the shared `AgentVisibleToolSummaryLinesForActor(...)` helper
- the primer path set is proven against the same `save_entity_field.field.enum` produced by `ToolDefinitionsForActor(...)`

## Governing refs / context

No exact current `platform-spec.yaml` section promotes this full follow-on lane by itself. Binding context is:

- issue #497 and its approved gate comment
- umbrella #510
- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`
  - decision 7 requirement 1
  - decision 7 requirement 4
  - finding 26
  - Child 3 nested-write authority as the path-expansion basis

## Semantic migration

- New canonical owner after the change: `save_entity_field.field.enum` as delivered by `ToolDefinitionsForActor(...)`, with agent-visible rendering consuming that delivered schema through `AgentVisibleToolSummaryLinesForActor(...)`.
- Old invalid path: tool-name-only startup/session primer treated as a complete agent-visible write-authority surface.
- Production paths checked: API startup prompt, CLI startup prompt, CLI startup probe, MCP delivery, and `formatEventForAgent(...)` shared-helper consumer.
- Migration completeness: complete for #497's approved first-slice class. Broader review-draft promotion work remains tracked under #510, with #499 and #500 as sibling promotion lanes.

## Tests

- `go test ./internal/runtime/tools -run '^TestToolDefinitionsForActor_DeriveWave1EntitySchemasFromActorContract$' -count=1`
- `go test ./internal/runtime/llm -run '^(TestAnthropicAPIRuntime_StartSessionAugmentsSystemPromptWithDerivedToolSurface|TestClaudeCLIRuntimePrompt_IncludesWritableEntityPathSummary|TestClaudeCLIRuntimePrompt_HidesNativeCapabilityFallbackToolsFromPostamble)$' -count=1`
- `go test ./internal/runtime/agents -run '^TestFormatEventForAgent_UsesPostCompositionToolSurface$' -count=1`
- `go test ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime/agents ./internal/runtime/mcp -count=1`