### PR TITLE
[agent-a][issue #565] Add timestamp-fork replay admission taxonomy

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -399,6 +399,9 @@ func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
 	if plan.UnsupportedBlockerCount != 0 {
 		t.Fatalf("UnsupportedBlockerCount = %d, want 0; blockers=%#v", plan.UnsupportedBlockerCount, plan.UnsupportedBlockers)
 	}
+	if plan.ReplayResumeAdmission.Owner != store.RunForkReplayResumeAdmissionOwner || !plan.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatalf("taxonomy = %#v, want canonical owner and state-only ready", plan.ReplayResumeAdmission)
+	}
 }
 
 func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
@@ -464,6 +467,9 @@ func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T)
 	if result.SourceRunID != runID || result.ForkRunID == "" || result.ForkRunStatus != store.RunForkMaterializedStatus {
 		t.Fatalf("materialization result = %#v", result)
 	}
+	if result.ReplayResumeAdmission.Owner != store.RunForkReplayResumeAdmissionOwner || !result.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatalf("materialization taxonomy = %#v, want canonical owner and state-only ready", result.ReplayResumeAdmission)
+	}
 	var forkState string
 	if err := db.QueryRowContext(ctx, `
 		SELECT current_state
@@ -507,6 +513,9 @@ func TestRunForkCommand_ActivateUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	}
 	if !result.Activated || !result.SourceFrozen || !result.HistoricalReplayBlocked {
 		t.Fatalf("activation result = %#v", result)
+	}
+	if result.ReplayResumeAdmission.Owner != store.RunForkReplayResumeAdmissionOwner || !result.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatalf("activation taxonomy = %#v, want canonical owner and state-only ready", result.ReplayResumeAdmission)
 	}
 	if result.SourceRunID != runID || result.ForkRunID != materialized.ForkRunID {
 		t.Fatalf("activation lineage = %#v", result)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3196,6 +3196,12 @@ run_model:
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
+    replay_resume_admission_taxonomy: 'Fork planning, materialization, and activation surfaces expose the
+      canonical store-backed replay_resume_admission taxonomy. This taxonomy is non-mutating: it classifies
+      historical source-run facts as reconstruct, lineage-only, fail-closed blockers, split siblings, or
+      no-historical-action. It does not authorize event copying, delivery redelivery, session/turn/timer/route
+      reconstruction, contract swap execution, or any runtime replay mutation. Full historical resume remains
+      separately gated even when state-only activation is ready.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -22,18 +22,19 @@ type RunForkActivateRequest struct {
 }
 
 type RunForkActivation struct {
-	SourceRunID              string                      `json:"source_run_id"`
-	ForkRunID                string                      `json:"fork_run_id"`
-	ForkRunStatus            string                      `json:"fork_run_status"`
-	SourceRunStatus          string                      `json:"source_run_status"`
-	ForkPoint                RunForkPoint                `json:"fork_point"`
-	Activated                bool                        `json:"activated"`
-	SourceFrozen             bool                        `json:"source_frozen"`
-	HistoricalReplayBlocked  bool                        `json:"historical_replay_blocked"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
-	MaterializedEntityCount  int                         `json:"materialized_entity_count"`
-	SourceAdvancedAfterFork  bool                        `json:"source_advanced_after_fork_point,omitempty"`
-	RepeatedActivationFailed bool                        `json:"repeated_activation_failed,omitempty"`
+	SourceRunID              string                       `json:"source_run_id"`
+	ForkRunID                string                       `json:"fork_run_id"`
+	ForkRunStatus            string                       `json:"fork_run_status"`
+	SourceRunStatus          string                       `json:"source_run_status"`
+	ForkPoint                RunForkPoint                 `json:"fork_point"`
+	Activated                bool                         `json:"activated"`
+	SourceFrozen             bool                         `json:"source_frozen"`
+	HistoricalReplayBlocked  bool                         `json:"historical_replay_blocked"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
+	MaterializedEntityCount  int                          `json:"materialized_entity_count"`
+	SourceAdvancedAfterFork  bool                         `json:"source_advanced_after_fork_point,omitempty"`
+	RepeatedActivationFailed bool                         `json:"repeated_activation_failed,omitempty"`
 }
 
 type runForkActivationLineage struct {
@@ -133,15 +134,24 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	if err != nil {
 		return result, err
 	}
+	result.ReplayResumeAdmission = plan.ReplayResumeAdmission
 	if !plan.ExecutionReady {
 		result.UnsupportedBlockers = plan.UnsupportedBlockers
 		return result, fmt.Errorf("fork activation requires execution-ready materialized fork; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
 	}
 	if err := ensureRunForkSourceNotAdvanced(ctx, tx, catalog, lineage); err != nil {
 		result.SourceAdvancedAfterFork = true
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
 		return result, err
 	}
 	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, lineage.ForkRunID); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
 		return result, err
 	}
 
@@ -325,7 +335,7 @@ func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, catalog sch
 			return fmt.Errorf("check %s: %w", check.code, err)
 		}
 		if exists {
-			return fmt.Errorf("fork activation blocked: %s", check.code)
+			return runForkReplayResumeError(check.code, RunForkReplayResumeFactSourceAdvanced, fmt.Sprintf("fork activation blocked: %s", check.code))
 		}
 	}
 	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, catalog, lineage); err != nil {
@@ -360,7 +370,7 @@ func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, cata
 		return fmt.Errorf("check source timer advancement: %w", err)
 	}
 	if exists {
-		return fmt.Errorf("fork activation blocked: source_timers_advanced_after_fork_point")
+		return runForkReplayResumeError("source_timers_advanced_after_fork_point", RunForkReplayResumeFactSourceAdvanced, "fork activation blocked: source_timers_advanced_after_fork_point")
 	}
 	return nil
 }
@@ -388,7 +398,7 @@ func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, cata
 		return fmt.Errorf("check source route advancement: %w", err)
 	}
 	if exists {
-		return fmt.Errorf("fork activation blocked: source_routes_advanced_after_fork_point")
+		return runForkReplayResumeError("source_routes_advanced_after_fork_point", RunForkReplayResumeFactSourceAdvanced, "fork activation blocked: source_routes_advanced_after_fork_point")
 	}
 	return nil
 }
@@ -419,7 +429,7 @@ func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, c
 			return fmt.Errorf("check %s: %w", check.code, err)
 		}
 		if exists {
-			return fmt.Errorf("fork activation blocked: %s", check.code)
+			return runForkReplayResumeError(check.code, RunForkReplayResumeFactForkReplayState, fmt.Sprintf("fork activation blocked: %s", check.code))
 		}
 	}
 	return nil

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -23,15 +23,16 @@ type RunForkMaterializeRequest struct {
 }
 
 type RunForkMaterialization struct {
-	SourceRunID              string                      `json:"source_run_id"`
-	ForkRunID                string                      `json:"fork_run_id"`
-	ForkRunStatus            string                      `json:"fork_run_status"`
-	ForkPoint                RunForkPoint                `json:"fork_point"`
-	MaterializedEntityCount  int                         `json:"materialized_entity_count"`
-	ExecutionReady           bool                        `json:"execution_ready"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
-	DeliveryResumeBlocked    bool                        `json:"delivery_resume_blocked"`
-	SourceRunStatusUnchanged bool                        `json:"source_run_status_unchanged"`
+	SourceRunID              string                       `json:"source_run_id"`
+	ForkRunID                string                       `json:"fork_run_id"`
+	ForkRunStatus            string                       `json:"fork_run_status"`
+	ForkPoint                RunForkPoint                 `json:"fork_point"`
+	MaterializedEntityCount  int                          `json:"materialized_entity_count"`
+	ExecutionReady           bool                         `json:"execution_ready"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
+	DeliveryResumeBlocked    bool                         `json:"delivery_resume_blocked"`
+	SourceRunStatusUnchanged bool                         `json:"source_run_status_unchanged"`
 }
 
 type runForkEntityMetadata struct {
@@ -89,6 +90,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 			SourceRunID:           plan.SourceRunID,
 			ForkPoint:             plan.ForkPoint,
 			ExecutionReady:        false,
+			ReplayResumeAdmission: plan.ReplayResumeAdmission,
 			UnsupportedBlockers:   plan.UnsupportedBlockers,
 			DeliveryResumeBlocked: true,
 		}, fmt.Errorf("fork materialization requires execution-ready plan; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
@@ -144,6 +146,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 		ForkPoint:                plan.ForkPoint,
 		MaterializedEntityCount:  len(plan.Entities),
 		ExecutionReady:           true,
+		ReplayResumeAdmission:    plan.ReplayResumeAdmission,
 		DeliveryResumeBlocked:    true,
 		SourceRunStatusUnchanged: true,
 	}, nil

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -89,6 +89,15 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if !result.DeliveryResumeBlocked || !result.SourceRunStatusUnchanged {
 		t.Fatalf("boundary flags = resume_blocked:%v source_unchanged:%v", result.DeliveryResumeBlocked, result.SourceRunStatusUnchanged)
 	}
+	if result.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
+		t.Fatalf("taxonomy owner = %q, want %q", result.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
+	}
+	if !result.ReplayResumeAdmission.StateOnlyExecutionReady || result.ReplayResumeAdmission.HistoricalReplaySupported {
+		t.Fatalf("taxonomy flags = state_only:%v historical_supported:%v, want true/false",
+			result.ReplayResumeAdmission.StateOnlyExecutionReady,
+			result.ReplayResumeAdmission.HistoricalReplaySupported,
+		)
+	}
 
 	var forkStatus, forkedFromRun, forkedFromEvent string
 	if err := db.QueryRowContext(ctx, `
@@ -261,9 +270,15 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 		t.Fatalf("seed pending delivery: %v", err)
 	}
 
