### PR TITLE
[agent-d][issue #373] Hydrate emit fields as CEL

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1638,6 +1638,59 @@ fan_out:
 	}
 }
 
+func TestRun_RejectsBareItemInHandlerEmitFields(t *testing.T) {
+	var handler runtimecontracts.SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+emit:
+  event: item.scored
+  fields:
+    bad: item
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": handler,
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "emit_field_expression_validation", "item") {
+		t.Fatalf("expected bare item in handler emit.fields to fail validation, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsBareItemInDataAccumulationExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+							Writes: []runtimecontracts.WorkflowDataWrite{
+								{TargetField: "last_item", Value: runtimecontracts.CELExpression("item")},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "data_accumulation_expression_validation", "item") {
+		t.Fatalf("expected bare item in data_accumulation expression to fail validation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesPermissionMismatchWarningsDuringMigration(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-permission-tool-mismatch")
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1542,6 +1542,76 @@ func TestRun_RejectsAccumulatedNamespaceInEmitFieldExpressions(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsYAMLScalarEmitFieldsAsExpressions(t *testing.T) {
+	var handler runtimecontracts.SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+emit:
+  event: item.scored
+  fields:
+    bad: accumulated.size()
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": handler,
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "emit_field_expression_validation", "accumulated.size()") {
+		t.Fatalf("expected YAML scalar emit.fields expression to fail validation, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AcceptsYAMLScalarFanOutEmitItemExpressions(t *testing.T) {
+	var handler runtimecontracts.SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+fan_out:
+  items_from: payload.industries
+  target: market-research-agent
+  emit:
+    event: market_research.industry_assigned
+    fields:
+      industry: item
+      taxonomy_categories: "[item]"
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"market_research.industry_assigned": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"industry":            {Type: "text"},
+						"taxonomy_categories": {Type: "text[]"},
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": {
+				ID: "scan-orchestrator",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"scan.requested": handler,
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Errors(), "emit_field_expression_validation", "item") {
+		t.Fatalf("unexpected item expression validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PreservesPermissionMismatchWarningsDuringMigration(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-permission-tool-mismatch")
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1542,6 +1542,32 @@ func TestRun_RejectsAccumulatedNamespaceInEmitFieldExpressions(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsDisallowedRefNamespaceInEmitFieldExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						Emit: runtimecontracts.EmitSpec{
+							Event: "item.scored",
+							Fields: map[string]runtimecontracts.ExpressionValue{
+								"bad": runtimecontracts.RefExpression("accumulated.count"),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "emit_field_expression_validation", "accumulated.count") {
+		t.Fatalf("expected accumulated namespace in emit.fields ref to fail validation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsYAMLScalarEmitFieldsAsExpressions(t *testing.T) {
 	var handler runtimecontracts.SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -391,7 +391,11 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	}
 	appendEmitExpressions := func(kindPrefix string, spec runtimecontracts.EmitSpec) {
 		for key, value := range spec.Fields {
-			if expr := strings.TrimSpace(value.CEL); expr != "" {
+			expr := strings.TrimSpace(value.CEL)
+			if expr == "" && value.Kind == runtimecontracts.ExpressionKindRef {
+				expr = strings.TrimSpace(value.Ref)
+			}
+			if expr != "" {
 				out = append(out, expressionReference{
 					Kind:       kindPrefix + " emit field " + strings.TrimSpace(key),
 					Expression: expr,

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -78,7 +78,7 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpression(expr.Expression); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem}); err != nil {
 					c.dataAccumulationExprFindings = append(c.dataAccumulationExprFindings, Finding{
 						CheckID:  "data_accumulation_expression_validation",
 						Severity: "error",
@@ -105,7 +105,7 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleEmitFields {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpression(expr.Expression); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem}); err != nil {
 					c.emitFieldExprFindings = append(c.emitFieldExprFindings, Finding{
 						CheckID:  "emit_field_expression_validation",
 						Severity: "error",
@@ -249,6 +249,7 @@ type expressionReference struct {
 	Expression      string
 	Phase           runtimepipeline.WorkflowEntityFieldLifecyclePhase
 	SelfTargetField string
+	AllowBareItem   bool
 }
 
 type handlerCondition struct {
@@ -389,7 +390,7 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			out = append(out, expressionReference{Kind: "count condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleCount})
 		}
 	}
-	appendEmitExpressions := func(kindPrefix string, spec runtimecontracts.EmitSpec) {
+	appendEmitExpressions := func(kindPrefix string, spec runtimecontracts.EmitSpec, allowBareItem bool) {
 		for key, value := range spec.Fields {
 			expr := strings.TrimSpace(value.CEL)
 			if expr == "" && value.Kind == runtimecontracts.ExpressionKindRef {
@@ -397,40 +398,41 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			}
 			if expr != "" {
 				out = append(out, expressionReference{
-					Kind:       kindPrefix + " emit field " + strings.TrimSpace(key),
-					Expression: expr,
-					Phase:      runtimepipeline.WorkflowEntityFieldLifecycleEmitFields,
+					Kind:          kindPrefix + " emit field " + strings.TrimSpace(key),
+					Expression:    expr,
+					Phase:         runtimepipeline.WorkflowEntityFieldLifecycleEmitFields,
+					AllowBareItem: allowBareItem,
 				})
 			}
 		}
 	}
-	appendEmitExpressions("handler", handler.Emit)
+	appendEmitExpressions("handler", handler.Emit, false)
 	if handler.FanOut != nil {
-		appendEmitExpressions("fan_out", handler.FanOut.Emit)
+		appendEmitExpressions("fan_out", handler.FanOut.Emit, true)
 	}
 	for _, rule := range handler.Rules {
-		appendEmitExpressions("rule", rule.Emit)
+		appendEmitExpressions("rule", rule.Emit, false)
 		if rule.FanOut != nil {
-			appendEmitExpressions("rule fan_out", rule.FanOut.Emit)
+			appendEmitExpressions("rule fan_out", rule.FanOut.Emit, true)
 		}
 	}
 	for _, rule := range handler.OnComplete {
-		appendEmitExpressions("on_complete", rule.Emit)
+		appendEmitExpressions("on_complete", rule.Emit, false)
 		if rule.FanOut != nil {
-			appendEmitExpressions("on_complete fan_out", rule.FanOut.Emit)
+			appendEmitExpressions("on_complete fan_out", rule.FanOut.Emit, true)
 		}
 	}
 	if handler.Accumulate != nil {
 		for _, rule := range handler.Accumulate.OnComplete {
-			appendEmitExpressions("accumulate.on_complete", rule.Emit)
+			appendEmitExpressions("accumulate.on_complete", rule.Emit, false)
 			if rule.FanOut != nil {
-				appendEmitExpressions("accumulate.on_complete fan_out", rule.FanOut.Emit)
+				appendEmitExpressions("accumulate.on_complete fan_out", rule.FanOut.Emit, true)
 			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
-			appendEmitExpressions("accumulate.on_timeout", handler.Accumulate.OnTimeout.Emit)
+			appendEmitExpressions("accumulate.on_timeout", handler.Accumulate.OnTimeout.Emit, false)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
-				appendEmitExpressions("accumulate.on_timeout fan_out", handler.Accumulate.OnTimeout.FanOut.Emit)
+				appendEmitExpressions("accumulate.on_timeout fan_out", handler.Accumulate.OnTimeout.FanOut.Emit, true)
 			}
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -78,17 +78,27 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("UNDEFINED-FIELD: emit field %q not in platform spec", key)
 			}
 		}
-		type shadow struct {
-			Event  string                     `yaml:"event"`
-			Fields map[string]ExpressionValue `yaml:"fields"`
-		}
-		var aux shadow
-		if err := node.Decode(&aux); err != nil {
-			return err
+		var event string
+		fields := map[string]ExpressionValue{}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			value := node.Content[i+1]
+			switch key {
+			case "event":
+				if err := value.Decode(&event); err != nil {
+					return err
+				}
+			case "fields":
+				decoded, err := decodeEmitFieldsNode(value)
+				if err != nil {
+					return err
+				}
+				fields = decoded
+			}
 		}
 		*e = EmitSpec{
-			Event:  strings.TrimSpace(aux.Event),
-			Fields: cloneExpressionValueMap(aux.Fields),
+			Event:  strings.TrimSpace(event),
+			Fields: fields,
 		}
 		if e.EventType() == "" && len(e.Fields) > 0 {
 			return fmt.Errorf("INVALID-EMIT: emit.event is required when emit.fields is present")
@@ -96,6 +106,52 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	default:
 		return fmt.Errorf("unsupported emit yaml node kind %d", node.Kind)
+	}
+}
+
+func decodeEmitFieldsNode(node *yaml.Node) (map[string]ExpressionValue, error) {
+	if node == nil {
+		return nil, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("INVALID-EMIT: emit.fields must be a mapping")
+	}
+	fields := make(map[string]ExpressionValue, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		target := strings.TrimSpace(node.Content[i].Value)
+		if target == "" {
+			continue
+		}
+		value, err := decodeEmitFieldValueNode(node.Content[i+1])
+		if err != nil {
+			return nil, fmt.Errorf("INVALID-EMIT: emit.fields.%s: %w", target, err)
+		}
+		fields[target] = value
+	}
+	return fields, nil
+}
+
+func decodeEmitFieldValueNode(node *yaml.Node) (ExpressionValue, error) {
+	if node == nil {
+		return ExpressionValue{}, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") || strings.TrimSpace(node.Value) == "" {
+			return ExpressionValue{}, nil
+		}
+		return CELExpression(node.Value), nil
+	case yaml.MappingNode:
+		var expr ExpressionValue
+		if err := node.Decode(&expr); err != nil {
+			return ExpressionValue{}, err
+		}
+		return expr, nil
+	default:
+		return ExpressionValue{}, fmt.Errorf("field value must be a scalar CEL expression or explicit expression mapping")
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -145,6 +145,9 @@ func decodeEmitFieldValueNode(node *yaml.Node) (ExpressionValue, error) {
 		}
 		return CELExpression(node.Value), nil
 	case yaml.MappingNode:
+		if err := validateEmitFieldExpressionMappingNode(node); err != nil {
+			return ExpressionValue{}, err
+		}
 		var expr ExpressionValue
 		if err := node.Decode(&expr); err != nil {
 			return ExpressionValue{}, err
@@ -153,6 +156,27 @@ func decodeEmitFieldValueNode(node *yaml.Node) (ExpressionValue, error) {
 	default:
 		return ExpressionValue{}, fmt.Errorf("field value must be a scalar CEL expression or explicit expression mapping")
 	}
+}
+
+func validateEmitFieldExpressionMappingNode(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	semanticKeys := 0
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		switch key {
+		case "literal", "ref", "cel", "expression":
+			semanticKeys++
+		case "kind":
+		default:
+			return fmt.Errorf("field value mapping must use explicit expression keys literal, ref, cel, or expression; found %q", key)
+		}
+	}
+	if semanticKeys == 0 {
+		return fmt.Errorf("field value mapping must declare literal, ref, cel, or expression")
+	}
+	return nil
 }
 
 func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -542,6 +542,55 @@ expression: entity.score + 1
 	}
 }
 
+func TestExpressionValueDecode_PreservesScalarAsLiteralOutsideEmitFields(t *testing.T) {
+	var expr ExpressionValue
+	if err := yaml.Unmarshal([]byte(`target_state`), &expr); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if expr.Kind != ExpressionKindLiteral {
+		t.Fatalf("Kind = %q, want %q", expr.Kind, ExpressionKindLiteral)
+	}
+	if got := expr.Literal; got != "target_state" {
+		t.Fatalf("Literal = %#v, want target_state", got)
+	}
+}
+
+func TestEmitSpecDecode_ScalarFieldsHydrateAsCELOnlyOnEmitFields(t *testing.T) {
+	var spec EmitSpec
+	if err := yaml.Unmarshal([]byte(`
+event: signals.category_ready
+fields:
+  mode: payload.mode
+  batch: "{'scan_id': payload.scan_id, 'geography': payload.geography}"
+  count: 0
+  quoted_literal: "'ready'"
+  explicit_literal:
+    literal: ready
+  explicit_ref:
+    ref: payload.mode
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	cases := map[string]string{
+		"mode":           "payload.mode",
+		"batch":          "{'scan_id': payload.scan_id, 'geography': payload.geography}",
+		"count":          "0",
+		"quoted_literal": "'ready'",
+	}
+	for field, want := range cases {
+		expr := spec.Fields[field]
+		if expr.Kind != ExpressionKindCEL || expr.CEL != want {
+			t.Fatalf("Fields[%s] = %#v, want CEL %q", field, expr, want)
+		}
+	}
+	if expr := spec.Fields["explicit_literal"]; expr.Kind != ExpressionKindLiteral || expr.Literal != "ready" {
+		t.Fatalf("explicit_literal = %#v, want literal ready", expr)
+	}
+	if expr := spec.Fields["explicit_ref"]; expr.Kind != ExpressionKindRef || expr.Ref != "payload.mode" {
+		t.Fatalf("explicit_ref = %#v, want ref payload.mode", expr)
+	}
+}
+
 func TestHandlerRuleEntryDecode_PreservesRuleLevelFanOut(t *testing.T) {
 	var rule HandlerRuleEntry
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -591,6 +591,22 @@ fields:
 	}
 }
 
+func TestEmitSpecDecode_RejectsUnstructuredObjectFieldMappings(t *testing.T) {
+	var spec EmitSpec
+	err := yaml.Unmarshal([]byte(`
+event: signals.category_ready
+fields:
+  batch:
+    scan_id: payload.scan_id
+`), &spec)
+	if err == nil {
+		t.Fatal("expected unstructured emit.fields object mapping to be rejected")
+	}
+	if !strings.Contains(err.Error(), "explicit expression keys") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHandlerRuleEntryDecode_PreservesRuleLevelFanOut(t *testing.T) {
 	var rule HandlerRuleEntry
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -17,6 +17,7 @@ import (
 	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/runtime/workflowexpr"
 )
 
 type Step string
@@ -910,7 +911,7 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 		}
 		frame.state.SetFanOut("item", item)
 		payload := map[string]any{}
-		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, spec.Emit)
+		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, spec.Emit, workflowexpr.ValueExpressionOptions{AllowBareItem: true})
 		if err != nil {
 			return false, err
 		}
@@ -1101,7 +1102,7 @@ func (e *Executor) stepTransform(frame *executionFrame) error {
 	}
 	// Resolve emit.fields against the current execution context so
 	// data_accumulation and rule-selected writes are visible to emitted payloads.
-	transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec)
+	transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
 	if err != nil {
 		return err
 	}
@@ -1619,7 +1620,7 @@ func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecont
 			continue
 		}
 		if write.Value.HasCELValue() {
-			value, err := evalWorkflowValueExpression(current, frame.state, write.Value.CEL)
+			value, err := evalWorkflowValueExpression(current, frame.state, write.Value.CEL, workflowexpr.ValueExpressionOptions{})
 			if err != nil {
 				return fmt.Errorf("data_accumulation target %s: %w", target, err)
 			}

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -137,7 +137,7 @@ func resolveRef(base BaseContext, state ExecutionState, ref string) any {
 	return value
 }
 
-func evalExpressionValue(base BaseContext, state ExecutionState, expr runtimecontracts.ExpressionValue) (any, bool, error) {
+func evalExpressionValue(base BaseContext, state ExecutionState, expr runtimecontracts.ExpressionValue, opts workflowexpr.ValueExpressionOptions) (any, bool, error) {
 	if expr.IsZero() {
 		return nil, false, nil
 	}
@@ -150,7 +150,7 @@ func evalExpressionValue(base BaseContext, state ExecutionState, expr runtimecon
 		}
 		return nil, false, nil
 	case runtimecontracts.ExpressionKindCEL:
-		value, err := evalWorkflowValueExpression(base, state, expr.CEL)
+		value, err := evalWorkflowValueExpression(base, state, expr.CEL, opts)
 		if err != nil {
 			return nil, false, err
 		}
@@ -204,7 +204,7 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 		case write.Value.HasLiteralValue():
 			setParsedValuePath(snapshot.StateCarrier.Metadata, parsed, write.Value.Literal)
 		case write.Value.HasCELValue():
-			value, err := evalWorkflowValueExpression(base, state, write.Value.CEL)
+			value, err := evalWorkflowValueExpression(base, state, write.Value.CEL, workflowexpr.ValueExpressionOptions{})
 			if err != nil {
 				return fmt.Errorf("data_accumulation target %s: %w", strings.TrimSpace(write.Target()), err)
 			}
@@ -225,14 +225,14 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 	return nil
 }
 
-func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string) (any, error) {
-	return workflowexpr.EvalValueExpression(expression, workflowexpr.ValueContext{
+func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string, opts workflowexpr.ValueExpressionOptions) (any, error) {
+	return workflowexpr.EvalValueExpressionWithOptions(expression, workflowexpr.ValueContext{
 		Entity:  base.Entity.Raw(),
 		Event:   base.Event.Raw(),
 		Payload: base.Payload.Raw(),
 		Policy:  base.Policy.Raw(),
 		FanOut:  state.FanOut,
-	})
+	}, opts)
 }
 
 func normalizeCELValue(value any) any {
@@ -243,7 +243,7 @@ func normalizedCELInputMap(source map[string]any) map[string]any {
 	return workflowexpr.NormalizeCELInputMap(source)
 }
 
-func emitFieldsPayload(base BaseContext, state ExecutionState, spec runtimecontracts.EmitSpec) (map[string]any, error) {
+func emitFieldsPayload(base BaseContext, state ExecutionState, spec runtimecontracts.EmitSpec, opts workflowexpr.ValueExpressionOptions) (map[string]any, error) {
 	if len(spec.Fields) == 0 {
 		return nil, nil
 	}
@@ -253,7 +253,7 @@ func emitFieldsPayload(base BaseContext, state ExecutionState, spec runtimecontr
 		if target == "" {
 			continue
 		}
-		value, ok, err := evalExpressionValue(base, state, valueSpec)
+		value, ok, err := evalExpressionValue(base, state, valueSpec, opts)
 		if err != nil {
 			return nil, fmt.Errorf("emit field %s: %w", target, err)
 		}

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -253,12 +253,12 @@ func emitFieldsPayload(base BaseContext, state ExecutionState, spec runtimecontr
 		if target == "" {
 			continue
 		}
-		if !valueSpec.HasCELValue() {
-			continue
-		}
-		value, err := evalWorkflowValueExpression(base, state, valueSpec.CEL)
+		value, ok, err := evalExpressionValue(base, state, valueSpec)
 		if err != nil {
 			return nil, fmt.Errorf("emit field %s: %w", target, err)
+		}
+		if !ok {
+			continue
 		}
 		setParsedValuePath(payload, paths.Parse(target), value)
 	}

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -8,6 +8,8 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/values"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestArrivalIdentifier_PriorityOrder(t *testing.T) {
@@ -111,6 +113,8 @@ func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 			"nested.score":   runtimecontracts.CELExpression("payload.score"),
 			"nested.state":   runtimecontracts.CELExpression("entity.current_state"),
 			"literal.string": runtimecontracts.CELExpression(`"hello"`),
+			"explicit.ref":   runtimecontracts.RefExpression("payload.score"),
+			"explicit.value": runtimecontracts.LiteralExpression("ready"),
 		},
 	})
 	if err != nil {
@@ -130,6 +134,16 @@ func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 	if !ok || literal["string"] != "hello" {
 		t.Fatalf("literal transform wrong: %#v", transformed)
 	}
+	explicit, ok := transformed["explicit"].(map[string]any)
+	if !ok {
+		t.Fatalf("explicit transform missing: %#v", transformed)
+	}
+	if got := explicit["ref"]; got != 9 {
+		t.Fatalf("explicit.ref = %#v, want 9", got)
+	}
+	if got := explicit["value"]; got != "ready" {
+		t.Fatalf("explicit.value = %#v, want ready", got)
+	}
 }
 
 func TestEmitFieldsPayload_NormalizesWholeNumberJSONInputs(t *testing.T) {
@@ -146,6 +160,52 @@ func TestEmitFieldsPayload_NormalizesWholeNumberJSONInputs(t *testing.T) {
 	}
 	if got := transformed["score"]; got != 50 {
 		t.Fatalf("score = %#v, want 50", got)
+	}
+}
+
+func TestEmitFieldsPayload_EvaluatesYAMLLoadedScalarEmitFieldsAsCEL(t *testing.T) {
+	var spec runtimecontracts.EmitSpec
+	if err := yaml.Unmarshal([]byte(`
+event: signals.category_ready
+fields:
+  mode: payload.mode
+  batch: "{'scan_id': payload.scan_id, 'geography': payload.geography}"
+  count: 0
+  quoted_literal: "'ready'"
+  explicit_literal:
+    literal: ready
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	base := BaseContext{
+		Payload: values.Wrap(map[string]any{
+			"mode":      "corpus",
+			"scan_id":   "scan-1",
+			"geography": "us",
+		}),
+	}
+	transformed, err := emitFieldsPayload(base, ExecutionState{}, spec)
+	if err != nil {
+		t.Fatalf("emitFieldsPayload(...) error = %v", err)
+	}
+	if got := transformed["mode"]; got != "corpus" {
+		t.Fatalf("mode = %#v, want corpus", got)
+	}
+	batch, ok := transformed["batch"].(map[string]any)
+	if !ok {
+		t.Fatalf("batch = %#v, want object", transformed["batch"])
+	}
+	if batch["scan_id"] != "scan-1" || batch["geography"] != "us" {
+		t.Fatalf("batch = %#v, want scan/geography from payload", batch)
+	}
+	if got := transformed["count"]; got != 0 {
+		t.Fatalf("count = %#v, want 0", got)
+	}
+	if got := transformed["quoted_literal"]; got != "ready" {
+		t.Fatalf("quoted_literal = %#v, want ready", got)
+	}
+	if got := transformed["explicit_literal"]; got != "ready" {
+		t.Fatalf("explicit_literal = %#v, want ready", got)
 	}
 }
 

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/values"
+	"swarm/internal/runtime/workflowexpr"
 
 	"gopkg.in/yaml.v3"
 )
@@ -116,7 +117,7 @@ func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 			"explicit.ref":   runtimecontracts.RefExpression("payload.score"),
 			"explicit.value": runtimecontracts.LiteralExpression("ready"),
 		},
-	})
+	}, workflowexpr.ValueExpressionOptions{})
 	if err != nil {
 		t.Fatalf("emitFieldsPayload(...) error = %v", err)
 	}
@@ -154,7 +155,7 @@ func TestEmitFieldsPayload_NormalizesWholeNumberJSONInputs(t *testing.T) {
 		Fields: map[string]runtimecontracts.ExpressionValue{
 			"score": runtimecontracts.CELExpression("payload.raw_score * 2"),
 		},
-	})
+	}, workflowexpr.ValueExpressionOptions{})
 	if err != nil {
 		t.Fatalf("emitFieldsPayload(...) error = %v", err)
 	}
@@ -184,7 +185,7 @@ fields:
 			"geography": "us",
 		}),
 	}
-	transformed, err := emitFieldsPayload(base, ExecutionState{}, spec)
+	transformed, err := emitFieldsPayload(base, ExecutionState{}, spec, workflowexpr.ValueExpressionOptions{})
 	if err != nil {
 		t.Fatalf("emitFieldsPayload(...) error = %v", err)
 	}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -80,15 +81,16 @@ fi
 count=$((count + 1))
 printf '%s' "$count" > "$state_file"
 cat > "$capture_dir/$count.stdin"
-if [ "$count" -eq 1 ]; then
+if grep -q '"name":"read_file"' "$capture_dir/$count.stdin"; then
+  printf '%s\n' '{"type":"result","result":"done"}'
+  exit 0
+fi
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"provider-sess-1"}'
   exit 0
-fi
-printf '%s\n' '{"type":"result","result":"done"}'
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
@@ -196,9 +198,9 @@ printf '%s\n' '{"type":"result","result":"done"}'
 		t.Fatalf("emitted events = %#v", recorder.Snapshot())
 	}
 
-	secondInput, err := os.ReadFile(filepath.Join(captureDir, "2.stdin"))
+	secondInput, err := capturedToolResultInput(captureDir)
 	if err != nil {
-		t.Fatalf("read second stdin: %v", err)
+		t.Fatalf("read tool-result stdin: %v", err)
 	}
 	var payload []map[string]any
 	if err := json.Unmarshal(secondInput, &payload); err != nil {
@@ -225,4 +227,22 @@ printf '%s\n' '{"type":"result","result":"done"}'
 	if len(content) != len(huge) {
 		t.Fatalf("read result content len = %d, want %d", len(content), len(huge))
 	}
+}
+
+func capturedToolResultInput(captureDir string) ([]byte, error) {
+	matches, err := filepath.Glob(filepath.Join(captureDir, "*.stdin"))
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(matches)
+	for _, match := range matches {
+		data, err := os.ReadFile(match)
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Contains(data, []byte(`"name":"read_file"`)) && bytes.Contains(data, []byte(`"ok":true`)) {
+			return data, nil
+		}
+	}
+	return nil, os.ErrNotExist
 }

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -80,6 +80,7 @@ func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 		"payload": NormalizeCELInputMap(ctx.Payload),
 		"policy":  NormalizeCELInputMap(ctx.Policy),
 		"fan_out": NormalizeCELInputMap(ctx.FanOut),
+		"item":    NormalizeCELValue(ctx.FanOut["item"]),
 	})
 	if err != nil {
 		return nil, err
@@ -272,6 +273,18 @@ func NormalizeCELValue(value any) any {
 			out = append(out, NormalizeCELValue(item))
 		}
 		return out
+	case []ref.Val:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, NormalizeCELValue(item))
+		}
+		return out
+	case map[ref.Val]ref.Val:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[fmt.Sprint(NormalizeCELValue(key))] = NormalizeCELValue(item)
+		}
+		return out
 	case map[string]any:
 		out := make(map[string]any, len(typed))
 		for key, item := range typed {
@@ -309,6 +322,7 @@ func dataExpressionEnvForContext() (*cel.Env, error) {
 			cel.Variable("payload", cel.DynType),
 			cel.Variable("policy", cel.DynType),
 			cel.Variable("fan_out", cel.DynType),
+			cel.Variable("item", cel.DynType),
 		)
 	})
 	return dataExpressionEnv, dataExpressionEnvErr

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -13,9 +13,12 @@ import (
 )
 
 var (
-	dataExpressionEnvOnce sync.Once
-	dataExpressionEnv     *cel.Env
-	dataExpressionEnvErr  error
+	dataExpressionEnvOnce             sync.Once
+	dataExpressionEnv                 *cel.Env
+	dataExpressionEnvErr              error
+	dataExpressionWithBareItemEnvOnce sync.Once
+	dataExpressionWithBareItemEnv     *cel.Env
+	dataExpressionWithBareItemEnvErr  error
 
 	workflowExpressionEntityReferencePattern        = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 	workflowExpressionEntityPresencePattern         = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
@@ -38,8 +41,16 @@ type ValueContext struct {
 	FanOut  map[string]any
 }
 
+type ValueExpressionOptions struct {
+	AllowBareItem bool
+}
+
 func ValidateValueExpression(expression string) error {
-	env, err := dataExpressionEnvForContext()
+	return ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{})
+}
+
+func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionOptions) error {
+	env, err := dataExpressionEnvForContext(opts)
 	if err != nil {
 		return err
 	}
@@ -55,7 +66,11 @@ func ValidateValueExpression(expression string) error {
 }
 
 func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
-	env, err := dataExpressionEnvForContext()
+	return EvalValueExpressionWithOptions(expression, ctx, ValueExpressionOptions{})
+}
+
+func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts ValueExpressionOptions) (any, error) {
+	env, err := dataExpressionEnvForContext(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -74,14 +89,17 @@ func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, _, err := program.Eval(map[string]any{
+	activation := map[string]any{
 		"entity":  NormalizeCELInputMap(ctx.Entity),
 		"event":   NormalizeCELInputMap(ctx.Event),
 		"payload": NormalizeCELInputMap(ctx.Payload),
 		"policy":  NormalizeCELInputMap(ctx.Policy),
 		"fan_out": NormalizeCELInputMap(ctx.FanOut),
-		"item":    NormalizeCELValue(ctx.FanOut["item"]),
-	})
+	}
+	if opts.AllowBareItem {
+		activation["item"] = NormalizeCELValue(ctx.FanOut["item"])
+	}
+	out, _, err := program.Eval(activation)
 	if err != nil {
 		return nil, err
 	}
@@ -314,18 +332,31 @@ func NormalizeCELInputMap(source map[string]any) map[string]any {
 	return normalized
 }
 
-func dataExpressionEnvForContext() (*cel.Env, error) {
+func dataExpressionEnvForContext(opts ValueExpressionOptions) (*cel.Env, error) {
+	if opts.AllowBareItem {
+		dataExpressionWithBareItemEnvOnce.Do(func() {
+			dataExpressionWithBareItemEnv, dataExpressionWithBareItemEnvErr = newDataExpressionEnv(true)
+		})
+		return dataExpressionWithBareItemEnv, dataExpressionWithBareItemEnvErr
+	}
 	dataExpressionEnvOnce.Do(func() {
-		dataExpressionEnv, dataExpressionEnvErr = cel.NewEnv(
-			cel.Variable("entity", cel.DynType),
-			cel.Variable("event", cel.DynType),
-			cel.Variable("payload", cel.DynType),
-			cel.Variable("policy", cel.DynType),
-			cel.Variable("fan_out", cel.DynType),
-			cel.Variable("item", cel.DynType),
-		)
+		dataExpressionEnv, dataExpressionEnvErr = newDataExpressionEnv(false)
 	})
 	return dataExpressionEnv, dataExpressionEnvErr
+}
+
+func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
+	variables := []cel.EnvOption{
+		cel.Variable("entity", cel.DynType),
+		cel.Variable("event", cel.DynType),
+		cel.Variable("payload", cel.DynType),
+		cel.Variable("policy", cel.DynType),
+		cel.Variable("fan_out", cel.DynType),
+	}
+	if allowBareItem {
+		variables = append(variables, cel.Variable("item", cel.DynType))
+	}
+	return cel.NewEnv(variables...)
 }
 
 func rewriteOutsideStringLiterals(expression string, rewrite func(string) string) string {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -30,6 +30,19 @@ func TestEvalValueExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
 	}
 }
 
+func TestEvalValueExpression_ExposesFanOutItemAlias(t *testing.T) {
+	value, err := EvalValueExpression(`[item]`, ValueContext{
+		FanOut: map[string]any{"item": "industry-a"},
+	})
+	if err != nil {
+		t.Fatalf("EvalValueExpression error = %v", err)
+	}
+	got, ok := value.([]any)
+	if !ok || len(got) != 1 || got[0] != "industry-a" {
+		t.Fatalf("EvalValueExpression value = %#v, want [industry-a]", value)
+	}
+}
+
 func TestValidateValueExpression_RejectsAccumulatedNamespace(t *testing.T) {
 	err := ValidateValueExpression(`accumulated.size()`)
 	if err == nil {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -31,15 +31,27 @@ func TestEvalValueExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
 }
 
 func TestEvalValueExpression_ExposesFanOutItemAlias(t *testing.T) {
-	value, err := EvalValueExpression(`[item]`, ValueContext{
+	value, err := EvalValueExpressionWithOptions(`[item]`, ValueContext{
 		FanOut: map[string]any{"item": "industry-a"},
-	})
+	}, ValueExpressionOptions{AllowBareItem: true})
 	if err != nil {
 		t.Fatalf("EvalValueExpression error = %v", err)
 	}
 	got, ok := value.([]any)
 	if !ok || len(got) != 1 || got[0] != "industry-a" {
 		t.Fatalf("EvalValueExpression value = %#v, want [industry-a]", value)
+	}
+}
+
+func TestEvalValueExpression_RejectsBareItemByDefault(t *testing.T) {
+	if err := ValidateValueExpression(`item`); err == nil {
+		t.Fatal("expected bare item to be rejected by default")
+	}
+	_, err := EvalValueExpression(`item`, ValueContext{
+		FanOut: map[string]any{"item": "industry-a"},
+	})
+	if err == nil {
+		t.Fatal("expected bare item eval to be rejected by default")
 	}
 }
 

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/nodes.yaml
@@ -10,5 +10,5 @@ routing-node:
         emit:
           event: routed.a
           fields:
-            kind: item.kind
+            item: item
       advances_to: routing


### PR DESCRIPTION
Part of #373

## Summary

- Hydrate scalar values under declarative system-node `emit.fields` as CEL expressions on the emit surface only.
- Preserve explicit `{literal: ...}` and `{ref: ...}` mapping forms for constants and refs.
- Evaluate all supported `ExpressionValue` kinds in the shared runtime emit payload constructor.
- Normalize CEL list/object results before placing them into emitted payloads.
- Expose the fan-out `item` alias through the shared value-expression context so fan-out emit fields remain aligned with current authored contracts.

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `handler.emit.fields`: `map of output_field_name -> CEL expression evaluated against handler context`.
- `system_node_runtime.emit_payload_default`: start from empty payload, evaluate `emit.fields`, attach envelope to carrier, no implicit passthrough.
- `strict_payload_contract.payload_rules.declarative_system_node_emit_surface`: runtime validates producer-authored payload fail-closed.
- Issue audit / gate: #373 pre-audit and independent gate approved this as a widened first slice under `strict_event_schema_cross_flow_contract_migration`.

## Semantic migration

Canonical owner after this change:
- `EmitSpec.UnmarshalYAML` owns emit-field surface hydration.
- `emitFieldsPayload` owns runtime business payload construction from hydrated emit fields.
- `workflowexpr.EvalValueExpression` owns CEL value normalization and fan-out `item` evaluation support.
- `bootverify` expression checks consume the same hydrated CEL form.

Old invalid path:
- Generic `ExpressionValue.UnmarshalYAML` decoded scalar emit fields as literals.
- `emitFieldsPayload` skipped non-CEL values, so authored `payload.*` fields were silently dropped.

Production paths checked:
- Handler top-level emit.
- Fan-out emit.
- Bootverify expression validation and payload-completeness checks.
- Current Empire verify and supported `make run-clear` path with paired Empire cleanup.

Migration completeness:
- Runtime/verify owner migration is complete for the approved first-slice class.
- A paired Empire PR quotes the one remaining authored string literal that strict scalar-as-CEL exposes.
