### PR TITLE
[agent-a][issue #569] Add timestamp-fork delivery/event replay primitive

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -476,6 +476,13 @@ func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
 		result.HistoricalReplayBlocked,
 		result.MaterializedEntityCount,
 	)
+	if result.DeliveryEventReplay != nil {
+		fmt.Fprintf(w, "Delivery/Event Replay: events=%d deliveries=%d owner=%s\n",
+			result.DeliveryEventReplay.ReplayedEventCount,
+			result.DeliveryEventReplay.ReplayedDeliveryCount,
+			result.DeliveryEventReplay.Owner,
+		)
+	}
 }
 
 func printRunForkMaterialization(w io.Writer, result store.RunForkMaterialization) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -404,6 +404,58 @@ func TestRunForkCommand_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
 	}
 }
 
+func TestRunForkCommand_DryRunJSONReportsDeliveryEventReplayReady(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000305, 0).UTC()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli.pending', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'cli-agent', 'pending', 0, 'matched_agent_subscription', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed pending delivery: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, t.TempDir(), []string{
+		"--dry-run",
+		"--run", runID,
+		"--at", eventID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var plan store.RunForkPlan
+	if err := json.Unmarshal(buf.Bytes(), &plan); err != nil {
+		t.Fatalf("decode fork plan json: %v\n%s", err, buf.String())
+	}
+	if !plan.ExecutionReady || !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.HistoricalReplaySupported {
+		t.Fatalf("dry-run replay admission = execution:%v admission:%#v", plan.ExecutionReady, plan.ReplayResumeAdmission)
+	}
+	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatalf("StateOnlyExecutionReady = true, want false for delivery/event replay dry-run")
+	}
+}
+
 func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2715,6 +2715,12 @@ platform_tables:
         \ status) WHERE run_id IS NOT NULL,\n    INDEX idx_deliveries_status (status, created_at),\n    INDEX idx_deliveries_event\
         \ (event_id),\n    INDEX idx_deliveries_active_session (active_session_id) WHERE active_session_id IS NOT NULL\n\
         );"
+    run_fork_delivery_event_replays:
+      description: Source-to-fork lineage table for the supported timestamp-fork delivery/event replay primitive. The fork
+        run gets fresh fork-local event_id and delivery_id values; this table records which source event/delivery facts
+        produced those fork-local rows. It is not a generic historical replay log and does not authorize session, turn,
+        timer, route, source-advanced, or contract-swap reconstruction.
+      ddl: "CREATE TABLE run_fork_delivery_event_replays (\n    replay_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id       UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id     UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id   UUID NOT NULL REFERENCES events(event_id),\n    source_delivery_id UUID NOT NULL REFERENCES event_deliveries(delivery_id),\n    fork_event_id     UUID NOT NULL REFERENCES events(event_id),\n    fork_delivery_id  UUID NOT NULL REFERENCES event_deliveries(delivery_id),\n    subscriber_type   TEXT NOT NULL CHECK (subscriber_type IN ('node', 'agent')),\n    subscriber_id     TEXT NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id, source_delivery_id),\n    UNIQUE (fork_delivery_id),\n    INDEX idx_run_fork_replays_fork (fork_run_id, fork_event_id),\n    INDEX idx_run_fork_replays_source (source_run_id, source_event_id)\n);"
     event_receipts:
       description: Handler completion acknowledgement. One receipt per event × subscriber. Replaces both pipeline_receipts
         and system_node_ledger. entity_id nullable for global events. subscriber_type + subscriber_id identify the handler
@@ -3188,20 +3194,26 @@ run_model:
       supported activation slice for forks whose state was produced by materialize-only admission. Activation
       requires a fork run with status=paused, fork lineage, fork-local entity_state rows, and a revalidated
       execution_ready=true planner result at the original fork point. Activation atomically transitions the
-      fork run to status=running and the source run to status=forked. It fails closed with no partial mutation
-      if the source run advanced after the fork point, if the fork already has events, deliveries, sessions, or
-      turns, or if pending delivery, timer, route, session, active-turn, replay, or contract-swap facts would
-      require historical replay. Activation does not copy, redeliver, replay, reconstruct, or mutate historical
-      event, delivery, timer, route, session, turn, or contract rows.'
+      fork run to status=running and the source run to status=forked. It may create fork-local event and delivery
+      rows only for source pending deliveries that the canonical replay_resume_admission taxonomy marks
+      delivery_event_replay_ready, using fresh fork event IDs and run_fork_delivery_event_replays lineage rows. It
+      fails closed with no partial mutation if the source run advanced after the fork point, if the fork already has
+      events, deliveries, sessions, or turns, or if in-progress, failed, dead-letter, committed replay-scope, timer,
+      route, session, active-turn, replay, or contract-swap facts would require unsupported historical replay.
+      Activation does not copy source event IDs, replay delivered/completed or receipt-only facts, reconstruct timer,
+      route, session, turn, or contract rows, or recompute recipients from current subscriptions.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
     replay_resume_admission_taxonomy: 'Fork planning, materialization, and activation surfaces expose the
-      canonical store-backed replay_resume_admission taxonomy. This taxonomy is non-mutating: it classifies
+      canonical store-backed replay_resume_admission taxonomy. This taxonomy classifies
       historical source-run facts as reconstruct, lineage-only, fail-closed blockers, split siblings, or
-      no-historical-action. It does not authorize event copying, delivery redelivery, session/turn/timer/route
-      reconstruction, contract swap execution, or any runtime replay mutation. Full historical resume remains
-      separately gated even when state-only activation is ready.'
+      no-historical-action. It also identifies the first supported delivery_event_replay_ready subset: pending
+      unstarted source deliveries whose fork-local event/delivery rows can be created under the fork run_id with
+      explicit source lineage. It does not authorize source event_id copying, delivered/completed redelivery,
+      receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime
+      replay mutation. Full historical resume remains separately gated even when state-only activation or delivery/event
+      replay is ready.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3222,11 +3234,13 @@ run_model:
         Source run status is unchanged. Copy reconstructed entity states into the fork context with fork-local
         revision=1 and source-at-T entered_state_at for the reconstructed current_state, then stop; do not boot,
         resume, redeliver, or mutate runtime delivery/session/timer/route state.'
