### PR TITLE
[agent-b][issue #547] Terminal markerless replay scope rows

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -101,6 +101,10 @@ active_issues:
     title: Reconcile stale active agent sessions against the delivery frontier on the supported path
     maps_to:
       - runtime_lifecycle_observability
+  - id: 547
+    title: Outbox sweeper repeatedly fails committed replay scope lookup on supported run
+    maps_to:
+      - delivery_and_replay_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -141,10 +145,12 @@ nodes:
       - direct-recipient delivery as a shadow semantic path
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
+      - markerless replay-eligible events can repeatedly fail committed replay-scope lookup on the supported outbox sweeper path
     representative_issues:
       - 112
       - 144
       - 145
+      - 547
     common_framing_mistakes:
       too_broad:
         - delivery is flaky

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -271,23 +271,25 @@ func (eb *EventBus) emitContradiction(ctx context.Context, source events.Event, 
 	return nil
 }
 
-func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, errText string) {
+func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
 	if eb == nil || eb.store == nil {
-		return
+		return nil
 	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
-		return
+		return nil
 	}
 	recorder, ok := eb.store.(PipelineReceiptPersistence)
 	if !ok {
-		return
+		return errors.New("event bus store does not support pipeline receipt persistence")
 	}
 	if err := recorder.UpsertPipelineReceipt(ctx, eventID, status, errText); err != nil {
 		eb.logRuntime(ctx, "error", "Persisting the pipeline receipt failed", "eventbus", "pipeline_receipt_persist_failed", eventID, "", "", "", "", nil, map[string]any{
 			"status": status,
 		}, err.Error(), 0)
+		return err
 	}
+	return nil
 }
 
 func (eb *EventBus) logAuthoritativeDeliveryIncomplete(ctx context.Context, evt events.Event, expected, delivered, missing, timedOut []string, cause error) error {

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"swarm/internal/events"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
@@ -114,8 +115,19 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			return redelivered, err
 		}
 		if err := eb.PublishPersistedRecipients(ctx, evt, recipients); err != nil {
+			if errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
+				if recordErr := eb.markCommittedReplayScopeUnavailable(ctx, evt, err); recordErr != nil {
+					_ = lease.Release(ctx)
+					return redelivered, recordErr
+				}
+				_ = lease.Release(ctx)
+				continue
+			}
 			if !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
-				eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error())
+				if recordErr := eb.markPipelineReceipt(ctx, evt.ID, "error", err.Error()); recordErr != nil {
+					_ = lease.Release(ctx)
+					return redelivered, recordErr
+				}
 			}
 			_ = lease.Release(ctx)
 			return redelivered, err
@@ -125,6 +137,21 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 		redelivered++
 	}
 	return redelivered, nil
+}
+
+func (eb *EventBus) markCommittedReplayScopeUnavailable(ctx context.Context, evt events.Event, cause error) error {
+	errText := strings.TrimSpace(cause.Error())
+	if errText == "" {
+		errText = runtimereplayclaim.ErrMissingCommittedReplayScope.Error()
+	}
+	if err := eb.markPipelineReceipt(ctx, evt.ID, "error", errText); err != nil {
+		return err
+	}
+	eb.logRuntime(ctx, "warn", "Persisted event replay skipped because committed replay scope is unavailable", "eventbus", "outbox_replay_scope_unavailable", evt.ID, string(evt.Type), "", evt.EntityID(), "", nil, map[string]any{
+		"reason":          "missing_committed_replay_scope",
+		"parent_event_id": strings.TrimSpace(evt.ParentEventID),
+	}, errText, 0)
+	return nil
 }
 
 func (eb *EventBus) authoritativeRecipientsForEvent(ctx context.Context, eventID string) ([]string, error) {

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -389,6 +389,75 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 	}
 }
 
