### PR TITLE
[agent-d][issue #555] Gate global entity tool delivery

### DIFF
--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -228,6 +228,65 @@ vertical:
 	}
 }
 
+func TestToolDefinitionsForActor_PreserveNonPlatformEntityToolNameOverrideWithoutActorContract(t *testing.T) {
+	lifecycle := models.AgentConfig{
+		ID:           "lifecycle-coordinator",
+		Role:         "lifecycle-coordinator",
+		SessionScope: "global",
+		Tools:        []string{"get_entity"},
+	}
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"lifecycle": {
+			AgentsYAML: entityToolAgentYAML(lifecycle),
+			ToolsYAML: `
+get_entity:
+  description: Lifecycle-owned external lookup override.
+  handler_type: http
+  input_schema:
+    type: object
+    properties:
+      query:
+        type: string
+    required: [query]
+  http:
+    method: POST
+    url: https://example.invalid/get_entity
+`,
+		},
+		"validation": {
+			EntitiesYAML: `
+validation_case:
+  status: text
+`,
+			AgentsYAML: entityToolAgentYAML(models.AgentConfig{ID: "validator", Role: "validator"}),
+		},
+	})
+
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		WorkflowSource: semanticview.Wrap(bundle),
+	})
+	defs := exec.ToolDefinitionsForActor(lifecycle)
+	defByName := make(map[string]llm.ToolDefinition, len(defs))
+	for _, def := range defs {
+		defByName[def.Name] = def
+	}
+	def, ok := defByName["get_entity"]
+	if !ok {
+		t.Fatalf("expected non-platform get_entity override to remain visible, got %v", toolDefinitionNames(defs))
+	}
+	if got := strings.TrimSpace(def.Description); got != "Lifecycle-owned external lookup override." {
+		t.Fatalf("get_entity description = %q, want scoped override", got)
+	}
+	schema, _ := def.Schema.(map[string]any)
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["query"]; !ok {
+		t.Fatalf("get_entity override schema = %#v, want query property", schema)
+	}
+	if _, ok := props["entity_id"]; ok {
+		t.Fatalf("get_entity override schema = %#v, should not be platform entity schema", schema)
+	}
+}
+
 func containsAnyString(values []any, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -192,6 +192,42 @@ signal:
 	}
 }
 
+func TestToolDefinitionsForActor_HideEntityScopedUniversalToolsWithoutActorContract(t *testing.T) {
+	lifecycle := models.AgentConfig{
+		ID:           "lifecycle-coordinator",
+		Role:         "lifecycle-coordinator",
+		SessionScope: "global",
+		Tools:        []string{"schedule"},
+	}
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"validation": {
+			EntitiesYAML: `
+validation_case:
+  status: text
+`,
+			AgentsYAML: entityToolAgentYAML(models.AgentConfig{ID: "validator", Role: "validator"}),
+		},
+		"scoring": {
+			EntitiesYAML: `
+vertical:
+  status: text
+`,
+			AgentsYAML: entityToolAgentYAML(models.AgentConfig{ID: "scorer", Role: "scorer"}),
+		},
+	})
+
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		WorkflowSource: semanticview.Wrap(bundle),
+	})
+	defs := exec.ToolDefinitionsForActor(lifecycle)
+	names := toolDefinitionNames(defs)
+	for _, toolName := range []string{"get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"} {
+		if containsString(names, toolName) {
+			t.Fatalf("expected %s to be hidden for actor with no entity contract/read scope, got %v", toolName, names)
+		}
+	}
+}
+
 func containsAnyString(values []any, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -209,6 +245,14 @@ func anyStrings(values []any) []string {
 		}
 	}
 	return out
+}
+
+func toolDefinitionNames(defs []llm.ToolDefinition) []string {
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Name)
+	}
+	return names
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -2049,6 +2049,7 @@ type entityToolFlowFixture struct {
 	TypesYAML    string
 	EntitiesYAML string
 	AgentsYAML   string
+	ToolsYAML    string
 }
 
 func loadWave1EntityToolMultiFlowBundle(t *testing.T, flows map[string]entityToolFlowFixture) *runtimecontracts.WorkflowContractBundle {
@@ -2101,6 +2102,9 @@ terminal_states: [finished, closed, killed]
 		}
 		if strings.TrimSpace(fixture.AgentsYAML) != "" {
 			writeEntityToolFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), fixture.AgentsYAML)
+		}
+		if strings.TrimSpace(fixture.ToolsYAML) != "" {
+			writeEntityToolFixtureFile(t, filepath.Join(root, "flows", flowID, "tools.yaml"), fixture.ToolsYAML)
 		}
 	}
 

--- a/internal/runtime/tools/policy.go
+++ b/internal/runtime/tools/policy.go
@@ -12,11 +12,28 @@ var universalRuntimeTools = map[string]struct{}{
 	"query_metrics":     {},
 }
 
