### PR TITLE
[agent-a][issue #536] Add timestamp fork dry-run planner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -78,6 +78,9 @@ func main() {
 	if len(os.Args) > 1 && strings.TrimSpace(os.Args[1]) == "status" {
 		os.Exit(runStatusCommand(context.Background(), repo, os.Args[2:], os.Stdout))
 	}
+	if len(os.Args) > 1 && strings.TrimSpace(os.Args[1]) == "fork" {
+		os.Exit(runForkCommand(context.Background(), repo, os.Args[2:], os.Stdout))
+	}
 	configPath := flag.String("config", "", "Optional path to Swarm runtime config")
 	contractsPath := flag.String("contracts", "", "Path to Swarm contract bundle root")
 	platformSpecPath := flag.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
@@ -321,6 +324,114 @@ type runStatusOptions struct {
 	LogsOnly      bool
 	LogsAllLevels bool
 	Component     string
+}
+
+func runForkCommand(ctx context.Context, repo string, args []string, out io.Writer) int {
+	fs := flag.NewFlagSet("fork", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
+	storeMode := fs.String("store", "postgres", "Store mode: postgres")
+	runID := fs.String("run", "", "Source run ID to plan from")
+	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
+	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: %v\n", err)
+		}
+		return 2
+	}
+	if !*dryRun {
+		if out != nil {
+			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run")
+		}
+		return 2
+	}
+	if err := loadRepoDotEnv(repo); err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: load .env: %v\n", err)
+		}
+		return 1
+	}
+	cfg, err := loadRuntimeConfig(resolvePath(repo, *configPath))
+	if err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: load config: %v\n", err)
+		}
+		return 1
+	}
+	stores, err := buildStores(ctx, *storeMode, cfg)
+	if err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: init stores: %v\n", err)
+		}
+		return 1
+	}
+	defer closeDB(stores.SQLDB)
+	if stores.Postgres == nil {
+		if out != nil {
+			fmt.Fprintln(out, "fork failed: postgres store required")
+		}
+		return 1
+	}
+	plan, err := stores.Postgres.PlanRunFork(ctx, store.RunForkPlanRequest{
+		SourceRunID: strings.TrimSpace(*runID),
+		At:          strings.TrimSpace(*at),
+	})
+	if err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: %v\n", err)
+		}
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(plan); err != nil {
+			fmt.Fprintf(out, "fork failed: encode json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printRunForkPlan(out, plan)
+	return 0
+}
+
+func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "Fork plan for run %s\n", plan.SourceRunID)
+	if strings.TrimSpace(plan.SourceRunStatus) != "" {
+		fmt.Fprintf(w, "Source Status: %s\n", plan.SourceRunStatus)
+	}
+	fmt.Fprintf(w, "Fork Point: %s (%s) at %s\n", plan.ForkPoint.EventName, plan.ForkPoint.EventID, plan.ForkPoint.Timestamp.Format(time.RFC3339Nano))
+	fmt.Fprintf(w, "Summary: events_at_fork=%d reconstructed_entities=%d pending_work=%d unsupported_blockers=%d execution_ready=%t\n",
+		plan.EventCountAtFork,
+		plan.ReconstructedEntityCount,
+		plan.PendingWorkCount,
+		plan.UnsupportedBlockerCount,
+		plan.ExecutionReady,
+	)
+	if len(plan.UnsupportedBlockers) > 0 {
+		fmt.Fprintln(w, "Unsupported Blockers:")
+		for _, blocker := range plan.UnsupportedBlockers {
+			fmt.Fprintf(w, "  %s: %s\n", blocker.Code, blocker.Message)
+		}
+	}
+	if len(plan.PendingWork) > 0 {
+		fmt.Fprintln(w, "Pending Work:")
+		for _, item := range plan.PendingWork {
+			fmt.Fprintf(w, "  %s %s subscriber=%s/%s status=%s class=%s\n",
+				item.EventID,
+				item.EventName,
+				item.SubscriberType,
+				item.SubscriberID,
+				item.Status,
+				item.Classification,
+			)
+		}
+	}
 }
 
 func runStatusCommand(ctx context.Context, repo string, args []string, out io.Writer) int {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -349,6 +349,91 @@ func TestLoadRunStatusReport_UsesCanonicalPersistedRunIDForRuntimeLogsAndMutatio
 	}
 }
 
+func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000300, 0).UTC()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'pending', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, t.TempDir(), []string{
+		"--dry-run",
+		"--run", runID,
+		"--at", eventID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var plan store.RunForkPlan
+	if err := json.Unmarshal(buf.Bytes(), &plan); err != nil {
+		t.Fatalf("decode fork plan json: %v\n%s", err, buf.String())
+	}
+	if plan.SourceRunID != runID {
+		t.Fatalf("SourceRunID = %q, want %q", plan.SourceRunID, runID)
+	}
+	if plan.ForkPoint.EventID != eventID {
+		t.Fatalf("ForkPoint.EventID = %q, want %q", plan.ForkPoint.EventID, eventID)
+	}
+	if plan.PendingWorkCount != 1 || plan.PendingWork[0].Classification != store.RunForkPendingClassificationPending {
+		t.Fatalf("pending work = %#v", plan.PendingWork)
+	}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false while unsupported blockers remain")
+	}
+}
+
+func setPostgresEnvFromDSN(t *testing.T, dsn string) {
+	t.Helper()
+	values := map[string]string{}
+	for _, part := range strings.Fields(dsn) {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		values[key] = value
+	}
+	for _, item := range []struct {
+		env string
+		key string
+	}{
+		{"PGHOST", "host"},
+		{"PGPORT", "port"},
+		{"PGDATABASE", "dbname"},
+		{"PGUSER", "user"},
+		{"PGPASSWORD", "password"},
+		{"SWARM_DB_SSLMODE", "sslmode"},
+	} {
+		if value := strings.TrimSpace(values[item.key]); value != "" {
+			t.Setenv(item.env, value)
+		}
+	}
+}
+
 func TestDefaultRuntimeConfig_RejectsUnsupportedRuntimeControlEnv(t *testing.T) {
 	t.Setenv("SWARM_LLM_RUNTIME_MODE", "api")
 	t.Setenv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "4")

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3198,6 +3198,15 @@ run_model:
       loading new contracts, and resuming execution. The system automatically determines which events need
       to be re-delivered. The original run is frozen. The forked run gets independent execution.'
     command: 'swarm fork --run <run_id> --at <event_id|timestamp> [--contracts <path>]'
