### PR TITLE
[agent-a][issue #558] Materialize timestamp-fork state snapshots

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -334,6 +334,7 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	runID := fs.String("run", "", "Source run ID to plan from")
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
+	materializeOnly := fs.Bool("materialize-only", false, "Create fork run and materialize state snapshot without resuming execution")
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	if err := fs.Parse(args); err != nil {
 		if out != nil {
@@ -341,7 +342,13 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 2
 	}
-	if !*dryRun {
+	if *dryRun && *materializeOnly {
+		if out != nil {
+			fmt.Fprintln(out, "fork failed: --dry-run and --materialize-only are mutually exclusive")
+		}
+		return 2
+	}
+	if !*dryRun && !*materializeOnly {
 		if out != nil {
 			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run")
 		}
@@ -374,6 +381,29 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 1
 	}
+	if *materializeOnly {
+		result, err := stores.Postgres.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
+			SourceRunID: strings.TrimSpace(*runID),
+			At:          strings.TrimSpace(*at),
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: %v\n", err)
+			}
+			return 1
+		}
+		if *asJSON {
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(result); err != nil {
+				fmt.Fprintf(out, "fork failed: encode json: %v\n", err)
+				return 1
+			}
+			return 0
+		}
+		printRunForkMaterialization(out, result)
+		return 0
+	}
 	plan, err := stores.Postgres.PlanRunFork(ctx, store.RunForkPlanRequest{
 		SourceRunID: strings.TrimSpace(*runID),
 		At:          strings.TrimSpace(*at),
@@ -395,6 +425,20 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	}
 	printRunForkPlan(out, plan)
 	return 0
+}
+
+func printRunForkMaterialization(w io.Writer, result store.RunForkMaterialization) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "Fork materialized for run %s\n", result.SourceRunID)
+	fmt.Fprintf(w, "Fork Run: %s status=%s\n", result.ForkRunID, result.ForkRunStatus)
+	fmt.Fprintf(w, "Fork Point: %s (%s) at %s\n", result.ForkPoint.EventName, result.ForkPoint.EventID, result.ForkPoint.Timestamp.Format(time.RFC3339Nano))
+	fmt.Fprintf(w, "Summary: materialized_entities=%d delivery_resume_blocked=%t source_status_unchanged=%t\n",
+		result.MaterializedEntityCount,
+		result.DeliveryResumeBlocked,
+		result.SourceRunStatusUnchanged,
+	)
 }
 
 func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -401,6 +401,96 @@ func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
 	}
 }
 
