### PR TITLE
[agent-d][issue #540] Add platform tool usage hints

### DIFF
--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -613,6 +613,7 @@ func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runt
 		defs = append(defs, llm.ToolDefinition{
 			Name:        "bash",
 			Description: "Execute a shell command locally in the agent workspace and return stdout, stderr, exit code, and duration.",
+			Usage:       runtimetools.NativeFallbackToolUsage("bash"),
 			Schema: runtimetools.ObjectSchema(map[string]any{
 				"command":         map[string]any{"type": "string"},
 				"timeout_seconds": map[string]any{"type": "integer", "minimum": 1, "maximum": 300},
@@ -623,6 +624,7 @@ func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runt
 		defs = append(defs, llm.ToolDefinition{
 			Name:        "web_search",
 			Description: "Search the web and return normalized results with title, url, and snippet.",
+			Usage:       runtimetools.NativeFallbackToolUsage("web_search"),
 			Schema: runtimetools.ObjectSchema(map[string]any{
 				"query":       map[string]any{"type": "string"},
 				"max_results": map[string]any{"type": "integer", "minimum": 1, "maximum": 20},
@@ -634,6 +636,7 @@ func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runt
 			llm.ToolDefinition{
 				Name:        "read_file",
 				Description: "Read a file from the agent workspace or mounted read-only data/contracts paths.",
+				Usage:       runtimetools.NativeFallbackToolUsage("read_file"),
 				Schema: runtimetools.ObjectSchema(map[string]any{
 					"path": map[string]any{"type": "string"},
 				}, "path"),
@@ -641,6 +644,7 @@ func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runt
 			llm.ToolDefinition{
 				Name:        "write_file",
 				Description: "Write a file within the agent workspace.",
+				Usage:       runtimetools.NativeFallbackToolUsage("write_file"),
 				Schema: runtimetools.ObjectSchema(map[string]any{
 					"path":    map[string]any{"type": "string"},
 					"content": map[string]any{"type": "string"},

--- a/internal/runtime/authority/source_provider.go
+++ b/internal/runtime/authority/source_provider.go
@@ -227,8 +227,8 @@ func buildProducerRegistry(source semanticview.Source) map[string][]string {
 		return map[string][]string{}
 	}
 	agentEvents := make(map[string][]string)
-	for role, entry := range source.AgentEntries() {
-		role = canonicalRole(firstNonEmpty(role, entry.Role))
+	for key, entry := range source.AgentEntries() {
+		role := canonicalRole(firstNonEmpty(entry.Role, key))
 		if role == "" {
 			continue
 		}

--- a/internal/runtime/authority/source_provider_test.go
+++ b/internal/runtime/authority/source_provider_test.go
@@ -32,6 +32,27 @@ func TestNewSourceProvider_UsesDeclaredAgentEmitEventsOnly(t *testing.T) {
 	}
 }
 
+func TestNewSourceProvider_UsesDeclaredRoleForProducerEvents(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-instance-1": {
+				ID:         "agent-instance-1",
+				Role:       "reviewer",
+				EmitEvents: []string{"review.completed"},
+			},
+		},
+	}
+
+	provider := NewSourceProvider(semanticview.Wrap(bundle))
+	got := provider.ProducerEventsForRole("reviewer")
+	if len(got) != 1 || got[0] != "review.completed" {
+		t.Fatalf("ProducerEventsForRole(reviewer) = %#v, want [review.completed]", got)
+	}
+	if got := provider.ProducerEventsForRole("agent-instance-1"); len(got) != 0 {
+		t.Fatalf("ProducerEventsForRole(agent-instance-1) = %#v, want nil/empty", got)
+	}
+}
+
 func TestNewSourceProvider_AuthorityMatrix(t *testing.T) {
 	provider := NewSourceProvider(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -54,6 +54,9 @@ type checkerContext struct {
 	toolLoaded   bool
 	toolFindings []Finding
 
+	toolUsageLoaded   bool
+	toolUsageFindings []Finding
+
 	runtimeToolNamesLoaded bool
 	runtimeToolNames       map[string]struct{}
 
@@ -197,6 +200,7 @@ var bootCheckRegistry = []Check{
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
+	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},
 	{ID: "prompt_exists", Severity: "warning", Run: checkPromptExists},
 	{ID: "produces_drift", Severity: "warning", Run: checkProducesDrift},
 	{ID: "invalid_field_detection", Severity: "error", Run: checkInvalidFieldDetection},
@@ -251,6 +255,7 @@ func checkNodeStateSchemaTypedCounterpart(c *checkerContext) []Finding {
 func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.requiredAgentsMatch() }
 func checkHandlerFieldCompliance(c *checkerContext) []Finding     { return c.handlerFieldCompliance() }
 func checkToolResolution(c *checkerContext) []Finding             { return c.toolResolution() }
+func checkPlatformToolUsageHints(c *checkerContext) []Finding     { return c.platformToolUsageHints() }
 func checkPromptExists(c *checkerContext) []Finding               { return c.promptExists() }
 func checkInvalidFieldDetection(c *checkerContext) []Finding      { return c.invalidFieldDetection() }
 func checkPolicyConflictDetection(c *checkerContext) []Finding    { return c.policyConflicts() }
@@ -502,6 +507,30 @@ func (c *checkerContext) toolResolution() []Finding {
 		}
 	}
 	return c.toolFindings
+}
+
+func (c *checkerContext) platformToolUsageHints() []Finding {
+	if c.toolUsageLoaded {
+		return c.toolUsageFindings
+	}
+	c.toolUsageLoaded = true
+	for _, item := range runtimetools.ValidateUsageHintCoverage(c.source, c.mcpDiscovered()) {
+		severity := SeverityLintEvidence
+		if item.Severity == "error" {
+			severity = SeverityHardInvalidity
+		}
+		location := strings.TrimSpace(item.ToolName)
+		if location == "" {
+			location = "runtime-tools"
+		}
+		c.toolUsageFindings = append(c.toolUsageFindings, Finding{
+			CheckID:  "platform_tool_usage_hints",
+			Severity: severity,
+			Message:  item.Message,
+			Location: location,
+		})
+	}
+	return c.toolUsageFindings
 }
 
 func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3284,8 +3284,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 45 {
-		t.Fatalf("bootCheckRegistry count = %d, want 45", got)
+	if got := len(bootCheckRegistry); got != 46 {
+		t.Fatalf("bootCheckRegistry count = %d, want 46", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -375,7 +375,7 @@ func (r *AnthropicAPIRuntime) buildRequest(ctx context.Context, s *Session, inpu
 	for _, t := range s.Tools {
 		tool := anthropicTool{
 			Name:        t.Name,
-			Description: t.Description,
+			Description: DeliveredToolDescription(t),
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
 		}
 		if t.Schema != nil {

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -830,9 +830,9 @@ func buildInitialPrompt(s *Session, firstMessage string) string {
 		for _, t := range s.Tools {
 			b.WriteString("- ")
 			b.WriteString(t.Name)
-			if t.Description != "" {
+			if delivered := strings.TrimSpace(DeliveredToolDescription(t)); delivered != "" {
 				b.WriteString(": ")
-				b.WriteString(t.Description)
+				b.WriteString(delivered)
 			}
 			b.WriteString("\n")
 		}

--- a/internal/runtime/llm/tool_description_test.go
+++ b/internal/runtime/llm/tool_description_test.go
@@ -1,0 +1,67 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	"swarm/internal/runtime/sessions"
+)
+
+func TestDeliveredToolDescription_AppendsUsageWithoutProtocolExtension(t *testing.T) {
+	def := ToolDefinition{
+		Name:        "query_entities",
+		Description: "Query entity_state rows.",
+		Usage:       "Use CEL equality with ==.",
+	}
+
+	got := DeliveredToolDescription(def)
+	if !strings.Contains(got, "Query entity_state rows.\n\nUsage:\nUse CEL equality with ==.") {
+		t.Fatalf("delivered description = %q", got)
+	}
+}
+
+func TestDeliveredToolDescription_DoesNotDuplicateUsageBlock(t *testing.T) {
+	def := ToolDefinition{
+		Name:        "query_entities",
+		Description: "Query entity_state rows.\n\nUsage:\nUse CEL equality with ==.",
+		Usage:       "Use CEL equality with ==.",
+	}
+
+	got := DeliveredToolDescription(def)
+	if strings.Count(got, "Usage:") != 1 {
+		t.Fatalf("delivered description duplicated usage block: %q", got)
+	}
+}
+
+func TestAnthropicAPIRuntimeBuildRequest_DeliversUsageInToolDescription(t *testing.T) {
+	runtime := NewAnthropicAPIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeAPI: config.ClaudeAPIConfig{DefaultModel: "claude-test"},
+		},
+	}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil)
+	session := &Session{
+		ID: "session-1",
+		Messages: []Message{{
+			Role:    "user",
+			Content: "work",
+		}},
+		Tools: []ToolDefinition{{
+			Name:        "query_entities",
+			Description: "Query entity_state rows.",
+			Usage:       "Use CEL equality with ==.",
+		}},
+	}
+
+	req, err := runtime.buildRequest(context.Background(), session, Message{Role: "user", Content: "continue"})
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if len(req.Tools) != 1 {
+		t.Fatalf("tool count = %d, want 1", len(req.Tools))
+	}
+	if !strings.Contains(req.Tools[0].Description, "\n\nUsage:\nUse CEL equality with ==.") {
+		t.Fatalf("tool description = %q, want usage block", req.Tools[0].Description)
+	}
+}

--- a/internal/runtime/llm/tool_description_test.go
+++ b/internal/runtime/llm/tool_description_test.go
@@ -65,3 +65,18 @@ func TestAnthropicAPIRuntimeBuildRequest_DeliversUsageInToolDescription(t *testi
 		t.Fatalf("tool description = %q, want usage block", req.Tools[0].Description)
 	}
 }
+
+func TestBuildInitialPrompt_DeliversUsageInPromptTransportFallback(t *testing.T) {
+	prompt := buildInitialPrompt(&Session{
+		SystemPrompt: "system",
+		Tools: []ToolDefinition{{
+			Name:        "query_entities",
+			Description: "Query entity_state rows.",
+			Usage:       "Use CEL equality with ==.",
+		}},
+	}, "continue")
+
+	if !strings.Contains(prompt, "- query_entities: Query entity_state rows.\n\nUsage:\nUse CEL equality with ==.") {
+		t.Fatalf("prompt = %q, want delivered usage in tool description", prompt)
+	}
+}

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"strings"
 
 	models "swarm/internal/runtime/core/actors"
 )
@@ -10,6 +11,26 @@ type ToolDefinition struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Schema      any    `json:"schema,omitempty"`
+	Usage       string `json:"-"`
+}
+
+func DeliveredToolDescription(def ToolDefinition) string {
+	return DescriptionWithUsage(def.Description, def.Usage)
+}
+
+func DescriptionWithUsage(description, usage string) string {
+	description = strings.TrimSpace(description)
+	usage = strings.TrimSpace(usage)
+	if usage == "" {
+		return description
+	}
+	if description == "" {
+		return "Usage:\n" + usage
+	}
+	if strings.Contains(description, "\n\nUsage:\n") {
+		return description
+	}
+	return description + "\n\nUsage:\n" + usage
 }
 
 type Message struct {

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -584,8 +584,8 @@ func (g *Gateway) mcpToolsForActor(actor models.AgentConfig, allowed map[string]
 			"additionalProperties": true,
 		})
 		if ok {
-			if strings.TrimSpace(def.Description) != "" {
-				desc = def.Description
+			if delivered := strings.TrimSpace(llm.DeliveredToolDescription(def)); delivered != "" {
+				desc = delivered
 			}
 			if def.Schema != nil {
 				schema = def.Schema

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -536,7 +536,7 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 			{Name: "workflow_custom_tool", Description: "global"},
 		},
 		actorDefs: []llm.ToolDefinition{
-			{Name: "query_entities", Description: "actor scoped"},
+			{Name: "query_entities", Description: "actor scoped", Usage: "Use CEL equality with ==."},
 		},
 	}, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
@@ -561,6 +561,9 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 	}
 	if tools[0].Name != "query_entities" {
 		t.Fatalf("tool name = %q, want query_entities", tools[0].Name)
+	}
+	if !strings.Contains(tools[0].Description, "actor scoped\n\nUsage:\nUse CEL equality with ==.") {
+		t.Fatalf("tool description = %q, want usage appended", tools[0].Description)
 	}
 }
 

--- a/internal/runtime/tools/contracts_test.go
+++ b/internal/runtime/tools/contracts_test.go
@@ -46,6 +46,26 @@ func TestContractDefinitionsForSource_UsesProvidedSource(t *testing.T) {
 	t.Fatal("expected source-backed agent_message definition")
 }
 
+func TestContractDefinitionsForSource_AttachesPlatformUsageHints(t *testing.T) {
+	defs, err := ContractDefinitionsForSource(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	if err != nil {
+		t.Fatalf("ContractDefinitionsForSource: %v", err)
+	}
+	for _, def := range defs {
+		if def.Name != "query_entities" {
+			continue
+		}
+		if !strings.Contains(def.Usage, "filter is CEL") {
+			t.Fatalf("query_entities usage = %q, want CEL guidance", def.Usage)
+		}
+		if strings.Contains(def.Description, "Usage:") {
+			t.Fatalf("canonical description should not be pre-concatenated: %q", def.Description)
+		}
+		return
+	}
+	t.Fatal("expected query_entities definition")
+}
+
 func TestContractDefinitionsForSource_DoesNotExposeCreateFlowInstance(t *testing.T) {
 	defs, err := ContractDefinitionsForSource(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
 	if err != nil {

--- a/internal/runtime/tools/emit.go
+++ b/internal/runtime/tools/emit.go
@@ -62,6 +62,7 @@ func GenerateEmitTools(
 		tools = append(tools, llm.ToolDefinition{
 			Name:        EmitToolName(eventType),
 			Description: schema.Description,
+			Usage:       EmitToolUsage(),
 			Schema:      schema.Schema,
 		})
 	}

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -139,6 +139,7 @@ func (r *EmitRegistry) GenerateEmitToolsForEvents(eventTypes []string, warn func
 		tools = append(tools, llm.ToolDefinition{
 			Name:        toolName,
 			Description: schema.Description,
+			Usage:       EmitToolUsage(),
 			Schema:      schema.Schema,
 		})
 	}
@@ -186,6 +187,7 @@ func (r *EmitRegistry) GenerateEmitToolsForActor(actor models.AgentConfig, warn 
 			tools = append(tools, llm.ToolDefinition{
 				Name:        toolName,
 				Description: schema.Description,
+				Usage:       EmitToolUsage(),
 				Schema:      schema.Schema,
 			})
 		}

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -51,6 +51,12 @@ func TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent(t *testing.
 	}, nil)
 	for _, def := range tools {
 		if def.Name == "emit_scan_requested" {
+			if strings.TrimSpace(def.Usage) == "" {
+				t.Fatal("emit_scan_requested usage hint is empty")
+			}
+			if strings.Contains(strings.ToLower(def.Usage), "cel") {
+				t.Fatalf("emit usage should not mention CEL: %q", def.Usage)
+			}
 			return
 		}
 	}

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -194,6 +194,7 @@ func (e *Executor) ToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 		filtered = append(filtered, llm.ToolDefinition{
 			Name:        name,
 			Description: strings.TrimSpace(entry.Description),
+			Usage:       strings.TrimSpace(entry.Usage),
 			Schema:      deepCloneJSONValue(entry.InputSchema),
 		})
 	}

--- a/internal/runtime/tools/native_tools.go
+++ b/internal/runtime/tools/native_tools.go
@@ -20,6 +20,7 @@ func nativeFallbackRegisteredTool(actor models.AgentConfig, name string) (Regist
 		return RegisteredTool{
 			Name:        name,
 			Description: "Execute a shell command locally in the agent workspace.",
+			Usage:       runtimeOwnedToolUsage(name),
 			HandlerType: implementationPlatformBuiltin,
 			InputSchema: ObjectSchema(map[string]any{
 				"command":         map[string]any{"type": "string"},
@@ -33,6 +34,7 @@ func nativeFallbackRegisteredTool(actor models.AgentConfig, name string) (Regist
 		return RegisteredTool{
 			Name:        name,
 			Description: "Search the web and return normalized results.",
+			Usage:       runtimeOwnedToolUsage(name),
 			HandlerType: implementationPlatformBuiltin,
 			InputSchema: ObjectSchema(map[string]any{
 				"query":       map[string]any{"type": "string"},
@@ -46,6 +48,7 @@ func nativeFallbackRegisteredTool(actor models.AgentConfig, name string) (Regist
 		return RegisteredTool{
 			Name:        name,
 			Description: "Read a file from the workspace or mounted read-only paths.",
+			Usage:       runtimeOwnedToolUsage(name),
 			HandlerType: implementationPlatformBuiltin,
 			InputSchema: ObjectSchema(map[string]any{
 				"path": map[string]any{"type": "string"},
@@ -58,6 +61,7 @@ func nativeFallbackRegisteredTool(actor models.AgentConfig, name string) (Regist
 		return RegisteredTool{
 			Name:        name,
 			Description: "Write a file within the agent workspace.",
+			Usage:       runtimeOwnedToolUsage(name),
 			HandlerType: implementationPlatformBuiltin,
 			InputSchema: ObjectSchema(map[string]any{
 				"path":    map[string]any{"type": "string"},
@@ -91,6 +95,7 @@ func nativeFallbackToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 		defs = append(defs, llm.ToolDefinition{
 			Name:        tool.Name,
 			Description: strings.TrimSpace(tool.Description),
+			Usage:       strings.TrimSpace(tool.Usage),
 			Schema:      deepCloneJSONValue(tool.InputSchema),
 		})
 	}

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -17,6 +17,7 @@ func builtinRegisteredTools(source semanticview.Source, actor *models.AgentConfi
 			Name:        strings.TrimSpace(name),
 			Category:    strings.TrimSpace(entry.Category),
 			Description: strings.TrimSpace(entry.Description),
+			Usage:       runtimeOwnedToolUsage(name),
 			HandlerType: implementationPlatformBuiltin,
 			InputSchema: deepCloneMap(entry.InputSchema),
 		}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -23,6 +23,7 @@ type RegisteredTool struct {
 	Name               string
 	Category           string
 	Description        string
+	Usage              string
 	RequiredPermission string
 	HandlerType        implementationClass
 	InputSchema        map[string]any
@@ -53,6 +54,7 @@ func toolDefinitionsForRuntime(source semanticview.Source, discovered map[string
 		defs = append(defs, llm.ToolDefinition{
 			Name:        name,
 			Description: strings.TrimSpace(entry.Description),
+			Usage:       strings.TrimSpace(entry.Usage),
 			Schema:      deepCloneJSONValue(entry.InputSchema),
 		})
 	}
@@ -78,6 +80,7 @@ func toolDefinitionsForActor(source semanticview.Source, actor models.AgentConfi
 		defs = append(defs, llm.ToolDefinition{
 			Name:        name,
 			Description: strings.TrimSpace(entry.Description),
+			Usage:       strings.TrimSpace(entry.Usage),
 			Schema:      deepCloneJSONValue(entry.InputSchema),
 		})
 	}
@@ -115,11 +118,12 @@ func registeredToolsForRuntime(source semanticview.Source, discovered map[string
 			continue
 		}
 		schema, _ := tool.InputSchema.(map[string]any)
+		schema = deepCloneMap(schema)
 		entries[name] = RegisteredTool{
 			Name:          name,
 			Description:   strings.TrimSpace(tool.Description),
 			HandlerType:   implementationMCP,
-			InputSchema:   deepCloneJSONValue(schema).(map[string]any),
+			InputSchema:   schema,
 			MCPServerName: strings.TrimSpace(tool.ServerName),
 			MCPRemoteName: strings.TrimSpace(tool.RemoteName),
 		}
@@ -210,6 +214,7 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 		Name:               strings.TrimSpace(name),
 		Category:           strings.TrimSpace(entry.Category),
 		Description:        strings.TrimSpace(entry.Description),
+		Usage:              runtimeOwnedToolUsage(name),
 		RequiredPermission: strings.TrimSpace(toolRequiredPermission(name, entry)),
 		HandlerType:        handlerType,
 		InputSchema:        inputSchema,

--- a/internal/runtime/tools/usage.go
+++ b/internal/runtime/tools/usage.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	models "swarm/internal/runtime/core/actors"
+	runtimeauthority "swarm/internal/runtime/authority"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	"swarm/internal/runtime/semanticview"
@@ -127,20 +127,9 @@ func validateEmitToolUsageHintCoverage(source semanticview.Source) []UsageHintFi
 	if source == nil {
 		return nil
 	}
-	registry := NewEmitRegistry(source, nil)
-	agentIDs := make([]string, 0, len(source.AgentEntries()))
-	for agentID := range source.AgentEntries() {
-		agentIDs = append(agentIDs, strings.TrimSpace(agentID))
-	}
-	sort.Strings(agentIDs)
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
 	findings := make([]UsageHintFinding, 0)
-	for _, agentID := range agentIDs {
-		entry := source.AgentEntries()[agentID]
-		actor := models.AgentConfig{
-			ID:         coalesceNonEmpty(entry.ID, agentID),
-			Role:       coalesceNonEmpty(entry.ID, agentID),
-			EmitEvents: append([]string{}, entry.EmitEvents...),
-		}
+	for _, actor := range providerSchemaValidationActors(source) {
 		for _, def := range registry.GenerateEmitToolsForActor(actor, nil) {
 			usage := strings.TrimSpace(def.Usage)
 			if usage == "" {

--- a/internal/runtime/tools/usage.go
+++ b/internal/runtime/tools/usage.go
@@ -1,0 +1,184 @@
+package tools
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	models "swarm/internal/runtime/core/actors"
+	llm "swarm/internal/runtime/llm"
+	runtimemcp "swarm/internal/runtime/mcp"
+	"swarm/internal/runtime/semanticview"
+)
+
+const maxUsageHintRunes = 1200
+
+var builtinToolUsageHints = map[string]string{
+	"agent_message":      "Use for agent-to-agent messages only. Provide the exact target agent ID and message content. Do not use this to publish workflow events; use emit_* tools for events.",
+	"mailbox_send":       "Use for human mailbox items only. Provide the task kind, subject/summary, priority when relevant, and structured context. Do not use this for agent-to-agent messages.",
+	"schedule":           "Use only when scheduling a future event/action for the current entity or actor. Provide concrete RFC3339 time or delay-derived timing and the event/action payload expected by the workflow.",
+	"agent_hire":         "Use only with explicit permission to spawn a runtime agent. Provide the agent config fields required by the target role; do not invent product-specific tool names.",
+	"agent_fire":         "Use only with explicit permission to terminate an agent session. Provide the target agent ID and a concrete reason.",
+	"agent_reconfigure":  "Use only with explicit permission to modify an existing agent. Provide only supported agent config fields such as model tier, runtime mode, tools, emit events, native tools, or prompt config.",
+	"get_entity":         "Read one existing entity by entity_id. Use flow_instance only as the owning-flow guard/address when needed; it must match the entity's owning flow root or instance. Returns envelope fields plus declared entity fields.",
+	"create_entity":      "Create a new entity in the inferred flow-owned contract. Do not provide entity_id, entity_type, subject_id, or other envelope fields. Put authored contract fields under fields using declared field names and declared value shapes.",
+	"save_entity_field":  "Write exactly one delivered writable field on an entity owned by your current flow. Do not write upstream/root/source entities from triggering events. Use only field names from this tool's enum/session writable-path summary. Value must match the declared field shape; lists require arrays and objects require objects.",
+	"query_entities":     "Read/query entity_state rows. entity_type, select, group_by, and filter paths must use delivered enum/declared scalar or enum leaf names. filter is CEL, so equality is ==, strings are quoted, and assignment = is invalid.",
+	"search_entities":    "Search entity_state rows with object field filters. entity_type and filter keys must use delivered declared field names for the target entity contract. Use query_entities when you need CEL, select, or group_by.",
+	"query_metrics":      "Aggregate entity_state rows. metric must be one of the delivered enum values. field and group_by must use delivered scalar or enum selector names. filter is CEL, so equality is == and strings are quoted.",
+	"human_task_request": "Create a human task only when human input is required. Provide a clear summary/context and deadline fields in supported shapes.",
+	"human_task_decide":  "Record a decision on an existing human task. Use only supported decision values such as approved, rejected, or deferred and include the target task reference.",
+}
+
+var nativeFallbackUsageHints = map[string]string{
+	"bash":       "Use only for local workspace commands. Provide command as a string and timeout_seconds when needed. Do not use for workflow event emission or entity persistence.",
+	"web_search": "Use for external web research only. Provide a concise query and max_results when needed. Do not use it to read Swarm entity state; use entity tools for that.",
+	"read_file":  "Read files by exact path from the workspace or mounted read-only data/contracts paths. Do not use for entity_state reads.",
+	"write_file": "Write files only within the agent workspace. Do not use file writes as a substitute for emit_* event publication or save_entity_field persistence.",
+}
+
+var emitToolUsageHint = "Call this emit_* tool only to publish the named workflow event. Provide concrete JSON payload values matching the input schema. Do not include envelope-owned fields unless the schema declares them. Arguments are concrete payload values, not workflow expressions."
+
+func runtimeOwnedToolUsage(name string) string {
+	name = strings.TrimSpace(name)
+	if usage := strings.TrimSpace(builtinToolUsageHints[name]); usage != "" {
+		return usage
+	}
+	if usage := strings.TrimSpace(nativeFallbackUsageHints[name]); usage != "" {
+		return usage
+	}
+	return ""
+}
+
+func NativeFallbackToolUsage(name string) string {
+	return runtimeOwnedToolUsage(name)
+}
+
+func EmitToolUsage() string {
+	return emitToolUsageHint
+}
+
+func PlatformOwnedToolUsage(name string) string {
+	return runtimeOwnedToolUsage(name)
+}
+
+func DescriptionWithUsage(description, usage string) string {
+	return llm.DescriptionWithUsage(description, usage)
+}
+
+type UsageHintFinding struct {
+	ToolName string
+	Severity string
+	Message  string
+}
+
+func ValidateUsageHintCoverage(source semanticview.Source, discovered map[string]runtimemcp.DiscoveredTool) []UsageHintFinding {
+	findings := make([]UsageHintFinding, 0)
+	entries, err := registeredToolsForRuntime(source, discovered)
+	if err != nil {
+		return []UsageHintFinding{{
+			Severity: "error",
+			Message:  fmt.Sprintf("resolve runtime tool registry: %v", err),
+		}}
+	}
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		entry := entries[name]
+		if runtimeToolHiddenFromAgents(name) {
+			continue
+		}
+		usage := strings.TrimSpace(entry.Usage)
+		switch entry.HandlerType {
+		case implementationPlatformBuiltin:
+			if usage == "" {
+				findings = append(findings, UsageHintFinding{
+					ToolName: name,
+					Severity: "error",
+					Message:  fmt.Sprintf("platform-owned delivered tool %s is missing a usage hint", name),
+				})
+				continue
+			}
+		case implementationMCP:
+			if usage == "" {
+				findings = append(findings, UsageHintFinding{
+					ToolName: name,
+					Severity: "lint",
+					Message:  fmt.Sprintf("external MCP/discovered tool %s has no platform-owned usage hint; advisory only", name),
+				})
+			}
+		}
+		if runeLen(usage) > maxUsageHintRunes {
+			findings = append(findings, UsageHintFinding{
+				ToolName: name,
+				Severity: "lint",
+				Message:  fmt.Sprintf("tool %s usage hint is over %d characters; keep provider-facing usage concise", name, maxUsageHintRunes),
+			})
+		}
+	}
+	findings = append(findings, validateEmitToolUsageHintCoverage(source)...)
+	return findings
+}
+
+func validateEmitToolUsageHintCoverage(source semanticview.Source) []UsageHintFinding {
+	if source == nil {
+		return nil
+	}
+	registry := NewEmitRegistry(source, nil)
+	agentIDs := make([]string, 0, len(source.AgentEntries()))
+	for agentID := range source.AgentEntries() {
+		agentIDs = append(agentIDs, strings.TrimSpace(agentID))
+	}
+	sort.Strings(agentIDs)
+	findings := make([]UsageHintFinding, 0)
+	for _, agentID := range agentIDs {
+		entry := source.AgentEntries()[agentID]
+		actor := models.AgentConfig{
+			ID:         coalesceNonEmpty(entry.ID, agentID),
+			Role:       coalesceNonEmpty(entry.ID, agentID),
+			EmitEvents: append([]string{}, entry.EmitEvents...),
+		}
+		for _, def := range registry.GenerateEmitToolsForActor(actor, nil) {
+			usage := strings.TrimSpace(def.Usage)
+			if usage == "" {
+				findings = append(findings, UsageHintFinding{
+					ToolName: def.Name,
+					Severity: "error",
+					Message:  fmt.Sprintf("generated platform-owned emit tool %s is missing the shared usage hint", def.Name),
+				})
+				continue
+			}
+			if strings.Contains(strings.ToLower(usage), "cel") {
+				findings = append(findings, UsageHintFinding{
+					ToolName: def.Name,
+					Severity: "error",
+					Message:  fmt.Sprintf("generated platform-owned emit tool %s usage hint must not instruct agent-facing CEL arguments", def.Name),
+				})
+			}
+			if runeLen(usage) > maxUsageHintRunes {
+				findings = append(findings, UsageHintFinding{
+					ToolName: def.Name,
+					Severity: "lint",
+					Message:  fmt.Sprintf("generated emit tool %s usage hint is over %d characters; keep provider-facing usage concise", def.Name, maxUsageHintRunes),
+				})
+			}
+		}
+	}
+	return findings
+}
+
+func coalesceNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func runeLen(value string) int {
+	return len([]rune(strings.TrimSpace(value)))
+}

--- a/internal/runtime/tools/usage_test.go
+++ b/internal/runtime/tools/usage_test.go
@@ -77,3 +77,40 @@ func TestValidateUsageHintCoverage_RejectsGeneratedEmitHintMentioningCEL(t *test
 	}
 	t.Fatalf("findings = %#v, want generated emit CEL usage rejection", findings)
 }
+
+func TestValidateUsageHintCoverage_CoversRoleDerivedEmitTools(t *testing.T) {
+	original := emitToolUsageHint
+	emitToolUsageHint = "Use CEL"
+	t.Cleanup(func() { emitToolUsageHint = original })
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-instance-1": {
+				ID:   "agent-instance-1",
+				Role: "reviewer",
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"reviewer": {
+				Produces: []string{"review.completed"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"review.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"entity_id": {Type: "string"},
+					},
+				},
+			},
+		},
+	})
+
+	findings := ValidateUsageHintCoverage(source, nil)
+	for _, finding := range findings {
+		if finding.ToolName == "emit_review_completed" && finding.Severity == "error" && strings.Contains(finding.Message, "must not instruct") {
+			return
+		}
+	}
+	t.Fatalf("findings = %#v, want role-derived generated emit usage rejection", findings)
+}

--- a/internal/runtime/tools/usage_test.go
+++ b/internal/runtime/tools/usage_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimemcp "swarm/internal/runtime/mcp"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestValidateUsageHintCoverage_RejectsMissingPlatformOwnedHint(t *testing.T) {
+	original := builtinToolUsageHints["query_entities"]
+	builtinToolUsageHints["query_entities"] = ""
+	t.Cleanup(func() { builtinToolUsageHints["query_entities"] = original })
+
+	findings := ValidateUsageHintCoverage(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), nil)
+	for _, finding := range findings {
+		if finding.ToolName == "query_entities" && finding.Severity == "error" && strings.Contains(finding.Message, "missing a usage hint") {
+			return
+		}
+	}
+	t.Fatalf("findings = %#v, want hard missing usage finding for query_entities", findings)
+}
+
+func TestValidateUsageHintCoverage_ExternalMCPMissingHintIsLintOnly(t *testing.T) {
+	findings := ValidateUsageHintCoverage(
+		semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		map[string]runtimemcp.DiscoveredTool{
+			"infra.ping": {
+				ServerName:  "infra",
+				RemoteName:  "ping",
+				Description: "Ping infra",
+				InputSchema: map[string]any{"type": "object"},
+			},
+		},
+	)
+	for _, finding := range findings {
+		if finding.ToolName == "infra.ping" {
+			if finding.Severity != "lint" {
+				t.Fatalf("external MCP severity = %q, want lint", finding.Severity)
+			}
+			return
+		}
+	}
+	t.Fatalf("findings = %#v, want external MCP lint finding", findings)
+}
+
+func TestValidateUsageHintCoverage_RejectsGeneratedEmitHintMentioningCEL(t *testing.T) {
+	original := emitToolUsageHint
+	emitToolUsageHint = "Use CEL"
+	t.Cleanup(func() { emitToolUsageHint = original })
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent": {
+				ID:         "agent",
+				EmitEvents: []string{"item.done"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"item.done": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"entity_id": {Type: "string"},
+					},
+				},
+			},
+		},
+	})
+
+	findings := ValidateUsageHintCoverage(source, nil)
+	for _, finding := range findings {
+		if finding.ToolName == "emit_item_done" && finding.Severity == "error" && strings.Contains(finding.Message, "must not instruct") {
+			return
+		}
+	}
+	t.Fatalf("findings = %#v, want generated emit CEL usage rejection", findings)
+}


### PR DESCRIPTION
## Summary

Adds a canonical runtime owner for platform-owned delivered tool usage hints and delivers those hints through existing provider-facing tool descriptions without adding a protocol extension.

Closes #540.
Related to yazzaoui/empire#14, yazzaoui/empire#25, yazzaoui/empire#26, and #544.

## Governing Context

Binding context is issue #540 body/thread and approved gate decision. Adjacent governing spec/context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` tool model, platform builtin tools, agent tool filtering, native tools, and entity tool schemas. The review draft `platform-spec.tool-usage-hints.yaml` constrained delivery to standard MCP/tool descriptions, hard coverage for platform-owned tools, advisory treatment for external/discovered MCP tools, and concrete payload guidance for generated emit tools.

## Semantic Migration

New canonical owner: `internal/runtime/tools/usage.go`, `RegisteredTool.Usage`, `llm.ToolDefinition.Usage`, and `llm.DeliveredToolDescription`.

Old non-authoritative guidance paths now invalid for this class: prompt prose alone, event descriptions alone, JSON schema enum constraints alone, and generated emit descriptions without shared usage. Empire prompt cleanup remains split to yazzaoui/empire#25.

Production paths checked: platform builtin registration, actor-scoped tool definitions, generated emit tools, native fallback tools, MCP `tools/list`, Anthropic API request construction, and bootverify. Migration is complete for Swarm-delivered platform usage hints; downstream prompt cleanup and startup/probe safety remain split.

## Proof

- `go test ./internal/runtime/llm ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/bootverify`
- `go test ./...`
- `go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec /Users/youmew/dev/swarm/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Supported path run `cb94a8de-8128-44f1-b96b-4244f9e1b802` reached validation and remained running at last snapshot with 304 events, 12 agent turns, `validation.started=1`, and 3 MCP exec errors total. Those 3 were early `save_entity_field` ownership writes emitted before the final generic `save_entity_field` hint was tightened; no new MCP exec-error class appeared after that snapshot. Runtime outbox replay warning was split to #547.