-	_, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	blocked, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
 		t.Fatalf("MaterializeRunFork error = %v, want delivery blocker", err)
+	}
+	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
+		t.Fatalf("blocked taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
+	}
+	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactDeliveryPendingHistory) {
+		t.Fatalf("blocked taxonomy missing pending delivery disposition: %#v", blocked.ReplayResumeAdmission)
 	}
 	var forkCount int
 	if err := db.QueryRowContext(ctx, `
@@ -325,6 +340,12 @@ func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.
 	}
 	if !activated.Activated || !activated.SourceFrozen {
 		t.Fatalf("activation flags = activated:%v frozen:%v", activated.Activated, activated.SourceFrozen)
+	}
+	if !activated.HistoricalReplayBlocked {
+		t.Fatal("HistoricalReplayBlocked = false, want true for activation-only boundary")
+	}
+	if activated.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !activated.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatalf("activation taxonomy = %#v, want owner and state-only ready", activated.ReplayResumeAdmission)
 	}
 	if activated.SourceRunID != sourceRunID || activated.ForkRunID != materialized.ForkRunID {
 		t.Fatalf("activation lineage = %#v", activated)
@@ -391,9 +412,15 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
 		t.Fatalf("seed post-fork event: %v", err)
 	}
-	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
 	if err == nil || !strings.Contains(err.Error(), "source_events_advanced_after_fork_point") {
 		t.Fatalf("ActivateRunFork advanced source error = %v, want source advanced blocker", err)
+	}
+	if !blocked.SourceAdvancedAfterFork || !runForkTestHasActivationBlocker(blocked, "source_events_advanced_after_fork_point") {
+		t.Fatalf("advanced-source activation result = %#v, want taxonomy-backed source advanced blocker", blocked)
+	}
+	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced) {
+		t.Fatalf("advanced-source taxonomy missing source-advanced disposition: %#v", blocked.ReplayResumeAdmission)
 	}
 	var forkStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
@@ -442,9 +469,12 @@ func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *tes
 	`, sourceRunID, eventID, at); err != nil {
 		t.Fatalf("seed pending delivery: %v", err)
 	}
