### PR TITLE
[agent-d][issue #525] Normalize bracket-list entity type refs

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -305,6 +305,7 @@ nodes:
       - adjacent entity-tool surfaces either bypass shared type normalization entirely or carry stale local interpreters of schema type handling
     representative_issues:
       - 402
+      - 525
     common_framing_mistakes:
       too_broad:
         - entity tools are broken
@@ -312,6 +313,29 @@ nodes:
       too_narrow:
         - one save_entity_field error string
         - one validation-agent transcript line
+    current_action_pressure: active
+  - id: entity_tool_bracket_list_type_ref_normalization_drift
+    title: Entity-Tool Bracket-List Type-Ref Normalization Drift
+    parent_class: runtime entity-tool semantics drift from authored entity_schema type annotations
+    canonical_owners:
+      - shared entity contract value normalization in internal/runtime/entityruntime/contracts.go
+      - entity-tool adapter normalization in internal/runtime/tools/entity_schema.go
+      - entity-tool result materialization in internal/runtime/tools/executor_entity.go
+    why_this_node_exists: authored Wave 1 entity contracts use bracket-form list refs such as [text] and [NamedType], but entityruntime previously recognized only list<T>, T[], and []T, so generic entity tools could reject valid declared fields on supported paths.
+    known_manifestations:
+      - get_entity result materialization rejects named objects containing bracket-list fields
+      - search_entities, query_entities, and query_metrics result materialization reject the same fields before filtering, projection, or aggregation
+      - save_entity_field and create_entity can reject valid values for fields whose declared type or nested named-type leaf uses bracket-list refs
+    representative_issues:
+      - 525
+    common_framing_mistakes:
+      too_broad:
+        - rewrite the entire contract type system
+        - merge event schema lowering and entityruntime in the same PR
+      too_narrow:
+        - one get_entity transcript error
+        - one query_entities materialization failure
+        - read-only materialization when write and create consume the same owner
     current_action_pressure: active
   - id: primitive_only_cross_flow_authored_contract_migration
     title: Primitive-Only Cross-Flow Authored Contract Migration

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -790,6 +790,7 @@ func isUUIDType(contract Contract, typeRef string) bool {
 func isListType(typeRef string) bool {
 	typeRef = strings.TrimSpace(typeRef)
 	return strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">") ||
+		strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]") ||
 		strings.HasSuffix(typeRef, "[]") ||
 		strings.HasPrefix(typeRef, "[]")
 }
