### PR TITLE
[agent-d][issue #509] Tighten node state schema typing

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -108,6 +108,9 @@ type checkerContext struct {
 	stateReachabilityLoaded   bool
 	stateReachabilityFindings []Finding
 
+	nodeStateSchemaLoaded   bool
+	nodeStateSchemaFindings []Finding
+
 	producesDriftLoaded   bool
 	producesDriftFindings []Finding
 
@@ -187,6 +190,7 @@ var bootCheckRegistry = []Check{
 	{ID: "condition_policy_alignment", Severity: "warning", Run: checkConditionPolicyAlignment},
 	{ID: "state_machine_coherence", Severity: "error", Run: checkStateMachineCoherence},
 	{ID: "semantic_drift_unreachable_state", Severity: "warning", Run: checkSemanticDriftUnreachableState},
+	{ID: "node_state_schema_typed_counterpart", Severity: SeverityHardInvalidity, Run: checkNodeStateSchemaTypedCounterpart},
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
@@ -235,8 +239,11 @@ func newCheckerContext(ctx context.Context, source semanticview.Source, opts Opt
 	}
 }
 
-func checkPayloadFieldCoverage(c *checkerContext) []Finding       { return c.payloadFieldCoverage() }
-func checkStateMachineCoherence(c *checkerContext) []Finding      { return c.stateMachineCoherence() }
+func checkPayloadFieldCoverage(c *checkerContext) []Finding  { return c.payloadFieldCoverage() }
+func checkStateMachineCoherence(c *checkerContext) []Finding { return c.stateMachineCoherence() }
+func checkNodeStateSchemaTypedCounterpart(c *checkerContext) []Finding {
+	return c.nodeStateSchemaTypedCounterpart()
+}
 func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.requiredAgentsMatch() }
 func checkHandlerFieldCompliance(c *checkerContext) []Finding     { return c.handlerFieldCompliance() }
 func checkToolResolution(c *checkerContext) []Finding             { return c.toolResolution() }

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3135,8 +3135,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 43 {
-		t.Fatalf("bootCheckRegistry count = %d, want 43", got)
+	if got := len(bootCheckRegistry); got != 44 {
+		t.Fatalf("bootCheckRegistry count = %d, want 44", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks.go
@@ -51,11 +51,11 @@ func (c *checkerContext) nodeStateSchemaTypedCounterpart() []Finding {
 				continue
 			}
 			if namedType, ok := runtimecontracts.NodeStateNamedTypeName(normalizedType); ok {
-				if _, declared := types.Types[namedType]; !declared {
+				if !nodeStateDeclaredTypeCatalogRef(types, namedType) {
 					c.nodeStateSchemaFindings = append(c.nodeStateSchemaFindings, Finding{
 						CheckID:  "node_state_schema_typed_counterpart",
 						Severity: SeverityHardInvalidity,
-						Message:  fmt.Sprintf("flow %s node %s state_schema field %s references undeclared named type %s; node state_schema named references must be declared in types.yaml", defaultFlowLabel(flowID), nodeID, fieldName, namedType),
+						Message:  fmt.Sprintf("flow %s node %s state_schema field %s references undeclared type catalog name %s; node state_schema named references must be declared in types.yaml", defaultFlowLabel(flowID), nodeID, fieldName, namedType),
 						Location: nodeID,
 					})
 				}
@@ -82,6 +82,23 @@ func (c *checkerContext) nodeStateSchemaTypedCounterpart() []Finding {
 		}
 	}
 	return c.nodeStateSchemaFindings
+}
+
+func nodeStateDeclaredTypeCatalogRef(types runtimecontracts.TypeCatalogDocument, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	if _, ok := types.Types[name]; ok {
+		return true
+	}
+	if _, ok := types.Enums[name]; ok {
+		return true
+	}
+	if _, ok := types.Scalars[name]; ok {
+		return true
+	}
+	return false
 }
 
 func nodeStateResolvedTypes(source semanticview.Source, flowID string) runtimecontracts.TypeCatalogDocument {

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks.go
@@ -1,0 +1,336 @@
+package bootverify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+type nodeStateTypedCounterpart struct {
+	FieldName     string
+	TypeRef       string
+	NamedListItem string
+	Surface       string
+}
+
+func (c *checkerContext) nodeStateSchemaTypedCounterpart() []Finding {
+	if c.nodeStateSchemaLoaded {
+		return c.nodeStateSchemaFindings
+	}
+	c.nodeStateSchemaLoaded = true
+
+	nodes := c.source.NodeEntries()
+	for _, nodeID := range sortedNodeIDs(c.source) {
+		node, ok := nodes[nodeID]
+		if !ok {
+			continue
+		}
+		flowID := ""
+		if sourceRef, ok := c.source.NodeContractSource(nodeID); ok {
+			flowID = strings.TrimSpace(sourceRef.FlowID)
+		}
+		types := nodeStateResolvedTypes(c.source, flowID)
+		counterparts := nodeStateTypedCounterparts(c.source, flowID)
+		for _, field := range node.StateSchema.Fields {
+			fieldName := strings.TrimSpace(field.Name)
+			if fieldName == "" {
+				continue
+			}
+			normalizedType, err := runtimecontracts.NormalizeNodeStateFieldType(field.Type)
+			if err != nil {
+				c.nodeStateSchemaFindings = append(c.nodeStateSchemaFindings, Finding{
+					CheckID:  "node_state_schema_typed_counterpart",
+					Severity: SeverityHardInvalidity,
+					Message:  fmt.Sprintf("flow %s node %s state_schema field %s has unsupported type %q: %v", defaultFlowLabel(flowID), nodeID, fieldName, strings.TrimSpace(field.Type), err),
+					Location: nodeID,
+				})
+				continue
+			}
+			if namedType, ok := runtimecontracts.NodeStateNamedTypeName(normalizedType); ok {
+				if _, declared := types.Types[namedType]; !declared {
+					c.nodeStateSchemaFindings = append(c.nodeStateSchemaFindings, Finding{
+						CheckID:  "node_state_schema_typed_counterpart",
+						Severity: SeverityHardInvalidity,
+						Message:  fmt.Sprintf("flow %s node %s state_schema field %s references undeclared named type %s; node state_schema named references must be declared in types.yaml", defaultFlowLabel(flowID), nodeID, fieldName, namedType),
+						Location: nodeID,
+					})
+				}
+				continue
+			}
+			if !runtimecontracts.IsNodeStateJSONBType(normalizedType) {
+				continue
+			}
+			if counterpart, ok := nodeStateJSONBTypedCounterpart(fieldName, counterparts); ok {
+				c.nodeStateSchemaFindings = append(c.nodeStateSchemaFindings, Finding{
+					CheckID:  "node_state_schema_typed_counterpart",
+					Severity: SeverityHardInvalidity,
+					Message:  fmt.Sprintf("flow %s node %s state_schema field %s is jsonb but has typed downstream counterpart %s %s:%s; switch the node state field to the declared named type instead of jsonb", defaultFlowLabel(flowID), nodeID, fieldName, counterpart.Surface, counterpart.FieldName, counterpart.TypeRef),
+					Location: nodeID,
+				})
+				continue
+			}
+			c.nodeStateSchemaFindings = append(c.nodeStateSchemaFindings, Finding{
+				CheckID:  "node_state_schema_typed_counterpart",
+				Severity: SeverityLintEvidence,
+				Message:  fmt.Sprintf("flow %s node %s state_schema field %s remains jsonb; confirm no typed downstream counterpart exists before accepting this shape-variant state", defaultFlowLabel(flowID), nodeID, fieldName),
+				Location: nodeID,
+			})
+		}
+	}
+	return c.nodeStateSchemaFindings
+}
+
+func nodeStateResolvedTypes(source semanticview.Source, flowID string) runtimecontracts.TypeCatalogDocument {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return runtimecontracts.TypeCatalogDocument{}
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return bundle.RootTypeCatalog()
+	}
+	return bundle.ResolvedTypeCatalogForFlow(flowID)
+}
+
+func nodeStateTypedCounterparts(source semanticview.Source, flowID string) []nodeStateTypedCounterpart {
+	out := make([]nodeStateTypedCounterpart, 0)
+	addEntity := func(view wave1EntityContractView) {
+		if !view.Defined {
+			return
+		}
+		fieldNames := make([]string, 0, len(view.Contract.Fields))
+		for fieldName := range view.Contract.Fields {
+			fieldNames = append(fieldNames, strings.TrimSpace(fieldName))
+		}
+		sort.Strings(fieldNames)
+		for _, fieldName := range fieldNames {
+			if fieldName == "" || wave1EntityEnvelopeField(fieldName) {
+				continue
+			}
+			typeRef := strings.TrimSpace(view.Contract.Fields[fieldName].Type)
+			if !nodeStateTypeIsTypedCounterpart(typeRef) {
+				continue
+			}
+			out = append(out, nodeStateTypedCounterpart{
+				FieldName:     fieldName,
+				TypeRef:       typeRef,
+				NamedListItem: nodeStateListNamedType(typeRef, view.Types),
+				Surface:       fmt.Sprintf("entity_type %s", view.EntityType),
+			})
+		}
+	}
+
+	if flowID = strings.TrimSpace(flowID); flowID != "" {
+		addEntity(wave1EntityContractForFlow(source, flowID))
+	}
+	addEntity(wave1EntityContractForFlow(source, ""))
+
+	for eventType, entry := range source.ResolvedEventCatalog() {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			continue
+		}
+		fieldNames := make([]string, 0, len(entry.Payload.Properties))
+		for fieldName := range entry.Payload.Properties {
+			fieldNames = append(fieldNames, strings.TrimSpace(fieldName))
+		}
+		sort.Strings(fieldNames)
+		for _, fieldName := range fieldNames {
+			if fieldName == "" {
+				continue
+			}
+			typeRef := strings.TrimSpace(entry.Payload.Properties[fieldName].Type)
+			if !nodeStateTypeIsTypedCounterpart(typeRef) {
+				continue
+			}
+			out = append(out, nodeStateTypedCounterpart{
+				FieldName: fieldName,
+				TypeRef:   typeRef,
+				Surface:   fmt.Sprintf("event %s payload", eventType),
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Surface == out[j].Surface {
+			return out[i].FieldName < out[j].FieldName
+		}
+		return out[i].Surface < out[j].Surface
+	})
+	return out
+}
+
+func nodeStateTypeIsTypedCounterpart(typeRef string) bool {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" {
+		return false
+	}
+	switch strings.ToLower(typeRef) {
+	case "json", "jsonb", "object":
+		return false
+	default:
+		return true
+	}
+}
+
+func nodeStateJSONBTypedCounterpart(fieldName string, counterparts []nodeStateTypedCounterpart) (nodeStateTypedCounterpart, bool) {
+	fieldName = strings.TrimSpace(fieldName)
+	if fieldName == "" {
+		return nodeStateTypedCounterpart{}, false
+	}
+	for _, counterpart := range counterparts {
+		if strings.EqualFold(counterpart.FieldName, fieldName) {
+			return counterpart, true
+		}
+	}
+	candidates := nodeStateAccumulatorCandidateNames(fieldName)
+	for _, counterpart := range counterparts {
+		if counterpart.NamedListItem == "" {
+			continue
+		}
+		if nodeStateNamedTypeMatchesAnyCandidate(counterpart.NamedListItem, candidates) {
+			return counterpart, true
+		}
+	}
+	return nodeStateTypedCounterpart{}, false
+}
+
+func nodeStateListNamedType(typeRef string, types runtimecontracts.TypeCatalogDocument) string {
+	item := nodeStateListItemType(typeRef)
+	if item == "" {
+		return ""
+	}
+	if scalar, ok := types.Scalars[item]; ok {
+		item = strings.TrimSpace(scalar.Base)
+	}
+	if _, ok := types.Types[item]; ok {
+		return item
+	}
+	return ""
+}
+
+func nodeStateListItemType(typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	switch {
+	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
+		return strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
+	case strings.HasSuffix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[:len(typeRef)-2])
+	case strings.HasPrefix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[2:])
+	default:
+		return ""
+	}
+}
+
+func nodeStateAccumulatorCandidateNames(fieldName string) []string {
+	base := strings.ToLower(strings.TrimSpace(fieldName))
+	if base == "" {
+		return nil
+	}
+	suffixes := []string{
+		"_received",
+		"_completed",
+		"_entries",
+		"_items",
+		"_records",
+		"_state",
+		"_evidence",
+		"_logs",
+		"_log",
+	}
+	candidates := []string{nodeStateNormalizeSemanticName(base)}
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(base, suffix) {
+			candidates = append(candidates, nodeStateNormalizeSemanticName(strings.TrimSuffix(base, suffix)))
+		}
+	}
+	for _, part := range strings.Split(base, "_") {
+		candidates = append(candidates, nodeStateNormalizeSemanticName(part))
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(candidates)*2)
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		for _, value := range []string{candidate, nodeStateSingular(candidate)} {
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func nodeStateNamedTypeMatchesAnyCandidate(namedType string, candidates []string) bool {
+	words := nodeStateCamelWords(namedType)
+	if len(words) == 0 {
+		return false
+	}
+	firstWord := nodeStateNormalizeSemanticName(words[0])
+	fullName := nodeStateNormalizeSemanticName(strings.Join(words, ""))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if candidate == firstWord || strings.HasPrefix(fullName, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeStateCamelWords(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	words := make([]string, 0, 4)
+	var current []rune
+	for i, r := range value {
+		if i > 0 && unicode.IsUpper(r) && len(current) > 0 {
+			words = append(words, string(current))
+			current = current[:0]
+		}
+		current = append(current, r)
+	}
+	if len(current) > 0 {
+		words = append(words, string(current))
+	}
+	return words
+}
+
+func nodeStateNormalizeSemanticName(value string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func nodeStateSingular(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 3 && strings.HasSuffix(value, "ies") {
+		return strings.TrimSuffix(value, "ies") + "y"
+	}
+	if len(value) > 1 && strings.HasSuffix(value, "s") {
+		return strings.TrimSuffix(value, "s")
+	}
+	return value
+}

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
@@ -1,0 +1,106 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ReportsNodeStateJSONBWithTypedCounterpart(t *testing.T) {
+	bundle := nodeStateSchemaTypingBundle()
+	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
+		ID:         "scoring-node",
+		StateTable: "scoring_state",
+		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+			{Name: "dimensions_received", Type: "jsonb"},
+		}},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "dimensions_received is jsonb but has typed downstream counterpart entity_type vertical scores:[DimensionScore]") {
+		t.Fatalf("expected node-state typed-counterpart hard invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_ReportsNodeStateJSONBLintEvidenceWithoutCounterpart(t *testing.T) {
+	bundle := nodeStateSchemaTypingBundle()
+	bundle.Nodes["build-node"] = runtimecontracts.SystemNodeContract{
+		ID:         "build-node",
+		StateTable: "build_state",
+		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+			{Name: "build_evidence", Type: "jsonb"},
+		}},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "build_evidence") {
+		t.Fatalf("unexpected hard invalidity for shape-variant node-state jsonb, got %#v", report.HardInvalidities())
+	}
+	if !reportContains(report.LintEvidence(), "node_state_schema_typed_counterpart", "build_evidence remains jsonb") {
+		t.Fatalf("expected node-state jsonb lint evidence, got %#v", report.LintEvidence())
+	}
+}
+
+func TestRun_ReportsUndeclaredNodeStateNamedType(t *testing.T) {
+	bundle := nodeStateSchemaTypingBundle()
+	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
+		ID:         "scoring-node",
+		StateTable: "scoring_state",
+		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+			{Name: "dimensions_received", Type: "[MissingScore]"},
+		}},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "references undeclared named type MissingScore") {
+		t.Fatalf("expected undeclared node-state named type hard invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_AllowsDeclaredNodeStateNamedType(t *testing.T) {
+	bundle := nodeStateSchemaTypingBundle()
+	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
+		ID:         "scoring-node",
+		StateTable: "scoring_state",
+		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+			{Name: "dimensions_received", Type: "[DimensionScore]"},
+		}},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "dimensions_received") {
+		t.Fatalf("unexpected node-state named type hard invalidity, got %#v", report.HardInvalidities())
+	}
+	if reportContains(report.LintEvidence(), "node_state_schema_typed_counterpart", "dimensions_received") {
+		t.Fatalf("unexpected node-state jsonb lint evidence for named type, got %#v", report.LintEvidence())
+	}
+}
+
+func nodeStateSchemaTypingBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{},
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"name":  {Type: "text"},
+						"score": {Type: "numeric"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"vertical": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"scores": {Type: "[DimensionScore]", Initial: []any{}},
+				},
+			},
+		},
+	}
+}

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
@@ -9,19 +9,23 @@ import (
 )
 
 func TestRun_ReportsNodeStateJSONBWithTypedCounterpart(t *testing.T) {
-	bundle := nodeStateSchemaTypingBundle()
-	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
-		ID:         "scoring-node",
-		StateTable: "scoring_state",
-		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
-			{Name: "dimensions_received", Type: "jsonb"},
-		}},
-	}
+	for _, fieldType := range []string{"jsonb", "json"} {
+		t.Run(fieldType, func(t *testing.T) {
+			bundle := nodeStateSchemaTypingBundle()
+			bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
+				ID:         "scoring-node",
+				StateTable: "scoring_state",
+				StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+					{Name: "dimensions_received", Type: fieldType},
+				}},
+			}
 
