### PR TITLE
[agent-a][issue #562] Activate materialized timestamp forks

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -335,6 +335,7 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
 	materializeOnly := fs.Bool("materialize-only", false, "Create fork run and materialize state snapshot without resuming execution")
+	activate := fs.Bool("activate", false, "Activate an already materialized state-only fork")
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	if err := fs.Parse(args); err != nil {
 		if out != nil {
@@ -342,15 +343,27 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 2
 	}
-	if *dryRun && *materializeOnly {
+	modeCount := 0
+	for _, enabled := range []bool{*dryRun, *materializeOnly, *activate} {
+		if enabled {
+			modeCount++
+		}
+	}
+	if modeCount > 1 {
 		if out != nil {
-			fmt.Fprintln(out, "fork failed: --dry-run and --materialize-only are mutually exclusive")
+			fmt.Fprintln(out, "fork failed: --dry-run, --materialize-only, and --activate are mutually exclusive")
 		}
 		return 2
 	}
-	if !*dryRun && !*materializeOnly {
+	if modeCount == 0 {
 		if out != nil {
-			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run")
+			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run, --materialize-only, or --activate")
+		}
+		return 2
+	}
+	if *activate && strings.TrimSpace(*at) != "" {
+		if out != nil {
+			fmt.Fprintln(out, "fork failed: --activate targets --run <fork_run_id> and does not accept --at")
 		}
 		return 2
 	}
@@ -380,6 +393,28 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			fmt.Fprintln(out, "fork failed: postgres store required")
 		}
 		return 1
+	}
+	if *activate {
+		result, err := stores.Postgres.ActivateRunFork(ctx, store.RunForkActivateRequest{
+			ForkRunID: strings.TrimSpace(*runID),
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: %v\n", err)
+			}
+			return 1
+		}
+		if *asJSON {
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(result); err != nil {
+				fmt.Fprintf(out, "fork failed: encode json: %v\n", err)
+				return 1
+			}
+			return 0
+		}
+		printRunForkActivation(out, result)
+		return 0
 	}
 	if *materializeOnly {
 		result, err := stores.Postgres.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
@@ -425,6 +460,22 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	}
 	printRunForkPlan(out, plan)
 	return 0
+}
+
+func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "Fork activated for source run %s\n", result.SourceRunID)
+	fmt.Fprintf(w, "Fork Run: %s status=%s\n", result.ForkRunID, result.ForkRunStatus)
+	fmt.Fprintf(w, "Source Run: %s status=%s\n", result.SourceRunID, result.SourceRunStatus)
+	fmt.Fprintf(w, "Fork Point: %s (%s) at %s\n", result.ForkPoint.EventName, result.ForkPoint.EventID, result.ForkPoint.Timestamp.Format(time.RFC3339Nano))
+	fmt.Fprintf(w, "Summary: activated=%t source_frozen=%t historical_replay_blocked=%t materialized_entities=%d\n",
+		result.Activated,
+		result.SourceFrozen,
+		result.HistoricalReplayBlocked,
+		result.MaterializedEntityCount,
+	)
 }
 
 func printRunForkMaterialization(w io.Writer, result store.RunForkMaterialization) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -477,6 +477,52 @@ func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T)
 	}
 }
 