+func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000310, 0).UTC()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli.materialize', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'cli-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"CLI Entity"'::jsonb, $3::uuid, 'platform', 'cli-test', 'seed', $4)
+	`, runID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'CLI Entity',
+			'ready', '{}'::jsonb, '{"name":"CLI Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, runID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, t.TempDir(), []string{
+		"--materialize-only",
+		"--run", runID,
+		"--at", eventID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var result store.RunForkMaterialization
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode fork materialization json: %v\n%s", err, buf.String())
+	}
+	if result.SourceRunID != runID || result.ForkRunID == "" || result.ForkRunStatus != store.RunForkMaterializedStatus {
+		t.Fatalf("materialization result = %#v", result)
+	}
+	var forkState string
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, result.ForkRunID, entityID).Scan(&forkState); err != nil {
+		t.Fatalf("load fork entity_state: %v", err)
+	}
+	if forkState != "ready" {
+		t.Fatalf("fork state = %q, want ready", forkState)
+	}
+}
+
+func TestRunForkCommand_NonDryRunWithoutMaterializeOnlyStaysFailClosed(t *testing.T) {
+	var buf bytes.Buffer
+	code := runForkCommand(context.Background(), t.TempDir(), []string{
+		"--run", uuid.NewString(),
+		"--at", uuid.NewString(),
+	}, &buf)
+	if code != 2 {
+		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "mutating fork execution is not implemented; use --dry-run") {
+		t.Fatalf("output = %q, want fail-closed fork execution message", buf.String())
+	}
+}
+
 func setPostgresEnvFromDSN(t *testing.T, dsn string) {
 	t.Helper()
 	values := map[string]string{}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3180,6 +3180,8 @@ run_model:
       processing, change contracts, or mutate delivery/session/timer/route state. Materialized fork current-state
       rows start a new fork-local revision sequence at revision=1; source-at-T entity_state.revision is not
       copied because revision is a current-row commit counter, not append-only historical state in entity_mutations.
+      Materialized fork rows preserve entered_state_at from the source-at-T current_state mutation evidence; they
+      MUST NOT stamp entered_state_at with the fork point unless that is when the current_state was entered.
       Full fork execution remains a separately gated operation.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
@@ -3202,7 +3204,8 @@ run_model:
       3a_materialize_only_run: 'For a materialize-only fork, insert the fork run row with status=paused,
         forked_from_run_id = source run, forked_from_event_id = target event, and event_count = 0.
         Source run status is unchanged. Copy reconstructed entity states into the fork context with fork-local
-        revision=1 and stop; do not boot, resume, redeliver, or mutate runtime delivery/session/timer/route state.'
+        revision=1 and source-at-T entered_state_at for the reconstructed current_state, then stop; do not boot,
+        resume, redeliver, or mutate runtime delivery/session/timer/route state.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3167,11 +3167,18 @@ run_model:
       to be re-delivered. The original run is frozen. The forked run gets independent execution.'
     command: 'swarm fork --run <run_id> --at <event_id|timestamp> [--contracts <path>]'
     dry_run_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --dry-run [--json]'
+    materialize_only_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --materialize-only [--json]'
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
       point, reconstructs provable state, classifies replay candidates, and returns execution_ready=false
       with named unsupported blockers whenever persisted recorder facts cannot prove safe execution. Dry-run
       MUST NOT create a forked run, mark the source run forked, copy entity state, redeliver events, or change
       runtime delivery/session/timer state.'
+    materialize_only_admission: 'The materialize-only form is the first supported mutating fork slice. It
+      consumes the canonical read-only planner, requires execution_ready=true, creates a fork run with
+      status=paused and fork lineage, and writes reconstructed entity_state rows under the fork run_id.
+      It does not mark the source run forked, freeze the source run, redeliver pending work, resume event
+      processing, change contracts, or mutate delivery/session/timer/route state. Full fork execution remains
+      a separately gated operation.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
@@ -3190,6 +3197,10 @@ run_model:
         events. These are the events the system will re-deliver.'
       3_create_run: 'Insert new run row with forked_from_run_id = source run, forked_from_event_id = target event
         (if event ID was provided). Copy reconstructed entity states into the fork context.'
+      3a_materialize_only_run: 'For a materialize-only fork, insert the fork run row with status=paused,
+        forked_from_run_id = source run, forked_from_event_id = target event, and event_count = 0.
+        Source run status is unchanged. Copy reconstructed entity states into the fork context and stop;
+        do not boot, resume, redeliver, or mutate runtime delivery/session/timer/route state.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3177,8 +3177,10 @@ run_model:
       consumes the canonical read-only planner, requires execution_ready=true, creates a fork run with
       status=paused and fork lineage, and writes reconstructed entity_state rows under the fork run_id.
       It does not mark the source run forked, freeze the source run, redeliver pending work, resume event
-      processing, change contracts, or mutate delivery/session/timer/route state. Full fork execution remains
-      a separately gated operation.'
+      processing, change contracts, or mutate delivery/session/timer/route state. Materialized fork current-state
+      rows start a new fork-local revision sequence at revision=1; source-at-T entity_state.revision is not
+      copied because revision is a current-row commit counter, not append-only historical state in entity_mutations.
+      Full fork execution remains a separately gated operation.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
@@ -3199,8 +3201,8 @@ run_model:
         (if event ID was provided). Copy reconstructed entity states into the fork context.'
       3a_materialize_only_run: 'For a materialize-only fork, insert the fork run row with status=paused,
         forked_from_run_id = source run, forked_from_event_id = target event, and event_count = 0.
-        Source run status is unchanged. Copy reconstructed entity states into the fork context and stop;
-        do not boot, resume, redeliver, or mutate runtime delivery/session/timer/route state.'
+        Source run status is unchanged. Copy reconstructed entity states into the fork context with fork-local
+        revision=1 and stop; do not boot, resume, redeliver, or mutate runtime delivery/session/timer/route state.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -117,6 +117,10 @@ active_issues:
     title: Promote run-scoped entity_state identity model for mutating fork isolation
     maps_to:
       - run_isolated_current_state_ownership
+  - id: 558
+    title: Materialize run-isolated timestamp-fork state snapshots without resuming execution
+    maps_to:
+      - run_isolated_current_state_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -199,11 +203,13 @@ nodes:
     known_manifestations:
       - entity_state previously had no run_id and used entity_id as a global primary key
       - state-only fork dry-run can be execution-ready, but mutating execution cannot materialize isolated current-state rows until live current state is run-scoped
+      - execution-ready timestamp-fork plans need a store-owned materialization operation that creates fork run lineage plus fork-scoped entity_state and entity_mutations rows without resuming delivery
       - runtime entity tools and workflow projection read and write entity_state by entity_id without run context
       - inbound routing, route ownership, workspace, digest, budget, and tests consume global current-state semantics
     representative_issues:
       - 549
       - 550
+      - 558
     common_framing_mistakes:
       too_broad:
         - implement all mutating fork execution in one PR

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -767,8 +767,10 @@ accounts:
 	pg := &store.PostgresStore{DB: db}
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
-	eventID := uuid.NewString()
+	stateEventID := uuid.NewString()
+	forkEventID := uuid.NewString()
 	at := time.Unix(1700000710, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -780,8 +782,10 @@ accounts:
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.revision', $3::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
-	`, sourceRunID, eventID, entityID, at); err != nil {
+		VALUES
+			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+	`, sourceRunID, stateEventID, forkEventID, entityID, at, forkAt); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -789,9 +793,9 @@ accounts:
 			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'revision-test', 'seed', $4),
-			($1::uuid, $2::uuid, 'status', 'null'::jsonb, '"open"'::jsonb, $3::uuid, 'platform', 'revision-test', 'seed', $4)
-	`, sourceRunID, entityID, eventID, at); err != nil {
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'revision-test', 'seed', $5),
+			($1::uuid, $2::uuid, 'status', 'null'::jsonb, '"open"'::jsonb, $4::uuid, 'platform', 'revision-test', 'field-only', $6)
+	`, sourceRunID, entityID, stateEventID, forkEventID, at, forkAt); err != nil {
 		t.Fatalf("seed mutations: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -806,7 +810,7 @@ accounts:
 	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
-	result, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	result, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: forkEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
 	}
@@ -832,6 +836,13 @@ accounts:
 	}
 	if got := strings.TrimSpace(asString(entity["current_state"])); got != "queued" {
 		t.Fatalf("fork get_entity current_state = %q, want queued", got)
+	}
+	enteredStateAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(asString(entity["entered_state_at"])))
+	if err != nil {
+		t.Fatalf("parse fork get_entity entered_state_at %q: %v", entity["entered_state_at"], err)
+	}
+	if !enteredStateAt.Equal(at) {
+		t.Fatalf("fork get_entity entered_state_at = %s, want state-entry timestamp %s", enteredStateAt, at)
 	}
 }
 

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -19,6 +19,7 @@ import (
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
 
@@ -747,6 +748,90 @@ func TestEntityTools_GetEntityReturnsStoredCurrentState(t *testing.T) {
 	}
 	if _, exists := entity["flow_states"]; exists {
 		t.Fatalf("unexpected legacy flow_states in entity payload: %#v", entity)
+	}
+}
+
+func TestEntityTools_GetEntityReturnsForkLocalMaterializedRevision(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"get_entity"},
+	}
+	bundle := loadWave1EntityToolBundle(t, actor, "review", "accounts", `
+types: {}
+`, `
+accounts:
+  status: text
+`)
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000710, 0).UTC()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.revision', $3::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'revision-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'status', 'null'::jsonb, '"open"'::jsonb, $3::uuid, 'platform', 'revision-test', 'seed', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'review/inst-1', 'default', 'done',
+			'{}'::jsonb, '{"status":"closed"}'::jsonb, '{}'::jsonb, 7, $3, $3, $3
+		)
+	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+	result, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		SQLDB:          db,
+		WorkflowSource: semanticview.Wrap(bundle),
+	})
+	forkCtx := runtimetools.WithActor(runtimecorrelation.WithRunID(context.Background(), result.ForkRunID), actor)
+	out, err := exec.Execute(forkCtx, "get_entity", map[string]any{"entity_id": entityID})
+	if err != nil {
+		t.Fatalf("get_entity fork entity: %v", err)
+	}
+	entity, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected entity map, got %#v", out)
+	}
+	if got := int(testNumericValue(entity["revision"])); got != 1 {
+		t.Fatalf("fork get_entity revision = %d, want fork-local revision 1", got)
+	}
+	fields, ok := entity["fields"].(map[string]any)
+	if !ok || strings.TrimSpace(asString(fields["status"])) != "open" {
+		t.Fatalf("fork get_entity fields = %#v, want status=open", entity["fields"])
+	}
+	if got := strings.TrimSpace(asString(entity["current_state"])); got != "queued" {
+		t.Fatalf("fork get_entity current_state = %q, want queued", got)
 	}
 }
 

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -275,6 +275,9 @@ func materializeRunForkEntityState(ctx context.Context, tx *sql.Tx, forkRunID st
 	if currentState == "" {
 		return fmt.Errorf("reconstructed current_state is required for entity %s", entityID)
 	}
+	if entity.EnteredStateAt == nil || entity.EnteredStateAt.IsZero() {
+		return fmt.Errorf("reconstructed entered_state_at is required for entity %s", entityID)
+	}
 	fieldsJSON, err := jsonMapArg(entity.Fields)
 	if err != nil {
 		return fmt.Errorf("encode fork fields for entity %s: %w", entityID, err)
@@ -299,7 +302,7 @@ func materializeRunForkEntityState(ctx context.Context, tx *sql.Tx, forkRunID st
 			$11, $12, $12
 		)
 	`, forkRunID, entityID, meta.FlowInstance, meta.EntityType, meta.Slug, meta.Name,
