### PR TITLE
[agent-d][issue #531] Align existing-entity flow instance guards

### DIFF
--- a/internal/runtime/tools/entity_flow_instance_scope.go
+++ b/internal/runtime/tools/entity_flow_instance_scope.go
@@ -28,7 +28,7 @@ func entityToolExistingFlowInstanceMatches(source semanticview.Source, requested
 	if !ok {
 		return false
 	}
-	return runtimeflowidentity.OwnedByScope(root, stored)
+	return stored == root || strings.HasPrefix(stored, root+"/")
 }
 
 func appendEntityToolExistingFlowInstanceFilter(source semanticview.Source, clauses []string, args []any, requested string) ([]string, []any) {

--- a/internal/runtime/tools/entity_flow_instance_scope.go
+++ b/internal/runtime/tools/entity_flow_instance_scope.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	"swarm/internal/runtime/semanticview"
+)
+
+func normalizeEntityToolFlowInstance(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "/")
+}
+
+func entityToolExistingFlowInstanceMatches(source semanticview.Source, requested, stored string) bool {
+	requested = normalizeEntityToolFlowInstance(requested)
+	stored = normalizeEntityToolFlowInstance(stored)
+	if requested == "" {
+		return true
+	}
+	if stored == "" {
+		return false
+	}
+	if requested == stored {
+		return true
+	}
+	root, ok := entityToolDeclaredFlowScopeRoot(source, requested)
+	if !ok {
+		return false
+	}
+	return runtimeflowidentity.OwnedByScope(root, stored)
+}
+
+func appendEntityToolExistingFlowInstanceFilter(source semanticview.Source, clauses []string, args []any, requested string) ([]string, []any) {
+	requested = normalizeEntityToolFlowInstance(requested)
+	if requested == "" {
+		return clauses, args
+	}
+	if root, ok := entityToolDeclaredFlowScopeRoot(source, requested); ok {
+		args = append(args, root, root+"/%")
+		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
+		return clauses, args
+	}
+	args = append(args, requested)
+	clauses = append(clauses, fmt.Sprintf("flow_instance = $%d", len(args)))
+	return clauses, args
+}
+
+func entityToolDeclaredFlowScopeRoot(source semanticview.Source, requested string) (string, bool) {
+	requested = normalizeEntityToolFlowInstance(requested)
+	if source == nil || requested == "" {
+		return "", false
+	}
+	for flowID := range source.FlowSchemaEntries() {
+		if root := normalizeEntityToolFlowInstance(runtimeflowidentity.ScopeKey(source, flowID)); root == requested {
+			return root, true
+		}
+	}
+	return "", false
+}

--- a/internal/runtime/tools/executor_entity_helpers_test.go
+++ b/internal/runtime/tools/executor_entity_helpers_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	models "swarm/internal/runtime/core/actors"
@@ -37,5 +38,22 @@ func TestEntityStateBaseQuery_OptionallyIncludesFlowInstance(t *testing.T) {
 	}
 	if !reflect.DeepEqual(argsWithFlow, []any{"subject-1", "review/inst-1"}) {
 		t.Fatalf("args with flow = %#v", argsWithFlow)
+	}
+}
+
+func TestExistingEntityFlowInstanceSchemaDocumentsRootSemantics(t *testing.T) {
+	entries := genericEntityRuntimeContractSchemas(entityReadTargetInputSchema(nil))
+	for _, toolName := range []string{"get_entity", "save_entity_field", "query_entities", "query_metrics", "search_entities"} {
+		properties := entries[toolName].InputSchema["properties"].(map[string]any)
+		flowSchema := properties["flow_instance"].(map[string]any)
+		description := strings.TrimSpace(flowSchema["description"].(string))
+		if !strings.Contains(description, "concrete flow instance path") || !strings.Contains(description, "declared semantic flow root") || !strings.Contains(description, "descendant") {
+			t.Fatalf("%s flow_instance description = %q, want concrete path and semantic-root descendant guidance", toolName, description)
+		}
+	}
+	createProperties := entries["create_entity"].InputSchema["properties"].(map[string]any)
+	createFlowSchema := createProperties["flow_instance"].(map[string]any)
+	if _, ok := createFlowSchema["description"]; ok {
+		t.Fatalf("create_entity flow_instance gained existing-entity guidance: %#v", createFlowSchema)
 	}
 }

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -202,10 +202,7 @@ func entityStateBaseQueryForContract(source semanticview.Source, contract entity
 		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
 	}
 	if includeFlowInstance {
-		if flowInstance := strings.Trim(strings.TrimSpace(asString(payload["flow_instance"])), "/"); flowInstance != "" {
-			args = append(args, flowInstance)
-			clauses = append(clauses, fmt.Sprintf("flow_instance = $%d", len(args)))
-		}
+		clauses, args = appendEntityToolExistingFlowInstanceFilter(source, clauses, args, asString(payload["flow_instance"]))
 	}
 	return clauses, args
 }

