### PR TITLE
[agent-d][issue #520] Enforce contract-derived run starts

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -34,7 +34,6 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
-	runtimerunstart "swarm/internal/runtime/runstart"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -319,20 +318,17 @@ type runStatusMutation struct {
 }
 
 type runStatusOptions struct {
-	LogsOnly        bool
-	LogsAllLevels   bool
-	Component       string
-	RootStartEvents []string
+	LogsOnly      bool
+	LogsAllLevels bool
+	Component     string
 }
 
 func runStatusCommand(ctx context.Context, repo string, args []string, out io.Writer) int {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
-	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
-	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	storeMode := fs.String("store", "postgres", "Store mode: postgres")
-	runID := fs.String("run-id", "", "Run ID to inspect; defaults to latest run started from a routable root input")
+	runID := fs.String("run-id", "", "Run ID to inspect; defaults to latest persisted run")
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	logsOnly := fs.Bool("logs", false, "Show runtime log-focused status output")
 	logsAll := fs.Bool("logs-all", false, "Include info-level runtime logs in status output")
@@ -376,22 +372,10 @@ func runStatusCommand(ctx context.Context, repo string, args []string, out io.Wr
 		}
 		return 1
 	}
-	rootStartEvents := []string(nil)
-	if strings.TrimSpace(*runID) == "" {
-		var err error
-		rootStartEvents, err = statusRootStartEvents(repo, *contractsPath, *platformSpecPath)
-		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "status failed: load root start inputs: %v\n", err)
-			}
-			return 1
-		}
-	}
 	report, err := loadRunStatusReport(ctx, stores.Postgres, strings.TrimSpace(*runID), runStatusOptions{
-		LogsOnly:        *logsOnly,
-		LogsAllLevels:   *logsAll,
-		Component:       strings.TrimSpace(*component),
-		RootStartEvents: rootStartEvents,
+		LogsOnly:      *logsOnly,
+		LogsAllLevels: *logsAll,
+		Component:     strings.TrimSpace(*component),
 	})
 	if err != nil {
 		if out != nil {
@@ -417,7 +401,7 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 		return runStatusReport{}, errors.New("postgres store is required")
 	}
 	if strings.TrimSpace(runID) == "" {
-		resolvedRunID, err := pg.ResolveLatestRunDebugRunID(ctx, opts.RootStartEvents)
+		resolvedRunID, err := pg.ResolveLatestRunDebugRunID(ctx)
 		if err != nil {
 			return runStatusReport{}, err
 		}
@@ -446,23 +430,6 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 	report.Heuristics = append([]string(nil), operational.Heuristics...)
 
 	return report, nil
-}
-
-func statusRootStartEvents(repoRoot, contractsPath, platformSpecPath string) ([]string, error) {
-	resolvedContractsPath := resolveContractsPath(repoRoot, contractsPath)
-	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
-	if err != nil {
-		return nil, err
-	}
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, contractsRoot, resolvePath(repoRoot, platformSpecPath))
-	if err != nil {
-		return nil, err
-	}
-	set, err := runtimerunstart.DeriveRootInputSet(semanticview.Wrap(bundle))
-	if err != nil {
-		return nil, err
-	}
-	return set.Routable, nil
 }
 
 func logLimitForStatus(opts runStatusOptions) int {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -34,6 +34,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerunstart "swarm/internal/runtime/runstart"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -318,17 +319,20 @@ type runStatusMutation struct {
 }
 
 type runStatusOptions struct {
-	LogsOnly      bool
-	LogsAllLevels bool
-	Component     string
+	LogsOnly        bool
+	LogsAllLevels   bool
+	Component       string
+	RootStartEvents []string
 }
 
 func runStatusCommand(ctx context.Context, repo string, args []string, out io.Writer) int {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
+	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
+	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	storeMode := fs.String("store", "postgres", "Store mode: postgres")
-	runID := fs.String("run-id", "", "Run ID to inspect; defaults to latest run with scan.requested")
+	runID := fs.String("run-id", "", "Run ID to inspect; defaults to latest run started from a routable root input")
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	logsOnly := fs.Bool("logs", false, "Show runtime log-focused status output")
 	logsAll := fs.Bool("logs-all", false, "Include info-level runtime logs in status output")
@@ -372,10 +376,22 @@ func runStatusCommand(ctx context.Context, repo string, args []string, out io.Wr
 		}
 		return 1
 	}
+	rootStartEvents := []string(nil)
+	if strings.TrimSpace(*runID) == "" {
+		var err error
+		rootStartEvents, err = statusRootStartEvents(repo, *contractsPath, *platformSpecPath)
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "status failed: load root start inputs: %v\n", err)
+			}
+			return 1
+		}
+	}
 	report, err := loadRunStatusReport(ctx, stores.Postgres, strings.TrimSpace(*runID), runStatusOptions{
-		LogsOnly:      *logsOnly,
-		LogsAllLevels: *logsAll,
-		Component:     strings.TrimSpace(*component),
+		LogsOnly:        *logsOnly,
+		LogsAllLevels:   *logsAll,
+		Component:       strings.TrimSpace(*component),
+		RootStartEvents: rootStartEvents,
 	})
 	if err != nil {
 		if out != nil {
@@ -401,7 +417,7 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 		return runStatusReport{}, errors.New("postgres store is required")
 	}
 	if strings.TrimSpace(runID) == "" {
-		resolvedRunID, err := pg.ResolveLatestRunDebugRunID(ctx)
+		resolvedRunID, err := pg.ResolveLatestRunDebugRunID(ctx, opts.RootStartEvents)
 		if err != nil {
 			return runStatusReport{}, err
 		}
@@ -430,6 +446,23 @@ func loadRunStatusReport(ctx context.Context, pg *store.PostgresStore, runID str
 	report.Heuristics = append([]string(nil), operational.Heuristics...)
 
 	return report, nil
+}
+
+func statusRootStartEvents(repoRoot, contractsPath, platformSpecPath string) ([]string, error) {
+	resolvedContractsPath := resolveContractsPath(repoRoot, contractsPath)
+	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, contractsRoot, resolvePath(repoRoot, platformSpecPath))
+	if err != nil {
+		return nil, err
+	}
+	set, err := runtimerunstart.DeriveRootInputSet(semanticview.Wrap(bundle))
+	if err != nil {
+		return nil, err
+	}
+	return set.Routable, nil
 }
 
 func logLimitForStatus(opts runStatusOptions) int {

--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	runtimecredentials "swarm/internal/runtime/credentials"
+	runtimerunstart "swarm/internal/runtime/runstart"
 )
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -102,6 +103,17 @@ func (h *handler) dispatchRPC(ctx context.Context, method string, params map[str
 			return nil, &RPCError{Code: -32602, Message: "run_id is required"}
 		}
 		inputs, _ := params["inputs"].(map[string]any)
+		if source := h.currentSemanticSource(); source != nil {
+			inputEvents := make([]string, 0, len(inputs))
+			for eventName := range inputs {
+				if strings.TrimSpace(eventName) != "" {
+					inputEvents = append(inputEvents, eventName)
+				}
+			}
+			if _, err := runtimerunstart.ValidateInputEvents(source, inputEvents); err != nil {
+				return nil, &RPCError{Code: -32602, Message: err.Error()}
+			}
+		}
 		breakpoints := asStringSlice(params["breakpoints"])
 		if err := h.runHub.startRun(ctx, runID, inputs, breakpoints); err != nil {
 			return nil, internalError(err)

--- a/internal/builder/handler_run_start_test.go
+++ b/internal/builder/handler_run_start_test.go
@@ -68,6 +68,48 @@ func TestHandlerRunStartRejectsUndeclaredInputBeforePublish(t *testing.T) {
 	}
 }
 
+func TestHandlerRunStartRejectsDeclaredUnroutableInputBeforePublish(t *testing.T) {
+	const eventName = "scan.unroutable_requested"
+	bundle := runStartInputBundle(eventName)
+	bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"] = runtimecontracts.SystemNodeContract{
+		ID:           "scan-orchestrator",
+		SubscribesTo: []string{"scan.other_requested"},
+	}
+	bundle.Nodes["scan-orchestrator"] = bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"]
+	source := semanticview.Wrap(bundle)
+	store := &runStartAppendStore{}
+	bus, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := NewHandler(Options{
+		AuthToken:      testBuilderAuthToken,
+		SemanticSource: source,
+		CurrentRuntime: func() *runtimepkg.Runtime {
+			return &runtimepkg.Runtime{Bus: bus}
+		},
+	})
+
+	resp := callBuilderRPCRaw(t, handler, Request{
+		JSONRPC: "2.0",
+		ID:      "reject-unroutable",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": "run-123",
+			"inputs": map[string]any{
+				eventName: map[string]any{"topic": "declared-but-unroutable"},
+			},
+		},
+	})
+
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Fatalf("rpc error = %+v, want invalid params", resp.Error)
+	}
+	if len(store.appended) != 0 {
+		t.Fatalf("published events = %#v, want none before invalid input failure", store.appended)
+	}
+}
+
 func TestHandlerRunStartAcceptsDeclaredRoutableInput(t *testing.T) {
 	const eventName = "scan.corpus_file_requested"
 	source := semanticview.Wrap(runStartInputBundle(eventName))

--- a/internal/builder/handler_run_start_test.go
+++ b/internal/builder/handler_run_start_test.go
@@ -1,0 +1,160 @@
+package builder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"swarm/internal/events"
+	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	"swarm/internal/runtime/semanticview"
+)
+
+type runStartAppendStore struct {
+	appended []string
+}
+
+func (s *runStartAppendStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.appended = append(s.appended, string(evt.Type))
+	return nil
+}
+
+func (*runStartAppendStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (*runStartAppendStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func TestHandlerRunStartRejectsUndeclaredInputBeforePublish(t *testing.T) {
+	source := semanticview.Wrap(runStartInputBundle("scan.corpus_file_requested"))
+	store := &runStartAppendStore{}
+	bus, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := NewHandler(Options{
+		AuthToken:      testBuilderAuthToken,
+		SemanticSource: source,
+		CurrentRuntime: func() *runtimepkg.Runtime {
+			return &runtimepkg.Runtime{Bus: bus}
+		},
+	})
+
+	resp := callBuilderRPCRaw(t, handler, Request{
+		JSONRPC: "2.0",
+		ID:      "reject",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": "run-123",
+			"inputs": map[string]any{
+				"scan.requested": map[string]any{"topic": "stale"},
+			},
+		},
+	})
+
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Fatalf("rpc error = %+v, want invalid params", resp.Error)
+	}
+	if len(store.appended) != 0 {
+		t.Fatalf("published events = %#v, want none before invalid input failure", store.appended)
+	}
+}
+
+func TestHandlerRunStartAcceptsDeclaredRoutableInput(t *testing.T) {
+	const eventName = "scan.corpus_file_requested"
+	source := semanticview.Wrap(runStartInputBundle(eventName))
+	store := &runStartAppendStore{}
+	bus, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := NewHandler(Options{
+		AuthToken:      testBuilderAuthToken,
+		SemanticSource: source,
+		CurrentRuntime: func() *runtimepkg.Runtime {
+			return &runtimepkg.Runtime{Bus: bus}
+		},
+	})
+
+	resp := callBuilderRPCRaw(t, handler, Request{
+		JSONRPC: "2.0",
+		ID:      "accept",
+		Method:  "run.start",
+		Params: map[string]any{
+			"run_id": "run-123",
+			"inputs": map[string]any{
+				eventName: map[string]any{"request": map[string]any{"geography": "US"}},
+			},
+		},
+	})
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected rpc error %+v", resp.Error)
+	}
+	if len(store.appended) != 1 || store.appended[0] != eventName {
+		t.Fatalf("published events = %#v, want %s", store.appended, eventName)
+	}
+}
+
+func callBuilderRPCRaw(t *testing.T, handler http.Handler, req Request) RPCResponse {
+	t.Helper()
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewReader(raw))
+	httpReq.Header.Set("Authorization", "Bearer "+testBuilderAuthToken)
+	handler.ServeHTTP(rec, httpReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func runStartInputBundle(eventName string) *runtimecontracts.WorkflowContractBundle {
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "discovery", Flow: "discovery"},
+		Path:  "discovery",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": {
+				ID:           "scan-orchestrator",
+				SubscribesTo: []string{eventName},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	return &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": flow.Nodes["scan-orchestrator"],
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"discovery": &root.Children[0],
+			},
+		},
+	}
+}