-      3b_activate_materialized_fork: 'For an activation-only fork, consume a previously materialized fork run.
+      3b_activate_materialized_fork: 'For an activation fork, consume a previously materialized fork run.
         Revalidate the original fork point against current source-run facts, require no source advancement and
-        no unsupported replay/timer/route/session/turn/contract-swap facts, then atomically mark the source run
-        forked and the fork run running. Future runtime work uses the fork run_id and fork-local entity_state
-        rows; historical delivery replay remains unsupported in this slice.'
+        no unsupported replay/timer/route/session/turn/contract-swap facts, optionally create fork-local event/delivery
+        rows for the delivery_event_replay_ready subset with explicit source lineage, then atomically mark the source run
+        forked and the fork run running. Future runtime work uses the fork run_id, fork-local entity_state rows, and
+        fork-local pending delivery rows; full historical replay remains unsupported outside the gated delivery/event
+        primitive.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3195,13 +3195,14 @@ run_model:
       requires a fork run with status=paused, fork lineage, fork-local entity_state rows, and a revalidated
       execution_ready=true planner result at the original fork point. Activation atomically transitions the
       fork run to status=running and the source run to status=forked. It may create fork-local event and delivery
-      rows only for source pending deliveries that the canonical replay_resume_admission taxonomy marks
-      delivery_event_replay_ready, using fresh fork event IDs and run_fork_delivery_event_replays lineage rows. It
-      fails closed with no partial mutation if the source run advanced after the fork point, if the fork already has
-      events, deliveries, sessions, or turns, or if in-progress, failed, dead-letter, committed replay-scope, timer,
-      route, session, active-turn, replay, or contract-swap facts would require unsupported historical replay.
-      Activation does not copy source event IDs, replay delivered/completed or receipt-only facts, reconstruct timer,
-      route, session, turn, or contract rows, or recompute recipients from current subscriptions.'
+      rows only for source pending unstarted agent deliveries that the canonical replay_resume_admission taxonomy marks
+      delivery_event_replay_ready, using fresh fork event IDs, a direct committed replay-scope marker, and
+      run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
+      after the fork point, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
+      failed, dead-letter, committed replay-scope, timer, route, session, active-turn, replay, or contract-swap facts
+      would require unsupported historical replay. Activation does not copy source event IDs, replay delivered/completed
+      or receipt-only facts, reconstruct timer, route, session, turn, or contract rows, or recompute recipients from
+      current subscriptions.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
@@ -3209,11 +3210,12 @@ run_model:
       canonical store-backed replay_resume_admission taxonomy. This taxonomy classifies
       historical source-run facts as reconstruct, lineage-only, fail-closed blockers, split siblings, or
       no-historical-action. It also identifies the first supported delivery_event_replay_ready subset: pending
-      unstarted source deliveries whose fork-local event/delivery rows can be created under the fork run_id with
-      explicit source lineage. It does not authorize source event_id copying, delivered/completed redelivery,
-      receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime
-      replay mutation. Full historical resume remains separately gated even when state-only activation or delivery/event
-      replay is ready.'
+      unstarted source agent deliveries whose fork-local event/delivery rows can be created under the fork run_id with
+      explicit source lineage and a direct committed replay-scope marker for the existing persisted delivery/recovery
+      consumer. It does not authorize source event_id copying, node delivery replay, delivered/completed redelivery,
+      receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime replay
+      mutation. Full historical resume remains separately gated even when state-only activation or delivery/event replay
+      is ready.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3237,10 +3239,10 @@ run_model:
       3b_activate_materialized_fork: 'For an activation fork, consume a previously materialized fork run.
         Revalidate the original fork point against current source-run facts, require no source advancement and
         no unsupported replay/timer/route/session/turn/contract-swap facts, optionally create fork-local event/delivery
-        rows for the delivery_event_replay_ready subset with explicit source lineage, then atomically mark the source run
-        forked and the fork run running. Future runtime work uses the fork run_id, fork-local entity_state rows, and
-        fork-local pending delivery rows; full historical replay remains unsupported outside the gated delivery/event
-        primitive.'
+        rows and direct committed replay-scope markers for the delivery_event_replay_ready subset with explicit source
+        lineage, then atomically mark the source run forked and the fork run running. Future runtime work uses the fork
+        run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
+        unsupported outside the gated delivery/event primitive.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -183,7 +183,7 @@ nodes:
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
       - markerless replay-eligible events can repeatedly fail committed replay-scope lookup on the supported outbox sweeper path
-      - timestamp forks need fork-local delivery/event replay lineage rather than direct source delivery redelivery or same-run outbox replay proof
+      - timestamp forks need fork-local delivery/event replay lineage and committed replay-scope proof rather than direct source delivery redelivery or markerless same-run outbox replay
     representative_issues:
       - 112
       - 144
@@ -212,7 +212,7 @@ nodes:
       - source advancement after the fork point remains fail-closed because no branch/replay policy proves safe divergence
       - timers and routing_rules are current rows without an append-only timestamp-fork reconstruction owner
       - agent_sessions and agent_turns are run-scoped facts without an at-T fork reconstruction/reuse policy
-      - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and keep unsafe delivery/session/timer/route cases fail-closed
+      - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and direct committed replay-scope proof for the runtime recovery consumer, while keeping unsafe delivery/session/timer/route cases fail-closed
     representative_issues:
       - 564
       - 565

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -135,6 +135,11 @@ active_issues:
     title: Define canonical timestamp-fork replay/resume ownership before historical execution
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 569
+    title: Gate timestamp-fork delivery/event replay primitive under fork run_id
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -178,12 +183,14 @@ nodes:
       - retry counters and delivery-state updates not atomic
       - replayed deliveries and restored timers without explicit shared-store ownership
       - markerless replay-eligible events can repeatedly fail committed replay-scope lookup on the supported outbox sweeper path