-	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
 	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
 		t.Fatalf("ActivateRunFork pending delivery error = %v, want delivery blocker", err)
+	}
+	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
+		t.Fatalf("blocked activation taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
 	}
 
 	orphanRunID := uuid.NewString()
@@ -454,6 +484,42 @@ func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *tes
 	_, err = pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: orphanRunID})
 	if err == nil || !strings.Contains(err.Error(), "requires fork lineage") {
 		t.Fatalf("ActivateRunFork orphan error = %v, want lineage failure", err)
+	}
+}
+
+func TestRunForkActivation_FailsClosedForForkReplayStateWithTaxonomy(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	forkEventID := uuid.NewString()
+	at := time.Unix(1700001050, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.replay_state', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, materialized.ForkRunID, forkEventID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed fork event: %v", err)
+	}
+
+	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err == nil || !strings.Contains(err.Error(), "fork_events_already_exist") {
+		t.Fatalf("ActivateRunFork fork replay state error = %v, want fork event blocker", err)
+	}
+	if !runForkTestHasActivationBlocker(blocked, "fork_events_already_exist") {
+		t.Fatalf("activation blockers = %#v, want fork_events_already_exist", blocked.UnsupportedBlockers)
+	}
+	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactForkReplayState) {
+		t.Fatalf("fork replay-state taxonomy missing disposition: %#v", blocked.ReplayResumeAdmission)
 	}
 }
 