+func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinues(t *testing.T) {
+	store := &sweeperTestStore{
+		events: []events.PersistedReplayEvent{
+			{Event: events.Event{
+				ID:        "evt-markerless",
+				Type:      events.EventType("custom.markerless"),
+				CreatedAt: time.Now().UTC(),
+			}},
+			{Event: events.Event{
+				ID:        "evt-good-after-markerless",
+				Type:      events.EventType("custom.good"),
+				CreatedAt: time.Now().UTC(),
+			}},
+		},
+		deliveries: map[string][]string{
+			"evt-markerless":            {"agent-missing"},
+			"evt-good-after-markerless": {"agent-good"},
+		},
+		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
+			"evt-good-after-markerless": runtimereplayclaim.CommittedReplayScopeSubscribed,
+		},
+	}
+	logger := &recordingLoggerHook{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	goodCh := eb.Subscribe("agent-good")
+	missingCh := eb.Subscribe("agent-missing")
+
+	count, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("swept count = %d, want 1", count)
+	}
+	if got := store.receipts["evt-markerless"]; got != "error" {
+		t.Fatalf("markerless receipt status = %q, want error", got)
+	}
+	if got := store.receiptErrs["evt-markerless"]; got != runtimereplayclaim.ErrMissingCommittedReplayScope.Error() {
+		t.Fatalf("markerless receipt error = %q, want missing committed replay scope", got)
+	}
+	if got := store.receipts["evt-good-after-markerless"]; got != "processed" {
+		t.Fatalf("good receipt status = %q, want processed", got)
+	}
+	foundTerminalLog := false
+	for _, entry := range logger.entries {
+		if entry.Action == "outbox_replay_scope_unavailable" {
+			foundTerminalLog = true
+		}
+		if entry.Action == "outbox_sweep_failed" {
+			t.Fatal("SweepUndispatched should not emit the global sweep-failed warning for terminal markerless rows")
+		}
+	}
+	if !foundTerminalLog {
+		t.Fatal("expected explicit terminal committed replay-scope warning")
+	}
+	waitForNoEvent(t, missingCh)
+	select {
+	case evt := <-goodCh:
+		if evt.ID != "evt-good-after-markerless" {
+			t.Fatalf("delivered event id = %q, want evt-good-after-markerless", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected good event after markerless row to be replayed")
+	}
+}
+
 func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -81,7 +81,7 @@ fi
 count=$((count + 1))
 printf '%s' "$count" > "$state_file"
 cat > "$capture_dir/$count.stdin"
-if grep -q '"name":"read_file"' "$capture_dir/$count.stdin" && grep -q '"ok":true' "$capture_dir/$count.stdin"; then
+if [ "$count" -gt 1 ] && grep -q '"name":"read_file"' "$capture_dir/$count.stdin" && grep -q '"ok":true' "$capture_dir/$count.stdin"; then
   printf '%s\n' '{"type":"result","result":"done"}'
   exit 0
 fi


### PR DESCRIPTION
## Summary

Closes #547.

This PR keeps the outbox sweeper inside the approved committed-replay-scope first-slice boundary. Markerless replay-eligible events are now treated as explicit terminal replay errors: the sweeper records a pipeline receipt error, emits a per-event `outbox_replay_scope_unavailable` warning, releases the replay claim, and continues with later replayable events instead of returning a global `outbox_sweep_failed` error every interval.

## Governing Context

No exact standalone platform spec section defines markerless committed replay-scope degradation. Binding context is issue #547, the approved gate comment on #547, and adjacent runtime replay/fork contracts in `internal/runtime/bus/committed_replay_scope.go`, `internal/runtime/replayclaim/contracts.go`, `internal/store/events.go`, recovery replay, and run-fork pending classification.

Canonical owner: committed replay scope remains owned by the Postgres replay-scope marker row plus `runtimereplayclaim.ScopeReader`, with runtime bus consuming that truth before direct-vs-subscribed replay.

Old invalid path: markerless replay rows previously caused sweep-wide `outbox_sweep_failed` returns after one row per interval. They are now explicit terminal event-level replay errors; they are not delivered and do not block later valid replay work.

Migration complete for this child: yes, for markerless committed replay-scope rows on the outbox sweeper path. Broader delivery/replay ownership remains tracked in `docs/watchlists/runtime-operations.yaml`.

## Validation

- `go test ./internal/runtime/bus -run 'TestSweepUndispatched|TestEventBusPublish.*ReplayScope' -count=1`
- `go test ./internal/runtime/pipeline -run 'Replay|CommittedReplayScope' -count=1`
- `go test ./internal/store -run 'ReplayScope|RunForkPlanner|MissingPipelineReceipt' -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store -count=1`
- `go test ./... -count=1`

I did not run live `make run-clear` because it clears the local DB and stops local containers; the focused sweeper proof covers the repeated-warning execution path without destructive local runtime reset.