### PR TITLE
[agent-d][issue #544] Make startup tool probes probe-safe

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -105,6 +105,10 @@ active_issues:
     title: Outbox sweeper repeatedly fails committed replay scope lookup on supported run
     maps_to:
       - delivery_and_replay_ownership
+  - id: 544
+    title: Startup MCP validation can flake on partial provider-visible tool surface and unsafe query_entities probe
+    maps_to:
+      - transport_policy_and_surface_parity
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -121,6 +125,7 @@ nodes:
       - supported no-read_file turns can emit runtime_read_file follow-up artifacts for oversized tool results even though the same turn surface cannot call read_file
       - oversized file-backed tool results on supported Claude helper turns can leak provider scratch paths back into later runtime read_file calls
       - CLI native tools can still use mixed provider-plus-platform fallback semantics, so visible turn surface does not equal callable provider-native truth for bash, web_search, and file_io
+      - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
     representative_issues:
       - 111
       - 136
@@ -129,6 +134,7 @@ nodes:
       - 406
       - 381
       - 444
+      - 544
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent

--- a/internal/runtime/core/toolcapabilities/toolcapabilities.go
+++ b/internal/runtime/core/toolcapabilities/toolcapabilities.go
@@ -20,12 +20,20 @@ const (
 	ContextRequirementTurnContext  ContextRequirement = "turn_context"
 )
 
+type StartupProbeMode string
+
+const (
+	StartupProbeModeVisibilityOnly  StartupProbeMode = "visibility_only"
+	StartupProbeModeCallEmptyObject StartupProbeMode = "call_empty_object"
+)
+
 type Capability struct {
 	Name               string             `json:"name"`
 	Kind               ToolKind           `json:"kind,omitempty"`
 	Visible            bool               `json:"visible"`
 	Callable           bool               `json:"callable"`
 	ContextRequirement ContextRequirement `json:"context_requirement,omitempty"`
+	StartupProbeMode   StartupProbeMode   `json:"startup_probe_mode,omitempty"`
 	DenialReason       string             `json:"denial_reason,omitempty"`
 	AuthorizationClass string             `json:"authorization_class,omitempty"`
 }

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -482,6 +482,60 @@ func filterCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolD
 	return filtered
 }
 
