### PR TITLE
[agent-d][issue #528] Preserve child-flow ownership identity

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -696,7 +696,7 @@ func defaultRuntimeConfig() (*config.Config, error) {
 			},
 			ClaudeCLI: config.ClaudeCLIConfig{
 				Command:              envOrDefault("SWARM_CLAUDE_CLI_COMMAND", "claude"),
-				Timeout:              envDuration("SWARM_CLAUDE_CLI_TIMEOUT", 15*time.Minute),
+				Timeout:              envDuration("SWARM_CLAUDE_CLI_TIMEOUT", time.Hour),
 				OutputFormat:         envOrDefault("SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "stream-json"),
 				Retries:              envInt("SWARM_CLAUDE_CLI_RETRIES", 1),
 				NoSessionPersistence: envBool("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", false),

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -126,34 +126,28 @@ func (r pipelineEngineStateRepo) LoadState(ctx context.Context, entityID identit
 	if entityID.IsZero() {
 		return runtimeengine.StateSnapshot{}, false, nil
 	}
-	state := r.coordinator.currentWorkflowState(ctx, entityID.String())
 	flowID := strings.TrimSpace(pipelineFlowScope(ctx))
-	carrier, err := runtimeengine.StateCarrierFromPersisted(workflowMaterializeEntityMetadata(r.coordinator.SemanticSource(), flowID, state.Metadata), nil)
-	if err != nil {
-		return runtimeengine.StateSnapshot{}, false, err
-	}
-	out := runtimeengine.StateSnapshot{
-		EntityID:     entityID,
-		CurrentState: strings.TrimSpace(string(state.Stage)),
-		StateCarrier: carrier,
-	}
 	if r.coordinator.workflowStore != nil && r.coordinator.workflowStore.Enabled() {
 		instance, ok, err := r.coordinator.workflowStore.Load(ctx, entityID.String())
 		if err != nil {
 			return runtimeengine.StateSnapshot{}, false, err
 		}
 		if ok {
-			out.WorkflowName = strings.TrimSpace(instance.WorkflowName)
-			out.WorkflowVersion = strings.TrimSpace(instance.WorkflowVersion)
 			carrier, err := runtimeengine.StateCarrierFromPersisted(workflowMaterializeEntityMetadata(r.coordinator.SemanticSource(), strings.TrimSpace(instance.WorkflowName), instance.Metadata), instance.StateBuckets)
 			if err != nil {
 				return runtimeengine.StateSnapshot{}, false, err
 			}
-			out.StateCarrier = carrier
+			out := runtimeengine.StateSnapshot{
+				EntityID:        entityID,
+				WorkflowName:    strings.TrimSpace(instance.WorkflowName),
+				WorkflowVersion: strings.TrimSpace(instance.WorkflowVersion),
+				CurrentState:    strings.TrimSpace(instance.CurrentState),
+				StateCarrier:    carrier,
+				EnteredStateAt:  instance.EnteredStageAt,
+			}
 			if strings.TrimSpace(instance.SubjectID) != "" {
 				out.StateCarrier.Metadata["subject_id"] = strings.TrimSpace(instance.SubjectID)
 			}
-			out.CurrentState = strings.TrimSpace(instance.CurrentState)
 			out.StateCarrier.Gates = workflowStateGatesForScope(
 				r.coordinator.SemanticSource(),
 				pipelineFlowScope(ctx),
@@ -171,9 +165,23 @@ func (r pipelineEngineStateRepo) LoadState(ctx context.Context, entityID identit
 					Cancelled: timer.Cancelled,
 				})
 			}
+			return out, true, nil
 		}
+		return runtimeengine.StateSnapshot{}, false, nil
 	}
-	return out, true, nil
+	state := r.coordinator.currentWorkflowState(ctx, entityID.String())
+	if strings.TrimSpace(string(state.Stage)) == "" && len(state.Metadata) == 0 {
+		return runtimeengine.StateSnapshot{}, false, nil
+	}
+	carrier, err := runtimeengine.StateCarrierFromPersisted(workflowMaterializeEntityMetadata(r.coordinator.SemanticSource(), flowID, state.Metadata), nil)
+	if err != nil {
+		return runtimeengine.StateSnapshot{}, false, err
+	}
+	return runtimeengine.StateSnapshot{
+		EntityID:     entityID,
+		CurrentState: strings.TrimSpace(string(state.Stage)),
+		StateCarrier: carrier,
+	}, true, nil
 }
 
 func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identity.EntityID, mutation runtimeengine.StateMutation) error {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -738,6 +738,53 @@ func TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite(t *testing.T) {
 	}
 }
 
+func TestPipelineEngineStateRepoLoadStateMissingEntityDoesNotMaterializeDefaults(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `
+name: runtime-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: review
+    flow: review
+    mode: static
+`,
+		"schema.yaml": "name: runtime-test\n",
+		"flows/review/schema.yaml": `
+name: review
+mode: static
+initial_state: queued
+states: [queued]
+`,
+		"flows/review/entities.yaml": `
+review_entity:
+  status:
+    type: text
+    initial: pending
+`,
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected temp workflow bundle")
+	}
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	repo := pipelineEngineStateRepo{
+		coordinator: &PipelineCoordinator{
+			workflowStore: NewWorkflowInstanceStore(db),
+			module:        &previewWorkflowModule{bundle: bundle},
+		},
+	}
+
+	loaded, ok, err := repo.LoadState(withPipelineFlowScope(context.Background(), "review"), identity.NormalizeEntityID(FlowInstanceEntityID("review/inst-missing")))
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if ok {
+		t.Fatalf("LoadState ok=true for missing entity, loaded metadata=%#v", loaded.Metadata)
+	}
+}
+
 func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1344,6 +1344,7 @@ node-a:
 	if got := instance.Metadata["revision_count"]; got != float64(0) && got != 0 {
 		t.Fatalf("persisted revision_count = %#v, want 0", got)
 	}