-		currentState, gatesJSON, fieldsJSON, accJSON, plan.ForkPoint.Timestamp, now); err != nil {
+		currentState, gatesJSON, fieldsJSON, accJSON, entity.EnteredStateAt, now); err != nil {
 		return fmt.Errorf("insert fork entity_state %s: %w", entityID, err)
 	}
 	return mutationlog.InsertEntityStateDiff(ctx, tx, entityID, mutationlog.EntityStateProjection{}, mutationlog.EntityStateProjection{

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/mutationlog"
+)
+
+const (
+	RunForkMaterializedStatus = "paused"
+)
+
+type RunForkMaterializeRequest struct {
+	SourceRunID string
+	At          string
+}
+
+type RunForkMaterialization struct {
+	SourceRunID              string                      `json:"source_run_id"`
+	ForkRunID                string                      `json:"fork_run_id"`
+	ForkRunStatus            string                      `json:"fork_run_status"`
+	ForkPoint                RunForkPoint                `json:"fork_point"`
+	MaterializedEntityCount  int                         `json:"materialized_entity_count"`
+	ExecutionReady           bool                        `json:"execution_ready"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
+	DeliveryResumeBlocked    bool                        `json:"delivery_resume_blocked"`
+	SourceRunStatusUnchanged bool                        `json:"source_run_status_unchanged"`
+}
+
+type runForkEntityMetadata struct {
+	FlowInstance string
+	EntityType   string
+	Slug         string
+	Name         string
+}
+
+func RequireRunForkMaterializerCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	if err := RequireCanonicalRunForkPlannerCapabilities(caps, catalog); err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"runs":         {"run_id", "status", "forked_from_run_id", "forked_from_event_id", "entity_count", "event_count", "started_at"},
+		"entity_state": {"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name", "current_state", "gates", "fields", "accumulator", "revision", "entered_state_at", "created_at", "updated_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run fork materializer requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunForkMaterializerCapabilities(ctx context.Context) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return RequireRunForkMaterializerCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMaterializeRequest) (RunForkMaterialization, error) {
+	if s == nil || s.DB == nil {
+		return RunForkMaterialization{}, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunForkMaterializerCapabilities(ctx); err != nil {
+		return RunForkMaterialization{}, err
+	}
+	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{
+		SourceRunID: strings.TrimSpace(req.SourceRunID),
+		At:          strings.TrimSpace(req.At),
+	})
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	if !plan.ExecutionReady {
+		return RunForkMaterialization{
+			SourceRunID:           plan.SourceRunID,
+			ForkPoint:             plan.ForkPoint,
+			ExecutionReady:        false,
+			UnsupportedBlockers:   plan.UnsupportedBlockers,
+			DeliveryResumeBlocked: true,
+		}, fmt.Errorf("fork materialization requires execution-ready plan; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
+	}
+
+	forkRunID := deterministicRunForkMaterializationID(plan.SourceRunID, plan.ForkPoint.EventID)
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("begin fork materialization: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
+		return RunForkMaterialization{}, err
+	}
+	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan.SourceRunID, plan.Entities)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, status, forked_from_run_id, forked_from_event_id,
+			entity_count, event_count, started_at
+		)
+		VALUES (
+			$1::uuid, $2, $3::uuid, $4::uuid,
+			$5, 0, $6
+		)
+	`, forkRunID, RunForkMaterializedStatus, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("insert fork run: %w", err)
+	}
+
+	forkCtx := runtimecorrelation.WithRunID(ctx, forkRunID)
+	for _, entity := range plan.Entities {
+		if err := materializeRunForkEntityState(forkCtx, tx, forkRunID, plan, entity, metadata[entity.EntityID], now); err != nil {
+			return RunForkMaterialization{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("commit fork materialization: %w", err)
+	}
+	committed = true
+	return RunForkMaterialization{
+		SourceRunID:              plan.SourceRunID,
+		ForkRunID:                forkRunID,
+		ForkRunStatus:            RunForkMaterializedStatus,
+		ForkPoint:                plan.ForkPoint,
+		MaterializedEntityCount:  len(plan.Entities),
+		ExecutionReady:           true,
+		DeliveryResumeBlocked:    true,
+		SourceRunStatusUnchanged: true,
+	}, nil
+}
+
+func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRunID, sourceRunID, forkEventID string) error {
+	var existing string
+	err := tx.QueryRowContext(ctx, `
+		SELECT run_id::text
+		FROM runs
+		WHERE run_id = $1::uuid
+		   OR (forked_from_run_id = $2::uuid AND forked_from_event_id = $3::uuid)
+		ORDER BY started_at ASC
+		LIMIT 1
+	`, forkRunID, sourceRunID, forkEventID).Scan(&existing)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check existing fork materialization: %w", err)
+	}
+	return fmt.Errorf("fork materialization already exists for source run %s at event %s: %s", sourceRunID, forkEventID, existing)
+}
+
+func loadRunForkEntityMetadata(ctx context.Context, tx *sql.Tx, sourceRunID string, entities []RunForkEntityState) (map[string]runForkEntityMetadata, error) {
+	out := make(map[string]runForkEntityMetadata, len(entities))
+	for _, entity := range entities {
+		entityID := strings.TrimSpace(entity.EntityID)
+		if entityID == "" {
+			return nil, fmt.Errorf("fork entity_id is required")
+		}
+		var meta runForkEntityMetadata
+		var slug, name sql.NullString
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COALESCE(flow_instance, ''), COALESCE(entity_type, ''), slug, name
+			FROM entity_state
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+		`, sourceRunID, entityID).Scan(&meta.FlowInstance, &meta.EntityType, &slug, &name); err != nil {
+			if err == sql.ErrNoRows {
+				return nil, fmt.Errorf("source entity_state metadata for entity %s is required for fork materialization", entityID)
+			}
+			return nil, fmt.Errorf("load source entity_state metadata for %s: %w", entityID, err)
+		}
+		meta.FlowInstance = strings.TrimSpace(meta.FlowInstance)
+		meta.EntityType = strings.TrimSpace(meta.EntityType)
+		if meta.FlowInstance == "" || meta.EntityType == "" {
+			return nil, fmt.Errorf("source entity_state metadata for entity %s must include flow_instance and entity_type", entityID)
+		}
+		if slug.Valid {
+			meta.Slug = strings.TrimSpace(slug.String)
+		}
+		if name.Valid {
+			meta.Name = strings.TrimSpace(name.String)
+		}
+		out[entityID] = meta
+	}
+	return out, nil
+}
+
+func materializeRunForkEntityState(ctx context.Context, tx *sql.Tx, forkRunID string, plan RunForkPlan, entity RunForkEntityState, meta runForkEntityMetadata, now time.Time) error {
+	entityID := strings.TrimSpace(entity.EntityID)
+	currentState := strings.TrimSpace(entity.CurrentState)
+	if currentState == "" {
+		return fmt.Errorf("reconstructed current_state is required for entity %s", entityID)
+	}
+	fieldsJSON, err := jsonMapArg(entity.Fields)
+	if err != nil {
+		return fmt.Errorf("encode fork fields for entity %s: %w", entityID, err)
+	}
+	gatesJSON, err := jsonMapArg(entity.Gates)
+	if err != nil {
+		return fmt.Errorf("encode fork gates for entity %s: %w", entityID, err)
+	}
+	accJSON, err := jsonMapArg(entity.Accumulator)
+	if err != nil {
+		return fmt.Errorf("encode fork accumulator for entity %s: %w", entityID, err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3, $4, NULLIF($5, ''), NULLIF($6, ''),
+			$7, $8::jsonb, $9::jsonb, $10::jsonb, 1,
+			$11, $12, $12
+		)
+	`, forkRunID, entityID, meta.FlowInstance, meta.EntityType, meta.Slug, meta.Name,
+		currentState, gatesJSON, fieldsJSON, accJSON, plan.ForkPoint.Timestamp, now); err != nil {
+		return fmt.Errorf("insert fork entity_state %s: %w", entityID, err)
+	}
+	return mutationlog.InsertEntityStateDiff(ctx, tx, entityID, mutationlog.EntityStateProjection{}, mutationlog.EntityStateProjection{
+		CurrentState: currentState,
+		Fields:       entity.Fields,
+		Gates:        entity.Gates,
+		Accumulator:  entity.Accumulator,
+	}, mutationlog.Writer{
+		Type:        "platform",
+		ID:          "run_fork_materializer",
+		HandlerStep: "materialize_snapshot",
+	})
+}
+
+func deterministicRunForkMaterializationID(sourceRunID, forkEventID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm:run-fork-materialization:"+strings.TrimSpace(sourceRunID)+":"+strings.TrimSpace(forkEventID))).String()
+}
+
+func jsonMapArg(values map[string]any) (string, error) {
+	if values == nil {
+		values = map[string]any{}
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func runForkBlockerCodes(blockers []RunForkUnsupportedBlocker) string {
+	if len(blockers) == 0 {
+		return "none"
+	}
+	codes := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		if code := strings.TrimSpace(blocker.Code); code != "" {
+			codes = append(codes, code)
+		}
+	}
+	if len(codes) == 0 {
+		return "unnamed"
+	}
+	return strings.Join(codes, ", ")
+}

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -109,7 +109,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
 	}