+func TestRunForkCommand_ActivateUsesCanonicalStoreOwnerJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	pg := &store.PostgresStore{DB: db}
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000320, 0).UTC()
+	ctx := context.Background()
+	seedRunForkCLIActivationSource(t, db, runID, entityID, eventID, at)
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, t.TempDir(), []string{
+		"--activate",
+		"--run", materialized.ForkRunID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var result store.RunForkActivation
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode fork activation json: %v\n%s", err, buf.String())
+	}
+	if !result.Activated || !result.SourceFrozen || !result.HistoricalReplayBlocked {
+		t.Fatalf("activation result = %#v", result)
+	}
+	if result.SourceRunID != runID || result.ForkRunID != materialized.ForkRunID {
+		t.Fatalf("activation lineage = %#v", result)
+	}
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, runID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != store.RunForkSourceFrozenStatus || forkStatus != store.RunForkActivatedStatus {
+		t.Fatalf("source/fork status = %s/%s, want forked/running", sourceStatus, forkStatus)
+	}
+}
+
 func TestRunForkCommand_NonDryRunWithoutMaterializeOnlyStaysFailClosed(t *testing.T) {
 	var buf bytes.Buffer
 	code := runForkCommand(context.Background(), t.TempDir(), []string{
@@ -486,8 +532,53 @@ func TestRunForkCommand_NonDryRunWithoutMaterializeOnlyStaysFailClosed(t *testin
 	if code != 2 {
 		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
 	}
-	if !strings.Contains(buf.String(), "mutating fork execution is not implemented; use --dry-run") {
+	if !strings.Contains(buf.String(), "mutating fork execution is not implemented; use --dry-run, --materialize-only, or --activate") {
 		t.Fatalf("output = %q, want fail-closed fork execution message", buf.String())
+	}
+}
+
+func seedRunForkCLIActivationSource(t *testing.T, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, runID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli.activate', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'cli-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"CLI Entity"'::jsonb, $3::uuid, 'platform', 'cli-test', 'seed', $4)
+	`, runID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'CLI Entity',
+			'ready', '{}'::jsonb, '{"name":"CLI Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, runID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3168,6 +3168,7 @@ run_model:
     command: 'swarm fork --run <run_id> --at <event_id|timestamp> [--contracts <path>]'
     dry_run_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --dry-run [--json]'
     materialize_only_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --materialize-only [--json]'
+    activation_command: 'swarm fork --run <fork_run_id> --activate [--json]'
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
       point, reconstructs provable state, classifies replay candidates, and returns execution_ready=false
       with named unsupported blockers whenever persisted recorder facts cannot prove safe execution. Dry-run
@@ -3183,6 +3184,15 @@ run_model:
       Materialized fork rows preserve entered_state_at from the source-at-T current_state mutation evidence; they
       MUST NOT stamp entered_state_at with the fork point unless that is when the current_state was entered.
       Full fork execution remains a separately gated operation.'
+    activation_admission: 'The activate form consumes an already materialized state-only fork and is the
+      supported activation slice for forks whose state was produced by materialize-only admission. Activation
+      requires a fork run with status=paused, fork lineage, fork-local entity_state rows, and a revalidated
+      execution_ready=true planner result at the original fork point. Activation atomically transitions the
+      fork run to status=running and the source run to status=forked. It fails closed with no partial mutation
+      if the source run advanced after the fork point, if the fork already has events, deliveries, sessions, or
+      turns, or if pending delivery, timer, route, session, active-turn, replay, or contract-swap facts would
+      require historical replay. Activation does not copy, redeliver, replay, reconstruct, or mutate historical
+      event, delivery, timer, route, session, turn, or contract rows.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
@@ -3206,6 +3216,11 @@ run_model:
         Source run status is unchanged. Copy reconstructed entity states into the fork context with fork-local
         revision=1 and source-at-T entered_state_at for the reconstructed current_state, then stop; do not boot,
         resume, redeliver, or mutate runtime delivery/session/timer/route state.'
+      3b_activate_materialized_fork: 'For an activation-only fork, consume a previously materialized fork run.
+        Revalidate the original fork point against current source-run facts, require no source advancement and
+        no unsupported replay/timer/route/session/turn/contract-swap facts, then atomically mark the source run
+        forked and the fork run running. Future runtime work uses the fork run_id and fork-local entity_state
+        rows; historical delivery replay remains unsupported in this slice.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -121,6 +121,10 @@ active_issues:
     title: Materialize run-isolated timestamp-fork state snapshots without resuming execution
     maps_to:
       - run_isolated_current_state_ownership
+  - id: 562
+    title: Activate materialized state-only timestamp forks without delivery replay
+    maps_to:
+      - run_isolated_current_state_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -204,12 +208,14 @@ nodes:
       - entity_state previously had no run_id and used entity_id as a global primary key
       - state-only fork dry-run can be execution-ready, but mutating execution cannot materialize isolated current-state rows until live current state is run-scoped
       - execution-ready timestamp-fork plans need a store-owned materialization operation that creates fork run lineage plus fork-scoped entity_state and entity_mutations rows without resuming delivery
+      - materialized state-only forks need store-owned activation that freezes the source run and starts future fork-local execution without historical delivery replay
       - runtime entity tools and workflow projection read and write entity_state by entity_id without run context
       - inbound routing, route ownership, workspace, digest, budget, and tests consume global current-state semantics
     representative_issues:
       - 549
       - 550
       - 558
+      - 562
     common_framing_mistakes:
       too_broad:
         - implement all mutating fork execution in one PR

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -846,6 +846,132 @@ accounts:
 	}
 }
 
+func TestEntityTools_SaveEntityFieldAfterForkActivationUsesForkRunID(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:    "tester",
+		Role:  "operator",
+		Tools: []string{"get_entity", "save_entity_field"},
+	}
+	bundle := loadWave1EntityToolBundle(t, actor, "review", "accounts", `
+types: {}
+`, `
+accounts:
+  status: text
+`)
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	stateEventID := uuid.NewString()
+	forkEventID := uuid.NewString()
+	at := time.Unix(1700000720, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+	`, sourceRunID, stateEventID, forkEventID, entityID, at, forkAt); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'activation-tool-test', 'seed', $5),
+			($1::uuid, $2::uuid, 'status', 'null'::jsonb, '"open"'::jsonb, $4::uuid, 'platform', 'activation-tool-test', 'field-only', $6)
+	`, sourceRunID, entityID, stateEventID, forkEventID, at, forkAt); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'review/inst-1', 'default', 'queued',
+			'{}'::jsonb, '{"status":"open"}'::jsonb, '{}'::jsonb, 1, $3, $4, $4
+		)
+	`, sourceRunID, entityID, at, forkAt); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: forkEventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	activated, err := pg.ActivateRunFork(ctx, store.RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if !activated.Activated || !activated.SourceFrozen {
+		t.Fatalf("activation result = %#v", activated)
+	}
+
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		SQLDB:          db,
+		WorkflowSource: semanticview.Wrap(bundle),
+	})
+	forkCtx := runtimetools.WithActor(runtimecorrelation.WithRunID(context.Background(), materialized.ForkRunID), actor)
+	if _, err := exec.Execute(forkCtx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "status",
+		"value":     "fork-active",
+	}); err != nil {
+		t.Fatalf("save_entity_field on activated fork: %v", err)
+	}
+
+	var sourceStatus, forkStatus string
+	var forkRevision int
+	if err := db.QueryRowContext(ctx, `
+		SELECT fields->>'status'
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source entity_state: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT fields->>'status', revision
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, materialized.ForkRunID, entityID).Scan(&forkStatus, &forkRevision); err != nil {
+		t.Fatalf("load fork entity_state: %v", err)
+	}
+	if sourceStatus != "open" || forkStatus != "fork-active" {
+		t.Fatalf("source/fork status = %s/%s, want open/fork-active", sourceStatus, forkStatus)
+	}
+	if forkRevision != 2 {
+		t.Fatalf("fork revision = %d, want 2 after fork-local write", forkRevision)
+	}
+	var forkMutationCount, sourceMutationCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM entity_mutations
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid AND field = 'status' AND writer_type = 'agent' AND handler_step = 'save_entity_field'
+	`, materialized.ForkRunID, entityID).Scan(&forkMutationCount); err != nil {
+		t.Fatalf("count fork status mutation: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM entity_mutations
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid AND field = 'status' AND writer_type = 'agent' AND handler_step = 'save_entity_field'
+	`, sourceRunID, entityID).Scan(&sourceMutationCount); err != nil {
+		t.Fatalf("count source status mutation: %v", err)
+	}
+	if forkMutationCount != 1 || sourceMutationCount != 0 {
+		t.Fatalf("fork/source save_entity_field mutation count = %d/%d, want 1/0", forkMutationCount, sourceMutationCount)
+	}
+}
+
 func TestEntityTools_SearchAndQueryUseStoredCurrentState(t *testing.T) {
 	ctx, exec, db := newEntityToolTestHarness(t)
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -1,0 +1,409 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+)
+
+const (
+	RunForkActivatedStatus    = "running"
+	RunForkSourceFrozenStatus = "forked"
+)
+
+type RunForkActivateRequest struct {
+	ForkRunID string
+}
+
+type RunForkActivation struct {
+	SourceRunID              string                      `json:"source_run_id"`
+	ForkRunID                string                      `json:"fork_run_id"`
+	ForkRunStatus            string                      `json:"fork_run_status"`
+	SourceRunStatus          string                      `json:"source_run_status"`
+	ForkPoint                RunForkPoint                `json:"fork_point"`
+	Activated                bool                        `json:"activated"`
+	SourceFrozen             bool                        `json:"source_frozen"`
+	HistoricalReplayBlocked  bool                        `json:"historical_replay_blocked"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
+	MaterializedEntityCount  int                         `json:"materialized_entity_count"`
+	SourceAdvancedAfterFork  bool                        `json:"source_advanced_after_fork_point,omitempty"`
+	RepeatedActivationFailed bool                        `json:"repeated_activation_failed,omitempty"`
+}
+
+type runForkActivationLineage struct {
+	ForkRunID       string
+	ForkStatus      string
+	SourceRunID     string
+	ForkEventID     string
+	ForkEventName   string
+	ForkEventTime   time.Time
+	SourceRunStatus string
+	EntityIDs       []string
+	FlowInstances   []string
+	SourceFlows     []string
+}
+
+func RequireRunForkActivationCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	if err := RequireRunForkMaterializerCapabilities(caps, catalog); err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"runs":         {"run_id", "status", "forked_from_run_id", "forked_from_event_id", "ended_at"},
+		"entity_state": {"run_id", "entity_id", "flow_instance", "updated_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run fork activation requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunForkActivationCapabilities(ctx context.Context) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return RequireRunForkActivationCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivateRequest) (RunForkActivation, error) {
+	if s == nil || s.DB == nil {
+		return RunForkActivation{}, fmt.Errorf("postgres store is required")
+	}
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return RunForkActivation{}, fmt.Errorf("fork run_id is required")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkActivation{}, fmt.Errorf("fork run_id must be a UUID: %w", err)
+	}
+	if err := s.requireRunForkActivationCapabilities(ctx); err != nil {
+		return RunForkActivation{}, err
+	}
+
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return RunForkActivation{}, fmt.Errorf("begin fork activation: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	lineage, err := loadRunForkActivationLineage(ctx, tx, forkRunID)
+	if err != nil {
+		return RunForkActivation{}, err
+	}
+	result := RunForkActivation{
+		SourceRunID:             lineage.SourceRunID,
+		ForkRunID:               lineage.ForkRunID,
+		ForkRunStatus:           lineage.ForkStatus,
+		SourceRunStatus:         lineage.SourceRunStatus,
+		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
+		HistoricalReplayBlocked: true,
+		MaterializedEntityCount: len(lineage.EntityIDs),
+	}
+	if lineage.ForkStatus != RunForkMaterializedStatus {
+		result.RepeatedActivationFailed = lineage.ForkStatus == RunForkActivatedStatus
+		return result, fmt.Errorf("fork activation requires materialized fork status %q; got %q", RunForkMaterializedStatus, lineage.ForkStatus)
+	}
+	if lineage.SourceRunStatus != "running" && lineage.SourceRunStatus != "paused" {
+		return result, fmt.Errorf("fork activation requires source run status running or paused before freeze; got %q", lineage.SourceRunStatus)
+	}
+	if len(lineage.EntityIDs) == 0 {
+		return result, fmt.Errorf("fork activation requires materialized fork entity_state rows")
+	}
+
+	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: lineage.SourceRunID, At: lineage.ForkEventID})
+	if err != nil {
+		return result, err
+	}
+	if !plan.ExecutionReady {
+		result.UnsupportedBlockers = plan.UnsupportedBlockers
+		return result, fmt.Errorf("fork activation requires execution-ready materialized fork; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
+	}
+	if err := ensureRunForkSourceNotAdvanced(ctx, tx, lineage); err != nil {
+		result.SourceAdvancedAfterFork = true
+		return result, err
+	}
+	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, lineage.ForkRunID); err != nil {
+		return result, err
+	}
+
+	now := time.Now().UTC()
+	sourceResult, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2, ended_at = COALESCE(ended_at, $3)
+		WHERE run_id = $1::uuid
+		  AND status IN ('running', 'paused')
+	`, lineage.SourceRunID, RunForkSourceFrozenStatus, now)
+	if err != nil {
+		return result, fmt.Errorf("freeze source run: %w", err)
+	}
+	if affected, err := sourceResult.RowsAffected(); err != nil {
+		return result, fmt.Errorf("confirm source freeze: %w", err)
+	} else if affected != 1 {
+		return result, fmt.Errorf("fork activation blocked: source_run_freeze_not_applied")
+	}
+	forkResult, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2, ended_at = NULL
+		WHERE run_id = $1::uuid
+		  AND status = $3
+	`, lineage.ForkRunID, RunForkActivatedStatus, RunForkMaterializedStatus)
+	if err != nil {
+		return result, fmt.Errorf("activate fork run: %w", err)
+	}
+	if affected, err := forkResult.RowsAffected(); err != nil {
+		return result, fmt.Errorf("confirm fork activation: %w", err)
+	} else if affected != 1 {
+		return result, fmt.Errorf("fork activation blocked: fork_run_activation_not_applied")
+	}
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("commit fork activation: %w", err)
+	}
+	committed = true
+	result.ForkRunStatus = RunForkActivatedStatus
+	result.SourceRunStatus = RunForkSourceFrozenStatus
+	result.Activated = true
+	result.SourceFrozen = true
+	return result, nil
+}
+
+func loadRunForkActivationLineage(ctx context.Context, tx *sql.Tx, forkRunID string) (runForkActivationLineage, error) {
+	var lineage runForkActivationLineage
+	var forkEventTime sql.NullTime
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			f.run_id::text,
+			COALESCE(f.status, ''),
+			COALESCE(f.forked_from_run_id::text, ''),
+			COALESCE(f.forked_from_event_id::text, ''),
+			COALESCE(s.status, ''),
+			COALESCE(e.event_name, ''),
+			e.created_at
+		FROM runs f
+		LEFT JOIN runs s ON s.run_id = f.forked_from_run_id
+		LEFT JOIN events e ON e.run_id = f.forked_from_run_id AND e.event_id = f.forked_from_event_id
+		WHERE f.run_id = $1::uuid
+		FOR UPDATE OF f
+	`, forkRunID).Scan(
+		&lineage.ForkRunID,
+		&lineage.ForkStatus,
+		&lineage.SourceRunID,
+		&lineage.ForkEventID,
+		&lineage.SourceRunStatus,
+		&lineage.ForkEventName,
+		&forkEventTime,
+	)
+	if err == sql.ErrNoRows {
+		return runForkActivationLineage{}, fmt.Errorf("fork run %s not found", forkRunID)
+	}
+	if err != nil {
+		return runForkActivationLineage{}, fmt.Errorf("load fork activation lineage: %w", err)
+	}
+	if lineage.SourceRunID == "" || lineage.ForkEventID == "" {
+		return runForkActivationLineage{}, fmt.Errorf("fork activation requires fork lineage")
+	}
+	if lineage.SourceRunStatus == "" || !forkEventTime.Valid {
+		return runForkActivationLineage{}, fmt.Errorf("fork activation requires source run and fork point event")
+	}
+	lineage.ForkEventTime = forkEventTime.Time
+	if err := tx.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid FOR UPDATE`, lineage.SourceRunID).Scan(&lineage.SourceRunStatus); err != nil {
+		return runForkActivationLineage{}, fmt.Errorf("lock source run: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT entity_id::text, COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		ORDER BY entity_id
+	`, lineage.ForkRunID)
+	if err != nil {
+		return runForkActivationLineage{}, fmt.Errorf("load fork materialized state facts: %w", err)
+	}
+	defer rows.Close()
+	flowSet := map[string]struct{}{}
+	sourceFlowSet := map[string]struct{}{}
+	for rows.Next() {
+		var entityID, flowInstance string
+		if err := rows.Scan(&entityID, &flowInstance); err != nil {
+			return runForkActivationLineage{}, fmt.Errorf("scan fork materialized state facts: %w", err)
+		}
+		if entityID = strings.TrimSpace(entityID); entityID != "" {
+			lineage.EntityIDs = append(lineage.EntityIDs, entityID)
+		}
+		if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
+			if _, ok := flowSet[flowInstance]; !ok {
+				flowSet[flowInstance] = struct{}{}
+				lineage.FlowInstances = append(lineage.FlowInstances, flowInstance)
+			}
+			if sourceFlow := runtimeflowidentity.SemanticScope(flowInstance); sourceFlow != "" {
+				sourceFlowSet[sourceFlow] = struct{}{}
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return runForkActivationLineage{}, fmt.Errorf("read fork materialized state facts: %w", err)
+	}
+	lineage.SourceFlows = stringSetValues(sourceFlowSet)
+	return lineage, nil
+}
+
+func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+	checks := []struct {
+		code  string
+		query string
+		args  []any
+	}{
+		{
+			code: "source_events_advanced_after_fork_point",
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM events
+					WHERE run_id = $1::uuid
+					  AND (created_at, event_id) > ($2::timestamptz, $3::uuid)
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
+		},
+		{
+			code: "source_mutations_advanced_after_fork_point",
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM entity_mutations
+					WHERE run_id = $1::uuid
+					  AND created_at > $2::timestamptz
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+		{
+			code: "source_current_state_advanced_after_fork_point",
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM entity_state
+					WHERE run_id = $1::uuid
+					  AND updated_at > $2::timestamptz
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+		{
+			code: "source_deliveries_advanced_after_fork_point",
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM event_deliveries d
+					WHERE d.run_id = $1::uuid
+					  AND (
+							d.created_at > $2::timestamptz
+							OR d.started_at > $2::timestamptz
+							OR d.delivered_at > $2::timestamptz
+					  )
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+	}
+	for _, check := range checks {
+		var exists bool
+		if err := tx.QueryRowContext(ctx, check.query, check.args...).Scan(&exists); err != nil {
+			return fmt.Errorf("check %s: %w", check.code, err)
+		}
+		if exists {
+			return fmt.Errorf("fork activation blocked: %s", check.code)
+		}
+	}
+	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, lineage); err != nil {
+		return err
+	}
+	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, lineage); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+	if len(lineage.EntityIDs) == 0 && len(lineage.FlowInstances) == 0 {
+		return nil
+	}
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE created_at > $1::timestamptz
+			  AND (
+					(entity_id IS NOT NULL AND entity_id::text = ANY($2::text[]))
+					OR
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($3::text[]))
+			  )
+		)
+	`, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&exists); err != nil {
+		return fmt.Errorf("check source timer advancement: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("fork activation blocked: source_timers_advanced_after_fork_point")
+	}
+	return nil
+}
+
+func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+	if len(lineage.FlowInstances) == 0 && len(lineage.SourceFlows) == 0 {
+		return nil
+	}
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM routing_rules
+			WHERE created_at > $1::timestamptz
+			  AND (
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($2::text[]))
+					OR
+					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($3::text[]))
+			  )
+		)
+	`, lineage.ForkEventTime, pq.Array(lineage.FlowInstances), pq.Array(lineage.SourceFlows)).Scan(&exists); err != nil {
+		return fmt.Errorf("check source route advancement: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("fork activation blocked: source_routes_advanced_after_fork_point")
+	}
+	return nil
+}
+
+func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, forkRunID string) error {
+	checks := []struct {
+		code  string
+		query string
+	}{
+		{"fork_events_already_exist", `SELECT EXISTS (SELECT 1 FROM events WHERE run_id = $1::uuid)`},
+		{"fork_deliveries_already_exist", `SELECT EXISTS (SELECT 1 FROM event_deliveries WHERE run_id = $1::uuid)`},
+		{"fork_sessions_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`},
+		{"fork_turns_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_turns WHERE run_id = $1::uuid)`},
+	}
+	for _, check := range checks {
+		var exists bool
+		if err := tx.QueryRowContext(ctx, check.query, forkRunID).Scan(&exists); err != nil {
+			return fmt.Errorf("check %s: %w", check.code, err)
+		}
+		if exists {
+			return fmt.Errorf("fork activation blocked: %s", check.code)
+		}
+	}
+	return nil
+}

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -66,16 +66,16 @@ func RequireRunForkActivationCapabilities(caps StoreSchemaCapabilities, catalog 
 	return nil
 }
 