@@ -567,4 +633,13 @@ func seedActivationReadySourceRun(t *testing.T, db execContextDB, sourceRunID, e
 	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
+}
+
+func runForkTestHasActivationBlocker(result RunForkActivation, code string) bool {
+	for _, blocker := range result.UnsupportedBlockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -30,19 +30,20 @@ type RunForkPlanRequest struct {
 }
 
 type RunForkPlan struct {
-	SourceRunID              string                      `json:"source_run_id"`
-	SourceRunStatus          string                      `json:"source_run_status,omitempty"`
-	SourceRunStartedAt       *time.Time                  `json:"source_run_started_at,omitempty"`
-	SourceRunEndedAt         *time.Time                  `json:"source_run_ended_at,omitempty"`
-	ForkPoint                RunForkPoint                `json:"fork_point"`
-	EventCountAtFork         int                         `json:"event_count_at_fork"`
-	ReconstructedEntityCount int                         `json:"reconstructed_entity_count"`
-	PendingWorkCount         int                         `json:"pending_work_count"`
-	UnsupportedBlockerCount  int                         `json:"unsupported_blocker_count"`
-	ExecutionReady           bool                        `json:"execution_ready"`
-	Entities                 []RunForkEntityState        `json:"entities,omitempty"`
-	PendingWork              []RunForkPendingWork        `json:"pending_work,omitempty"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker `json:"unsupported_blockers,omitempty"`
+	SourceRunID              string                       `json:"source_run_id"`
+	SourceRunStatus          string                       `json:"source_run_status,omitempty"`
+	SourceRunStartedAt       *time.Time                   `json:"source_run_started_at,omitempty"`
+	SourceRunEndedAt         *time.Time                   `json:"source_run_ended_at,omitempty"`
+	ForkPoint                RunForkPoint                 `json:"fork_point"`
+	EventCountAtFork         int                          `json:"event_count_at_fork"`
+	ReconstructedEntityCount int                          `json:"reconstructed_entity_count"`
+	PendingWorkCount         int                          `json:"pending_work_count"`
+	UnsupportedBlockerCount  int                          `json:"unsupported_blocker_count"`
+	ExecutionReady           bool                         `json:"execution_ready"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
+	Entities                 []RunForkEntityState         `json:"entities,omitempty"`
+	PendingWork              []RunForkPendingWork         `json:"pending_work,omitempty"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
 }
 
 type RunForkPoint struct {
@@ -208,9 +209,10 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
-	plan.UnsupportedBlockers = runForkUnsupportedBlockers(evidence)
+	plan.ReplayResumeAdmission = runForkReplayResumeAdmission(evidence)
+	plan.UnsupportedBlockers = plan.ReplayResumeAdmission.UnsupportedBlockers
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
-	plan.ExecutionReady = plan.UnsupportedBlockerCount == 0
+	plan.ExecutionReady = plan.ReplayResumeAdmission.StateOnlyExecutionReady
 	return plan, nil
 }
 
@@ -718,43 +720,6 @@ func (s *PostgresStore) hasRunForkActiveTurn(ctx context.Context, catalog schema
 		return false, fmt.Errorf("check fork active turn blockers: %w", err)
 	}
 	return exists, nil
-}
-
-func runForkUnsupportedBlockers(evidence runForkAdmissionEvidence) []RunForkUnsupportedBlocker {
-	blockers := []RunForkUnsupportedBlocker{}
-	add := func(code, message string) {
-		for _, existing := range blockers {
-			if existing.Code == code {
-				return
-			}
-		}
-		blockers = append(blockers, RunForkUnsupportedBlocker{Code: code, Message: message})
-	}
-	if runForkHasUnsupportedPendingWork(evidence.Pending) {
-		add("delivery_history_unproven", "event_deliveries stores current delivery state; arbitrary historical delivery transitions at the fork point are not append-only proven")
-	}
-	if evidence.RelevantTimer {
-		add("timer_history_unproven", "timers are current-state rows and timer creation/cancellation is not represented in the mutation log")
-	}
-	if evidence.RelevantRoute {
-		add("flow_route_history_unproven", "routing_rules are current-state rows and cannot prove historical flow-route membership at the fork point")
-	}
-	if evidence.ActiveSession {
-		add("session_history_unproven", "source-run session facts reference current session rows without append-only session-state proof at the fork point")
-	}
-	if evidence.ActiveTurn {
-		add("active_turn_history_unproven", "active turn ownership at the fork point cannot be proven from current session/turn rows alone")
-	}
-	return blockers
-}
-
-func runForkHasUnsupportedPendingWork(pending []RunForkPendingWork) bool {
-	for _, item := range pending {
-		if item.Classification != RunForkPendingClassificationDeliveredCompleted {
-			return true
-		}
-	}
-	return false
 }
 
 func runForkPendingReferencesActiveSession(pending []RunForkPendingWork) bool {

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -197,6 +197,15 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	if plan.ExecutionReady {
 		t.Fatal("ExecutionReady = true, want false while recorder blockers remain")
 	}
+	if plan.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
+		t.Fatalf("taxonomy owner = %q, want %q", plan.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
+	}
+	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatal("taxonomy StateOnlyExecutionReady = true, want false")
+	}
+	if !plan.ReplayResumeAdmission.HistoricalReplayRequired || plan.ReplayResumeAdmission.HistoricalReplaySupported {
+		t.Fatalf("taxonomy replay flags = required:%v supported:%v, want required true/supported false", plan.ReplayResumeAdmission.HistoricalReplayRequired, plan.ReplayResumeAdmission.HistoricalReplaySupported)
+	}
 	blockers := map[string]bool{}
 	for _, blocker := range plan.UnsupportedBlockers {
 		blockers[blocker.Code] = true
@@ -213,6 +222,18 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	for _, code := range []string{"timer_history_unproven", "flow_route_history_unproven"} {
 		if blockers[code] {
 			t.Fatalf("unexpected unrelated blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+	for _, fact := range []string{
+		RunForkReplayResumeFactDeliveryCompletedHistory,
+		RunForkReplayResumeFactDeliveryPendingHistory,
+		RunForkReplayResumeFactDeliveryInProgressHistory,
+		RunForkReplayResumeFactDeliveryFailedHistory,
+		RunForkReplayResumeFactDeliveryDeadLetterHistory,
+		RunForkReplayResumeFactCommittedReplayScope,
+	} {
+		if !runForkTestHasDisposition(plan.ReplayResumeAdmission, fact) {
+			t.Fatalf("missing taxonomy disposition for %s; admission=%#v", fact, plan.ReplayResumeAdmission)
 		}
 	}
 }
@@ -274,6 +295,22 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 	}
 	if plan.UnsupportedBlockerCount != 0 {
 		t.Fatalf("UnsupportedBlockerCount = %d, want 0; blockers=%#v", plan.UnsupportedBlockerCount, plan.UnsupportedBlockers)
+	}
+	if plan.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
+		t.Fatalf("taxonomy owner = %q, want %q", plan.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
+	}
+	if !plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.HistoricalReplayRequired || plan.ReplayResumeAdmission.HistoricalReplaySupported {
+		t.Fatalf("taxonomy flags = state_only:%v historical_required:%v historical_supported:%v, want true/false/false",
+			plan.ReplayResumeAdmission.StateOnlyExecutionReady,
+			plan.ReplayResumeAdmission.HistoricalReplayRequired,
+			plan.ReplayResumeAdmission.HistoricalReplaySupported,
+		)
+	}
+	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactEntityStateSnapshot) {
+		t.Fatalf("missing entity-state taxonomy disposition; admission=%#v", plan.ReplayResumeAdmission)
+	}
+	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactHistoricalReplayExecution) {
+		t.Fatalf("missing split historical replay taxonomy disposition; admission=%#v", plan.ReplayResumeAdmission)
 	}
 	if plan.ReconstructedEntityCount != 1 {
 		t.Fatalf("ReconstructedEntityCount = %d, want 1", plan.ReconstructedEntityCount)
@@ -338,6 +375,11 @@ func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
 	for _, code := range []string{"timer_history_unproven", "flow_route_history_unproven"} {
 		if !runForkTestHasBlocker(plan, code) {
 			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+	for _, fact := range []string{RunForkReplayResumeFactTimerHistory, RunForkReplayResumeFactRouteHistory} {
+		if !runForkTestHasDisposition(plan.ReplayResumeAdmission, fact) {
+			t.Fatalf("missing taxonomy disposition for %s; admission=%#v", fact, plan.ReplayResumeAdmission)
 		}
 	}
 }
@@ -734,6 +776,15 @@ func TestRunForkPlanner_FailsClosedWhenDeadLettersUnavailable(t *testing.T) {
 func runForkTestHasBlocker(plan RunForkPlan, code string) bool {
 	for _, blocker := range plan.UnsupportedBlockers {
 		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkTestHasDisposition(admission RunForkReplayResumeAdmission, fact string) bool {
+	for _, disposition := range admission.Dispositions {
+		if disposition.Fact == fact {
 			return true
 		}
 	}

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -1,0 +1,283 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	RunForkReplayResumeAdmissionOwner = "store.run_fork.replay_resume_admission"
+
+	RunForkReplayResumeDispositionReconstruct        = "reconstruct"
+	RunForkReplayResumeDispositionLineageOnly        = "lineage_only"
+	RunForkReplayResumeDispositionFailClosedBlocker  = "fail_closed_blocker"
+	RunForkReplayResumeDispositionSplitSibling       = "split_sibling"
+	RunForkReplayResumeDispositionNoHistoricalAction = "no_historical_action"
+)
+
+const (
+	RunForkReplayResumeFactEntityStateSnapshot       = "entity_state_snapshot"
+	RunForkReplayResumeFactDeliveryCompletedHistory  = "delivery_completed_history"
+	RunForkReplayResumeFactDeliveryPendingHistory    = "delivery_pending_history"
+	RunForkReplayResumeFactDeliveryInProgressHistory = "delivery_in_progress_history"
+	RunForkReplayResumeFactDeliveryFailedHistory     = "delivery_failed_history"
+	RunForkReplayResumeFactDeliveryDeadLetterHistory = "delivery_dead_letter_history"
+	RunForkReplayResumeFactCommittedReplayScope      = "committed_replay_scope"
+	RunForkReplayResumeFactTimerHistory              = "timer_history"
+	RunForkReplayResumeFactRouteHistory              = "flow_route_history"
+	RunForkReplayResumeFactSessionHistory            = "session_history"
+	RunForkReplayResumeFactActiveTurnHistory         = "active_turn_history"
+	RunForkReplayResumeFactSourceAdvanced            = "source_advanced_after_fork_point"
+	RunForkReplayResumeFactForkReplayState           = "fork_replay_state"
+	RunForkReplayResumeFactContractSwap              = "contract_swap"
+	RunForkReplayResumeFactHistoricalReplayExecution = "historical_replay_execution"
+)
+
+const (
+	RunForkBlockerDeliveryHistoryUnproven   = "delivery_history_unproven"
+	RunForkBlockerTimerHistoryUnproven      = "timer_history_unproven"
+	RunForkBlockerFlowRouteHistoryUnproven  = "flow_route_history_unproven"
+	RunForkBlockerSessionHistoryUnproven    = "session_history_unproven"
+	RunForkBlockerActiveTurnHistoryUnproven = "active_turn_history_unproven"
+)
+
+type RunForkReplayResumeAdmission struct {
+	Owner                     string                           `json:"owner"`
+	StateOnlyExecutionReady   bool                             `json:"state_only_execution_ready"`
+	HistoricalReplaySupported bool                             `json:"historical_replay_supported"`
+	HistoricalReplayRequired  bool                             `json:"historical_replay_required"`
+	Dispositions              []RunForkReplayResumeDisposition `json:"dispositions,omitempty"`
+	UnsupportedBlockers       []RunForkUnsupportedBlocker      `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkReplayResumeDisposition struct {
+	Fact           string `json:"fact"`
+	Disposition    string `json:"disposition"`
+	BlockerCode    string `json:"blocker_code,omitempty"`
+	Classification string `json:"classification,omitempty"`
+	Message        string `json:"message"`
+}
+
+func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkReplayResumeAdmission {
+	dispositions := []RunForkReplayResumeDisposition{
+		{
+			Fact:        RunForkReplayResumeFactEntityStateSnapshot,
+			Disposition: RunForkReplayResumeDispositionReconstruct,
+			Message:     "fork current-state snapshots are reconstructed from entity_mutations and may be materialized by the state-only fork owner",
+		},
+		{
+			Fact:        RunForkReplayResumeFactHistoricalReplayExecution,
+			Disposition: RunForkReplayResumeDispositionSplitSibling,
+			Message:     "historical replay execution remains a separate gated child; this admission taxonomy is non-mutating",
+		},
+		{
+			Fact:        RunForkReplayResumeFactContractSwap,
+			Disposition: RunForkReplayResumeDispositionSplitSibling,
+			Message:     "contract-swap execution belongs to full historical resume and is not implemented by this admission taxonomy",
+		},
+	}
+	blockers := []RunForkUnsupportedBlocker{}
+	hasHistoricalReplayRequirement := false
+
+	for _, item := range evidence.Pending {
+		disposition := runForkReplayResumeDispositionForPendingWork(item)
+		dispositions = append(dispositions, disposition)
+		if strings.TrimSpace(disposition.BlockerCode) != "" {
+			blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(disposition.BlockerCode))
+			hasHistoricalReplayRequirement = true
+		}
+	}
+	if len(evidence.Pending) == 0 {
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactDeliveryCompletedHistory,
+			Disposition: RunForkReplayResumeDispositionNoHistoricalAction,
+			Message:     "no delivery or receipt facts at the fork point require historical replay",
+		})
+	}
+	if evidence.RelevantTimer {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerTimerHistoryUnproven)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactTimerHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+	if evidence.RelevantRoute {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerFlowRouteHistoryUnproven)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactRouteHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+	if evidence.ActiveSession {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerSessionHistoryUnproven)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactSessionHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+	if evidence.ActiveTurn {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerActiveTurnHistoryUnproven)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactActiveTurnHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+
+	return RunForkReplayResumeAdmission{
+		Owner:                     RunForkReplayResumeAdmissionOwner,
+		StateOnlyExecutionReady:   len(blockers) == 0,
+		HistoricalReplaySupported: false,
+		HistoricalReplayRequired:  hasHistoricalReplayRequirement,
+		Dispositions:              dispositions,
+		UnsupportedBlockers:       blockers,
+	}
+}
+
+func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunForkReplayResumeDisposition {
+	switch item.Classification {
+	case RunForkPendingClassificationDeliveredCompleted:
+		return RunForkReplayResumeDisposition{
+			Fact:           RunForkReplayResumeFactDeliveryCompletedHistory,
+			Disposition:    RunForkReplayResumeDispositionLineageOnly,
+			Classification: item.Classification,
+			Message:        "completed delivery and receipt facts are preserved as source-run lineage/proof only; they are not redelivered into the fork",
+		}
+	case RunForkPendingClassificationPending:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
+	case RunForkPendingClassificationInProgress:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryInProgressHistory)
+	case RunForkPendingClassificationFailedRetryable, RunForkPendingClassificationFailedTerminal:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryFailedHistory)
+	case RunForkPendingClassificationDeadLetter:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryDeadLetterHistory)
+	case RunForkPendingClassificationCommittedReplay:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactCommittedReplayScope)
+	default:
+		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
+	}
+}
+
+func runForkReplayResumePendingBlocker(item RunForkPendingWork, fact string) RunForkReplayResumeDisposition {
+	blocker := runForkReplayResumeBlocker(RunForkBlockerDeliveryHistoryUnproven)
+	return RunForkReplayResumeDisposition{
+		Fact:           fact,
+		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
+		BlockerCode:    blocker.Code,
+		Classification: item.Classification,
+		Message:        blocker.Message,
+	}
+}
+
+func runForkReplayResumeAdmissionWithBlocker(admission RunForkReplayResumeAdmission, fact string, blocker RunForkUnsupportedBlocker) RunForkReplayResumeAdmission {
+	if strings.TrimSpace(admission.Owner) == "" {
+		admission.Owner = RunForkReplayResumeAdmissionOwner
+	}
+	admission.StateOnlyExecutionReady = false
+	admission.HistoricalReplaySupported = false
+	admission.HistoricalReplayRequired = true
+	admission.UnsupportedBlockers = appendRunForkBlocker(admission.UnsupportedBlockers, blocker)
+	admission.Dispositions = append(admission.Dispositions, RunForkReplayResumeDisposition{
+		Fact:        fact,
+		Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+		BlockerCode: blocker.Code,
+		Message:     blocker.Message,
+	})
+	return admission
+}
+
+type runForkReplayResumeBlockerError struct {
+	blocker RunForkUnsupportedBlocker
+	fact    string
+	message string
+}
+
+func (e runForkReplayResumeBlockerError) Error() string {
+	return e.message
+}
+
+func runForkReplayResumeError(code, fact, message string) error {
+	return runForkReplayResumeBlockerError{
+		blocker: RunForkUnsupportedBlocker{
+			Code:    strings.TrimSpace(code),
+			Message: strings.TrimSpace(message),
+		},
+		fact:    strings.TrimSpace(fact),
+		message: strings.TrimSpace(message),
+	}
+}
+
+func runForkReplayResumeBlockerFromError(err error) (RunForkUnsupportedBlocker, string, bool) {
+	var blockerErr runForkReplayResumeBlockerError
+	if !errors.As(err, &blockerErr) {
+		return RunForkUnsupportedBlocker{}, "", false
+	}
+	return blockerErr.blocker, blockerErr.fact, true
+}
+
+func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
+	switch strings.TrimSpace(code) {
+	case RunForkBlockerDeliveryHistoryUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerDeliveryHistoryUnproven,
+			Message: "event_deliveries stores current delivery state; arbitrary historical delivery transitions at the fork point are not append-only proven",
+		}
+	case RunForkBlockerTimerHistoryUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerTimerHistoryUnproven,
+			Message: "timers are current-state rows and timer creation/cancellation is not represented in the mutation log",
+		}
+	case RunForkBlockerFlowRouteHistoryUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerFlowRouteHistoryUnproven,
+			Message: "routing_rules are current-state rows and cannot prove historical flow-route membership at the fork point",
+		}
+	case RunForkBlockerSessionHistoryUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerSessionHistoryUnproven,
+			Message: "source-run session facts reference current session rows without append-only session-state proof at the fork point",
+		}
+	case RunForkBlockerActiveTurnHistoryUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerActiveTurnHistoryUnproven,
+			Message: "active turn ownership at the fork point cannot be proven from current session/turn rows alone",
+		}
+	default:
+		code = strings.TrimSpace(code)
+		if code == "" {
+			code = "historical_replay_unproven"
+		}
+		return RunForkUnsupportedBlocker{
+			Code:    code,
+			Message: fmt.Sprintf("timestamp-fork historical replay/resume is not proven for %s by the canonical admission taxonomy", code),
+		}
+	}
+}
+
+func appendRunForkBlocker(blockers []RunForkUnsupportedBlocker, blocker RunForkUnsupportedBlocker) []RunForkUnsupportedBlocker {
+	if strings.TrimSpace(blocker.Code) == "" {
+		return blockers
+	}
+	for _, existing := range blockers {
+		if existing.Code == blocker.Code {
+			return blockers
+		}
+	}
+	return append(blockers, blocker)
+}