-	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan.SourceRunID, plan.Entities)
+	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan)
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
@@ -168,40 +168,105 @@ func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRu
 	return fmt.Errorf("fork materialization already exists for source run %s at event %s: %s", sourceRunID, forkEventID, existing)
 }
 
-func loadRunForkEntityMetadata(ctx context.Context, tx *sql.Tx, sourceRunID string, entities []RunForkEntityState) (map[string]runForkEntityMetadata, error) {
-	out := make(map[string]runForkEntityMetadata, len(entities))
-	for _, entity := range entities {
+func loadRunForkEntityMetadata(ctx context.Context, tx *sql.Tx, plan RunForkPlan) (map[string]runForkEntityMetadata, error) {
+	out := make(map[string]runForkEntityMetadata, len(plan.Entities))
+	for _, entity := range plan.Entities {
 		entityID := strings.TrimSpace(entity.EntityID)
 		if entityID == "" {
 			return nil, fmt.Errorf("fork entity_id is required")
 		}
-		var meta runForkEntityMetadata
-		var slug, name sql.NullString
-		if err := tx.QueryRowContext(ctx, `
-			SELECT COALESCE(flow_instance, ''), COALESCE(entity_type, ''), slug, name
-			FROM entity_state
-			WHERE run_id = $1::uuid
-			  AND entity_id = $2::uuid
-		`, sourceRunID, entityID).Scan(&meta.FlowInstance, &meta.EntityType, &slug, &name); err != nil {
-			if err == sql.ErrNoRows {
-				return nil, fmt.Errorf("source entity_state metadata for entity %s is required for fork materialization", entityID)
-			}
-			return nil, fmt.Errorf("load source entity_state metadata for %s: %w", entityID, err)
+		flowInstance, err := loadRunForkEntityFlowInstance(ctx, tx, plan, entityID)
+		if err != nil {
+			return nil, err
 		}
-		meta.FlowInstance = strings.TrimSpace(meta.FlowInstance)
-		meta.EntityType = strings.TrimSpace(meta.EntityType)
+		entityType, err := runForkEntityTypeFromForkPoint(ctx, tx, plan.SourceRunID, entityID, entity.Fields)
+		if err != nil {
+			return nil, err
+		}
+		meta := runForkEntityMetadata{
+			FlowInstance: flowInstance,
+			EntityType:   entityType,
+			Slug:         stringFieldValue(entity.Fields, "slug"),
+			Name:         stringFieldValue(entity.Fields, "name"),
+		}
 		if meta.FlowInstance == "" || meta.EntityType == "" {
 			return nil, fmt.Errorf("source entity_state metadata for entity %s must include flow_instance and entity_type", entityID)
-		}
-		if slug.Valid {
-			meta.Slug = strings.TrimSpace(slug.String)
-		}
-		if name.Valid {
-			meta.Name = strings.TrimSpace(name.String)
 		}
 		out[entityID] = meta
 	}
 	return out, nil
+}
+
+func loadRunForkEntityFlowInstance(ctx context.Context, tx *sql.Tx, plan RunForkPlan, entityID string) (string, error) {
+	var flowInstance string
+	err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(flow_instance, '')
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND COALESCE(flow_instance, '') <> ''
+		  AND (created_at, event_id) <= ($3::timestamptz, $4::uuid)
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, plan.SourceRunID, entityID, plan.ForkPoint.Timestamp, plan.ForkPoint.EventID).Scan(&flowInstance)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("fork-point flow_instance metadata for entity %s is required for fork materialization", entityID)
+	}
+	if err != nil {
+		return "", fmt.Errorf("load fork-point flow_instance metadata for %s: %w", entityID, err)
+	}
+	flowInstance = strings.TrimSpace(flowInstance)
+	if flowInstance == "" {
+		return "", fmt.Errorf("fork-point flow_instance metadata for entity %s is required for fork materialization", entityID)
+	}
+	return flowInstance, nil
+}
+
+func runForkEntityTypeFromForkPoint(ctx context.Context, tx *sql.Tx, sourceRunID, entityID string, fields map[string]any) (string, error) {
+	entityType := stringFieldValue(fields, "entity_type")
+	if entityType != "" {
+		return entityType, nil
+	}
+	var currentEntityType string
+	err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(NULLIF(entity_type, ''), 'default')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, sourceRunID, entityID).Scan(&currentEntityType)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("source entity_state metadata for entity %s is required for fork materialization", entityID)
+	}
+	if err != nil {
+		return "", fmt.Errorf("load source entity_type guard for %s: %w", entityID, err)
+	}
+	currentEntityType = strings.TrimSpace(currentEntityType)
+	if currentEntityType == "" || currentEntityType == "default" {
+		return "default", nil
+	}
+	return "", fmt.Errorf("fork-point entity_type metadata for entity %s is required for non-default source entity_type %q", entityID, currentEntityType)
+}
+
+func stringFieldValue(fields map[string]any, key string) string {
+	value, ok := fields[strings.TrimSpace(key)]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.RawMessage:
+		var out string
+		if err := json.Unmarshal(typed, &out); err == nil {
+			return strings.TrimSpace(out)
+		}
+	case []byte:
+		var out string
+		if err := json.Unmarshal(typed, &out); err == nil {
+			return strings.TrimSpace(out)
+		}
+	}
+	return ""
 }
 
 func materializeRunForkEntityState(ctx context.Context, tx *sql.Tx, forkRunID string, plan RunForkPlan, entity RunForkEntityState, meta runForkEntityMetadata, now time.Time) error {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -1,0 +1,272 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	firstEventID := uuid.NewString()
+	secondEventID := uuid.NewString()
+	at := time.Unix(1700000500, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'fork.before', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.after', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+	`, sourceRunID, firstEventID, secondEventID, entityID, at, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
+			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6)
+	`, sourceRunID, entityID, firstEventID, secondEventID, at, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'entity-one', 'Entity One',
+			'done', '{"ready": true}'::jsonb, '{"title": "after-title"}'::jsonb, '{"score": 9}'::jsonb, 4,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+
+	result, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: firstEventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if result.ForkRunID == "" {
+		t.Fatal("ForkRunID is empty")
+	}
+	if result.ForkRunStatus != RunForkMaterializedStatus {
+		t.Fatalf("ForkRunStatus = %q, want %q", result.ForkRunStatus, RunForkMaterializedStatus)
+	}
+	if !result.DeliveryResumeBlocked || !result.SourceRunStatusUnchanged {
+		t.Fatalf("boundary flags = resume_blocked:%v source_unchanged:%v", result.DeliveryResumeBlocked, result.SourceRunStatusUnchanged)
+	}
+
+	var forkStatus, forkedFromRun, forkedFromEvent string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status, forked_from_run_id::text, forked_from_event_id::text
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent); err != nil {
+		t.Fatalf("load fork run: %v", err)
+	}
+	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != firstEventID {
+		t.Fatalf("fork run = status:%s from:%s event:%s", forkStatus, forkedFromRun, forkedFromEvent)
+	}
+	var sourceStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source run status: %v", err)
+	}
+	if sourceStatus != "running" {
+		t.Fatalf("source status = %q, want running", sourceStatus)
+	}
+
+	var sourceState, forkState, sourceTitle, forkTitle string
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state, fields->>'title'
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID).Scan(&sourceState, &sourceTitle); err != nil {
+		t.Fatalf("load source entity_state: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state, fields->>'title'
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, result.ForkRunID, entityID).Scan(&forkState, &forkTitle); err != nil {
+		t.Fatalf("load fork entity_state: %v", err)
+	}
+	if sourceState != "done" || sourceTitle != "after-title" {
+		t.Fatalf("source state/title = %s/%s, want done/after-title", sourceState, sourceTitle)
+	}
+	if forkState != "queued" || forkTitle != "before-title" {
+		t.Fatalf("fork state/title = %s/%s, want queued/before-title", forkState, forkTitle)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE entity_state
+		SET fields = jsonb_set(fields, '{title}', '"fork-title"'::jsonb, true)
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, result.ForkRunID, entityID); err != nil {
+		t.Fatalf("diverge fork entity_state: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT fields->>'title'
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID).Scan(&sourceTitle); err != nil {
+		t.Fatalf("reload source title: %v", err)
+	}
+	if sourceTitle != "after-title" {
+		t.Fatalf("source title after fork divergence = %q, want after-title", sourceTitle)
+	}
+
+	for _, field := range []string{"current_state", "title", "gates.ready", "accumulator.score"} {
+		var count int
+		if err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM entity_mutations
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND field = $3
+			  AND writer_type = 'platform'
+			  AND writer_id = 'run_fork_materializer'
+		`, result.ForkRunID, entityID, field).Scan(&count); err != nil {
+			t.Fatalf("count mutation %s: %v", field, err)
+		}
+		if count != 1 {
+			t.Fatalf("mutation count for %s = %d, want 1", field, count)
+		}
+	}
+
+	sideEffectQueries := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{name: "event_deliveries", query: `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`, args: []any{result.ForkRunID}},
+		{name: "timers", query: `SELECT COUNT(*) FROM timers WHERE entity_id = $1::uuid`, args: []any{entityID}},
+		{name: "agent_sessions", query: `SELECT COUNT(*) FROM agent_sessions WHERE run_id = $1::uuid`, args: []any{result.ForkRunID}},
+		{name: "agent_turns", query: `SELECT COUNT(*) FROM agent_turns WHERE run_id = $1::uuid`, args: []any{result.ForkRunID}},
+	}
+	for _, check := range sideEffectQueries {
+		var count int
+		if err := db.QueryRowContext(ctx, check.query, check.args...).Scan(&count); err != nil {
+			t.Fatalf("count side-effect rows %s: %v", check.name, err)
+		}
+		if count != 0 {
+			t.Fatalf("side-effect row count for %s = %d, want 0", check.name, count)
+		}
+	}
+}
+
+func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000600, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.pending', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'seed', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'ready',
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, $3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'pending-node', 'pending', $3)
+	`, sourceRunID, eventID, at); err != nil {
+		t.Fatalf("seed pending delivery: %v", err)
+	}
+
+	_, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
+		t.Fatalf("MaterializeRunFork error = %v, want delivery blocker", err)
+	}
+	var forkCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE forked_from_run_id = $1::uuid
+	`, sourceRunID).Scan(&forkCount); err != nil {
+		t.Fatalf("count blocked fork rows: %v", err)
+	}
+	if forkCount != 0 {
+		t.Fatalf("blocked fork rows = %d, want 0", forkCount)
+	}
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM event_deliveries WHERE run_id = $1::uuid`, sourceRunID); err != nil {
+		t.Fatalf("clear pending delivery: %v", err)
+	}
+	first, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork first: %v", err)
+	}
+	_, err = pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("MaterializeRunFork repeat error = %v, want already exists", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE forked_from_run_id = $1::uuid
+		  AND forked_from_event_id = $2::uuid
+	`, sourceRunID, eventID).Scan(&forkCount); err != nil {
+		t.Fatalf("count fork rows after repeat: %v", err)
+	}
+	if forkCount != 1 {
+		t.Fatalf("fork rows after repeat = %d, want 1", forkCount)
+	}
+	if first.ForkRunID == "" {
+		t.Fatal("first ForkRunID is empty")
+	}
+}

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -103,25 +103,32 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	}
 
 	var sourceState, forkState, sourceTitle, forkTitle string