+	assertCreatedChildFlowIdentityCoherent(t, db, "validation", entityID, emitted, instance)
 
 	rows, err := db.QueryContext(context.Background(), `
 		SELECT field, COALESCE(writer_type, ''), COALESCE(writer_id, ''), COALESCE(handler_step, '')
@@ -1373,6 +1374,133 @@ node-a:
 		t.Fatalf("expected initial-value mutation for revision_count, got %#v", initialMutations)
 	} else if got[2] != "create_entity" {
 		t.Fatalf("revision_count initial mutation metadata = %#v, want handler_step create_entity", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerCreateEntityPersistsNonValidationChildFlowIdentity(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bus := &recordingPipelineBus{}
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `
+name: runtime-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: review
+    flow: review
+    mode: static
+`,
+		"schema.yaml": "name: runtime-test\n",
+		"flows/review/schema.yaml": `
+name: review
+mode: static
+initial_state: queued
+states: [queued]
+`,
+		"flows/review/entities.yaml": `
+review_entity:
+  status:
+    type: text
+    initial: pending
+`,
+		"flows/review/nodes.yaml": `
+node-a:
+  id: node-a
+  execution_type: system_node
+`,
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected temp workflow bundle")
+	}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("review", []WorkflowStage{
+				{Name: "queued"},
+			}, nil),
+		},
+	}
+
+	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		Guard:        &runtimecontracts.GuardSpec{Check: `entity.status == "pending"`},
+		Emit: runtimecontracts.EmitSpec{
+			Event: "review.created",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"status": runtimecontracts.CELExpression("entity.status"),
+			},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{Type: events.EventType("candidate.ready")},
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	emitted := bus.publishedEvent(0)
+	entityID := emitted.EntityID()
+	if entityID == "" {
+		t.Fatal("expected emitted event to carry created entity id")
+	}
+	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected created entity to persist")
+	}
+	if got := instance.Metadata["status"]; got != "pending" {
+		t.Fatalf("persisted status = %#v, want pending", got)
+	}
+	assertCreatedChildFlowIdentityCoherent(t, db, "review", entityID, emitted, instance)
+}
+
+func assertCreatedChildFlowIdentityCoherent(t *testing.T, db *sql.DB, flowID, entityID string, emitted events.Event, instance WorkflowInstance) {
+	t.Helper()
+	instanceID := strings.TrimSpace(asString(instance.Metadata["instance_id"]))
+	if instanceID == "" {
+		t.Fatalf("created %s entity %s missing instance_id metadata: %#v", flowID, entityID, instance.Metadata)
+	}
+	flowPath := flowID + "/" + instanceID
+	if got := strings.TrimSpace(instance.StorageRef); got != flowPath {
+		t.Fatalf("created %s entity storage_ref = %q, want %q", flowID, got, flowPath)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["storage_ref"])); got != flowPath {
+		t.Fatalf("created %s entity metadata storage_ref = %q, want %q", flowID, got, flowPath)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["flow_path"])); got != flowPath {
+		t.Fatalf("created %s entity flow_path = %q, want %q", flowID, got, flowPath)
+	}
+	if got := entityID; got != FlowInstanceEntityID(flowPath) {
+		t.Fatalf("created %s entity id = %q, want %q for flow path %q", flowID, got, FlowInstanceEntityID(flowPath), flowPath)
+	}
+	if got := emitted.FlowInstance(); got != flowPath {
+		t.Fatalf("created %s emitted flow_instance = %q, want %q", flowID, got, flowPath)
+	}
+	var rowOwner string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT flow_instance
+		FROM entity_state
+		WHERE entity_id = $1::uuid
+	`, entityID).Scan(&rowOwner); err != nil {
+		t.Fatalf("query created %s entity_state owner: %v", flowID, err)
+	}
+	if got := strings.TrimSpace(rowOwner); got != flowPath {
+		t.Fatalf("created %s entity_state.flow_instance = %q, want %q", flowID, got, flowPath)
 	}
 }
 

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -90,10 +90,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 	if entityID != "" {
 		emitted = emitted.WithEntityID(entityID)
 	}