+var entityScopedUniversalRuntimeTools = map[string]struct{}{
+	"get_entity":        {},
+	"save_entity_field": {},
+	"query_entities":    {},
+	"search_entities":   {},
+	"query_metrics":     {},
+}
+
 func IsUniversal(toolName string) bool {
 	toolName = strings.TrimSpace(toolName)
 	if toolName == "" {
 		return false
 	}
 	_, ok := universalRuntimeTools[toolName]
+	return ok
+}
+
+func isEntityScopedUniversalRuntimeTool(toolName string) bool {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return false
+	}
+	_, ok := entityScopedUniversalRuntimeTools[toolName]
 	return ok
 }

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -198,7 +198,8 @@ func removeUnavailableEntityScopedUniversalTools(entries map[string]RegisteredTo
 		return
 	}
 	for name := range entries {
-		if isEntityScopedUniversalRuntimeTool(name) {
+		tool := entries[name]
+		if tool.HandlerType == implementationPlatformBuiltin && isEntityScopedUniversalRuntimeTool(name) {
 			delete(entries, name)
 		}
 	}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -6,6 +6,7 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/entityruntime"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	"swarm/internal/runtime/semanticview"
@@ -178,7 +179,29 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 		}
 		entries[name] = tool
 	}
+	removeUnavailableEntityScopedUniversalTools(entries, source, actor)
 	return entries, nil
+}
+
+func removeUnavailableEntityScopedUniversalTools(entries map[string]RegisteredTool, source semanticview.Source, actor models.AgentConfig) {
+	if len(entries) == 0 || source == nil {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(actor.SessionScope), "global") {
+		return
+	}
+	actorID := strings.TrimSpace(actor.ID)
+	if actorID == "" {
+		return
+	}
+	if _, ok := entityruntime.ResolveForActor(source, actorID); ok {
+		return
+	}
+	for name := range entries {
+		if isEntityScopedUniversalRuntimeTool(name) {
+			delete(entries, name)
+		}
+	}
 }
 
 func resolveRegisteredToolForActor(source semanticview.Source, actor models.AgentConfig, toolName string, discovered map[string]runtimemcp.DiscoveredTool) (RegisteredTool, bool, error) {


### PR DESCRIPTION
## Summary

Closes #555.

This PR closes the approved first-slice #555 class: authored global/no-contract actors were receiving provider-visible generic entity tools even though their actor scope had no valid entity contract/read surface. Runtime execution already failed closed, but delivery was still misleading the model into impossible calls.

The fix gates entity-scoped universal tools for `session_scope: global` actors with no resolved actor entity contract. This hides `get_entity`, `save_entity_field`, `query_entities`, `search_entities`, and `query_metrics` from the lifecycle/global no-contract surface while preserving executor-side fail-closed validation for forged calls.

## Governing Context

- #555 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice.
- Binding gate boundary: lifecycle/global no-contract entity-tool delivery/schema precision only.
- Do not absorb #556 root/run entity read row.
- Do not weaken executor ownership checks or #542/#543 fail-closed behavior.
- Strategic architecture escape hatch tracked separately in Empire #27: retire authored `session_scope: global` by modeling lifecycle as a flow.

Relevant platform context:

- Current spec still contains older universal-tool language for entity tools.
- Runtime ownership model is flow-local and executor guards reject cross-flow/foreign entity reads and writes.
- The gate treats this as a tactical delivery precision repair while the deeper `session_scope: global` modeling gap remains tracked outside this PR.

## Semantic Migration

- New canonical owner: actor-scoped registered tool delivery consumes actor entity-contract scope before exposing entity-scoped universal runtime tools.
- Old non-authoritative path invalidated: provider-visible universal delivery of entity read/query/search/metrics/write tools to authored global/no-contract actors.
- Production paths checked: `ToolDefinitionsForActor`, registered tool construction, MCP/provider-visible tool definitions, lifecycle-coordinator supported turn evidence, direct executor rejection tests.
- Migration completeness: complete for the approved lifecycle/global no-contract slice. Remaining split lanes: Swarm #556, Empire #25, Empire #28, and Empire #27.

## Proof

Focused tests:

```sh
go test ./internal/runtime/tools -run 'TestToolDefinitionsForActor_(DeriveWave1EntitySchemasFromActorContract|ExcludeForeignReadTargets|HideEntityScopedUniversalToolsWithoutActorContract)|TestEntityTools_GetEntityRejectsCrossFlowRead'
go test ./internal/runtime/conformance -run TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites
go test ./internal/runtime/tools
go test ./internal/runtime/agents
go test ./internal/runtime/mcp
go test ./internal/runtime/...
```

Contract proof:

```sh
go run ./cmd/swarm verify --contracts /Users/youmew/swarm/empire/contracts --platform-spec /tmp/swarm-current-baseline/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
```

Supported path proof:

- Run id: `5ba9769d-4257-41c6-907f-7a0386ebd9d5`
- Swarm head for proof: `4c605089c0d40ee1e9ab1b1c4e451ec1876e104e` plus this PR patch
- Empire head: `a8f1c127137ec3e48d0d0a727cf7c6d98af2cb01`
- Lifecycle-coordinator turn on `scoring/vertical.marginal` had available tools:
  `emit_opco_escalation_response`, `emit_opco_spinup_requested`, `emit_opco_teardown_requested`, `emit_template_migration_completed`, `emit_template_migration_failed`, `emit_vertical_resumed`
- Lifecycle-coordinator had no `get_entity`, `save_entity_field`, `query_entities`, `search_entities`, or `query_metrics` exposed.
- Lifecycle-coordinator produced no `mcp.tools.call.exec_error` rows in the supported snapshot.

Current supported-run residue classification:

- `market-research-agent/get_entity`: split to Swarm #556.
- `business-research-agent/query_entities` and `spec-reviewer/query_entities`: Empire #25.
- `analysis-agent/emit_vertical_derived`: split to Empire #28 and recorded on Empire #14.
