### PR TITLE
[agent-a][issue #572] Gate fork session turn replay admission

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -213,10 +213,12 @@ nodes:
       - timers and routing_rules are current rows without an append-only timestamp-fork reconstruction owner
       - agent_sessions and agent_turns are run-scoped facts without an at-T fork reconstruction/reuse policy
       - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and direct committed replay-scope proof for the runtime recovery consumer, while keeping unsafe delivery/session/timer/route cases fail-closed
+      - session/turn replay remains an admission-policy first slice; source active sessions, active turns, active task conversation audits, and fork-local pre-existing session/turn rows are permanent fail-closed blockers until a run-scoped reconstruction owner is approved
     representative_issues:
       - 564
       - 565
       - 569
+      - 572
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -426,6 +426,12 @@ func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, c
 			query string
 		}{"fork_sessions_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`})
 	}
+	if catalog.hasColumns("agent_conversation_audits", "run_id") {
+		checks = append(checks, struct {
+			code  string
+			query string
+		}{"fork_conversation_audits_already_exist", `SELECT EXISTS (SELECT 1 FROM agent_conversation_audits WHERE run_id = $1::uuid)`})
+	}
 	if catalog.hasColumns("agent_turns", "run_id") {
 		checks = append(checks, struct {
 			code  string

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -477,6 +477,16 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	if reasonCode != "fork_replay:matched_agent_subscription" || !activeSessionNull || !startedNull || !deliveredNull {
 		t.Fatalf("fork delivery replay fields = reason:%q activeNull:%v startedNull:%v deliveredNull:%v", reasonCode, activeSessionNull, startedNull, deliveredNull)
 	}
+	var forkSessionCount, forkTurnCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_sessions WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkSessionCount); err != nil {
+		t.Fatalf("count fork sessions: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_turns WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkTurnCount); err != nil {
+		t.Fatalf("count fork turns: %v", err)
+	}
+	if forkSessionCount != 0 || forkTurnCount != 0 {
+		t.Fatalf("fork replay created session/turn rows = %d/%d, want 0/0", forkSessionCount, forkTurnCount)
+	}
 
 	var lineageCount int
 	if err := db.QueryRowContext(ctx, `
@@ -685,6 +695,82 @@ func TestRunForkActivation_FailsClosedForForkReplayStateWithTaxonomy(t *testing.
 	}
 	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactForkReplayState) {
 		t.Fatalf("fork replay-state taxonomy missing disposition: %#v", blocked.ReplayResumeAdmission)
+	}
+}
+
+func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		seed      func(context.Context, *sql.DB, string, time.Time) error
+		wantCode  string
+		wantError string
+	}{
+		{
+			name: "fork session",
+			seed: func(ctx context.Context, db *sql.DB, forkRunID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_sessions (
+						session_id, run_id, agent_id, scope_key, scope, runtime_mode, status, created_at, updated_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-a', 'global', 'global', 'session', 'active', $3, $3)
+				`, uuid.NewString(), forkRunID, at)
+				return err
+			},
+			wantCode:  "fork_sessions_already_exist",
+			wantError: "fork_sessions_already_exist",
+		},
+		{
+			name: "fork turn",
+			seed: func(ctx context.Context, db *sql.DB, forkRunID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_turns (
+						turn_id, run_id, agent_id, session_id, runtime_mode, created_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'session', $4)
+				`, uuid.NewString(), forkRunID, uuid.NewString(), at)
+				return err
+			},
+			wantCode:  "fork_turns_already_exist",
+			wantError: "fork_turns_already_exist",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+
+			sourceRunID := uuid.NewString()
+			entityID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700001060, 0).UTC()
+			seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+			materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+			if err != nil {
+				t.Fatalf("MaterializeRunFork: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO agents (
+					agent_id, role, model_tier, llm_backend, conversation_mode, created_at
+				)
+				VALUES ('agent-a', 'worker', 'standard', 'mock', 'session', $1)
+			`, at); err != nil {
+				t.Fatalf("seed agent: %v", err)
+			}
+			if err := tc.seed(ctx, db, materialized.ForkRunID, at.Add(time.Second)); err != nil {
+				t.Fatalf("seed %s: %v", tc.name, err)
+			}
+
+			blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("ActivateRunFork error = %v, want %s", err, tc.wantError)
+			}
+			if !runForkTestHasActivationBlocker(blocked, tc.wantCode) {
+				t.Fatalf("activation blockers = %#v, want %s", blocked.UnsupportedBlockers, tc.wantCode)
+			}
+			if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactForkReplayState) {
+				t.Fatalf("fork replay-state taxonomy missing disposition: %#v", blocked.ReplayResumeAdmission)
+			}
+		})
 	}
 }
 

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -720,6 +720,20 @@ func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testin
 			wantError: "fork_sessions_already_exist",
 		},
 		{
+			name: "fork conversation audit",
+			seed: func(ctx context.Context, db *sql.DB, forkRunID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_conversation_audits (
+						session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state, status, created_at, updated_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-task', 'global', 'global', 'task', '{}'::jsonb, 'active', $3, $3)
+				`, uuid.NewString(), forkRunID, at)
+				return err
+			},
+			wantCode:  "fork_conversation_audits_already_exist",
+			wantError: "fork_conversation_audits_already_exist",
+		},
+		{
 			name: "fork turn",
 			seed: func(ctx context.Context, db *sql.DB, forkRunID string, at time.Time) error {
 				_, err := db.ExecContext(ctx, `

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -567,7 +567,7 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 			return runForkAdmissionEvidence{}, err
 		}
 	}
-	activeConversationAudit, err := s.hasRunForkActiveConversationAudit(ctx, catalog, runID, cursor)
+	activeConversationAudit, err := s.hasRunForkConversationAuditHistory(ctx, catalog, runID, cursor)
 	if err != nil {
 		return runForkAdmissionEvidence{}, err
 	}
@@ -705,8 +705,8 @@ func (s *PostgresStore) hasRunForkActiveSession(ctx context.Context, catalog sch
 	return exists, nil
 }
 
-func (s *PostgresStore) hasRunForkActiveConversationAudit(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("agent_conversation_audits", "run_id", "status", "created_at") {
+func (s *PostgresStore) hasRunForkConversationAuditHistory(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("agent_conversation_audits", "run_id", "created_at") {
 		return false, nil
 	}
 	var exists bool
@@ -716,7 +716,6 @@ func (s *PostgresStore) hasRunForkActiveConversationAudit(ctx context.Context, c
 			FROM agent_conversation_audits
 			WHERE run_id = $1::uuid
 			  AND created_at <= $2::timestamptz
-			  AND COALESCE(status, '') IN ('active', 'suspended')
 		)
 	`, runID, cursor.CreatedAt).Scan(&exists); err != nil {
 		return false, fmt.Errorf("check fork conversation audit blockers: %w", err)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -92,11 +92,12 @@ type runForkEventCursor struct {
 }
 
 type runForkAdmissionEvidence struct {
-	Pending       []RunForkPendingWork
-	RelevantTimer bool
-	RelevantRoute bool
-	ActiveSession bool
-	ActiveTurn    bool
+	Pending                 []RunForkPendingWork
+	RelevantTimer           bool
+	RelevantRoute           bool
+	ActiveSession           bool
+	ActiveConversationAudit bool
+	ActiveTurn              bool
 }
 
 type runForkSourceFacts struct {
@@ -566,6 +567,10 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 			return runForkAdmissionEvidence{}, err
 		}
 	}
+	activeConversationAudit, err := s.hasRunForkActiveConversationAudit(ctx, catalog, runID, cursor)
+	if err != nil {
+		return runForkAdmissionEvidence{}, err
+	}
 	activeTurn := runForkPendingReferencesActiveSession(pending)
 	if !activeTurn {
 		activeTurn, err = s.hasRunForkActiveTurn(ctx, catalog, runID, cursor)
@@ -574,11 +579,12 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 		}
 	}
 	return runForkAdmissionEvidence{
-		Pending:       pending,
-		RelevantTimer: relevantTimer,
-		RelevantRoute: relevantRoute,
-		ActiveSession: activeSession,
-		ActiveTurn:    activeTurn,
+		Pending:                 pending,
+		RelevantTimer:           relevantTimer,
+		RelevantRoute:           relevantRoute,
+		ActiveSession:           activeSession,
+		ActiveConversationAudit: activeConversationAudit,
+		ActiveTurn:              activeTurn,
 	}, nil
 }
 
@@ -695,6 +701,25 @@ func (s *PostgresStore) hasRunForkActiveSession(ctx context.Context, catalog sch
 		)
 	`, activePredicate), runID, cursor.CreatedAt).Scan(&exists); err != nil {
 		return false, fmt.Errorf("check fork session blockers: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *PostgresStore) hasRunForkActiveConversationAudit(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("agent_conversation_audits", "run_id", "status", "created_at") {
+		return false, nil
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM agent_conversation_audits
+			WHERE run_id = $1::uuid
+			  AND created_at <= $2::timestamptz
+			  AND COALESCE(status, '') IN ('active', 'suspended')
+		)
+	`, runID, cursor.CreatedAt).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork conversation audit blockers: %w", err)
 	}
 	return exists, nil
 }

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -828,6 +828,121 @@ func TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers(t *testing.T
 			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
 		}
 	}
+	for _, fact := range []string{RunForkReplayResumeFactSessionHistory, RunForkReplayResumeFactActiveTurnHistory} {
+		if !runForkTestHasDisposition(plan.ReplayResumeAdmission, fact) {
+			t.Fatalf("missing disposition %q; admission=%#v", fact, plan.ReplayResumeAdmission)
+		}
+	}
+}
+
+func TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	auditSessionID := uuid.NewString()
+	at := time.Unix(1700000295, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.task_audit', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-task', 'global', 'global', 'task', '{}'::jsonb, 'active', $3, $3)
+	`, auditSessionID, runID, at.Add(-time.Second)); err != nil {
+		t.Fatalf("seed active task audit: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false for active task conversation audit facts")
+	}
+	if !runForkTestHasBlocker(plan, RunForkBlockerConversationAuditUnproven) {
+		t.Fatalf("missing conversation audit blocker; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactConversationAuditHistory) {
+		t.Fatalf("missing conversation audit disposition; admission=%#v", plan.ReplayResumeAdmission)
+	}
+}
+
+func TestRunForkPlanner_TerminatedSessionAndAuditBeforeForkAreLineageOnly(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditSessionID := uuid.NewString()
+	at := time.Unix(1700000297, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.completed_session', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model_tier, llm_backend, conversation_mode, created_at
+		)
+		VALUES ('agent-a', 'worker', 'standard', 'mock', 'session', $1)
+	`, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, status, termination_reason, terminated_at, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', 'global', 'global', 'session', 'terminated', 'normal', $3, $4, $3)
+	`, sessionID, runID, at.Add(-time.Second), at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed terminated session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-task', 'global', 'global', 'task', '{}'::jsonb, 'terminated', $3, $3)
+	`, auditSessionID, runID, at.Add(-time.Second)); err != nil {
+		t.Fatalf("seed terminated audit: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	for _, code := range []string{RunForkBlockerSessionHistoryUnproven, RunForkBlockerConversationAuditUnproven, RunForkBlockerActiveTurnHistoryUnproven} {
+		if runForkTestHasBlocker(plan, code) {
+			t.Fatalf("completed lineage emitted blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want completed session/audit lineage-only plan ready; blockers=%#v", plan.UnsupportedBlockers)
+	}
 }
 
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -882,7 +882,7 @@ func TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker(t *testing.T
 	}
 }
 
-func TestRunForkPlanner_TerminatedSessionAndAuditBeforeForkAreLineageOnly(t *testing.T) {
+func TestRunForkPlanner_TerminatedSessionBeforeForkIsLineageOnly(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -890,7 +890,6 @@ func TestRunForkPlanner_TerminatedSessionAndAuditBeforeForkAreLineageOnly(t *tes
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	sessionID := uuid.NewString()
-	auditSessionID := uuid.NewString()
 	at := time.Unix(1700000297, 0).UTC()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -922,12 +921,49 @@ func TestRunForkPlanner_TerminatedSessionAndAuditBeforeForkAreLineageOnly(t *tes
 	`, sessionID, runID, at.Add(-time.Second), at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed terminated session: %v", err)
 	}
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	for _, code := range []string{RunForkBlockerSessionHistoryUnproven, RunForkBlockerActiveTurnHistoryUnproven} {
+		if runForkTestHasBlocker(plan, code) {
+			t.Fatalf("completed lineage emitted blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
+		}
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, want completed session lineage-only plan ready; blockers=%#v", plan.UnsupportedBlockers)
+	}
+}
+
+func TestRunForkPlanner_TerminatedAuditStillBlocksWithoutAtForkTerminationProof(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	auditSessionID := uuid.NewString()
+	at := time.Unix(1700000298, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.terminated_audit', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO agent_conversation_audits (
 			session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state, status, created_at, updated_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'agent-task', 'global', 'global', 'task', '{}'::jsonb, 'terminated', $3, $3)
-	`, auditSessionID, runID, at.Add(-time.Second)); err != nil {
+		VALUES ($1::uuid, $2::uuid, 'agent-task', 'global', 'global', 'task', '{}'::jsonb, 'terminated', $3, $4)
+	`, auditSessionID, runID, at.Add(-time.Second), at.Add(time.Second)); err != nil {
 		t.Fatalf("seed terminated audit: %v", err)
 	}
 
@@ -935,13 +971,14 @@ func TestRunForkPlanner_TerminatedSessionAndAuditBeforeForkAreLineageOnly(t *tes
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
 	}
-	for _, code := range []string{RunForkBlockerSessionHistoryUnproven, RunForkBlockerConversationAuditUnproven, RunForkBlockerActiveTurnHistoryUnproven} {
-		if runForkTestHasBlocker(plan, code) {
-			t.Fatalf("completed lineage emitted blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
-		}
+	if plan.ExecutionReady {
+		t.Fatal("ExecutionReady = true, want false because audit termination is not append-only proven at fork T")
 	}
-	if !plan.ExecutionReady {
-		t.Fatalf("ExecutionReady = false, want completed session/audit lineage-only plan ready; blockers=%#v", plan.UnsupportedBlockers)
+	if !runForkTestHasBlocker(plan, RunForkBlockerConversationAuditUnproven) {
+		t.Fatalf("missing conversation audit blocker; blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactConversationAuditHistory) {
+		t.Fatalf("missing conversation audit disposition; admission=%#v", plan.ReplayResumeAdmission)
 	}
 }
 

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -308,7 +308,7 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 	case RunForkBlockerConversationAuditUnproven:
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerConversationAuditUnproven,
-			Message: "source-run task conversation audit facts are audit/debug lineage and are not a fork-local session reconstruction source",
+			Message: "source-run task conversation audit facts do not carry append-only termination proof at the fork point and are not a fork-local session reconstruction source",
 		}
 	case RunForkBlockerActiveTurnHistoryUnproven:
 		return RunForkUnsupportedBlocker{

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -28,6 +28,7 @@ const (
 	RunForkReplayResumeFactTimerHistory              = "timer_history"
 	RunForkReplayResumeFactRouteHistory              = "flow_route_history"
 	RunForkReplayResumeFactSessionHistory            = "session_history"
+	RunForkReplayResumeFactConversationAuditHistory  = "conversation_audit_history"
 	RunForkReplayResumeFactActiveTurnHistory         = "active_turn_history"
 	RunForkReplayResumeFactSourceAdvanced            = "source_advanced_after_fork_point"
 	RunForkReplayResumeFactForkReplayState           = "fork_replay_state"
@@ -40,6 +41,7 @@ const (
 	RunForkBlockerTimerHistoryUnproven      = "timer_history_unproven"
 	RunForkBlockerFlowRouteHistoryUnproven  = "flow_route_history_unproven"
 	RunForkBlockerSessionHistoryUnproven    = "session_history_unproven"
+	RunForkBlockerConversationAuditUnproven = "conversation_audit_history_unproven"
 	RunForkBlockerActiveTurnHistoryUnproven = "active_turn_history_unproven"
 )
 
@@ -130,6 +132,17 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		blockers = appendRunForkBlocker(blockers, blocker)
 		dispositions = append(dispositions, RunForkReplayResumeDisposition{
 			Fact:        RunForkReplayResumeFactSessionHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+	if evidence.ActiveConversationAudit {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerConversationAuditUnproven)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactConversationAuditHistory,
 			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
 			BlockerCode: blocker.Code,
 			Message:     blocker.Message,
@@ -291,6 +304,11 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerSessionHistoryUnproven,
 			Message: "source-run session facts reference current session rows without append-only session-state proof at the fork point",
+		}
+	case RunForkBlockerConversationAuditUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerConversationAuditUnproven,
+			Message: "source-run task conversation audit facts are audit/debug lineage and are not a fork-local session reconstruction source",
 		}
 	case RunForkBlockerActiveTurnHistoryUnproven:
 		return RunForkUnsupportedBlocker{


### PR DESCRIPTION
## Summary

Implements the approved #572 first slice for canonical timestamp-fork session/turn admission policy.

This PR:
- keeps session/turn work policy/admission-only, with no source session/turn copy, reconstruction, provider-session reuse, or live session registry migration;
- adds a canonical `conversation_audit_history` admission fact and `conversation_audit_history_unproven` blocker for source task conversation audit rows at or before the fork point, because audit termination is not append-only proven;
- blocks fork-local pre-existing conversation-audit rows during activation as unsupported fork replay state;
- preserves #570 safe pending agent delivery/event replay only when no session/turn/audit coupling is present;
- proves fork-local delivery/event replay creates no session/turn rows;
- proves fork-local pre-existing session/audit/turn rows remain taxonomy-backed activation blockers;
- updates the runtime-operations watchlist node for #572 and the reconstruction sibling.

Closes #572

## Governing refs / context

Exact spec refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.run_id.present_on`
- `run_model.fork.activation_admission`
- `run_model.fork.replay_resume_admission_taxonomy`
- `run_model.fork.semantics.3b_activate_materialized_fork`
- `run_model.fork.isolation`
- `flight_recorder.joined_trace_surface`

Binding issue/gate context:
- #572 Pre-Implementation Coverage Audit
- #572 Independent Gate Review: `approved as first slice`
- Parent trackers #549 and #564
- Prior slices #565/#567 and #569/#570

## Canonical owner / migration accounting

Canonical owner after this change:
- `internal/store/run_fork_replay_resume_admission.go`
- `internal/store/run_fork_planner.go`
- `internal/store/run_fork_activation.go`

Old producer / reader / writer path now invalid:
- No source-to-fork session/turn/audit copy path is introduced or authorized.
- `internal/runtime/sessions/postgres.go` remains the live runtime session owner, explicitly split from fork historical reconstruction.

Production paths checked for surviving old behavior:
- planner admission evidence;
- activation no-fork-replay-state guard;
- delivery/event replay fork-local row creation;
- runtime session/turn/audit persistence surfaces as evidence/consumers only.

Migration complete for this first-slice policy class: yes. Parent reconstruction remains open under #549/#564/watchlist.

## Tests

- `go test ./internal/store -run 'TestRunForkPlanner_(PendingUnstartedDeliveryIsDeliveryEventReplayReady|RunScopedActiveSessionAndTurnRemainBlockers|ActiveConversationAuditRemainsPolicyBlocker|TerminatedSessionBeforeForkIsLineageOnly|TerminatedAuditStillBlocksWithoutAtForkTerminationProof|ClassifiesPendingWorkAndNamedBlockers)|TestRunForkActivation_(ReplaysSafePendingDeliveryWithForkLocalLineage|FailsClosedForForkSessionAndTurnReplayState|FailsClosedForForkReplayStateWithTaxonomy|FailsClosedForInProgressDeliveryAndMissingLineage)' -count=1`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`