### PR TITLE
[agent-d][issue #401] Preserve validation output identity

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1704,10 +1704,10 @@ func (e *Executor) newEmitIntent(frame *executionFrame, eventType string, payloa
 	if entityID != "" {
 		evt = evt.WithEntityID(entityID)
 	}
-	flowInstance := strings.Trim(strings.TrimSpace(firstNonEmpty(
-		asString(frame.req.State.StateCarrier.Metadata["flow_path"]),
-		frame.req.Event.FlowInstance(),
-	)), "/")
+	flowInstance := firstNonEmpty(
+		normalizedFlowInstanceCandidate(asString(frame.req.State.StateCarrier.Metadata["flow_path"])),
+		normalizedFlowInstanceCandidate(frame.req.Event.FlowInstance()),
+	)
 	if flowInstance != "" {
 		evt = evt.WithFlowInstance(flowInstance)
 	}
@@ -1720,6 +1720,10 @@ func (e *Executor) newEmitIntent(frame *executionFrame, eventType string, payloa
 		ChainDepth:    chainDepth,
 		ParentEventID: strings.TrimSpace(frame.req.Event.ID),
 	}, nil
+}
+
+func normalizedFlowInstanceCandidate(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "/")
 }
 
 func (e *Executor) queueEmitIntent(frame *executionFrame, eventType string, payload map[string]any) (bool, error) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1705,8 +1705,8 @@ func (e *Executor) newEmitIntent(frame *executionFrame, eventType string, payloa
 		evt = evt.WithEntityID(entityID)
 	}
 	flowInstance := strings.Trim(strings.TrimSpace(firstNonEmpty(
-		frame.req.Event.FlowInstance(),
 		asString(frame.req.State.StateCarrier.Metadata["flow_path"]),
+		frame.req.Event.FlowInstance(),
 	)), "/")
 	if flowInstance != "" {
 		evt = evt.WithFlowInstance(flowInstance)

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1372,6 +1372,46 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 	}
 }
 
+func TestExecutor_EmitIntentFallsBackToInboundFlowWhenStateFlowPathNormalizesEmpty(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "root",
+		Event: (events.Event{
+			ID:      "evt-1",
+			Type:    "root.started",
+			Payload: json.RawMessage(`{}`),
+		}).WithEntityID("entity-1").WithFlowInstance("source/inst-1"),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Emit: runtimecontracts.EmitSpec{Event: "root.done"},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"flow_path": "/",
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", got)
+	}
+	if got := result.EmitIntents[0].Event.FlowInstance(); got != "source/inst-1" {
+		t.Fatalf("emitted flow_instance = %q, want inbound fallback source/inst-1", got)
+	}
+}
+
 func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSourceWithRootEntityContract(),

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1293,6 +1293,85 @@ func TestExecutor_PayloadTransformSeesDataAccumulationWrites(t *testing.T) {
 	}
 }
 
+func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	const (
+		targetEntityID     = "validation-entity"
+		targetFlowInstance = "validation/inst-1"
+		sourceEntityID     = "scoring-entity"
+		sourceFlowInstance = "scoring/inst-1"
+	)
+	manifestations := []string{
+		"validation.started",
+		"validation.package_ready",
+		"brand.requested",
+		"cto.spec_review_requested",
+		"spec.revision_requested",
+	}
+	for _, eventType := range manifestations {
+		t.Run(eventType, func(t *testing.T) {
+			state := testStateSnapshot("researching", map[string]any{
+				"flow_path": targetFlowInstance,
+			}, nil, map[string]map[string]any{})
+			state.EntityID = identity.NormalizeEntityID(targetEntityID)
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: targetEntityID,
+				NodeID:   "validation-router",
+				FlowID:   "validation",
+				Event: (events.Event{
+					ID:      "evt-1",
+					Type:    "scoring/vertical.resumed",
+					Payload: json.RawMessage(`{"vertical_id":"` + sourceEntityID + `"}`),
+				}).WithEntityID(sourceEntityID).WithFlowInstance(sourceFlowInstance),
+				Handler: runtimecontracts.SystemNodeEventHandler{
+					Emit: runtimecontracts.EmitSpec{
+						Event: eventType,
+						Fields: map[string]runtimecontracts.ExpressionValue{
+							"source_entity_id":     runtimecontracts.CELExpression("event.entity_id"),
+							"source_flow_instance": runtimecontracts.CELExpression("event.flow_instance"),
+						},
+					},
+				},
+				State: state,
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if got := len(result.EmitIntents); got != 1 {
+				t.Fatalf("EmitIntents count = %d, want 1", got)
+			}
+			emitted := result.EmitIntents[0].Event
+			if got := emitted.EntityID(); got != targetEntityID {
+				t.Fatalf("emitted entity_id = %q, want target validation entity %q", got, targetEntityID)
+			}
+			if got := emitted.FlowInstance(); got != targetFlowInstance {
+				t.Fatalf("emitted flow_instance = %q, want target validation flow %q", got, targetFlowInstance)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(emitted.Payload, &payload); err != nil {
+				t.Fatalf("unmarshal payload: %v", err)
+			}
+			if got := payload["source_entity_id"]; got != sourceEntityID {
+				t.Fatalf("source_entity_id = %#v, want explicit source entity %q", got, sourceEntityID)
+			}
+			if got := payload["source_flow_instance"]; got != sourceFlowInstance {
+				t.Fatalf("source_flow_instance = %#v, want explicit source flow %q", got, sourceFlowInstance)
+			}
+		})
+	}
+}
+
 func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSourceWithRootEntityContract(),