### PR DESCRIPTION
## Summary

Closes #565.
Part of #549.
Related to #564.

Implements the approved first slice only: a non-mutating canonical replay/resume admission taxonomy for timestamp forks.

- Adds the store-backed taxonomy owner in `internal/store/run_fork_replay_resume_admission.go`.
- Moves planner blocker construction through that taxonomy owner.
- Exposes the same `replay_resume_admission` object through planner, materializer, activation, and CLI JSON consumers.
- Keeps delivery redelivery, event copying, session/turn/timer/route reconstruction, source-advanced branch semantics, contract swap, and runtime replay mutation blocked.

## Governing Refs

- #565 pre-audit and independent gate: `approved as first slice`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork` planning/materialize/activation/resume sections.
- This PR updates the fork spec with the non-mutating `replay_resume_admission_taxonomy` contract because the supported JSON surfaces now expose the taxonomy.

## Semantic Migration / Owner Accounting

New canonical owner: `internal/store/run_fork_replay_resume_admission.go`.

Old non-authoritative paths now invalidated or reduced to consumers:

- Planner-local `runForkUnsupportedBlockers(...)` was removed.
- `PlanRunFork` now computes `ExecutionReady` and blockers from the taxonomy owner.
- `MaterializeRunFork` carries the taxonomy result instead of relying only on local delivery-resume boundary flags.
- `ActivateRunFork` carries the taxonomy result and adapts source-advanced / fork replay-state guards into taxonomy-backed blockers.
- `cmd/swarm` remains a consumer through store-owned JSON structs; no CLI SQL/helper replay path was added.

Production paths checked for surviving old behavior:

- `internal/store/run_fork_planner.go`
- `internal/store/run_fork_materializer.go`
- `internal/store/run_fork_activation.go`
- `cmd/swarm/main.go`
- same-run replay/outbox recovery seams remain separate and unchanged

Migration completeness for this approved child: complete. Full historical replay/resume execution remains open under #549/#564 and is not claimed closed.

## Validation

- `go test ./internal/store -run 'TestRunFork(Planner|Materializer|Activation)' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand' -count=1`
- `go test ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`