+      - timestamp forks need fork-local delivery/event replay lineage rather than direct source delivery redelivery or same-run outbox replay proof
     representative_issues:
       - 112
       - 144
       - 145
       - 547
       - 564
+      - 569
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -205,9 +212,11 @@ nodes:
       - source advancement after the fork point remains fail-closed because no branch/replay policy proves safe divergence
       - timers and routing_rules are current rows without an append-only timestamp-fork reconstruction owner
       - agent_sessions and agent_turns are run-scoped facts without an at-T fork reconstruction/reuse policy
+      - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and keep unsafe delivery/session/timer/route cases fail-closed
     representative_issues:
       - 564
       - 565
+      - 569
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -22,19 +22,20 @@ type RunForkActivateRequest struct {
 }
 
 type RunForkActivation struct {
-	SourceRunID              string                       `json:"source_run_id"`
-	ForkRunID                string                       `json:"fork_run_id"`
-	ForkRunStatus            string                       `json:"fork_run_status"`
-	SourceRunStatus          string                       `json:"source_run_status"`
-	ForkPoint                RunForkPoint                 `json:"fork_point"`
-	Activated                bool                         `json:"activated"`
-	SourceFrozen             bool                         `json:"source_frozen"`
-	HistoricalReplayBlocked  bool                         `json:"historical_replay_blocked"`
-	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
-	MaterializedEntityCount  int                          `json:"materialized_entity_count"`
-	SourceAdvancedAfterFork  bool                         `json:"source_advanced_after_fork_point,omitempty"`
-	RepeatedActivationFailed bool                         `json:"repeated_activation_failed,omitempty"`
+	SourceRunID              string                            `json:"source_run_id"`
+	ForkRunID                string                            `json:"fork_run_id"`
+	ForkRunStatus            string                            `json:"fork_run_status"`
+	SourceRunStatus          string                            `json:"source_run_status"`
+	ForkPoint                RunForkPoint                      `json:"fork_point"`
+	Activated                bool                              `json:"activated"`
+	SourceFrozen             bool                              `json:"source_frozen"`
+	HistoricalReplayBlocked  bool                              `json:"historical_replay_blocked"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission      `json:"replay_resume_admission"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`
+	MaterializedEntityCount  int                               `json:"materialized_entity_count"`
+	DeliveryEventReplay      *RunForkDeliveryEventReplayResult `json:"delivery_event_replay,omitempty"`
+	SourceAdvancedAfterFork  bool                              `json:"source_advanced_after_fork_point,omitempty"`
+	RepeatedActivationFailed bool                              `json:"repeated_activation_failed,omitempty"`
 }
 
 type runForkActivationLineage struct {
@@ -55,8 +56,9 @@ func RequireRunForkActivationCapabilities(caps StoreSchemaCapabilities, catalog 
 		return err
 	}
 	required := map[string][]string{
-		"runs":         {"run_id", "status", "forked_from_run_id", "forked_from_event_id", "ended_at"},
-		"entity_state": {"run_id", "entity_id", "flow_instance", "updated_at"},
+		"runs":                          {"run_id", "status", "forked_from_run_id", "forked_from_event_id", "ended_at"},
+		"entity_state":                  {"run_id", "entity_id", "flow_instance", "updated_at"},
+		runForkDeliveryEventReplayTable: {"fork_run_id", "source_run_id", "source_event_id", "source_delivery_id", "fork_event_id", "fork_delivery_id", "subscriber_type", "subscriber_id"},
 	}
 	for tableName, columns := range required {
 		if catalog.hasColumns(tableName, columns...) {
@@ -170,6 +172,10 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	} else if affected != 1 {
 		return result, fmt.Errorf("fork activation blocked: source_run_freeze_not_applied")
 	}
+	replayResult, err := applyRunForkDeliveryEventReplay(ctx, tx, lineage, plan, now)
+	if err != nil {
+		return result, err
+	}
 	forkResult, err := tx.ExecContext(ctx, `
 		UPDATE runs
 		SET status = $2, ended_at = NULL
@@ -192,6 +198,9 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	result.SourceRunStatus = RunForkSourceFrozenStatus
 	result.Activated = true
 	result.SourceFrozen = true
+	if replayResult.ReplayedEventCount > 0 || replayResult.ReplayedDeliveryCount > 0 {
+		result.DeliveryEventReplay = &replayResult
+	}
 	return result, nil
 }
 

--- a/internal/store/run_fork_delivery_event_replay.go
+++ b/internal/store/run_fork_delivery_event_replay.go
@@ -68,6 +68,9 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 			if err != nil {
 				return result, err
 			}
+			if err := insertRunForkReplayScopeMarker(ctx, tx, lineage.ForkRunID, forkEventID, now); err != nil {
+				return result, err
+			}
 			if inserted {
 				result.ReplayedEventCount++
 			}
@@ -155,6 +158,26 @@ func insertRunForkReplayEvent(ctx context.Context, tx *sql.Tx, forkRunID, forkEv
 	return rowsAffected(res)
 }
 