-func (s *PostgresStore) requireRunForkActivationCapabilities(ctx context.Context) error {
+func (s *PostgresStore) requireRunForkActivationCapabilities(ctx context.Context) (schemaColumnCatalog, error) {
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
-		return err
+		return schemaColumnCatalog{}, err
 	}
 	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
 	if err != nil {
-		return err
+		return schemaColumnCatalog{}, err
 	}
-	return RequireRunForkActivationCapabilities(caps, catalog)
+	return catalog, RequireRunForkActivationCapabilities(caps, catalog)
 }
 
 func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivateRequest) (RunForkActivation, error) {
@@ -89,7 +89,8 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	if _, err := uuid.Parse(forkRunID); err != nil {
 		return RunForkActivation{}, fmt.Errorf("fork run_id must be a UUID: %w", err)
 	}
-	if err := s.requireRunForkActivationCapabilities(ctx); err != nil {
+	catalog, err := s.requireRunForkActivationCapabilities(ctx)
+	if err != nil {
 		return RunForkActivation{}, err
 	}
 
@@ -136,11 +137,11 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		result.UnsupportedBlockers = plan.UnsupportedBlockers
 		return result, fmt.Errorf("fork activation requires execution-ready materialized fork; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
 	}
-	if err := ensureRunForkSourceNotAdvanced(ctx, tx, lineage); err != nil {
+	if err := ensureRunForkSourceNotAdvanced(ctx, tx, catalog, lineage); err != nil {
 		result.SourceAdvancedAfterFork = true
 		return result, err
 	}
-	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, lineage.ForkRunID); err != nil {
+	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, lineage.ForkRunID); err != nil {
 		return result, err
 	}
 
@@ -263,7 +264,7 @@ func loadRunForkActivationLineage(ctx context.Context, tx *sql.Tx, forkRunID str
 	return lineage, nil
 }
 
-func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
 	checks := []struct {
 		code  string
 		query string
@@ -327,16 +328,19 @@ func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, lineage run
 			return fmt.Errorf("fork activation blocked: %s", check.code)
 		}
 	}
-	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, lineage); err != nil {
+	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, catalog, lineage); err != nil {
 		return err
 	}