+    dry_run_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --dry-run [--json]'
+    planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
+      point, reconstructs provable state, classifies replay candidates, and returns execution_ready=false
+      with named unsupported blockers whenever persisted recorder facts cannot prove safe execution. Dry-run
+      MUST NOT create a forked run, mark the source run forked, copy entity state, redeliver events, or change
+      runtime delivery/session/timer state.'
+    planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
+      Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
+      fork planning with direct SQL joins.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -1,0 +1,453 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/runtime/mutationlog"
+)
+
+const (
+	RunForkPendingClassificationDeliveredCompleted = "delivered_completed"
+	RunForkPendingClassificationPending            = "pending"
+	RunForkPendingClassificationInProgress         = "in_progress"
+	RunForkPendingClassificationFailedRetryable    = "failed_retryable"
+	RunForkPendingClassificationFailedTerminal     = "failed_terminal"
+	RunForkPendingClassificationDeadLetter         = "dead_letter"
+	RunForkPendingClassificationCommittedReplay    = "committed_replay_scope"
+)
+
+type RunForkPlanRequest struct {
+	SourceRunID string
+	At          string
+}
+
+type RunForkPlan struct {
+	SourceRunID              string                      `json:"source_run_id"`
+	SourceRunStatus          string                      `json:"source_run_status,omitempty"`
+	SourceRunStartedAt       *time.Time                  `json:"source_run_started_at,omitempty"`
+	SourceRunEndedAt         *time.Time                  `json:"source_run_ended_at,omitempty"`
+	ForkPoint                RunForkPoint                `json:"fork_point"`
+	EventCountAtFork         int                         `json:"event_count_at_fork"`
+	ReconstructedEntityCount int                         `json:"reconstructed_entity_count"`
+	PendingWorkCount         int                         `json:"pending_work_count"`
+	UnsupportedBlockerCount  int                         `json:"unsupported_blocker_count"`
+	ExecutionReady           bool                        `json:"execution_ready"`
+	Entities                 []RunForkEntityState        `json:"entities,omitempty"`
+	PendingWork              []RunForkPendingWork        `json:"pending_work,omitempty"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkPoint struct {
+	Input     string    `json:"input"`
+	EventID   string    `json:"event_id"`
+	EventName string    `json:"event_name,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type RunForkEntityState struct {
+	EntityID     string         `json:"entity_id"`
+	CurrentState string         `json:"current_state,omitempty"`
+	Fields       map[string]any `json:"fields,omitempty"`
+	Gates        map[string]any `json:"gates,omitempty"`
+	Accumulator  map[string]any `json:"accumulator,omitempty"`
+}
+
+type RunForkPendingWork struct {
+	EventID         string     `json:"event_id"`
+	EventName       string     `json:"event_name"`
+	DeliveryID      string     `json:"delivery_id,omitempty"`
+	SubscriberType  string     `json:"subscriber_type,omitempty"`
+	SubscriberID    string     `json:"subscriber_id,omitempty"`
+	Classification  string     `json:"classification"`
+	Status          string     `json:"status,omitempty"`
+	RetryCount      int        `json:"retry_count,omitempty"`
+	ReasonCode      string     `json:"reason_code,omitempty"`
+	ActiveSessionID string     `json:"active_session_id,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	DeliveredAt     *time.Time `json:"delivered_at,omitempty"`
+	ReceiptOutcome  string     `json:"receipt_outcome,omitempty"`
+	ReceiptAt       *time.Time `json:"receipt_at,omitempty"`
+}
+
+type RunForkUnsupportedBlocker struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type runForkEventCursor struct {
+	EventID   string
+	EventName string
+	CreatedAt time.Time
+}
+
+func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	switch {
+	case !caps.Events.HasRuns:
+		return fmt.Errorf("run fork planner requires canonical runs table")
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case !caps.Events.LogRunID:
+		return fmt.Errorf("run fork planner requires canonical events.run_id")
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case !caps.Events.DeliveryRunID:
+		return fmt.Errorf("run fork planner requires canonical event_deliveries.run_id")
+	case caps.Events.Receipts != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	}
+	required := map[string][]string{
+		"runs":             {"run_id", "status"},
+		"events":           {"event_id", "run_id", "event_name", "created_at"},
+		"event_deliveries": {"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count", "reason_code", "active_session_id", "started_at", "delivered_at", "created_at"},
+		"event_receipts":   {"event_id", "subscriber_type", "subscriber_id", "outcome", "reason_code", "processed_at"},
+		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "new_value", "caused_by_event", "created_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run fork planner requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunForkPlannerCapabilities(ctx context.Context) (schemaColumnCatalog, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return schemaColumnCatalog{}, err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return schemaColumnCatalog{}, err
+	}
+	return catalog, RequireCanonicalRunForkPlannerCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest) (RunForkPlan, error) {
+	if s == nil || s.DB == nil {
+		return RunForkPlan{}, fmt.Errorf("postgres store is required")
+	}
+	catalog, err := s.requireRunForkPlannerCapabilities(ctx)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	runID := strings.TrimSpace(req.SourceRunID)
+	if runID == "" {
+		return RunForkPlan{}, fmt.Errorf("source run_id is required")
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return RunForkPlan{}, fmt.Errorf("source run_id must be a UUID: %w", err)
+	}
+	at := strings.TrimSpace(req.At)
+	if at == "" {
+		return RunForkPlan{}, fmt.Errorf("fork point --at value is required")
+	}
+
+	plan := RunForkPlan{SourceRunID: runID}
+	if err := s.loadRunForkSourceSummary(ctx, &plan); err != nil {
+		return RunForkPlan{}, err
+	}
+	cursor, err := s.resolveRunForkPoint(ctx, runID, at)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	plan.ForkPoint = RunForkPoint{
+		Input:     at,
+		EventID:   cursor.EventID,
+		EventName: cursor.EventName,
+		Timestamp: cursor.CreatedAt,
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND (created_at, event_id) <= ($2::timestamptz, $3::uuid)
+	`, runID, cursor.CreatedAt, cursor.EventID).Scan(&plan.EventCountAtFork); err != nil {
+		return RunForkPlan{}, fmt.Errorf("count fork events: %w", err)
+	}
+
+	entities, err := s.loadRunForkEntityStates(ctx, runID, cursor)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	plan.Entities = entities
+	plan.ReconstructedEntityCount = len(entities)
+
+	pending, err := s.loadRunForkPendingWork(ctx, runID, cursor)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	plan.PendingWork = pending
+	plan.PendingWorkCount = len(pending)
+	plan.UnsupportedBlockers = runForkUnsupportedBlockers(catalog, pending)
+	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
+	plan.ExecutionReady = plan.UnsupportedBlockerCount == 0
+	return plan, nil
+}
+
+func (s *PostgresStore) loadRunForkSourceSummary(ctx context.Context, plan *RunForkPlan) error {
+	var started, ended sql.NullTime
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), started_at, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, plan.SourceRunID).Scan(&plan.SourceRunStatus, &started, &ended); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("source run %s not found", plan.SourceRunID)
+		}
+		return fmt.Errorf("load source run: %w", err)
+	}
+	if started.Valid {
+		tm := started.Time
+		plan.SourceRunStartedAt = &tm
+	}
+	if ended.Valid {
+		tm := ended.Time
+		plan.SourceRunEndedAt = &tm
+	}
+	return nil
+}
+
+func (s *PostgresStore) resolveRunForkPoint(ctx context.Context, runID, at string) (runForkEventCursor, error) {
+	if _, err := uuid.Parse(at); err == nil {
+		var cursor runForkEventCursor
+		if err := s.DB.QueryRowContext(ctx, `
+			SELECT event_id::text, event_name, created_at
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_id = $2::uuid
+		`, runID, at).Scan(&cursor.EventID, &cursor.EventName, &cursor.CreatedAt); err != nil {
+			if err == sql.ErrNoRows {
+				return runForkEventCursor{}, fmt.Errorf("fork point event %s not found in source run %s", at, runID)
+			}
+			return runForkEventCursor{}, fmt.Errorf("resolve fork event: %w", err)
+		}
+		return cursor, nil
+	}
+	atTime, err := time.Parse(time.RFC3339Nano, at)
+	if err != nil {
+		return runForkEventCursor{}, fmt.Errorf("fork point --at must be an event UUID or RFC3339 timestamp: %w", err)
+	}
+	var cursor runForkEventCursor
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT event_id::text, event_name, created_at
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND created_at <= $2::timestamptz
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, runID, atTime).Scan(&cursor.EventID, &cursor.EventName, &cursor.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return runForkEventCursor{}, fmt.Errorf("no source-run event exists at or before fork timestamp %s", at)
+		}
+		return runForkEventCursor{}, fmt.Errorf("resolve fork timestamp: %w", err)
+	}
+	return cursor, nil
+}
+
+func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID string, cursor runForkEventCursor) ([]RunForkEntityState, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			m.entity_id::text,
+			m.field,
+			COALESCE(m.new_value, 'null'::jsonb)
+		FROM entity_mutations m
+		LEFT JOIN events e
+			ON e.event_id = m.caused_by_event
+		   AND e.run_id = m.run_id
+		WHERE m.run_id = $1::uuid
+		  AND (
+				(e.event_id IS NOT NULL AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid))
+				OR
+				(e.event_id IS NULL AND m.created_at <= $2::timestamptz)
+		  )
+		ORDER BY m.entity_id ASC, m.created_at ASC, m.mutation_id ASC
+	`, runID, cursor.CreatedAt, cursor.EventID)
+	if err != nil {
+		return nil, fmt.Errorf("load fork entity mutations: %w", err)
+	}
+	defer rows.Close()
+
+	grouped := map[string][]mutationlog.ProjectionMutation{}
+	entityOrder := []string{}
+	seen := map[string]struct{}{}
+	for rows.Next() {
+		var entityID, field string
+		var raw []byte
+		if err := rows.Scan(&entityID, &field, &raw); err != nil {
+			return nil, fmt.Errorf("scan fork entity mutation: %w", err)
+		}
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("decode fork entity mutation %s/%s: %w", entityID, field, err)
+		}
+		entityID = strings.TrimSpace(entityID)
+		if _, ok := seen[entityID]; !ok {
+			seen[entityID] = struct{}{}
+			entityOrder = append(entityOrder, entityID)
+		}
+		grouped[entityID] = append(grouped[entityID], mutationlog.ProjectionMutation{
+			Field:    field,
+			NewValue: value,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read fork entity mutations: %w", err)
+	}
+
+	out := make([]RunForkEntityState, 0, len(entityOrder))
+	for _, entityID := range entityOrder {
+		projection, err := mutationlog.ReconstructEntityStateProjection(grouped[entityID])
+		if err != nil {
+			return nil, fmt.Errorf("reconstruct entity %s at fork point: %w", entityID, err)
+		}
+		out = append(out, RunForkEntityState{
+			EntityID:     entityID,
+			CurrentState: projection.CurrentState,
+			Fields:       projection.Fields,
+			Gates:        projection.Gates,
+			Accumulator:  projection.Accumulator,
+		})
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string, cursor runForkEventCursor) ([]RunForkPendingWork, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id::text,
+			e.event_name,
+			d.delivery_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id::text, ''),
+			d.created_at,
+			d.started_at,
+			d.delivered_at,
+			COALESCE(r.outcome, ''),
+			r.processed_at,
+			CASE WHEN dl.original_event_id IS NULL THEN FALSE ELSE TRUE END
+		FROM events e
+		INNER JOIN event_deliveries d ON d.event_id = e.event_id
+		LEFT JOIN event_receipts r
+			ON r.event_id = d.event_id
+		   AND r.subscriber_type = d.subscriber_type
+		   AND r.subscriber_id = d.subscriber_id
+		   AND r.processed_at <= $2::timestamptz
+		LEFT JOIN dead_letters dl
+			ON dl.original_event_id = e.event_id
+		   AND dl.created_at <= $2::timestamptz
+		WHERE e.run_id = $1::uuid
+		  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
+		  AND d.created_at <= $2::timestamptz
+		ORDER BY e.created_at ASC, e.event_id ASC, d.created_at ASC, d.delivery_id ASC
+	`, runID, cursor.CreatedAt, cursor.EventID)
+	if err != nil {
+		return nil, fmt.Errorf("load fork pending work: %w", err)
+	}
+	defer rows.Close()
+
+	out := []RunForkPendingWork{}
+	for rows.Next() {
+		var item RunForkPendingWork
+		var started, delivered, receipt sql.NullTime
+		var deadLetter bool
+		if err := rows.Scan(
+			&item.EventID,
+			&item.EventName,
+			&item.DeliveryID,
+			&item.SubscriberType,
+			&item.SubscriberID,
+			&item.Status,
+			&item.RetryCount,
+			&item.ReasonCode,
+			&item.ActiveSessionID,
+			&item.CreatedAt,
+			&started,
+			&delivered,
+			&item.ReceiptOutcome,
+			&receipt,
+			&deadLetter,
+		); err != nil {
+			return nil, fmt.Errorf("scan fork pending work: %w", err)
+		}
+		item.StartedAt = nullableTimePtr(started)
+		item.DeliveredAt = nullableTimePtr(delivered)
+		item.ReceiptAt = nullableTimePtr(receipt)
+		item.Classification = classifyRunForkPendingWork(item, deadLetter)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read fork pending work: %w", err)
+	}
+	return out, nil
+}
+
+func classifyRunForkPendingWork(item RunForkPendingWork, deadLetter bool) string {
+	if item.SubscriberType == replayScopeMarkerSubscriberType && item.SubscriberID == replayScopeMarkerSubscriberID {
+		if _, ok := committedReplayScopeFromReasonCode(item.ReasonCode); ok {
+			return RunForkPendingClassificationCommittedReplay
+		}
+	}
+	if deadLetter || strings.TrimSpace(item.Status) == "dead_letter" || strings.TrimSpace(item.ReceiptOutcome) == "dead_letter" {
+		return RunForkPendingClassificationDeadLetter
+	}
+	switch strings.TrimSpace(item.Status) {
+	case "pending":
+		return RunForkPendingClassificationPending
+	case "in_progress":
+		return RunForkPendingClassificationInProgress
+	case "failed":
+		if item.RetryCount < 2 {
+			return RunForkPendingClassificationFailedRetryable
+		}
+		return RunForkPendingClassificationFailedTerminal
+	case "delivered":
+		return RunForkPendingClassificationDeliveredCompleted
+	default:
+		if item.ReceiptAt != nil {
+			return RunForkPendingClassificationDeliveredCompleted
+		}
+		return RunForkPendingClassificationPending
+	}
+}
+
+func runForkUnsupportedBlockers(catalog schemaColumnCatalog, pending []RunForkPendingWork) []RunForkUnsupportedBlocker {
+	blockers := []RunForkUnsupportedBlocker{}
+	add := func(code, message string) {
+		for _, existing := range blockers {
+			if existing.Code == code {
+				return
+			}
+		}
+		blockers = append(blockers, RunForkUnsupportedBlocker{Code: code, Message: message})
+	}
+	if len(pending) > 0 {
+		add("delivery_history_unproven", "event_deliveries stores current delivery state; arbitrary historical delivery transitions at the fork point are not append-only proven")
+	}
+	if catalog.hasTable("timers") {
+		add("timer_history_unproven", "timers are current-state rows and timer creation/cancellation is not represented in the mutation log")
+	}
+	if catalog.hasTable("routing_rules") {
+		add("flow_route_history_unproven", "routing_rules are current-state rows and cannot prove historical flow-route membership at the fork point")
+	}
+	for _, item := range pending {
+		if strings.TrimSpace(item.ActiveSessionID) == "" {
+			continue
+		}
+		add("session_history_unproven", "delivery active_session_id references current session rows without append-only session-state proof at the fork point")
+		add("active_turn_history_unproven", "active turn ownership at the fork point cannot be proven from current delivery/session rows alone")
+		break
+	}
+	return blockers
+}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -328,13 +328,23 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 			d.delivery_id::text,
 			COALESCE(d.subscriber_type, ''),
 			COALESCE(d.subscriber_id, ''),