+func insertRunForkReplayScopeMarker(ctx context.Context, tx *sql.Tx, forkRunID, forkEventID string, now time.Time) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
+			status, retry_count, reason_code, last_error, active_session_id,
+			started_at, delivered_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, $4, $5,
+			'delivered', 0, $6, NULL, NULL,
+			NULL, $7, $7
+		)
+		ON CONFLICT (delivery_id) DO NOTHING
+	`, deterministicRunForkReplayScopeMarkerDeliveryID(forkRunID, forkEventID), forkRunID, forkEventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, replayScopeReasonDirect, now)
+	if err != nil {
+		return fmt.Errorf("insert fork replay committed scope marker for fork event %s: %w", forkEventID, err)
+	}
+	return nil
+}
+
 func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, item RunForkPendingWork, sourceEventID, forkEventID, forkDeliveryID string, now time.Time) (bool, error) {
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
@@ -220,6 +243,10 @@ func deterministicRunForkReplayEventID(forkRunID, sourceEventID string) string {
 
 func deterministicRunForkReplayDeliveryID(forkRunID, sourceDeliveryID string) string {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm/run-fork/delivery-event-replay/delivery/"+strings.TrimSpace(forkRunID)+"/"+strings.TrimSpace(sourceDeliveryID))).String()
+}
+
+func deterministicRunForkReplayScopeMarkerDeliveryID(forkRunID, forkEventID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm/run-fork/delivery-event-replay/scope/"+strings.TrimSpace(forkRunID)+"/"+strings.TrimSpace(forkEventID))).String()
 }
 
 func nullStringText(value sql.NullString) string {

--- a/internal/store/run_fork_delivery_event_replay.go
+++ b/internal/store/run_fork_delivery_event_replay.go
@@ -1,0 +1,238 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	RunForkDeliveryEventReplayOwner = "store.run_fork.delivery_event_replay"
+	runForkDeliveryEventReplayTable = "run_fork_delivery_event_replays"
+	runForkDeliveryReplayReasonCode = "fork_replay"
+)
+
+type RunForkDeliveryEventReplayResult struct {
+	Owner                 string `json:"owner"`
+	SourceRunID           string `json:"source_run_id"`
+	ForkRunID             string `json:"fork_run_id"`
+	ReplayedEventCount    int    `json:"replayed_event_count"`
+	ReplayedDeliveryCount int    `json:"replayed_delivery_count"`
+}
+
+type runForkReplaySourceEvent struct {
+	EventID        string
+	EventName      string
+	EntityID       sql.NullString
+	FlowInstance   sql.NullString
+	Scope          string
+	Payload        json.RawMessage
+	ProducedBy     sql.NullString
+	ProducedByType sql.NullString
+	HandlerNode    sql.NullString
+}
+
+func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, plan RunForkPlan, now time.Time) (RunForkDeliveryEventReplayResult, error) {
+	result := RunForkDeliveryEventReplayResult{
+		Owner:       RunForkDeliveryEventReplayOwner,
+		SourceRunID: lineage.SourceRunID,
+		ForkRunID:   lineage.ForkRunID,
+	}
+	replayable := runForkReplayablePendingWork(plan.PendingWork)
+	if len(replayable) == 0 {
+		return result, nil
+	}
+
+	sourceEvents := map[string]runForkReplaySourceEvent{}
+	insertedEvents := map[string]string{}
+	for _, item := range replayable {
+		sourceEventID := strings.TrimSpace(item.EventID)
+		sourceEvent, ok := sourceEvents[sourceEventID]
+		if !ok {
+			loaded, err := loadRunForkReplaySourceEvent(ctx, tx, lineage.SourceRunID, sourceEventID)
+			if err != nil {
+				return result, err
+			}
+			sourceEvent = loaded
+			sourceEvents[sourceEventID] = sourceEvent
+		}
+		forkEventID, ok := insertedEvents[sourceEventID]
+		if !ok {
+			forkEventID = deterministicRunForkReplayEventID(lineage.ForkRunID, sourceEventID)
+			inserted, err := insertRunForkReplayEvent(ctx, tx, lineage.ForkRunID, forkEventID, sourceEvent, now)
+			if err != nil {
+				return result, err
+			}
+			if inserted {
+				result.ReplayedEventCount++
+			}
+			insertedEvents[sourceEventID] = forkEventID
+		}
+		forkDeliveryID := deterministicRunForkReplayDeliveryID(lineage.ForkRunID, item.DeliveryID)
+		inserted, err := insertRunForkReplayDelivery(ctx, tx, lineage, item, sourceEventID, forkEventID, forkDeliveryID, now)
+		if err != nil {
+			return result, err
+		}
+		if inserted {
+			result.ReplayedDeliveryCount++
+		}
+	}
+	if err := syncRunForkReplayEventCount(ctx, tx, lineage.ForkRunID); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func runForkReplayablePendingWork(pending []RunForkPendingWork) []RunForkPendingWork {
+	out := make([]RunForkPendingWork, 0, len(pending))
+	for _, item := range pending {
+		if runForkPendingWorkReplayable(item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func loadRunForkReplaySourceEvent(ctx context.Context, tx *sql.Tx, sourceRunID, sourceEventID string) (runForkReplaySourceEvent, error) {
+	var event runForkReplaySourceEvent
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			event_id::text,
+			event_name,
+			entity_id::text,
+			flow_instance,
+			scope,
+			COALESCE(payload, '{}'::jsonb),
+			produced_by,
+			produced_by_type,
+			handler_node
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, sourceRunID, sourceEventID).Scan(
+		&event.EventID,
+		&event.EventName,
+		&event.EntityID,
+		&event.FlowInstance,
+		&event.Scope,
+		&event.Payload,
+		&event.ProducedBy,
+		&event.ProducedByType,
+		&event.HandlerNode,
+	)
+	if err == sql.ErrNoRows {
+		return runForkReplaySourceEvent{}, fmt.Errorf("fork delivery/event replay source event %s not found in run %s", sourceEventID, sourceRunID)
+	}
+	if err != nil {
+		return runForkReplaySourceEvent{}, fmt.Errorf("load fork delivery/event replay source event: %w", err)
+	}
+	if !json.Valid(event.Payload) {
+		return runForkReplaySourceEvent{}, fmt.Errorf("source event %s payload is not valid json", sourceEventID)
+	}
+	return event, nil
+}
+
+func insertRunForkReplayEvent(ctx context.Context, tx *sql.Tx, forkRunID, forkEventID string, event runForkReplaySourceEvent, now time.Time) (bool, error) {
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, handler_node, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3, NULLIF($4, '')::uuid, NULLIF($5, ''), $6, $7::jsonb,
+			0, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULL, $11
+		)
+		ON CONFLICT (event_id) DO NOTHING
+	`, forkEventID, forkRunID, event.EventName, nullStringText(event.EntityID), nullStringText(event.FlowInstance), event.Scope, string(event.Payload), nullStringText(event.ProducedBy), nullStringText(event.ProducedByType), nullStringText(event.HandlerNode), now)
+	if err != nil {
+		return false, fmt.Errorf("insert fork replay event %s from source event %s: %w", forkEventID, event.EventID, err)
+	}
+	return rowsAffected(res)
+}
+
+func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, item RunForkPendingWork, sourceEventID, forkEventID, forkDeliveryID string, now time.Time) (bool, error) {
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
+			status, retry_count, reason_code, last_error, active_session_id,
+			started_at, delivered_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, $4, $5,
+			'pending', 0, $6, NULL, NULL,
+			NULL, NULL, $7
+		)
+		ON CONFLICT (delivery_id) DO NOTHING
+	`, forkDeliveryID, lineage.ForkRunID, forkEventID, item.SubscriberType, item.SubscriberID, runForkReplayReasonCode(item), now)
+	if err != nil {
+		return false, fmt.Errorf("insert fork replay delivery %s from source delivery %s: %w", forkDeliveryID, item.DeliveryID, err)
+	}
+	inserted, err := rowsAffected(res)
+	if err != nil {
+		return false, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_fork_delivery_event_replays (
+			fork_run_id, source_run_id, source_event_id, source_delivery_id,
+			fork_event_id, fork_delivery_id, subscriber_type, subscriber_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, $4::uuid,
+			$5::uuid, $6::uuid, $7, $8, $9
+		)
+		ON CONFLICT (fork_run_id, source_delivery_id) DO NOTHING
+	`, lineage.ForkRunID, lineage.SourceRunID, sourceEventID, item.DeliveryID, forkEventID, forkDeliveryID, item.SubscriberType, item.SubscriberID, now); err != nil {
+		return false, fmt.Errorf("insert fork delivery/event replay lineage for source delivery %s: %w", item.DeliveryID, err)
+	}
+	return inserted, nil
+}
+
+func runForkReplayReasonCode(item RunForkPendingWork) string {
+	if reason := strings.TrimSpace(item.ReasonCode); reason != "" {
+		return "fork_replay:" + reason
+	}
+	return runForkDeliveryReplayReasonCode
+}
+
+func syncRunForkReplayEventCount(ctx context.Context, tx *sql.Tx, forkRunID string) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET event_count = (
+			SELECT COUNT(*)::integer
+			FROM events
+			WHERE run_id = $1::uuid
+		)
+		WHERE run_id = $1::uuid
+	`, forkRunID); err != nil {
+		return fmt.Errorf("sync fork replay event count: %w", err)
+	}
+	return nil
+}
+
+func deterministicRunForkReplayEventID(forkRunID, sourceEventID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm/run-fork/delivery-event-replay/event/"+strings.TrimSpace(forkRunID)+"/"+strings.TrimSpace(sourceEventID))).String()
+}
+
+func deterministicRunForkReplayDeliveryID(forkRunID, sourceDeliveryID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm/run-fork/delivery-event-replay/delivery/"+strings.TrimSpace(forkRunID)+"/"+strings.TrimSpace(sourceDeliveryID))).String()
+}
+
+func nullStringText(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
+}
+
+func rowsAffected(res sql.Result) (bool, error) {
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read affected rows: %w", err)
+	}
+	return rows > 0, nil
+}

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/testutil"
 )
 
@@ -463,6 +466,8 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 		       COALESCE(reason_code, ''), active_session_id IS NULL, started_at IS NULL, delivered_at IS NULL
 		FROM event_deliveries
 		WHERE run_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'safe-agent'
 	`, materialized.ForkRunID).Scan(&forkDeliveryID, &deliveryRunID, &deliveryEventID, &subscriberType, &subscriberID, &status, &retryCount, &reasonCode, &activeSessionNull, &startedNull, &deliveredNull); err != nil {
 		t.Fatalf("load fork replay delivery: %v", err)
 	}