--- a/internal/runtime/tools/executor_entity_read.go
+++ b/internal/runtime/tools/executor_entity_read.go
@@ -26,8 +26,8 @@ func (e *Executor) execGetEntity(ctx context.Context, _ models.AgentConfig, inpu
 	if !found {
 		return nil, NewRuntimeError("not_found", "tool-executor", "exec_get_entity.lookup", false, "entity %s not found", entityID)
 	}
-	if flowInstance := strings.Trim(strings.TrimSpace(asString(payload["flow_instance"])), "/"); flowInstance != "" {
-		if strings.Trim(strings.TrimSpace(asString(entity["flow_instance"])), "/") != flowInstance {
+	if flowInstance := normalizeEntityToolFlowInstance(asString(payload["flow_instance"])); flowInstance != "" {
+		if !entityToolExistingFlowInstanceMatches(source, flowInstance, asString(entity["flow_instance"])) {
 			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_get_entity.flow_instance", false, "flow_instance does not match entity ownership")
 		}
 	}

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -1626,6 +1626,192 @@ foreign:
 	}
 }
 
+func TestEntityTools_ExistingEntityFlowInstanceAcceptsDeclaredRootAndExactPath(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:    "validator",
+		Role:  "validator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field", "query_entities", "query_metrics", "search_entities"},
+	}
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"validation": {
+			EntitiesYAML: `
+validation_case:
+  status: text
+  score: integer
+`,
+			AgentsYAML: entityToolAgentYAML(actor),
+		},
+		"operating": {
+			EntitiesYAML: `
+operating_case:
+  status: text
+`,
+		},
+	})
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	firstID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/case-1",
+		"fields": map[string]any{
+			"status": "open",
+			"score":  10,
+		},
+	})
+	secondID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "validation/case-2",
+		"fields": map[string]any{
+			"status": "open",
+			"score":  20,
+		},
+	})
+
+	for name, flowInstance := range map[string]string{
+		"declared root": "validation",
+		"exact path":    "validation/case-1",
+	} {
+		out, err := exec.Execute(ctx, "get_entity", map[string]any{
+			"entity_id":     firstID,
+			"flow_instance": flowInstance,
+		})
+		if err != nil {
+			t.Fatalf("get_entity %s: %v", name, err)
+		}
+		entity := out.(map[string]any)
+		if got := strings.TrimSpace(asString(entity["entity_id"])); got != firstID {
+			t.Fatalf("get_entity %s entity_id = %q, want %s", name, got, firstID)
+		}
+	}
+	if _, err := exec.Execute(ctx, "get_entity", map[string]any{
+		"entity_id":     firstID,
+		"flow_instance": "operating",
+	}); err == nil || !strings.Contains(err.Error(), "flow_instance does not match entity ownership") {
+		t.Fatalf("get_entity wrong root error = %v, want flow_instance mismatch", err)
+	}
+
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id":     firstID,
+		"flow_instance": "validation",
+		"field":         "status",
+		"value":         "root-saved",
+	}); err != nil {
+		t.Fatalf("save_entity_field declared root: %v", err)
+	}
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id":     firstID,
+		"flow_instance": "validation/case-1",
+		"field":         "status",
+		"value":         "exact-saved",
+	}); err != nil {
+		t.Fatalf("save_entity_field exact path: %v", err)
+	}
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id":     firstID,
+		"flow_instance": "operating",
+		"field":         "status",
+		"value":         "wrong-root",
+	}); err == nil || !strings.Contains(err.Error(), "flow_instance does not match entity ownership") {
+		t.Fatalf("save_entity_field wrong root error = %v, want flow_instance mismatch", err)
+	}
+
+	queryOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"flow_instance": "validation",
+		"select":        []string{"status", "score"},
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities declared root: %v", err)
+	}
+	queryRows := queryOut.(map[string]any)["results"].([]map[string]any)
+	if len(queryRows) != 2 {
+		t.Fatalf("query_entities root rows = %#v, want 2", queryRows)
+	}
+	queryExactOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"flow_instance": "validation/case-2",
+		"select":        []string{"status", "score"},
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities exact path: %v", err)
+	}
+	queryExactRows := queryExactOut.(map[string]any)["results"].([]map[string]any)
+	if len(queryExactRows) != 1 || strings.TrimSpace(asString(queryExactRows[0]["entity_id"])) != secondID {
+		t.Fatalf("query_entities exact rows = %#v, want %s", queryExactRows, secondID)
+	}
+	queryWrongOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"flow_instance": "operating",
+		"select":        []string{"status"},
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("query_entities wrong root: %v", err)
+	}
+	if rows := queryWrongOut.(map[string]any)["results"].([]map[string]any); len(rows) != 0 {
+		t.Fatalf("query_entities wrong root rows = %#v, want none", rows)
+	}
+
+	searchOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"flow_instance": "validation",
+		"current_state": "queued",
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("search_entities declared root: %v", err)
+	}
+	if total := searchOut.(map[string]any)["total"].(int); total != 2 {
+		t.Fatalf("search_entities root total = %d, want 2", total)
+	}
+	searchExactOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"flow_instance": "validation/case-1",
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("search_entities exact path: %v", err)
+	}
+	if total := searchExactOut.(map[string]any)["total"].(int); total != 1 {
+		t.Fatalf("search_entities exact total = %d, want 1", total)
+	}
+	searchWrongOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"flow_instance": "operating",
+		"limit":         10,
+	})
+	if err != nil {
+		t.Fatalf("search_entities wrong root: %v", err)
+	}
+	if total := searchWrongOut.(map[string]any)["total"].(int); total != 0 {
+		t.Fatalf("search_entities wrong root total = %d, want 0", total)
+	}
+
+	metricsOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"flow_instance": "validation",
+		"metric":        "count",
+	})
+	if err != nil {
+		t.Fatalf("query_metrics declared root: %v", err)
+	}
+	if got := testNumericValue(metricsOut.(map[string]any)["value"]); got != 2 {
+		t.Fatalf("query_metrics root count = %#v, want 2", metricsOut)
+	}
+	metricsExactOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"flow_instance": "validation/case-1",
+		"metric":        "count",
+	})
+	if err != nil {
+		t.Fatalf("query_metrics exact path: %v", err)
+	}
+	if got := testNumericValue(metricsExactOut.(map[string]any)["value"]); got != 1 {
+		t.Fatalf("query_metrics exact count = %#v, want 1", metricsExactOut)
+	}
+	metricsWrongOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"flow_instance": "operating",
+		"metric":        "count",
+	})
+	if err != nil {
+		t.Fatalf("query_metrics wrong root: %v", err)
+	}
+	if got := testNumericValue(metricsWrongOut.(map[string]any)["value"]); got != 0 {
+		t.Fatalf("query_metrics wrong root count = %#v, want 0", metricsWrongOut)
+	}
+}
+
 func TestEntityTools_FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity(t *testing.T) {
 	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
 		"analyzer-flow": {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -1648,7 +1648,7 @@ operating_case:
 `,
 		},
 	})
-	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
 	firstID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/case-1",
 		"fields": map[string]any{
@@ -1663,6 +1663,11 @@ operating_case:
 			"score":  20,
 		},
 	})
+	deepID := uuid.NewString()
+	seedEntityStateRow(t, db, deepID, deepID, "validation/nested/case-3", "validation_case", "queued", map[string]any{
+		"status": "open",
+		"score":  30,
+	}, time.Now().UTC().Truncate(time.Second))
 
 	for name, flowInstance := range map[string]string{
 		"declared root": "validation",
@@ -1685,6 +1690,16 @@ operating_case:
 		"flow_instance": "operating",
 	}); err == nil || !strings.Contains(err.Error(), "flow_instance does not match entity ownership") {
 		t.Fatalf("get_entity wrong root error = %v, want flow_instance mismatch", err)
+	}
+	deepOut, err := exec.Execute(ctx, "get_entity", map[string]any{
+		"entity_id":     deepID,
+		"flow_instance": "validation",
+	})
+	if err != nil {
+		t.Fatalf("get_entity declared root for deep descendant: %v", err)
+	}
+	if got := strings.TrimSpace(asString(deepOut.(map[string]any)["entity_id"])); got != deepID {
+		t.Fatalf("get_entity deep descendant entity_id = %q, want %s", got, deepID)
 	}
 
 	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
@@ -1721,8 +1736,8 @@ operating_case:
 		t.Fatalf("query_entities declared root: %v", err)
 	}
 	queryRows := queryOut.(map[string]any)["results"].([]map[string]any)
-	if len(queryRows) != 2 {
-		t.Fatalf("query_entities root rows = %#v, want 2", queryRows)
+	if len(queryRows) != 3 {
+		t.Fatalf("query_entities root rows = %#v, want 3", queryRows)
 	}
 	queryExactOut, err := exec.Execute(ctx, "query_entities", map[string]any{
 		"flow_instance": "validation/case-2",
@@ -1756,8 +1771,8 @@ operating_case:
 	if err != nil {
 		t.Fatalf("search_entities declared root: %v", err)
 	}
-	if total := searchOut.(map[string]any)["total"].(int); total != 2 {
-		t.Fatalf("search_entities root total = %d, want 2", total)
+	if total := searchOut.(map[string]any)["total"].(int); total != 3 {
+		t.Fatalf("search_entities root total = %d, want 3", total)
 	}
 	searchExactOut, err := exec.Execute(ctx, "search_entities", map[string]any{
 		"flow_instance": "validation/case-1",
@@ -1787,8 +1802,8 @@ operating_case:
 	if err != nil {
 		t.Fatalf("query_metrics declared root: %v", err)
 	}
-	if got := testNumericValue(metricsOut.(map[string]any)["value"]); got != 2 {
-		t.Fatalf("query_metrics root count = %#v, want 2", metricsOut)
+	if got := testNumericValue(metricsOut.(map[string]any)["value"]); got != 3 {
+		t.Fatalf("query_metrics root count = %#v, want 3", metricsOut)
 	}
 	metricsExactOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
 		"flow_instance": "validation/case-1",

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -37,8 +37,8 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if !found {
 		return nil, NewRuntimeError("not_found", "tool-executor", "exec_save_entity_field.lookup", false, "entity %s not found", entityID)
 	}
-	if flowInstance := strings.Trim(strings.TrimSpace(asString(payload["flow_instance"])), "/"); flowInstance != "" {
-		if strings.Trim(strings.TrimSpace(asString(row["flow_instance"])), "/") != flowInstance {
+	if flowInstance := normalizeEntityToolFlowInstance(asString(payload["flow_instance"])); flowInstance != "" {
+		if !entityToolExistingFlowInstanceMatches(source, flowInstance, asString(row["flow_instance"])) {
 			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.flow_instance", false, "flow_instance does not match entity ownership")
 		}
 	}

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -58,7 +58,7 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 			Category:    "entity_persistence",
 			Description: "Read a full entity_state row by entity id.",
 			InputSchema: ObjectSchema(map[string]any{
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"entity_id":     map[string]any{"type": "string"},
 			}, "entity_id"),
 		},
@@ -66,7 +66,7 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 			Category:    "entity_persistence",
 			Description: "Write a single declared field or dotted subfield path on an entity.",
 			InputSchema: ObjectSchema(map[string]any{
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"entity_id":     map[string]any{"type": "string"},
 				"field":         map[string]any{"type": "string"},
 				"value":         anyValueSchema,
@@ -99,7 +99,7 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 			Description: "Query entity_state rows using validated selectors and optional grouping.",
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"filter":        map[string]any{"type": "string"},
 				"select": map[string]any{
 					"type":  "array",
@@ -115,7 +115,7 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"subject_id":    map[string]any{"type": "string"},
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"current_state": map[string]any{"type": "string"},
 				"filter": map[string]any{
 					"type":                 "object",
@@ -131,7 +131,7 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 			Description: "Aggregate metrics across entity_state rows.",
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"metric": map[string]any{
 					"type": "string",
 					"enum": []any{"count", "sum", "avg", "min", "max"},
@@ -141,6 +141,13 @@ func genericEntityRuntimeContractSchemas(readTargetSchema map[string]any) map[st
 				"filter":   map[string]any{"type": "string"},
 			}, "metric"),
 		},
+	}
+}
+
+func existingEntityFlowInstanceSchema() map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": "Optional existing-entity flow guard/filter. Accepts a concrete flow instance path or a declared semantic flow root; roots match descendant instances.",
 	}
 }
 
@@ -189,7 +196,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 			Category:    "entity_persistence",
 			Description: "Read a full entity_state row by entity id.",
 			InputSchema: ObjectSchema(map[string]any{
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"entity_id":     map[string]any{"type": "string"},
 			}, "entity_id"),
 		},
@@ -197,7 +204,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 			Category:    "entity_persistence",
 			Description: "Write a single declared field or dotted subfield path on an entity.",
 			InputSchema: ObjectSchema(map[string]any{
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"entity_id":     map[string]any{"type": "string"},
 				"field": map[string]any{
 					"type": "string",
@@ -212,7 +219,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
 				"subject_id":    map[string]any{"type": "string"},
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"current_state": map[string]any{"type": "string"},
 				"filter": map[string]any{
 					"type":                 "object",
@@ -228,7 +235,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 			Description: "Query entity_state rows using validated selectors and optional grouping.",
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"filter":        map[string]any{"type": "string"},
 				"select": map[string]any{
 					"type": "array",
@@ -249,7 +256,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 			Description: "Aggregate metrics across entity_state rows.",
 			InputSchema: ObjectSchema(map[string]any{
 				"entity_type":   deepCloneJSONValue(readTargetSchema),
-				"flow_instance": map[string]any{"type": "string"},
+				"flow_instance": existingEntityFlowInstanceSchema(),
 				"metric": map[string]any{
 					"type": "string",
 					"enum": []any{"count", "sum", "avg", "min", "max"},


### PR DESCRIPTION
## Summary
- Align existing-entity `flow_instance` guard/filter semantics across `get_entity`, `save_entity_field`, `query_entities`, `query_metrics`, and `search_entities`.
- Accept declared semantic flow roots such as `validation` as root+descendant guards/filters while preserving exact concrete path support.
- Update provider-facing schemas for the five existing-entity tools with explicit concrete-path/semantic-root guidance.

## Governing refs / context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `flow_identity.flow_scope_key`, `flow_identity.flow_instance_path`, `flow_identity.not_interchangeable`, `entity_tool_schemas.*`, `state_composition.cross_flow_writes`, `ownership_semantics`.
- Binding issue/gate context: #531 pre-audit and lead approval define this as the existing-entity tool `flow_instance` guard/filter first slice under #415.
- `create_entity.flow_instance` remains split as new-row ownership selection.

## Semantic migration
- New canonical owner: shared existing-entity flow-instance matching/filter helper in `internal/runtime/tools`, backed by `internal/runtime/core/flowidentity` semantic scope rules.
- Old producer/reader/writer paths now invalid: inline exact caller `flow_instance == entity_state.flow_instance` checks and exact SQL filtering for caller-supplied semantic roots on existing-entity tools.
- Production paths checked: `get_entity`, `save_entity_field`, `query_entities`, `query_metrics`, `search_entities`, provider-facing builtin schemas, and true write-ownership enforcement.
- Migration complete for #531’s approved first-slice class; parent #415 remains open.

## Proof
- `go test ./internal/runtime/tools -run 'TestEntityTools_(ExistingEntityFlowInstanceAcceptsDeclaredRootAndExactPath|GetEntityAllowsCrossFlowRead|SaveEntityFieldRejectsCrossFlowWrite|FlowOwnedActorCanReadForeignEntityAndWriteOwnEntity)|TestExistingEntityFlowInstanceSchemaDocumentsRootSemantics|TestEntityStateBaseQuery_OptionallyIncludesFlowInstance' -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/pipeline -run 'Test(FlowInstanceIdentity|ActivateFlowInstance|WorkflowInstanceStore|ResolveHandlerEntityIDForFlow|HandlerEmitPayload|CreateFlowInstance|createFlowInstance)' -count=1`
- Supported run `e3fd5852-ad45-4afe-b401-6be01c0dcaee` reached `validation/validation.started`; observed `0` `get_entity`/`save_entity_field` flow-instance mismatch errors and `0` joined dead letters at the validation seam.

Closes #531