--- a/internal/runtime/runstart/root_inputs.go
+++ b/internal/runtime/runstart/root_inputs.go
@@ -1,0 +1,125 @@
+package runstart
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimebus "swarm/internal/runtime/bus"
+	"swarm/internal/runtime/semanticview"
+)
+
+type RootInputSet struct {
+	Declared []string
+	Routable []string
+}
+
+func DeriveRootInputSet(source semanticview.Source) (RootInputSet, error) {
+	if source == nil {
+		return RootInputSet{}, fmt.Errorf("semantic source is required")
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil || bundle.RootSchema == nil {
+		return RootInputSet{}, fmt.Errorf("root schema is required")
+	}
+	declared := normalizeUnique(bundle.RootSchema.Pins.Inputs.Events)
+	routeTable, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		return RootInputSet{}, err
+	}
+	routable := make([]string, 0, len(declared))
+	for _, eventType := range declared {
+		if len(routeTable.Resolve(eventType)) > 0 || rootInputConsumedByFlow(source, eventType) {
+			routable = append(routable, eventType)
+		}
+	}
+	return RootInputSet{Declared: declared, Routable: routable}, nil
+}
+
+func ValidateInputEvents(source semanticview.Source, inputEvents []string) (RootInputSet, error) {
+	inputEvents = normalizeUnique(inputEvents)
+	if len(inputEvents) == 0 {
+		return RootInputSet{}, nil
+	}
+	set, err := DeriveRootInputSet(source)
+	if err != nil {
+		return set, err
+	}
+	declared := stringSet(set.Declared)
+	routable := stringSet(set.Routable)
+	for _, eventType := range inputEvents {
+		if _, ok := declared[eventType]; !ok {
+			return set, fmt.Errorf("run.start input %q is not declared in root input pins; declared root inputs: %s", eventType, strings.Join(set.Declared, ", "))
+		}
+		if _, ok := routable[eventType]; !ok {
+			return set, fmt.Errorf("run.start input %q is declared but has no runtime route; routable root inputs: %s", eventType, strings.Join(set.Routable, ", "))
+		}
+	}
+	return set, nil
+}
+
+func normalizeUnique(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func rootInputConsumedByFlow(source semanticview.Source, eventType string) bool {
+	eventType = strings.TrimSpace(eventType)
+	if source == nil || eventType == "" {
+		return false
+	}
+	for _, scope := range source.FlowScopes() {
+		if !containsString(scope.InputEvents, eventType) {
+			continue
+		}
+		for _, node := range scope.Nodes {
+			nodeID := strings.TrimSpace(node.ID)
+			if nodeID == "" {
+				continue
+			}
+			if containsString(source.NodeRuntimeSubscriptions(nodeID), eventType) {
+				return true
+			}
+		}
+		for _, agent := range scope.Agents {
+			if containsString(agent.Subscriptions, eventType) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsString(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	for _, value := range values {
+		if strings.TrimSpace(value) == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/runstart/root_inputs_test.go
+++ b/internal/runtime/runstart/root_inputs_test.go
@@ -25,6 +25,20 @@ func TestDeriveRootInputSetRequiresDeclaredAndRoutableRootInput(t *testing.T) {
 	}
 }
 
+func TestValidateInputEventsRejectsDeclaredUnroutableRootInput(t *testing.T) {
+	const eventName = "scan.unroutable_requested"
+	bundle := rootInputTestBundle(eventName)
+	bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"] = runtimecontracts.SystemNodeContract{
+		ID:           "scan-orchestrator",
+		SubscribesTo: []string{"scan.other_requested"},
+	}
+	bundle.Nodes["scan-orchestrator"] = bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"]
+
+	if _, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{eventName}); err == nil {
+		t.Fatal("expected declared but unroutable root input to fail")
+	}
+}
+
 func rootInputTestBundle(eventName string) *runtimecontracts.WorkflowContractBundle {
 	flow := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "discovery", Flow: "discovery"},

--- a/internal/runtime/runstart/root_inputs_test.go
+++ b/internal/runtime/runstart/root_inputs_test.go
@@ -1,0 +1,61 @@
+package runstart
+
+import (
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestDeriveRootInputSetRequiresDeclaredAndRoutableRootInput(t *testing.T) {
+	bundle := rootInputTestBundle("scan.corpus_file_requested")
+	set, err := DeriveRootInputSet(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("DeriveRootInputSet: %v", err)
+	}
+	if got, want := set.Declared, []string{"scan.corpus_file_requested"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("declared = %#v, want %#v", got, want)
+	}
+	if got, want := set.Routable, []string{"scan.corpus_file_requested"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("routable = %#v, want %#v", got, want)
+	}
+	if _, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{"scan.requested"}); err == nil {
+		t.Fatal("expected retired undeclared root input to fail")
+	}
+}
+
+func rootInputTestBundle(eventName string) *runtimecontracts.WorkflowContractBundle {
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "discovery", Flow: "discovery"},
+		Path:  "discovery",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": {
+				ID:           "scan-orchestrator",
+				SubscribesTo: []string{eventName},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	return &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": flow.Nodes["scan-orchestrator"],
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"discovery": &root.Children[0],
+			},
+		},
+	}
+}

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -230,27 +229,25 @@ func (s *PostgresStore) requireRunDebugCapabilities(ctx context.Context) error {
 	return RequireCanonicalRunDebugCapabilities(caps, catalog)
 }
 