@@ -799,6 +800,8 @@ func listItemType(typeRef string) string {
 	switch {
 	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
 		return strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
 	case strings.HasSuffix(typeRef, "[]"):
 		return strings.TrimSpace(typeRef[:len(typeRef)-2])
 	case strings.HasPrefix(typeRef, "[]"):

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -800,12 +800,12 @@ func listItemType(typeRef string) string {
 	switch {
 	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
 		return strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
-	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
-		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
 	case strings.HasSuffix(typeRef, "[]"):
 		return strings.TrimSpace(typeRef[:len(typeRef)-2])
 	case strings.HasPrefix(typeRef, "[]"):
 		return strings.TrimSpace(typeRef[2:])
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
 	default:
 		return typeRef
 	}

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -33,3 +33,62 @@ func TestNormalizeFieldValue_AcceptsBuiltInNumberAndJSONTypes(t *testing.T) {
 		t.Fatalf("details = %#v", details)
 	}
 }
+
+func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"tags": {Type: "[text]"},
+				"spec": {Type: "Spec"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Spec": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"features": {Type: "[Feature]"},
+						"notes":    {Type: "[text]"},
+					},
+				},
+				"Feature": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"name": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	materialized, err := Materialize(contract, nil)
+	if err != nil {
+		t.Fatalf("Materialize defaults: %v", err)
+	}
+	if !reflect.DeepEqual(materialized["tags"], []any{}) {
+		t.Fatalf("tags default = %#v, want empty list", materialized["tags"])
+	}
+	spec, ok := materialized["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec default = %#v, want object", materialized["spec"])
+	}
+	if !reflect.DeepEqual(spec["features"], []any{}) {
+		t.Fatalf("spec.features default = %#v, want empty list", spec["features"])
+	}
+	if !reflect.DeepEqual(spec["notes"], []any{}) {
+		t.Fatalf("spec.notes default = %#v, want empty list", spec["notes"])
+	}
+
+	features, err := NormalizeFieldValue(contract, "spec.features", []any{map[string]any{"name": "Search"}})
+	if err != nil {
+		t.Fatalf("NormalizeFieldValue(spec.features): %v", err)
+	}
+	if !reflect.DeepEqual(features, []any{map[string]any{"name": "Search"}}) {
+		t.Fatalf("features = %#v, want normalized feature list", features)
+	}
+
+	if _, err := NormalizeFieldValue(contract, "spec.features", map[string]any{"name": "Search"}); err == nil {
+		t.Fatalf("NormalizeFieldValue(spec.features object) = nil, want list type error")
+	}
+	if _, err := NormalizeFieldValue(contract, "spec.features", []any{map[string]any{"unknown": "x"}}); err == nil {
+		t.Fatalf("NormalizeFieldValue(spec.features undeclared field) = nil, want named-type field error")
+	}
+}

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -38,16 +38,19 @@ func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 	contract := Contract{
 		Entity: runtimecontracts.EntityContract{
 			Fields: map[string]runtimecontracts.EntityFieldDecl{
-				"tags": {Type: "[text]"},
-				"spec": {Type: "Spec"},
+				"tags":          {Type: "[text]"},
+				"legacy_tags":   {Type: "[text][]"},
+				"prefixed_tags": {Type: "[][text]"},
+				"spec":          {Type: "Spec"},
 			},
 		},
 		Types: runtimecontracts.TypeCatalogDocument{
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"Spec": {
 					Fields: map[string]runtimecontracts.TypeFieldSpec{
-						"features": {Type: "[Feature]"},
-						"notes":    {Type: "[text]"},
+						"features":        {Type: "[Feature]"},
+						"legacy_features": {Type: "[Feature][]"},
+						"notes":           {Type: "[text]"},
 					},
 				},
 				"Feature": {
@@ -66,12 +69,21 @@ func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 	if !reflect.DeepEqual(materialized["tags"], []any{}) {
 		t.Fatalf("tags default = %#v, want empty list", materialized["tags"])
 	}
+	if !reflect.DeepEqual(materialized["legacy_tags"], []any{}) {
+		t.Fatalf("legacy_tags default = %#v, want empty list", materialized["legacy_tags"])
+	}
+	if !reflect.DeepEqual(materialized["prefixed_tags"], []any{}) {
+		t.Fatalf("prefixed_tags default = %#v, want empty list", materialized["prefixed_tags"])
+	}
 	spec, ok := materialized["spec"].(map[string]any)
 	if !ok {
 		t.Fatalf("spec default = %#v, want object", materialized["spec"])
 	}
 	if !reflect.DeepEqual(spec["features"], []any{}) {
 		t.Fatalf("spec.features default = %#v, want empty list", spec["features"])
+	}
+	if !reflect.DeepEqual(spec["legacy_features"], []any{}) {
+		t.Fatalf("spec.legacy_features default = %#v, want empty list", spec["legacy_features"])
 	}
 	if !reflect.DeepEqual(spec["notes"], []any{}) {
 		t.Fatalf("spec.notes default = %#v, want empty list", spec["notes"])
@@ -83,6 +95,13 @@ func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(features, []any{map[string]any{"name": "Search"}}) {
 		t.Fatalf("features = %#v, want normalized feature list", features)
+	}
+	legacyFeatures, err := NormalizeFieldValue(contract, "spec.legacy_features", []any{[]any{map[string]any{"name": "Search"}}})
+	if err != nil {
+		t.Fatalf("NormalizeFieldValue(spec.legacy_features): %v", err)
+	}
+	if !reflect.DeepEqual(legacyFeatures, []any{[]any{map[string]any{"name": "Search"}}}) {
+		t.Fatalf("legacyFeatures = %#v, want normalized nested feature list", legacyFeatures)
 	}
 
 	if _, err := NormalizeFieldValue(contract, "spec.features", map[string]any{"name": "Search"}); err == nil {

--- a/internal/runtime/testdata/generic-swarm-bundle/entities.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/entities.yaml
@@ -3,4 +3,4 @@ item:
   status: string
   priority: string
   score: number
-  gates: GateState
+  gate_state: GateState

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -1043,6 +1043,146 @@ signal:
 	}
 }
 
+func TestEntityTools_BracketListTypeRefsAcrossConsumers(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:    "validator",
+		Role:  "validator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
+	}
+	bundle := loadWave1EntityToolBundle(t, actor, "validation", "validation_case", `
+types:
+  Feature:
+    name: text
+  BrandCandidate:
+    name: text
+  MvpSpec:
+    core_features: "[Feature]"
+    out_of_scope: "[text]"
+  Brand:
+    alternatives: "[BrandCandidate]"
+  ValidationKit:
+    risk_flags: "[text]"
+`, `
+validation_case:
+  mvp_spec:
+    type: MvpSpec
+    initial: {}
+  brand:
+    type: Brand
+    initial: {}
+  validation_kit:
+    type: ValidationKit
+    initial: {}
+  score: integer
+`)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/case-1",
+		"fields": map[string]any{
+			"score": 7,
+		},
+	})
+	_ = mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/case-2",
+		"fields": map[string]any{
+			"mvp_spec": map[string]any{
+				"core_features": []any{map[string]any{"name": "Import"}},
+				"out_of_scope":  []any{"mobile"},
+			},
+			"score": 3,
+		},
+	})
+	if _, err := db.ExecContext(ctx, `UPDATE entity_state SET current_state = 'marginal_review' WHERE entity_id = $1::uuid`, entityID); err != nil {
+		t.Fatalf("seed current_state: %v", err)
+	}
+
+	getOut, err := exec.Execute(ctx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity bracket-list fields: %v", err)
+	}
+	getEntity := getOut.(map[string]any)
+	getFields := getEntity["fields"].(map[string]any)
+	if features := getFields["mvp_spec"].(map[string]any)["core_features"]; len(features.([]any)) != 0 {
+		t.Fatalf("mvp_spec.core_features default = %#v, want empty list", features)
+	}
+	if alternatives := getFields["brand"].(map[string]any)["alternatives"]; len(alternatives.([]any)) != 0 {
+		t.Fatalf("brand.alternatives default = %#v, want empty list", alternatives)
+	}
+	if riskFlags := getFields["validation_kit"].(map[string]any)["risk_flags"]; len(riskFlags.([]any)) != 0 {
+		t.Fatalf("validation_kit.risk_flags default = %#v, want empty list", riskFlags)
+	}
+
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "mvp_spec.core_features",
+		"value": []any{
+			map[string]any{"name": "Guided setup"},
+		},
+	}); err != nil {
+		t.Fatalf("save_entity_field bracket list-of-named: %v", err)
+	}
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "validation_kit.risk_flags",
+		"value":     []any{"pricing risk"},
+	}); err != nil {
+		t.Fatalf("save_entity_field bracket list-of-text: %v", err)
+	}
+
+	searchOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"current_state": "marginal_review",
+		"filter":        map[string]any{"score": 7},
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("search_entities bracket-list materialization: %v", err)
+	}
+	searchRows := searchOut.(map[string]any)["results"].([]map[string]any)
+	if len(searchRows) != 1 {
+		t.Fatalf("search results = %#v, want one row", searchRows)
+	}
+	if _, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"filter": map[string]any{"mvp_spec.core_features": []any{map[string]any{"name": "Guided setup"}}},
+		"limit":  10,
+	}); err == nil || strings.Contains(err.Error(), "unsupported type") {
+		t.Fatalf("search_entities composite list filter = %v, want fail-closed validation before unsupported type", err)
+	}
+
+	queryOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `score == 7`,
+		"select": []string{"score"},
+		"limit":  10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities bracket-list materialization: %v", err)
+	}
+	queryRows := queryOut.(map[string]any)["results"].([]map[string]any)
+	if len(queryRows) != 1 {
+		t.Fatalf("query results = %#v, want one row", queryRows)
+	}
+
+	metricOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"metric": "sum",
+		"field":  "score",
+		"filter": `score == 7`,
+	})
+	if err != nil {
+		t.Fatalf("query_metrics bracket-list materialization: %v", err)
+	}
+	if got := testNumericValue(metricOut.(map[string]any)["value"]); got != 7 {
+		t.Fatalf("metric value = %#v, want 7", metricOut)
+	}
+
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "mvp_spec.core_features",
+		"value":     map[string]any{"name": "not a list"},
+	}); err == nil {
+		t.Fatalf("save_entity_field bracket list accepted object, want invalid_tool_input")
+	}
+}
+
 func TestEntityTools_ReadTargetValidationRejectsUndeclaredBeforeEval(t *testing.T) {
 	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
 		"discovery": {


### PR DESCRIPTION
Closes #525

## Summary

This closes the approved #525 class by making shared entityruntime contract normalization understand bracket-form list type refs such as `[text]` and `[NamedType]`. The fix is intentionally at the canonical owner used by entity tool materialization and write/create normalization, not at individual tool call sites.

## Governing Context

- Issue gate: #525 approved implementation boundary, including shared entityruntime list type-ref normalization across `get_entity`, `search_entities`, `query_entities`, `query_metrics`, `save_entity_field`, and `create_entity`.
- Spec context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` entity contracts and type-system vocabulary for declared entity field schemas and list forms; entity tool schemas must consume declared contracts rather than weaker local type interpreters.
- Prior art: #402 closed annotation normalization drift, but did not cover bracket-list contract refs.

## Semantic Migration

- New canonical owner: `internal/runtime/entityruntime/contracts.go` list type-ref helpers consumed by `Materialize` and `NormalizeFieldValue`.
- Old invalid path: entityruntime recognized `list<T>`, `T[]`, and `[]T`, but not the authored bracket form `[T]`, so supported entity tools could reject valid declared entity fields.
- Production paths checked: focused tests cover `get_entity`, `search_entities`, `query_entities`, `query_metrics`, `save_entity_field`, and `create_entity`; `search_entities` object-filter normalization remains fail-closed for unsupported composite filters rather than surfacing stale `unsupported type` drift.
- Migration completeness: complete for the approved #525 bracket-list entity-tool class. Broader cross-package type-ref parser unification remains watchlist/architecture feedback, not part of this closure.

## Verification

- `go test ./internal/runtime/entityruntime -count=1`
- `go test ./internal/runtime/tools -run 'TestEntityTools_BracketListTypeRefsAcrossConsumers|TestEntityTools_ReadToolsUseExplicitTargetContract|TestEntityTool|TestQueryEntities|TestSearchEntities|Test.*Entity' -count=1`
- `go test ./internal/runtime/entityruntime ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/entityruntime ./internal/runtime/tools -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec /Users/youmew/dev/swarm/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `git diff --check`

Supported-path proof was also attempted with `make run-clear`; run `25519c6b-12a5-483d-ad7b-ad728665a86b` did not reach validation/#525 locally because `market-research-agent` remained active in a long-running session before validation, with zero dead letters and no bracket-list materialization errors observed before that point.