### PR TITLE
[agent-a][issue #550] Promote run-scoped entity_state identity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2731,19 +2731,20 @@ platform_tables:
         \ entity_id IS NOT NULL,\n    INDEX idx_receipts_subscriber (subscriber_id, processed_at),\n    INDEX idx_receipts_idempotency\
         \ (idempotency_key) WHERE idempotency_key IS NOT NULL\n);"
     entity_state:
-      description: Current state of every entity. This IS the entity registry — no separate registry table. slug and name
-        are top-level columns for fast lookup/display without JSONB queries. entity_type records the inferred flow-scoped
-        entity contract for the row; callers do not author or choose multiple entity kinds inside one flow in Wave 1.
-        fields JSONB holds all contract-driven entity fields. Generic store reads use entity_state for listing, filtering,
-        and lookup.
-      ddl: "CREATE TABLE entity_state (\n    entity_id         UUID PRIMARY KEY,\n    flow_instance     TEXT NOT NULL,\n    entity_type       TEXT NOT NULL DEFAULT 'default',\n    slug              TEXT,\n\
+      description: Current run-scoped state of every entity. This IS the run-scoped entity registry — no separate registry
+        table. Current-state identity is (run_id, entity_id), allowing source and fork runs to preserve the same entity_id
+        while diverging independently. slug and name are top-level columns for fast lookup/display without JSONB queries.
+        entity_type records the inferred flow-scoped entity contract for the row; callers do not author or choose multiple
+        entity kinds inside one flow in Wave 1. fields JSONB holds all contract-driven entity fields. Generic store reads
+        use entity_state for run-scoped listing, filtering, and lookup.
+      ddl: "CREATE TABLE entity_state (\n    run_id            UUID NOT NULL REFERENCES runs(run_id),\n    entity_id         UUID NOT NULL,\n    flow_instance     TEXT NOT NULL,\n    entity_type       TEXT NOT NULL DEFAULT 'default',\n    slug              TEXT,\n\
         \    name              TEXT,\n    current_state     TEXT NOT NULL,\n    gates             JSONB NOT NULL DEFAULT '{}',\n\
         \    fields            JSONB NOT NULL DEFAULT '{}',\n    accumulator       JSONB NOT NULL DEFAULT '{}',\n    revision\
         \          INTEGER NOT NULL DEFAULT 0,\n    entered_state_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    created_at\
-        \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX\
-        \ idx_entity_flow (flow_instance, current_state),\n\
-        \    INDEX idx_entity_state (current_state),\n    INDEX idx_entity_type (entity_type),\n    INDEX idx_entity_slug\
-        \ (slug) WHERE slug IS NOT NULL\n);"
+        \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    PRIMARY\
+        \ KEY (run_id, entity_id),\n    INDEX idx_entity_flow (run_id, flow_instance, current_state),\n\
+        \    INDEX idx_entity_state (run_id, current_state),\n    INDEX idx_entity_type (run_id, entity_type),\n    INDEX\
+        \ idx_entity_slug (run_id, slug) WHERE slug IS NOT NULL,\n    INDEX idx_entity_cross_run (entity_id)\n);"
     agents:
       description: 'Runtime agent registry. One row per agent instance. Carries the full persisted runtime descriptor:
         role/model_tier/llm_backend/conversation_mode/parent_agent_id as typed columns, subscriptions/emit_events/tools/permissions
@@ -3035,22 +3036,23 @@ platform_tables:
         duration: event_receipts.duration_ms
       note: Every handler execution already produces an event_receipt. The receipt captures state_before, state_after, outcome,
         duration, and side_effects. This IS the pipeline transition record. No separate table needed.
-  entity_registry_policy: There is no separate entity registry table. entity_state IS the registry. Generic reads (list entities,
-    find by slug, count by state) query entity_state directly. Contract-driven entity tables are optional optimizations —
-    they materialize fields JSONB into typed columns for query performance. Not required for correctness.
+  entity_registry_policy: There is no separate entity registry table. entity_state IS the run-scoped current registry.
+    Generic reads (list entities, find by slug, count by state) query entity_state through an explicit run context.
+    Contract-driven entity tables are optional optimizations — they materialize fields JSONB into typed columns for
+    query performance. Not required for correctness.
   entity_lifecycle_scoping:
-    description: Entities are global and persistent. Entity queries (search_entities, query_entities, get_entity) return
-      entities from ALL runs, not scoped to the current run. This is intentional — a vertical discovered in one run
-      and killed in another is still visible to future queries. Products use this for dedup, historical analysis, and
-      trend detection.
-    rationale: In a continuous system where discovery runs periodically, entities accumulate over time. A killed vertical
-      should remain visible so the system does not rediscover the same opportunity. An operating vertical should be visible
-      so new discoveries can be checked against active investments. Global visibility enables agents to make informed decisions
-      about duplicate detection, market evolution, and portfolio context.
-    dedup_responsibility: Duplicate detection across runs is a product concern, not a platform concern. The platform
-      provides global entity queries. Products implement dedup logic in their agents and guards — checking entity names,
-      geographies, opportunity patterns, and current states to decide whether a newly discovered entity is genuinely new
-      or a rediscovery of an existing one.
+    description: Entity identity can be compared across runs, but current entity state is run-scoped. Entity queries
+      (search_entities, query_entities, get_entity) return entity_state rows from the current run context only. Cross-run
+      duplicate detection or historical analysis must use an explicit cross-run read model rather than the live current-state
+      registry.
+    rationale: Mutating timestamp forks require source and fork runs to preserve entity_id while diverging safely. Global
+      live current state would let forked execution overwrite or read source-run state by accident. Products that need
+      historical or portfolio-wide duplicate detection must consume explicit cross-run history/read surfaces.
+    dedup_responsibility: Duplicate detection across runs is a product concern, not a live current-state registry concern.
+      Products that need cross-run dedup consume explicit cross-run history/read surfaces, not unscoped entity_state
+      queries. Products implement dedup logic in their agents and guards — checking entity names, geographies, opportunity
+      patterns, and scoped current states to decide whether a newly discovered entity is genuinely new or a rediscovery
+      of an existing one.
     entity_state_for_dedup: 'When an agent checks for duplicates, the entity''s current_state provides context for the
       decision: active or in-pipeline entities are strong duplicates (skip). Recently killed entities are likely duplicates
       (skip unless evidence changed). Entities killed long ago may warrant re-evaluation if market conditions shifted.
@@ -3100,8 +3102,8 @@ platform_tables:
       as opaque JSONB. Products own their secrets.
 run_model:
   description: 'A run is the top-level execution context for the platform. Every event, delivery, session, turn,
-    and entity mutation belongs to exactly one run. Runs provide isolation for observability, debugging, and
-    fork/replay. The run_id is the primary correlation key across all platform tables.'
+    entity mutation, and current entity-state row belongs to exactly one run. Runs provide isolation for observability,
+    debugging, and fork/replay. The run_id is the primary correlation key across all platform tables.'
   lineage:
     description: 'Event lineage is tracked via two fields: run_id (which run this event belongs to) and
       source_event_id (which event caused this event to be emitted). Together they replace the former trace_id
@@ -3118,6 +3120,7 @@ run_model:
       - agent_conversation_audits.run_id
       - agent_turns.run_id
       - entity_mutations.run_id
+      - entity_state.run_id
       propagation_rule: 'Child event run_id = parent event run_id. The bus publish path reads run_id from
         the inbound event context and stamps it on every outbound event. No handler or agent code touches
         run_id directly.'
@@ -3202,19 +3205,20 @@ run_model:
       composite ordering. The fork point is inclusive: mutations from the target moment are included in
       reconstructed state. Only mutations strictly after T are undone.'
     isolation: 'Forked runs are fully isolated. They get their own event stream, their own entity state copies,
-      and their own agent sessions. Results can be compared side-by-side with the original run.'
+      and their own agent sessions. Fork state materialization writes entity_state rows under the fork run_id while
+      preserving entity_id from the source run. Results can be compared side-by-side with the original run.'
     original_run: 'The source run transitions to status=forked. It is frozen — no new events are processed.
       Its data is preserved for comparison and audit.'
   mutation_log:
     description: 'The entity_mutations table is the audit trail for all entity state changes. It serves three
       purposes: (1) flight recorder — step-by-step view of what happened, (2) fork — state reconstruction at
       any point in time, (3) drift detection — verify entity_state matches the mutation history.'
-    write_contract: 'Every write to entity_state MUST produce a corresponding entity_mutations row in the same
-      transaction. This includes system node handler writes (data_accumulation, compute, sets_gate, advances_to,
-      clear) and agent tool writes (save_entity_field). The runtime enforces this — there is no code path that
-      mutates entity_state without logging the mutation.'
+    write_contract: 'Every write to entity_state MUST carry an explicit run_id and produce a corresponding
+      entity_mutations row with the same run_id in the same transaction. This includes system node handler writes
+      (data_accumulation, compute, sets_gate, advances_to, clear) and agent tool writes (save_entity_field).
+      The runtime enforces this — there is no code path that mutates entity_state without logging the mutation.'
     drift_detection: 'swarm verify --run <run_id> reconstructs entity state from the mutation log and compares
-      it to current entity_state. Any mismatch indicates a write that bypassed the mutation log. This is a
+      it to current entity_state rows for that same run_id. Any mismatch indicates a write that bypassed the mutation log. This is a
       correctness check, not a normal operation — run it when debugging unexpected state.'
     retention: 'Mutation rows are never auto-deleted. Retention policy is an operational concern. The platform
       may provide a future archive/purge API for mutations older than N days on terminated entities.'

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1535,12 +1535,13 @@ CREATE TABLE event_receipts (
 
 ### entity_state
 
-- `description`: Current state of every entity. This IS the entity registry — no separate registry table. slug and name are top-level columns for fast lookup/display without JSONB queries. entity_type distinguishes entity kinds within a flow (e.g., order, instance, ticket). fields JSONB holds all contract-driven entity fields. Generic store reads use entity_state for listing, filtering, and lookup.
+- `description`: Current run-scoped state of every entity. This IS the run-scoped entity registry — no separate registry table. Current-state identity is (run_id, entity_id), allowing source and fork runs to preserve the same entity_id while diverging independently. slug and name are top-level columns for fast lookup/display without JSONB queries. entity_type records the inferred flow-scoped entity contract for the row; callers do not author or choose multiple entity kinds inside one flow in Wave 1. fields JSONB holds all contract-driven entity fields. Generic store reads use entity_state for run-scoped listing, filtering, and lookup.
 ### ddl
 
 ```sql
 CREATE TABLE entity_state (
-    entity_id         UUID PRIMARY KEY,
+    run_id            UUID NOT NULL REFERENCES runs(run_id),
+    entity_id         UUID NOT NULL,
     flow_instance     TEXT NOT NULL,
     entity_type       TEXT NOT NULL DEFAULT 'default',
     slug              TEXT,
@@ -1553,10 +1554,12 @@ CREATE TABLE entity_state (
     entered_state_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    INDEX idx_entity_flow (flow_instance, current_state),
-    INDEX idx_entity_state (current_state),
-    INDEX idx_entity_type (entity_type),
-    INDEX idx_entity_slug (slug) WHERE slug IS NOT NULL
+    PRIMARY KEY (run_id, entity_id),
+    INDEX idx_entity_flow (run_id, flow_instance, current_state),
+    INDEX idx_entity_state (run_id, current_state),
+    INDEX idx_entity_type (run_id, entity_type),
+    INDEX idx_entity_slug (run_id, slug) WHERE slug IS NOT NULL,
+    INDEX idx_entity_cross_run (entity_id)
 );
 ```
 

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -109,6 +109,14 @@ active_issues:
     title: Startup MCP validation can flake on partial provider-visible tool surface and unsafe query_entities probe
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 549
+    title: Define run-isolated entity-state ownership before mutating timestamp fork execution
+    maps_to:
+      - run_isolated_current_state_ownership
+  - id: 550
+    title: Promote run-scoped entity_state identity model for mutating fork isolation
+    maps_to:
+      - run_isolated_current_state_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -179,6 +187,31 @@ nodes:
         - persistence is nonatomic
       too_narrow:
         - one update statement races
+    current_action_pressure: active
+  - id: run_isolated_current_state_ownership
+    title: Run-Isolated Current State Ownership
+    parent_class: runtime replay, recovery, historical-state reconstruction, and current-state ownership
+    canonical_owners:
+      - run-scoped current-state identity model for entity_state
+      - explicit runtime/store current-state context owner for all entity_state reads, writes, queries, and ownership checks
+      - entity_mutations.run_id as append-only history and reconstruction owner
+    why_this_node_exists: mutating timestamp forks require source and fork runs to diverge safely while preserving entity identity; global entity_state keyed only by entity_id lets forked execution collide with or overwrite source state
+    known_manifestations:
+      - entity_state previously had no run_id and used entity_id as a global primary key
+      - state-only fork dry-run can be execution-ready, but mutating execution cannot materialize isolated current-state rows until live current state is run-scoped
+      - runtime entity tools and workflow projection read and write entity_state by entity_id without run context
+      - inbound routing, route ownership, workspace, digest, budget, and tests consume global current-state semantics
+    representative_issues:
+      - 549
+      - 550
+    common_framing_mistakes:
+      too_broad:
+        - implement all mutating fork execution in one PR
+        - merge delivery, timer, route, session, and current-state migration into one undifferentiated replay rewrite
+      too_narrow:
+        - enable swarm fork by changing only CLI or run_fork_planner
+        - add a local entity_state copy helper while leaving global readers and writers live
+        - add run_id to one query without defining the canonical current-state context owner
     current_action_pressure: active
   - id: boot_wiring_dependency_ownership
     title: Boot Wiring Dependency Ownership

--- a/internal/digest/source.go
+++ b/internal/digest/source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lib/pq"
 	"swarm/internal/runtime"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -55,12 +56,17 @@ func normalizeTerminalStates(states []string) []string {
 }
 
 func (s *Source) CountActiveInstances(ctx context.Context) (int, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return 0, err
+	}
 	var n int
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*)
 		FROM entity_state
-		WHERE NOT (current_state = ANY($1::text[]))
-	`, pq.Array(s.terminalStates)).Scan(&n)
+		WHERE run_id = $1::uuid
+		  AND NOT (current_state = ANY($2::text[]))
+	`, runID, pq.Array(s.terminalStates)).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("count active instances: %w", err)
 	}
@@ -68,6 +74,10 @@ func (s *Source) CountActiveInstances(ctx context.Context) (int, error) {
 }
 
 func (s *Source) ListInstanceDigestRows(ctx context.Context, limit int) ([]runtime.InstanceDigestRow, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 10
 	}