-func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context, rootStartEvents []string) (string, error) {
+func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context) (string, error) {
 	if s == nil || s.DB == nil {
 		return "", fmt.Errorf("postgres store is required")
 	}
 	if err := s.requireRunDebugCapabilities(ctx); err != nil {
 		return "", err
 	}
-	rootStartEvents = normalizeRunDebugRootStartEvents(rootStartEvents)
-	if len(rootStartEvents) == 0 {
-		return "", fmt.Errorf("no routable root start inputs configured")
-	}
 	var runID string
 	if err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(run_id::text, '')
-		FROM events
-		WHERE event_name = ANY($1)
-		  AND run_id IS NOT NULL
-		  AND produced_by = 'builder'
-		ORDER BY created_at DESC
+		SELECT r.run_id::text
+		FROM runs r
+		WHERE EXISTS (
+			SELECT 1
+			FROM events e
+			WHERE e.run_id = r.run_id
+		)
+		ORDER BY r.started_at DESC, r.run_id DESC
 		LIMIT 1
-	`, pq.Array(rootStartEvents)).Scan(&runID); err != nil {
+	`).Scan(&runID); err != nil {
 		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("no current run found")
 		}
@@ -261,24 +258,6 @@ func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context, rootStar
 		return "", fmt.Errorf("no current run found")
 	}
 	return runID, nil