+	var sourceRevision, forkRevision int
 	if err := db.QueryRowContext(ctx, `
-		SELECT current_state, fields->>'title'
+		SELECT current_state, fields->>'title', revision
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, sourceRunID, entityID).Scan(&sourceState, &sourceTitle); err != nil {
+	`, sourceRunID, entityID).Scan(&sourceState, &sourceTitle, &sourceRevision); err != nil {
 		t.Fatalf("load source entity_state: %v", err)
 	}
 	if err := db.QueryRowContext(ctx, `
-		SELECT current_state, fields->>'title'
+		SELECT current_state, fields->>'title', revision
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, result.ForkRunID, entityID).Scan(&forkState, &forkTitle); err != nil {
+	`, result.ForkRunID, entityID).Scan(&forkState, &forkTitle, &forkRevision); err != nil {
 		t.Fatalf("load fork entity_state: %v", err)
 	}
 	if sourceState != "done" || sourceTitle != "after-title" {
 		t.Fatalf("source state/title = %s/%s, want done/after-title", sourceState, sourceTitle)
 	}
+	if sourceRevision != 4 {
+		t.Fatalf("source revision = %d, want 4", sourceRevision)
+	}
 	if forkState != "queued" || forkTitle != "before-title" {
 		t.Fatalf("fork state/title = %s/%s, want queued/before-title", forkState, forkTitle)
+	}
+	if forkRevision != 1 {
+		t.Fatalf("fork revision = %d, want fork-local revision 1", forkRevision)
 	}
 	var forkSlug, forkName string
 	if err := db.QueryRowContext(ctx, `

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -19,7 +19,10 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	entityID := uuid.NewString()
 	firstEventID := uuid.NewString()
 	secondEventID := uuid.NewString()
+	thirdEventID := uuid.NewString()
 	at := time.Unix(1700000500, 0).UTC()
+	fieldOnlyAt := at.Add(30 * time.Second)
+	afterAt := at.Add(time.Minute)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
 		VALUES ($1::uuid, 'running', $2)
@@ -32,8 +35,9 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		)
 		VALUES
 			($1::uuid, $2::uuid, 'fork.before', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.after', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
-	`, sourceRunID, firstEventID, secondEventID, entityID, at, at.Add(time.Minute)); err != nil {
+			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $6),
+			($1::uuid, $7::uuid, 'fork.after', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $8)
+	`, sourceRunID, firstEventID, secondEventID, entityID, at, fieldOnlyAt, thirdEventID, afterAt); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -47,11 +51,12 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Before Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
-			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
-			($1::uuid, $2::uuid, 'slug', '"before-slug"'::jsonb, '"after-slug"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
-			($1::uuid, $2::uuid, 'name', '"Before Name"'::jsonb, '"After Name"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6)
-	`, sourceRunID, entityID, firstEventID, secondEventID, at, at.Add(time.Minute)); err != nil {
+			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"fork-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'field-only', $6),
+			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
+			($1::uuid, $2::uuid, 'title', '"fork-title"'::jsonb, '"after-title"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
+			($1::uuid, $2::uuid, 'slug', '"before-slug"'::jsonb, '"after-slug"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
+			($1::uuid, $2::uuid, 'name', '"Before Name"'::jsonb, '"After Name"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8)
+	`, sourceRunID, entityID, firstEventID, secondEventID, at, fieldOnlyAt, thirdEventID, afterAt); err != nil {
 		t.Fatalf("seed mutations: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -65,11 +70,11 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 			'done', '{"ready": true}'::jsonb, '{"title": "after-title", "slug": "after-slug", "name": "After Name"}'::jsonb, '{"score": 9}'::jsonb, 4,
 			$3, $3, $3
 		)
-	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+	`, sourceRunID, entityID, afterAt); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
 
-	result, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: firstEventID})
+	result, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: secondEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
 	}