+func providerNativeCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	if len(surface.ProviderBuiltinTools) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(surface.ProviderBuiltinTools))
+	seen := make(map[string]struct{}, len(surface.ProviderBuiltinTools))
+	for _, name := range surface.ProviderBuiltinTools {
+		canonical := toolidentity.CanonicalName(name)
+		if canonical == "" {
+			continue
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func filterProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition, observed []string) []string {
+	if len(observed) == 0 {
+		return nil
+	}
+	expected := providerNativeCanonicalVisibleToolsForActor(actor, tools)
+	if len(expected) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		allowed[name] = struct{}{}
+	}
+	filtered := make([]string, 0, len(observed))
+	seen := make(map[string]struct{}, len(observed))
+	for _, name := range observed {
+		canonical := toolidentity.CanonicalName(name)
+		if canonical == "" || isCLIControlToolName(canonical) {
+			continue
+		}
+		if _, ok := allowed[canonical]; !ok {
+			continue
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		filtered = append(filtered, canonical)
+	}
+	slices.Sort(filtered)
+	return filtered
+}
+
 func claudeAllowedToolNamesForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
 	surface := cliExecutionToolSurfaceForActor(actor, tools)
 	allowed := make([]string, 0, len(surface.ProviderMCPTools)+len(surface.LocalFallbackTools)+len(surface.ProviderBuiltinTools)+len(claudeControlToolNames()))

--- a/internal/runtime/llm/cli_runtime_helpers.go
+++ b/internal/runtime/llm/cli_runtime_helpers.go
@@ -508,13 +508,13 @@ func filterProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools []
 	if len(observed) == 0 {
 		return nil
 	}
-	expected := providerNativeCanonicalVisibleToolsForActor(actor, tools)
-	if len(expected) == 0 {
-		return nil
-	}
-	allowed := make(map[string]struct{}, len(expected))
-	for _, name := range expected {
-		allowed[name] = struct{}{}
+	providerNative := make(map[string]struct{}, len(claudeProviderBuiltinToolNames))
+	for _, name := range claudeProviderBuiltinToolNames {
+		canonical := toolidentity.CanonicalName(name)
+		if canonical == "" {
+			continue
+		}
+		providerNative[canonical] = struct{}{}
 	}
 	filtered := make([]string, 0, len(observed))
 	seen := make(map[string]struct{}, len(observed))
@@ -523,7 +523,7 @@ func filterProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools []
 		if canonical == "" || isCLIControlToolName(canonical) {
 			continue
 		}
-		if _, ok := allowed[canonical]; !ok {
+		if _, ok := providerNative[canonical]; !ok {
 			continue
 		}
 		if _, ok := seen[canonical]; ok {

--- a/internal/runtime/llm/cli_runtime_startup_probe.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe.go
@@ -99,6 +99,17 @@ func PlannedCanonicalVisibleToolsForActor(actor models.AgentConfig, tools []Tool
 	return plannedCanonicalVisibleToolsForActor(actor, tools)
 }
 
+func ObservedProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition, resp *Response) []string {
+	if resp == nil {
+		return nil
+	}
+	return filterProviderNativeVisibleToolsForActor(actor, tools, resp.VisibleTools)
+}
+
+func PlannedProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools []ToolDefinition) []string {
+	return providerNativeCanonicalVisibleToolsForActor(actor, tools)
+}
+
 func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []string, target *workspace.Target, input string) (*Response, error) {
 	timeout := r.effectiveCLITimeout(ctx)
 	if target == nil || !target.Enabled() {

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -106,8 +106,8 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 			if err != nil {
 				return fmt.Errorf("provider-native startup probe failed for agent %s: %w", agentID, err)
 			}
-			expectedVisible := llm.PlannedCanonicalVisibleToolsForActor(agentCfg, sessionTools)
-			actualVisible := llm.ObservedCanonicalVisibleToolsForActor(agentCfg, sessionTools, probeResp)
+			expectedVisible := llm.PlannedProviderNativeVisibleToolsForActor(agentCfg, sessionTools)
+			actualVisible := llm.ObservedProviderNativeVisibleToolsForActor(agentCfg, sessionTools, probeResp)
 			if !equalSortedStrings(actualVisible, expectedVisible) {
 				return fmt.Errorf("provider-native startup probe returned unexpected visible tool surface for agent %s: expected [%s], got [%s]", agentID, strings.Join(expectedVisible, ", "), strings.Join(actualVisible, ", "))
 			}
@@ -145,9 +145,12 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 		if !equalSortedStrings(actualNames, expectedNames) {
 			return fmt.Errorf("mcp tools/list returned unexpected tool surface for agent %s: expected [%s], got [%s]", agentID, strings.Join(expectedNames, ", "), strings.Join(actualNames, ", "))
 		}
-		probeName, ok := selectStartupCallableTool(actualTools, capabilities)
+		probeName, ok, err := selectStartupCallableTool(actualTools, capabilities)
+		if err != nil {
+			return fmt.Errorf("mcp startup probe select callable tool for agent %s: %w", agentID, err)
+		}
 		if !ok {
-			return fmt.Errorf("mcp startup probe found no probe-safe callable non-emit tool for agent %s", agentID)
+			continue
 		}
 		binding, enabled, err = llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
 			AgentID: agentID,
@@ -244,7 +247,7 @@ func equalSortedStrings(left []string, right []string) bool {
 	return true
 }
 
-func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapabilities.Set) (string, bool) {
+func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapabilities.Set) (string, bool, error) {
 	for _, tool := range tools {
 		name := strings.TrimSpace(tool.Name)
 		if name == "" {
@@ -254,12 +257,15 @@ func selectStartupCallableTool(tools []runtimemcp.ToolDef, capabilities toolcapa
 		if !ok || !capability.Callable || capability.Kind == toolcapabilities.KindEmit {
 			continue
 		}
-		if !schemaAllowsEmptyObjectArguments(tool.InputSchema) {
+		if capability.StartupProbeMode != toolcapabilities.StartupProbeModeCallEmptyObject {
 			continue
 		}
-		return name, true
+		if !schemaAllowsEmptyObjectArguments(tool.InputSchema) {
+			return "", false, fmt.Errorf("tool %s is marked startup-probe call_empty_object but its schema requires arguments", name)
+		}
+		return name, true, nil
 	}
-	return "", false
+	return "", false, nil
 }
 
 func schemaAllowsEmptyObjectArguments(schema any) bool {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -417,6 +417,49 @@ func TestValidateClaudeMCPToolsForManagedAgents_ComparesProviderNativeSurfaceOnl
 	}
 }
 
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedProviderNativeTool(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:   "trend-research-agent",
+		Role: "trend_research",
+		NativeTools: runtimeactors.NativeToolConfig{
+			WebSearch: true,
+		},
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{
+			{Name: "query_entities", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+			{Name: "emit_trend_identified", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+		},
+		caps: map[string]toolcapabilities.Capability{
+			"query_entities":        {Name: "query_entities", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementActorContext},
+			"emit_trend_identified": {Name: "emit_trend_identified", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{
+		resp: &llm.Response{
+			VisibleTools: []string{"WebSearch", "Bash"},
+		},
+	}
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "unexpected visible tool surface") {
+		t.Fatalf("expected provider-native visible-surface mismatch, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"trend-research-agent"}) {
+		t.Fatalf("probe calls = %#v, want startup visible-surface probe", probe.calls)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no MCP startup probe after provider-native mismatch", exec.executed)
+	}
+}
+
 func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenNativeBuiltinVisibleSurfaceMismatches(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -206,6 +206,7 @@ func startupProbeCaps() map[string]toolcapabilities.Capability {
 			Visible:            true,
 			Callable:           true,
 			ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+			StartupProbeMode:   toolcapabilities.StartupProbeModeCallEmptyObject,
 		},
 	}
 }
@@ -374,6 +375,48 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesLiveVisibleSurfaceForNativeB
 	}
 }
 
+func TestValidateClaudeMCPToolsForManagedAgents_ComparesProviderNativeSurfaceOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:   "trend-research-agent",
+		Role: "trend_research",
+		NativeTools: runtimeactors.NativeToolConfig{
+			WebSearch: true,
+		},
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{
+			{Name: "query_entities", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+			{Name: "emit_trend_identified", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+		},
+		caps: map[string]toolcapabilities.Capability{
+			"query_entities":        {Name: "query_entities", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementActorContext},
+			"emit_trend_identified": {Name: "emit_trend_identified", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{
+		resp: &llm.Response{
+			VisibleTools: []string{"WebSearch"},
+		},
+	}
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"trend-research-agent"}) {
+		t.Fatalf("probe calls = %#v, want startup visible-surface probe", probe.calls)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want MCP visibility-only proof when no explicit safe startup call exists", exec.executed)
+	}
+}
+
 func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenNativeBuiltinVisibleSurfaceMismatches(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
@@ -413,7 +456,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenNativeBuiltinVisi
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsRequireInput(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenNoExplicitSafeStartupCallExists(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	for _, tc := range []struct {
@@ -447,18 +490,51 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsRequi
 			}
 			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-			err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
-			if err == nil || !strings.Contains(err.Error(), "found no probe-safe callable non-emit tool") {
-				t.Fatalf("expected no probe-safe callable tool error, got %v", err)
+			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 			}
 			if len(exec.executed) != 0 {
-				t.Fatalf("executed = %#v, want no tools/call smoke for required-input-only surface", exec.executed)
+				t.Fatalf("executed = %#v, want visibility-only startup proof for required-input-only surface", exec.executed)
 			}
 		})
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsAreEmitOnly(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_DoesNotCallSchemaOnlyEmptyObjectTool(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "lifecycle-coordinator", Role: "lifecycle_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{{
+			Name:   "query_entities",
+			Schema: map[string]any{"type": "object", "properties": map[string]any{}},
+		}},
+		caps: map[string]toolcapabilities.Capability{
+			"query_entities": {
+				Name:               "query_entities",
+				Visible:            true,
+				Callable:           true,
+				ContextRequirement: toolcapabilities.ContextRequirementActorContext,
+			},
+		},
+		execErrs: map[string]error{
+			"query_entities": errors.New("flow-owned entity contract is not available for actor lifecycle-coordinator"),
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want query_entities visibility-only despite empty-object schema", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenVisibleToolsAreEmitOnly(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 	manager := runtimemanager.NewAgentManager(nil, nil)
@@ -482,12 +558,43 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenVisibleToolsAreEm
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
-	if err == nil || !strings.Contains(err.Error(), "found no probe-safe callable non-emit tool") {
-		t.Fatalf("expected no probe-safe callable tool error, got %v", err)
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if len(exec.executed) != 0 {
-		t.Fatalf("executed = %#v, want no tools/call smoke for emit-only surface", exec.executed)
+		t.Fatalf("executed = %#v, want visibility-only startup proof for emit-only surface", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenExplicitProbeSafeToolRequiresInput(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "campaign-coordinator", Role: "campaign_coordinator"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{{
+			Name:   "health_check",
+			Schema: map[string]any{"type": "object", "properties": map[string]any{"probe": map[string]any{"type": "string"}}, "required": []any{"probe"}},
+		}},
+		caps: map[string]toolcapabilities.Capability{
+			"health_check": {
+				Name:             "health_check",
+				Visible:          true,
+				Callable:         true,
+				StartupProbeMode: toolcapabilities.StartupProbeModeCallEmptyObject,
+			},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "call_empty_object") {
+		t.Fatalf("expected explicit probe-safe schema mismatch error, got %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no tools/call smoke for invalid explicit startup probe policy", exec.executed)
 	}
 }
 

--- a/internal/runtime/tools/tool_capability_context.go
+++ b/internal/runtime/tools/tool_capability_context.go
@@ -17,6 +17,7 @@ func capabilityForTool(actor models.AgentConfig, toolName string, requestAllowed
 		Visible:            decision.allowed,
 		Callable:           decision.allowed,
 		ContextRequirement: toolContextRequirementPolicy(name),
+		StartupProbeMode:   toolStartupProbeModePolicy(name),
 		AuthorizationClass: string(decision.class),
 	}
 	if len(requestAllowed) > 0 {

--- a/internal/runtime/tools/tool_capability_policy.go
+++ b/internal/runtime/tools/tool_capability_policy.go
@@ -77,6 +77,10 @@ func toolContextRequirementPolicy(toolName string) toolcapabilities.ContextRequi
 	}
 }
 
+func toolStartupProbeModePolicy(toolName string) toolcapabilities.StartupProbeMode {
+	return toolcapabilities.StartupProbeModeVisibilityOnly
+}
+
 func extractAllowedTools(actor models.AgentConfig) (map[string]struct{}, bool) {
 	allowed := make(map[string]struct{})
 	if len(actor.Tools) == 0 {


### PR DESCRIPTION
## Summary

Closes #544.

This PR fixes managed-agent startup validation/probe correctness for the approved #544 first-slice boundary:

- Compares provider-native startup init output against provider-native planned tools only.
- Keeps runtime MCP visibility proof on MCP `tools/list`.
- Adds explicit startup probe policy ownership to tool capabilities via `StartupProbeMode`.
- Stops treating empty-object JSON Schema acceptance as semantic startup-call safety.
- Uses visibility-only startup proof when no explicit safe zero-argument startup call exists.

## Governing refs / context

Exact governing context:

- #544 issue body and approved pre-audit gate.
- `docs/IMPLEMENTER_GUIDELINES.md`.
- `docs/SEMANTIC_DRIFT.md`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `boot_sequence`: fail closed startup validation, no partial startup.
  - `engine.agent_session_management.native_tools`: provider-native CLI tools are a separate channel and provider-visible truth must match callable truth.
  - `engine.agent_session_management.emit_tool_convention`: platform-generated emit tools are runtime tools, not provider-native tools.
  - `tool_model`: platform owns MCP `tools/list` / `tools/call` schemas, call validation, and runtime tool routing.
  - `tool_model.agent_tool_filtering`: visible/callable tool filtering is runtime-owned and fail-closed.

## Semantic migration

New canonical owner:

- `toolcapabilities.Capability.StartupProbeMode` owns whether a visible callable tool may be executed as a startup zero-argument probe or should only be visibility-proven.

Old invalid path:

- `selectStartupCallableTool` no longer treats `schemaAllowsEmptyObjectArguments(...)` by itself as proof that a tool is semantically safe to execute at startup.
- Provider-native startup validation no longer compares provider init observed tools against full canonical runtime-visible MCP/local fallback tools.

Production paths checked for surviving old behavior:

- `validateClaudeMCPToolsForManagedAgents` provider-native probe path.
- MCP `tools/list` startup proof path.
- MCP `tools/call` startup probe path.
- Runtime tool capability construction in `internal/runtime/tools`.
- CLI startup surface helpers in `internal/runtime/llm`.

Migration completeness:

- Complete for the #544 startup validation/probe child class.
- Broader transport-surface parity parent remains tracked in `docs/watchlists/runtime-operations.yaml` / `transport_policy_and_surface_parity`.

## Proof

Focused tests:

```bash
go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents' -count=1
go test ./internal/runtime ./internal/runtime/llm ./internal/runtime/mcp ./internal/runtime/tools ./internal/runtime/core/toolcapabilities -count=1
go test ./...
```

Supported startup proof:

```bash
set -a; source /Users/youmew/dev/swarm/.env; set +a; make run-clear
```

Run id: `c89768ce-a237-4330-9b96-00963a738173`.

Observed startup proof:

- Runtime started successfully.
- No `/tmp/swarm-empire.log` matches for `provider-native startup probe returned`, `unexpected visible tool surface`, `mcp.tools.call.exec_error`, or `flow-owned entity contract`.
- `agent_turns where run_id is null`: `0` rows.
- Null-run query tool turns: `0`.
- Null-run flow-owned entity contract errors: `0`.

Downstream note:

- The supported run later emitted a run-scoped `get_entity` failure after startup. That is not a #544 startup probe artifact and is not absorbed here.