-}
-
-func normalizeRunDebugRootStartEvents(values []string) []string {
-	seen := map[string]struct{}{}
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunDebugRunSummary, error) {

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -229,22 +230,27 @@ func (s *PostgresStore) requireRunDebugCapabilities(ctx context.Context) error {
 	return RequireCanonicalRunDebugCapabilities(caps, catalog)
 }
 
-func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context) (string, error) {
+func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context, rootStartEvents []string) (string, error) {
 	if s == nil || s.DB == nil {
 		return "", fmt.Errorf("postgres store is required")
 	}
 	if err := s.requireRunDebugCapabilities(ctx); err != nil {
 		return "", err
 	}
+	rootStartEvents = normalizeRunDebugRootStartEvents(rootStartEvents)
+	if len(rootStartEvents) == 0 {
+		return "", fmt.Errorf("no routable root start inputs configured")
+	}
 	var runID string
 	if err := s.DB.QueryRowContext(ctx, `
 		SELECT COALESCE(run_id::text, '')
 		FROM events
-		WHERE event_name = 'scan.requested'
+		WHERE event_name = ANY($1)
 		  AND run_id IS NOT NULL
+		  AND produced_by = 'builder'
 		ORDER BY created_at DESC
 		LIMIT 1
-	`).Scan(&runID); err != nil {
+	`, pq.Array(rootStartEvents)).Scan(&runID); err != nil {
 		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("no current run found")
 		}
@@ -255,6 +261,24 @@ func (s *PostgresStore) ResolveLatestRunDebugRunID(ctx context.Context) (string,
 		return "", fmt.Errorf("no current run found")
 	}
 	return runID, nil
+}
+
+func normalizeRunDebugRootStartEvents(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunDebugRunSummary, error) {

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -84,6 +84,44 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 	}
 }
 
+func TestRunDebugReadSurface_ResolveLatestRunDebugRunID_UsesConfiguredBuilderRootInputs(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	targetRunID := uuid.NewString()
+	retiredRunID := uuid.NewString()
+	nonBuilderRunID := uuid.NewString()
+	now := time.Unix(1700000000, 0).UTC()
+	for _, runID := range []string{targetRunID, retiredRunID, nonBuilderRunID} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES ($1::uuid, 'running', $2)
+		`, runID, now); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, gen_random_uuid(), 'scan.corpus_file_requested', 'global', '{}'::jsonb, 'builder', 'agent', $4),
+			($2::uuid, gen_random_uuid(), 'scan.requested', 'global', '{}'::jsonb, 'builder', 'agent', $5),
+			($3::uuid, gen_random_uuid(), 'system.directive', 'global', '{}'::jsonb, 'operator', 'agent', $6)
+	`, targetRunID, retiredRunID, nonBuilderRunID, now.Add(-3*time.Minute), now.Add(-2*time.Minute), now.Add(-1*time.Minute)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	got, err := pg.ResolveLatestRunDebugRunID(ctx, []string{"scan.corpus_file_requested", "system.directive"})
+	if err != nil {
+		t.Fatalf("ResolveLatestRunDebugRunID: %v", err)
+	}
+	if got != targetRunID {
+		t.Fatalf("latest run = %q, want %q", got, targetRunID)
+	}
+}
+
 func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMutations(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -84,36 +84,36 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 	}
 }
 
-func TestRunDebugReadSurface_ResolveLatestRunDebugRunID_UsesConfiguredBuilderRootInputs(t *testing.T) {
+func TestRunDebugReadSurface_ResolveLatestRunDebugRunID_UsesLatestPersistedRun(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
 	targetRunID := uuid.NewString()
-	retiredRunID := uuid.NewString()
-	nonBuilderRunID := uuid.NewString()
+	olderRunID := uuid.NewString()
+	emptyRunID := uuid.NewString()
 	now := time.Unix(1700000000, 0).UTC()
-	for _, runID := range []string{targetRunID, retiredRunID, nonBuilderRunID} {
-		if _, err := db.ExecContext(ctx, `
-			INSERT INTO runs (run_id, status, started_at)
-			VALUES ($1::uuid, 'running', $2)
-		`, runID, now); err != nil {
-			t.Fatalf("seed run %s: %v", runID, err)
-		}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES
+			($1::uuid, 'running', $4),
+			($2::uuid, 'completed', $5),
+			($3::uuid, 'running', $6)
+	`, targetRunID, olderRunID, emptyRunID, now, now.Add(-1*time.Hour), now.Add(1*time.Hour)); err != nil {
+		t.Fatalf("seed runs: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
 		)
 		VALUES
-			($1::uuid, gen_random_uuid(), 'scan.corpus_file_requested', 'global', '{}'::jsonb, 'builder', 'agent', $4),
-			($2::uuid, gen_random_uuid(), 'scan.requested', 'global', '{}'::jsonb, 'builder', 'agent', $5),
-			($3::uuid, gen_random_uuid(), 'system.directive', 'global', '{}'::jsonb, 'operator', 'agent', $6)
-	`, targetRunID, retiredRunID, nonBuilderRunID, now.Add(-3*time.Minute), now.Add(-2*time.Minute), now.Add(-1*time.Minute)); err != nil {
+			($1::uuid, gen_random_uuid(), 'scan.corpus_file_requested', 'global', '{}'::jsonb, 'builder', 'agent', $3),
+			($2::uuid, gen_random_uuid(), 'scan.requested', 'global', '{}'::jsonb, 'builder', 'agent', $4)
+	`, targetRunID, olderRunID, now.Add(time.Second), now.Add(-59*time.Minute)); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
 