-			COALESCE(d.status, ''),
+			CASE
+				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.status, '')
+				WHEN d.started_at IS NOT NULL AND d.started_at <= $2::timestamptz THEN 'in_progress'
+				ELSE 'pending'
+			END,
 			COALESCE(d.retry_count, 0),
 			COALESCE(d.reason_code, ''),
-			COALESCE(d.active_session_id::text, ''),
+			CASE
+				WHEN d.started_at IS NOT NULL
+				 AND d.started_at <= $2::timestamptz
+				 AND (d.delivered_at IS NULL OR d.delivered_at > $2::timestamptz)
+				THEN COALESCE(d.active_session_id::text, '')
+				ELSE ''
+			END,
 			d.created_at,
-			d.started_at,
-			d.delivered_at,
+			CASE WHEN d.started_at <= $2::timestamptz THEN d.started_at ELSE NULL END,
+			CASE WHEN d.delivered_at <= $2::timestamptz THEN d.delivered_at ELSE NULL END,
 			COALESCE(r.outcome, ''),
 			r.processed_at,
 			EXISTS (

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -107,6 +107,7 @@ func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, ca
 		"events":           {"event_id", "run_id", "event_name", "created_at"},
 		"event_deliveries": {"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count", "reason_code", "active_session_id", "started_at", "delivered_at", "created_at"},
 		"event_receipts":   {"event_id", "subscriber_type", "subscriber_id", "outcome", "reason_code", "processed_at"},
+		"dead_letters":     {"original_event_id", "handler_node", "created_at"},
 		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "new_value", "caused_by_event", "created_at"},
 	}
 	for tableName, columns := range required {
@@ -336,7 +337,15 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 			d.delivered_at,
 			COALESCE(r.outcome, ''),
 			r.processed_at,
-			CASE WHEN dl.original_event_id IS NULL THEN FALSE ELSE TRUE END
+			EXISTS (
+				SELECT 1
+				FROM dead_letters dl
+				WHERE dl.original_event_id = e.event_id
+				  AND dl.created_at <= $2::timestamptz
+				  AND COALESCE(dl.handler_node, '') <> ''
+				  AND COALESCE(d.subscriber_type, '') = 'node'
+				  AND dl.handler_node = d.subscriber_id
+			)
 		FROM events e
 		INNER JOIN event_deliveries d ON d.event_id = e.event_id
 		LEFT JOIN event_receipts r
@@ -344,9 +353,6 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 		   AND r.subscriber_type = d.subscriber_type
 		   AND r.subscriber_id = d.subscriber_id
 		   AND r.processed_at <= $2::timestamptz
-		LEFT JOIN dead_letters dl
-			ON dl.original_event_id = e.event_id
-		   AND dl.created_at <= $2::timestamptz
 		WHERE e.run_id = $1::uuid
 		  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
 		  AND d.created_at <= $2::timestamptz

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -322,57 +322,112 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 
 func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string, cursor runForkEventCursor) ([]RunForkPendingWork, error) {
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT
-			e.event_id::text,
-			e.event_name,
-			d.delivery_id::text,
-			COALESCE(d.subscriber_type, ''),
-			COALESCE(d.subscriber_id, ''),
-			CASE
-				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.status, '')
-				WHEN d.started_at IS NOT NULL AND d.started_at <= $2::timestamptz THEN 'in_progress'
-				ELSE 'pending'
-			END,
-			CASE
-				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.retry_count, 0)
-				ELSE 0
-			END,
-			CASE
-				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.reason_code, '')
-				ELSE ''
-			END,
-			CASE
-				WHEN d.started_at IS NOT NULL
-				 AND d.started_at <= $2::timestamptz
-				 AND (d.delivered_at IS NULL OR d.delivered_at > $2::timestamptz)
-				THEN COALESCE(d.active_session_id::text, '')
-				ELSE ''
-			END,
-			d.created_at,
-			CASE WHEN d.started_at <= $2::timestamptz THEN d.started_at ELSE NULL END,
-			CASE WHEN d.delivered_at <= $2::timestamptz THEN d.delivered_at ELSE NULL END,
-			COALESCE(r.outcome, ''),
-			r.processed_at,
-			EXISTS (
+		WITH delivery_rows AS (
+			SELECT
+				e.event_id::text AS event_id,
+				e.event_name AS event_name,
+				d.delivery_id::text AS delivery_id,
+				COALESCE(d.subscriber_type, '') AS subscriber_type,
+				COALESCE(d.subscriber_id, '') AS subscriber_id,
+				CASE
+					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.status, '')
+					WHEN d.started_at IS NOT NULL AND d.started_at <= $2::timestamptz THEN 'in_progress'
+					ELSE 'pending'
+				END AS status,
+				CASE
+					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.retry_count, 0)
+					ELSE 0
+				END AS retry_count,
+				CASE
+					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.reason_code, '')
+					ELSE ''
+				END AS reason_code,
+				CASE
+					WHEN d.started_at IS NOT NULL
+					 AND d.started_at <= $2::timestamptz
+					 AND (d.delivered_at IS NULL OR d.delivered_at > $2::timestamptz)
+					THEN COALESCE(d.active_session_id::text, '')
+					ELSE ''
+				END AS active_session_id,
+				d.created_at AS created_at,
+				CASE WHEN d.started_at <= $2::timestamptz THEN d.started_at ELSE NULL END AS started_at,
+				CASE WHEN d.delivered_at <= $2::timestamptz THEN d.delivered_at ELSE NULL END AS delivered_at,
+				COALESCE(r.outcome, '') AS receipt_outcome,
+				r.processed_at AS receipt_at,
+				EXISTS (
+					SELECT 1
+					FROM dead_letters dl
+					WHERE dl.original_event_id = e.event_id
+					  AND dl.created_at <= $2::timestamptz
+					  AND COALESCE(dl.handler_node, '') <> ''
+					  AND COALESCE(d.subscriber_type, '') = 'node'
+					  AND dl.handler_node = d.subscriber_id
+				) AS dead_letter
+			FROM events e
+			INNER JOIN event_deliveries d ON d.event_id = e.event_id
+			LEFT JOIN event_receipts r
+				ON r.event_id = d.event_id
+			   AND r.subscriber_type = d.subscriber_type
+			   AND r.subscriber_id = d.subscriber_id
+			   AND r.processed_at <= $2::timestamptz
+			WHERE e.run_id = $1::uuid
+			  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
+			  AND d.created_at <= $2::timestamptz
+		),
+		receipt_only_rows AS (
+			SELECT
+				e.event_id::text AS event_id,
+				e.event_name AS event_name,
+				''::text AS delivery_id,
+				COALESCE(r.subscriber_type, '') AS subscriber_type,
+				COALESCE(r.subscriber_id, '') AS subscriber_id,
+				''::text AS status,
+				0 AS retry_count,
+				COALESCE(r.reason_code, '') AS reason_code,
+				''::text AS active_session_id,
+				r.processed_at AS created_at,
+				NULL::timestamptz AS started_at,
+				r.processed_at AS delivered_at,
+				COALESCE(r.outcome, '') AS receipt_outcome,
+				r.processed_at AS receipt_at,
+				FALSE AS dead_letter
+			FROM events e
+			INNER JOIN event_receipts r ON r.event_id = e.event_id
+			WHERE e.run_id = $1::uuid
+			  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
+			  AND r.processed_at <= $2::timestamptz
+			  AND r.subscriber_type IN ('platform', 'node')
+			  AND NOT EXISTS (
 				SELECT 1
-				FROM dead_letters dl
-				WHERE dl.original_event_id = e.event_id
-				  AND dl.created_at <= $2::timestamptz
-				  AND COALESCE(dl.handler_node, '') <> ''
-				  AND COALESCE(d.subscriber_type, '') = 'node'
-				  AND dl.handler_node = d.subscriber_id
-			)
-		FROM events e
-		INNER JOIN event_deliveries d ON d.event_id = e.event_id
-		LEFT JOIN event_receipts r
-			ON r.event_id = d.event_id
-		   AND r.subscriber_type = d.subscriber_type
-		   AND r.subscriber_id = d.subscriber_id
-		   AND r.processed_at <= $2::timestamptz
-		WHERE e.run_id = $1::uuid
-		  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
-		  AND d.created_at <= $2::timestamptz
-		ORDER BY e.created_at ASC, e.event_id ASC, d.created_at ASC, d.delivery_id ASC
+				FROM event_deliveries d
+				WHERE d.event_id = r.event_id
+				  AND d.subscriber_type = r.subscriber_type
+				  AND d.subscriber_id = r.subscriber_id
+				  AND d.created_at <= $2::timestamptz
+			  )
+		)
+		SELECT
+			event_id,
+			event_name,
+			delivery_id,
+			subscriber_type,
+			subscriber_id,
+			status,
+			retry_count,
+			reason_code,
+			active_session_id,
+			created_at,
+			started_at,
+			delivered_at,
+			receipt_outcome,
+			receipt_at,
+			dead_letter
+		FROM (
+			SELECT * FROM delivery_rows
+			UNION ALL
+			SELECT * FROM receipt_only_rows
+		) work
+		ORDER BY created_at ASC, event_id ASC, delivery_id ASC, subscriber_type ASC, subscriber_id ASC
 	`, runID, cursor.CreatedAt, cursor.EventID)
 	if err != nil {
 		return nil, fmt.Errorf("load fork pending work: %w", err)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -333,8 +333,14 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 				WHEN d.started_at IS NOT NULL AND d.started_at <= $2::timestamptz THEN 'in_progress'
 				ELSE 'pending'
 			END,
-			COALESCE(d.retry_count, 0),
-			COALESCE(d.reason_code, ''),
+			CASE
+				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.retry_count, 0)
+				ELSE 0
+			END,
+			CASE
+				WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.reason_code, '')
+				ELSE ''
+			END,
 			CASE
 				WHEN d.started_at IS NOT NULL
 				 AND d.started_at <= $2::timestamptz

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -295,6 +295,69 @@ func TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery(t *testing.T) {
 	}
 }
 
+func TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000260, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'agent', 'completed-after-fork', 'delivered', 0, 'ok', $3, $4, $3),
+			($1::uuid, $2::uuid, 'agent', 'started-after-fork', 'delivered', 0, 'ok', $4, $5, $3)
+	`, runID, eventID, at, at.Add(time.Minute), at.Add(2*time.Minute)); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	got := map[string]RunForkPendingWork{}
+	for _, item := range plan.PendingWork {
+		got[item.SubscriberID] = item
+	}
+	inProgress := got["completed-after-fork"]
+	if inProgress.Classification != RunForkPendingClassificationInProgress {
+		t.Fatalf("completed-after-fork classification = %q, want %q; item=%#v", inProgress.Classification, RunForkPendingClassificationInProgress, inProgress)
+	}
+	if inProgress.Status != "in_progress" {
+		t.Fatalf("completed-after-fork status = %q, want in_progress", inProgress.Status)
+	}
+	if inProgress.DeliveredAt != nil {
+		t.Fatalf("completed-after-fork delivered_at = %v, want nil because completion happened after fork", inProgress.DeliveredAt)
+	}
+	pending := got["started-after-fork"]
+	if pending.Classification != RunForkPendingClassificationPending {
+		t.Fatalf("started-after-fork classification = %q, want %q; item=%#v", pending.Classification, RunForkPendingClassificationPending, pending)
+	}
+	if pending.Status != "pending" {
+		t.Fatalf("started-after-fork status = %q, want pending", pending.Status)
+	}
+	if pending.StartedAt != nil || pending.DeliveredAt != nil {
+		t.Fatalf("started-after-fork timestamps = started %v delivered %v, want both nil at fork", pending.StartedAt, pending.DeliveredAt)
+	}
+}
+
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -415,6 +415,70 @@ func TestRunForkPlanner_SuppressesPostForkTerminalMetadata(t *testing.T) {
 	}
 }
 