-	flowInstance := strings.Trim(strings.TrimSpace(actor.CanonicalFlowPath()), "/")
-	if flowInstance == "" {
-		flowInstance = strings.Trim(strings.TrimSpace(inbound.FlowInstance()), "/")
-	}
+	flowInstance := emitFlowInstanceForActorEvent(actor, inbound)
 	if flowInstance != "" {
 		emitted = emitted.WithFlowInstance(flowInstance)
 	}
@@ -125,6 +122,24 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		"event_id":   emitted.ID,
 		"event_type": eventType,
 	}, nil
+}
+
+func emitFlowInstanceForActorEvent(actor models.AgentConfig, inbound events.Event) string {
+	actorFlow := strings.Trim(strings.TrimSpace(actor.CanonicalFlowPath()), "/")
+	inboundFlow := strings.Trim(strings.TrimSpace(inbound.FlowInstance()), "/")
+	if inboundFlow != "" && flowWithinActorScope(actorFlow, inboundFlow) {
+		return inboundFlow
+	}
+	return actorFlow
+}
+
+func flowWithinActorScope(actorFlow, inboundFlow string) bool {
+	actorFlow = strings.Trim(strings.TrimSpace(actorFlow), "/")
+	inboundFlow = strings.Trim(strings.TrimSpace(inboundFlow), "/")
+	if actorFlow == "" || inboundFlow == "" {
+		return false
+	}
+	return inboundFlow == actorFlow || strings.HasPrefix(inboundFlow, actorFlow+"/")
 }
 
 func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eventType string) string {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/flowmodel"
@@ -99,6 +100,121 @@ func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
 	}
 	if bus.count != 1 {
 		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
+}
+
+func TestHandleEmitTool_PreservesInboundChildFlowOwnerWithinActorScope(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"research.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"summary": {Type: "string"},
+					},
+					Required: []string{"summary"},
+				},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"validation": {
+					Paths: runtimecontracts.FlowContractPaths{
+						ID:   "validation",
+						Flow: "validation",
+					},
+					Events: map[string]runtimecontracts.EventCatalogEntry{
+						"research.completed": {},
+					},
+					Path: "validation",
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "business-research-agent",
+		Role:       "business_research",
+		Mode:       "validation",
+		FlowPath:   "validation",
+		EmitEvents: []string{"research.completed"},
+	}
+	inbound := (events.Event{
+		Type: events.EventType("validation/validation.started"),
+	}).WithEntityID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").WithFlowInstance("validation/inst-1")
+	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
+
+	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
+		"summary": "research done",
+	})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	if got, want := bus.event.EntityID(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"; got != want {
+		t.Fatalf("published event entity_id = %q, want %q", got, want)
+	}
+	if got, want := bus.event.FlowInstance(), "validation/inst-1"; got != want {
+		t.Fatalf("published event flow_instance = %q, want %q", got, want)
+	}
+}
+
+func TestHandleEmitTool_DoesNotAdoptForeignInboundFlowOwner(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"research.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"summary": {Type: "string"},
+					},
+					Required: []string{"summary"},
+				},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"validation": {
+					Paths: runtimecontracts.FlowContractPaths{
+						ID:   "validation",
+						Flow: "validation",
+					},
+					Events: map[string]runtimecontracts.EventCatalogEntry{
+						"research.completed": {},
+					},
+					Path: "validation",
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "business-research-agent",
+		Role:       "business_research",
+		Mode:       "validation",
+		FlowPath:   "validation",
+		EmitEvents: []string{"research.completed"},
+	}
+	inbound := (events.Event{
+		Type: events.EventType("scoring/vertical.shortlisted"),
+	}).WithEntityID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").WithFlowInstance("scoring/inst-1")
+	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
+
+	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
+		"summary": "research done",
+	})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	if got, want := bus.event.FlowInstance(), "validation"; got != want {
+		t.Fatalf("published event flow_instance = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #528.

This PR fixes runtime ownership identity coherence for `create_entity` / `create_flow_instance` child-flow entities by preserving the canonical child-flow owner across activation persistence, load/projection, state carrier metadata, emitted event metadata, entity read/query consumers, and write enforcement.

Root cause: `pipelineEngineStateRepo.LoadState` treated a missing persisted child-flow row as an existing state when schema defaults materialized non-empty metadata. The runtime then merged that synthetic default state over the create-entity base state and lost the canonical `flow_path` / `storage_ref` / `instance_id`, causing same-child-flow writes to look cross-flow. Separately, emit tools preferred a static actor flow path over the inbound child-flow owner, so entity-scoped child-flow agents could emit follow-up events with bare flow metadata.

## Governing Context

- Issue #528 approved widened gate: runtime ownership identity coherence for create_flow_instance / create_entity true child-flow entities.
- Parent class: #415 runtime/authored boundary residuals remains open.
- Exact spec context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` ownership/flow identity semantics for runtime-owned entity/event envelope identity and child-flow ownership.

## Semantic Migration

- New canonical owner after the change: persisted child-flow workflow instance identity (`flow_instances.storage_ref` / `entity_state.flow_instance`) plus inbound same-scope child-flow envelope identity for agent-emitted follow-up events.
- Old invalid path: synthetic schema-default materialization for a missing workflow row and static actor flow fallback for same-entity child-flow emits.
- Production paths checked: activation persistence, workflow state load/projection, entity state owner row, emitted event envelope metadata, read/write enforcement, and supported `make run-clear` path.
- Migration complete for the approved #528 child class. #415 broader residuals remain separate.

## Proof

- `go test ./internal/runtime/tools -run 'TestHandleEmitTool_(PreservesInboundChildFlowOwnerWithinActorScope|DoesNotAdoptForeignInboundFlowOwner)|TestEntityTools_(SaveEntityFieldRejectsCrossFlowWrite|FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity|CreateEntityRejectsForeignFlowInstance)$' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestPipelineEngineStateRepoLoadStateMissingEntityDoesNotMaterializeDefaults|TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite|TestExecuteNodeContractHandlerCreateEntityPersistsSchemaInitialValuesBeforeGuardReads|TestExecuteNodeContractHandlerCreateEntityPersistsNonValidationChildFlowIdentity' -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/engine -run 'Test.*Emit|Test.*State|Test.*CreateEntity|Test.*Flow' -count=1`
- `go test ./internal/runtime/... -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec /Users/youmew/dev/swarm/worktrees/origin-master-current/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Supported path: `set -a; source /Users/youmew/dev/swarm/.env; set +a; make run-clear`, run `ab10dc2d-25c0-44e3-895c-c202c209c011`; after the market-research timeout/retry completed, the same run reached scoring and validation with zero run-scoped dead letters, `validation/validation.started=2`, and coherent validation child-flow identity for the observed validation events (`validation/0dc78ac4-6172-4f26-bdcf-c6ca451adbf5` and `validation/07d72414-a4b6-4b86-9eb2-a3d69ddbff3c`).
