### PR TITLE
[agent-a][issue #574] Classify non-agent fork deliveries as blocked

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -140,6 +140,11 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 574
+    title: Gate timestamp-fork node/system delivery replay under fork run_id
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -184,6 +189,7 @@ nodes:
       - replayed deliveries and restored timers without explicit shared-store ownership
       - markerless replay-eligible events can repeatedly fail committed replay-scope lookup on the supported outbox sweeper path
       - timestamp forks need fork-local delivery/event replay lineage and committed replay-scope proof rather than direct source delivery redelivery or markerless same-run outbox replay
+      - timestamp-fork non-agent delivery facts are not safe to replay through the agent delivery primitive; node/system delivery execution requires a separate handler/idempotency/receipt owner
     representative_issues:
       - 112
       - 144
@@ -191,6 +197,7 @@ nodes:
       - 547
       - 564
       - 569
+      - 574
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -214,11 +221,13 @@ nodes:
       - agent_sessions and agent_turns are run-scoped facts without an at-T fork reconstruction/reuse policy
       - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and direct committed replay-scope proof for the runtime recovery consumer, while keeping unsafe delivery/session/timer/route cases fail-closed
       - session/turn replay remains an admission-policy first slice; source active sessions, active turns, active task conversation audits, and fork-local pre-existing session/turn rows are permanent fail-closed blockers until a run-scoped reconstruction owner is approved
+      - non-agent delivery replay remains admission-policy only; source node/system/platform/internal delivery facts and committed replay-scope markers are lineage-only or named fail-closed blockers until runtime handler replay ownership is approved
     representative_issues:
       - 564
       - 565
       - 569
       - 572
+      - 574
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -274,8 +274,8 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	}
 
 	blocked, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
-	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
-		t.Fatalf("MaterializeRunFork error = %v, want delivery blocker", err)
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("MaterializeRunFork error = %v, want non-agent delivery blocker", err)
 	}
 	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
 		t.Fatalf("blocked taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
@@ -645,8 +645,8 @@ func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *
 		t.Fatalf("seed in-progress delivery: %v", err)
 	}
 	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