+func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000280, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES
+			($1::uuid, 'platform', 'pipeline', 'success', 'pipeline_processed', '{}'::jsonb, $2),
+			($1::uuid, 'node', 'node-a', 'no_op', 'idempotent_no_op', '{}'::jsonb, $2)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed receipt-only processing facts: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.PendingWorkCount != 2 || len(plan.PendingWork) != 2 {
+		t.Fatalf("pending work count = %d/%d, want 2 receipt-only processing facts; items=%#v", plan.PendingWorkCount, len(plan.PendingWork), plan.PendingWork)
+	}
+	got := map[string]RunForkPendingWork{}
+	for _, item := range plan.PendingWork {
+		got[item.SubscriberType+"/"+item.SubscriberID] = item
+	}
+	for key, wantOutcome := range map[string]string{
+		"platform/pipeline": "success",
+		"node/node-a":       "no_op",
+	} {
+		item, ok := got[key]
+		if !ok {
+			t.Fatalf("missing receipt-only processing fact %s; all=%#v", key, got)
+		}
+		if item.DeliveryID != "" {
+			t.Fatalf("%s delivery_id = %q, want empty for receipt-only row", key, item.DeliveryID)
+		}
+		if item.Classification != RunForkPendingClassificationDeliveredCompleted {
+			t.Fatalf("%s classification = %q, want %q; item=%#v", key, item.Classification, RunForkPendingClassificationDeliveredCompleted, item)
+		}
+		if item.ReceiptOutcome != wantOutcome || item.ReceiptAt == nil {
+			t.Fatalf("%s receipt = outcome %q at %v, want outcome %q with timestamp", key, item.ReceiptOutcome, item.ReceiptAt, wantOutcome)
+		}
+	}
+}
+
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -214,6 +214,87 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	}
 }
 