### PR DESCRIPTION
## Summary

Fixes the approved #401 validation child-flow output-boundary identity class by making runtime emit intents prefer the handler target entity's `flow_path` over the inbound source event's `flow_instance`.

This keeps emitted validation events on the validation flow instance after `create_entity: true`, while source/scoring identity remains available only where explicitly authored as payload fields. It does not weaken `cross_flow_write_forbidden` and does not touch #525 entity-tool read/materialization behavior.

Closes #401.

## Governing Refs / Context

- #401 approved widened gate: validation child-flow output-boundary target-entity identity drift after `create_entity: true`.
- #401 latest reassessment: current head materialized `validation/validation.started` with validation entity ID but scoring `flow_instance`, making #401 active again.
- #525 is intentionally split: post-start entity-tool read/write materialization for named/list contract types.
- Exact platform spec section: no narrower exact platform-spec section was cited for this implementation seam; binding context is the approved #401 gate/reassessment plus the validation contract output-boundary behavior.

## Semantic Owner

- New canonical owner for emitted event flow identity: `internal/runtime/engine/executor.go::Executor.newEmitIntent`.
- Old non-authoritative ordering now invalid: inbound/source event `FlowInstance()` no longer overrides the handler target state's `flow_path` when constructing emitted event envelopes.
- Production paths checked: declarative/system handler emit intents through `Executor.Execute`; agent emit tool path remains separate and already uses actor flow identity.
- Migration complete for the approved #401 runtime emit-intent identity class.

## Proof

- `go test ./internal/runtime/engine -run TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource -count=1`
- `go test ./internal/runtime/engine ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/engine ./internal/runtime/pipeline ./cmd/swarm -count=1`
- `set -a; source /Users/youmew/dev/swarm/.env; set +a; make run-clear`

Supported run proof:

- Run ID: `e5c8849a-112b-433b-b2b5-a96ba1d8f7d4`
- Swarm base before patch: `19c7819c31bc641f53d6fa794f9bf2539cdd95bd`; PR head: `06d716c`
- Empire head: `36a43080b860fb9881f4d2068bd24546feff9bb9`
- `validation/validation.started`: 1
- Persisted event: entity `1b498486-342d-5603-b264-0f562f2340fe`, flow `validation/06d27f99-8e89-4c82-921e-5a9553591b55`, payload `{}`
- Source event `vertical.resumed`: entity `b562b110-e276-5289-900e-6263247798c6`, flow `scoring/59e4608f-6cb7-4b49-9032-438a5925330c`
- Validation entity row: entity `1b498486-342d-5603-b264-0f562f2340fe`, flow `validation/06d27f99-8e89-4c82-921e-5a9553591b55`, state `researching`
- Dead letters: 0
- Later validation outputs are still blocked by #525 materialization errors, e.g. unsupported `[MvpFeature]`, `[BrandCandidate]`, `[text]` in entity-tool read/write surfaces.