-	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "dimensions_received is jsonb but has typed downstream counterpart entity_type vertical scores:[DimensionScore]") {
-		t.Fatalf("expected node-state typed-counterpart hard invalidity, got %#v", report.HardInvalidities())
+			if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "dimensions_received is jsonb but has typed downstream counterpart entity_type vertical scores:[DimensionScore]") {
+				t.Fatalf("expected node-state typed-counterpart hard invalidity, got %#v", report.HardInvalidities())
+			}
+		})
 	}
 }
 
@@ -57,7 +61,7 @@ func TestRun_ReportsUndeclaredNodeStateNamedType(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "references undeclared named type MissingScore") {
+	if !reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "references undeclared type catalog name MissingScore") {
 		t.Fatalf("expected undeclared node-state named type hard invalidity, got %#v", report.HardInvalidities())
 	}
 }
@@ -82,10 +86,35 @@ func TestRun_AllowsDeclaredNodeStateNamedType(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsDeclaredNodeStateScalarAndEnumRefs(t *testing.T) {
+	bundle := nodeStateSchemaTypingBundle()
+	bundle.RootTypes.Scalars["ScoreID"] = runtimecontracts.ScalarTypeDecl{Base: "text"}
+	bundle.RootTypes.Enums["ScoreStatus"] = runtimecontracts.EnumTypeDecl{Values: []string{"ready", "done"}}
+	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
+		ID:         "scoring-node",
+		StateTable: "scoring_state",
+		StateSchema: runtimecontracts.NodeStateSchema{Fields: []runtimecontracts.NodeStateField{
+			{Name: "score_id", Type: "ScoreID"},
+			{Name: "score_status", Type: "ScoreStatus"},
+		}},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "score_id") {
+		t.Fatalf("unexpected node-state scalar ref hard invalidity, got %#v", report.HardInvalidities())
+	}
+	if reportContains(report.HardInvalidities(), "node_state_schema_typed_counterpart", "score_status") {
+		t.Fatalf("unexpected node-state enum ref hard invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
 func nodeStateSchemaTypingBundle() *runtimecontracts.WorkflowContractBundle {
 	return &runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{},
 		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Scalars: map[string]runtimecontracts.ScalarTypeDecl{},
+			Enums:   map[string]runtimecontracts.EnumTypeDecl{},
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"DimensionScore": {
 					Fields: map[string]runtimecontracts.TypeFieldSpec{

--- a/internal/runtime/contracts/node_state_types.go
+++ b/internal/runtime/contracts/node_state_types.go
@@ -7,6 +7,7 @@ import (
 )
 
 var nodeStateNumericTypePattern = regexp.MustCompile(`(?i)^numeric\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
+var nodeStateNamedTypePattern = regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*$`)
 
 // NormalizeNodeStateFieldType enforces the supported canonical vocabulary for
 // node-local accumulator/state fields. Unlike the Wave 1 entity/event contract
@@ -17,6 +18,16 @@ func NormalizeNodeStateFieldType(raw string) (string, error) {
 	if raw == "" {
 		return "", fmt.Errorf("state_schema field type is required")
 	}
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		base := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]"))
+		if base == "" {
+			return "", fmt.Errorf("state_schema list type requires an element type")
+		}
+		if !nodeStateNamedTypePattern.MatchString(base) {
+			return "", fmt.Errorf("unsupported state_schema named list type %q; use [NamedType] for declared types.yaml references", raw)
+		}
+		return "[" + base + "]", nil
+	}
 	if strings.HasSuffix(raw, "[]") {
 		base := strings.TrimSpace(strings.TrimSuffix(raw, "[]"))
 		if base == "" {
@@ -25,6 +36,9 @@ func NormalizeNodeStateFieldType(raw string) (string, error) {
 		normalizedBase, err := NormalizeNodeStateFieldType(base)
 		if err != nil {
 			return "", err
+		}
+		if named, ok := NodeStateNamedTypeName(normalizedBase); ok {
+			return "[" + named + "]", nil
 		}
 		return normalizedBase + "[]", nil
 	}
@@ -46,5 +60,26 @@ func NormalizeNodeStateFieldType(raw string) (string, error) {
 	if strings.ContainsAny(raw, " \t\r\n") {
 		return "", fmt.Errorf("state_schema field type %q is not canonical; descriptive notes and inline modifiers must not appear in type declarations", raw)
 	}
-	return "", fmt.Errorf("unsupported state_schema field type %q; use a canonical scalar, numeric(p,s), or [] form", raw)
+	if nodeStateNamedTypePattern.MatchString(raw) {
+		return raw, nil
+	}
+	return "", fmt.Errorf("unsupported state_schema field type %q; use a canonical scalar, numeric(p,s), [NamedType], or [] form", raw)
+}
+
+func NodeStateNamedTypeName(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		raw = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]"))
+	}
+	if !nodeStateNamedTypePattern.MatchString(raw) {
+		return "", false
+	}
+	return raw, true
+}
+
+func IsNodeStateJSONBType(raw string) bool {
+	return strings.EqualFold(strings.TrimSpace(raw), "jsonb")
 }

--- a/internal/runtime/contracts/node_state_types.go
+++ b/internal/runtime/contracts/node_state_types.go
@@ -81,5 +81,10 @@ func NodeStateNamedTypeName(raw string) (string, bool) {
 }
 
 func IsNodeStateJSONBType(raw string) bool {
-	return strings.EqualFold(strings.TrimSpace(raw), "jsonb")
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "json", "jsonb":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runtime/contracts/node_state_types_test.go
+++ b/internal/runtime/contracts/node_state_types_test.go
@@ -9,18 +9,21 @@ import (
 
 func TestNormalizeNodeStateFieldType_AllowsCanonicalNodeStateTypes(t *testing.T) {
 	cases := map[string]string{
-		"text":           "text",
-		"string":         "string",
-		"integer":        "integer",
-		"bool":           "boolean",
-		"boolean":        "boolean",
-		"float":          "float",
-		"numeric(8, 2)":  "numeric(8,2)",
-		"jsonb":          "jsonb",
-		"timestamptz":    "timestamptz",
-		"uuid":           "uuid",
-		"text[]":         "text[]",
-		"numeric(5,2)[]": "numeric(5,2)[]",
+		"text":             "text",
+		"string":           "string",
+		"integer":          "integer",
+		"bool":             "boolean",
+		"boolean":          "boolean",
+		"float":            "float",
+		"numeric(8, 2)":    "numeric(8,2)",
+		"jsonb":            "jsonb",
+		"timestamptz":      "timestamptz",
+		"uuid":             "uuid",
+		"text[]":           "text[]",
+		"numeric(5,2)[]":   "numeric(5,2)[]",
+		"DimensionScore":   "DimensionScore",
+		"[DimensionScore]": "[DimensionScore]",
+		"DimensionScore[]": "[DimensionScore]",
 	}
 	for raw, want := range cases {
 		t.Run(raw, func(t *testing.T) {

--- a/internal/runtime/contracts/node_state_types_test.go
+++ b/internal/runtime/contracts/node_state_types_test.go
@@ -16,6 +16,7 @@ func TestNormalizeNodeStateFieldType_AllowsCanonicalNodeStateTypes(t *testing.T)
 		"boolean":          "boolean",
 		"float":            "float",
 		"numeric(8, 2)":    "numeric(8,2)",
+		"json":             "json",
 		"jsonb":            "jsonb",
 		"timestamptz":      "timestamptz",
 		"uuid":             "uuid",

--- a/internal/runtime/swarmflowtest/catalog_runner_expected_yaml_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_expected_yaml_test.go
@@ -99,7 +99,7 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]
 `,
 		"{}\n",
 		`

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -66,6 +66,17 @@ func SchemaFieldTypeToDDL(schemaType string) (string, error) {
 	return "", fmt.Errorf("%w %q", ErrUnknownSchemaType, schemaType)
 }
 
+func NodeStateFieldTypeToDDL(schemaType string) (string, error) {
+	normalized, err := runtimecontracts.NormalizeNodeStateFieldType(schemaType)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := runtimecontracts.NodeStateNamedTypeName(normalized); ok {
+		return "JSONB", nil
+	}
+	return SchemaFieldTypeToDDL(normalized)
+}
+
 func GeneratePlatformTableDDLs(spec runtimecontracts.PlatformSpecDocument) ([]SchemaTableDDL, error) {
 	if len(spec.PlatformTables.Tables) == 0 {
 		return nil, fmt.Errorf("platform spec platform_tables.tables.*.ddl is required")
@@ -239,11 +250,7 @@ func GenerateNodeStateTableDDLs(nodes map[string]runtimecontracts.SystemNodeCont
 				return nil, fmt.Errorf("node %s state table %s declares duplicate column %s", strings.TrimSpace(nodeID), tableName, columnName)
 			}
 			seenColumns[columnName] = struct{}{}
-			normalizedType, err := runtimecontracts.NormalizeNodeStateFieldType(field.Type)
-			if err != nil {
-				return nil, fmt.Errorf("node %s state table %s field %s: %w", strings.TrimSpace(nodeID), tableName, columnName, err)
-			}
-			columnType, err := SchemaFieldTypeToDDL(normalizedType)
+			columnType, err := NodeStateFieldTypeToDDL(field.Type)
 			if err != nil {
 				return nil, fmt.Errorf("node %s state table %s field %s: %w", strings.TrimSpace(nodeID), tableName, columnName, err)
 			}

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -47,6 +47,26 @@ func TestSchemaFieldTypeToDDLError(t *testing.T) {
 	}
 }
 
+func TestNodeStateFieldTypeToDDL_AllowsNamedTypesAsJSONB(t *testing.T) {
+	cases := map[string]string{
+		"DimensionScore":   "JSONB",
+		"[DimensionScore]": "JSONB",
+		"DimensionScore[]": "JSONB",
+		"text[]":           "TEXT[]",
+	}
+	for schemaType, wantDDL := range cases {
+		t.Run(schemaType, func(t *testing.T) {
+			got, err := NodeStateFieldTypeToDDL(schemaType)
+			if err != nil {
+				t.Fatalf("NodeStateFieldTypeToDDL(%q): %v", schemaType, err)
+			}
+			if got != wantDDL {
+				t.Fatalf("NodeStateFieldTypeToDDL(%q) = %q, want %q", schemaType, got, wantDDL)
+			}
+		})
+	}
+}
+
 func TestGeneratePlatformTableDDLs(t *testing.T) {
 	var spec runtimecontracts.PlatformSpecDocument
 	spec.PlatformTables.Tables = map[string]struct {
@@ -224,6 +244,7 @@ func TestGenerateNodeStateTableDDLs(t *testing.T) {
 					{Name: "attempts", Type: "integer"},
 					{Name: "last_error", Type: "text"},
 					{Name: "score", Type: "float"},
+					{Name: "dimensions_received", Type: "[DimensionScore]"},
 				},
 			},
 		},
@@ -243,7 +264,7 @@ func TestGenerateNodeStateTableDDLs(t *testing.T) {
 	if !strings.Contains(createStmt, `"node_id" TEXT NOT NULL`) {
 		t.Fatalf("expected node_id column, got %q", createStmt)
 	}
-	if !strings.Contains(createStmt, `"attempts" BIGINT`) || !strings.Contains(createStmt, `"last_error" TEXT`) || !strings.Contains(createStmt, `"score" DOUBLE PRECISION`) {
+	if !strings.Contains(createStmt, `"attempts" BIGINT`) || !strings.Contains(createStmt, `"last_error" TEXT`) || !strings.Contains(createStmt, `"score" DOUBLE PRECISION`) || !strings.Contains(createStmt, `"dimensions_received" JSONB`) {
 		t.Fatalf("expected state_schema fields, got %q", createStmt)
 	}
 	if !strings.Contains(createStmt, `PRIMARY KEY ("entity_id", "node_id")`) {

--- a/tests/tier2-accumulation/test-accumulate-all/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/nodes.yaml
@@ -13,4 +13,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/nodes.yaml
@@ -13,4 +13,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/nodes.yaml
@@ -13,4 +13,4 @@ test-node:
   state_schema:
     fields:
       item_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-from-filter/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/nodes.yaml
@@ -14,4 +14,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-idempotent/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/nodes.yaml
@@ -14,4 +14,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/nodes.yaml
@@ -18,4 +18,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-partial/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/nodes.yaml
@@ -13,4 +13,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-threshold/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/nodes.yaml
@@ -14,4 +14,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-timeout/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/nodes.yaml
@@ -14,4 +14,4 @@ test-node:
   state_schema:
     fields:
       expected_count: integer
-      received_items: jsonb
+      received_items: text[]

--- a/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/nodes.yaml
@@ -28,4 +28,4 @@ test-node:
     fields:
       expected_count: integer
       composite: float
-      received_items: jsonb
+      received_items: text[]


### PR DESCRIPTION
## Summary

Part of #509.

This PR implements the approved Swarm first slice for node `state_schema` typed-counterpart tightening:

- Extends node-state type normalization to accept declared named refs and named-list refs such as `[DimensionScore]` while preserving pseudo-type rejection.
- Lowers node-state named refs through the node-state DDL path as `JSONB`, avoiding the old primitive-only DDL reinterpretation.
- Adds supported bootverify enforcement for node-state `jsonb` with typed downstream counterparts.
- Emits `lint_evidence` for remaining allowed node-state `jsonb` fields.

This PR intentionally does not close #509. The issue must remain open until the paired Empire authored migration / exception classification lands for `dimensions_received`, `gate_state`, and `build_evidence`.

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`, `wave_2_committed_children.child_6_node_state_schema_tightening`
- Adjacent current spec context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` node `state_schema`, boot verification, and `lint_evidence` sections
- Approved pre-audit gate on #509: `approved as first slice`

## Semantic migration note

New canonical owners after this Swarm slice:

- Parser / vocabulary: `internal/runtime/contracts/node_state_types.go`
- Node-state DDL lowering: `internal/store/schema_ddl.go`
- Supported verify / boot accounting: `internal/runtime/bootverify/workflow_node_state_schema_checks.go`

Old path now invalid:

- Treating every node-state `jsonb` as silently acceptable even when a typed downstream counterpart exists.
- Treating node-state type strings as primitive/jsonb-only on the DDL path.

Migration completeness:

- Swarm enforcement and proof are complete for the approved first slice.
- First-party Empire authored migration is not included here and remains required before #509 can close.

## Proof

- `go test ./internal/runtime/contracts -run 'NodeState|WorkflowContractBundle_LoadsWave1Type' -count=1`
- `go test ./internal/store -run 'NodeState|SchemaFieldType' -count=1`
- `go test ./internal/runtime/bootverify -run 'NodeStateSchema|NodeStateJSONB|DeclaredNodeState' -count=1`
- `go test ./internal/runtime/contracts ./internal/store ./internal/runtime/bootverify ./cmd/swarm -count=1`
- Current Empire supported verify now fails as expected on `scoring-node.dimensions_received: jsonb` with typed downstream counterpart `[DimensionScore]`.
- Temporary migrated Empire copy replacing `dimensions_received: jsonb` with `dimensions_received: "[DimensionScore]"` passes supported verify and emits node-state `jsonb` lint evidence for `gate_state` and `build_evidence`.

## Residual

#509 remains open. The next closure-bearing slice is the paired Empire migration / exception classification.