-	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, lineage); err != nil {
+	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, catalog, lineage); err != nil {
 		return err
 	}
 	return nil
 }
 
-func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
+	if !catalog.hasColumns("timers", "entity_id", "flow_instance", "created_at") {
+		return nil
+	}
 	if len(lineage.EntityIDs) == 0 && len(lineage.FlowInstances) == 0 {
 		return nil
 	}
@@ -361,7 +365,10 @@ func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, line
 	return nil
 }
 
-func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
+	if !catalog.hasColumns("routing_rules", "flow_instance", "source_flow", "created_at") {
+		return nil
+	}
 	if len(lineage.FlowInstances) == 0 && len(lineage.SourceFlows) == 0 {
 		return nil
 	}
@@ -386,15 +393,25 @@ func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, line
 	return nil
 }
 
-func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, forkRunID string) error {
+func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID string) error {
 	checks := []struct {
 		code  string
 		query string
 	}{
 		{"fork_events_already_exist", `SELECT EXISTS (SELECT 1 FROM events WHERE run_id = $1::uuid)`},
 		{"fork_deliveries_already_exist", `SELECT EXISTS (SELECT 1 FROM event_deliveries WHERE run_id = $1::uuid)`},
-		{"fork_sessions_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`},
-		{"fork_turns_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_turns WHERE run_id = $1::uuid)`},
+	}
+	if catalog.hasColumns("agent_sessions", "run_id") {
+		checks = append(checks, struct {
+			code  string
+			query string
+		}{"fork_sessions_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`})
+	}
+	if catalog.hasColumns("agent_turns", "run_id") {
+		checks = append(checks, struct {
+			code  string
+			query string
+		}{"fork_turns_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_turns WHERE run_id = $1::uuid)`})
 	}
 	for _, check := range checks {
 		var exists bool

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -457,6 +457,52 @@ func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *tes
 	}
 }
 
+func TestRunForkActivation_ToleratesOptionalLegacyReplaySchemas(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700001100, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS timers CASCADE`); err != nil {
+		t.Fatalf("drop timers: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules CASCADE`); err != nil {
+		t.Fatalf("drop routing_rules: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_turns CASCADE`); err != nil {
+		t.Fatalf("drop agent_turns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
+		t.Fatalf("drop agent_sessions: %v", err)
+	}
+	for name, ddl := range map[string]string{
+		"timers":         `CREATE TABLE timers (timer_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), entity_id UUID, flow_instance TEXT)`,
+		"routing_rules":  `CREATE TABLE routing_rules (rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), flow_instance TEXT)`,
+		"agent_sessions": `CREATE TABLE agent_sessions (session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), status TEXT NOT NULL DEFAULT 'active', created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`,
+		"agent_turns":    `CREATE TABLE agent_turns (turn_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), session_id UUID NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`,
+	} {
+		if _, err := db.ExecContext(ctx, ddl); err != nil {
+			t.Fatalf("create legacy %s: %v", name, err)
+		}
+	}
+
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork with optional legacy schemas: %v", err)
+	}
+	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork with optional legacy schemas: %v", err)
+	}
+	if !activated.Activated || activated.ForkRunStatus != RunForkActivatedStatus || activated.SourceRunStatus != RunForkSourceFrozenStatus {
+		t.Fatalf("activation result = %#v", activated)
+	}
+}
+
 type sqlNullTime struct {
 	Time  time.Time
 	Valid bool

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -299,5 +301,224 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	}
 	if first.ForkRunID == "" {
 		t.Fatal("first ForkRunID is empty")
+	}
+}
+
+func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000800, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if !activated.Activated || !activated.SourceFrozen {
+		t.Fatalf("activation flags = activated:%v frozen:%v", activated.Activated, activated.SourceFrozen)
+	}
+	if activated.SourceRunID != sourceRunID || activated.ForkRunID != materialized.ForkRunID {
+		t.Fatalf("activation lineage = %#v", activated)
+	}
+	if activated.ForkRunStatus != RunForkActivatedStatus || activated.SourceRunStatus != RunForkSourceFrozenStatus {
+		t.Fatalf("activation statuses = fork:%s source:%s", activated.ForkRunStatus, activated.SourceRunStatus)
+	}
+
+	var sourceStatus, forkStatus string
+	var sourceEndedAt sqlNullTime
+	if err := db.QueryRowContext(ctx, `
+		SELECT status, ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, sourceRunID).Scan(&sourceStatus, &sourceEndedAt); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != RunForkSourceFrozenStatus || !sourceEndedAt.Valid {
+		t.Fatalf("source status/ended_at = %s/%v, want forked/valid", sourceStatus, sourceEndedAt.Valid)
+	}
+	if forkStatus != RunForkActivatedStatus {
+		t.Fatalf("fork status = %q, want running", forkStatus)
+	}
+
+	var sourceState, forkState string
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID).Scan(&sourceState); err != nil {
+		t.Fatalf("load source state: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, materialized.ForkRunID, entityID).Scan(&forkState); err != nil {
+		t.Fatalf("load fork state: %v", err)
+	}
+	if sourceState != "ready" || forkState != "ready" {
+		t.Fatalf("source/fork state = %s/%s, want ready/ready", sourceState, forkState)
+	}
+}
+
+func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	afterEventID := uuid.NewString()
+	at := time.Unix(1700000900, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.after', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed post-fork event: %v", err)
+	}
+	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err == nil || !strings.Contains(err.Error(), "source_events_advanced_after_fork_point") {
+		t.Fatalf("ActivateRunFork advanced source error = %v, want source advanced blocker", err)
+	}
+	var forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status after blocked activation: %v", err)
+	}
+	if forkStatus != RunForkMaterializedStatus {
+		t.Fatalf("fork status after blocked activation = %q, want paused", forkStatus)
+	}
+
+	cleanSourceRunID := uuid.NewString()
+	cleanEntityID := uuid.NewString()
+	cleanEventID := uuid.NewString()
+	seedActivationReadySourceRun(t, db, cleanSourceRunID, cleanEntityID, cleanEventID, at.Add(time.Minute))
+	cleanMaterialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: cleanSourceRunID, At: cleanEventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork clean: %v", err)
+	}
+	if _, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: cleanMaterialized.ForkRunID}); err != nil {
+		t.Fatalf("ActivateRunFork clean: %v", err)
+	}
+	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: cleanMaterialized.ForkRunID})
+	if err == nil || !strings.Contains(err.Error(), "requires materialized fork status") {
+		t.Fatalf("ActivateRunFork repeat error = %v, want materialized-status failure", err)
+	}
+}
+
+func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700001000, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'blocked-node', 'pending', $3)
+	`, sourceRunID, eventID, at); err != nil {
+		t.Fatalf("seed pending delivery: %v", err)
+	}
+	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
+		t.Fatalf("ActivateRunFork pending delivery error = %v, want delivery blocker", err)
+	}
+
+	orphanRunID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'paused', $2)`, orphanRunID, at); err != nil {
+		t.Fatalf("seed orphan paused run: %v", err)
+	}
+	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: orphanRunID})
+	if err == nil || !strings.Contains(err.Error(), "requires fork lineage") {
+		t.Fatalf("ActivateRunFork orphan error = %v, want lineage failure", err)
+	}
+}
+
+type sqlNullTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+type execContextDB interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func (n *sqlNullTime) Scan(value any) error {
+	if value == nil {
+		n.Valid = false
+		return nil
+	}
+	tm, ok := value.(time.Time)
+	if !ok {
+		return fmt.Errorf("sqlNullTime expected time.Time, got %T", value)
+	}
+	n.Time = tm
+	n.Valid = true
+	return nil
+}
+
+func seedActivationReadySourceRun(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'activation-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Activation Entity"'::jsonb, $3::uuid, 'platform', 'activation-test', 'seed', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'Activation Entity',
+			'ready', '{}'::jsonb, '{"name":"Activation Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds the canonical store-owned `ActivateRunFork(...)` path for already materialized state-only timestamp forks.
- Wires `swarm fork --run <fork_run_id> --activate [--json]` as a thin CLI consumer of that owner.
- Promotes the activation slice into `platform-spec.yaml` and updates the runtime-operations watchlist mapping for #562.

Closes #562

## Governing refs/context
- Issue #562 approved gate: activation of an already materialized state-only timestamp fork without historical delivery replay.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.activation_admission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3b_activate_materialized_fork`
- Existing fork spec context: `run_model.fork.materialize_only_admission`, `run_model.fork.isolation`, and `run_model.mutation_log.write_contract`.

## Semantic migration accounting
- New canonical owner: `internal/store/run_fork_activation.go` / `PostgresStore.ActivateRunFork(...)`.
- Old producer / reader / writer path now invalid: activation is no longer absent or represented as generic non-dry-run CLI execution; CLI must call the store owner and must not perform direct SQL activation.
- Production paths checked for surviving old behavior: `cmd/swarm/main.go` remains a consumer only; fork planner/materializer remain separate owners; runtime entity tools already consume run-scoped current-state ownership and are proof-covered after activation.
- Migration completeness: complete for the approved #562 first slice. Delivery replay, timers, sessions, turns, routes, contract swap, Builder/dashboard UI remain explicitly out of scope and blocked/split by gate.

## Proof
- `go test ./internal/store -run 'TestRunFork(Activation|Materializer|Planner)' -count=1`
- `go test ./internal/runtime/tools -run 'TestEntityTools_(GetEntityReturnsForkLocalMaterializedRevision|SaveEntityFieldAfterForkActivationUsesForkRunID)' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand_(ActivateUsesCanonicalStoreOwnerJSON|MaterializeOnlyUsesCanonicalStoreOwnerJSON|NonDryRunWithoutMaterializeOnlyStaysFailClosed|DryRunUsesCanonicalPlannerJSON)' -count=1`
- `go test ./internal/store -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`