@@ -502,6 +507,50 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	}
 	if sourceDeliveryRun != sourceRunID || sourceDeliveryStatus != "pending" {
 		t.Fatalf("source delivery mutated = run:%s status:%s", sourceDeliveryRun, sourceDeliveryStatus)
+	}
+
+	scope, err := pg.LoadCommittedReplayScope(ctx, forkEventID)
+	if err != nil {
+		t.Fatalf("LoadCommittedReplayScope(fork event): %v", err)
+	}
+	if scope != runtimereplayclaim.CommittedReplayScopeDirect {
+		t.Fatalf("fork replay scope = %q, want direct", scope)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, eventID, "processed", ""); err != nil {
+		t.Fatalf("mark source event pipeline receipt: %v", err)
+	}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("safe-agent", events.EventType("fork.ready"))
+	replayed, err := eb.SweepUndispatched(ctx, time.Hour, 10)
+	if err != nil {
+		t.Fatalf("SweepUndispatched: %v", err)
+	}
+	if replayed != 1 {
+		t.Fatalf("SweepUndispatched replayed = %d, want 1", replayed)
+	}
+	select {
+	case evt := <-ch:
+		if evt.ID != forkEventID || evt.RunID != materialized.ForkRunID {
+			t.Fatalf("delivered fork replay event = id:%s run:%s", evt.ID, evt.RunID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for fork replay event delivery")
+	}
+	var pipelineOutcome, pipelineReason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, forkEventID).Scan(&pipelineOutcome, &pipelineReason); err != nil {
+		t.Fatalf("load fork replay pipeline receipt: %v", err)
+	}
+	if pipelineOutcome != "success" || pipelineReason != "pipeline_persisted" {
+		t.Fatalf("fork replay pipeline receipt = outcome:%s reason:%s", pipelineOutcome, pipelineReason)
 	}
 }
 

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -263,11 +263,11 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, started_at, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'node', 'pending-node', 'pending', $3)
-	`, sourceRunID, eventID, at); err != nil {
-		t.Fatalf("seed pending delivery: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'node', 'in-progress-node', 'in_progress', $4::uuid, $3, $3)
+	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
+		t.Fatalf("seed in-progress delivery: %v", err)
 	}
 
 	blocked, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
@@ -277,8 +277,8 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
 		t.Fatalf("blocked taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
 	}
-	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactDeliveryPendingHistory) {
-		t.Fatalf("blocked taxonomy missing pending delivery disposition: %#v", blocked.ReplayResumeAdmission)
+	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactDeliveryInProgressHistory) {
+		t.Fatalf("blocked taxonomy missing in-progress delivery disposition: %#v", blocked.ReplayResumeAdmission)
 	}
 	var forkCount int
 	if err := db.QueryRowContext(ctx, `
