### PR TITLE
[agent-d][issue #475] Add contract-aware entity read targets

### DIFF
--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -48,6 +48,104 @@ func ResolveForActor(source semanticview.Source, actorID string) (Contract, bool
 	return ResolveForFlow(source, contractSource.FlowID)
 }
 
+func ResolveForReadTarget(source semanticview.Source, actorID, target string) (Contract, bool, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		contract, ok := ResolveForActor(source, actorID)
+		return contract, ok, nil
+	}
+	if source == nil {
+		return Contract{}, false, fmt.Errorf("workflow source is not configured")
+	}
+	if idx := strings.LastIndex(target, "."); idx > 0 && idx < len(target)-1 {
+		flowID := strings.TrimSpace(target[:idx])
+		entityType := strings.TrimSpace(target[idx+1:])
+		contract, ok := ResolveForFlow(source, flowID)
+		if !ok {
+			return Contract{}, false, fmt.Errorf("entity_type %q does not resolve to a flow-owned entity contract", target)
+		}
+		if !strings.EqualFold(contract.EntityType, entityType) {
+			return Contract{}, false, fmt.Errorf("entity_type %q resolves to flow %q, which owns %q", target, flowID, contract.EntityType)
+		}
+		return contract, true, nil
+	}
+
+	matches := make([]Contract, 0, 2)
+	for _, contract := range ReadTargetContracts(source) {
+		if strings.EqualFold(contract.EntityType, target) {
+			matches = append(matches, contract)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], true, nil
+	case 0:
+		return Contract{}, false, fmt.Errorf("entity_type %q does not resolve to a flow-owned entity contract", target)
+	default:
+		names := make([]string, 0, len(matches))
+		for _, contract := range matches {
+			names = append(names, CanonicalReadTargetName(contract))
+		}
+		sort.Strings(names)
+		return Contract{}, false, fmt.Errorf("entity_type %q is ambiguous; use one of: %s", target, strings.Join(names, ", "))
+	}
+}
+
+func ReadTargetContracts(source semanticview.Source) []Contract {
+	if source == nil {
+		return nil
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return nil
+	}
+	flowIDs := make([]string, 0, len(source.FlowSchemaEntries()))
+	for flowID := range source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID != "" {
+			flowIDs = append(flowIDs, flowID)
+		}
+	}
+	sort.Strings(flowIDs)
+	out := make([]Contract, 0, len(flowIDs)+len(bundle.RootEntityContracts()))
+	for _, flowID := range flowIDs {
+		if contract, ok := ResolveForFlow(source, flowID); ok {
+			out = append(out, contract)
+		}
+	}
+	if len(bundle.RootEntityContracts()) == 1 {
+		if contract, ok := ResolveForFlow(source, ""); ok {
+			out = append(out, contract)
+		}
+	}
+	return out
+}
+
+func ReadTargetNames(source semanticview.Source) []string {
+	contracts := ReadTargetContracts(source)
+	names := make([]string, 0, len(contracts))
+	for _, contract := range contracts {
+		name := CanonicalReadTargetName(contract)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func CanonicalReadTargetName(contract Contract) string {
+	entityType := strings.TrimSpace(contract.EntityType)
+	flowID := strings.TrimSpace(contract.FlowID)
+	if entityType == "" {
+		return ""
+	}
+	if flowID == "" {
+		return entityType
+	}
+	return flowID + "." + entityType
+}
+
 func ResolveForFlowInstance(source semanticview.Source, flowInstance string) (Contract, bool) {
 	return ResolveForFlow(source, ResolveFlowIDForInstance(source, flowInstance))
 }

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -88,6 +88,11 @@ review_subject:
 
 	searchSchema := defByName["search_entities"]
 	searchProps, _ := searchSchema["properties"].(map[string]any)
+	searchTarget, _ := searchProps["entity_type"].(map[string]any)
+	searchTargets, _ := searchTarget["enum"].([]any)
+	if !containsAnyString(searchTargets, "review.review_subject") {
+		t.Fatalf("search_entities entity_type enum = %#v, want review.review_subject", searchTargets)
+	}
 	filterSchema, _ := searchProps["filter"].(map[string]any)
 	filterProps, _ := filterSchema["properties"].(map[string]any)
 	if _, ok := filterProps["metadata.region"]; !ok {
@@ -102,6 +107,11 @@ review_subject:
 
 	querySchema := defByName["query_entities"]
 	queryProps, _ := querySchema["properties"].(map[string]any)
+	queryTarget, _ := queryProps["entity_type"].(map[string]any)
+	queryTargets, _ := queryTarget["enum"].([]any)
+	if !containsAnyString(queryTargets, "review.review_subject") {
+		t.Fatalf("query_entities entity_type enum = %#v, want review.review_subject", queryTargets)
+	}
 	selectSchema, _ := queryProps["select"].(map[string]any)
 	selectItems, _ := selectSchema["items"].(map[string]any)
 	selectEnum, _ := selectItems["enum"].([]any)
@@ -114,6 +124,11 @@ review_subject:
 
 	metricSchema := defByName["query_metrics"]
 	metricProps, _ := metricSchema["properties"].(map[string]any)
+	metricTarget, _ := metricProps["entity_type"].(map[string]any)
+	metricTargets, _ := metricTarget["enum"].([]any)
+	if !containsAnyString(metricTargets, "review.review_subject") {
+		t.Fatalf("query_metrics entity_type enum = %#v, want review.review_subject", metricTargets)
+	}
 	metricField, _ := metricProps["field"].(map[string]any)
 	metricFieldEnum, _ := metricField["enum"].([]any)
 	if !containsAnyString(metricFieldEnum, "status") {

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -37,6 +37,21 @@ func entityToolSchemaForActor(source semanticview.Source, actorID string) (entit
 	return entityToolSchema{Defined: true, Contract: contract}, nil
 }
 
+func entityToolSchemaForReadTarget(source semanticview.Source, actorID string, payload map[string]any) (entityToolSchema, error) {
+	if source == nil {
+		return entityToolSchema{}, fmt.Errorf("workflow source is not configured")
+	}
+	target := strings.TrimSpace(asString(payload["entity_type"]))
+	contract, ok, err := entityruntime.ResolveForReadTarget(source, actorID, target)
+	if err != nil {
+		return entityToolSchema{}, err
+	}
+	if !ok {
+		return entityToolSchema{}, fmt.Errorf("flow-owned entity contract is not available for actor %s", strings.TrimSpace(actorID))
+	}
+	return entityToolSchema{Defined: true, Contract: contract}, nil
+}
+
 func entityToolSchemaForEntityRow(source semanticview.Source, row map[string]any) (entityToolSchema, error) {
 	if source == nil {
 		return entityToolSchema{}, fmt.Errorf("workflow source is not configured")

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -11,6 +11,7 @@ import (
 	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	models "swarm/internal/runtime/core/actors"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
 )
@@ -20,11 +21,11 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForActor(source, actor.ID)
+	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_search_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args := entityStateBaseQuery(source, actor, payload, true)
+	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
 	currentStateFilter := strings.TrimSpace(asString(payload["current_state"]))
 	if currentStateFilter != "" {
 		args = append(args, currentStateFilter)
@@ -89,11 +90,11 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForActor(source, actor.ID)
+	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args := entityStateBaseQuery(source, actor, payload, true)
+	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
 	whereClause := joinEntityStateWhere(filterSQL)
 	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
 	if err != nil {
@@ -132,7 +133,7 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForActor(source, actor.ID)
+	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_metrics.schema", false, err, "resolve entity contract")
 	}
@@ -155,7 +156,7 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 			return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_metrics.group_by", false, err, "validate group_by")
 		}
 	}
-	filterSQL, args := entityStateBaseQuery(source, actor, payload, true)
+	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
 	whereClause := joinEntityStateWhere(filterSQL)
 	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
 	if err != nil {
@@ -184,13 +185,18 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 }
 
 func entityStateBaseQuery(source semanticview.Source, actor models.AgentConfig, payload map[string]any, includeFlowInstance bool) ([]string, []any) {
+	contract, _ := entityruntime.ResolveForActor(source, actor.ID)
+	return entityStateBaseQueryForContract(source, contract, payload, includeFlowInstance)
+}
+
+func entityStateBaseQueryForContract(source semanticview.Source, contract entityruntime.Contract, payload map[string]any, includeFlowInstance bool) ([]string, []any) {
 	clauses := make([]string, 0, 4)
 	args := make([]any, 0, 4)
 	if subjectID := strings.TrimSpace(asString(payload["subject_id"])); subjectID != "" {
 		args = append(args, subjectID)
 		clauses = append(clauses, fmt.Sprintf("subject_id = $%d::uuid", len(args)))
 	}
-	flowRoot := actorFlowOwnershipRoot(source, actor.ID)
+	flowRoot := entityReadFlowScopeRoot(source, contract)
 	if flowRoot != "" {
 		args = append(args, flowRoot, flowRoot+"/%")
 		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
@@ -202,6 +208,14 @@ func entityStateBaseQuery(source semanticview.Source, actor models.AgentConfig, 
 		}
 	}
 	return clauses, args
+}
+
+func entityReadFlowScopeRoot(source semanticview.Source, contract entityruntime.Contract) string {
+	flowID := strings.TrimSpace(contract.FlowID)
+	if source == nil || flowID == "" {
+		return ""
+	}
+	return runtimeflowidentity.ScopeKey(source, flowID)
 }
 
 func joinEntityStateWhere(clauses []string) string {
@@ -309,6 +323,15 @@ func entityFilterSelectorReferences(parsed *cel.Ast) []entityFilterSelectorRefer
 	refs := make([]entityFilterSelectorReference, 0)
 	var visit func(expr celast.NavigableExpr)
 	visit = func(expr celast.NavigableExpr) {
+		if expr.Kind() == celast.IdentKind && !entityFilterSelectorHasParent(expr) {
+			if ref, ok := entityFilterSelectorBase(expr); ok {
+				key := fmt.Sprintf("%t:%s", ref.EntityScoped, ref.Path)
+				if _, exists := seen[key]; !exists {
+					seen[key] = struct{}{}
+					refs = append(refs, ref)
+				}
+			}
+		}
 		if expr.Kind() == celast.SelectKind && !entityFilterSelectorHasParent(expr) {
 			if ref, ok := entityFilterSelectorReferenceFromExpr(expr); ok {
 				key := fmt.Sprintf("%t:%s", ref.EntityScoped, ref.Path)

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -952,6 +952,166 @@ func TestEntityTools_QueryMetricsFilterRejectsUndeclaredFieldBeforeEval(t *testi
 	}
 }
 
+func TestEntityTools_ReadToolsUseExplicitTargetContract(t *testing.T) {
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"discovery": {
+			EntitiesYAML: `
+campaign:
+  status: text
+`,
+			AgentsYAML: entityToolAgentYAML(models.AgentConfig{ID: "researcher", Role: "researcher", Tools: []string{"query_entities", "query_metrics", "search_entities"}}),
+		},
+		"signal-search": {
+			EntitiesYAML: `
+signal:
+  signal_strength: integer
+  processed: boolean
+  status: text
+`,
+		},
+	})
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
+		ID:    "researcher",
+		Role:  "researcher",
+		Tools: []string{"query_entities", "query_metrics", "search_entities"},
+	}, bundle)
+	subjectID := uuid.NewString()
+	seedEntityStateRow(t, db, uuid.NewString(), subjectID, "discovery/run-1", "campaign", "active", map[string]any{"status": "open"}, time.Now().UTC().Truncate(time.Second))
+	seedEntityStateRow(t, db, uuid.NewString(), subjectID, "signal-search/run-1", "signal", "active", map[string]any{
+		"signal_strength": 80,
+		"processed":       false,
+		"status":          "new",
+	}, time.Now().UTC().Truncate(time.Second))
+
+	queryOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"entity_type": "signal-search.signal",
+		"filter":      `signal_strength >= 70 && processed == false`,
+		"select":      []string{"signal_strength", "processed"},
+		"limit":       10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities explicit target: %v", err)
+	}
+	queryResult, ok := queryOut.(map[string]any)
+	if !ok {
+		t.Fatalf("expected query result map, got %#v", queryOut)
+	}
+	queryRows, ok := queryResult["results"].([]map[string]any)
+	if !ok || len(queryRows) != 1 {
+		t.Fatalf("query results = %#v, want one signal row", queryResult["results"])
+	}
+	if got := fmt.Sprint(queryRows[0]["signal_strength"]); got != "80" {
+		t.Fatalf("signal_strength = %q, want 80", got)
+	}
+
+	searchOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"entity_type":   "signal-search.signal",
+		"current_state": "active",
+		"filter":        map[string]any{"processed": false},
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("search_entities explicit target: %v", err)
+	}
+	searchResult, ok := searchOut.(map[string]any)
+	if !ok {
+		t.Fatalf("expected search result map, got %#v", searchOut)
+	}
+	searchRows, ok := searchResult["results"].([]map[string]any)
+	if !ok || len(searchRows) != 1 {
+		t.Fatalf("search results = %#v, want one signal row", searchResult["results"])
+	}
+	if got := strings.TrimSpace(asString(searchRows[0]["entity_type"])); got != "signal" {
+		t.Fatalf("search entity_type = %q, want signal", got)
+	}
+
+	metricOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"entity_type": "signal-search.signal",
+		"metric":      "sum",
+		"field":       "signal_strength",
+		"filter":      `processed == false`,
+	})
+	if err != nil {
+		t.Fatalf("query_metrics explicit target: %v", err)
+	}
+	metricResult, ok := metricOut.(map[string]any)
+	if !ok {
+		t.Fatalf("expected metric result map, got %#v", metricOut)
+	}
+	if got := testNumericValue(metricResult["value"]); got != 80 {
+		t.Fatalf("metric value = %#v, want 80", metricResult["value"])
+	}
+}
+
+func TestEntityTools_ReadTargetValidationRejectsUndeclaredBeforeEval(t *testing.T) {
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"discovery": {
+			EntitiesYAML: `
+campaign:
+  status: text
+`,
+			AgentsYAML: entityToolAgentYAML(models.AgentConfig{ID: "researcher", Role: "researcher", Tools: []string{"query_entities", "query_metrics", "search_entities"}}),
+		},
+		"signal-search": {
+			EntitiesYAML: `
+signal:
+  signal_strength: integer
+  processed: boolean
+`,
+		},
+	})
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, models.AgentConfig{
+		ID:    "researcher",
+		Role:  "researcher",
+		Tools: []string{"query_entities", "query_metrics", "search_entities"},
+	}, bundle)
+
+	_, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"entity_type": "signal-search.signal",
+		"filter":      `signal_strenght >= 70`,
+	})
+	re, ok := runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected query_entities invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "signal_strenght") || !strings.Contains(err.Error(), "did you mean signal_strength?") {
+		t.Fatalf("expected nearest-match target diagnostic, got %v", err)
+	}
+
+	_, err = exec.Execute(ctx, "query_metrics", map[string]any{
+		"entity_type": "signal-search.signal",
+		"metric":      "sum",
+		"field":       "signal_strenght",
+	})
+	re, ok = runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected query_metrics invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "signal_strenght") {
+		t.Fatalf("expected target field diagnostic, got %v", err)
+	}
+
+	_, err = exec.Execute(ctx, "search_entities", map[string]any{
+		"entity_type": "signal-search.signal",
+		"filter":      map[string]any{"signal_strenght": 80},
+	})
+	re, ok = runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected search_entities invalid_tool_input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "signal_strenght") {
+		t.Fatalf("expected target object-filter field diagnostic, got %v", err)
+	}
+
+	_, err = exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `signal_strength >= 70`,
+	})
+	re, ok = runtimetools.AsRuntimeError(err)
+	if err == nil || !ok || re.Code != "invalid_tool_input" {
+		t.Fatalf("expected default actor contract to reject target-only field, got %v", err)
+	}
+}
+
 func TestEntityTools_GetSubjectStatusReturnsEmptyForUnknownSubject(t *testing.T) {
 	ctx, exec := newEntityToolTestExecutor(t)
 	subjectID := uuid.NewString()
@@ -1516,6 +1676,19 @@ func asString(v any) string {
 		return t
 	default:
 		return ""
+	}
+}
+
+func testNumericValue(v any) float64 {
+	switch n := v.(type) {
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case float64:
+		return n
+	default:
+		return 0
 	}
 }
 

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -25,9 +25,14 @@ func builtinRegisteredTools(source semanticview.Source, actor *models.AgentConfi
 }
 
 func builtinRuntimeContractSchemas(source semanticview.Source, actor *models.AgentConfig) map[string]ContractSchemaEntry {
-	out := genericEntityRuntimeContractSchemas()
+	readTargetSchema := entityReadTargetInputSchema(source)
+	out := genericEntityRuntimeContractSchemas(readTargetSchema)
 	if contract, ok := resolveEntityToolContract(source, actor); ok {
-		for name, entry := range entityToolSchemaEntriesForContract(contract) {
+		readContracts := entityruntime.ReadTargetContracts(source)
+		if len(readContracts) == 0 {
+			readContracts = []entityruntime.Contract{contract}
+		}
+		for name, entry := range entityToolSchemaEntriesForContract(contract, readContracts, readTargetSchema) {
 			out[name] = entry
 		}
 	}
@@ -46,7 +51,7 @@ func resolveEntityToolContract(source semanticview.Source, actor *models.AgentCo
 	return entityruntime.ResolveForFlow(source, "")
 }
 
-func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
+func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[string]ContractSchemaEntry {
 	anyValueSchema := map[string]any{}
 	return map[string]ContractSchemaEntry{
 		"get_entity": {
@@ -93,6 +98,7 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 			Category:    "entity_persistence",
 			Description: "Query entity_state rows using validated selectors and optional grouping.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"flow_instance": map[string]any{"type": "string"},
 				"filter":        map[string]any{"type": "string"},
 				"select": map[string]any{
@@ -107,6 +113,7 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 			Category:    "entity_persistence",
 			Description: "Query entity_state rows by state, metadata, and declared field matches.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"subject_id":    map[string]any{"type": "string"},
 				"flow_instance": map[string]any{"type": "string"},
 				"current_state": map[string]any{"type": "string"},
@@ -123,6 +130,7 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 			Category:    "entity_persistence",
 			Description: "Aggregate metrics across entity_state rows.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"flow_instance": map[string]any{"type": "string"},
 				"metric": map[string]any{
 					"type": "string",
@@ -136,18 +144,14 @@ func genericEntityRuntimeContractSchemas() map[string]ContractSchemaEntry {
 	}
 }
 
-func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[string]ContractSchemaEntry {
+func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readContracts []entityruntime.Contract, readTargetSchema map[string]any) map[string]ContractSchemaEntry {
 	topLevelFields := entityruntime.FieldNames(contract)
 	writablePaths := entityToolWritablePathNames(contract)
-	filterSelectors := entityToolLeafSelectorNames(contract)
-	selectableSelectors := entityToolSelectableFieldNames(contract)
+	filterSelectors := entityToolReadLeafSelectorNames(readContracts)
+	selectableSelectors := entityToolReadSelectableFieldNames(readContracts)
 	filterProperties := make(map[string]any, len(filterSelectors))
 	for _, name := range filterSelectors {
-		field, err := entityruntime.ResolveLeafField(contract, name)
-		if err != nil {
-			continue
-		}
-		filterProperties[name] = entityContractJSONSchema(contract, field.Type, map[string]struct{}{})
+		filterProperties[name] = entityToolReadFilterPropertySchema(readContracts, name)
 	}
 	fieldProperties := make(map[string]any, len(topLevelFields))
 	for _, name := range topLevelFields {
@@ -206,6 +210,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 			Category:    "entity_persistence",
 			Description: "Query entity_state rows by state, metadata, and declared field matches.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"subject_id":    map[string]any{"type": "string"},
 				"flow_instance": map[string]any{"type": "string"},
 				"current_state": map[string]any{"type": "string"},
@@ -222,6 +227,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 			Category:    "entity_persistence",
 			Description: "Query entity_state rows using validated selectors and optional grouping.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"flow_instance": map[string]any{"type": "string"},
 				"filter":        map[string]any{"type": "string"},
 				"select": map[string]any{
@@ -242,6 +248,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 			Category:    "entity_persistence",
 			Description: "Aggregate metrics across entity_state rows.",
 			InputSchema: ObjectSchema(map[string]any{
+				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"flow_instance": map[string]any{"type": "string"},
 				"metric": map[string]any{
 					"type": "string",
@@ -266,6 +273,66 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract) map[str
 			}, "subject_id"),
 		},
 	}
+}
+
+func entityReadTargetInputSchema(source semanticview.Source) map[string]any {
+	schema := map[string]any{
+		"type":        "string",
+		"description": "Optional read target entity contract. Use the delivered flow-qualified form, for example flow_id.entity_type; omitted defaults to the caller flow-owned entity contract.",
+	}
+	names := entityruntime.ReadTargetNames(source)
+	if len(names) > 0 {
+		enum := make([]any, 0, len(names))
+		for _, name := range names {
+			enum = append(enum, name)
+		}
+		schema["enum"] = enum
+	}
+	return schema
+}
+
+func entityToolReadSelectableFieldNames(contracts []entityruntime.Contract) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, contract := range contracts {
+		for _, name := range entityToolSelectableFieldNames(contract) {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func entityToolReadLeafSelectorNames(contracts []entityruntime.Contract) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, contract := range contracts {
+		for _, name := range entityToolLeafSelectorNames(contract) {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func entityToolReadFilterPropertySchema(contracts []entityruntime.Contract, name string) map[string]any {
+	name = strings.TrimSpace(name)
+	for _, contract := range contracts {
+		field, err := entityruntime.ResolveLeafField(contract, name)
+		if err != nil {
+			continue
+		}
+		return entityContractJSONSchema(contract, field.Type, map[string]struct{}{})
+	}
+	return map[string]any{}
 }
 
 func entityToolSelectableFieldNames(contract entityruntime.Contract) []string {


### PR DESCRIPTION
## Summary
- Adds explicit read-target resolution for `query_entities`, `query_metrics`, and `search_entities` via optional `entity_type`.
- Uses the selected contract for row scoping plus filter/select/group/metric/object-filter validation.
- Exposes readable entity targets in delivered tool schemas and keeps executor validation fail-closed against the selected target.

Closes #475

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `entity_tool_wave_1_contract.query_entities`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `platform_builtin_tools.query_entities`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `platform_builtin_tools.query_metrics`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `state_composition.cross_flow_writes.reads`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `entity_lifecycle_scoping`
- Issue #475 pre-audit comment `4314046520`, scope repair `4314116451`, gate approval `4314131379`

## Semantic Migration
- New canonical owner: `entityruntime.ResolveForReadTarget` for read-side target contract resolution, consumed through `entityToolSchemaForReadTarget`.
- Old path now invalid: `query_entities`, `query_metrics`, and `search_entities` may no longer infer only the caller actor flow contract when an explicit read target is supplied.
- Production paths checked for surviving old behavior: `execQueryEntities`, `execQueryMetrics`, `execSearchEntities`, delivered builtin schema generation, row-scope query construction, CEL selector validation, object-filter validation, select/group/metric validation.
- Migration completeness: complete for the approved #475 first-slice class; broader query/filter safety parent remains outside this PR.

## Proof
- `go test ./internal/runtime/entityruntime ./internal/runtime/tools -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec /Users/youmew/dev/swarm/worktrees/agent-d-475/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Code probe: `rg -n 'entityToolSchemaForActor\(|entityToolSchemaForReadTarget|ResolveForReadTarget|exec(QueryEntities|QueryMetrics|SearchEntities)|parseEntityFilter\(' internal/runtime/tools internal/runtime/entityruntime internal/runtime/llm`