### PR TITLE
[agent-a][issue #397] Scope authoritative event owners by canonical identity

### DIFF
--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -23,15 +23,15 @@ var tier11FlowCompositionFixtures = []string{
 	"test-required-agents-child",
 	"test-child-flow-sibling-isolation",
 	"test-multi-level-policy-inherit",
+	"test-sibling-both-instantiated-isolated",
 	"test-subject-id-cross-flow-inherit",
 	"test-tool-override",
 	"test-wildcard-deep-subscription",
 }
 
 var tier11ExcludedFixtures = map[string]catalogExcludedFixture{
-	"test-dynamic-flow-instance":              {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
-	"test-sibling-both-instantiated-isolated": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
-	"test-subject-id-first-flow-seeds":        {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
+	"test-dynamic-flow-instance":       {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
+	"test-subject-id-first-flow-seeds": {reason: "new conformance fixture not yet wired into runtime catalog execution set"},
 }
 
 var tier11StartedRuntimeFixtures = map[string]struct{}{

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -153,6 +153,27 @@ func TestLoadWorkflowContractBundleRejectsTier8DialectFixtures(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowContractBundleAllowsSiblingFlowLocalAuthoritativeOwners(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	if owners := bundle.RuntimeEventOwners("work.begin"); len(owners) != 0 {
+		t.Fatalf("expected no authoritative owners for root work.begin, got %v", owners)
+	}
+	if owners := bundle.RuntimeEventOwners("flow-a/work.begin"); !hasAll(owners, "alpha-intake") || hasAny(owners, "beta-intake") {
+		t.Fatalf("expected only alpha-intake to own flow-a/work.begin, got %v", owners)
+	}
+	if owners := bundle.RuntimeEventOwners("flow-b/work.begin"); !hasAll(owners, "beta-intake") || hasAny(owners, "alpha-intake") {
+		t.Fatalf("expected only beta-intake to own flow-b/work.begin, got %v", owners)
+	}
+}
+
 func contractErrorContains(err error, substr string) bool {
 	if err == nil || strings.TrimSpace(substr) == "" {
 		return false
@@ -167,4 +188,30 @@ func contractErrorContains(err error, substr string) bool {
 	}
 	text := err.Error()
 	return strings.Contains(text, substr)
+}
+
+func hasAll(values []string, wants ...string) bool {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[strings.TrimSpace(value)] = struct{}{}
+	}
+	for _, want := range wants {
+		if _, ok := seen[strings.TrimSpace(want)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasAny(values []string, wants ...string) bool {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[strings.TrimSpace(value)] = struct{}{}
+	}
+	for _, want := range wants {
+		if _, ok := seen[strings.TrimSpace(want)]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -174,7 +174,7 @@ func TestLoadWorkflowContractBundleAllowsSiblingFlowLocalAuthoritativeOwners(t *
 	}
 }
 
-func TestRuntimeEventOwnersScopesFlowLocalWildcardHandlers(t *testing.T) {
+func TestLoadWorkflowContractBundleAllowsSiblingFlowLocalWildcardAuthoritativeOwners(t *testing.T) {
 	repoRoot := contractRepoRoot(t)
 	root := t.TempDir()
 	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -182,17 +182,19 @@ name: wildcard-owner-test
 version: "1.0.0"
 platform_version: ">=1.0.0"
 flows:
-  - id: child
-    flow: child
+  - id: flow-a
+    flow: flow-a
+  - id: flow-b
+    flow: flow-b
 `)
 	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: wildcard-owner-test\n")
 	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "package.yaml"), "name: child\n")
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
-name: child
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "package.yaml"), "name: flow-a\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "schema.yaml"), `
+name: flow-a
 initial_state: active
 terminal_states: [done]
 states: [active, done]
@@ -200,15 +202,40 @@ pins:
   outputs:
     events: [task.done]
 `)
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), "{}\n")
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), "{}\n")
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "events.yaml"), `
 task.done:
   entity_id: string
 `)
-	writeFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
-child-wildcard:
-  id: child-wildcard
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-a", "nodes.yaml"), `
+flow-a-wildcard:
+  id: flow-a-wildcard
+  execution_type: system_node
+  subscribes_to: [task.*]
+  event_handlers:
+    task.*:
+      advances_to: done
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "package.yaml"), "name: flow-b\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "schema.yaml"), `
+name: flow-b
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "events.yaml"), `
+task.done:
+  entity_id: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "flow-b", "nodes.yaml"), `
+flow-b-wildcard:
+  id: flow-b-wildcard
   execution_type: system_node
   subscribes_to: [task.*]
   event_handlers:
@@ -221,8 +248,14 @@ child-wildcard:
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 
-	if owners := bundle.RuntimeEventOwners("child/task.done"); !hasAll(owners, "child-wildcard") {
-		t.Fatalf("expected child-wildcard to own child/task.done through flow-local wildcard, got %v", owners)
+	if owners := bundle.RuntimeEventOwners("task.done"); len(owners) != 0 {
+		t.Fatalf("expected no authoritative owners for ambiguous root task.done, got %v", owners)
+	}
+	if owners := bundle.RuntimeEventOwners("flow-a/task.done"); !hasAll(owners, "flow-a-wildcard") || hasAny(owners, "flow-b-wildcard") {
+		t.Fatalf("expected only flow-a-wildcard to own flow-a/task.done, got %v", owners)
+	}
+	if owners := bundle.RuntimeEventOwners("flow-b/task.done"); !hasAll(owners, "flow-b-wildcard") || hasAny(owners, "flow-a-wildcard") {
+		t.Fatalf("expected only flow-b-wildcard to own flow-b/task.done, got %v", owners)
 	}
 }
 

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -174,6 +174,58 @@ func TestLoadWorkflowContractBundleAllowsSiblingFlowLocalAuthoritativeOwners(t *
 	}
 }
 
+func TestRuntimeEventOwnersScopesFlowLocalWildcardHandlers(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: wildcard-owner-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: child
+    flow: child
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: wildcard-owner-test\n")
+	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "package.yaml"), "name: child\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+task.done:
+  entity_id: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
+child-wildcard:
+  id: child-wildcard
+  execution_type: system_node
+  subscribes_to: [task.*]
+  event_handlers:
+    task.*:
+      advances_to: done
+`)
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	if owners := bundle.RuntimeEventOwners("child/task.done"); !hasAll(owners, "child-wildcard") {
+		t.Fatalf("expected child-wildcard to own child/task.done through flow-local wildcard, got %v", owners)
+	}
+}
+
 func contractErrorContains(err error, substr string) bool {
 	if err == nil || strings.TrimSpace(substr) == "" {
 		return false

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -722,7 +722,7 @@ func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 			if pattern == "" || !strings.Contains(pattern, "*") {
 				continue
 			}
-			canonicalPattern := strings.TrimSpace(b.ResolveNodeEventReference(nodeID, pattern))
+			canonicalPattern := strings.TrimSpace(b.resolveNodeEventOwnerPattern(nodeID, pattern))
 			if canonicalPattern == "" {
 				canonicalPattern = pattern
 			}
@@ -761,6 +761,29 @@ func (b *WorkflowContractBundle) runtimeEventOwnersForQuery(eventType string) []
 		matched = append([]string{}, owners...)
 	}
 	return matched
+}
+
+func (b *WorkflowContractBundle) resolveNodeEventOwnerPattern(nodeID, pattern string) string {
+	pattern = eventidentity.Normalize(pattern)
+	if b == nil || pattern == "" {
+		return pattern
+	}
+	flowID := b.nodeFlowID(nodeID)
+	scope := b.nodeEventScope(nodeID)
+	resolved := strings.TrimSpace(scope.ResolveSubscriptionPattern(pattern, b.flowEventDescendants(flowID)))
+	if resolved == "" || resolved != pattern || strings.Contains(pattern, "/") {
+		return resolved
+	}
+	path := eventidentity.Normalize(scope.Path)
+	if path == "" {
+		return resolved
+	}
+	for _, localEvent := range scope.LocalEvents {
+		if eventidentity.MatchPattern(pattern, localEvent) {
+			return path + "/" + pattern
+		}
+	}
+	return resolved
 }
 
 func (b *WorkflowContractBundle) localizeNodeEventType(nodeID, eventType string) string {

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -714,8 +714,8 @@ func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 	if b == nil {
 		return nil
 	}
-	rawEventType := strings.TrimSpace(eventType)
-	owners := append([]string{}, b.Semantics.EventOwners[rawEventType]...)
+	rawEventType := eventidentity.Normalize(eventType)
+	owners := b.runtimeEventOwnersForQuery(rawEventType)
 	for nodeID, handlers := range b.Semantics.NodeHandlers {
 		for pattern := range handlers {
 			pattern = strings.TrimSpace(pattern)
@@ -733,6 +733,34 @@ func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 		}
 	}
 	return owners
+}
+
+func (b *WorkflowContractBundle) runtimeEventOwnersForQuery(eventType string) []string {
+	eventType = eventidentity.Normalize(eventType)
+	if b == nil || eventType == "" {
+		return nil
+	}
+	if owners := b.Semantics.EventOwners[eventType]; len(owners) > 0 {
+		return append([]string{}, owners...)
+	}
+	if strings.Contains(eventType, "/") {
+		return nil
+	}
+
+	var matched []string
+	for canonical, owners := range b.Semantics.EventOwners {
+		canonical = eventidentity.Normalize(canonical)
+		if eventidentity.LeafName(canonical) != eventType {
+			continue
+		}
+		if matched != nil {
+			// A local name that resolves to more than one canonical owner is
+			// ambiguous; callers must use the scoped event identity.
+			return nil
+		}
+		matched = append([]string{}, owners...)
+	}
+	return matched
 }
 
 func (b *WorkflowContractBundle) localizeNodeEventType(nodeID, eventType string) string {

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -717,23 +717,16 @@ func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 	rawEventType := strings.TrimSpace(eventType)
 	owners := append([]string{}, b.Semantics.EventOwners[rawEventType]...)
 	for nodeID, handlers := range b.Semantics.NodeHandlers {
-		localEventType := b.localizeNodeEventType(nodeID, rawEventType)
-		if _, ok := handlers[localEventType]; ok {
-			owners = appendIfMissingString(owners, nodeID)
-			continue
-		}
-		if rawEventType != "" && rawEventType != localEventType {
-			if _, ok := handlers[rawEventType]; ok {
-				owners = appendIfMissingString(owners, nodeID)
+		for pattern := range handlers {
+			pattern = strings.TrimSpace(pattern)
+			if pattern == "" || !strings.Contains(pattern, "*") {
 				continue
 			}
-		}
-		for pattern := range handlers {
-			if handlerPatternMatches(pattern, localEventType) {
-				owners = appendIfMissingString(owners, nodeID)
-				break
+			canonicalPattern := strings.TrimSpace(b.ResolveNodeEventReference(nodeID, pattern))
+			if canonicalPattern == "" {
+				canonicalPattern = pattern
 			}
-			if rawEventType != "" && rawEventType != localEventType && handlerPatternMatches(pattern, rawEventType) {
+			if handlerPatternMatches(canonicalPattern, rawEventType) {
 				owners = appendIfMissingString(owners, nodeID)
 				break
 			}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -95,7 +95,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				continue
 			}
 			handlers[rawEventType] = handler
-			ownerEventType := strings.TrimSpace(bundle.ResolveNodeEventReference(nodeID, rawEventType))
+			ownerEventType := strings.TrimSpace(bundle.resolveNodeEventOwnerPattern(nodeID, rawEventType))
 			if ownerEventType == "" {
 				ownerEventType = rawEventType
 			}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -90,17 +90,21 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		handlers := make(map[string]SystemNodeEventHandler, len(node.EventHandlers))
 		source, _ := bundle.NodeContractSource(nodeID)
 		for eventType, handler := range node.EventHandlers {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
+			rawEventType := strings.TrimSpace(eventType)
+			if rawEventType == "" {
 				continue
 			}
-			handlers[eventType] = handler
-			semantics.EventOwners[eventType] = appendIfMissingString(semantics.EventOwners[eventType], nodeID)
+			handlers[rawEventType] = handler
+			ownerEventType := strings.TrimSpace(bundle.ResolveNodeEventReference(nodeID, rawEventType))
+			if ownerEventType == "" {
+				ownerEventType = rawEventType
+			}
+			semantics.EventOwners[ownerEventType] = appendIfMissingString(semantics.EventOwners[ownerEventType], nodeID)
 			transition := HandlerTransitionSemantic{
-				ID:               fmt.Sprintf("%s:%s", nodeID, eventType),
+				ID:               fmt.Sprintf("%s:%s", nodeID, rawEventType),
 				NodeID:           nodeID,
 				FlowID:           strings.TrimSpace(source.FlowID),
-				EventType:        eventType,
+				EventType:        rawEventType,
 				Action:           handler.Action,
 				Guard:            handler.Guard,
 				AdvancesTo:       strings.TrimSpace(handler.AdvancesTo),
@@ -134,7 +138,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 			if semantics.HandlerTransitionIndex[nodeID] == nil {
 				semantics.HandlerTransitionIndex[nodeID] = map[string]HandlerTransitionSemantic{}
 			}
-			semantics.HandlerTransitionIndex[nodeID][eventType] = transition
+			semantics.HandlerTransitionIndex[nodeID][rawEventType] = transition
 		}
 		semantics.NodeHandlers[nodeID] = handlers
 	}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -586,16 +586,17 @@ func (pc *PipelineCoordinator) dispatchWorkflowNodeEventResult(ctx context.Conte
 	if eventType == "" {
 		return false, nil
 	}
+	handledAny := false
 	for _, node := range pc.WorkflowNodes() {
 		handled, err := pc.executeNodeHandlerPlanResult(ctx, strings.TrimSpace(node.ID), evt)
 		if err != nil {
-			return handled, err
+			return handledAny || handled, err
 		}
 		if handled {
-			return true, nil
+			handledAny = true
 		}
 	}
-	return false, nil
+	return handledAny, nil
 }
 
 func deriveWorkflowEventDelivery(entry runtimecontracts.EventCatalogEntry) (consume bool, visible bool) {

--- a/internal/runtime/semanticview/runtime_event_owners_test.go
+++ b/internal/runtime/semanticview/runtime_event_owners_test.go
@@ -1,0 +1,61 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestRuntimeEventOwners_UsesScopedAuthoritativeOwners(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	if owners := source.RuntimeEventOwners("work.begin"); len(owners) != 0 {
+		t.Fatalf("expected no semanticview authoritative owners for root work.begin, got %v", owners)
+	}
+	if owners := source.RuntimeEventOwners("flow-a/work.begin"); !testHasAll(owners, "alpha-intake") || testHasAny(owners, "beta-intake") {
+		t.Fatalf("expected only alpha-intake for flow-a/work.begin, got %v", owners)
+	}
+	if owners := source.RuntimeEventOwners("flow-b/work.begin"); !testHasAll(owners, "beta-intake") || testHasAny(owners, "alpha-intake") {
+		t.Fatalf("expected only beta-intake for flow-b/work.begin, got %v", owners)
+	}
+}
+
+func testHasAll(values []string, wants ...string) bool {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, want := range wants {
+		if _, ok := seen[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func testHasAny(values []string, wants ...string) bool {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, want := range wants {
+		if _, ok := seen[want]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/expected.yaml
+++ b/tests/tier11-flow-composition/test-sibling-both-instantiated-isolated/expected.yaml
@@ -5,6 +5,7 @@ trigger:
 
 expected:
   handler_outcome: success
+  emitted_events: [work.begin]
   flow_entities:
     flow-a:
       entity_state: processed


### PR DESCRIPTION
## Summary

Closes #397.

This PR fixes the original authoritative-owner collision for `test-sibling-both-instantiated-isolated`. The contract loader now records system-node event ownership by canonical event identity instead of collapsing sibling flow-local handler keys like `work.begin` into one root event owner set. `RuntimeEventOwners(...)` consumes that same canonical owner truth, including unique local-name lookups and flow-local wildcard owner patterns, so the runtime accessor moves with the load validator instead of leaving a second interpretation live.

The loader-time wildcard seam is also covered: two sibling child flows can both declare the same local wildcard handler pattern (`task.*`) without colliding as duplicate owners of raw `task.*`; their owner identities are scoped before load validation.

The supported `cataloge2e` sibling fixture now passes on current `origin/master`. The previous post-load `flow-b not found` residual no longer reproduces after rebasing; no new residual blocker remains from that failure. The fixture expectation now records the real root `work.begin` emission so runtime-outcome accounting is honest.

Closure level: chosen first-slice failure class eliminated.

## Scope

In scope:
- canonical authoritative-owner classification for flow-local system-node handlers
- contract-load validation over that owner truth
- `RuntimeEventOwners(...)` accessor behavior over the same owner truth
- admission of `test-sibling-both-instantiated-isolated` into normal tier11 runtime execution

Out of scope:
- #446 first child-flow subject lineage
- #398 emitted-event proof work, already closed
- broad #125 fixture-family redesign

## Governing Context

Exact spec references:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_identity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `single_node_handler_rule`

Process refs:
- Pre-audit: https://github.com/yazzaoui/Swarm/issues/397#issuecomment-4256190399
- Gate: https://github.com/yazzaoui/Swarm/issues/397#issuecomment-4256191769

## Validation

- `go test ./internal/runtime/contracts -run 'Test(LoadWorkflowContractBundleAllowsSiblingFlowLocalAuthoritativeOwners|LoadWorkflowContractBundleAllowsSiblingFlowLocalWildcardAuthoritativeOwners|ValidateWorkflowContractBundleLoadConstraintsRejectsMultipleAuthoritativeOwners)$' -count=1`
- `go test ./internal/runtime/semanticview -run 'TestRuntimeEventOwners_UsesScopedAuthoritativeOwners$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-sibling-both-instantiated-isolated$' -count=1`
- `go test ./internal/runtime/testcases -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/pipeline ./internal/runtime/testcases -count=1`