-	got, err := pg.ResolveLatestRunDebugRunID(ctx, []string{"scan.corpus_file_requested", "system.directive"})
+	got, err := pg.ResolveLatestRunDebugRunID(ctx)
 	if err != nil {
 		t.Fatalf("ResolveLatestRunDebugRunID: %v", err)
 	}

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -30,8 +30,9 @@ START_TIMEOUT="${START_TIMEOUT:-60}"
 DIRECTIVE_AGENT="${DIRECTIVE_AGENT:-}"
 DIRECTIVE_MESSAGE="${DIRECTIVE_MESSAGE:-}"
 CORPUS_PATH="${CORPUS_PATH:-/data/test-signals-25.jsonl}"
-CORPUS_MODE="${CORPUS_MODE:-corpus}"
 CORPUS_GEOGRAPHY="${CORPUS_GEOGRAPHY:-US}"
+RUN_CLEAR_INPUT_EVENT="${RUN_CLEAR_INPUT_EVENT:-scan.corpus_file_requested}"
+RUN_CLEAR_INPUT_PAYLOAD_JSON="${RUN_CLEAR_INPUT_PAYLOAD_JSON:-}"
 SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 if [[ -n "${SWARM_TOOL_GATEWAY_URL:-}" && -n "${SWARM_TOOL_GATEWAY_CONTAINER_URL:-}" ]]; then