@@ -78,12 +88,13 @@ func (s *Source) ListInstanceDigestRows(ctx context.Context, limit int) ([]runti
 			es.current_state,
 			es.updated_at
 		FROM entity_state es
-		WHERE NOT (es.current_state = ANY($2::text[]))
+		WHERE es.run_id = $2::uuid
+		  AND NOT (es.current_state = ANY($3::text[]))
 		ORDER BY es.updated_at DESC, es.created_at ASC
 		LIMIT $1
 	`
 
-	rows, err := s.db.QueryContext(ctx, q, limit, pq.Array(s.terminalStates))
+	rows, err := s.db.QueryContext(ctx, q, limit, runID, pq.Array(s.terminalStates))
 	if err != nil {
 		return nil, fmt.Errorf("list digest rows: %w", err)
 	}

--- a/internal/digest/source_test.go
+++ b/internal/digest/source_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
 )
@@ -36,20 +37,28 @@ func TestSource_FiltersTerminalStatesFromDigestReads(t *testing.T) {
 
 	activeID := uuid.NewString()
 	doneID := uuid.NewString()
-	if _, err := db.ExecContext(context.Background(), `
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name, current_state,
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		) VALUES
-			($1::uuid, 'review/inst-1', 'default', 'active-co', 'ActiveCo', 'active',
+			($1::uuid, $2::uuid, 'review/inst-1', 'default', 'active-co', 'ActiveCo', 'active',
 			 '{}'::jsonb, '{"name":"ActiveCo"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
-			($2::uuid, 'review/inst-2', 'default', 'done-co', 'DoneCo', 'done',
+			($1::uuid, $3::uuid, 'review/inst-2', 'default', 'done-co', 'DoneCo', 'done',
 			 '{}'::jsonb, '{"name":"DoneCo"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
-	`, activeID, doneID); err != nil {
+	`, runID, activeID, doneID); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
 
-	n, err := source.CountActiveInstances(context.Background())
+	n, err := source.CountActiveInstances(ctx)
 	if err != nil {
 		t.Fatalf("CountActiveInstances: %v", err)
 	}
@@ -57,7 +66,7 @@ func TestSource_FiltersTerminalStatesFromDigestReads(t *testing.T) {
 		t.Fatalf("CountActiveInstances = %d, want 1", n)
 	}
 
-	rows, err := source.ListInstanceDigestRows(context.Background(), 10)
+	rows, err := source.ListInstanceDigestRows(ctx, 10)
 	if err != nil {
 		t.Fatalf("ListInstanceDigestRows: %v", err)
 	}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -100,6 +100,9 @@ func (e Event) ContextMap(currentState string) map[string]any {
 	if parentEventID := strings.TrimSpace(e.ParentEventID); parentEventID != "" {
 		out["source_event_id"] = parentEventID
 	}
+	if runID := strings.TrimSpace(e.RunID); runID != "" {
+		out["run_id"] = runID
+	}
 	if !e.CreatedAt.IsZero() {
 		out["emitted_at"] = e.CreatedAt.UTC().Format(time.RFC3339Nano)
 	}

--- a/internal/runtime/budget.go
+++ b/internal/runtime/budget.go
@@ -14,6 +14,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	models "swarm/internal/runtime/core/actors"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
@@ -160,6 +161,13 @@ func (t *BudgetTracker) EvaluateAll(ctx context.Context) {
 	if t == nil || t.db == nil {
 		return
 	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		if t.logger != nil {
+			handleRuntimeLogPersistenceError("budget", "evaluate_run_context_missing", t.logger.Warn(ctx, "budget", "evaluate_run_context_missing", nil, err))
+		}
+		return
+	}
 	// Evaluate system-wide budget.
 	if err := t.evaluateAndEmit(ctx, ""); err != nil {
 		if t.logger != nil {
@@ -171,9 +179,10 @@ func (t *BudgetTracker) EvaluateAll(ctx context.Context) {
 	rows, err := t.db.QueryContext(ctx, `
 		SELECT entity_id::text
 		FROM entity_state
-		WHERE NOT (current_state = ANY($1::text[]))
+		WHERE run_id = $1::uuid
+		  AND NOT (current_state = ANY($2::text[]))
 		ORDER BY created_at ASC
-	`, pq.Array(t.TerminalInstanceStates()))
+	`, runID, pq.Array(t.TerminalInstanceStates()))
 	if err != nil {
 		return
 	}
@@ -326,12 +335,17 @@ func (t *BudgetTracker) resolveSpendFlowInstance(ctx context.Context, entityID s
 	if entityID == "" {
 		return "global", nil
 	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return "", err
+	}
 	var flowInstance string
 	if err := t.db.QueryRowContext(ctx, `
 		SELECT COALESCE(flow_instance, '')
 		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, entityID).Scan(&flowInstance); err != nil {
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, identity.RunID, identity.EntityID).Scan(&flowInstance); err != nil {
 		return "", fmt.Errorf("resolve spend flow_instance for entity %s: %w", entityID, err)
 	}
 	flowInstance = strings.TrimSpace(flowInstance)

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -29,6 +29,21 @@ import (
 	"swarm/internal/testutil"
 )
 
+const eventBusTestRunID = "99999999-9999-9999-9999-999999999999"
+
+func eventBusTestRunContext(t *testing.T, db *sql.DB) context.Context {
+	t.Helper()
+	ctx := runtimecorrelation.WithRunID(context.Background(), eventBusTestRunID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, eventBusTestRunID); err != nil {
+		t.Fatalf("seed event bus test run: %v", err)
+	}
+	return ctx
+}
+
 type fixtureWorkflowModule struct {
 	source         semanticview.Source
 	workflow       *runtimepipeline.WorkflowDefinition
@@ -1342,6 +1357,7 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 	childEntityID := runtimepipeline.FlowInstanceEntityID("child/inst-1")
 	grandchildEntityID := runtimepipeline.FlowInstanceEntityID("child/grandchild/inst-1")
 	store := runtimepipeline.NewWorkflowInstanceStore(db)
+	ctx := eventBusTestRunContext(t, db)
 	for _, instance := range []runtimepipeline.WorkflowInstance{
 		{
 			InstanceID:      rootEntityID,
@@ -1378,25 +1394,26 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 			},
 		},
 	} {
-		if err := store.Upsert(context.Background(), instance); err != nil {
+		if err := store.Upsert(ctx, instance); err != nil {
 			t.Fatalf("seed workflow instance %q: %v", instance.InstanceID, err)
 		}
 	}
 
-	if err := eb.Publish(context.Background(), (events.Event{
+	if err := eb.Publish(ctx, (events.Event{
 		ID:          "11111111-2222-3333-4444-555555555555",
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
+		RunID:       eventBusTestRunID,
 		Payload:     []byte(`{"entity_id":"` + grandchildEntityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(grandchildEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if err := eb.WaitForQuiescence(context.Background()); err != nil {
+	if err := eb.WaitForQuiescence(ctx); err != nil {
 		t.Fatalf("WaitForQuiescence: %v", err)
 	}
 
-	child, found, err := store.Load(context.Background(), childEntityID)
+	child, found, err := store.Load(ctx, childEntityID)
 	if err != nil {
 		t.Fatalf("load child instance: %v", err)
 	}
@@ -1407,7 +1424,7 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		t.Fatalf("child current_state = %q, want waiting", got)
 	}
 
-	root, found, err := store.Load(context.Background(), rootEntityID)
+	root, found, err := store.Load(ctx, rootEntityID)
 	if err != nil {
 		t.Fatalf("load root instance: %v", err)
 	}
@@ -1485,7 +1502,9 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 	}
 
 	const rootEntityID = "11111111-1111-1111-1111-111111111111"
-	if err := runtimepipeline.NewWorkflowInstanceStore(db).Upsert(context.Background(), runtimepipeline.WorkflowInstance{
+	ctx := eventBusTestRunContext(t, db)
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	if err := workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      rootEntityID,
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -1494,20 +1513,21 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(context.Background(), (events.Event{
+	if err := eb.Publish(ctx, (events.Event{
 		ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		Type:        events.EventType("pipeline.start"),
 		SourceAgent: "cataloge2e",
+		RunID:       eventBusTestRunID,
 		Payload:     []byte(`{"entity_id":"` + rootEntityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(rootEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if err := eb.WaitForQuiescence(context.Background()); err != nil {
+	if err := eb.WaitForQuiescence(ctx); err != nil {
 		t.Fatalf("WaitForQuiescence: %v", err)
 	}
 
-	root, found, err := runtimepipeline.NewWorkflowInstanceStore(db).Load(context.Background(), rootEntityID)
+	root, found, err := workflowStore.Load(ctx, rootEntityID)
 	if err != nil {
 		t.Fatalf("load root instance: %v", err)
 	}
@@ -1526,11 +1546,11 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 				}
 			}
 		}
-		instances, _ := runtimepipeline.NewWorkflowInstanceStore(db).List(context.Background())
+		instances, _ := workflowStore.List(ctx)
 		t.Fatalf("root current_state = %q, want idle without subject-link back-propagation; events=%v instances=%#v", got, dump, instances)
 	}
 
-	instances, err := runtimepipeline.NewWorkflowInstanceStore(db).List(context.Background())
+	instances, err := workflowStore.List(ctx)
 	if err != nil {
 		t.Fatalf("list workflow instances: %v", err)
 	}
@@ -1610,7 +1630,9 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 	}
 
 	const rootEntityID = "11111111-1111-1111-1111-111111111111"
-	if err := runtimepipeline.NewWorkflowInstanceStore(db).Upsert(context.Background(), runtimepipeline.WorkflowInstance{
+	ctx := eventBusTestRunContext(t, db)
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	if err := workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      rootEntityID,
 		StorageRef:      rootEntityID,
 		WorkflowName:    bundle.WorkflowName(),
@@ -1623,20 +1645,21 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(context.Background(), (events.Event{
+	if err := eb.Publish(ctx, (events.Event{
 		ID:          "11111111-2222-3333-4444-555555555555",
 		Type:        events.EventType("validate.requested"),
 		SourceAgent: "cataloge2e",
+		RunID:       eventBusTestRunID,
 		Payload:     []byte(`{"entity_id":"` + rootEntityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(rootEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if err := eb.WaitForQuiescence(context.Background()); err != nil {
+	if err := eb.WaitForQuiescence(ctx); err != nil {
 		t.Fatalf("WaitForQuiescence: %v", err)
 	}
 
-	root, found, err := runtimepipeline.NewWorkflowInstanceStore(db).Load(context.Background(), rootEntityID)
+	root, found, err := workflowStore.Load(ctx, rootEntityID)
 	if err != nil {
 		t.Fatalf("load root instance: %v", err)
 	}
@@ -1655,7 +1678,7 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 				}
 			}
 		}
-		instances, _ := runtimepipeline.NewWorkflowInstanceStore(db).List(context.Background())
+		instances, _ := workflowStore.List(ctx)
 		t.Fatalf("root current_state = %q, want pending without subject-link back-propagation; root metadata=%#v events=%v instances=%#v", got, root.Metadata, dump, instances)
 	}
 }

--- a/internal/runtime/cataloge2e/assertions.go
+++ b/internal/runtime/cataloge2e/assertions.go
@@ -9,9 +9,14 @@ import (
 	"testing"
 	"time"
 
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
+
+func catalogRuntimeContext() context.Context {
+	return runtimecorrelation.WithRunID(context.Background(), catalogRuntimeRunID)
+}
 
 func assertCatalogRuntimeOutcome(t testing.TB, h *runtimeHarness, expected catalogExpectedDocument) {
 	t.Helper()
@@ -134,7 +139,7 @@ func assertGates(t testing.TB, workflow *runtimepipeline.WorkflowInstanceStore, 
 	if workflow == nil {
 		t.Fatal("workflow instance store is required for gates assertions")
 	}
-	instance, ok, err := workflow.Load(context.Background(), strings.TrimSpace(entityID))
+	instance, ok, err := workflow.Load(catalogRuntimeContext(), strings.TrimSpace(entityID))
 	if err != nil {
 		t.Fatalf("load workflow instance %s for gates: %v", entityID, err)
 	}
@@ -168,7 +173,7 @@ func assertEntityFields(t testing.TB, workflow *runtimepipeline.WorkflowInstance
 	if workflow == nil {
 		t.Fatal("workflow instance store is required for entity_fields assertions")
 	}
-	instance, ok, err := workflow.Load(context.Background(), strings.TrimSpace(entityID))
+	instance, ok, err := workflow.Load(catalogRuntimeContext(), strings.TrimSpace(entityID))
 	if err != nil {
 		t.Fatalf("load workflow instance %s for entity_fields: %v", entityID, err)
 	}
@@ -206,7 +211,7 @@ func assertEntityState(t testing.TB, db *sql.DB, workflow *runtimepipeline.Workf
 	if workflow == nil {
 		t.Fatal("workflow instance store is required")
 	}
-	instance, ok, err := workflow.Load(context.Background(), strings.TrimSpace(entityID))
+	instance, ok, err := workflow.Load(catalogRuntimeContext(), strings.TrimSpace(entityID))
 	if err != nil {
 		t.Fatalf("load workflow instance %s: %v", entityID, err)
 	}
@@ -231,7 +236,7 @@ func assertFlowState(t testing.TB, h *runtimeHarness, entityID, flowID, wantStat
 	if h == nil || h.workflow == nil {
 		t.Fatal("workflow instance store is required")
 	}
-	instance, ok, err := h.workflow.Load(context.Background(), strings.TrimSpace(entityID))
+	instance, ok, err := h.workflow.Load(catalogRuntimeContext(), strings.TrimSpace(entityID))
 	if err != nil {
 		t.Fatalf("load workflow instance %s for flow state: %v", entityID, err)
 	}
@@ -259,7 +264,7 @@ func catalogFlowInstanceForCausalFlow(workflow *runtimepipeline.WorkflowInstance
 	if workflow == nil {
 		return runtimepipeline.WorkflowInstance{}, false, nil
 	}
-	rows, err := workflow.List(context.Background())
+	rows, err := workflow.List(catalogRuntimeContext())
 	if err != nil {
 		return runtimepipeline.WorkflowInstance{}, false, err
 	}

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -20,6 +20,14 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	childID := "22222222-2222-2222-2222-222222222222"
 	grandchildID := "33333333-3333-3333-3333-333333333333"
 	pg := &store.PostgresStore{DB: db}
+	ctx := catalogRuntimeContext()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, catalogRuntimeRunID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 	startedAt := time.Now().UTC().Add(-time.Second)
 
 	for _, stmt := range []struct {
@@ -31,15 +39,15 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 		{entityID: childID, flow: "child", state: "completed"},
 		{entityID: grandchildID, flow: "grandchild", state: "finished"},
 	} {
-		if _, err := db.ExecContext(context.Background(), `
+		if _, err := db.ExecContext(ctx, `
 			INSERT INTO entity_state (
-				entity_id, flow_instance, entity_type, current_state,
+				run_id, entity_id, flow_instance, entity_type, current_state,
 				gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 			)
 			VALUES (
-				$1::uuid, $2, 'default', $3, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
+				$1::uuid, $2::uuid, $3, 'default', $4, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 			)
-		`, stmt.entityID, stmt.flow, stmt.state); err != nil {
+		`, catalogRuntimeRunID, stmt.entityID, stmt.flow, stmt.state); err != nil {
 			t.Fatalf("insert entity_state %s: %v", stmt.entityID, err)
 		}
 	}
@@ -50,6 +58,7 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	if err := pg.AppendEvent(context.Background(), (events.Event{
 		ID:        rootEventID,
 		Type:      "root.started",
+		RunID:     catalogRuntimeRunID,
 		Payload:   []byte(`{"entity_id":"` + rootID + `"}`),
 		CreatedAt: time.Now().UTC(),
 	}).WithEntityID(rootID)); err != nil {
@@ -58,6 +67,7 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	if err := pg.AppendEvent(context.Background(), (events.Event{
 		ID:            childEventID,
 		Type:          "child.started",
+		RunID:         catalogRuntimeRunID,
 		Payload:       []byte(`{"entity_id":"` + childID + `"}`),
 		ParentEventID: rootEventID,
 		CreatedAt:     time.Now().UTC(),
@@ -67,6 +77,7 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	if err := pg.AppendEvent(context.Background(), (events.Event{
 		ID:            grandchildEventID,
 		Type:          "grandchild.done",
+		RunID:         catalogRuntimeRunID,
 		Payload:       []byte(`{"entity_id":"` + grandchildID + `"}`),
 		ParentEventID: childEventID,
 		CreatedAt:     time.Now().UTC(),
@@ -192,6 +203,7 @@ func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testin
 		ID:          uuid.NewString(),
 		Type:        "score.requested",
 		SourceAgent: "runtime",
+		RunID:       catalogRuntimeRunID,
 		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(entityID)); err != nil {
@@ -205,9 +217,17 @@ func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {
 	t.Helper()
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
+	ctx := catalogRuntimeContext()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, catalogRuntimeRunID); err != nil {
+		t.Fatalf("seed catalog assertion run: %v", err)
+	}
 	return &runtimeHarness{
 		t:              t,
-		ctx:            context.Background(),
+		ctx:            ctx,
 		db:             db,
 		pg:             &store.PostgresStore{DB: db},
 		workflow:       runtimepipeline.NewWorkflowInstanceStore(db),
@@ -221,16 +241,16 @@ func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {
 
 func insertCatalogAssertionEntityState(t *testing.T, h *runtimeHarness, entityID, state string) {
 	t.Helper()
-	if _, err := h.db.ExecContext(context.Background(), `
+	if _, err := h.db.ExecContext(h.ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, current_state,
+			run_id, entity_id, flow_instance, entity_type, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, 'root', 'default', $2,
+			$1::uuid, $2::uuid, 'root', 'default', $3,
 			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 		)
-	`, entityID, state); err != nil {
+	`, catalogRuntimeRunID, entityID, state); err != nil {
 		t.Fatalf("insert entity_state %s: %v", entityID, err)
 	}
 }
@@ -241,6 +261,7 @@ func insertCatalogAssertionDeadLetterEvent(t *testing.T, h *runtimeHarness, enti
 		ID:          uuid.NewString(),
 		Type:        "platform.dead_letter",
 		SourceAgent: "runtime",
+		RunID:       catalogRuntimeRunID,
 		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(entityID)); err != nil {

--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -16,12 +16,15 @@ import (
 	"swarm/internal/events"
 	runtime "swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
+
+const catalogRuntimeRunID = "88888888-8888-8888-8888-888888888888"
 
 type catalogTriggerStep struct {
 	Event                         string         `yaml:"event"`
@@ -164,8 +167,15 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 	loadAgentFixtures(t, fixtureRoot, llmRuntime)
 	pg := &store.PostgresStore{DB: db}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(runtimecorrelation.WithRunID(context.Background(), catalogRuntimeRunID))
 	t.Cleanup(cancel)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, catalogRuntimeRunID); err != nil {
+		t.Fatalf("seed catalog runtime run: %v", err)
+	}
 
 	rt, err := runtime.NewRuntime(ctx, cfg, runtime.Stores{
 		SQLDB:             db,
@@ -291,6 +301,7 @@ func (h *runtimeHarness) publishConcurrentAndWait(steps []catalogTriggerStep, ti
 			ID:          uuid.NewString(),
 			Type:        events.EventType(strings.TrimSpace(step.Event)),
 			SourceAgent: "cataloge2e",
+			RunID:       catalogRuntimeRunID,
 			Payload:     raw,
 			CreatedAt:   time.Now().UTC(),
 		}
@@ -352,6 +363,7 @@ func (h *runtimeHarness) publishRuntimeEventResult(eventType, sourceAgent string
 		ID:          uuid.NewString(),
 		Type:        events.EventType(strings.TrimSpace(eventType)),
 		SourceAgent: strings.TrimSpace(sourceAgent),
+		RunID:       catalogRuntimeRunID,
 		Payload:     raw,
 		CreatedAt:   time.Now().UTC(),
 	}

--- a/internal/runtime/cataloge2e/tier11_probe_test.go
+++ b/internal/runtime/cataloge2e/tier11_probe_test.go
@@ -51,7 +51,7 @@ func TestTier11Probe(t *testing.T) {
 				t.Fatalf("debug rows: %v", err)
 			}
 			t.Logf("rows=%s", rows)
-			instance, ok, err := h.workflow.Load(context.Background(), "11111111-1111-4111-8111-111111111111")
+			instance, ok, err := h.workflow.Load(catalogRuntimeContext(), "11111111-1111-4111-8111-111111111111")
 			if err == nil && ok {
 				t.Logf("root metadata=%#v", instance.Metadata)
 			}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -754,11 +754,18 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 }
 
 func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
-	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
 	pg := &store.PostgresStore{DB: db}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 
 	requireCanonicalRuntimeLogSurface(t, ctx, pg)
 
@@ -1946,8 +1953,15 @@ func TestCanonicalRuntimeLogTurnBlockSurface_RoundTripsThroughConversationReader
 }
 
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrites(t *testing.T) {
-	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 
 	requireMutationSurface(t, db)
 
@@ -1991,13 +2005,13 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrite
 		t.Fatalf("update workflow instance: %v", err)
 	}
 
-	if err := trackedMutationStateMatchesEntityState(db, entityID); err != nil {
+	if err := trackedMutationStateMatchesEntityState(db, runID, entityID); err != nil {
 		t.Fatalf("trackedMutationStateMatchesEntityState(workflow): %v", err)
 	}
 }
 
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t *testing.T) {
-	ctx, exec, db := newEntityToolConformanceHarness(t)
+	ctx, exec, db, runID := newEntityToolConformanceHarness(t)
 
 	requireMutationSurface(t, db)
 
@@ -2027,31 +2041,31 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t 
 		t.Fatalf("save_entity_field: %v", err)
 	}
 
-	if err := trackedMutationStateMatchesEntityState(db, entityID); err != nil {
+	if err := trackedMutationStateMatchesEntityState(db, runID, entityID); err != nil {
 		t.Fatalf("trackedMutationStateMatchesEntityState(tool): %v", err)
 	}
 }
 
 func TestCanonicalMutationSurface_FailsOnMalformedCanonicalMutationField(t *testing.T) {
-	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
 	requireMutationSurface(t, db)
 
 	entityID := uuid.NewString()
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, current_state, gates, fields, accumulator
-		)
-		VALUES (
-			$1::uuid, 'mutation-flow/inst-1', 'default', 'queued', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb
-		)
-	`, entityID); err != nil {
-		t.Fatalf("seed entity_state: %v", err)
-	}
-	runID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id) VALUES ($1::uuid)`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state, gates, fields, accumulator
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'mutation-flow/inst-1', 'default', 'queued', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb
+		)
+	`, runID, entityID); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
@@ -2063,7 +2077,7 @@ func TestCanonicalMutationSurface_FailsOnMalformedCanonicalMutationField(t *test
 		t.Fatalf("seed malformed mutation: %v", err)
 	}
 
-	err := trackedMutationStateMatchesEntityState(db, entityID)
+	err := trackedMutationStateMatchesEntityState(db, runID, entityID)
 	if err == nil || !strings.Contains(err.Error(), "gates mutation key is required") {
 		t.Fatalf("trackedMutationStateMatchesEntityState error = %v, want malformed gates failure", err)
 	}
@@ -2153,7 +2167,7 @@ func countTurnSummaryBlocks(blocks []dashboardserver.ConversationTurnBlock) int 
 	return count
 }
 
-func trackedMutationStateMatchesEntityState(db *sql.DB, entityID string) error {
+func trackedMutationStateMatchesEntityState(db *sql.DB, runID, entityID string) error {
 	var (
 		currentState string
 		fieldsRaw    []byte
@@ -2166,9 +2180,9 @@ func trackedMutationStateMatchesEntityState(db *sql.DB, entityID string) error {
 			COALESCE(fields, '{}'::jsonb),
 			COALESCE(gates, '{}'::jsonb),
 			COALESCE(accumulator, '{}'::jsonb)
-		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw); err != nil {
+			FROM entity_state
+			WHERE run_id = $1::uuid AND entity_id = $2::uuid
+		`, runID, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw); err != nil {
 		return fmt.Errorf("load entity_state projection: %w", err)
 	}
 
@@ -2192,10 +2206,10 @@ func trackedMutationStateMatchesEntityState(db *sql.DB, entityID string) error {
 
 	rows, err := db.QueryContext(context.Background(), `
 		SELECT field, new_value
-		FROM entity_mutations
-		WHERE entity_id = $1::uuid
-		ORDER BY created_at ASC, mutation_id ASC
-	`, entityID)
+			FROM entity_mutations
+			WHERE run_id = $1::uuid AND entity_id = $2::uuid
+			ORDER BY created_at ASC, mutation_id ASC
+		`, runID, entityID)
 	if err != nil {
 		return fmt.Errorf("query mutations: %w", err)
 	}
@@ -2294,9 +2308,16 @@ func mustCanonicalJSON(t *testing.T, value any) string {
 	return string(raw)
 }
 
-func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB) {
+func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB, string) {
 	t.Helper()
 	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
 		SQLDB: db,
 		WorkflowSource: runtimesemanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
@@ -2314,12 +2335,13 @@ func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetoo
 			},
 		}),
 	})
-	ctx := runtimetools.WithActor(context.Background(), runtimeactors.AgentConfig{
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimetools.WithActor(ctx, runtimeactors.AgentConfig{
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "save_entity_field"},
 	})
-	return ctx, exec, db
+	return ctx, exec, db, runID
 }
 
 func readString(value any) string {

--- a/internal/runtime/currentstate/currentstate.go
+++ b/internal/runtime/currentstate/currentstate.go
@@ -1,0 +1,51 @@
+package currentstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+type Identity struct {
+	RunID    string
+	EntityID string
+}
+
+func RequireRunID(ctx context.Context) (string, error) {
+	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
+	if runID == "" {
+		if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+			runID = strings.TrimSpace(inbound.RunID)
+		}
+	}
+	return ValidateRunID(runID)
+}
+
+func ValidateRunID(runID string) (string, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return "", fmt.Errorf("entity_state current-state run_id is required")
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", fmt.Errorf("entity_state current-state run_id must be uuid: %w", err)
+	}
+	return runID, nil
+}
+
+func RequireIdentity(ctx context.Context, entityID string) (Identity, error) {
+	runID, err := RequireRunID(ctx)
+	if err != nil {
+		return Identity{}, err
+	}
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return Identity{}, fmt.Errorf("entity_state current-state entity_id is required")
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return Identity{}, fmt.Errorf("entity_state current-state entity_id must be uuid: %w", err)
+	}
+	return Identity{RunID: runID, EntityID: entityID}, nil
+}

--- a/internal/runtime/currentstate/currentstate.go
+++ b/internal/runtime/currentstate/currentstate.go
@@ -15,13 +15,31 @@ type Identity struct {
 }
 
 func RequireRunID(ctx context.Context) (string, error) {
+	runID, ok, err := RunIDFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("entity_state current-state run_id is required")
+	}
+	return runID, nil
+}
+
+func RunIDFromContext(ctx context.Context) (string, bool, error) {
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
 	if runID == "" {
 		if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
 			runID = strings.TrimSpace(inbound.RunID)
 		}
 	}
-	return ValidateRunID(runID)
+	if runID == "" {
+		return "", false, nil
+	}
+	runID, err := ValidateRunID(runID)
+	if err != nil {
+		return "", true, err
+	}
+	return runID, true, nil
 }
 
 func ValidateRunID(runID string) (string, error) {

--- a/internal/runtime/currentstate/currentstate_test.go
+++ b/internal/runtime/currentstate/currentstate_test.go
@@ -1,0 +1,29 @@
+package currentstate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+func TestRequireIdentityRequiresRunID(t *testing.T) {
+	_, err := RequireIdentity(context.Background(), uuid.NewString())
+	if err == nil || !strings.Contains(err.Error(), "run_id is required") {
+		t.Fatalf("RequireIdentity error = %v, want missing run_id", err)
+	}
+}
+
+func TestRequireIdentityAcceptsRunScopedEntity(t *testing.T) {
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	got, err := RequireIdentity(runtimecorrelation.WithRunID(context.Background(), runID), entityID)
+	if err != nil {
+		t.Fatalf("RequireIdentity: %v", err)
+	}
+	if got.RunID != runID || got.EntityID != entityID {
+		t.Fatalf("identity = %+v, want run=%s entity=%s", got, runID, entityID)
+	}
+}

--- a/internal/runtime/currentstate/currentstate_test.go
+++ b/internal/runtime/currentstate/currentstate_test.go
@@ -16,6 +16,16 @@ func TestRequireIdentityRequiresRunID(t *testing.T) {
 	}
 }
 
+func TestRunIDFromContextReportsAbsentRunID(t *testing.T) {
+	runID, ok, err := RunIDFromContext(context.Background())
+	if err != nil {
+		t.Fatalf("RunIDFromContext: %v", err)
+	}
+	if ok || runID != "" {
+		t.Fatalf("RunIDFromContext = (%q, %v), want absent", runID, ok)
+	}
+}
+
 func TestRequireIdentityAcceptsRunScopedEntity(t *testing.T) {
 	runID := uuid.NewString()
 	entityID := uuid.NewString()

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -13,6 +13,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
@@ -683,6 +684,15 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
+	const runID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 
 	routeStore := &flowActivationTestRouteStore{}
 	bus := &flowActivationTestBus{routeStore: routeStore}
@@ -692,10 +702,10 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	const subjectID = "11111111-1111-1111-1111-111111111111"
 	req := testActivationRequest(bundle, "review", "inst-1", subjectID, "review/inst-1")
 
-	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+	if err := am.ActivateFlowInstance(ctx, req); err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
-	if err := store.Mutate(context.Background(), req.Instance.EntityID, func(instance *runtimepipeline.WorkflowInstance) {
+	if err := store.Mutate(ctx, req.Instance.EntityID, func(instance *runtimepipeline.WorkflowInstance) {
 		instance.CurrentState = "completed"
 	}); err != nil {
 		t.Fatalf("Mutate: %v", err)
@@ -709,7 +719,7 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	}
 	am.mu.Unlock()
 
-	if err := am.DeactivateFlowInstanceModel(context.Background(), runtimepipeline.FlowInstanceDeactivationRequest{
+	if err := am.DeactivateFlowInstanceModel(ctx, runtimepipeline.FlowInstanceDeactivationRequest{
 		ContractBundle: semanticview.Wrap(bundle),
 		Instance:       req.Instance,
 		FinalState:     "completed",
@@ -739,7 +749,7 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 		t.Fatalf("routing_rules.status = %q, want inactive", routeStatus)
 	}
 
-	instance, ok, err := store.Load(context.Background(), req.Instance.EntityID)
+	instance, ok, err := store.Load(ctx, req.Instance.EntityID)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/google/uuid"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
-
-var syntheticRunNamespace = uuid.MustParse("7e7e89e6-0d4f-4eeb-a8a0-99a3e8ec2ef1")
 
 func ErrInvalidMutationLogWriter(message string) error {
 	return fmt.Errorf("mutation log completeness violation: %s", strings.TrimSpace(message))
@@ -64,7 +63,10 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 		return ErrInvalidMutationLogWriter("entity_id, field, writer_type, and writer_id are required")
 	}
 
-	runID := normalizeRunID(runtimecorrelation.RunIDFromContext(ctx))
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return ErrInvalidMutationLogWriter(err.Error())
+	}
 	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{}); err != nil {
 		return err
 	}
@@ -344,17 +346,6 @@ func deleteProjectionMapValue(target map[string]any, path []string) bool {
 		delete(target, segment)
 	}
 	return len(target) == 0
-}
-
-func normalizeRunID(runID string) string {
-	if parsed := validUUIDString(runID); parsed != "" {
-		return parsed
-	}
-	runID = strings.TrimSpace(runID)
-	if runID == "" {
-		return uuid.NewString()
-	}
-	return uuid.NewSHA1(syntheticRunNamespace, []byte(runID)).String()
 }
 
 func validUUIDString(raw string) string {

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -28,7 +28,7 @@ func (s eventReceiptsCapabilityStub) resolve(context.Context) (bool, error) {
 
 func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	ctx := context.Background()
+	ctx := testPipelineRunContext(t, db)
 	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
 		return errors.New("boom")
 	})
@@ -75,6 +75,7 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 		ID:          uuid.NewString(),
 		Type:        "chain.start",
 		SourceAgent: "src",
+		RunID:       testPipelineRunID,
 		Payload:     []byte(`{}`),
 		CreatedAt:   time.Now().UTC(),
 		ChainDepth:  5,
@@ -100,7 +101,7 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
 		Module: module,
 	})
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -15,6 +15,7 @@ import (
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
 	runtimeregistry "swarm/internal/runtime/core/registry"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/entityruntime"
 	runtimeeventpayload "swarm/internal/runtime/eventpayload"
@@ -345,19 +346,23 @@ func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext,
 			return 0, err
 		}
 	}
-	return queryEntityStateCount(e.coordinator.db, e.coordinator.SemanticSource(), contract, parsed)
+	return queryEntityStateCount(asString(ctx.Event["run_id"]), e.coordinator.db, e.coordinator.SemanticSource(), contract, parsed)
 }
 
-func queryEntityStateCount(db *sql.DB, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {
+func queryEntityStateCount(runID string, db *sql.DB, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {
 	if db == nil {
 		return 0, nil
 	}
+	runID, err := runtimecurrentstate.ValidateRunID(runID)
+	if err != nil {
+		return 0, err
+	}
 	flowRoot := runtimeflowidentity.ScopeKey(source, contract.FlowID)
-	where := ""
-	var args []any
+	where := " WHERE run_id = $1::uuid"
+	args := []any{runID}
 	if flowRoot != "" {
-		args = []any{flowRoot, flowRoot + "/%"}
-		where = " WHERE (flow_instance = $1 OR flow_instance LIKE $2)"
+		args = append(args, flowRoot, flowRoot+"/%")
+		where += " AND (flow_instance = $2 OR flow_instance LIKE $3)"
 	}
 	rows, err := db.QueryContext(context.Background(), `
 		SELECT COALESCE(fields, '{}'::jsonb), current_state

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -153,7 +153,7 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 	})
 
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "root",
@@ -164,7 +164,7 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := pc.maybeDeactivateTerminalFlowInstance(context.Background(), entityID, "done"); err != nil {
+	if err := pc.maybeDeactivateTerminalFlowInstance(testPipelineCoordinatorRunContext(t, pc), entityID, "done"); err != nil {
 		t.Fatalf("maybeDeactivateTerminalFlowInstance: %v", err)
 	}
 	if deactivated {
@@ -208,7 +208,7 @@ func TestMaybeDeactivateTerminalFlowInstance_PassesTerminalStateToTemplateDeacti
 	const flowPath = "review/inst-1"
 	entityID := FlowInstanceEntityID(flowPath)
 	const parentEntityID = "22222222-2222-2222-2222-222222222222"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "inst-1",
 		StorageRef:      flowPath,
 		WorkflowName:    "review",
@@ -224,7 +224,7 @@ func TestMaybeDeactivateTerminalFlowInstance_PassesTerminalStateToTemplateDeacti
 		t.Fatalf("seed template instance: %v", err)
 	}
 
-	if err := pc.maybeDeactivateTerminalFlowInstance(context.Background(), entityID, "completed"); err != nil {
+	if err := pc.maybeDeactivateTerminalFlowInstance(testPipelineCoordinatorRunContext(t, pc), entityID, "completed"); err != nil {
 		t.Fatalf("maybeDeactivateTerminalFlowInstance: %v", err)
 	}
 	if !called {
@@ -348,7 +348,7 @@ func TestUpdateEntityState_ReturnsWorkflowStoreMutationError(t *testing.T) {
 		},
 	}
 
-	err := pc.updateEntityState(context.Background(), "11111111-1111-1111-1111-111111111111", "marginal_review", "scoring/vertical.marginal")
+	err := pc.updateEntityState(testPipelineRunContextNoSeed(), "11111111-1111-1111-1111-111111111111", "marginal_review", "scoring/vertical.marginal")
 	if err == nil {
 		t.Fatal("expected updateEntityState to fail when workflow store mutate fails")
 	}
@@ -358,7 +358,7 @@ func TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	store := NewWorkflowInstanceStore(db)
 	entityID := "11111111-1111-1111-1111-111111111111"
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "flow-a",
@@ -384,7 +384,7 @@ func TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite(t *testing.T) {
 			},
 		},
 	}
-	ctx := withPipelineFlowScope(context.Background(), "flow-b")
+	ctx := withPipelineFlowScope(testWorkflowStoreRunContext(t, store), "flow-b")
 	err := repo.SaveState(ctx, identity.NormalizeEntityID(entityID), testEngineStateMutation(map[string]any{"note": "bad write"}, nil, nil))
 	if err == nil || !strings.Contains(err.Error(), "cross_flow_write_forbidden") {
 		t.Fatalf("expected cross_flow_write_forbidden, got %v", err)
@@ -429,7 +429,7 @@ review_entity:
 		},
 	}
 
-	loaded, ok, err := repo.LoadState(withPipelineFlowScope(context.Background(), "review"), identity.NormalizeEntityID(FlowInstanceEntityID("review/inst-missing")))
+	loaded, ok, err := repo.LoadState(withPipelineFlowScope(testWorkflowStoreRunContext(t, repo.coordinator.workflowStore), "review"), identity.NormalizeEntityID(FlowInstanceEntityID("review/inst-missing")))
 	if err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
@@ -449,7 +449,7 @@ func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
 		},
 	}
 	entityID := identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111")
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID.String(),
 		StorageRef:      entityID.String(),
 		WorkflowName:    "root",
@@ -466,10 +466,10 @@ func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
 		map[string]map[string]any{"evidence": {"count": 2}},
 	)
 
-	if err := repo.SaveState(context.Background(), entityID, mutation); err != nil {
+	if err := repo.SaveState(testWorkflowStoreRunContext(t, repo.coordinator.workflowStore), entityID, mutation); err != nil {
 		t.Fatalf("SaveState: %v", err)
 	}
-	loaded, ok, err := repo.LoadState(context.Background(), entityID)
+	loaded, ok, err := repo.LoadState(testWorkflowStoreRunContext(t, repo.coordinator.workflowStore), entityID)
 	if err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestPipelineEngineStateRepoLoadStateRejectsMalformedPersistedCarrier(t *tes
 
 	t.Run("state_buckets", func(t *testing.T) {
 		store := NewWorkflowInstanceStore(db)
-		if err := store.Upsert(context.Background(), WorkflowInstance{
+		if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 			InstanceID:      "22222222-2222-2222-2222-222222222222",
 			StorageRef:      "22222222-2222-2222-2222-222222222222",
 			WorkflowName:    "root",
@@ -506,7 +506,7 @@ func TestPipelineEngineStateRepoLoadStateRejectsMalformedPersistedCarrier(t *tes
 			t.Fatalf("upsert malformed state bucket instance: %v", err)
 		}
 		repo := pipelineEngineStateRepo{coordinator: &PipelineCoordinator{workflowStore: store}}
-		_, _, err := repo.LoadState(context.Background(), identity.NormalizeEntityID("22222222-2222-2222-2222-222222222222"))
+		_, _, err := repo.LoadState(testWorkflowStoreRunContext(t, repo.coordinator.workflowStore), identity.NormalizeEntityID("22222222-2222-2222-2222-222222222222"))
 		if err == nil || !strings.Contains(err.Error(), "invalid workflow state bucket") {
 			t.Fatalf("LoadState error = %v, want invalid workflow state bucket", err)
 		}
@@ -522,7 +522,7 @@ func TestRecordWorkflowEvidence_ReturnsWorkflowStoreMutationError(t *testing.T) 
 		workflowStore: NewWorkflowInstanceStore(db),
 	}
 
-	err := pc.recordWorkflowEvidence(context.Background(), "11111111-1111-1111-1111-111111111111", "research", map[string]any{"summary": "done"})
+	err := pc.recordWorkflowEvidence(testPipelineRunContextNoSeed(), "11111111-1111-1111-1111-111111111111", "research", map[string]any{"summary": "done"})
 	if err == nil {
 		t.Fatal("expected recordWorkflowEvidence to fail when workflow store mutate fails")
 	}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -146,7 +146,7 @@ func TestExecuteNodeContractHandlerPublishesCollectedEventsWithoutParentCollecto
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"),
@@ -171,7 +171,7 @@ func TestExecuteNodeContractHandlerUsesTypedEnvelopeIdentityOverPayload(t *testi
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
 		Event: (events.Event{
@@ -244,7 +244,7 @@ node-a:
 		},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "name", Value: runtimecontracts.LiteralExpression("Minted Entity")},
@@ -275,7 +275,7 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 
 	pc, bus := newEmitPersistenceTestCoordinator(db)
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -286,7 +286,7 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "business_brief"},
@@ -313,7 +313,7 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 		t.Fatalf("published count = %d, want 0 when persistence prerequisite is missing", got)
 	}
 
-	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, loadErr := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if loadErr != nil {
 		t.Fatalf("load workflow instance: %v", loadErr)
 	}
@@ -334,7 +334,7 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 
 	pc, bus := newEmitPersistenceTestCoordinator(db)
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -345,7 +345,7 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "business_brief"},
@@ -380,7 +380,7 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 		t.Fatalf("published type = %q, want spec.requested", got)
 	}
 
-	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, loadErr := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if loadErr != nil {
 		t.Fatalf("load workflow instance: %v", loadErr)
 	}
@@ -402,7 +402,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -433,12 +433,12 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 		if idx == 1 {
 			payload["business_brief"] = map[string]any{"summary": "validated"}
 		}
-		result, err := pc.executeNodeContractHandler(context.Background(), "node-a", handler, workflowTriggerContext{
+		result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", handler, workflowTriggerContext{
 			Event: events.Event{
 				Type:    events.EventType("research.completed"),
 				Payload: mustJSON(payload),
 			}.WithEntityID(entityID),
-			State: pc.currentWorkflowState(context.Background(), entityID),
+			State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 		}, false)
 		if err != nil {
 			t.Fatalf("executeNodeContractHandler(%d): %v", idx, err)
@@ -467,7 +467,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 		t.Fatalf("received_count = %#v, want 2", got)
 	}
 
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -498,7 +498,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Accumulate: &runtimecontracts.AccumulateSpec{
 			ExpectedFrom: "entity.expected_count",
 			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
@@ -511,7 +511,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 			Type:    events.EventType("research.completed"),
 			Payload: mustJSON(map[string]any{"item_id": 1}),
 		}.WithEntityID(entityID),
-		State: pc.currentWorkflowState(context.Background(), entityID),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err == nil {
 		t.Fatal("expected executeNodeContractHandler to fail on on_complete evaluation error")
@@ -529,7 +529,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 		t.Fatalf("commit_outcome = %q, want rolled_back", got)
 	}
 
-	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, loadErr := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if loadErr != nil {
 		t.Fatalf("load workflow instance: %v", loadErr)
 	}
@@ -547,7 +547,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -560,7 +560,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Accumulate: &runtimecontracts.AccumulateSpec{
 			ExpectedFrom: "entity.expected_count",
 			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
@@ -576,7 +576,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 			Type:    events.EventType("research.completed"),
 			Payload: mustJSON(map[string]any{"item_id": 1}),
 		}.WithEntityID(entityID),
-		State: pc.currentWorkflowState(context.Background(), entityID),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if !errors.Is(err, runtimeengine.ErrEmitPersistencePrerequisite) {
 		t.Fatalf("executeNodeContractHandler error = %v, want %v", err, runtimeengine.ErrEmitPersistencePrerequisite)
@@ -594,7 +594,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 		t.Fatalf("commit_outcome = %q, want rolled_back", got)
 	}
 
-	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, loadErr := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if loadErr != nil {
 		t.Fatalf("load workflow instance: %v", loadErr)
 	}
@@ -629,7 +629,7 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 		}},
 	})
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -642,7 +642,7 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "revision_count", Value: runtimecontracts.CELExpression("entity.revision_count + 1")},
@@ -650,13 +650,13 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 		},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
-		State: pc.currentWorkflowState(context.Background(), entityID),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
 		t.Fatalf("executeNodeContractHandler: %v", err)
 	}
 
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -700,7 +700,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 		}},
 	})
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -711,7 +711,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "revision_count", Value: runtimecontracts.CELExpression("entity.revision_count + 1")},
@@ -719,7 +719,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 		},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
-		State: pc.currentWorkflowState(context.Background(), entityID),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err == nil {
 		t.Fatal("expected executeNodeContractHandler to fail on data accumulation CEL runtime error")
@@ -728,7 +728,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 		t.Fatalf("error = %v, want data_accumulation target context", err)
 	}
 
-	instance, ok, loadErr := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, loadErr := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if loadErr != nil {
 		t.Fatalf("load workflow instance: %v", loadErr)
 	}
@@ -764,7 +764,7 @@ func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpr
 		}},
 	})
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "validation",
@@ -775,7 +775,7 @@ func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpr
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "kill_reason_missing", Value: runtimecontracts.CELExpression("entity.kill_reason == null")},
@@ -783,13 +783,13 @@ func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpr
 		},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("validation.spec_requested")}.WithEntityID(entityID),
-		State: pc.currentWorkflowState(context.Background(), entityID),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
 		t.Fatalf("executeNodeContractHandler: %v", err)
 	}
 
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -1191,7 +1191,7 @@ func TestExecuteNodeContractHandlerRejectsMalformedPersistedGateShape(t *testing
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"),
 		State: WorkflowState{
 			Stage:    WorkflowStateID("queued"),
@@ -1278,7 +1278,7 @@ node-a:
 		},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		CreateEntity: true,
 		Guard:        &runtimecontracts.GuardSpec{Check: `entity.revision_count == 0 && entity.kill_reason == ""`},
 		Emit: runtimecontracts.EmitSpec{
@@ -1313,7 +1313,7 @@ node-a:
 		t.Fatalf("emitted payload revision_count = %#v, want 0", got)
 	}
 
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("workflowStore.Load: %v", err)
 	}
@@ -1408,7 +1408,7 @@ node-a:
 		},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		CreateEntity: true,
 		Guard:        &runtimecontracts.GuardSpec{Check: `entity.status == "pending"`},
 		Emit: runtimecontracts.EmitSpec{
@@ -1435,7 +1435,7 @@ node-a:
 	if entityID == "" {
 		t.Fatal("expected emitted event to carry created entity id")
 	}
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("workflowStore.Load: %v", err)
 	}
@@ -1535,7 +1535,7 @@ node-a:
 		},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		CreateEntity: true,
 		Clear:        &runtimecontracts.ClearSpec{Target: "entity.revision_count"},
 		Emit:         runtimecontracts.EmitSpec{Event: "entity.created"},
@@ -1557,7 +1557,7 @@ node-a:
 		t.Fatal("expected emitted event to carry created entity id")
 	}
 
-	instance, ok, err := pc.workflowStore.Load(context.Background(), entityID)
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), entityID)
 	if err != nil {
 		t.Fatalf("workflowStore.Load: %v", err)
 	}
@@ -1699,7 +1699,7 @@ func TestExecuteNodeContractHandlerReturnsTerminalRejectForTerminalEntity(t *tes
 		},
 	}
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"),
 		State: WorkflowState{Stage: WorkflowStateID("done"), Metadata: map[string]any{}},
 	}, false)
@@ -1722,7 +1722,7 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
@@ -1776,7 +1776,7 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsSparseFieldPresenceCheck(t *
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
@@ -1849,7 +1849,7 @@ node-a:
 		},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
@@ -1910,7 +1910,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	)
 	childEntityID := FlowInstanceEntityID("child/inst-1")
 	grandchildEntityID := FlowInstanceEntityID("child/grandchild/inst-1")
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      childEntityID,
 		StorageRef:      "child/inst-1",
 		WorkflowName:    "child",
@@ -1924,7 +1924,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      grandchildEntityID,
 		StorageRef:      "child/grandchild/inst-1",
 		WorkflowName:    "grandchild",
@@ -1944,7 +1944,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	handled, err := pc.dispatchWorkflowNodeEventResult(context.Background(), events.Event{
+	handled, err := pc.dispatchWorkflowNodeEventResult(testWorkflowStoreRunContext(t, store), events.Event{
 		Type: events.EventType("child/grandchild/micro.done"),
 	}.WithEntityID(grandchildEntityID))
 	if err != nil {
@@ -1953,7 +1953,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	if !handled {
 		t.Fatal("expected handler to execute")
 	}
-	child, found, err := store.Load(context.Background(), childEntityID)
+	child, found, err := store.Load(testWorkflowStoreRunContext(t, store), childEntityID)
 	if err != nil {
 		t.Fatalf("load child instance: %v", err)
 	}
@@ -1976,7 +1976,7 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRules(
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "default.emitted"},
 		Rules: []runtimecontracts.HandlerRuleEntry{
 			{ID: "pick-rule", Condition: "true", Emit: runtimecontracts.EmitSpec{Event: "rule.emitted"}},
@@ -2004,7 +2004,7 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRulesW
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "default.emitted"},
 		Rules: []runtimecontracts.HandlerRuleEntry{
 			{ID: "pick-rule", Condition: "true", AdvancesTo: "done"},
@@ -2032,7 +2032,7 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 		entityLocks:    map[string]*sync.Mutex{},
 	}
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{
 				{TargetField: "branch_target", Value: runtimecontracts.LiteralExpression("handler")},
@@ -2062,7 +2062,7 @@ func TestExecuteNodeContractHandlerExecutesEmitInsideEngine(t *testing.T) {
 	})
 	entityID := "ent-1"
 
-	result, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
 		Event: events.Event{Type: events.EventType("custom.trigger")}.WithEntityID(entityID),
@@ -2122,7 +2122,7 @@ func newDeclarativeEmitContractCoordinatorWithBundle(bundle *runtimecontracts.Wo
 func TestExecuteNodeContractHandler_UsesEmitFieldsAsOnlyBusinessPayloadSource(t *testing.T) {
 	pc, bus := newDeclarativeEmitContractCoordinator("custom.emitted")
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
@@ -2177,7 +2177,7 @@ func TestExecuteNodeContractHandler_GuardEscalateUsesOnlyRuntimeOwnedEnvelope(t 
 		Payload: runtimecontracts.EventPayloadSpec{},
 	}))
 
-	_, err := pc.executeNodeContractHandler(context.Background(), "node-a", runtimecontracts.SystemNodeEventHandler{
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Guard: &runtimecontracts.GuardSpec{
 			Check:  "payload.score >= 70",
 			OnFail: "escalate:guard.failed",
@@ -2337,7 +2337,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pc, bus := newDeclarativeEmitContractCoordinator("custom.emitted")
-			_, err := pc.executeNodeContractHandler(context.Background(), "node-a", tc.handler, workflowTriggerContext{
+			_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", tc.handler, workflowTriggerContext{
 				Event: tc.event,
 				State: tc.state,
 			}, false)

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -29,7 +29,7 @@ func TestUpdateEntityState_LogsMutationRowForStateTransition(t *testing.T) {
 			},
 		},
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "mutation-flow",
@@ -39,7 +39,7 @@ func TestUpdateEntityState_LogsMutationRowForStateTransition(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	if err := pc.updateEntityState(context.Background(), entityID, "done", "flow.transitioned"); err != nil {
+	if err := pc.updateEntityState(testPipelineCoordinatorRunContext(t, pc), entityID, "done", "flow.transitioned"); err != nil {
 		t.Fatalf("updateEntityState: %v", err)
 	}
 
@@ -86,7 +86,7 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 	store := NewWorkflowInstanceStore(db)
 	entityID := uuid.NewString()
 
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "mutation-flow",
@@ -105,7 +105,7 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "mutation-flow",
@@ -150,7 +150,7 @@ func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
 	pc := testMutationLoggingCoordinator(db)
 	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
 
-	if err := pc.applyWorkflowGateMutation(context.Background(), entityID, "workflow.ready", "g_ready", false); err != nil {
+	if err := pc.applyWorkflowGateMutation(testPipelineCoordinatorRunContext(t, pc), entityID, "workflow.ready", "g_ready", false); err != nil {
 		t.Fatalf("applyWorkflowGateMutation: %v", err)
 	}
 
@@ -169,7 +169,7 @@ func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
 	pc := testMutationLoggingCoordinator(db)
 	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
 
-	if err := pc.recordWorkflowEvidence(context.Background(), entityID, "research", map[string]any{"summary": "done"}); err != nil {
+	if err := pc.recordWorkflowEvidence(testPipelineCoordinatorRunContext(t, pc), entityID, "research", map[string]any{"summary": "done"}); err != nil {
 		t.Fatalf("recordWorkflowEvidence: %v", err)
 	}
 
@@ -216,7 +216,7 @@ func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *te
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
 		dropEntityMutationsTable(t, db)
 
-		err := pc.updateEntityState(context.Background(), entityID, "done", "flow.transitioned")
+		err := pc.updateEntityState(testPipelineCoordinatorRunContext(t, pc), entityID, "done", "flow.transitioned")
 		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
 			t.Fatalf("updateEntityState err = %v, want entity_mutations failure", err)
 		}
@@ -230,7 +230,7 @@ func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *te
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
 		dropEntityMutationsTable(t, db)
 
-		err := pc.applyWorkflowGateMutation(context.Background(), entityID, "workflow.ready", "g_ready", false)
+		err := pc.applyWorkflowGateMutation(testPipelineCoordinatorRunContext(t, pc), entityID, "workflow.ready", "g_ready", false)
 		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
 			t.Fatalf("applyWorkflowGateMutation err = %v, want entity_mutations failure", err)
 		}
@@ -244,7 +244,7 @@ func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *te
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
 		dropEntityMutationsTable(t, db)
 
-		err := pc.recordWorkflowEvidence(context.Background(), entityID, "research", map[string]any{"summary": "done"})
+		err := pc.recordWorkflowEvidence(testPipelineCoordinatorRunContext(t, pc), entityID, "research", map[string]any{"summary": "done"})
 		if err == nil || !strings.Contains(err.Error(), "entity_mutations") {
 			t.Fatalf("recordWorkflowEvidence err = %v, want entity_mutations failure", err)
 		}
@@ -268,7 +268,7 @@ func testMutationLoggingCoordinator(db *sql.DB) *PipelineCoordinator {
 
 func seedMutationLoggingInstance(t *testing.T, store *WorkflowInstanceStore, entityID string) {
 	t.Helper()
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "mutation-flow",

--- a/internal/runtime/pipeline/on_timeout_pipeline_test.go
+++ b/internal/runtime/pipeline/on_timeout_pipeline_test.go
@@ -67,7 +67,7 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 			},
 		},
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), instance); err != nil {
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), instance); err != nil {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
@@ -85,9 +85,9 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 		}),
 		CreatedAt: time.Now().UTC(),
 	}.WithEntityID("ent-001")
-	result, err := pc.executeAuthoritativeNodeHandler(context.Background(), timeoutEvt, workflowTriggerContext{
+	result, err := pc.executeAuthoritativeNodeHandler(testPipelineCoordinatorRunContext(t, pc), timeoutEvt, workflowTriggerContext{
 		Event: timeoutEvt,
-		State: pc.currentWorkflowState(context.Background(), "ent-001"),
+		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), "ent-001"),
 	})
 	if err != nil {
 		t.Fatalf("executeAuthoritativeNodeHandler: %v", err)

--- a/internal/runtime/pipeline/run_scoped_test_helpers_test.go
+++ b/internal/runtime/pipeline/run_scoped_test_helpers_test.go
@@ -1,0 +1,56 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+const testPipelineRunID = "77777777-7777-7777-7777-777777777777"
+
+func testPipelineRunContext(t *testing.T, db *sql.DB) context.Context {
+	t.Helper()
+	if db == nil {
+		t.Fatal("test pipeline run context requires db")
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), testPipelineRunID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, testPipelineRunID); err != nil {
+		t.Fatalf("seed pipeline test run: %v", err)
+	}
+	return ctx
+}
+
+func testPipelineRunContextNoSeed() context.Context {
+	return runtimecorrelation.WithRunID(context.Background(), testPipelineRunID)
+}
+
+func testWorkflowStoreRunContext(t *testing.T, store *WorkflowInstanceStore) context.Context {
+	t.Helper()
+	if store == nil {
+		t.Fatal("test workflow store run context requires store")
+	}
+	if store.db == nil {
+		return testPipelineRunContextNoSeed()
+	}
+	return testPipelineRunContext(t, store.db)
+}
+
+func testPipelineCoordinatorRunContext(t *testing.T, pc *PipelineCoordinator) context.Context {
+	t.Helper()
+	if pc == nil {
+		t.Fatal("test pipeline coordinator run context requires coordinator")
+	}
+	if pc.db != nil {
+		return testPipelineRunContext(t, pc.db)
+	}
+	if pc.workflowStore != nil {
+		return testWorkflowStoreRunContext(t, pc.workflowStore)
+	}
+	return testPipelineRunContextNoSeed()
+}

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
 )
 
@@ -290,6 +291,10 @@ func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
 }
 
 func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, forUpdate bool) (WorkflowInstance, bool, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return WorkflowInstance{}, false, err
+	}
 	var (
 		item         WorkflowInstance
 		gatesRaw     []byte
@@ -325,13 +330,14 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 		FROM entity_state es
 		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
 		WHERE es.entity_id = ANY($1::uuid[])
+		  AND es.run_id = $2::uuid
 		ORDER BY es.created_at DESC, es.entity_id DESC
 		LIMIT 1
 	`
 	if forUpdate {
 		query += ` FOR UPDATE OF es`
 	}
-	err := dbQueryRowContext(ctx, s.db, query, pqStringArray(keys)).Scan(
+	err = dbQueryRowContext(ctx, s.db, query, pqStringArray(keys), runID).Scan(
 		&item.InstanceID,
 		&item.WorkflowName,
 		&item.WorkflowVersion,
@@ -399,6 +405,10 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 }
 
 func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstance, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := dbQueryContext(ctx, s.db, `
 		SELECT
 			es.entity_id::text,
@@ -420,8 +430,9 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			es.updated_at
 		FROM entity_state es
 		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = $1::uuid
 		ORDER BY es.created_at ASC
-	`)
+	`, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -510,6 +521,10 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 }
 
 func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRef string, instance WorkflowInstance) error {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return err
+	}
 	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
 	if err != nil {
 		return err
@@ -522,7 +537,7 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			}
 		}()
 	}
-	previous, err := loadTrackedEntityStateProjection(ctx, tx, rowID)
+	previous, err := loadTrackedEntityStateProjection(ctx, tx, runID, rowID)
 	if err != nil {
 		return err
 	}
@@ -566,16 +581,16 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name,
+			run_id, entity_id, flow_instance, entity_type, slug, name,
 			current_state, gates, fields, accumulator, revision,
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2, $3, NULLIF($4,''), NULLIF($5,''),
-			$6, $7::jsonb, $8::jsonb, $9::jsonb, 1,
-			$10, now(), now()
+			$1::uuid, $2::uuid, $3, $4, NULLIF($5,''), NULLIF($6,''),
+			$7, $8::jsonb, $9::jsonb, $10::jsonb, 1,
+			$11, now(), now()
 		)
-		ON CONFLICT (entity_id) DO UPDATE SET
+		ON CONFLICT (run_id, entity_id) DO UPDATE SET
 			flow_instance = EXCLUDED.flow_instance,
 			entity_type = EXCLUDED.entity_type,
 			slug = EXCLUDED.slug,
@@ -587,7 +602,7 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			revision = entity_state.revision + 1,
 			entered_state_at = EXCLUDED.entered_state_at,
 			updated_at = now()
-	`, rowID, storageRef, projection.Control.EntityType, projection.Control.Slug, projection.Control.Name, instance.CurrentState,
+	`, runID, rowID, storageRef, projection.Control.EntityType, projection.Control.Slug, projection.Control.Name, instance.CurrentState,
 		jsonOrDefault(gatesJSON, "{}"),
 		jsonOrDefault(fieldsJSON, "{}"),
 		jsonOrDefault(accumulatorState, "{}"),
@@ -742,7 +757,7 @@ func oldValueOrNil(value any, ok bool) any {
 	return value
 }
 
-func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, entityID string) (runtimemutationlog.EntityStateProjection, error) {
+func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, runID, entityID string) (runtimemutationlog.EntityStateProjection, error) {
 	if tx == nil || strings.TrimSpace(entityID) == "" {
 		return runtimemutationlog.EntityStateProjection{}, nil
 	}
@@ -759,9 +774,10 @@ func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, entityID 
 			COALESCE(gates, '{}'::jsonb),
 			COALESCE(accumulator, '{}'::jsonb)
 		FROM entity_state
-		WHERE entity_id = $1::uuid
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
 		FOR UPDATE
-	`, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw)
+	`, runID, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw)
 	if err == sql.ErrNoRows {
 		return runtimemutationlog.EntityStateProjection{}, nil
 	}

--- a/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
@@ -18,7 +18,7 @@ func TestWorkflowInstanceStoreMutate_SerializesOverlappingMutations(t *testing.T
 	entityID := uuid.NewString()
 	seedWorkflowInstanceForMutationTest(t, store, entityID)
 
-	ctx := context.Background()
+	ctx := testWorkflowStoreRunContext(t, store)
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	secondEntered := make(chan struct{})
@@ -90,7 +90,7 @@ func TestUpdateEntityState_PreservesMutationCommittedWhileTransitionWaits(t *tes
 		entityLocks:   map[string]*sync.Mutex{},
 	}
 
-	ctx := context.Background()
+	ctx := testWorkflowStoreRunContext(t, store)
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	errCh := make(chan error, 2)
@@ -143,7 +143,7 @@ func TestWorkflowInstanceStoreMutate_PersistsSingleWriterUpdates(t *testing.T) {
 	entityID := uuid.NewString()
 	seedWorkflowInstanceForMutationTest(t, store, entityID)
 
-	if err := store.Mutate(context.Background(), entityID, func(instance *WorkflowInstance) {
+	if err := store.Mutate(testWorkflowStoreRunContext(t, store), entityID, func(instance *WorkflowInstance) {
 		setWorkflowGate(instance, "g_single")
 		appendWorkflowEvidence(instance, "audit", map[string]any{"writer": "single"})
 		instance.CurrentState = "processing"
@@ -151,7 +151,7 @@ func TestWorkflowInstanceStoreMutate_PersistsSingleWriterUpdates(t *testing.T) {
 		t.Fatalf("mutate: %v", err)
 	}
 
-	instance, ok, err := store.Load(context.Background(), entityID)
+	instance, ok, err := store.Load(testWorkflowStoreRunContext(t, store), entityID)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestWorkflowInstanceStoreMutate_IgnoresSchedulerOwnedTimerRows(t *testing.T
 	entityID := uuid.NewString()
 	storageRef := entityID
 	now := time.Now().UTC().Round(time.Microsecond)
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      storageRef,
 		WorkflowName:    "mutation-flow",
@@ -212,13 +212,13 @@ func TestWorkflowInstanceStoreMutate_IgnoresSchedulerOwnedTimerRows(t *testing.T
 		t.Fatalf("insert scheduler-owned timer row: %v", err)
 	}
 
-	if err := store.Mutate(context.Background(), entityID, func(instance *WorkflowInstance) {
+	if err := store.Mutate(testWorkflowStoreRunContext(t, store), entityID, func(instance *WorkflowInstance) {
 		instance.CurrentState = "active"
 	}); err != nil {
 		t.Fatalf("mutate with scheduler-owned timer row present: %v", err)
 	}
 
-	instance, ok, err := store.Load(context.Background(), entityID)
+	instance, ok, err := store.Load(testWorkflowStoreRunContext(t, store), entityID)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestWorkflowInstanceStoreMutate_IgnoresSchedulerOwnedTimerRows(t *testing.T
 
 func seedWorkflowInstanceForMutationTest(t *testing.T, store *WorkflowInstanceStore, entityID string) {
 	t.Helper()
-	if err := store.Upsert(context.Background(), WorkflowInstance{
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
 		WorkflowName:    "mutation-flow",

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -63,11 +63,11 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 		},
 	}
 
-	if err := store.Upsert(context.Background(), instance); err != nil {
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), instance); err != nil {
 		t.Fatalf("upsert workflow instance: %v", err)
 	}
 
-	loaded, ok, err := store.Load(context.Background(), storageRef)
+	loaded, ok, err := store.Load(testWorkflowStoreRunContext(t, store), storageRef)
 	if err != nil {
 		t.Fatalf("load workflow instance: %v", err)
 	}
@@ -148,11 +148,11 @@ func TestWorkflowInstanceStoreProjection_StaticRowsDoNotGainMaterializedFlowPath
 		StateBuckets: map[string]any{},
 	}
 
-	if err := store.Upsert(context.Background(), instance); err != nil {
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), instance); err != nil {
 		t.Fatalf("upsert static workflow instance: %v", err)
 	}
 
-	loaded, ok, err := store.Load(context.Background(), storageRef)
+	loaded, ok, err := store.Load(testWorkflowStoreRunContext(t, store), storageRef)
 	if err != nil {
 		t.Fatalf("load static workflow instance: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 
 			store := NewWorkflowInstanceStore(db)
 			storageRef := "storage-ref"
-			if err := store.Upsert(context.Background(), WorkflowInstance{
+			if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
 				InstanceID:      "inst-1",
 				StorageRef:      storageRef,
 				WorkflowName:    "projection-flow",
@@ -258,7 +258,7 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 				t.Fatalf("mutate malformed persisted shape: %v", err)
 			}
 
-			loaded, ok, err := store.Load(context.Background(), storageRef)
+			loaded, ok, err := store.Load(testWorkflowStoreRunContext(t, store), storageRef)
 			if tc.wantContains == "" {
 				if err != nil {
 					t.Fatalf("load with slash-only flow_path: %v", err)

--- a/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/testutil"
+)
+
+func TestWorkflowInstanceStore_RequiresRunContext(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := NewWorkflowInstanceStore(db)
+
+	err := store.Upsert(context.Background(), WorkflowInstance{
+		InstanceID:      uuid.NewString(),
+		StorageRef:      uuid.NewString(),
+		WorkflowName:    "run-scope",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+	})
+	if err == nil || !strings.Contains(err.Error(), "run_id is required") {
+		t.Fatalf("Upsert error = %v, want missing run_id", err)
+	}
+}
+
+func TestWorkflowInstanceStore_RunScopedCurrentStateRowsDoNotBleed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := NewWorkflowInstanceStore(db)
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	for _, runID := range []string{runA, runB} {
+		if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	ctxA := runtimecorrelation.WithRunID(context.Background(), runA)
+	ctxB := runtimecorrelation.WithRunID(context.Background(), runB)
+	for _, tc := range []struct {
+		ctx   context.Context
+		state string
+	}{
+		{ctx: ctxA, state: "source_state"},
+		{ctx: ctxB, state: "fork_state"},
+	} {
+		if err := store.Upsert(tc.ctx, WorkflowInstance{
+			InstanceID:      entityID,
+			StorageRef:      entityID,
+			WorkflowName:    "run-scope",
+			WorkflowVersion: "1.0.0",
+			CurrentState:    tc.state,
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", tc.state, err)
+		}
+	}
+	gotA, ok, err := store.Load(ctxA, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load source ok=%v err=%v", ok, err)
+	}
+	gotB, ok, err := store.Load(ctxB, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load fork ok=%v err=%v", ok, err)
+	}
+	if gotA.CurrentState != "source_state" || gotB.CurrentState != "fork_state" {
+		t.Fatalf("states = source:%q fork:%q", gotA.CurrentState, gotB.CurrentState)
+	}
+}

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -95,7 +95,7 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 		t.Fatal("expected coordinator")
 	}
 
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -112,7 +112,7 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
 
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "test-node", evt); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "test-node", evt); !handled {
 		t.Fatal("expected timer.scheduled handler to be handled")
 	}
 	if len(store.schedules) != 1 {
@@ -156,7 +156,7 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 		t.Fatal("expected coordinator")
 	}
 
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -177,7 +177,7 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	if !handled {
 		t.Fatal("expected timer.scheduled to be interceptable")
 	}
-	passThrough, emitted, err := pc.Intercept(context.Background(), evt)
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), evt)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestPersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel(t *t
 		TaskID:       "timer-a",
 	}
 
-	pc.persistWorkflowTimerCancellation(context.Background(), sc)
+	pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc)
 
 	if got := store.cancelOwned; got != 1 {
 		t.Fatalf("cancel owned calls = %d, want 1", got)
@@ -246,7 +246,7 @@ func TestPersistWorkflowTimerCancellation_StillCancelsSchedulerWhenClaimReleaseF
 		t.Fatalf("Register(schedule): %v", err)
 	}
 
-	pc.persistWorkflowTimerCancellation(context.Background(), sc)
+	pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc)
 
 	if got := store.cancelOwned; got != 1 {
 		t.Fatalf("cancel owned calls = %d, want 1", got)
@@ -277,7 +277,7 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -294,10 +294,10 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
 
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "dispatcher", evt); handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "dispatcher", evt); handled {
 		t.Fatal("dispatcher should not handle child/task.done")
 	}
-	instance, ok, err := pc.workflowStore.Load(context.Background(), "ent-001")
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), "ent-001")
 	if err != nil {
 		t.Fatalf("load workflow instance after wrong node execution: %v", err)
 	}
@@ -308,10 +308,10 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 		t.Fatalf("state after wrong node execution = %q, want waiting", got)
 	}
 
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "listener", evt); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "listener", evt); !handled {
 		t.Fatal("listener should handle child/task.done")
 	}
-	instance, ok, err = pc.workflowStore.Load(context.Background(), "ent-001")
+	instance, ok, err = pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), "ent-001")
 	if err != nil {
 		t.Fatalf("load workflow instance after listener execution: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 		t.Fatal("expected coordinator")
 	}
 
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -363,7 +363,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 		CreatedAt:   start,
 	}.WithEntityID("ent-001")
 
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "test-node", evt); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "test-node", evt); !handled {
 		t.Fatal("expected item.arrived handler to be handled")
 	}
 	if len(store.schedules) != 1 {
@@ -417,7 +417,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		t.Fatal("expected coordinator")
 	}
 
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -434,7 +434,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		Payload:     []byte(`{"entity_id":"ent-001","item_id":"a"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "test-node", evt); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "test-node", evt); !handled {
 		t.Fatal("expected item.arrived handler to be handled")
 	}
 
@@ -454,7 +454,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		}),
 		CreatedAt: time.Now().UTC(),
 	}.WithEntityID("ent-001")
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "test-node", timeoutEvt); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "test-node", timeoutEvt); !handled {
 		t.Fatal("expected accumulate.timeout handler to be handled")
 	}
 	if len(store.cancels) != 1 {
@@ -489,7 +489,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -506,10 +506,10 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
 
-	if handled := pc.executeNodeHandlerPlan(context.Background(), "child-worker", trigger); !handled {
+	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "child-worker", trigger); !handled {
 		t.Fatal("child-worker should handle work.requested through the input-pin alias")
 	}
-	instance, ok, err := pc.workflowStore.Load(context.Background(), "ent-001")
+	instance, ok, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), "ent-001")
 	if err != nil {
 		t.Fatalf("load workflow instance after child-worker execution: %v", err)
 	}
@@ -520,7 +520,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 		t.Fatalf("root state after child-worker execution = %q, want ready", got)
 	}
 
-	listenerCtx := withPipelineFlowScope(context.Background(), "child")
+	listenerCtx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child")
 	completion := events.Event{
 		ID:          "evt-child-work-completed",
 		Type:        events.EventType("child/work.completed"),
@@ -532,9 +532,9 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	if !ok {
 		t.Fatal("parent-listener handler missing for child/work.completed")
 	}
-	result, err := pc.executeNodeContractHandler(withPipelineFlowScope(context.Background(), "child"), "parent-listener", handler, workflowTriggerContext{
+	result, err := pc.executeNodeContractHandler(withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child"), "parent-listener", handler, workflowTriggerContext{
 		Event: completion,
-		State: pc.currentWorkflowState(withPipelineFlowScope(context.Background(), ""), "ent-001"),
+		State: pc.currentWorkflowState(withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), ""), "ent-001"),
 	}, false)
 	if err != nil {
 		t.Fatalf("executeNodeContractHandler: %v", err)
@@ -546,7 +546,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	if handled := pc.executeNodeHandlerPlan(listenerCtx, "parent-listener", completion); !handled {
 		t.Fatal("parent-listener should clear inherited child flow scope and handle child/work.completed")
 	}
-	instance, ok, err = pc.workflowStore.Load(context.Background(), "ent-001")
+	instance, ok, err = pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), "ent-001")
 	if err != nil {
 		t.Fatalf("load workflow instance after parent-listener execution: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 	if pc == nil {
 		t.Fatal("expected coordinator")
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      "ent-001",
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -597,7 +597,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
-	passThrough, emitted, err := pc.Intercept(context.Background(), completion)
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
 	}
@@ -634,7 +634,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 	const rootEntityID = "11111111-1111-1111-1111-111111111111"
 	childEntityID := FlowInstanceEntityID("child/inst-1")
 	grandchildEntityID := FlowInstanceEntityID("child/grandchild/inst-1")
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      childEntityID,
 		StorageRef:      "child/inst-1",
 		WorkflowName:    "child",
@@ -648,7 +648,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      grandchildEntityID,
 		StorageRef:      "child/grandchild/inst-1",
 		WorkflowName:    "grandchild",
@@ -663,7 +663,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
 
-	passThrough, emitted, err := pc.Intercept(context.Background(), (events.Event{
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), (events.Event{
 		ID:          "evt-nested-done",
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
@@ -680,7 +680,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 		t.Fatalf("emitted = %#v, want none without subject-link back-propagation", emitted)
 	}
 
-	child, found, err := pc.workflowStore.Load(context.Background(), childEntityID)
+	child, found, err := pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), childEntityID)
 	if err != nil {
 		t.Fatalf("load child instance: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 		childFlowPath = "child/9c38251c-4fba-4a18-9afc-774ede7cc866"
 	)
 	childRowID := FlowInstanceEntityID(childFlowPath)
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      rootEntityID,
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -727,7 +727,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	}); err != nil {
 		t.Fatalf("seed root instance: %v", err)
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      childRowID,
 		StorageRef:      childFlowPath,
 		WorkflowName:    "child",
@@ -747,7 +747,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	passThrough, emitted, err := pc.Intercept(context.Background(), (events.Event{
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), (events.Event{
 		ID:          "evt-nested-done-parent-targeted",
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
@@ -795,7 +795,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 		childFlowPath = "child/9c38251c-4fba-4a18-9afc-774ede7cc866"
 	)
 	childRowID := FlowInstanceEntityID(childFlowPath)
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      rootEntityID,
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
@@ -803,7 +803,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	}); err != nil {
 		t.Fatalf("seed root instance: %v", err)
 	}
-	if err := pc.workflowStore.Upsert(context.Background(), WorkflowInstance{
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      childRowID,
 		StorageRef:      childFlowPath,
 		WorkflowName:    "child",
@@ -822,7 +822,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 		t.Fatalf("BeginTx: %v", err)
 	}
 	t.Cleanup(func() { _ = tx.Rollback() })
-	ctx := WithPipelineSQLTxContext(context.Background(), tx)
+	ctx := WithPipelineSQLTxContext(testPipelineCoordinatorRunContext(t, pc), tx)
 
 	passThrough, emitted, err := pc.Intercept(ctx, (events.Event{
 		ID:          "evt-nested-done-tx",

--- a/internal/runtime/tools/executor_entity.go
+++ b/internal/runtime/tools/executor_entity.go
@@ -10,12 +10,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
 )
 
 var entityStateTopLevelFields = map[string]struct{}{
 	"entity_id":        {},
+	"run_id":           {},
 	"flow_instance":    {},
 	"entity_type":      {},
 	"name":             {},
@@ -59,7 +61,11 @@ func parseEntityID(raw any) (string, error) {
 }
 
 func loadEntityState(ctx context.Context, db *sql.DB, entityID string) (map[string]any, bool, error) {
-	row := db.QueryRowContext(ctx, entityStateRowQuery(" WHERE entity_id = $1::uuid"), entityID)
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return nil, false, err
+	}
+	row := db.QueryRowContext(ctx, entityStateRowQuery(" WHERE run_id = $1::uuid AND entity_id = $2::uuid"), identity.RunID, identity.EntityID)
 	var raw []byte
 	if err := row.Scan(&raw); err != nil {
 		if err == sql.ErrNoRows {
@@ -98,6 +104,7 @@ func entityStateRowQuery(suffix string) string {
 		FROM (
 			SELECT
 				entity_id::text AS entity_id,
+				run_id::text AS run_id,
 				COALESCE(flow_instance, '') AS flow_instance,
 				COALESCE(entity_type, '') AS entity_type,
 				name,
@@ -116,7 +123,7 @@ func entityStateRowQuery(suffix string) string {
 
 func queryEntityStateRows(ctx context.Context, db *sql.DB, suffix string, args ...any) ([]map[string]any, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT entity_id::text, COALESCE(flow_instance, ''), COALESCE(entity_type, ''), name, current_state,
+		SELECT entity_id::text, run_id::text, COALESCE(flow_instance, ''), COALESCE(entity_type, ''), name, current_state,
 		       COALESCE(gates, '{}'::jsonb), COALESCE(fields, '{}'::jsonb), COALESCE(accumulator, '{}'::jsonb),
 		       revision, entered_state_at, created_at, updated_at
 		FROM entity_state`+suffix, args...)
@@ -127,13 +134,14 @@ func queryEntityStateRows(ctx context.Context, db *sql.DB, suffix string, args .
 
 	out := make([]map[string]any, 0)
 	for rows.Next() {
-		var entityID, flowInstance, entityType, currentState string
+		var entityID, runID, flowInstance, entityType, currentState string
 		var name sql.NullString
 		var gatesRaw, fieldsRaw, accumulatorRaw []byte
 		var revision int
 		var enteredStateAt, createdAt, updatedAt time.Time
 		if err := rows.Scan(
 			&entityID,
+			&runID,
 			&flowInstance,
 			&entityType,
 			&name,
@@ -162,6 +170,7 @@ func queryEntityStateRows(ctx context.Context, db *sql.DB, suffix string, args .
 		}
 		row := map[string]any{
 			"entity_id":        entityID,
+			"run_id":           runID,
 			"flow_instance":    flowInstance,
 			"entity_type":      entityType,
 			"name":             nullStringValue(name),

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
 )
@@ -25,7 +26,10 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_search_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
+	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	if err != nil {
+		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_search_entities.run_context", true, err, "resolve entity_state run context")
+	}
 	currentStateFilter := strings.TrimSpace(asString(payload["current_state"]))
 	if currentStateFilter != "" {
 		args = append(args, currentStateFilter)
@@ -95,7 +99,10 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
+	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	if err != nil {
+		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_entities.run_context", true, err, "resolve entity_state run context")
+	}
 	whereClause := joinEntityStateWhere(filterSQL)
 	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
 	if err != nil {
@@ -158,7 +165,10 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 			return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_metrics.group_by", false, err, "validate group_by")
 		}
 	}
-	filterSQL, args := entityStateBaseQueryForContract(source, schema.Contract, payload, true)
+	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	if err != nil {
+		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_metrics.run_context", true, err, "resolve entity_state run context")
+	}
 	whereClause := joinEntityStateWhere(filterSQL)
 	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
 	if err != nil {
@@ -204,6 +214,24 @@ func entityStateBaseQueryForContract(source semanticview.Source, contract entity
 		clauses, args = appendEntityToolExistingFlowInstanceFilter(source, clauses, args, asString(payload["flow_instance"]))
 	}
 	return clauses, args
+}
+
+func entityStateBaseQueryForContractRun(ctx context.Context, source semanticview.Source, contract entityruntime.Contract, payload map[string]any, includeFlowInstance bool) ([]string, []any, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	clauses := []string{"run_id = $1::uuid"}
+	args := []any{runID}
+	flowRoot := entityReadFlowScopeRoot(source, contract)
+	if flowRoot != "" {
+		args = append(args, flowRoot, flowRoot+"/%")
+		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
+	}
+	if includeFlowInstance {
+		clauses, args = appendEntityToolExistingFlowInstanceFilter(source, clauses, args, asString(payload["flow_instance"]))
+	}
+	return clauses, args, nil
 }
 
 func entityReadFlowScopeRoot(source semanticview.Source, contract entityruntime.Contract) string {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
@@ -1918,11 +1919,26 @@ accounts:
 func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
 	_, db, _ := testutil.StartPostgres(t)
+	ensureEntityToolTestRun(t, db)
+	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
 		SQLDB:          db,
 		WorkflowSource: semanticview.Wrap(bundle),
 	})
-	return runtimetools.WithActor(context.Background(), actor), exec, db
+	return runtimetools.WithActor(ctx, actor), exec, db
+}
+
+const entityToolTestRunID = "11111111-1111-1111-1111-111111111111"
+
+func ensureEntityToolTestRun(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, entityToolTestRunID); err != nil {
+		t.Fatalf("seed entity tool test run: %v", err)
+	}
 }
 
 func asString(v any) string {
@@ -2106,16 +2122,16 @@ func seedEntityStateRow(t *testing.T, db *sql.DB, entityID, _ string, flowInstan
 	}
 	if _, err := db.Exec(`
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, name,
+			run_id, entity_id, flow_instance, entity_type, name,
 			current_state, gates, fields, accumulator, revision,
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2, $3, '',
-			$4, '{}'::jsonb, $5::jsonb, '{}'::jsonb, 1,
-			$6, $6, $6
+			$1::uuid, $2::uuid, $3, $4, '',
+			$5, '{}'::jsonb, $6::jsonb, '{}'::jsonb, 1,
+			$7, $7, $7
 		)
-	`, entityID, flowInstance, entityType, currentState, string(fieldsJSON), enteredAt); err != nil {
+	`, entityToolTestRunID, entityID, flowInstance, entityType, currentState, string(fieldsJSON), enteredAt); err != nil {
 		t.Fatalf("seed entity_state(%s): %v", entityID, err)
 	}
 }

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lib/pq"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	"swarm/internal/runtime/entityruntime"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -26,6 +27,10 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	entityID, err := parseEntityID(payload["entity_id"])
 	if err != nil {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.entity_id", false, err.Error())
+	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.run_context", true, err, "resolve entity_state run context")
 	}
 	if err := enforceEntityWriteOwnership(ctx, db, source, actor, entityID, e.runtimeLogSink()); err != nil {
 		return nil, err
@@ -90,11 +95,12 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 
 	var oldValue []byte
 	if err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $2::text[], 'null'::jsonb)
+		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $3::text[], 'null'::jsonb)
 		FROM entity_state
-		WHERE entity_id = $1::uuid
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
 		FOR UPDATE
-	`, entityID, pathArray).Scan(&oldValue); err != nil {
+	`, identity.RunID, identity.EntityID, pathArray).Scan(&oldValue); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, NewRuntimeError("not_found", "tool-executor", "exec_save_entity_field.lookup", false, "entity %s not found", entityID)
 		}
@@ -109,8 +115,9 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 			revision = revision + 1,
 			updated_at = now()
 		WHERE entity_id = $1::uuid
+		  AND run_id = $4::uuid
 		RETURNING revision
-	`, entityID, pathArray, string(valueJSON)).Scan(&revision); err != nil {
+	`, identity.EntityID, pathArray, string(valueJSON), identity.RunID).Scan(&revision); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.update", true, err, "save entity field %s", fieldName)
 	}
 	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
@@ -172,8 +179,12 @@ func enforceEntityWriteOwnership(ctx context.Context, db *sql.DB, source semanti
 	if flowRoot == "" || db == nil {
 		return nil
 	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return WrapRuntimeError("query_failed", "tool-executor", "entity_write_ownership.run_context", true, err, "resolve entity_state run context")
+	}
 	var flowInstance sql.NullString
-	if err := db.QueryRowContext(ctx, `SELECT COALESCE(flow_instance, '') FROM entity_state WHERE entity_id = $1::uuid`, entityID).Scan(&flowInstance); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(flow_instance, '') FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, identity.RunID, identity.EntityID).Scan(&flowInstance); err != nil {
 		if err == sql.ErrNoRows {
 			return nil
 		}
@@ -241,6 +252,10 @@ func (e *Executor) execCreateEntity(ctx context.Context, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.run_context", true, err, "resolve entity_state run context")
+	}
 	if strings.TrimSpace(asString(payload["entity_id"])) != "" {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_create_entity.entity_id", false, "entity_id is platform-minted and must not be supplied")
 	}
@@ -304,16 +319,16 @@ func (e *Executor) execCreateEntity(ctx context.Context, actor models.AgentConfi
 	}()
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, name,
+			run_id, entity_id, flow_instance, entity_type, name,
 			current_state, gates, fields, accumulator, revision,
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2, $3, NULLIF($4, ''),
-			$5, '{}'::jsonb, $6::jsonb, '{}'::jsonb, 1,
-			$7, $7, $7
+			$1::uuid, $2::uuid, $3, $4, NULLIF($5, ''),
+			$6, '{}'::jsonb, $7::jsonb, '{}'::jsonb, 1,
+			$8, $8, $8
 		)
-	`, entityID, flowInstance, contract.EntityType, name, currentState, string(fieldsJSON), now); err != nil {
+	`, runID, entityID, flowInstance, contract.EntityType, name, currentState, string(fieldsJSON), now); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.insert", false, err, "create entity %s", entityID)
 	}
 	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -289,9 +289,17 @@ func (m *DockerManager) RuntimeWorkspaceContainers(ctx context.Context) ([]strin
 	}
 
 	if m.db != nil {
-		runID, err := runtimecurrentstate.RequireRunID(ctx)
+		runID, ok, err := runtimecurrentstate.RunIDFromContext(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if !ok {
+			out := make([]string, 0, len(set))
+			for c := range set {
+				out = append(out, c)
+			}
+			sort.Strings(out)
+			return out, nil
 		}
 		rows, err := m.db.QueryContext(ctx, `
 			SELECT DISTINCT COALESCE(NULLIF(es.slug, ''), '')

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -14,6 +14,7 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -288,12 +289,17 @@ func (m *DockerManager) RuntimeWorkspaceContainers(ctx context.Context) ([]strin
 	}
 
 	if m.db != nil {
+		runID, err := runtimecurrentstate.RequireRunID(ctx)
+		if err != nil {
+			return nil, err
+		}
 		rows, err := m.db.QueryContext(ctx, `
 			SELECT DISTINCT COALESCE(NULLIF(es.slug, ''), '')
 			FROM entity_state es
 			JOIN flow_instances fi ON fi.instance_id = es.flow_instance
-			WHERE COALESCE(fi.config->>'instance_kind', '') = 'entity'
-		`)
+			WHERE es.run_id = $1::uuid
+			  AND COALESCE(fi.config->>'instance_kind', '') = 'entity'
+		`, runID)
 		if err != nil {
 			return nil, fmt.Errorf("list instance slugs: %w", err)
 		}
@@ -759,12 +765,17 @@ func (m *DockerManager) LookupEntitySlug(ctx context.Context, entityID string) (
 	if m.db == nil {
 		return SanitizeSlug(trimmedID), nil
 	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, trimmedID)
+	if err != nil {
+		return "", err
+	}
 	var slug string
 	if err := m.db.QueryRowContext(ctx, `
 		SELECT COALESCE(NULLIF(slug, ''), '')
 		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, trimmedID).Scan(&slug); err != nil {
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, identity.RunID, identity.EntityID).Scan(&slug); err != nil {
 		return "", fmt.Errorf("lookup instance slug: %w", err)
 	}
 	slug = SanitizeSlug(slug)

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/testutil"
 )
 
 func TestWorkspaceClassesForSource(t *testing.T) {
@@ -178,6 +179,21 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 	joined := strings.Join(created, " ")
 	if !strings.Contains(joined, "workspaces_flow_shared-work-001:/workspace") {
 		t.Fatalf("expected shared flow workspace volume, got %v", created)
+	}
+}
+
+func TestRuntimeWorkspaceContainersWithoutRunContextReturnsStaticContainers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	manager := NewDockerManager(db)
+	containers, err := manager.RuntimeWorkspaceContainers(context.Background())
+	if err != nil {
+		t.Fatalf("RuntimeWorkspaceContainers: %v", err)
+	}
+	got := strings.Join(containers, ",")
+	for _, expected := range []string{"swarm-scaffold", "swarm-system"} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("containers = %v, want %s", containers, expected)
+		}
 	}
 }
 

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
 )
@@ -327,12 +328,17 @@ func (s *PostgresStore) EnsureEntitySchema(ctx context.Context, entityID string)
 	if _, err := uuid.Parse(strings.TrimSpace(entityID)); err != nil {
 		return nil
 	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return fmt.Errorf("lookup entity slug: %w", err)
+	}
 	var slug string
-	err := s.DB.QueryRowContext(ctx, `
+	err = s.DB.QueryRowContext(ctx, `
 		SELECT COALESCE(NULLIF(slug, ''), '')
 		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, entityID).Scan(&slug)
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, identity.RunID, identity.EntityID).Scan(&slug)
 	if err != nil {
 		return fmt.Errorf("lookup entity slug: %w", err)
 	}

--- a/internal/store/entity_state_run_scope_test.go
+++ b/internal/store/entity_state_run_scope_test.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestEntityStateSchema_AllowsSameEntityIDInDifferentRuns(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	for _, runID := range []string{runA, runB} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		)
+		VALUES
+			($1::uuid, $3::uuid, 'flow/source', 'default', 'source_state', '{}'::jsonb, '{"side":"source"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($2::uuid, $3::uuid, 'flow/fork', 'default', 'fork_state', '{}'::jsonb, '{"side":"fork"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
+	`, runA, runB, entityID); err != nil {
+		t.Fatalf("insert run-scoped entity rows: %v", err)
+	}
+	var sourceState, forkState string
+	if err := db.QueryRowContext(ctx, `SELECT current_state FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, runA, entityID).Scan(&sourceState); err != nil {
+		t.Fatalf("load source row: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT current_state FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, runB, entityID).Scan(&forkState); err != nil {
+		t.Fatalf("load fork row: %v", err)
+	}
+	if sourceState != "source_state" || forkState != "fork_state" {
+		t.Fatalf("states = source:%q fork:%q", sourceState, forkState)
+	}
+}

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -36,6 +37,10 @@ func (s *PostgresStore) RecordInboundEvent(ctx context.Context, providerEventID,
 }
 
 func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, provider string) (runtime.InboundTarget, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtime.InboundTarget{}, err
+	}
 	entityKey = strings.TrimSpace(entityKey)
 	provider = strings.TrimSpace(strings.ToLower(provider))
 	if entityKey == "" {
@@ -44,10 +49,25 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 	if provider == "" {
 		return runtime.InboundTarget{}, fmt.Errorf("provider is required")
 	}
-	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	runID, ok, err := runtimecurrentstate.RunIDFromContext(ctx)
 	if err != nil {
 		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
 	}
+	if ok {
+		return s.resolveInboundTargetForRun(ctx, entityKey, provider, runID)
+	}
+	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
+		if caps.EntityState != SchemaFlavorCanonical {
+			return runtime.InboundTarget{}, unsupportedSchemaCapability("entity_state", caps.EntityState)
+		}
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: entity_state.run_id schema capability is required")
+	}
+
+	return s.resolveInboundTargetUnambiguous(ctx, entityKey, provider)
+}
+
+func (s *PostgresStore) resolveInboundTargetForRun(ctx context.Context, entityKey, provider, runID string) (runtime.InboundTarget, error) {
+	_ = provider
 
 	var target runtime.InboundTarget
 	const q = `
@@ -61,7 +81,7 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 		LIMIT 1
 	`
 	if err := s.DB.QueryRowContext(ctx, q, entityKey, runID).Scan(&target.EntityID, &target.EntitySlug); err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "no rows") {
+		if err == sql.ErrNoRows {
 			return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
 		}
 		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
@@ -70,6 +90,49 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 		target.EntitySlug = entityKey
 	}
 	return target, nil
+}
+
+func (s *PostgresStore) resolveInboundTargetUnambiguous(ctx context.Context, entityKey, provider string) (runtime.InboundTarget, error) {
+	_ = provider
+
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			entity_id::text,
+			COALESCE(NULLIF(slug, ''), ''),
+			run_id::text
+		FROM entity_state
+		WHERE slug = $1 OR entity_id::text = $1
+		ORDER BY CASE WHEN slug = $1 THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
+		LIMIT 2
+	`, entityKey)
+	if err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
+	}
+	defer rows.Close()
+
+	var matches []runtime.InboundTarget
+	for rows.Next() {
+		var target runtime.InboundTarget
+		var runID string
+		if err := rows.Scan(&target.EntityID, &target.EntitySlug, &runID); err != nil {
+			return runtime.InboundTarget{}, fmt.Errorf("scan inbound target: %w", err)
+		}
+		if target.EntitySlug == "" {
+			target.EntitySlug = entityKey
+		}
+		matches = append(matches, target)
+	}
+	if err := rows.Err(); err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("iterate inbound targets: %w", err)
+	}
+	switch len(matches) {
+	case 0:
+		return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
+	case 1:
+		return matches[0], nil
+	default:
+		return runtime.InboundTarget{}, fmt.Errorf("entity key %s is ambiguous across runs; run_id is required", entityKey)
+	}
 }
 
 func (s *PostgresStore) PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error) {

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -9,6 +9,7 @@ import (
 
 	"swarm/internal/runtime"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 )
 
 func (s *PostgresStore) RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
@@ -43,6 +44,10 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 	if provider == "" {
 		return runtime.InboundTarget{}, fmt.Errorf("provider is required")
 	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
+	}
 
 	var target runtime.InboundTarget
 	const q = `
@@ -50,12 +55,12 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 			entity_id::text,
 			COALESCE(NULLIF(slug, ''), '')
 		FROM entity_state
-		WHERE slug = $1
-		   OR entity_id::text = $1
+		WHERE run_id = $2::uuid
+		  AND (slug = $1 OR entity_id::text = $1)
 		ORDER BY CASE WHEN slug = $1 THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
 		LIMIT 1
 	`
-	if err := s.DB.QueryRowContext(ctx, q, entityKey).Scan(&target.EntityID, &target.EntitySlug); err != nil {
+	if err := s.DB.QueryRowContext(ctx, q, entityKey, runID).Scan(&target.EntityID, &target.EntitySlug); err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "no rows") {
 			return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
 		}

--- a/internal/store/manager_error_branches_test.go
+++ b/internal/store/manager_error_branches_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/testutil"
 )
@@ -15,7 +16,8 @@ import (
 func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	const runID = "44444444-4444-4444-4444-444444444444"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
 	// UpsertAgent: missing id.
 	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{Config: runtimeactors.AgentConfig{}}); err == nil {
@@ -25,6 +27,13 @@ func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
 	// EnsureEntitySchema: invalid/missing slug.
 	vid := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
 		VALUES ('entity-no-slug', 'test', 'static', '{}'::jsonb, 'active', now())
 	`); err != nil {
@@ -32,13 +41,13 @@ func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, current_state,
+			run_id, entity_id, flow_instance, entity_type, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		) VALUES (
-			$1::uuid, 'entity-no-slug', 'default', 'operating',
+			$1::uuid, $2::uuid, 'entity-no-slug', 'default', 'operating',
 			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 		)
-	`, vid); err != nil {
+	`, runID, vid); err != nil {
 		t.Fatalf("seed entity state: %v", err)
 	}
 	if err := pg.EnsureEntitySchema(ctx, vid); err == nil {

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -17,6 +17,8 @@ import (
 	"swarm/internal/testutil"
 )
 
+const retryPolicyEntityStateRunID = "22222222-2222-2222-2222-222222222222"
+
 func TestUpsertEventReceipt_DeadLettersAfterOneRetry_V2(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()
@@ -929,6 +931,13 @@ func seedEntityAndAgent(t *testing.T, ctx context.Context, pg *store.PostgresSto
 
 	entityID = uuid.NewString()
 	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, retryPolicyEntityStateRunID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
 		VALUES ('retry-policy-entity', 'test', 'static', '{"instance_kind":"entity","workflow_version":"v1"}'::jsonb, 'active', now())
 	`); err != nil {
@@ -936,12 +945,12 @@ func seedEntityAndAgent(t *testing.T, ctx context.Context, pg *store.PostgresSto
 	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name, current_state,
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		)
-		VALUES ($1::uuid, 'retry-policy-entity', 'default', 'retry-policy', 'Store Retry Policy Test', 'approved',
+		VALUES ($1::uuid, $2::uuid, 'retry-policy-entity', 'default', 'retry-policy', 'Store Retry Policy Test', 'approved',
 			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
-	`, entityID); err != nil {
+	`, retryPolicyEntityStateRunID, entityID); err != nil {
 		t.Fatalf("seed entity: %v", err)
 	}
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -161,6 +161,85 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return fmt.Errorf("drop deprecated entity_state.subject_id column: %w", err)
 		}
 	}
+	if !catalog.hasColumns("entity_state", "run_id") {
+		var rows int
+		if err := s.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_state`).Scan(&rows); err != nil {
+			return fmt.Errorf("inspect entity_state rows before run_id migration: %w", err)
+		}
+		if rows > 0 {
+			return fmt.Errorf("entity_state.run_id migration requires explicit run ownership; refusing to infer run_id for %d existing rows", rows)
+		}
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE entity_state ADD COLUMN run_id UUID NOT NULL REFERENCES runs(run_id)`); err != nil {
+			return fmt.Errorf("add entity_state.run_id column: %w", err)
+		}
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		DO $$
+		DECLARE pk_name TEXT;
+		BEGIN
+			SELECT c.conname
+			INTO pk_name
+			FROM pg_constraint c
+			WHERE c.conrelid = 'entity_state'::regclass
+			  AND c.contype = 'p'
+			  AND NOT (
+				c.conkey = ARRAY[
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'entity_state'::regclass AND attname = 'run_id'),
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'entity_state'::regclass AND attname = 'entity_id')
+				]
+			  );
+			IF pk_name IS NOT NULL THEN
+				EXECUTE format('ALTER TABLE entity_state DROP CONSTRAINT %I', pk_name);
+			END IF;
+			IF NOT EXISTS (
+				SELECT 1
+				FROM pg_constraint c
+				WHERE c.conrelid = 'entity_state'::regclass
+				  AND c.contype = 'p'
+				  AND c.conkey = ARRAY[
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'entity_state'::regclass AND attname = 'run_id'),
+					(SELECT attnum FROM pg_attribute WHERE attrelid = 'entity_state'::regclass AND attname = 'entity_id')
+				  ]
+			) THEN
+				ALTER TABLE entity_state ADD PRIMARY KEY (run_id, entity_id);
+			END IF;
+		END
+		$$;
+	`); err != nil {
+		return fmt.Errorf("ensure entity_state run-scoped primary key: %w", err)
+	}
+	for _, stmt := range []string{
+		`DROP INDEX IF EXISTS idx_entity_flow`,
+		`DROP INDEX IF EXISTS idx_entity_state`,
+		`DROP INDEX IF EXISTS idx_entity_type`,
+		`DROP INDEX IF EXISTS idx_entity_slug`,
+	} {
+		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure entity_state run-scoped indexes: %w", err)
+		}
+	}
+	catalog, err = loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	indexes := []struct {
+		stmt    string
+		columns []string
+	}{
+		{`CREATE INDEX IF NOT EXISTS idx_entity_flow ON entity_state(run_id, flow_instance, current_state)`, []string{"run_id", "flow_instance", "current_state"}},
+		{`CREATE INDEX IF NOT EXISTS idx_entity_state ON entity_state(run_id, current_state)`, []string{"run_id", "current_state"}},
+		{`CREATE INDEX IF NOT EXISTS idx_entity_type ON entity_state(run_id, entity_type)`, []string{"run_id", "entity_type"}},
+		{`CREATE INDEX IF NOT EXISTS idx_entity_slug ON entity_state(run_id, slug) WHERE slug IS NOT NULL`, []string{"run_id", "slug"}},
+		{`CREATE INDEX IF NOT EXISTS idx_entity_cross_run ON entity_state(entity_id)`, []string{"entity_id"}},
+	}
+	for _, index := range indexes {
+		if !catalog.hasColumns("entity_state", index.columns...) {
+			continue
+		}
+		if _, err := s.DB.ExecContext(ctx, index.stmt); err != nil {
+			return fmt.Errorf("ensure entity_state run-scoped indexes: %w", err)
+		}
+	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
 }

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/config"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/testutil"
 )
@@ -74,12 +75,20 @@ func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPostgresStore: %v", err)
 	}
-	ctx := context.Background()
+	const runID = "55555555-5555-5555-5555-555555555555"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	if err := pg.Ping(ctx); err != nil {
 		t.Fatalf("Ping: %v", err)
 	}
 
 	entityID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
 		VALUES ('testco', 'test', 'static', '{"instance_kind":"entity","workflow_version":"v1"}'::jsonb, 'active', now())
@@ -88,13 +97,13 @@ func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name, current_state,
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		) VALUES (
-			$1::uuid, 'testco', 'default', 'testco', 'TestCo', 'active',
+			$1::uuid, $2::uuid, 'testco', 'default', 'testco', 'TestCo', 'active',
 			'{}'::jsonb, '{"users_total":10,"mrr":1234}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 		)
-	`, entityID); err != nil {
+	`, runID, entityID); err != nil {
 		t.Fatalf("seed entity state: %v", err)
 	}
 

--- a/internal/store/postgres_smoke_test.go
+++ b/internal/store/postgres_smoke_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/testutil"
@@ -17,10 +18,18 @@ import (
 func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	const runID = "66666666-6666-6666-6666-666666666666"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
 	// Seed entity.
 	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
 		VALUES ('testco', 'test', 'static', '{"instance_kind":"entity","workflow_version":"v1"}'::jsonb, 'active', now())
@@ -29,13 +38,13 @@ func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name, current_state,
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		) VALUES (
-			$1::uuid, 'testco', 'default', 'testco', 'TestCo', 'operating',
+			$1::uuid, $2::uuid, 'testco', 'default', 'testco', 'TestCo', 'operating',
 			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 		)
-	`, entityID); err != nil {
+	`, runID, entityID); err != nil {
 		t.Fatalf("seed entity state: %v", err)
 	}
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3337,6 +3337,51 @@ func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
 	_ = time.Second
 }
 
+func TestManagerStore_LoadRoutingRules_DoesNotJoinRunScopedEntityState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, runA, runB); err != nil {
+		t.Fatalf("insert runs: %v", err)
+	}
+	for _, runID := range []string{runA, runB} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name, current_state
+			)
+			VALUES ($1::uuid, $2::uuid, 'shared-flow', 'default', 'shared', 'Shared', 'active')
+		`, runID, entityID); err != nil {
+			t.Fatalf("insert entity_state for run %s: %v", runID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance,
+			is_wildcard, is_materialized, status, created_at
+		)
+		VALUES ('work.*', 'agent', 'worker', 'shared-flow', true, false, 'active', now())
+	`); err != nil {
+		t.Fatalf("insert routing rule: %v", err)
+	}
+
+	rules, err := pg.LoadRoutingRules(ctx)
+	if err != nil {
+		t.Fatalf("LoadRoutingRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("LoadRoutingRules returned %d rules, want 1: %#v", len(rules), rules)
+	}
+	if rules[0].EntityID != "" {
+		t.Fatalf("LoadRoutingRules entity_id = %q, want empty persisted route identity", rules[0].EntityID)
+	}
+}
+
 func TestManagerStore_EnsureEntitySchema(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -14,6 +14,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	llm "swarm/internal/runtime/llm"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -22,6 +23,8 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/testutil"
 )
+
+const specEntityStateRunID = "33333333-3333-3333-3333-333333333333"
 
 func resetAgentSessionsSpecTable(t *testing.T, ctx context.Context, pg *PostgresStore) {
 	t.Helper()
@@ -1033,6 +1036,13 @@ func TestPostgresStore_AgentSessionSuccessorInvariantsRejectCrossScopeAndLegacyW
 
 func seedSpecEntityState(t *testing.T, ctx context.Context, db execer, entityID, flowInstance, slug, name, state string) {
 	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, specEntityStateRunID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
 	if strings.TrimSpace(flowInstance) == "" {
 		flowInstance = strings.TrimSpace(slug)
 	}
@@ -1051,14 +1061,14 @@ func seedSpecEntityState(t *testing.T, ctx context.Context, db execer, entityID,
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
-			entity_id, flow_instance, entity_type, slug, name, current_state,
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
 			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
 		) VALUES (
-			$1::uuid, $2, 'default', NULLIF($3,''), NULLIF($4,''), $5,
+			$1::uuid, $2::uuid, $3, 'default', NULLIF($4,''), NULLIF($5,''), $6,
 			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
 		)
-		ON CONFLICT (entity_id) DO NOTHING
-	`, entityID, flowInstance, slug, name, state); err != nil {
+		ON CONFLICT (run_id, entity_id) DO NOTHING
+	`, specEntityStateRunID, entityID, flowInstance, slug, name, state); err != nil {
 		t.Fatalf("seed entity state: %v", err)
 	}
 }
@@ -3227,7 +3237,7 @@ func TestManagerStore_MarkEventDeliveryInProgress_RequiresIDs(t *testing.T) {
 func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
 	entityID := uuid.NewString()
 	seedSpecEntityState(t, ctx, db, entityID, "v-flow", "v", "V", "operating")
@@ -3276,7 +3286,7 @@ func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
 func TestManagerStore_EnsureEntitySchema(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
 	entityID := uuid.NewString()
 	seedSpecEntityState(t, ctx, db, entityID, "entity-schema-flow", "vslug", "TestCo", "operating")
@@ -3289,7 +3299,7 @@ func TestManagerStore_EnsureEntitySchema(t *testing.T) {
 func TestManagerStore_RoutingRules_DeactivateAndBootstrapVersion(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
 	entityID := uuid.NewString()
 	seedSpecEntityState(t, ctx, db, entityID, "vslug-flow", "vslug", "V", "operating")
@@ -5253,7 +5263,7 @@ func TestManagerStore_LoadAgents_FailsClosedWithoutHotPathSchemaRepair(t *testin
 func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 	resetAgentSessionsSpecTable(t, ctx, pg)
 
 	entityID := uuid.NewString()

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2123,6 +2123,60 @@ func TestPostgresStore_Inbound_ValidationAndNotFound(t *testing.T) {
 	}
 }
 
+func TestPostgresStore_Inbound_ResolveWithoutRunContextAllowsUnambiguousTarget(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state
+		)
+		VALUES ($1::uuid, $2::uuid, 'root', 'default', 'customer-a', 'Customer A', 'active')
+	`, runID, entityID); err != nil {
+		t.Fatalf("insert entity state: %v", err)
+	}
+
+	target, err := s.ResolveInboundTarget(ctx, "customer-a", "chat")
+	if err != nil {
+		t.Fatalf("ResolveInboundTarget: %v", err)
+	}
+	if target.EntityID != entityID || target.EntitySlug != "customer-a" {
+		t.Fatalf("target = %+v, want entity=%s slug=customer-a", target, entityID)
+	}
+}
+
+func TestPostgresStore_Inbound_ResolveWithoutRunContextRejectsAmbiguousTarget(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')`, runA, runB); err != nil {
+		t.Fatalf("insert runs: %v", err)
+	}
+	for _, runID := range []string{runA, runB} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name, current_state
+			)
+			VALUES ($1::uuid, $2::uuid, 'root', 'default', 'customer-a', 'Customer A', 'active')
+		`, runID, entityID); err != nil {
+			t.Fatalf("insert entity state for run %s: %v", runID, err)
+		}
+	}
+
+	_, err := s.ResolveInboundTarget(ctx, "customer-a", "chat")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous across runs") {
+		t.Fatalf("ResolveInboundTarget error = %v, want ambiguous across runs", err)
+	}
+}
+
 func TestPostgresStore_Inbound_PurgeDeletes(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	s := &PostgresStore{DB: db}

--- a/internal/store/routing_rules_store.go
+++ b/internal/store/routing_rules_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimemanager "swarm/internal/runtime/manager"
 )
 
@@ -163,12 +164,17 @@ func (s *PostgresStore) DeactivateRoutingRulesByEntity(ctx context.Context, enti
 }
 
 func routingRuleFlowInstance(ctx context.Context, s *PostgresStore, entityID string) (string, error) {
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return "", fmt.Errorf("lookup routing rule flow instance: %w", err)
+	}
 	var flowInstance string
 	if err := s.DB.QueryRowContext(ctx, `
 		SELECT flow_instance
 		FROM entity_state
-		WHERE entity_id = $1::uuid
-	`, entityID).Scan(&flowInstance); err != nil {
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, identity.RunID, identity.EntityID).Scan(&flowInstance); err != nil {
 		return "", fmt.Errorf("lookup routing rule flow instance: %w", err)
 	}
 	flowInstance = strings.TrimSpace(flowInstance)

--- a/internal/store/routing_rules_store.go
+++ b/internal/store/routing_rules_store.go
@@ -97,7 +97,7 @@ func (s *PostgresStore) UpsertRoutingRule(ctx context.Context, rule runtimemanag
 func (s *PostgresStore) LoadRoutingRules(ctx context.Context) ([]runtimemanager.PersistedRoutingRule, error) {
 	const q = `
 		SELECT
-			COALESCE(es.entity_id::text, ''),
+			'',
 			rr.event_pattern,
 			rr.subscriber_id,
 			rr.subscriber_id,
@@ -106,7 +106,6 @@ func (s *PostgresStore) LoadRoutingRules(ctx context.Context) ([]runtimemanager.
 			COALESCE(rr.source_flow, ''),
 			0
 		FROM routing_rules rr
-		LEFT JOIN entity_state es ON es.flow_instance = rr.flow_instance
 		WHERE rr.status = 'active'
 		  AND rr.subscriber_type = 'agent'
 		  AND rr.is_materialized = false

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -42,10 +42,12 @@ type ConversationSchemaCapabilities struct {
 
 type StoreSchemaCapabilities struct {
 	Agents        SchemaFlavor
+	EntityState   SchemaFlavor
 	Schedules     SchemaFlavor
 	Mailbox       SchemaFlavor
 	Events        EventSchemaCapabilities
 	Conversations ConversationSchemaCapabilities
+	EntityRunID   bool
 }
 
 type schemaColumnCatalog struct {
@@ -133,6 +135,19 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			"started_at", "last_active_at",
 		},
 	)
+	caps.EntityState = detectSchemaFlavor(catalog, "entity_state",
+		[]string{
+			"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name",
+			"current_state", "gates", "fields", "accumulator", "revision",
+			"entered_state_at", "created_at", "updated_at",
+		},
+		[]string{
+			"entity_id", "flow_instance", "entity_type", "slug", "name",
+			"current_state", "gates", "fields", "accumulator", "revision",
+			"entered_state_at", "created_at", "updated_at",
+		},
+	)
+	caps.EntityRunID = catalog.hasColumns("entity_state", "run_id")
 
 	caps.Events = EventSchemaCapabilities{
 		Log: detectSchemaFlavor(catalog, "events",

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -40,6 +40,11 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		"outcome", "reason_code", "state_before", "state_after", "side_effects",
 		"duration_ms", "idempotency_key", "processed_at",
 	)
+	addColumns("entity_state",
+		"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name",
+		"current_state", "gates", "fields", "accumulator", "revision",
+		"entered_state_at", "created_at", "updated_at",
+	)
 	addColumns("agent_sessions",
 		"session_id", "run_id", "agent_id", "entity_id", "flow_instance", "scope_key", "scope",
 		"conversation", "turn_count", "runtime_mode", "runtime_state", "lease_holder",
@@ -83,6 +88,9 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	}
 	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
 		t.Fatalf("delivery caps = %+v", caps.Events)
+	}
+	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
+		t.Fatalf("entity_state caps = %+v run_id=%v", caps.EntityState, caps.EntityRunID)
 	}
 	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
 		t.Fatalf("session caps = %+v", caps.Conversations)

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -2,9 +2,13 @@ package store
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	stdruntime "runtime"
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
 	runtimecontracts "swarm/internal/runtime/contracts"
 )
 
@@ -128,6 +132,48 @@ func TestGeneratePlatformTableDDLs_ExtractsInlineUniquePartialIndex(t *testing.T
 	}
 	if got := plans[0].Statements[1]; !strings.Contains(got, `CREATE UNIQUE INDEX IF NOT EXISTS "agent_sessions_nonterminated_unique" ON "agent_sessions"(agent_id, scope_key) WHERE status <> 'terminated'`) {
 		t.Fatalf("unexpected unique partial index statement: %q", got)
+	}
+}
+
+func TestPlatformSpecEntityStateUsesRunScopedIdentity(t *testing.T) {
+	_, file, _, _ := stdruntime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	var entityState SchemaTableDDL
+	for _, plan := range plans {
+		if plan.TableName == "entity_state" {
+			entityState = plan
+			break
+		}
+	}
+	if entityState.TableName == "" {
+		t.Fatal("entity_state ddl plan missing")
+	}
+	joined := strings.Join(entityState.Statements, "\n")
+	for _, want := range []string{
+		"run_id            UUID NOT NULL REFERENCES runs(run_id)",
+		"entity_id         UUID NOT NULL",
+		"PRIMARY KEY (run_id, entity_id)",
+		`CREATE INDEX IF NOT EXISTS "idx_entity_flow" ON "entity_state"(run_id, flow_instance, current_state)`,
+		`CREATE INDEX IF NOT EXISTS "idx_entity_cross_run" ON "entity_state"(entity_id)`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("entity_state ddl missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "entity_id         UUID PRIMARY KEY") {
+		t.Fatalf("entity_state ddl kept global entity_id primary key:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #550.

This PR implements the approved first slice for run-isolated current entity-state ownership. It promotes `entity_state` from global `entity_id` identity to run-scoped `(run_id, entity_id)` identity, introduces the canonical current-state run-context owner, and moves or fail-closes the current live-state consumers covered by the gate.

It does not implement mutating timestamp-fork execution: no fork run creation, source freeze, live-state copy, redelivery/resume, or contract-swap execution is added.

## Governing refs and context

- Issue #550 pre-audit and independent gate: `approved as first slice`.
- Parent architecture tracker: #549.
- Prior fork planner/admission context: #536 and #545.
- Replay sibling context: #547.
- Authoritative spec promoted in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Watchlist node: `runtime_operations.run_isolated_current_state_ownership` in `docs/watchlists/runtime-operations.yaml`.

## Semantic migration

New canonical owner:

- `internal/runtime/currentstate` owns explicit current-state run identity validation.
- `entity_state` current-state identity is now `(run_id, entity_id)`.
- `entity_mutations.run_id` remains append-only reconstruction/history, not live current-state identity.

Old producer/reader/writer paths now invalid or moved:

- Global `entity_state` primary key on `entity_id`.
- `INSERT INTO entity_state` without `run_id`.
- `ON CONFLICT (entity_id)` current-state upserts.
- Live current-state reads/writes by `entity_id` alone.
- Mutation-log writes that synthesize a run id when current-state context is missing.

Production paths checked and moved/fail-closed:

- `WorkflowInstanceStore` load/list/upsert/mutation projection.
- pipeline entity-state counts.
- entity tools: create/get/search/query/metrics/save and ownership checks.
- mutation log insert contract.
- inbound target resolution, routing rules, agent schema check, workspace, digest, and budget current-state readers.
- cataloge2e/conformance proof surfaces and test harnesses.
- run-fork planner remains read-only over `entity_mutations` and is not a state materialization owner.

Migration completeness:

- Complete for the #550 first-slice model foundation.
- Parent #549 remains open for mutating fork execution and sibling blockers: state materialization/copy, delivery/replay, timers/routes/sessions/turns, pending deliveries, and operator/debug comparison surfaces.

## Proof

Focused tests:

```sh
go test ./internal/runtime/currentstate ./internal/runtime/mutationlog ./internal/store ./internal/runtime/pipeline ./internal/runtime/tools ./internal/runtime/cataloge2e ./internal/runtime/conformance ./internal/digest ./cmd/swarm -count=1
go test ./internal/store -run 'TestRunForkPlanner' -count=1
go test ./cmd/swarm -run 'TestRunForkCommand_DryRunUsesCanonicalPlannerJSON' -count=1
go test ./internal/store -run 'TestPlatformSpecEntityStateUsesRunScopedIdentity|TestGeneratePlatformTableDDLs' -count=1
```

Full suite:

```sh
go test ./... -count=1
```

Additional static check:

```sh
git diff --cached --check
```