@@ -389,6 +389,122 @@ func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.
 	}
 }
 
+func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000850, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+
+	var sourceDeliveryID string
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'safe-agent', 'pending', 0, 'matched_agent_subscription', $3)
+		RETURNING delivery_id::text
+	`, sourceRunID, eventID, at).Scan(&sourceDeliveryID); err != nil {
+		t.Fatalf("seed safe pending delivery: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if !plan.ExecutionReady || !plan.ReplayResumeAdmission.DeliveryEventReplayReady {
+		t.Fatalf("plan replay readiness = execution:%v admission:%#v", plan.ExecutionReady, plan.ReplayResumeAdmission)
+	}
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if activated.DeliveryEventReplay == nil {
+		t.Fatalf("DeliveryEventReplay = nil, want fork-local replay result: %#v", activated)
+	}
+	if activated.DeliveryEventReplay.Owner != RunForkDeliveryEventReplayOwner ||
+		activated.DeliveryEventReplay.ReplayedEventCount != 1 ||
+		activated.DeliveryEventReplay.ReplayedDeliveryCount != 1 {
+		t.Fatalf("DeliveryEventReplay = %#v", activated.DeliveryEventReplay)
+	}
+
+	var forkEventID, forkRunID, eventName, forkEntityID, flowInstance, payload string
+	var sourceEventNull bool
+	var chainDepth int
+	if err := db.QueryRowContext(ctx, `
+		SELECT event_id::text, run_id::text, event_name, entity_id::text, COALESCE(flow_instance, ''), payload::text, source_event_id IS NULL, chain_depth
+		FROM events
+		WHERE run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&forkEventID, &forkRunID, &eventName, &forkEntityID, &flowInstance, &payload, &sourceEventNull, &chainDepth); err != nil {
+		t.Fatalf("load fork replay event: %v", err)
+	}
+	if forkEventID == eventID || forkRunID != materialized.ForkRunID || eventName != "fork.ready" || forkEntityID != entityID || flowInstance != "flow-a/1" {
+		t.Fatalf("fork event = id:%s run:%s name:%s entity:%s flow:%s", forkEventID, forkRunID, eventName, forkEntityID, flowInstance)
+	}
+	if !sourceEventNull || chainDepth != 0 {
+		t.Fatalf("fork event source/chain = null:%v depth:%d, want fresh fork-local event tree", sourceEventNull, chainDepth)
+	}
+	if payload != "{}" {
+		t.Fatalf("fork event payload = %s, want {}", payload)
+	}
+
+	var forkDeliveryID, deliveryRunID, deliveryEventID, subscriberType, subscriberID, status, reasonCode string
+	var retryCount int
+	var activeSessionNull, startedNull, deliveredNull bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT delivery_id::text, run_id::text, event_id::text, subscriber_type, subscriber_id, status, retry_count,
+		       COALESCE(reason_code, ''), active_session_id IS NULL, started_at IS NULL, delivered_at IS NULL
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&forkDeliveryID, &deliveryRunID, &deliveryEventID, &subscriberType, &subscriberID, &status, &retryCount, &reasonCode, &activeSessionNull, &startedNull, &deliveredNull); err != nil {
+		t.Fatalf("load fork replay delivery: %v", err)
+	}
+	if deliveryRunID != materialized.ForkRunID || deliveryEventID != forkEventID || subscriberType != "agent" || subscriberID != "safe-agent" || status != "pending" || retryCount != 0 {
+		t.Fatalf("fork delivery = run:%s event:%s subscriber:%s/%s status:%s retry:%d", deliveryRunID, deliveryEventID, subscriberType, subscriberID, status, retryCount)
+	}
+	if reasonCode != "fork_replay:matched_agent_subscription" || !activeSessionNull || !startedNull || !deliveredNull {
+		t.Fatalf("fork delivery replay fields = reason:%q activeNull:%v startedNull:%v deliveredNull:%v", reasonCode, activeSessionNull, startedNull, deliveredNull)
+	}
+
+	var lineageCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_delivery_event_replays
+		WHERE fork_run_id = $1::uuid
+		  AND source_run_id = $2::uuid
+		  AND source_event_id = $3::uuid
+		  AND source_delivery_id = $4::uuid
+		  AND fork_event_id = $5::uuid
+		  AND fork_delivery_id = $6::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'safe-agent'
+	`, materialized.ForkRunID, sourceRunID, eventID, sourceDeliveryID, forkEventID, forkDeliveryID).Scan(&lineageCount); err != nil {
+		t.Fatalf("count fork replay lineage: %v", err)
+	}
+	if lineageCount != 1 {
+		t.Fatalf("lineage rows = %d, want 1", lineageCount)
+	}
+
+	var sourceDeliveryRun, sourceDeliveryStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT run_id::text, status
+		FROM event_deliveries
+		WHERE delivery_id = $1::uuid
+	`, sourceDeliveryID).Scan(&sourceDeliveryRun, &sourceDeliveryStatus); err != nil {
+		t.Fatalf("load source delivery after activation: %v", err)
+	}
+	if sourceDeliveryRun != sourceRunID || sourceDeliveryStatus != "pending" {
+		t.Fatalf("source delivery mutated = run:%s status:%s", sourceDeliveryRun, sourceDeliveryStatus)
+	}
+}
+
 func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -447,7 +563,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	}
 }
 