@@ -217,10 +218,18 @@ echo "Swarm ready at http://${HOST_HTTP_ADDR}"
 
 run_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 echo "Starting default corpus run ${run_id}..."
+if [[ -z "${RUN_CLEAR_INPUT_PAYLOAD_JSON}" ]]; then
+  if [[ "${RUN_CLEAR_INPUT_EVENT}" != "scan.corpus_file_requested" ]]; then
+    echo "RUN_CLEAR_INPUT_PAYLOAD_JSON is required when RUN_CLEAR_INPUT_EVENT is ${RUN_CLEAR_INPUT_EVENT}"
+    exit 1
+  fi
+  RUN_CLEAR_INPUT_PAYLOAD_JSON="$(ruby -rjson -e 'print JSON.generate({request: {geography: ARGV[0]}, corpus_path: ARGV[1]})' "${CORPUS_GEOGRAPHY}" "${CORPUS_PATH}")"
+fi
+run_start_body="$(ruby -rjson -e 'print JSON.generate({jsonrpc: "2.0", id: "run-clear", method: "run.start", params: {run_id: ARGV[0], inputs: {ARGV[1] => JSON.parse(ARGV[2])}}})' "${run_id}" "${RUN_CLEAR_INPUT_EVENT}" "${RUN_CLEAR_INPUT_PAYLOAD_JSON}")"
 run_response="$(curl -sS "http://${HOST_HTTP_ADDR}/api/rpc" \
   -H 'content-type: application/json' \
   -H "Authorization: Bearer ${SWARM_BUILDER_AUTH_TOKEN}" \