+func TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000250, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'node', 'node-dead', 'failed', 1, 'retryable_error', $3, NULL, $3),
+			($1::uuid, $2::uuid, 'node', 'node-ok', 'delivered', 0, 'ok', NULL, $3, $3),
+			($1::uuid, $2::uuid, 'agent', 'agent-ok', 'delivered', 0, 'ok', NULL, $3, $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES
+			($1::uuid, 'node', 'node-ok', 'success', 'ok', '{}'::jsonb, $2),
+			($1::uuid, 'agent', 'agent-ok', 'success', 'ok', '{}'::jsonb, $2)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed receipts: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dead_letters (
+			original_event_id, original_event, original_payload, flow_instance,
+			failure_type, error_message, retry_count, handler_node, created_at
+		)
+		VALUES
+			($1::uuid, 'fork.work', '{}'::jsonb, 'runtime', 'handler_error', 'node failed', 1, 'node-dead', $2),
+			($1::uuid, 'fork.work', '{}'::jsonb, 'runtime', 'retry_exhausted', 'different node failed', 3, 'node-other', $2)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed dead letters: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.PendingWorkCount != 3 || len(plan.PendingWork) != 3 {
+		t.Fatalf("pending work count = %d/%d, want 3 without dead-letter row multiplication; items=%#v", plan.PendingWorkCount, len(plan.PendingWork), plan.PendingWork)
+	}
+	got := map[string]string{}
+	for _, item := range plan.PendingWork {
+		got[item.SubscriberID] = item.Classification
+	}
+	want := map[string]string{
+		"node-dead": RunForkPendingClassificationDeadLetter,
+		"node-ok":   RunForkPendingClassificationDeliveredCompleted,
+		"agent-ok":  RunForkPendingClassificationDeliveredCompleted,
+	}
+	for subscriber, classification := range want {
+		if got[subscriber] != classification {
+			t.Fatalf("classification[%s] = %q, want %q; all=%#v", subscriber, got[subscriber], classification, got)
+		}
+	}
+	if _, ok := got["node-other"]; ok {
+		t.Fatalf("dead-letter-only handler became pending work row; all=%#v", got)
+	}
+}
+
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -230,5 +311,24 @@ func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "entity_mutations") {
 		t.Fatalf("PlanRunFork error = %v, want entity_mutations capability failure", err)
+	}
+}
+
+func TestRunForkPlanner_FailsClosedWhenDeadLettersUnavailable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `DROP TABLE dead_letters`); err != nil {
+		t.Fatalf("drop dead_letters: %v", err)
+	}
+	_, err := pg.PlanRunFork(ctx, RunForkPlanRequest{
+		SourceRunID: uuid.NewString(),
+		At:          uuid.NewString(),
+	})
+	if err == nil {
+		t.Fatal("PlanRunFork error = nil, want fail-closed missing dead_letters error")
+	}
+	if !strings.Contains(err.Error(), "dead_letters") {
+		t.Fatalf("PlanRunFork error = %v, want dead_letters capability failure", err)
 	}
 }

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -1,0 +1,234 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	firstEventID := "00000000-0000-0000-0000-000000000001"
+	secondEventID := "00000000-0000-0000-0000-000000000002"
+	at := time.Unix(1700000000, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'fork.first', 'global', '{}'::jsonb, 'test', 'platform', $4),
+			($1::uuid, $3::uuid, 'fork.second', 'global', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, firstEventID, secondEventID, at); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	byEvent, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: firstEventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork(event): %v", err)
+	}
+	if byEvent.ForkPoint.EventID != firstEventID {
+		t.Fatalf("event fork point = %s, want %s", byEvent.ForkPoint.EventID, firstEventID)
+	}
+	if byEvent.EventCountAtFork != 1 {
+		t.Fatalf("event count at event fork = %d, want 1", byEvent.EventCountAtFork)
+	}
+
+	byTimestamp, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: at.Format(time.RFC3339Nano)})
+	if err != nil {
+		t.Fatalf("PlanRunFork(timestamp): %v", err)
+	}
+	if byTimestamp.ForkPoint.EventID != secondEventID {
+		t.Fatalf("timestamp fork point = %s, want same-timestamp max event %s", byTimestamp.ForkPoint.EventID, secondEventID)
+	}
+	if byTimestamp.EventCountAtFork != 2 {
+		t.Fatalf("event count at timestamp fork = %d, want 2", byTimestamp.EventCountAtFork)
+	}
+}
+
+func TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	firstEventID := uuid.NewString()
+	secondEventID := uuid.NewString()
+	at := time.Unix(1700000100, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'fork.before', $4::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.after', $4::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $6)
+	`, runID, firstEventID, secondEventID, entityID, at, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
+			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
+			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
+			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
+			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $4::uuid, 'platform', 'planner-test', 'after', $6),
+			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'planner-test', 'after', $6)
+	`, runID, entityID, firstEventID, secondEventID, at, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: firstEventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ReconstructedEntityCount != 1 || len(plan.Entities) != 1 {
+		t.Fatalf("reconstructed entities = %d/%d, want 1", plan.ReconstructedEntityCount, len(plan.Entities))
+	}
+	got := plan.Entities[0]
+	if got.EntityID != entityID {
+		t.Fatalf("entity_id = %s, want %s", got.EntityID, entityID)
+	}
+	if got.CurrentState != "queued" {
+		t.Fatalf("current_state = %q, want queued", got.CurrentState)
+	}
+	if got.Fields["title"] != "before-title" {
+		t.Fatalf("field title = %#v, want before-title", got.Fields["title"])
+	}
+	if got.Gates["ready"] != true {
+		t.Fatalf("gate ready = %#v, want true", got.Gates["ready"])
+	}
+	if got.Accumulator["score"] != float64(7) {
+		t.Fatalf("accumulator score = %#v, want 7", got.Accumulator["score"])
+	}
+}
+
+func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	at := time.Unix(1700000200, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, active_session_id, started_at, delivered_at, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'agent', 'done-agent', 'delivered', 0, 'ok', NULL, NULL, $3, $3),
+			($1::uuid, $2::uuid, 'agent', 'pending-agent', 'pending', 0, 'matched_agent_subscription', NULL, NULL, NULL, $3),
+			($1::uuid, $2::uuid, 'agent', 'progress-agent', 'in_progress', 0, 'agent_processing', $4::uuid, $3, NULL, $3),
+			($1::uuid, $2::uuid, 'agent', 'retry-agent', 'failed', 1, 'retryable_error', NULL, $3, $3, $3),
+			($1::uuid, $2::uuid, 'agent', 'terminal-agent', 'failed', 2, 'max_retries', NULL, $3, $3, $3),
+			($1::uuid, $2::uuid, 'agent', 'dead-agent', 'dead_letter', 3, 'dead_letter', NULL, $3, $3, $3),
+			($1::uuid, $2::uuid, 'node', '__runtime_replay_scope__', 'delivered', 0, 'replay_scope_direct', NULL, NULL, $3, $3)
+	`, runID, eventID, at, sessionID); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES ($1::uuid, 'agent', 'done-agent', 'success', 'ok', '{}'::jsonb, $2)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed receipt: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	got := map[string]string{}
+	for _, item := range plan.PendingWork {
+		got[item.SubscriberID] = item.Classification
+	}
+	want := map[string]string{
+		"done-agent":               RunForkPendingClassificationDeliveredCompleted,
+		"pending-agent":            RunForkPendingClassificationPending,
+		"progress-agent":           RunForkPendingClassificationInProgress,
+		"retry-agent":              RunForkPendingClassificationFailedRetryable,
+		"terminal-agent":           RunForkPendingClassificationFailedTerminal,
+		"dead-agent":               RunForkPendingClassificationDeadLetter,
+		"__runtime_replay_scope__": RunForkPendingClassificationCommittedReplay,
+	}
+	for subscriber, classification := range want {
+		if got[subscriber] != classification {
+			t.Fatalf("classification[%s] = %q, want %q; all=%#v", subscriber, got[subscriber], classification, got)
+		}
+	}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false while recorder blockers remain")
+	}
+	blockers := map[string]bool{}
+	for _, blocker := range plan.UnsupportedBlockers {
+		blockers[blocker.Code] = true
+	}
+	for _, code := range []string{
+		"delivery_history_unproven",
+		"timer_history_unproven",
+		"flow_route_history_unproven",
+		"session_history_unproven",
+		"active_turn_history_unproven",
+	} {
+		if !blockers[code] {
+			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+}
+
+func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `DROP TABLE entity_mutations`); err != nil {
+		t.Fatalf("drop entity_mutations: %v", err)
+	}
+	_, err := pg.PlanRunFork(ctx, RunForkPlanRequest{
+		SourceRunID: uuid.NewString(),
+		At:          uuid.NewString(),
+	})
+	if err == nil {
+		t.Fatal("PlanRunFork error = nil, want fail-closed missing mutation log error")
+	}
+	if !strings.Contains(err.Error(), "entity_mutations") {
+		t.Fatalf("PlanRunFork error = %v, want entity_mutations capability failure", err)
+	}
+}

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -358,6 +358,63 @@ func TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork(t *test
 	}
 }
 
+func TestRunForkPlanner_SuppressesPostForkTerminalMetadata(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000270, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'agent', 'failed-after-fork', 'failed', 2, 'retry_exhausted', $3, $4, $3),
+			($1::uuid, $2::uuid, 'agent', 'pending-then-failed-after-fork', 'failed', 2, 'retry_exhausted', $4, $5, $3)
+	`, runID, eventID, at, at.Add(time.Minute), at.Add(2*time.Minute)); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	got := map[string]RunForkPendingWork{}
+	for _, item := range plan.PendingWork {
+		got[item.SubscriberID] = item
+	}
+	inProgress := got["failed-after-fork"]
+	if inProgress.Classification != RunForkPendingClassificationInProgress {
+		t.Fatalf("failed-after-fork classification = %q, want %q; item=%#v", inProgress.Classification, RunForkPendingClassificationInProgress, inProgress)
+	}
+	if inProgress.RetryCount != 0 || inProgress.ReasonCode != "" {
+		t.Fatalf("failed-after-fork terminal metadata leaked: retry_count=%d reason_code=%q", inProgress.RetryCount, inProgress.ReasonCode)
+	}
+	pending := got["pending-then-failed-after-fork"]
+	if pending.Classification != RunForkPendingClassificationPending {
+		t.Fatalf("pending-then-failed-after-fork classification = %q, want %q; item=%#v", pending.Classification, RunForkPendingClassificationPending, pending)
+	}
+	if pending.RetryCount != 0 || pending.ReasonCode != "" {
+		t.Fatalf("pending-then-failed-after-fork terminal metadata leaked: retry_count=%d reason_code=%q", pending.RetryCount, pending.ReasonCode)
+	}
+}
+
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary

