### PR TITLE
[agent-a][issue #545] Scope timestamp-fork dry-run blockers to source evidence

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -370,15 +370,6 @@ func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, created_at
-		)
-		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'pending', $3)
-	`, runID, eventID, at); err != nil {
-		t.Fatalf("seed delivery: %v", err)
-	}
-
 	var buf bytes.Buffer
 	code := runForkCommand(ctx, t.TempDir(), []string{
 		"--dry-run",
@@ -399,11 +390,14 @@ func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
 	if plan.ForkPoint.EventID != eventID {
 		t.Fatalf("ForkPoint.EventID = %q, want %q", plan.ForkPoint.EventID, eventID)
 	}
-	if plan.PendingWorkCount != 1 || plan.PendingWork[0].Classification != store.RunForkPendingClassificationPending {
-		t.Fatalf("pending work = %#v", plan.PendingWork)
+	if plan.PendingWorkCount != 0 || len(plan.PendingWork) != 0 {
+		t.Fatalf("pending work = %#v, want none", plan.PendingWork)
 	}
-	if plan.ExecutionReady {
-		t.Fatal("ExecutionReady = true, want false while unsupported blockers remain")
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want true for state-only dry-run; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if plan.UnsupportedBlockerCount != 0 {
+		t.Fatalf("UnsupportedBlockerCount = %d, want 0; blockers=%#v", plan.UnsupportedBlockerCount, plan.UnsupportedBlockers)
 	}
 }
 

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/mutationlog"
 )
 
@@ -99,6 +100,7 @@ type runForkAdmissionEvidence struct {
 type runForkSourceFacts struct {
 	EntityIDs     []string
 	FlowInstances []string
+	SourceFlows   []string
 }
 
 func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
@@ -556,6 +558,7 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string, cursor runForkEventCursor, entities []RunForkEntityState) (runForkSourceFacts, error) {
 	entitySet := map[string]struct{}{}
 	flowSet := map[string]struct{}{}
+	sourceFlowSet := map[string]struct{}{}
 	for _, entity := range entities {
 		if entityID := strings.TrimSpace(entity.EntityID); entityID != "" {
 			entitySet[entityID] = struct{}{}
@@ -581,6 +584,9 @@ func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string
 		}
 		if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
 			flowSet[flowInstance] = struct{}{}
+			if sourceFlow := runtimeflowidentity.SemanticScope(flowInstance); sourceFlow != "" {
+				sourceFlowSet[sourceFlow] = struct{}{}
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -589,6 +595,7 @@ func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string
 	return runForkSourceFacts{
 		EntityIDs:     stringSetValues(entitySet),
 		FlowInstances: stringSetValues(flowSet),
+		SourceFlows:   stringSetValues(sourceFlowSet),
 	}, nil
 }
 
@@ -621,7 +628,7 @@ func (s *PostgresStore) hasRunForkRelevantRoute(ctx context.Context, catalog sch
 	if !catalog.hasColumns("routing_rules", "flow_instance", "source_flow", "created_at") {
 		return false, nil
 	}
-	if len(facts.FlowInstances) == 0 {
+	if len(facts.FlowInstances) == 0 && len(facts.SourceFlows) == 0 {
 		return false, nil
 	}
 	var exists bool
@@ -633,10 +640,10 @@ func (s *PostgresStore) hasRunForkRelevantRoute(ctx context.Context, catalog sch
 			  AND (
 					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($2::text[]))
 					OR
-					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($2::text[]))
+					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($3::text[]))
 			  )
 		)
-	`, cursor.CreatedAt, pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
+	`, cursor.CreatedAt, pq.Array(facts.FlowInstances), pq.Array(facts.SourceFlows)).Scan(&exists); err != nil {
 		return false, fmt.Errorf("check fork route blockers: %w", err)
 	}
 	return exists, nil

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"swarm/internal/runtime/mutationlog"
 )
 
@@ -85,6 +86,19 @@ type runForkEventCursor struct {
 	EventID   string
 	EventName string
 	CreatedAt time.Time
+}
+
+type runForkAdmissionEvidence struct {
+	Pending       []RunForkPendingWork
+	RelevantTimer bool
+	RelevantRoute bool
+	ActiveSession bool
+	ActiveTurn    bool
+}
+
+type runForkSourceFacts struct {
+	EntityIDs     []string
+	FlowInstances []string
 }
 
 func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
@@ -187,7 +201,11 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	}
 	plan.PendingWork = pending
 	plan.PendingWorkCount = len(pending)
-	plan.UnsupportedBlockers = runForkUnsupportedBlockers(catalog, pending)
+	evidence, err := s.loadRunForkAdmissionEvidence(ctx, catalog, runID, cursor, entities, pending)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	plan.UnsupportedBlockers = runForkUnsupportedBlockers(evidence)
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
 	plan.ExecutionReady = plan.UnsupportedBlockerCount == 0
 	return plan, nil
@@ -499,7 +517,182 @@ func classifyRunForkPendingWork(item RunForkPendingWork, deadLetter bool) string
 	}
 }
 
-func runForkUnsupportedBlockers(catalog schemaColumnCatalog, pending []RunForkPendingWork) []RunForkUnsupportedBlocker {
+func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor, entities []RunForkEntityState, pending []RunForkPendingWork) (runForkAdmissionEvidence, error) {
+	facts, err := s.loadRunForkSourceFacts(ctx, runID, cursor, entities)
+	if err != nil {
+		return runForkAdmissionEvidence{}, err
+	}
+	relevantTimer, err := s.hasRunForkRelevantTimer(ctx, catalog, facts, cursor)
+	if err != nil {
+		return runForkAdmissionEvidence{}, err
+	}
+	relevantRoute, err := s.hasRunForkRelevantRoute(ctx, catalog, facts, cursor)
+	if err != nil {
+		return runForkAdmissionEvidence{}, err
+	}
+	activeSession := runForkPendingReferencesActiveSession(pending)
+	if !activeSession {
+		activeSession, err = s.hasRunForkActiveSession(ctx, catalog, runID, cursor)
+		if err != nil {
+			return runForkAdmissionEvidence{}, err
+		}
+	}
+	activeTurn := runForkPendingReferencesActiveSession(pending)
+	if !activeTurn {
+		activeTurn, err = s.hasRunForkActiveTurn(ctx, catalog, runID, cursor)
+		if err != nil {
+			return runForkAdmissionEvidence{}, err
+		}
+	}
+	return runForkAdmissionEvidence{
+		Pending:       pending,
+		RelevantTimer: relevantTimer,
+		RelevantRoute: relevantRoute,
+		ActiveSession: activeSession,
+		ActiveTurn:    activeTurn,
+	}, nil
+}
+
+func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string, cursor runForkEventCursor, entities []RunForkEntityState) (runForkSourceFacts, error) {
+	entitySet := map[string]struct{}{}
+	flowSet := map[string]struct{}{}
+	for _, entity := range entities {
+		if entityID := strings.TrimSpace(entity.EntityID); entityID != "" {
+			entitySet[entityID] = struct{}{}
+		}
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(entity_id::text, ''), COALESCE(flow_instance, '')
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND (created_at, event_id) <= ($2::timestamptz, $3::uuid)
+	`, runID, cursor.CreatedAt, cursor.EventID)
+	if err != nil {
+		return runForkSourceFacts{}, fmt.Errorf("load fork source facts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var entityID, flowInstance string
+		if err := rows.Scan(&entityID, &flowInstance); err != nil {
+			return runForkSourceFacts{}, fmt.Errorf("scan fork source facts: %w", err)
+		}
+		if entityID = strings.TrimSpace(entityID); entityID != "" {
+			entitySet[entityID] = struct{}{}
+		}
+		if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
+			flowSet[flowInstance] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return runForkSourceFacts{}, fmt.Errorf("read fork source facts: %w", err)
+	}
+	return runForkSourceFacts{
+		EntityIDs:     stringSetValues(entitySet),
+		FlowInstances: stringSetValues(flowSet),
+	}, nil
+}
+
+func (s *PostgresStore) hasRunForkRelevantTimer(ctx context.Context, catalog schemaColumnCatalog, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("timers", "entity_id", "flow_instance", "created_at") {
+		return false, nil
+	}
+	if len(facts.EntityIDs) == 0 && len(facts.FlowInstances) == 0 {
+		return false, nil
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE created_at <= $1::timestamptz
+			  AND (
+					(entity_id IS NOT NULL AND entity_id::text = ANY($2::text[]))
+					OR
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($3::text[]))
+			  )
+		)
+	`, cursor.CreatedAt, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork timer blockers: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *PostgresStore) hasRunForkRelevantRoute(ctx context.Context, catalog schemaColumnCatalog, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("routing_rules", "flow_instance", "source_flow", "created_at") {
+		return false, nil
+	}
+	if len(facts.FlowInstances) == 0 {
+		return false, nil
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM routing_rules
+			WHERE created_at <= $1::timestamptz
+			  AND (
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($2::text[]))
+					OR
+					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($2::text[]))
+			  )
+		)
+	`, cursor.CreatedAt, pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork route blockers: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *PostgresStore) hasRunForkActiveSession(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("agent_sessions", "run_id", "status", "created_at") {
+		return false, nil
+	}
+	activePredicate := "COALESCE(status, '') IN ('active', 'suspended')"
+	if catalog.hasColumns("agent_sessions", "terminated_at") {
+		activePredicate = "(COALESCE(status, '') IN ('active', 'suspended') OR (COALESCE(status, '') = 'terminated' AND terminated_at > $2::timestamptz))"
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM agent_sessions
+			WHERE run_id = $1::uuid
+			  AND created_at <= $2::timestamptz
+			  AND %s
+		)
+	`, activePredicate), runID, cursor.CreatedAt).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork session blockers: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *PostgresStore) hasRunForkActiveTurn(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("agent_turns", "run_id", "session_id", "created_at") ||
+		!catalog.hasColumns("agent_sessions", "session_id", "run_id", "status", "created_at") {
+		return false, nil
+	}
+	activePredicate := "COALESCE(s.status, '') IN ('active', 'suspended')"
+	if catalog.hasColumns("agent_sessions", "terminated_at") {
+		activePredicate = "(COALESCE(s.status, '') IN ('active', 'suspended') OR (COALESCE(s.status, '') = 'terminated' AND s.terminated_at > $2::timestamptz))"
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM agent_turns t
+			INNER JOIN agent_sessions s ON s.session_id = t.session_id
+			WHERE t.run_id = $1::uuid
+			  AND s.run_id = $1::uuid
+			  AND t.created_at <= $2::timestamptz
+			  AND s.created_at <= $2::timestamptz
+			  AND %s
+		)
+	`, activePredicate), runID, cursor.CreatedAt).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork active turn blockers: %w", err)
+	}
+	return exists, nil
+}
+
+func runForkUnsupportedBlockers(evidence runForkAdmissionEvidence) []RunForkUnsupportedBlocker {
 	blockers := []RunForkUnsupportedBlocker{}
 	add := func(code, message string) {
 		for _, existing := range blockers {
@@ -509,22 +702,49 @@ func runForkUnsupportedBlockers(catalog schemaColumnCatalog, pending []RunForkPe
 		}
 		blockers = append(blockers, RunForkUnsupportedBlocker{Code: code, Message: message})
 	}
-	if len(pending) > 0 {
+	if runForkHasUnsupportedPendingWork(evidence.Pending) {
 		add("delivery_history_unproven", "event_deliveries stores current delivery state; arbitrary historical delivery transitions at the fork point are not append-only proven")
 	}
-	if catalog.hasTable("timers") {
+	if evidence.RelevantTimer {
 		add("timer_history_unproven", "timers are current-state rows and timer creation/cancellation is not represented in the mutation log")
 	}
-	if catalog.hasTable("routing_rules") {
+	if evidence.RelevantRoute {
 		add("flow_route_history_unproven", "routing_rules are current-state rows and cannot prove historical flow-route membership at the fork point")
 	}
-	for _, item := range pending {
-		if strings.TrimSpace(item.ActiveSessionID) == "" {
-			continue
-		}
-		add("session_history_unproven", "delivery active_session_id references current session rows without append-only session-state proof at the fork point")
-		add("active_turn_history_unproven", "active turn ownership at the fork point cannot be proven from current delivery/session rows alone")
-		break
+	if evidence.ActiveSession {
+		add("session_history_unproven", "source-run session facts reference current session rows without append-only session-state proof at the fork point")
+	}
+	if evidence.ActiveTurn {
+		add("active_turn_history_unproven", "active turn ownership at the fork point cannot be proven from current session/turn rows alone")
 	}
 	return blockers
+}
+
+func runForkHasUnsupportedPendingWork(pending []RunForkPendingWork) bool {
+	for _, item := range pending {
+		if item.Classification != RunForkPendingClassificationDeliveredCompleted {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkPendingReferencesActiveSession(pending []RunForkPendingWork) bool {
+	for _, item := range pending {
+		if strings.TrimSpace(item.ActiveSessionID) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSetValues(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	return out
 }

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -203,12 +203,140 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	}
 	for _, code := range []string{
 		"delivery_history_unproven",
-		"timer_history_unproven",
-		"flow_route_history_unproven",
 		"session_history_unproven",
 		"active_turn_history_unproven",
 	} {
 		if !blockers[code] {
+			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+	for _, code := range []string{"timer_history_unproven", "flow_route_history_unproven"} {
+		if blockers[code] {
+			t.Fatalf("unexpected unrelated blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+}
+
+func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000210, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.state', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'planner-test', 'seed', $4)
+	`, runID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
+		)
+		VALUES ('unrelated', $1::uuid, 'flow-other/1', 'timer.fire', $2, 'other-node', 'timer', 'active', $3)
+	`, uuid.NewString(), at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed unrelated timer: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow, is_materialized, status, created_at
+		)
+		VALUES ('other.event', 'node', 'other-node', 'flow-other/1', 'flow-other', true, 'active', $1)
+	`, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed unrelated route: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want true for state-only plan; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if plan.UnsupportedBlockerCount != 0 {
+		t.Fatalf("UnsupportedBlockerCount = %d, want 0; blockers=%#v", plan.UnsupportedBlockerCount, plan.UnsupportedBlockers)
+	}
+	if plan.ReconstructedEntityCount != 1 {
+		t.Fatalf("ReconstructedEntityCount = %d, want 1", plan.ReconstructedEntityCount)
+	}
+}
+
+func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000220, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.timer_route', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"waiting"'::jsonb, $3::uuid, 'platform', 'planner-test', 'seed', $4)
+	`, runID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
+		)
+		VALUES ('relevant', $1::uuid, 'flow-a/1', 'timer.fire', $2, 'node-a', 'timer', 'active', $3)
+	`, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed relevant timer: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow, is_materialized, status, created_at
+		)
+		VALUES ('fork.timer_route', 'node', 'node-a', 'flow-a/1', 'flow-a', true, 'active', $1)
+	`, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed relevant route: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false for relevant timer/route facts")
+	}
+	for _, code := range []string{"timer_history_unproven", "flow_route_history_unproven"} {
+		if !runForkTestHasBlocker(plan, code) {
 			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
 		}
 	}
@@ -447,13 +575,29 @@ func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testi
 	`, eventID, at); err != nil {
 		t.Fatalf("seed receipt-only processing facts: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-done', 'delivered', 0, 'ok', $3, $3, $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed delivered processing fact: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES ($1::uuid, 'agent', 'agent-done', 'success', 'ok', '{}'::jsonb, $2)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed delivered receipt: %v", err)
+	}
 
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
 	}
-	if plan.PendingWorkCount != 2 || len(plan.PendingWork) != 2 {
-		t.Fatalf("pending work count = %d/%d, want 2 receipt-only processing facts; items=%#v", plan.PendingWorkCount, len(plan.PendingWork), plan.PendingWork)
+	if plan.PendingWorkCount != 3 || len(plan.PendingWork) != 3 {
+		t.Fatalf("pending work count = %d/%d, want 3 completed processing facts; items=%#v", plan.PendingWorkCount, len(plan.PendingWork), plan.PendingWork)
 	}
 	got := map[string]RunForkPendingWork{}
 	for _, item := range plan.PendingWork {
@@ -462,12 +606,13 @@ func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testi
 	for key, wantOutcome := range map[string]string{
 		"platform/pipeline": "success",
 		"node/node-a":       "no_op",
+		"agent/agent-done":  "success",
 	} {
 		item, ok := got[key]
 		if !ok {
-			t.Fatalf("missing receipt-only processing fact %s; all=%#v", key, got)
+			t.Fatalf("missing completed processing fact %s; all=%#v", key, got)
 		}
-		if item.DeliveryID != "" {
+		if key != "agent/agent-done" && item.DeliveryID != "" {
 			t.Fatalf("%s delivery_id = %q, want empty for receipt-only row", key, item.DeliveryID)
 		}
 		if item.Classification != RunForkPendingClassificationDeliveredCompleted {
@@ -475,6 +620,75 @@ func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testi
 		}
 		if item.ReceiptOutcome != wantOutcome || item.ReceiptAt == nil {
 			t.Fatalf("%s receipt = outcome %q at %v, want outcome %q with timestamp", key, item.ReceiptOutcome, item.ReceiptAt, wantOutcome)
+		}
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want true for completed-only delivery/receipt facts; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if runForkTestHasBlocker(plan, "delivery_history_unproven") {
+		t.Fatalf("completed-only delivery/receipt facts emitted delivery blocker: %#v", plan.UnsupportedBlockers)
+	}
+}
+
+func TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700000290, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.session', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model_tier, llm_backend, conversation_mode, created_at
+		)
+		VALUES ('agent-a', 'worker', 'standard', 'mock', 'session', $1)
+	`, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', 'global', 'global', 'session', 'active', $3, $3)
+	`, sessionID, runID, at.Add(-time.Second)); err != nil {
+		t.Fatalf("seed active session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, trigger_event_id, trigger_event_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'session', $4::uuid, 'fork.session', $5)
+	`, turnID, runID, sessionID, eventID, at); err != nil {
+		t.Fatalf("seed active turn: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false for source-run active session/turn facts")
+	}
+	for _, code := range []string{"session_history_unproven", "active_turn_history_unproven"} {
+		if !runForkTestHasBlocker(plan, code) {
+			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
 		}
 	}
 }
@@ -515,4 +729,13 @@ func TestRunForkPlanner_FailsClosedWhenDeadLettersUnavailable(t *testing.T) {
 	if !strings.Contains(err.Error(), "dead_letters") {
 		t.Fatalf("PlanRunFork error = %v, want dead_letters capability failure", err)
 	}
+}
+
+func runForkTestHasBlocker(plan RunForkPlan, code string) bool {
+	for _, blocker := range plan.UnsupportedBlockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -323,7 +323,7 @@ func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
 		INSERT INTO routing_rules (
 			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow, is_materialized, status, created_at
 		)
-		VALUES ('fork.timer_route', 'node', 'node-a', 'flow-a/1', 'flow-a', true, 'active', $1)
+		VALUES ('fork.timer_route', 'node', 'node-a', 'flow-a/2', 'flow-a', true, 'active', $1)
 	`, at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed relevant route: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #545.

Implements the approved first-slice boundary for timestamp-fork dry-run admission precision. The canonical planner now emits unsupported blockers from source-run evidence at or before fork T instead of table existence or unrelated persisted rows.

Governing refs/context:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork` dry-run planning/admission semantics.
- Platform table specs for `events`, `entity_mutations`, `event_deliveries`, `event_receipts`, `timers`, `routing_rules`, `agent_sessions`, and `agent_turns`.
- Binding gate on #545: approved as first slice.

## Canonical Owner / Migration Accounting

Canonical owner after this change:
- `internal/store/run_fork_planner.go`

Old non-authoritative behavior invalidated:
- `timers` / `routing_rules` table existence no longer emits fork blockers by itself.
- Completed delivery / receipt-only processing facts no longer emit `delivery_history_unproven` when no redelivery is required.

Production paths checked for surviving old behavior:
- `cmd/swarm fork --dry-run --json` still consumes `PostgresStore.PlanRunFork(...)` and does not implement alternate admission logic.
- No Builder/API/dashboard fork wrapper is introduced or changed.

Migration complete for this child: yes. Mutating fork execution remains out of scope.

## Validation

- `go test ./internal/store -run 'TestRunForkPlanner' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand_DryRunUsesCanonicalPlannerJSON' -count=1`
- `go test ./cmd/swarm ./internal/store -count=1`
- `go test ./... -count=1`