-  --data-binary "{\"jsonrpc\":\"2.0\",\"id\":\"run-clear\",\"method\":\"run.start\",\"params\":{\"run_id\":\"${run_id}\",\"inputs\":{\"scan.requested\":{\"mode\":\"${CORPUS_MODE}\",\"geography\":\"${CORPUS_GEOGRAPHY}\",\"corpus_path\":\"${CORPUS_PATH}\"}}}}")"
+  --data-binary "${run_start_body}")"
 echo "${run_response}"
 if ! grep -q '"status":"started"' <<<"${run_response}"; then
   echo "Corpus run failed to start. Current log:"

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -50,6 +50,18 @@ func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
 	if !strings.Contains(result.rpcBody, `"method":"run.start"`) {
 		t.Fatalf("rpc body = %q, want run.start request", result.rpcBody)
 	}
+	if !strings.Contains(result.rpcBody, `"scan.corpus_file_requested"`) {
+		t.Fatalf("rpc body = %q, want typed corpus root input", result.rpcBody)
+	}
+	if strings.Contains(result.rpcBody, `"scan.requested"`) {
+		t.Fatalf("rpc body = %q, want no retired scan.requested input", result.rpcBody)
+	}
+	if !strings.Contains(result.rpcBody, `"request":{"geography":"US"}`) {
+		t.Fatalf("rpc body = %q, want typed request geography", result.rpcBody)
+	}
+	if !strings.Contains(result.rpcBody, `"corpus_path":"/data/test-signals-25.jsonl"`) {
+		t.Fatalf("rpc body = %q, want corpus_path payload", result.rpcBody)
+	}
 	if !strings.Contains(result.stdout, `"status":"started"`) {
 		t.Fatalf("stdout = %q, want started response", result.stdout)
 	}