@@ -91,7 +96,7 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent); err != nil {
 		t.Fatalf("load fork run: %v", err)
 	}
-	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != firstEventID {
+	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != secondEventID {
 		t.Fatalf("fork run = status:%s from:%s event:%s", forkStatus, forkedFromRun, forkedFromEvent)
 	}
 	var sourceStatus string
@@ -104,6 +109,7 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 
 	var sourceState, forkState, sourceTitle, forkTitle string
 	var sourceRevision, forkRevision int
+	var forkEnteredStateAt time.Time
 	if err := db.QueryRowContext(ctx, `
 		SELECT current_state, fields->>'title', revision
 		FROM entity_state
@@ -112,10 +118,10 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		t.Fatalf("load source entity_state: %v", err)
 	}
 	if err := db.QueryRowContext(ctx, `
-		SELECT current_state, fields->>'title', revision
+		SELECT current_state, fields->>'title', revision, entered_state_at
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, result.ForkRunID, entityID).Scan(&forkState, &forkTitle, &forkRevision); err != nil {
+	`, result.ForkRunID, entityID).Scan(&forkState, &forkTitle, &forkRevision, &forkEnteredStateAt); err != nil {
 		t.Fatalf("load fork entity_state: %v", err)
 	}
 	if sourceState != "done" || sourceTitle != "after-title" {
@@ -124,11 +130,14 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if sourceRevision != 4 {
 		t.Fatalf("source revision = %d, want 4", sourceRevision)
 	}
-	if forkState != "queued" || forkTitle != "before-title" {
-		t.Fatalf("fork state/title = %s/%s, want queued/before-title", forkState, forkTitle)
+	if forkState != "queued" || forkTitle != "fork-title" {
+		t.Fatalf("fork state/title = %s/%s, want queued/fork-title", forkState, forkTitle)
 	}
 	if forkRevision != 1 {
 		t.Fatalf("fork revision = %d, want fork-local revision 1", forkRevision)
+	}
+	if !forkEnteredStateAt.Equal(at) {
+		t.Fatalf("fork entered_state_at = %s, want state-entry timestamp %s", forkEnteredStateAt, at)
 	}
 	var forkSlug, forkName string
 	if err := db.QueryRowContext(ctx, `
@@ -143,7 +152,7 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	}
 	if _, err := db.ExecContext(ctx, `
 		UPDATE entity_state
-		SET fields = jsonb_set(fields, '{title}', '"fork-title"'::jsonb, true)
+		SET fields = jsonb_set(fields, '{title}', '"fork-local-title"'::jsonb, true)
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
 	`, result.ForkRunID, entityID); err != nil {
 		t.Fatalf("diverge fork entity_state: %v", err)

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -43,10 +43,14 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		VALUES
 			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'slug', 'null'::jsonb, '"before-slug"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Before Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
 			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
-			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6)
+			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
+			($1::uuid, $2::uuid, 'slug', '"before-slug"'::jsonb, '"after-slug"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6),
+			($1::uuid, $2::uuid, 'name', '"Before Name"'::jsonb, '"After Name"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'after', $6)
 	`, sourceRunID, entityID, firstEventID, secondEventID, at, at.Add(time.Minute)); err != nil {
 		t.Fatalf("seed mutations: %v", err)
 	}
@@ -57,8 +61,8 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'entity-one', 'Entity One',
-			'done', '{"ready": true}'::jsonb, '{"title": "after-title"}'::jsonb, '{"score": 9}'::jsonb, 4,
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'after-slug', 'After Name',
+			'done', '{"ready": true}'::jsonb, '{"title": "after-title", "slug": "after-slug", "name": "After Name"}'::jsonb, '{"score": 9}'::jsonb, 4,
 			$3, $3, $3
 		)
 	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
@@ -119,6 +123,17 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if forkState != "queued" || forkTitle != "before-title" {
 		t.Fatalf("fork state/title = %s/%s, want queued/before-title", forkState, forkTitle)
 	}
+	var forkSlug, forkName string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(slug, ''), COALESCE(name, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, result.ForkRunID, entityID).Scan(&forkSlug, &forkName); err != nil {
+		t.Fatalf("load fork display metadata: %v", err)
+	}
+	if forkSlug != "before-slug" || forkName != "Before Name" {
+		t.Fatalf("fork display metadata = %s/%s, want before-slug/Before Name", forkSlug, forkName)
+	}
 	if _, err := db.ExecContext(ctx, `
 		UPDATE entity_state
 		SET fields = jsonb_set(fields, '{title}', '"fork-title"'::jsonb, true)
@@ -137,7 +152,7 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		t.Fatalf("source title after fork divergence = %q, want after-title", sourceTitle)
 	}
 
-	for _, field := range []string{"current_state", "title", "gates.ready", "accumulator.score"} {
+	for _, field := range []string{"current_state", "title", "slug", "name", "gates.ready", "accumulator.score"} {
 		var count int
 		if err := db.QueryRowContext(ctx, `
 			SELECT COUNT(*)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -53,11 +53,12 @@ type RunForkPoint struct {
 }
 
 type RunForkEntityState struct {
-	EntityID     string         `json:"entity_id"`
-	CurrentState string         `json:"current_state,omitempty"`
-	Fields       map[string]any `json:"fields,omitempty"`
-	Gates        map[string]any `json:"gates,omitempty"`
-	Accumulator  map[string]any `json:"accumulator,omitempty"`
+	EntityID       string         `json:"entity_id"`
+	CurrentState   string         `json:"current_state,omitempty"`
+	EnteredStateAt *time.Time     `json:"entered_state_at,omitempty"`
+	Fields         map[string]any `json:"fields,omitempty"`
+	Gates          map[string]any `json:"gates,omitempty"`
+	Accumulator    map[string]any `json:"accumulator,omitempty"`
 }
 
 type RunForkPendingWork struct {
@@ -278,7 +279,8 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 		SELECT
 			m.entity_id::text,
 			m.field,
-			COALESCE(m.new_value, 'null'::jsonb)
+			COALESCE(m.new_value, 'null'::jsonb),
+			m.created_at
 		FROM entity_mutations m
 		LEFT JOIN events e
 			ON e.event_id = m.caused_by_event
@@ -296,13 +298,18 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 	}
 	defer rows.Close()
 
-	grouped := map[string][]mutationlog.ProjectionMutation{}
+	type timedProjectionMutation struct {
+		mutationlog.ProjectionMutation
+		CreatedAt time.Time
+	}
+	grouped := map[string][]timedProjectionMutation{}
 	entityOrder := []string{}
 	seen := map[string]struct{}{}
 	for rows.Next() {
 		var entityID, field string
 		var raw []byte
-		if err := rows.Scan(&entityID, &field, &raw); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&entityID, &field, &raw, &createdAt); err != nil {
 			return nil, fmt.Errorf("scan fork entity mutation: %w", err)
 		}
 		var value any
@@ -314,9 +321,12 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 			seen[entityID] = struct{}{}
 			entityOrder = append(entityOrder, entityID)
 		}
-		grouped[entityID] = append(grouped[entityID], mutationlog.ProjectionMutation{
-			Field:    field,
-			NewValue: value,
+		grouped[entityID] = append(grouped[entityID], timedProjectionMutation{
+			ProjectionMutation: mutationlog.ProjectionMutation{
+				Field:    field,
+				NewValue: value,
+			},
+			CreatedAt: createdAt,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -325,16 +335,27 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 
 	out := make([]RunForkEntityState, 0, len(entityOrder))
 	for _, entityID := range entityOrder {
-		projection, err := mutationlog.ReconstructEntityStateProjection(grouped[entityID])
+		mutations := grouped[entityID]
+		projectionMutations := make([]mutationlog.ProjectionMutation, 0, len(mutations))
+		var enteredStateAt *time.Time
+		for _, mutation := range mutations {
+			projectionMutations = append(projectionMutations, mutation.ProjectionMutation)
+			if strings.TrimSpace(mutation.Field) == "current_state" {
+				tm := mutation.CreatedAt
+				enteredStateAt = &tm
+			}
+		}
+		projection, err := mutationlog.ReconstructEntityStateProjection(projectionMutations)
 		if err != nil {
 			return nil, fmt.Errorf("reconstruct entity %s at fork point: %w", entityID, err)
 		}
 		out = append(out, RunForkEntityState{
-			EntityID:     entityID,
-			CurrentState: projection.CurrentState,
-			Fields:       projection.Fields,
-			Gates:        projection.Gates,
-			Accumulator:  projection.Accumulator,
+			EntityID:       entityID,
+			CurrentState:   projection.CurrentState,
+			EnteredStateAt: enteredStateAt,
+			Fields:         projection.Fields,
+			Gates:          projection.Gates,
+			Accumulator:    projection.Accumulator,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## Summary
- Adds the store-owned timestamp-fork materializer that consumes `PlanRunFork` and requires `execution_ready=true` before mutating anything.
- Creates a paused fork run with `forked_from_run_id` / `forked_from_event_id`, writes reconstructed fork-scoped `entity_state`, and records matching fork-run `entity_mutations` in the same transaction.
- Defines materialize-only fork rows as starting a fork-local current-state revision sequence at `revision=1`; source-at-T revision is not copied because it is not append-only historical state in `entity_mutations`.
- Preserves `entered_state_at` from the source-at-T `current_state` mutation evidence, so a fork at a later field-only event keeps the earlier state-entry timestamp.
- Wires `cmd/swarm fork --materialize-only [--json]` as the supported consumer while keeping full fork execution/resume fail-closed.
- Promotes the materialize-only fork semantics into `platform-spec.yaml` and maps #558 into the runtime operations watchlist.

Closes #558

## Governing refs / context
- Approved #558 pre-audit and gate: `approved as first slice`.
- Parent fork stream: #536, #545, #549, #550, #553.
- Spec refs: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork`, `run_model.mutation_log`, `platform_tables.entity_state`, `platform_tables.runs`.

## Semantic migration accounting
- New canonical owner for this child: `internal/store/run_fork_materializer.go` under the store/runtime boundary.
- Consuming surface moved/added: `cmd/swarm fork --materialize-only` consumes the store owner instead of doing direct SQL or local materialization.
- Old invalid path: full non-dry-run `swarm fork` still fails closed; no dashboard, Builder, delivery, timer, route, session, active-turn, or resume path is made authoritative by this PR.
- Production paths checked for surviving old behavior: CLI fork path, planner path, run lineage rows, run-scoped entity_state, entity_mutations, supported `get_entity` read surface, delivery/session/timer/turn side effects.
- Migration completeness: complete for the approved materialize-only first slice; full mutating fork execution remains explicitly blocked/split.

## Proof run
- `go test ./internal/store -run 'TestRunFork(Materializer|Planner)' -count=1`
- `go test ./internal/runtime/tools -run 'TestEntityTools_GetEntityReturnsForkLocalMaterializedRevision' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand_(MaterializeOnlyUsesCanonicalStoreOwnerJSON|NonDryRunWithoutMaterializeOnlyStaysFailClosed|DryRunUsesCanonicalPlannerJSON)' -count=1`
- `go test ./internal/store -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./... -count=1`