-	if err == nil || !strings.Contains(err.Error(), "delivery_history_unproven") {
-		t.Fatalf("ActivateRunFork in-progress delivery error = %v, want delivery blocker", err)
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("ActivateRunFork in-progress delivery error = %v, want non-agent delivery blocker", err)
 	}
 	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
 		t.Fatalf("blocked activation taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -212,6 +212,7 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	}
 	for _, code := range []string{
 		"delivery_history_unproven",
+		RunForkBlockerCommittedReplayScopeReplayUnsupported,
 		"session_history_unproven",
 		"active_turn_history_unproven",
 	} {
@@ -328,8 +329,204 @@ func TestRunForkPlanner_NodePendingDeliveryRemainsBlocked(t *testing.T) {
 	if plan.ExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady {
 		t.Fatalf("node pending plan became replay-ready: %#v", plan.ReplayResumeAdmission)
 	}
-	if !runForkTestHasBlocker(plan, RunForkBlockerDeliveryHistoryUnproven) {
-		t.Fatalf("node pending blockers = %#v, want delivery_history_unproven", plan.UnsupportedBlockers)
+	if !runForkTestHasBlocker(plan, RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("node pending blockers = %#v, want non-agent delivery replay blocker", plan.UnsupportedBlockers)
+	}
+	if !runForkTestHasDispositionBlocker(plan.ReplayResumeAdmission, RunForkReplayResumeFactDeliveryPendingHistory, RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("node pending admission = %#v, want non-agent delivery replay disposition", plan.ReplayResumeAdmission)
+	}
+}
+
+func TestRunForkPlanner_NonAgentDeliveryStatesRemainNamedBlockers(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		status        string
+		retryCount    int
+		reasonCode    string
+		activeSession bool
+		delivered     bool
+		wantFact      string
+		wantClass     string
+	}{
+		{
+			name:       "pending node",
+			status:     "pending",
+			reasonCode: "matched_node_subscription",
+			wantFact:   RunForkReplayResumeFactDeliveryPendingHistory,
+			wantClass:  RunForkPendingClassificationPending,
+		},
+		{
+			name:          "in progress node",
+			status:        "in_progress",
+			reasonCode:    "node_processing",
+			activeSession: true,
+			wantFact:      RunForkReplayResumeFactDeliveryInProgressHistory,
+			wantClass:     RunForkPendingClassificationInProgress,
+		},
+		{
+			name:       "failed node",
+			status:     "failed",
+			retryCount: 1,
+			reasonCode: "retryable_node_error",
+			delivered:  true,
+			wantFact:   RunForkReplayResumeFactDeliveryFailedHistory,
+			wantClass:  RunForkPendingClassificationFailedRetryable,
+		},
+		{
+			name:       "dead letter node",
+			status:     "dead_letter",
+			retryCount: 3,
+			reasonCode: "dead_letter",
+			delivered:  true,
+			wantFact:   RunForkReplayResumeFactDeliveryDeadLetterHistory,
+			wantClass:  RunForkPendingClassificationDeadLetter,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+
+			runID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700000265, 0).UTC()
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO runs (run_id, status, started_at)
+				VALUES ($1::uuid, 'running', $2)
+			`, runID, at.Add(-time.Minute)); err != nil {
+				t.Fatalf("seed run: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO events (
+					run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+				)
+				VALUES ($1::uuid, $2::uuid, 'fork.non_agent', 'global', '{}'::jsonb, 'test', 'platform', $3)
+			`, runID, eventID, at); err != nil {
+				t.Fatalf("seed event: %v", err)
+			}
+			var activeSessionID any
+			var startedAt any
+			var deliveredAt any
+			if tc.activeSession {
+				activeSessionID = uuid.NewString()
+				startedAt = at
+			}
+			if tc.delivered {
+				deliveredAt = at
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO event_deliveries (
+					run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, active_session_id, started_at, delivered_at, created_at
+				)
+				VALUES ($1::uuid, $2::uuid, 'node', 'node-handler', $3, $4, $5, $6::uuid, $7, $8, $9)
+			`, runID, eventID, tc.status, tc.retryCount, tc.reasonCode, activeSessionID, startedAt, deliveredAt, at); err != nil {
+				t.Fatalf("seed node delivery: %v", err)
+			}
+
+			plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+			if err != nil {
+				t.Fatalf("PlanRunFork: %v", err)
+			}
+			if plan.ExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady {
+				t.Fatalf("non-agent delivery became replay-ready: %#v", plan.ReplayResumeAdmission)
+			}
+			if !runForkTestHasBlocker(plan, RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+				t.Fatalf("blockers = %#v, want non-agent delivery replay blocker", plan.UnsupportedBlockers)
+			}
+			if !runForkTestHasDispositionBlocker(plan.ReplayResumeAdmission, tc.wantFact, RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+				t.Fatalf("admission = %#v, want %s/%s disposition", plan.ReplayResumeAdmission, tc.wantFact, RunForkBlockerNonAgentDeliveryReplayUnsupported)
+			}
+			if len(plan.PendingWork) != 1 {
+				t.Fatalf("pending work = %#v, want one non-agent item", plan.PendingWork)
+			}
+			if plan.PendingWork[0].Classification != tc.wantClass {
+				t.Fatalf("classification = %q, want %q; item=%#v", plan.PendingWork[0].Classification, tc.wantClass, plan.PendingWork[0])
+			}
+		})
+	}
+}
+
+func TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000266, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.replay_scope', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3, $4, 'delivered', 0, $5, $6, $6)
+	`, runID, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, replayScopeReasonDirect, at); err != nil {
+		t.Fatalf("seed replay-scope marker: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady {
+		t.Fatalf("replay-scope marker became replay-ready: %#v", plan.ReplayResumeAdmission)
+	}
+	if !runForkTestHasBlocker(plan, RunForkBlockerCommittedReplayScopeReplayUnsupported) {
+		t.Fatalf("blockers = %#v, want committed replay-scope blocker", plan.UnsupportedBlockers)
+	}
+	if !runForkTestHasDispositionBlocker(plan.ReplayResumeAdmission, RunForkReplayResumeFactCommittedReplayScope, RunForkBlockerCommittedReplayScopeReplayUnsupported) {
+		t.Fatalf("admission = %#v, want committed replay-scope blocker disposition", plan.ReplayResumeAdmission)
+	}
+	if len(plan.PendingWork) != 1 || plan.PendingWork[0].Classification != RunForkPendingClassificationCommittedReplay {
+		t.Fatalf("pending work = %#v, want committed replay-scope marker classification", plan.PendingWork)
+	}
+}
+
+func TestRunForkPlanner_SystemDeliveryRowsAreNotCanonicalEventDeliveries(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000267, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.system_delivery', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'system', 'system-handler', 'pending', 0, 'matched_system_subscription', $3)
+	`, runID, eventID, at)
+	if err == nil {
+		t.Fatal("seed system delivery succeeded, want canonical event_deliveries subscriber_type check to reject system rows")
+	}
+	if !strings.Contains(err.Error(), "subscriber_type") {
+		t.Fatalf("system delivery error = %v, want subscriber_type constraint proof", err)
 	}
 }
 
@@ -1032,6 +1229,15 @@ func runForkTestHasBlocker(plan RunForkPlan, code string) bool {
 func runForkTestHasDisposition(admission RunForkReplayResumeAdmission, fact string) bool {
 	for _, disposition := range admission.Dispositions {
 		if disposition.Fact == fact {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkTestHasDispositionBlocker(admission RunForkReplayResumeAdmission, fact, blockerCode string) bool {
+	for _, disposition := range admission.Dispositions {
+		if disposition.Fact == fact && disposition.BlockerCode == blockerCode {
 			return true
 		}
 	}

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -37,12 +37,14 @@ const (
 )
 
 const (
-	RunForkBlockerDeliveryHistoryUnproven   = "delivery_history_unproven"
-	RunForkBlockerTimerHistoryUnproven      = "timer_history_unproven"
-	RunForkBlockerFlowRouteHistoryUnproven  = "flow_route_history_unproven"
-	RunForkBlockerSessionHistoryUnproven    = "session_history_unproven"
-	RunForkBlockerConversationAuditUnproven = "conversation_audit_history_unproven"
-	RunForkBlockerActiveTurnHistoryUnproven = "active_turn_history_unproven"
+	RunForkBlockerDeliveryHistoryUnproven               = "delivery_history_unproven"
+	RunForkBlockerNonAgentDeliveryReplayUnsupported     = "non_agent_delivery_replay_unsupported"
+	RunForkBlockerCommittedReplayScopeReplayUnsupported = "committed_replay_scope_replay_unsupported"
+	RunForkBlockerTimerHistoryUnproven                  = "timer_history_unproven"
+	RunForkBlockerFlowRouteHistoryUnproven              = "flow_route_history_unproven"
+	RunForkBlockerSessionHistoryUnproven                = "session_history_unproven"
+	RunForkBlockerConversationAuditUnproven             = "conversation_audit_history_unproven"
+	RunForkBlockerActiveTurnHistoryUnproven             = "active_turn_history_unproven"
 )
 
 type RunForkReplayResumeAdmission struct {
@@ -192,16 +194,31 @@ func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunFo
 				Message:        "pending unstarted source delivery can be replayed by creating fork-local event and delivery rows with explicit source lineage",
 			}
 		}
+		if runForkPendingWorkIsNonAgent(item) {
+			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
 	case RunForkPendingClassificationInProgress:
+		if runForkPendingWorkIsNonAgent(item) {
+			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryInProgressHistory)
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryInProgressHistory)
 	case RunForkPendingClassificationFailedRetryable, RunForkPendingClassificationFailedTerminal:
+		if runForkPendingWorkIsNonAgent(item) {
+			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryFailedHistory)
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryFailedHistory)
 	case RunForkPendingClassificationDeadLetter:
+		if runForkPendingWorkIsNonAgent(item) {
+			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryDeadLetterHistory)
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryDeadLetterHistory)
 	case RunForkPendingClassificationCommittedReplay:
-		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactCommittedReplayScope)
+		return runForkReplayResumeCommittedReplayScopeBlocker(item)
 	default:
+		if runForkPendingWorkIsNonAgent(item) {
+			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
+		}
 		return runForkReplayResumePendingBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
 	}
 }
@@ -225,10 +242,36 @@ func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
 		item.ReceiptAt == nil
 }
 
+func runForkPendingWorkIsNonAgent(item RunForkPendingWork) bool {
+	return strings.TrimSpace(item.SubscriberType) != "agent"
+}
+
 func runForkReplayResumePendingBlocker(item RunForkPendingWork, fact string) RunForkReplayResumeDisposition {
 	blocker := runForkReplayResumeBlocker(RunForkBlockerDeliveryHistoryUnproven)
 	return RunForkReplayResumeDisposition{
 		Fact:           fact,
+		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
+		BlockerCode:    blocker.Code,
+		Classification: item.Classification,
+		Message:        blocker.Message,
+	}
+}
+
+func runForkReplayResumeNonAgentBlocker(item RunForkPendingWork, fact string) RunForkReplayResumeDisposition {
+	blocker := runForkReplayResumeBlocker(RunForkBlockerNonAgentDeliveryReplayUnsupported)
+	return RunForkReplayResumeDisposition{
+		Fact:           fact,
+		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
+		BlockerCode:    blocker.Code,
+		Classification: item.Classification,
+		Message:        blocker.Message,
+	}
+}
+
+func runForkReplayResumeCommittedReplayScopeBlocker(item RunForkPendingWork) RunForkReplayResumeDisposition {
+	blocker := runForkReplayResumeBlocker(RunForkBlockerCommittedReplayScopeReplayUnsupported)
+	return RunForkReplayResumeDisposition{
+		Fact:           RunForkReplayResumeFactCommittedReplayScope,
 		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
 		BlockerCode:    blocker.Code,
 		Classification: item.Classification,
@@ -289,6 +332,16 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerDeliveryHistoryUnproven,
 			Message: "event_deliveries stores current delivery state; arbitrary historical delivery transitions at the fork point are not append-only proven",
+		}
+	case RunForkBlockerNonAgentDeliveryReplayUnsupported:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerNonAgentDeliveryReplayUnsupported,
+			Message: "non-agent delivery replay requires runtime handler, idempotency, receipt, route, and side-effect semantics and is not supported by the timestamp-fork delivery/event replay primitive",
+		}
+	case RunForkBlockerCommittedReplayScopeReplayUnsupported:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerCommittedReplayScopeReplayUnsupported,
+			Message: "committed replay-scope marker rows are same-run replay proof and are not node work to replay into a timestamp fork",
 		}
 	case RunForkBlockerTimerHistoryUnproven:
 		return RunForkUnsupportedBlocker{


### PR DESCRIPTION
## Summary

Closes #574.

This implements the approved first slice for non-mutating non-agent timestamp-fork delivery admission policy. It keeps the canonical owner in the store-backed run-fork replay/resume admission family and does not add node/system/non-agent replay execution.

## Governing context

- Issue #574 pre-audit and independent gate result: `approved as first slice`.
- Parent context: #549 and #564.
- Prior fork spine: #565/#567, #569/#570, #572/#573.
- Spec refs: `platform-spec.yaml` `run_model.fork.activation_admission`, `run_model.fork.replay_resume_admission_taxonomy`, `run_model.fork.semantics.3b_activate_materialized_fork`, `run_model.fork.semantics.5_resume`, and `run_model.fork.isolation`.

## Semantic migration

- New canonical owner: `internal/store/run_fork_replay_resume_admission.go` keeps the typed admission policy for non-agent delivery facts.
- Old invalid path: non-agent fork replay falling through the generic `delivery_history_unproven` bucket without a named policy.
- Production paths checked: planner pending-work evidence, activation/materialization consumers, existing safe-agent replay owner, same-run recovery/outbox consumers, receipt-only platform/node facts, committed replay-scope marker rows.
- Migration completeness: complete for the approved #574 policy slice. Actual node/system replay execution remains blocked and out of scope.

## Tests

- `go test ./internal/store -run 'TestRunForkPlanner_(PendingUnstartedDeliveryIsDeliveryEventReplayReady|NodePendingDeliveryRemainsBlocked|NonAgentDeliveryStatesRemainNamedBlockers|ReplayScopeMarkerRemainsCommittedReplayBlocker|SystemDeliveryRowsAreNotCanonicalEventDeliveries|AccountsForReceiptOnlyPlatformAndNodeProcessing|ClassifiesPendingWorkAndNamedBlockers)|TestRunForkActivation_(ReplaysSafePendingDeliveryWithForkLocalLineage|FailsClosedForForkReplayStateWithTaxonomy|FailsClosedForInProgressDeliveryAndMissingLineage)|TestRunForkMaterialize_.*' -count=1`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`