### PR TITLE
[agent-d][issue #522] Validate generated emit tool schemas

### DIFF
--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -111,7 +111,7 @@ func normalizeEventFieldType(raw string) (string, string) {
 	if raw == "" {
 		return "", ""
 	}
-	for _, base := range []string{"string", "integer", "number", "boolean", "object", "array"} {
+	for _, base := range []string{"string", "integer", "number", "numeric", "boolean", "object", "array"} {
 		if raw == base {
 			return base, ""
 		}
@@ -119,10 +119,33 @@ func normalizeEventFieldType(raw string) (string, string) {
 			desc := strings.TrimSpace(strings.TrimPrefix(raw, base))
 			desc = strings.TrimLeft(desc, " -:\t")
 			desc = strings.TrimSpace(strings.Trim(desc, "()"))
+			if base == "numeric" && isNumericPrecisionModifier(desc) {
+				return base, ""
+			}
 			return base, desc
 		}
 	}
 	return raw, ""
+}
+
+func isNumericPrecisionModifier(value string) bool {
+	left, right, ok := strings.Cut(strings.TrimSpace(value), ",")
+	if !ok {
+		return false
+	}
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	for _, part := range []string{left, right} {
+		for _, ch := range part {
+			if ch < '0' || ch > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func appendEventSchemas(out map[string]EventSchema, bundle *WorkflowContractBundle, flowID string, entries map[string]EventCatalogEntry, types TypeCatalogDocument) {
@@ -399,7 +422,7 @@ func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen 
 	if isEventListType(typeRef) {
 		return map[string]any{
 			"type":  "array",
-			"items": eventSchemaForResolvedType(eventListItemType(typeRef), types, seen),
+			"items": eventSchemaForTypeRefSchema(eventListItemType(typeRef), types, seen),
 		}
 	}
 	if enumName, ok := eventEnumTypeName(types, typeRef); ok {
@@ -435,7 +458,7 @@ func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen 
 				continue
 			}
 			spec := named.Fields[fieldName]
-			props[fieldName] = eventSchemaForResolvedType(spec.Type, types, seen)
+			props[fieldName] = eventSchemaForTypeRefSchema(spec.Type, types, seen)
 			required = append(required, fieldName)
 		}
 		return map[string]any{
@@ -473,6 +496,11 @@ func eventTypeName(types TypeCatalogDocument, typeRef string) string {
 		return strings.TrimSpace(scalar.Base)
 	}
 	return typeRef
+}
+
+func eventSchemaForTypeRefSchema(raw string, types TypeCatalogDocument, seen map[string]struct{}) map[string]any {
+	schema, _ := eventSchemaForTypeRef(raw, types, seen)
+	return schema
 }
 
 func eventNamedTypeName(types TypeCatalogDocument, typeRef string) (string, bool) {

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -37,6 +37,45 @@ func TestEventSchemaRegistryFromCatalog_NormalizesAnnotatedFieldTypes(t *testing
 	}
 }
 
+func TestEventSchemaRegistryFromCatalog_NormalizesPrecisionQualifiedTypeRefsRecursively(t *testing.T) {
+	schema := eventSchemaFromCatalogEntry("category.assessed", EventCatalogEntry{
+		Payload: EventPayloadSpec{
+			Properties: map[string]EventFieldSpec{
+				"score":        {Type: "numeric(5,2)"},
+				"capabilities": {Type: "RequiredCapabilities"},
+				"history":      {Type: "[RequiredCapabilities]"},
+			},
+		},
+	}, TypeCatalogDocument{
+		Types: map[string]NamedTypeDecl{
+			"RequiredCapabilities": {
+				Fields: map[string]TypeFieldSpec{
+					"automation_with_unlock": {Type: "numeric(5,2)"},
+				},
+			},
+		},
+	})
+
+	props, _ := schema.Schema["properties"].(map[string]any)
+	score, _ := props["score"].(map[string]any)
+	if got := score["type"]; got != "number" {
+		t.Fatalf("score type = %#v, want number", got)
+	}
+	capabilities, _ := props["capabilities"].(map[string]any)
+	capabilityProps, _ := capabilities["properties"].(map[string]any)
+	automation, _ := capabilityProps["automation_with_unlock"].(map[string]any)
+	if got := automation["type"]; got != "number" {
+		t.Fatalf("nested automation type = %#v, want number", got)
+	}
+	history, _ := props["history"].(map[string]any)
+	items, _ := history["items"].(map[string]any)
+	itemProps, _ := items["properties"].(map[string]any)
+	itemAutomation, _ := itemProps["automation_with_unlock"].(map[string]any)
+	if got := itemAutomation["type"]; got != "number" {
+		t.Fatalf("list item automation type = %#v, want number", got)
+	}
+}
+
 func TestEventSchemaRegistryFromBundle_PreservesWave1TypeMeaning(t *testing.T) {
 	reviewFlow := FlowContractView{
 		Paths: FlowContractPaths{ID: "review", Flow: "review"},

--- a/internal/runtime/llm/provider_tool_schema.go
+++ b/internal/runtime/llm/provider_tool_schema.go
@@ -1,0 +1,140 @@
+package llm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var providerJSONSchemaTypes = map[string]struct{}{
+	"array":   {},
+	"boolean": {},
+	"integer": {},
+	"null":    {},
+	"number":  {},
+	"object":  {},
+	"string":  {},
+}
+
+// ValidateProviderToolSchema validates the JSON Schema subset this runtime
+// generates for provider-facing tool input schemas. Providers reject unknown
+// JSON Schema type values before agent execution starts, so verify must catch
+// those recursively instead of relying on payload validation.
+func ValidateProviderToolSchema(toolName string, schema any) error {
+	path := strings.TrimSpace(toolName)
+	if path == "" {
+		path = "tool"
+	}
+	if err := validateProviderSchemaNode(schema, path+".input_schema"); err != nil {
+		return fmt.Errorf("provider tool schema %s: %w", path, err)
+	}
+	return nil
+}
+
+func ValidateProviderToolDefinitions(tools []ToolDefinition) error {
+	for _, tool := range tools {
+		if err := ValidateProviderToolSchema(tool.Name, tool.Schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProviderSchemaNode(schema any, path string) error {
+	if schema == nil {
+		return nil
+	}
+	obj, ok := schema.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must be a JSON object schema, got %T", path, schema)
+	}
+	if rawType, ok := obj["type"]; ok {
+		if err := validateProviderSchemaType(rawType, path+".type"); err != nil {
+			return err
+		}
+	}
+	if rawProperties, ok := obj["properties"]; ok {
+		props, ok := rawProperties.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.properties must be an object, got %T", path, rawProperties)
+		}
+		names := make([]string, 0, len(props))
+		for name := range props {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if err := validateProviderSchemaNode(props[name], path+".properties."+name); err != nil {
+				return err
+			}
+		}
+	}
+	if rawItems, ok := obj["items"]; ok {
+		if err := validateProviderSchemaNode(rawItems, path+".items"); err != nil {
+			return err
+		}
+	}
+	if rawAdditional, ok := obj["additionalProperties"]; ok {
+		switch additional := rawAdditional.(type) {
+		case bool:
+		case map[string]any:
+			if err := validateProviderSchemaNode(additional, path+".additionalProperties"); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%s.additionalProperties must be boolean or object schema, got %T", path, rawAdditional)
+		}
+	}
+	if rawRequired, ok := obj["required"]; ok {
+		if err := validateProviderRequired(rawRequired, path+".required"); err != nil {
+			return err
+		}
+	}
+	if rawEnum, ok := obj["enum"]; ok {
+		if _, ok := rawEnum.([]any); !ok {
+			return fmt.Errorf("%s.enum must be an array, got %T", path, rawEnum)
+		}
+	}
+	return nil
+}
+
+func validateProviderSchemaType(raw any, path string) error {
+	switch value := raw.(type) {
+	case string:
+		value = strings.TrimSpace(value)
+		if _, ok := providerJSONSchemaTypes[value]; !ok {
+			return fmt.Errorf("%s has unsupported JSON Schema type %q", path, value)
+		}
+	case []any:
+		for i, item := range value {
+			if err := validateProviderSchemaType(item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	case []string:
+		for i, item := range value {
+			if err := validateProviderSchemaType(item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("%s must be a string or string array, got %T", path, raw)
+	}
+	return nil
+}
+
+func validateProviderRequired(raw any, path string) error {
+	switch values := raw.(type) {
+	case []string:
+		return nil
+	case []any:
+		for i, value := range values {
+			if _, ok := value.(string); !ok {
+				return fmt.Errorf("%s[%d] must be a string, got %T", path, i, value)
+			}
+		}
+	default:
+		return fmt.Errorf("%s must be an array, got %T", path, raw)
+	}
+	return nil
+}

--- a/internal/runtime/llm/provider_tool_schema_test.go
+++ b/internal/runtime/llm/provider_tool_schema_test.go
@@ -1,0 +1,57 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderToolSchemaRejectsUnsupportedNestedType(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"capabilities": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"automation_with_unlock": map[string]any{
+						"type": "numeric(5,2)",
+					},
+				},
+			},
+		},
+	}
+
+	err := ValidateProviderToolSchema("emit_category_assessed", schema)
+	if err == nil {
+		t.Fatal("ValidateProviderToolSchema returned nil, want unsupported type error")
+	}
+	for _, want := range []string{
+		"emit_category_assessed.input_schema.properties.capabilities.properties.automation_with_unlock.type",
+		"numeric(5,2)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestValidateProviderToolSchemaChecksArrayItems(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"history": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "numeric(10,2)",
+				},
+			},
+		},
+	}
+
+	err := ValidateProviderToolSchema("emit_spend_request", schema)
+	if err == nil {
+		t.Fatal("ValidateProviderToolSchema returned nil, want unsupported item type error")
+	}
+	if !strings.Contains(err.Error(), "emit_spend_request.input_schema.properties.history.items.type") {
+		t.Fatalf("error = %q, want item path", err)
+	}
+}

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -239,6 +240,113 @@ func (r *EmitRegistry) GeneratedEmitSchemasForAgentRoles() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func ValidateGeneratedEmitToolSchemasForSource(source semanticview.Source) []error {
+	if source == nil {
+		return nil
+	}
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+	var errs []error
+	for _, actor := range providerSchemaValidationActors(source) {
+		for _, tool := range registry.GenerateEmitToolsForActor(actor, nil) {
+			if err := llm.ValidateProviderToolSchema(tool.Name, tool.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("agent %s: %w", strings.TrimSpace(actor.ID), err))
+			}
+		}
+	}
+	return errs
+}
+
+func providerSchemaValidationActors(source semanticview.Source) []models.AgentConfig {
+	if source == nil {
+		return nil
+	}
+	var actors []models.AgentConfig
+	seen := map[string]struct{}{}
+	appendActor := func(actor models.AgentConfig) {
+		key := strings.Join([]string{
+			strings.TrimSpace(actor.ID),
+			strings.TrimSpace(actor.Role),
+			strings.TrimSpace(actor.Mode),
+			strings.Join(UniqueNonEmpty(actor.EmitEvents), ","),
+		}, "|")
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		actors = append(actors, actor)
+	}
+	for _, scope := range source.ProjectScopes() {
+		for _, id := range sortedEmitSchemaAgentIDs(scope.Agents) {
+			entry := scope.Agents[id]
+			appendActor(models.AgentConfig{
+				ID:               strings.TrimSpace(id),
+				Type:             strings.TrimSpace(entry.Type),
+				Role:             strings.TrimSpace(entry.Role),
+				ModelTier:        strings.TrimSpace(entry.ModelTier),
+				ConversationMode: strings.TrimSpace(entry.ConversationMode),
+				SessionScope:     strings.TrimSpace(entry.SessionScope),
+				MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+				Subscriptions:    UniqueNonEmpty(append(append([]string{}, entry.Subscriptions...), append(entry.SubscriptionsBootstrap, entry.SubscribesTo...)...)),
+				EmitEvents:       UniqueNonEmpty(entry.EmitEvents),
+				Tools:            UniqueNonEmpty(entry.ConfiguredTools()),
+				Permissions:      UniqueNonEmpty(entry.Permissions),
+			})
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		for _, id := range sortedEmitSchemaAgentIDs(scope.Agents) {
+			entry := scope.Agents[id]
+			appendActor(models.AgentConfig{
+				ID:               strings.TrimSpace(id),
+				Type:             strings.TrimSpace(entry.Type),
+				Role:             strings.TrimSpace(entry.Role),
+				Mode:             strings.TrimSpace(scope.ID),
+				ModelTier:        strings.TrimSpace(entry.ModelTier),
+				ConversationMode: strings.TrimSpace(entry.ConversationMode),
+				SessionScope:     strings.TrimSpace(entry.SessionScope),
+				MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+				Subscriptions:    UniqueNonEmpty(append(append([]string{}, entry.Subscriptions...), append(entry.SubscriptionsBootstrap, entry.SubscribesTo...)...)),
+				EmitEvents:       UniqueNonEmpty(entry.EmitEvents),
+				Tools:            UniqueNonEmpty(entry.ConfiguredTools()),
+				Permissions:      UniqueNonEmpty(entry.Permissions),
+				FlowPath:         strings.Trim(strings.TrimSpace(scope.Path), "/"),
+			})
+		}
+	}
+	for _, id := range sortedEmitSchemaAgentIDs(source.AgentEntries()) {
+		entry := source.AgentEntries()[id]
+		appendActor(models.AgentConfig{
+			ID:               strings.TrimSpace(id),
+			Type:             strings.TrimSpace(entry.Type),
+			Role:             strings.TrimSpace(entry.Role),
+			ModelTier:        strings.TrimSpace(entry.ModelTier),
+			ConversationMode: strings.TrimSpace(entry.ConversationMode),
+			SessionScope:     strings.TrimSpace(entry.SessionScope),
+			MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+			Subscriptions:    UniqueNonEmpty(append(append([]string{}, entry.Subscriptions...), append(entry.SubscriptionsBootstrap, entry.SubscribesTo...)...)),
+			EmitEvents:       UniqueNonEmpty(entry.EmitEvents),
+			Tools:            UniqueNonEmpty(entry.ConfiguredTools()),
+			Permissions:      UniqueNonEmpty(entry.Permissions),
+		})
+	}
+	return actors
+}
+
+func sortedEmitSchemaAgentIDs(agents map[string]runtimecontracts.AgentRegistryEntry) []string {
+	ids := make([]string, 0, len(agents))
+	for id := range agents {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func (r *EmitRegistry) EventSchemaSnapshot() map[string]EmitSchema {

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -283,10 +283,15 @@ func providerSchemaValidationActors(source semanticview.Source) []models.AgentCo
 	for _, scope := range source.ProjectScopes() {
 		for _, id := range sortedEmitSchemaAgentIDs(scope.Agents) {
 			entry := scope.Agents[id]
+			proof := semanticview.ResolveAgentSessionScopeProof(source, semanticview.AgentSessionScopeLocator{
+				AgentID:         id,
+				ProjectScopeKey: scope.Key,
+			})
 			appendActor(models.AgentConfig{
 				ID:               strings.TrimSpace(id),
 				Type:             strings.TrimSpace(entry.Type),
 				Role:             strings.TrimSpace(entry.Role),
+				Mode:             strings.TrimSpace(proof.OwningFlowID),
 				ModelTier:        strings.TrimSpace(entry.ModelTier),
 				ConversationMode: strings.TrimSpace(entry.ConversationMode),
 				SessionScope:     strings.TrimSpace(entry.SessionScope),
@@ -295,6 +300,7 @@ func providerSchemaValidationActors(source semanticview.Source) []models.AgentCo
 				EmitEvents:       UniqueNonEmpty(entry.EmitEvents),
 				Tools:            UniqueNonEmpty(entry.ConfiguredTools()),
 				Permissions:      UniqueNonEmpty(entry.Permissions),
+				FlowPath:         strings.Trim(strings.TrimSpace(proof.FlowPath), "/"),
 			})
 		}
 	}

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -325,6 +326,100 @@ func TestValidateGeneratedEmitToolSchemasForSourceRejectsUnloweredContractRefs(t
 	}
 	if got := errs[0].Error(); !strings.Contains(got, "unsupported JSON Schema type \"NotDeclared\"") {
 		t.Fatalf("error = %q, want unsupported type", got)
+	}
+}
+
+func TestValidateGeneratedEmitToolSchemasForSourceUsesPackageOwningFlowMode(t *testing.T) {
+	root := t.TempDir()
+	writeEmitFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: provider-schema-validation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: support
+    flow: support
+    mode: static
+  - id: other
+    flow: other
+    mode: static
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "entities.yaml"), "item:\n  item_id: uuid\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: provider-schema-validation\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+states:
+  - waiting
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "tools.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+local.done:
+  unsupported: NotDeclared
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+flow-agent:
+  id: flow-agent
+  role: flow_agent
+  emit_events:
+    - local.done
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "package.yaml"), `
+name: other
+version: "1.0.0"
+flows: []
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "schema.yaml"), `
+name: other
+initial_state: waiting
+states:
+  - waiting
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "policy.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "tools.yaml"), "{}\n")
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "events.yaml"), `
+local.done:
+  ok: string
+`)
+	writeEmitFixtureFile(t, filepath.Join(root, "flows", "other", "agents.yaml"), "{}\n")
+
+	repoRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	errs := ValidateGeneratedEmitToolSchemasForSource(semanticview.Wrap(bundle))
+	if len(errs) != 1 {
+		t.Fatalf("errors = %#v, want one provider schema error", errs)
+	}
+	got := errs[0].Error()
+	for _, want := range []string{"flow-agent", "emit_local_done", "unsupported JSON Schema type \"NotDeclared\""} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func writeEmitFixtureFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(content, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }
 

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -3,12 +3,14 @@ package tools
 import (
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	runtimeauthority "swarm/internal/runtime/authority"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/flowmodel"
+	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -237,6 +239,92 @@ func TestGenerateEmitToolsForActor_ResolvesInstanceScopedFlowEmitEventsThroughOw
 	}
 	if tools[0].Name != "emit_scan_requested" {
 		t.Fatalf("tool name = %q, want emit_scan_requested", tools[0].Name)
+	}
+}
+
+func TestGenerateEmitToolsForActor_ProviderSchemaNormalizesPrecisionRefs(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"RequiredCapabilities": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"automation_with_unlock": {Type: "numeric(5,2)"},
+					},
+				},
+			},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"market-research-agent": {
+				ID:         "market-research-agent",
+				Role:       "market_research",
+				EmitEvents: []string{"category.assessed"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"required_capabilities": {Type: "RequiredCapabilities"},
+						"scores":                {Type: "[numeric(5,2)]"},
+					},
+					Required: []string{"required_capabilities"},
+				},
+			},
+		},
+	})
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+
+	defs := registry.GenerateEmitToolsForActor(models.AgentConfig{
+		ID:         "market-research-agent",
+		Role:       "market_research",
+		EmitEvents: []string{"category.assessed"},
+	}, nil)
+	if len(defs) != 1 {
+		t.Fatalf("tool count = %d, want 1 (%#v)", len(defs), defs)
+	}
+	if err := llm.ValidateProviderToolDefinitions(defs); err != nil {
+		t.Fatalf("ValidateProviderToolDefinitions: %v", err)
+	}
+	props := defs[0].Schema.(map[string]any)["properties"].(map[string]any)
+	requiredCapabilities := props["required_capabilities"].(map[string]any)
+	capabilityProps := requiredCapabilities["properties"].(map[string]any)
+	automation := capabilityProps["automation_with_unlock"].(map[string]any)
+	if got := automation["type"]; got != "number" {
+		t.Fatalf("automation type = %#v, want number", got)
+	}
+	scores := props["scores"].(map[string]any)
+	scoreItems := scores["items"].(map[string]any)
+	if got := scoreItems["type"]; got != "number" {
+		t.Fatalf("scores item type = %#v, want number", got)
+	}
+}
+
+func TestValidateGeneratedEmitToolSchemasForSourceRejectsUnloweredContractRefs(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"market-research-agent": {
+				ID:         "market-research-agent",
+				Role:       "market_research",
+				EmitEvents: []string{"category.assessed"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"category.assessed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"unsupported": {Type: "NotDeclared"},
+					},
+				},
+			},
+		},
+	})
+
+	errs := ValidateGeneratedEmitToolSchemasForSource(source)
+	if len(errs) != 1 {
+		t.Fatalf("errors = %#v, want one provider schema error", errs)
+	}
+	if got := errs[0].Error(); !strings.Contains(got, "unsupported JSON Schema type \"NotDeclared\"") {
+		t.Fatalf("error = %q, want unsupported type", got)
 	}
 }
 

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -25,6 +25,7 @@ type WorkflowContractValidationResult struct {
 	BootReport                  runtimebootverify.Report
 	ToolImplementationWarnings  []error
 	MissingEmitSchemaEventTypes []string
+	GeneratedEmitSchemaErrors   []error
 }
 
 func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Store) WorkflowContractValidationOptions {
@@ -77,6 +78,10 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 			sample = sample[:10]
 		}
 		return result, fmt.Errorf("emit schema strict mode enabled: %d agent-emitted schemas are missing explicit EventSchemaRegistry entries (sample: %s)", len(result.MissingEmitSchemaEventTypes), strings.Join(sample, ", "))
