### PR TITLE
[agent-a][issue #449] Allow startup with manager recovery skipped

### DIFF
--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -9,6 +9,8 @@ import (
 	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -41,6 +43,7 @@ func (*recoveryGuardManagerStore) ListPendingSubscribedEvents(context.Context, s
 
 type recoveryGuardEventStore struct {
 	missing []events.PersistedReplayEvent
+	routes  []runtimeflowidentity.Route
 }
 
 func (*recoveryGuardEventStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -53,12 +56,22 @@ func (*recoveryGuardEventStore) UpsertCommittedReplayScope(context.Context, stri
 func (*recoveryGuardEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return nil, nil
 }
+func (*recoveryGuardEventStore) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {
+	return nil
+}
+func (*recoveryGuardEventStore) DeleteFlowInstanceRoute(context.Context, runtimeflowidentity.Route) error {
+	return nil
+}
+func (s *recoveryGuardEventStore) ListFlowInstanceRoutes(context.Context) ([]runtimeflowidentity.Route, error) {
+	return append([]runtimeflowidentity.Route(nil), s.routes...), nil
+}
 func (s *recoveryGuardEventStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
 	return append([]events.PersistedReplayEvent(nil), s.missing...), nil
 }
 func (*recoveryGuardEventStore) ClaimPipelineReplay(context.Context, string) (runtimeownership.Lease, bool, error) {
 	return nil, true, nil
 }
+func (*recoveryGuardEventStore) SupportsPersistedReplay() bool { return false }
 
 type minimalRuntimeEventStore struct{}
 
@@ -106,7 +119,7 @@ func TestRuntimeStart_FailsWhenRecoveryDisabledAndActiveSchedulesExist(t *testin
 	}
 }
 
-func TestRuntimeStart_FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists(t *testing.T) {
+func TestRuntimeStart_AllowsRecoveryDisabledWithManagerSnapshotWork(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &recoveryGuardEventStore{
 		missing: []events.PersistedReplayEvent{{
@@ -115,10 +128,18 @@ func TestRuntimeStart_FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists(
 				Type: "support.item_created",
 			},
 		}},
+		routes: []runtimeflowidentity.Route{
+			runtimeflowidentity.DeriveRoute("child", "inst-1"),
+		},
+	}
+	managerStore := &recoveryGuardManagerStore{
+		agents: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{ID: "persisted-agent"},
+		}},
 	}
 	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
 		EventStore:   eventStore,
-		ManagerStore: &recoveryGuardManagerStore{},
+		ManagerStore: managerStore,
 	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -127,9 +148,11 @@ func TestRuntimeStart_FailsWhenRecoveryDisabledAndPipelineRecoverableWorkExists(
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
-	err = rt.Start(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "runtime.recovery_on_startup=false") || !strings.Contains(err.Error(), "events missing pipeline receipts") {
-		t.Fatalf("Start error = %v, want explicit pipeline recovery denial", err)
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -10,7 +10,9 @@ import (
 
 	"swarm/internal/config"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -24,6 +26,7 @@ func (startupRecoveryTestLease) Release(context.Context) error { return nil }
 
 type startupRecoveryManagerStore struct {
 	loadErr error
+	agents  []runtimemanager.PersistedAgent
 }
 
 func (s startupRecoveryManagerStore) UpsertAgent(context.Context, runtimemanager.PersistedAgent) error {
@@ -34,7 +37,7 @@ func (s startupRecoveryManagerStore) LoadAgents(context.Context) ([]runtimemanag
 	if s.loadErr != nil {
 		return nil, s.loadErr
 	}
-	return nil, nil
+	return append([]runtimemanager.PersistedAgent(nil), s.agents...), nil
 }
 
 func (startupRecoveryManagerStore) MarkAgentTerminated(context.Context, string) error { return nil }
@@ -165,6 +168,7 @@ func (startupRecoveryCapabilityEventStore) SupportsPersistedReplay() bool { retu
 
 type startupRecoveryEventStore struct {
 	missing  []events.PersistedReplayEvent
+	routes   []runtimeflowidentity.Route
 	claimErr error
 }
 
@@ -184,6 +188,18 @@ func (startupRecoveryEventStore) UpsertCommittedReplayScope(context.Context, str
 
 func (startupRecoveryEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return nil, nil
+}
+
+func (startupRecoveryEventStore) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {
+	return nil
+}
+
+func (startupRecoveryEventStore) DeleteFlowInstanceRoute(context.Context, runtimeflowidentity.Route) error {
+	return nil
+}
+
+func (s startupRecoveryEventStore) ListFlowInstanceRoutes(context.Context) ([]runtimeflowidentity.Route, error) {
+	return append([]runtimeflowidentity.Route(nil), s.routes...), nil
 }
 
 func (s startupRecoveryEventStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
@@ -386,7 +402,7 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *t
 	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "active schedules")
 }
 
-func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork(t *testing.T) {
+func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
@@ -395,12 +411,20 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork(t
 		missing: []events.PersistedReplayEvent{{
 			Event: events.Event{ID: "evt-1", Type: "support.item_created"},
 		}},
+		routes: []runtimeflowidentity.Route{
+			runtimeflowidentity.DeriveRoute("child", "inst-1"),
+		},
+	}
+	managerStore := &startupRecoveryManagerStore{
+		agents: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{ID: "persisted-agent"},
+		}},
 	}
 
 	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(false), Stores{
 		SQLDB:        db,
 		EventStore:   eventStore,
-		ManagerStore: &recoveryGuardManagerStore{},
+		ManagerStore: managerStore,
 	}, RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -410,22 +434,50 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForReplayEligibleWork(t
 		t.Fatalf("NewRuntime: %v", err)
 	}
 
-	err = rt.Start(ctx)
-	if err == nil || !strings.Contains(err.Error(), "events missing pipeline receipts") {
-		t.Fatalf("Start error = %v, want replay-eligible denial", err)
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
+	defer func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}()
 
-	level, _, _, detail := latestStartupRecoveryDecisionLog(t, db)
+	level, message, errorText, detail := latestStartupRecoveryDecisionLog(t, db)
 	if level != "warn" {
 		t.Fatalf("log level = %q, want warn", level)
 	}
-	if got := detailString(detail["decision_outcome"]); got != "denied" {
-		t.Fatalf("decision_outcome = %q, want denied", got)
+	if message != "Runtime startup allowed with manager recovery skipped" {
+		t.Fatalf("log message = %q, want manager recovery skipped", message)
+	}
+	if errorText != "" {
+		t.Fatalf("log error = %q, want empty", errorText)
+	}
+	if got := detailString(detail["decision_outcome"]); got != "allowed" {
+		t.Fatalf("decision_outcome = %q, want allowed", got)
+	}
+	if got := detailString(detail["decision_reason_code"]); got != string(startupRecoveryReasonDisabledWithManagerWork) {
+		t.Fatalf("decision_reason_code = %q, want %q", got, startupRecoveryReasonDisabledWithManagerWork)
+	}
+	if !detailBool(detail["manager_recoverable_work_present"]) {
+		t.Fatalf("manager_recoverable_work_present = %#v, want true", detail["manager_recoverable_work_present"])
+	}
+	if detailBool(detail["startup_blocking_recoverable_work_present"]) {
+		t.Fatalf("startup_blocking_recoverable_work_present = %#v, want false", detail["startup_blocking_recoverable_work_present"])
+	}
+	if got := detailInt(detail["persisted_agent_count"]); got != 1 {
+		t.Fatalf("persisted_agent_count = %d, want 1", got)
+	}
+	if got := detailInt(detail["persisted_flow_instance_route_count"]); got != 1 {
+		t.Fatalf("persisted_flow_instance_route_count = %d, want 1", got)
 	}
 	if !detailBool(detail["replay_eligible_event_present"]) {
 		t.Fatalf("replay_eligible_event_present = %#v, want true", detail["replay_eligible_event_present"])
 	}
-	assertContainsClass(t, detailClasses(detail["recoverable_work_classes"]), "events missing pipeline receipts")
+	classes := detailClasses(detail["recoverable_work_classes"])
+	assertContainsClass(t, classes, "persisted agents")
+	assertContainsClass(t, classes, "persisted flow instance routes")
+	assertContainsClass(t, classes, "events missing pipeline receipts")
 }
 
 func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -21,13 +21,14 @@ const (
 type startupRecoveryReasonCode string
 
 const (
-	startupRecoveryReasonDisabledNoWork   startupRecoveryReasonCode = "recovery_disabled_no_persisted_work"
-	startupRecoveryReasonDisabledWithWork startupRecoveryReasonCode = "recovery_disabled_with_persisted_work"
-	startupRecoveryReasonEnabledNoWork    startupRecoveryReasonCode = "recovery_enabled_no_persisted_work"
-	startupRecoveryReasonEnabledWithWork  startupRecoveryReasonCode = "recovery_enabled_with_persisted_work"
-	startupRecoveryReasonInspectFailed    startupRecoveryReasonCode = "startup_recovery_inspection_failed"
-	startupRecoveryReasonScheduleRestore  startupRecoveryReasonCode = "schedule_restore_failed"
-	startupRecoveryReasonRecoverFailed    startupRecoveryReasonCode = "startup_recovery_failed"
+	startupRecoveryReasonDisabledNoWork          startupRecoveryReasonCode = "recovery_disabled_no_persisted_work"
+	startupRecoveryReasonDisabledWithWork        startupRecoveryReasonCode = "recovery_disabled_with_persisted_work"
+	startupRecoveryReasonDisabledWithManagerWork startupRecoveryReasonCode = "recovery_disabled_with_manager_snapshot_work"
+	startupRecoveryReasonEnabledNoWork           startupRecoveryReasonCode = "recovery_enabled_no_persisted_work"
+	startupRecoveryReasonEnabledWithWork         startupRecoveryReasonCode = "recovery_enabled_with_persisted_work"
+	startupRecoveryReasonInspectFailed           startupRecoveryReasonCode = "startup_recovery_inspection_failed"
+	startupRecoveryReasonScheduleRestore         startupRecoveryReasonCode = "schedule_restore_failed"
+	startupRecoveryReasonRecoverFailed           startupRecoveryReasonCode = "startup_recovery_failed"
 )
 
 type startupRecoverySnapshot struct {
@@ -41,6 +42,10 @@ func (s startupRecoverySnapshot) HasRecoverableWork() bool {
 	return s.ActiveScheduleCount > 0 || s.Manager.HasRecoverableWork()
 }
 
+func (s startupRecoverySnapshot) HasStartupBlockingRecoverableWork() bool {
+	return s.ActiveScheduleCount > 0
+}
+
 func (s startupRecoverySnapshot) WorkClasses() []string {
 	classes := make([]string, 0, 1+len(s.Manager.Classes()))
 	if s.ActiveScheduleCount > 0 {
@@ -51,6 +56,13 @@ func (s startupRecoverySnapshot) WorkClasses() []string {
 	return classes
 }
 
+func (s startupRecoverySnapshot) StartupBlockingWorkClasses() []string {
+	if s.ActiveScheduleCount <= 0 {
+		return nil
+	}
+	return []string{"active schedules"}
+}
+
 func (s startupRecoverySnapshot) Detail() map[string]any {
 	detail := map[string]any{
 		"recovery_on_startup":          s.RecoveryOnStartup,
@@ -59,7 +71,10 @@ func (s startupRecoverySnapshot) Detail() map[string]any {
 	if s.InspectionComplete {
 		detail["active_schedule_count"] = s.ActiveScheduleCount
 		detail["recoverable_work_present"] = s.HasRecoverableWork()
+		detail["startup_blocking_recoverable_work_present"] = s.HasStartupBlockingRecoverableWork()
+		detail["manager_recoverable_work_present"] = s.Manager.HasRecoverableWork()
 		detail["recoverable_work_classes"] = s.WorkClasses()
+		detail["startup_blocking_recoverable_work_classes"] = s.StartupBlockingWorkClasses()
 		for key, value := range s.Manager.Detail() {
 			detail[key] = value
 		}
@@ -96,9 +111,11 @@ func newStartupRecoveryDecisionReport(snapshot startupRecoverySnapshot) startupR
 		report.ReasonCode = startupRecoveryReasonEnabledWithWork
 	case snapshot.RecoveryOnStartup:
 		report.ReasonCode = startupRecoveryReasonEnabledNoWork
-	case snapshot.HasRecoverableWork():
+	case snapshot.HasStartupBlockingRecoverableWork():
 		report.Outcome = startupRecoveryOutcomeDenied
 		report.ReasonCode = startupRecoveryReasonDisabledWithWork
+	case snapshot.Manager.HasRecoverableWork():
+		report.ReasonCode = startupRecoveryReasonDisabledWithManagerWork
 	default:
 		report.ReasonCode = startupRecoveryReasonDisabledNoWork
 	}
@@ -109,7 +126,7 @@ func (r startupRecoveryDecisionReport) denialError() error {
 	if r.Outcome != startupRecoveryOutcomeDenied {
 		return nil
 	}
-	return fmt.Errorf("runtime.recovery_on_startup=false but persisted runtime-owned work exists: %s", strings.Join(r.Snapshot.WorkClasses(), ", "))
+	return fmt.Errorf("runtime.recovery_on_startup=false but persisted runtime-owned work exists: %s", strings.Join(r.Snapshot.StartupBlockingWorkClasses(), ", "))
 }
 
 func (r startupRecoveryDecisionReport) message() string {
@@ -118,6 +135,11 @@ func (r startupRecoveryDecisionReport) message() string {
 		return "Runtime startup denied by recovery admission"
 	case startupRecoveryOutcomeDegraded:
 		return "Runtime startup recovery completed in a degraded state"
+	case startupRecoveryOutcomeAllowed:
+		if r.ReasonCode == startupRecoveryReasonDisabledWithManagerWork {
+			return "Runtime startup allowed with manager recovery skipped"
+		}
+		return "Runtime startup recovery decision recorded"
 	default:
 		return "Runtime startup recovery decision recorded"
 	}
@@ -130,6 +152,9 @@ func (r startupRecoveryDecisionReport) level() string {
 	case startupRecoveryOutcomeDegraded:
 		return "error"
 	default:
+		if r.ReasonCode == startupRecoveryReasonDisabledWithManagerWork {
+			return "warn"
+		}
 		return "info"
 	}
 }


### PR DESCRIPTION
## Summary

Closes #449.

This PR fixes the approved first-slice startup recovery-admission child for manager-snapshot recoverable state. Recovery-disabled startup no longer fails solely because manager-owned persisted state exists; instead it records a warning decision that manager recovery was skipped. Schedule-owned active recovery work remains a hard startup denial and stays outside this child.

## Governing Context

No exact governing spec section defines this startup admission split. Binding context is:
- #449 issue body and approved refreshed pre-audit/gate outcome
- #449 lead gate comment: approved as first slice
- adjacent platform context in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` for persisted runtime tables and runtime recovery/admin events
- `docs/IMPLEMENTER_GUIDELINES.md`
- `docs/SEMANTIC_DRIFT.md`

## Canonical Owner / Migration

New canonical owner behavior stays in `internal/runtime/startup_recovery_diagnostics.go` with manager classification from `internal/runtime/manager/runtime.go::AgentManager.RecoverableStateSnapshot(...)`.

Old invalid path: treating every manager-snapshot class as `recovery_disabled_with_persisted_work` fatal admission denial.

Production paths checked for surviving old behavior:
- `Runtime.Start(...)` startup decision path
- manager snapshot classes: persisted agents, persisted flow instance routes, replay-eligible events missing pipeline receipts
- active schedule recovery-admission sibling
- direct `cmd/swarm` supported startup surface

Migration completeness: complete for the chosen #449 manager-snapshot child. Active schedules remain intentionally split as a different owner sibling.

## Proof

Focused tests:
```bash
go test ./internal/runtime -run 'TestRuntimeStart_(FailsWhenRecoveryDisabledAndActiveSchedulesExist|AllowsRecoveryDisabledWithManagerSnapshotWork|AllowsRecoveryDisabledWhenNoRecoverableWorkExists|AllowsRecoveryDisabledWithNonReplayEventStore|RecoveryDisabled(EmitsDeniedDecisionForActiveSchedules|AllowsAndLogsManagerSnapshotWork))' -count=1
```

Affected runtime suite:
```bash
go test ./internal/runtime/... -count=1
```

Full suite:
```bash
go test ./... -count=1
```

Supported direct startup proof:
```bash
set -a; source /Users/youmew/dev/swarm/.env; set +a
go run ./cmd/swarm -contracts /Users/youmew/swarm/empire/contracts -health-addr 127.0.0.1:18081
```

Result: the original recovery-admission denial is gone. Startup advanced past boot step 15, then hit a separate downstream Claude MCP startup probe failure; that downstream gate is not part of #449.