@@ -471,6 +483,8 @@ printf '{}'
 		"SWARM_BUILDER_AUTH_TOKEN",
 		"SWARM_TOOL_GATEWAY_URL",
 		"SWARM_TOOL_GATEWAY_CONTAINER_URL",
+		"RUN_CLEAR_INPUT_EVENT",
+		"RUN_CLEAR_INPUT_PAYLOAD_JSON",
 	), []string{
 		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"PYTHON_OPERATOR_TOKEN_SINK=" + operatorTokenSink,


### PR DESCRIPTION
## Summary

Closes #520.

This PR closes the widened #520 root-start input class across the approved surfaces:
- `run-clear` now emits a current typed corpus root input instead of retired `scan.requested`.
- `run.start` validates supplied inputs against the loaded contract-derived declared/routable root-input interface before publishing.
- `cmd/swarm status` and latest-run lookup no longer use hard-coded `scan.requested`; implicit status now selects the latest persisted run and reports its first emitted event as the root event.

## Governing refs / context

Binding refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- #520 repaired pre-audit and approved gate
- #401 supported-path reassessment that extracted #520

Relevant spec context:
- `engine.event_identity.cross_flow_routing.root_events`
- `workflow_contracts.workflow_boot.validate_pins`
- `contract_formats.workflow.schema.pins`
- `verify_checks.flow_input_producer_coverage`
- `docs/specs/swarm-platform/platform/BUILDER-API.md#run.start` as adjacent RPC shape context

Semantic migration:
- New canonical owner for admission: loaded bundle root `schema.yaml` `pins.inputs.events` plus contract-derived root-input routability.
- Status/read-side root event source: canonical persisted run selected from `runs`; root event is the first persisted event for that run, which `LoadRunDebugReport` already reports.
- Old producer / reader path now invalid: `scripts/run_clear.sh` emitted retired `scan.requested`; status help and latest-run lookup treated `scan.requested` as canonical.
- Production paths checked: `scripts`, `cmd`, and `internal` production/support residue sweep for `scan.requested`.
- Migration complete for the approved #520 surfaces.

## Proof

- `go test ./internal/runtime/runstart ./internal/builder ./internal/store ./cmd/swarm ./scripts ./internal/dashboard/server -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `set -a; source /Users/youmew/dev/swarm/.env; set +a; make run-clear`
- `go run ./cmd/swarm status --json` resolved the latest run without contract flags and reported `root_event_type: scan.corpus_file_requested`.
- DB proof after `make run-clear`: `scan.requested` count `0`, `scan.corpus_file_requested` count `1`, discovery event `discovery/market_research.corpus_file_assigned` present.
- Production/support residue: `rg -n "scan\.requested" scripts cmd internal -S --glob '!**/*_test.go'` returned no matches.