Closes #536.

This PR implements the approved first slice only: canonical timestamp-fork planning/admission and dry-run proof. It does not implement mutating fork execution: no forked run row, no source-run `status=forked`, no state copying, no event redelivery, and no contract-swap execution.

## Governing refs

- Issue/gate authority: #536, gate outcome `approved as first slice`.
- Spec refs: `docs/specs/swarm-platform/platform/FLIGHT-RECORDER.md`; `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork`; platform tables `runs`, `events`, `event_deliveries`, `event_receipts`, `entity_mutations`, `timers`, `routing_rules`, `agent_sessions`, `agent_turns`.
- Spec promotion: `platform-spec.yaml` now documents the dry-run planning/admission command and canonical planner ownership.

## Semantic migration accounting

- New canonical owner: `internal/store/run_fork_planner.go` via `PostgresStore.PlanRunFork(...)`.
- Operator consumer: `cmd/swarm fork --run <id> --at <event_id|timestamp> --dry-run [--json]` consumes only the canonical store planner.
- Old producer/reader/writer path invalidated: there was no prior implemented fork planner; this PR prevents new CLI/direct SQL planner ownership by making the store planner the first and canonical owner.
- Production paths checked for surviving old behavior: `cmd/swarm`, `internal/builder`, `internal/dashboard`, run-debug/read surfaces, event/delivery/receipt/replay store paths. No alternate fork planner exists.
- Migration complete for this first slice: planner/admission owner and CLI dry-run surface complete; mutating fork execution remains out of scope.

## Validation

- `go test ./internal/store -run 'TestRunForkPlanner' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand' -count=1`
- `go test ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`

Note: an intermediate full-suite run exposed a transient `internal/runtime/llm` test failure; targeted rerun of that test passed, and the final `go test ./... -count=1` passed.