-func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *testing.T) {
+func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -463,15 +579,15 @@ func TestRunForkActivation_FailsClosedForPendingDeliveryAndMissingLineage(t *tes
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, started_at, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'node', 'blocked-node', 'pending', $3)
-	`, sourceRunID, eventID, at); err != nil {
-		t.Fatalf("seed pending delivery: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'node', 'blocked-node', 'in_progress', $4::uuid, $3, $3)
+	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
+		t.Fatalf("seed in-progress delivery: %v", err)
 	}
 	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
 	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
-		t.Fatalf("ActivateRunFork pending delivery error = %v, want delivery blocker", err)
+		t.Fatalf("ActivateRunFork in-progress delivery error = %v, want delivery blocker", err)
 	}
 	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
 		t.Fatalf("blocked activation taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -212,7 +212,7 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	plan.ReplayResumeAdmission = runForkReplayResumeAdmission(evidence)
 	plan.UnsupportedBlockers = plan.ReplayResumeAdmission.UnsupportedBlockers
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
-	plan.ExecutionReady = plan.ReplayResumeAdmission.StateOnlyExecutionReady
+	plan.ExecutionReady = plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady
 	return plan, nil
 }
 
@@ -383,6 +383,10 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 				END AS retry_count,
 				CASE
 					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.reason_code, '')
+					WHEN COALESCE(d.status, '') = 'pending'
+					 AND d.started_at IS NULL
+					 AND d.delivered_at IS NULL
+					THEN COALESCE(d.reason_code, '')
 					ELSE ''
 				END AS reason_code,
 				CASE

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -290,6 +290,49 @@ func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *te
 	t.Fatalf("missing fork_replay disposition for pending delivery; admission=%#v", plan.ReplayResumeAdmission)
 }
 
+func TestRunForkPlanner_NodePendingDeliveryRemainsBlocked(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000260, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.node_pending', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'node-handler', 'pending', 0, 'matched_node_subscription', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed node pending delivery: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady {
+		t.Fatalf("node pending plan became replay-ready: %#v", plan.ReplayResumeAdmission)
+	}
+	if !runForkTestHasBlocker(plan, RunForkBlockerDeliveryHistoryUnproven) {
+		t.Fatalf("node pending blockers = %#v, want delivery_history_unproven", plan.UnsupportedBlockers)
+	}
+}
+
 func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -238,6 +238,58 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	}
 }
 
+func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000250, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.safe_pending', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'safe-agent', 'pending', 0, 'matched_agent_subscription', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed safe pending delivery: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want true for safe pending delivery; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
+		t.Fatal("StateOnlyExecutionReady = true, want false because delivery/event replay is required")
+	}
+	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.HistoricalReplayRequired || !plan.ReplayResumeAdmission.HistoricalReplaySupported {
+		t.Fatalf("replay flags = %#v, want delivery-event replay ready and supported", plan.ReplayResumeAdmission)
+	}
+	for _, disposition := range plan.ReplayResumeAdmission.Dispositions {
+		if disposition.Fact == RunForkReplayResumeFactDeliveryPendingHistory && disposition.Disposition == RunForkReplayResumeDispositionForkReplay {
+			return
+		}
+	}
+	t.Fatalf("missing fork_replay disposition for pending delivery; admission=%#v", plan.ReplayResumeAdmission)
+}
+
 func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -200,9 +200,7 @@ func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
 	if strings.TrimSpace(item.DeliveryID) == "" || strings.TrimSpace(item.SubscriberID) == "" {
 		return false
 	}
-	switch strings.TrimSpace(item.SubscriberType) {
-	case "node", "agent":
-	default:
+	if strings.TrimSpace(item.SubscriberType) != "agent" {
 		return false
 	}
 	if strings.TrimSpace(item.Status) != "pending" || item.RetryCount != 0 {

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -10,6 +10,7 @@ const (
 	RunForkReplayResumeAdmissionOwner = "store.run_fork.replay_resume_admission"
 
 	RunForkReplayResumeDispositionReconstruct        = "reconstruct"
+	RunForkReplayResumeDispositionForkReplay         = "fork_replay"
 	RunForkReplayResumeDispositionLineageOnly        = "lineage_only"
 	RunForkReplayResumeDispositionFailClosedBlocker  = "fail_closed_blocker"
 	RunForkReplayResumeDispositionSplitSibling       = "split_sibling"
@@ -45,6 +46,7 @@ const (
 type RunForkReplayResumeAdmission struct {
 	Owner                     string                           `json:"owner"`
 	StateOnlyExecutionReady   bool                             `json:"state_only_execution_ready"`
+	DeliveryEventReplayReady  bool                             `json:"delivery_event_replay_ready"`
 	HistoricalReplaySupported bool                             `json:"historical_replay_supported"`
 	HistoricalReplayRequired  bool                             `json:"historical_replay_required"`
 	Dispositions              []RunForkReplayResumeDisposition `json:"dispositions,omitempty"`
@@ -79,13 +81,19 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 	}
 	blockers := []RunForkUnsupportedBlocker{}
 	hasHistoricalReplayRequirement := false
+	hasReplayableDeliveryEvent := false
 
 	for _, item := range evidence.Pending {
 		disposition := runForkReplayResumeDispositionForPendingWork(item)
 		dispositions = append(dispositions, disposition)
+		if item.Classification != RunForkPendingClassificationDeliveredCompleted {
+			hasHistoricalReplayRequirement = true
+		}
+		if disposition.Disposition == RunForkReplayResumeDispositionForkReplay {
+			hasReplayableDeliveryEvent = true
+		}
 		if strings.TrimSpace(disposition.BlockerCode) != "" {
 			blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(disposition.BlockerCode))
-			hasHistoricalReplayRequirement = true
 		}
 	}
 	if len(evidence.Pending) == 0 {
@@ -140,10 +148,13 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		hasHistoricalReplayRequirement = true
 	}
 
+	deliveryEventReplayReady := hasReplayableDeliveryEvent && len(blockers) == 0
+	stateOnlyExecutionReady := len(blockers) == 0 && !hasHistoricalReplayRequirement
 	return RunForkReplayResumeAdmission{
 		Owner:                     RunForkReplayResumeAdmissionOwner,
-		StateOnlyExecutionReady:   len(blockers) == 0,
-		HistoricalReplaySupported: false,
+		StateOnlyExecutionReady:   stateOnlyExecutionReady,
+		DeliveryEventReplayReady:  deliveryEventReplayReady,
+		HistoricalReplaySupported: deliveryEventReplayReady,
 		HistoricalReplayRequired:  hasHistoricalReplayRequirement,
 		Dispositions:              dispositions,
 		UnsupportedBlockers:       blockers,
@@ -160,6 +171,14 @@ func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunFo
 			Message:        "completed delivery and receipt facts are preserved as source-run lineage/proof only; they are not redelivered into the fork",
 		}
 	case RunForkPendingClassificationPending:
+		if runForkPendingWorkReplayable(item) {
+			return RunForkReplayResumeDisposition{
+				Fact:           RunForkReplayResumeFactDeliveryPendingHistory,
+				Disposition:    RunForkReplayResumeDispositionForkReplay,
+				Classification: item.Classification,
+				Message:        "pending unstarted source delivery can be replayed by creating fork-local event and delivery rows with explicit source lineage",
+			}
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
 	case RunForkPendingClassificationInProgress:
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryInProgressHistory)
@@ -172,6 +191,27 @@ func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunFo
 	default:
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
 	}
+}
+
+func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
+	if item.Classification != RunForkPendingClassificationPending {
+		return false
+	}
+	if strings.TrimSpace(item.DeliveryID) == "" || strings.TrimSpace(item.SubscriberID) == "" {
+		return false
+	}
+	switch strings.TrimSpace(item.SubscriberType) {
+	case "node", "agent":
+	default:
+		return false
+	}
+	if strings.TrimSpace(item.Status) != "pending" || item.RetryCount != 0 {
+		return false
+	}
+	return strings.TrimSpace(item.ActiveSessionID) == "" &&
+		item.StartedAt == nil &&
+		item.DeliveredAt == nil &&
+		item.ReceiptAt == nil
 }
 
 func runForkReplayResumePendingBlocker(item RunForkPendingWork, fact string) RunForkReplayResumeDisposition {
@@ -190,6 +230,7 @@ func runForkReplayResumeAdmissionWithBlocker(admission RunForkReplayResumeAdmiss
 		admission.Owner = RunForkReplayResumeAdmissionOwner
 	}
 	admission.StateOnlyExecutionReady = false
+	admission.DeliveryEventReplayReady = false
 	admission.HistoricalReplaySupported = false
 	admission.HistoricalReplayRequired = true
 	admission.UnsupportedBlockers = appendRunForkBlocker(admission.UnsupportedBlockers, blocker)

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -331,6 +331,8 @@ func platformTableOrder(name string) int {
 		return 70
 	case "event_deliveries":
 		return 80
+	case "run_fork_delivery_event_replays":
+		return 85
 	case "event_receipts":
 		return 90
 	case "entity_mutations":


### PR DESCRIPTION
## Summary

Closes #569.
Related to #549 and #564.

Implements the approved first slice for timestamp-fork delivery/event replay under the fork `run_id`:
- refines the canonical `replay_resume_admission` taxonomy so safe pending/unstarted agent deliveries can become `delivery_event_replay_ready` without making state-only and full historical replay equivalent;
- adds the canonical store owner `store.run_fork.delivery_event_replay` in the run-fork activation path;
- creates fork-local event and delivery rows with fresh IDs, explicit `run_fork_delivery_event_replays` source lineage, and direct committed replay-scope markers for the existing persisted recovery consumer;
- proves `SweepUndispatched` can deliver the fork-local replay event without quarantining it as missing committed replay scope;
- keeps delivered/completed, receipt-only, node, in-progress, failed, dead-letter, committed replay-scope, timer/route/session/turn/source-advanced/contract-swap cases lineage-only, fail-closed, or split.

## Governing refs

- Issue #569 pre-audit and independent gate: `approved as first slice`.
- Parent trackers: #549 and #564.
- Prior taxonomy owner: #565 / PR #567.
- Spec refs updated in this PR: `platform_tables.tables.run_fork_delivery_event_replays`, `run_model.fork.activation_admission`, `run_model.fork.replay_resume_admission_taxonomy`, `run_model.fork.semantics.3b_activate_materialized_fork`.

## Semantic migration

- New canonical owner: `internal/store/run_fork_delivery_event_replay.go` (`store.run_fork.delivery_event_replay`).
- Existing canonical taxonomy owner remains: `internal/store/run_fork_replay_resume_admission.go`.
- Old invalid paths remain invalid: direct CLI SQL replay, raw source event ID copying, markerless same-run outbox/sweeper replay as fork proof, recomputing recipients from current subscriptions, and dashboard/Builder-only joins.
- Production paths checked: planner/materializer/activation, event persistence, delivery rows, committed replay-scope loading, outbox sweeper recovery, CLI JSON consumer, spec DDL generation, and runtime-operations watchlist mapping.
- Migration completeness: complete for the approved safe pending agent delivery/event replay primitive only. Full historical replay/resume remains open under #564.

## Proof run

- `go test ./internal/store -run 'TestRunFork(Planner|Materializer|Activation)|TestGeneratePlatformTableDDLs' -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand' -count=1`
- `go test ./internal/store ./cmd/swarm ./internal/runtime/bus -count=1`
- `go test ./... -count=1`