+	}
+	result.GeneratedEmitSchemaErrors = runtimetools.ValidateGeneratedEmitToolSchemasForSource(source)
+	if len(result.GeneratedEmitSchemaErrors) > 0 {
+		return result, fmt.Errorf("generated emit tool schema validation failed:\n%s", formatValidationErrors(result.GeneratedEmitSchemaErrors))
 	}
 
 	return result, nil

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -113,6 +113,75 @@ func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T
 	}
 }
 
+func TestValidateWorkflowContractSurfaceRejectsInvalidGeneratedEmitToolSchema(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+		"agent-1": {ID: "agent-1", Role: "agent", EmitEvents: []string{"ready.event"}},
+		"agent-2": {ID: "agent-2", Role: "consumer", Subscriptions: []string{"ready.event"}},
+	}
+	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
+		"ready.event": {
+			Payload: runtimecontracts.EventPayloadSpec{
+				Properties: map[string]runtimecontracts.EventFieldSpec{
+					"unsupported": {Type: "NotDeclared"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+
+	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
+	if err == nil || !strings.Contains(err.Error(), "generated emit tool schema validation failed") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want generated schema failure", err)
+	}
+	if len(result.GeneratedEmitSchemaErrors) != 1 {
+		t.Fatalf("GeneratedEmitSchemaErrors = %#v, want one error", result.GeneratedEmitSchemaErrors)
+	}
+	if got := result.GeneratedEmitSchemaErrors[0].Error(); !strings.Contains(got, "unsupported JSON Schema type \"NotDeclared\"") {
+		t.Fatalf("GeneratedEmitSchemaErrors[0] = %q, want unsupported type", got)
+	}
+}
+
+func TestValidateWorkflowContractSurfaceAllowsPrecisionQualifiedGeneratedEmitToolSchema(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.RootTypes = runtimecontracts.TypeCatalogDocument{
+		Types: map[string]runtimecontracts.NamedTypeDecl{
+			"RequiredCapabilities": {
+				Fields: map[string]runtimecontracts.TypeFieldSpec{
+					"automation_with_unlock": {Type: "numeric(5,2)"},
+				},
+			},
+		},
+	}
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+		"agent-1": {ID: "agent-1", Role: "agent", EmitEvents: []string{"ready.event"}},
+		"agent-2": {ID: "agent-2", Role: "consumer", Subscriptions: []string{"ready.event"}},
+	}
+	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
+		"ready.event": {
+			Payload: runtimecontracts.EventPayloadSpec{
+				Properties: map[string]runtimecontracts.EventFieldSpec{
+					"capabilities": {Type: "RequiredCapabilities"},
+					"amounts":      {Type: "[numeric(10,2)]"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+
+	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
+	if err != nil {
+		t.Fatalf("ValidateWorkflowContractSurface: %v", err)
+	}
+	if len(result.GeneratedEmitSchemaErrors) != 0 {
+		t.Fatalf("GeneratedEmitSchemaErrors = %#v, want none", result.GeneratedEmitSchemaErrors)
+	}
+}
+
 func TestValidateWorkflowContractSurface_FatalToolImplementationWarningsFollowSharedOptions(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 	bundle := testRuntimeWorkflowValidationBundle()


### PR DESCRIPTION
## Summary

Closes #522.

This PR fixes provider-facing generated emit tool schema lowering so precision-qualified contract refs like `numeric(5,2)` are normalized before they reach Claude/MCP-visible generated schemas. It also adds recursive provider-schema validation to the supported workflow verification path for generated emit tools.

## Governing refs

- Issue #522 approved gate and pre-audit context
- Parent reassessment: #401 extracted #522 after the market-research agent hit Claude provider schema rejection
- Authoritative contract context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Draft review context: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.contract-type-system.yaml`

## Semantic migration

- New canonical owner for provider-facing generated emit schema safety: event schema lowering in `internal/runtime/contracts/schema_registry.go`, consumed by `internal/runtime/tools.EmitRegistry`.
- Old invalid path: nested/list named-type fields could bypass type-ref normalization and emit raw contract refs such as `numeric(5,2)` as JSON Schema `type` values.
- Production paths checked: generated emit tools for actors, supported `cmd/swarm verify`, MCP exposure by construction through `Executor.ToolDefinitionsForActor`, and supported `make run-clear` market-research startup.
- Migration complete for #522's approved class; broader provider/transport parity remains parent context.

## Proof

- `go test ./cmd/swarm ./internal/runtime/contracts ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `set -a; source /Users/youmew/dev/swarm/.env; set +a; make run-clear`
- Run id `62a0592c-5c8c-4954-a383-b6f446cf3a12`: market-research agent reached Claude streaming/WebSearch path with no `input_schema` 400, no warn/error runtime logs, and no dead letters at status check.