### PR TITLE
[agent-a][issue #577] Add non-mutating fork contract frontier admission

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -34,6 +34,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerunforkadmission "swarm/internal/runtime/runforkadmission"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -330,6 +331,8 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	fs := flag.NewFlagSet("fork", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
+	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for non-mutating dry-run admission")
+	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	storeMode := fs.String("store", "postgres", "Store mode: postgres")
 	runID := fs.String("run", "", "Source run ID to plan from")
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
@@ -358,6 +361,12 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	if modeCount == 0 {
 		if out != nil {
 			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run, --materialize-only, or --activate")
+		}
+		return 2
+	}
+	if strings.TrimSpace(*contractsPath) != "" && !*dryRun {
+		if out != nil {
+			fmt.Fprintln(out, "fork failed: --contracts is only supported for non-mutating --dry-run admission")
 		}
 		return 2
 	}
@@ -449,6 +458,35 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 1
 	}
+	if contracts := strings.TrimSpace(*contractsPath); contracts != "" {
+		contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, contracts))
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
+			}
+			return 1
+		}
+		_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
+			}
+			return 1
+		}
+		source := semanticview.Wrap(bundle)
+		admission, err := runtimerunforkadmission.AdmitContractFrontier(runtimerunforkadmission.ContractFrontierRequest{
+			Plan:              plan,
+			Source:            source,
+			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: admit selected contract frontier: %v\n", err)
+			}
+			return 1
+		}
+		plan.ContractFrontierAdmission = &admission
+	}
 	if *asJSON {
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
@@ -533,6 +571,15 @@ func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {
 				item.Classification,
 			)
 		}
+	}
+	if plan.ContractFrontierAdmission != nil {
+		admission := plan.ContractFrontierAdmission
+		fmt.Fprintf(w, "Contract Frontier Admission: owner=%s non_mutating=%t frontier_events=%d historical_execution_supported=%t\n",
+			admission.Owner,
+			admission.NonMutating,
+			admission.FrontierEventCount,
+			admission.HistoricalExecutionSupported,
+		)
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -456,6 +456,86 @@ func TestRunForkCommand_DryRunJSONReportsDeliveryEventReplayReady(t *testing.T) 
 	}
 }
 
+func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000307, 0).UTC()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'flow-a/work.begin', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'source-node', 'pending', 0, 'matched_node_subscription', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed pending node delivery: %v", err)
+	}
+
+	repo := repoRoot()
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, repo, []string{
+		"--dry-run",
+		"--run", runID,
+		"--at", eventID,
+		"--contracts", filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated"),
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var plan store.RunForkPlan
+	if err := json.Unmarshal(buf.Bytes(), &plan); err != nil {
+		t.Fatalf("decode fork plan json: %v\n%s", err, buf.String())
+	}
+	if plan.ContractFrontierAdmission == nil {
+		t.Fatalf("ContractFrontierAdmission = nil; output=%s", buf.String())
+	}
+	admission := plan.ContractFrontierAdmission
+	if admission.Owner != store.RunForkContractFrontierAdmissionOwner || !admission.NonMutating || admission.HistoricalExecutionSupported {
+		t.Fatalf("contract frontier admission = %#v", admission)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v", admission.FrontierEvents)
+	}
+	if !runForkPlanHasString(admission.FrontierEvents[0].RuntimeEventOwners, "alpha-intake") {
+		t.Fatalf("runtime event owners = %#v, want alpha-intake from selected contract", admission.FrontierEvents[0].RuntimeEventOwners)
+	}
+	if !runForkPlanHasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierExecutionUnsupported) {
+		t.Fatalf("contract frontier blockers = %#v, want execution unsupported", admission.UnsupportedBlockers)
+	}
+}
+
+func TestRunForkCommand_ContractsRemainDryRunOnly(t *testing.T) {
+	var buf bytes.Buffer
+	code := runForkCommand(context.Background(), t.TempDir(), []string{
+		"--materialize-only",
+		"--contracts", t.TempDir(),
+		"--run", uuid.NewString(),
+		"--at", uuid.NewString(),
+	}, &buf)
+	if code != 2 {
+		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "--contracts is only supported for non-mutating --dry-run admission") {
+		t.Fatalf("output = %q, want dry-run-only contracts failure", buf.String())
+	}
+}
+
 func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)
@@ -641,6 +721,24 @@ func seedRunForkCLIActivationSource(t *testing.T, db interface {
 	`, runID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
+}
+
+func runForkPlanHasBlocker(blockers []store.RunForkUnsupportedBlocker, code string) bool {
+	for _, blocker := range blockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkPlanHasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func setPostgresEnvFromDSN(t *testing.T, dsn string) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3172,14 +3172,15 @@ run_model:
       loading new contracts, and resuming execution. The system automatically determines which events need
       to be re-delivered. The original run is frozen. The forked run gets independent execution.'
     command: 'swarm fork --run <run_id> --at <event_id|timestamp> [--contracts <path>]'
-    dry_run_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --dry-run [--json]'
+    dry_run_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --dry-run [--contracts <path>] [--json]'
     materialize_only_command: 'swarm fork --run <run_id> --at <event_id|timestamp> --materialize-only [--json]'
     activation_command: 'swarm fork --run <fork_run_id> --activate [--json]'
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
-      point, reconstructs provable state, classifies replay candidates, and returns execution_ready=false
+      point, reconstructs provable state, classifies replay candidates, optionally loads selected contracts
+      for non-mutating contract/frontier/route admission, and returns execution_ready=false
       with named unsupported blockers whenever persisted recorder facts cannot prove safe execution. Dry-run
       MUST NOT create a forked run, mark the source run forked, copy entity state, redeliver events, or change
-      runtime delivery/session/timer state.'
+      runtime delivery/session/timer/route state.'
     materialize_only_admission: 'The materialize-only form is the first supported mutating fork slice. It
       consumes the canonical read-only planner, requires execution_ready=true, creates a fork run with
       status=paused and fork lineage, and writes reconstructed entity_state rows under the fork run_id.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -145,6 +145,10 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 577
+    title: Gate non-mutating fork contract/frontier/route admission
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -222,12 +226,14 @@ nodes:
       - the first supported timestamp-fork delivery/event replay primitive must create fresh fork event/delivery IDs with source lineage and direct committed replay-scope proof for the runtime recovery consumer, while keeping unsafe delivery/session/timer/route cases fail-closed
       - session/turn replay remains an admission-policy first slice; source active sessions, active turns, active task conversation audits, and fork-local pre-existing session/turn rows are permanent fail-closed blockers until a run-scoped reconstruction owner is approved
       - non-agent delivery replay remains admission-policy only; source node/system/platform/internal delivery facts and committed replay-scope markers are lineage-only or named fail-closed blockers until runtime handler replay ownership is approved
+      - selected-contract timestamp-fork re-admission needs a non-mutating contract/frontier/route admission owner before node/system delivery facts can become executable fork work
     representative_issues:
       - 564
       - 565
       - 569
       - 572
       - 574
+      - 577
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -1,0 +1,226 @@
+package runforkadmission
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+type ContractFrontierRequest struct {
+	Plan              store.RunForkPlan
+	Source            semanticview.Source
+	ContractSelection store.RunForkContractSelection
+}
+
+func SelectedContractSelection(source semanticview.Source, contractsRoot string) store.RunForkContractSelection {
+	selection := store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: strings.TrimSpace(contractsRoot),
+	}
+	if source != nil {
+		selection.WorkflowName = strings.TrimSpace(source.WorkflowName())
+		selection.WorkflowVersion = strings.TrimSpace(source.WorkflowVersion())
+	}
+	return selection
+}
+
+func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFrontierAdmission, error) {
+	if req.Source == nil {
+		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("selected contract semantic source is required")
+	}
+	selection := req.ContractSelection
+	if strings.TrimSpace(selection.Mode) == "" {
+		selection = SelectedContractSelection(req.Source, selection.ContractsRoot)
+	}
+	if strings.TrimSpace(selection.WorkflowName) == "" {
+		selection.WorkflowName = strings.TrimSpace(req.Source.WorkflowName())
+	}
+	if strings.TrimSpace(selection.WorkflowVersion) == "" {
+		selection.WorkflowVersion = strings.TrimSpace(req.Source.WorkflowVersion())
+	}
+
+	routeTable, err := runtimebus.DeriveRouteTable(req.Source)
+	if err != nil {
+		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract fork routes: %w", err)
+	}
+	workflowNodes, err := runtimepipeline.LoadWorkflowNodes(req.Source)
+	if err != nil {
+		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract workflow nodes: %w", err)
+	}
+
+	frontier := runForkFrontierEvents(req.Plan.PendingWork)
+	for i := range frontier {
+		eventName := frontier[i].EventName
+		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
+		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, eventName)
+		frontier[i].DerivedRecipients = contractFrontierRecipients(routeTable.Resolve(eventName))
+	}
+	sort.Slice(frontier, func(i, j int) bool {
+		if frontier[i].EventName != frontier[j].EventName {
+			return frontier[i].EventName < frontier[j].EventName
+		}
+		return frontier[i].SourceEventID < frontier[j].SourceEventID
+	})
+
+	blockers := []store.RunForkUnsupportedBlocker{}
+	if len(frontier) > 0 {
+		blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerContractFrontierExecutionUnsupported,
+			Message: "selected-contract frontier admission is non-mutating; handler execution and fork-local delivery writes remain separately gated",
+		})
+	}
+	for _, event := range frontier {
+		if len(event.DerivedRecipients) > 0 || len(event.RuntimeEventOwners) > 0 || len(event.WorkflowNodeSubscribers) > 0 {
+			continue
+		}
+		blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerContractFrontierRouteUnresolved,
+			Message: "selected-contract frontier event has no derived route, workflow subscriber, or runtime event owner",
+		})
+	}
+
+	return store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		ContractSelection:            selection,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		FrontierEventCount:           len(frontier),
+		FrontierEvents:               frontier,
+		UnsupportedBlockers:          blockers,
+	}, nil
+}
+
+func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkContractFrontierEvent {
+	type aggregate struct {
+		event           store.RunForkContractFrontierEvent
+		classifications map[string]struct{}
+		subscriberTypes map[string]struct{}
+		subscriberIDs   map[string]struct{}
+	}
+	byEvent := map[string]*aggregate{}
+	for _, item := range pending {
+		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
+			continue
+		}
+		eventID := strings.TrimSpace(item.EventID)
+		if eventID == "" {
+			continue
+		}
+		agg := byEvent[eventID]
+		if agg == nil {
+			agg = &aggregate{
+				event: store.RunForkContractFrontierEvent{
+					SourceEventID: eventID,
+					EventName:     strings.TrimSpace(item.EventName),
+				},
+				classifications: map[string]struct{}{},
+				subscriberTypes: map[string]struct{}{},
+				subscriberIDs:   map[string]struct{}{},
+			}
+			byEvent[eventID] = agg
+		}
+		addString(agg.classifications, item.Classification)
+		addString(agg.subscriberTypes, item.SubscriberType)
+		addString(agg.subscriberIDs, item.SubscriberID)
+	}
+	out := make([]store.RunForkContractFrontierEvent, 0, len(byEvent))
+	for _, agg := range byEvent {
+		agg.event.SourceClassifications = sortedSet(agg.classifications)
+		agg.event.SourceSubscriberTypes = sortedSet(agg.subscriberTypes)
+		agg.event.SourceSubscriberIDs = sortedSet(agg.subscriberIDs)
+		out = append(out, agg.event)
+	}
+	return out
+}
+
+func workflowNodeSubscribers(nodes []runtimepipeline.WorkflowNode, eventName string) []string {
+	eventName = strings.TrimSpace(eventName)
+	if eventName == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, node := range nodes {
+		for _, subscription := range node.Subscriptions {
+			if strings.TrimSpace(string(subscription)) != eventName {
+				continue
+			}
+			addString(seen, node.ID)
+		}
+	}
+	return sortedSet(seen)
+}
+
+func contractFrontierRecipients(in []runtimebus.Subscriber) []store.RunForkContractFrontierRecipient {
+	out := make([]store.RunForkContractFrontierRecipient, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, subscriber := range in {
+		recipient := store.RunForkContractFrontierRecipient{
+			SubscriberType: strings.TrimSpace(subscriber.Type),
+			SubscriberID:   strings.TrimSpace(subscriber.ID),
+			Path:           strings.TrimSpace(subscriber.Path),
+			RouteSource:    strings.TrimSpace(subscriber.RouteSource),
+		}
+		if recipient.SubscriberID == "" || recipient.SubscriberType == "" {
+			continue
+		}
+		key := strings.Join([]string{recipient.SubscriberType, recipient.SubscriberID, recipient.Path, recipient.RouteSource}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, recipient)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := strings.Join([]string{out[i].SubscriberType, out[i].SubscriberID, out[i].Path, out[i].RouteSource}, "\x00")
+		right := strings.Join([]string{out[j].SubscriberType, out[j].SubscriberID, out[j].Path, out[j].RouteSource}, "\x00")
+		return left < right
+	})
+	return out
+}
+
+func appendRunForkBlocker(blockers []store.RunForkUnsupportedBlocker, blocker store.RunForkUnsupportedBlocker) []store.RunForkUnsupportedBlocker {
+	code := strings.TrimSpace(blocker.Code)
+	if code == "" {
+		return blockers
+	}
+	for _, existing := range blockers {
+		if strings.TrimSpace(existing.Code) == code {
+			return blockers
+		}
+	}
+	blocker.Code = code
+	blocker.Message = strings.TrimSpace(blocker.Message)
+	return append(blockers, blocker)
+}
+
+func sortedUnique(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		addString(seen, value)
+	}
+	return sortedSet(seen)
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func addString(values map[string]struct{}, value string) {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		values[value] = struct{}{}
+	}
+}

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
@@ -47,6 +49,9 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 	routeTable, err := runtimebus.DeriveRouteTable(req.Source)
 	if err != nil {
 		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract fork routes: %w", err)
+	}
+	if err := installContractFrontierFlowInstanceRoutes(routeTable, req.Source, req.Plan.PendingWork); err != nil {
+		return store.RunForkContractFrontierAdmission{}, err
 	}
 	workflowNodes, err := runtimepipeline.LoadWorkflowNodes(req.Source)
 	if err != nil {
@@ -99,12 +104,14 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkCo
 	type aggregate struct {
 		event           store.RunForkContractFrontierEvent
 		classifications map[string]struct{}
+		flowInstances   map[string]struct{}
 		subscriberTypes map[string]struct{}
 		subscriberIDs   map[string]struct{}
 	}
 	byEvent := map[string]*aggregate{}
 	for _, item := range pending {
-		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
+		switch strings.TrimSpace(item.Classification) {
+		case store.RunForkPendingClassificationDeliveredCompleted, store.RunForkPendingClassificationCommittedReplay:
 			continue
 		}
 		eventID := strings.TrimSpace(item.EventID)
@@ -119,23 +126,145 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkCo
 					EventName:     strings.TrimSpace(item.EventName),
 				},
 				classifications: map[string]struct{}{},
+				flowInstances:   map[string]struct{}{},
 				subscriberTypes: map[string]struct{}{},
 				subscriberIDs:   map[string]struct{}{},
 			}
 			byEvent[eventID] = agg
 		}
 		addString(agg.classifications, item.Classification)
+		addString(agg.flowInstances, item.FlowInstance)
 		addString(agg.subscriberTypes, item.SubscriberType)
 		addString(agg.subscriberIDs, item.SubscriberID)
 	}
 	out := make([]store.RunForkContractFrontierEvent, 0, len(byEvent))
 	for _, agg := range byEvent {
 		agg.event.SourceClassifications = sortedSet(agg.classifications)
+		agg.event.SourceFlowInstances = sortedSet(agg.flowInstances)
 		agg.event.SourceSubscriberTypes = sortedSet(agg.subscriberTypes)
 		agg.event.SourceSubscriberIDs = sortedSet(agg.subscriberIDs)
 		out = append(out, agg.event)
 	}
 	return out
+}
+
+func installContractFrontierFlowInstanceRoutes(routeTable *runtimebus.RouteTable, source semanticview.Source, pending []store.RunForkPendingWork) error {
+	for _, route := range contractFrontierFlowInstanceRoutes(source, pending) {
+		if err := routeTable.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, route); err != nil {
+			return fmt.Errorf("derive selected-contract flow-instance route %s: %w", route.InstancePath, err)
+		}
+	}
+	return nil
+}
+
+func contractFrontierFlowInstanceRoutes(source semanticview.Source, pending []store.RunForkPendingWork) []runtimeflowidentity.Route {
+	seen := map[string]struct{}{}
+	out := make([]runtimeflowidentity.Route, 0)
+	for _, item := range pending {
+		for _, instancePath := range contractFrontierFlowInstances(source, item) {
+			route := runtimeflowidentity.StoredRoute("", "", instancePath)
+			if !route.Valid() {
+				continue
+			}
+			key := strings.Join([]string{route.ScopeKey, route.InstanceID, route.InstancePath}, "\x00")
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, route)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.Join([]string{out[i].ScopeKey, out[i].InstanceID, out[i].InstancePath}, "\x00") <
+			strings.Join([]string{out[j].ScopeKey, out[j].InstanceID, out[j].InstancePath}, "\x00")
+	})
+	return out
+}
+
+func contractFrontierFlowInstances(source semanticview.Source, item store.RunForkPendingWork) []string {
+	seen := map[string]struct{}{}
+	add := func(value string) {
+		value = strings.Trim(strings.TrimSpace(value), "/")
+		if value != "" && isContractFrontierTemplateInstancePath(source, value) {
+			seen[value] = struct{}{}
+		}
+	}
+	add(item.FlowInstance)
+	add(inferContractFrontierFlowInstanceFromEvent(source, item.EventName))
+	return sortedSet(seen)
+}
+
+func isContractFrontierTemplateInstancePath(source semanticview.Source, instancePath string) bool {
+	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
+	if source == nil || instancePath == "" {
+		return false
+	}
+	for _, scope := range source.FlowScopes() {
+		if !strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+			continue
+		}
+		scopePath := strings.Trim(strings.TrimSpace(scope.Path), "/")
+		if scopePath == "" || instancePath == scopePath {
+			continue
+		}
+		if strings.HasPrefix(instancePath, scopePath+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func inferContractFrontierFlowInstanceFromEvent(source semanticview.Source, eventName string) string {
+	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
+	if source == nil || eventName == "" {
+		return ""
+	}
+	type templateScope struct {
+		path        string
+		localEvents []string
+	}
+	templates := make([]templateScope, 0)
+	for _, scope := range source.FlowScopes() {
+		if !strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+			continue
+		}
+		path := strings.Trim(strings.TrimSpace(scope.Path), "/")
+		if path == "" {
+			continue
+		}
+		localEvents := map[string]struct{}{}
+		for eventType := range scope.Events {
+			addString(localEvents, eventType)
+		}
+		for _, eventType := range scope.InputEvents {
+			addString(localEvents, eventType)
+		}
+		for _, eventType := range scope.OutputEvents {
+			addString(localEvents, eventType)
+		}
+		addString(localEvents, scope.AutoEmitEvent)
+		templates = append(templates, templateScope{path: path, localEvents: sortedSet(localEvents)})
+	}
+	sort.Slice(templates, func(i, j int) bool {
+		return len(templates[i].path) > len(templates[j].path)
+	})
+	for _, template := range templates {
+		if !strings.HasPrefix(eventName, template.path+"/") {
+			continue
+		}
+		for _, localEvent := range template.localEvents {
+			suffix := "/" + strings.Trim(strings.TrimSpace(localEvent), "/")
+			if suffix == "/" || !strings.HasSuffix(eventName, suffix) {
+				continue
+			}
+			instancePath := strings.Trim(strings.TrimSuffix(eventName, suffix), "/")
+			if instancePath == template.path || !strings.HasPrefix(instancePath, template.path+"/") {
+				continue
+			}
+			return instancePath
+		}
+	}
+	return ""
 }
 
 func workflowNodeSubscribers(nodes []runtimepipeline.WorkflowNode, eventName string) []string {

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -1,0 +1,195 @@
+package runforkadmission
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+func TestAdmitContractFrontier_DerivesSelectedContractRecipientsWithoutMutating(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	source := testContractFrontierSource("consumer-node")
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.Owner != store.RunForkContractFrontierAdmissionOwner {
+		t.Fatalf("owner = %q, want %q", admission.Owner, store.RunForkContractFrontierAdmissionOwner)
+	}
+	if !admission.NonMutating || admission.HistoricalExecutionSupported {
+		t.Fatalf("admission mutation flags = non_mutating:%v historical_supported:%v", admission.NonMutating, admission.HistoricalExecutionSupported)
+	}
+	if admission.ContractSelection.ContractsRoot != "/tmp/contracts-a" {
+		t.Fatalf("contracts root = %q", admission.ContractSelection.ContractsRoot)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %d/%d, want 1", admission.FrontierEventCount, len(admission.FrontierEvents))
+	}
+	event := admission.FrontierEvents[0]
+	if event.EventName != "producer/scan.requested" {
+		t.Fatalf("event name = %q", event.EventName)
+	}
+	if !hasString(event.SourceSubscriberTypes, "node") || !hasString(event.SourceSubscriberIDs, "source-node") {
+		t.Fatalf("source delivery evidence = types:%v ids:%v", event.SourceSubscriberTypes, event.SourceSubscriberIDs)
+	}
+	if !hasString(event.WorkflowNodeSubscribers, "consumer-node") {
+		t.Fatalf("workflow node subscribers = %v, want consumer-node", event.WorkflowNodeSubscribers)
+	}
+	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "consumer-node" || event.DerivedRecipients[0].SubscriberType != "node" {
+		t.Fatalf("derived recipients = %#v, want selected contract consumer-node", event.DerivedRecipients)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierExecutionUnsupported) {
+		t.Fatalf("blockers = %#v, want execution unsupported", admission.UnsupportedBlockers)
+	}
+}
+
+func TestAdmitContractFrontier_SelectedContractChangesRecipients(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	sourceA := testContractFrontierSource("consumer-a")
+	sourceB := testContractFrontierSource("consumer-b")
+
+	admissionA, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            sourceA,
+		ContractSelection: SelectedContractSelection(sourceA, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier A: %v", err)
+	}
+	admissionB, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            sourceB,
+		ContractSelection: SelectedContractSelection(sourceB, "/tmp/contracts-b"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier B: %v", err)
+	}
+	gotA := admissionA.FrontierEvents[0].DerivedRecipients[0].SubscriberID
+	gotB := admissionB.FrontierEvents[0].DerivedRecipients[0].SubscriberID
+	if gotA != "consumer-a" || gotB != "consumer-b" {
+		t.Fatalf("selected contract recipients = %q/%q, want consumer-a/consumer-b", gotA, gotB)
+	}
+}
+
+func TestAdmitContractFrontier_DeliveredCompletedHistoryIsNotFrontierWork(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	source := testContractFrontierSource("consumer-node")
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.FrontierEventCount != 0 || len(admission.FrontierEvents) != 0 {
+		t.Fatalf("frontier events = %#v, want none for delivered/completed history", admission.FrontierEvents)
+	}
+	if len(admission.UnsupportedBlockers) != 0 {
+		t.Fatalf("blockers = %#v, want none without unresolved frontier", admission.UnsupportedBlockers)
+	}
+}
+
+func TestAdmitContractFrontier_FailsClosedWithoutSelectedSource(t *testing.T) {
+	_, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan: testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node"),
+	})
+	if err == nil {
+		t.Fatal("AdmitContractFrontier error = nil, want selected source failure")
+	}
+}
+
+func testRunForkPlan(eventName, classification, subscriberType, subscriberID string) store.RunForkPlan {
+	now := time.Unix(1700001000, 0).UTC()
+	eventID := uuid.NewString()
+	return store.RunForkPlan{
+		SourceRunID: uuid.NewString(),
+		ForkPoint: store.RunForkPoint{
+			Input:     eventID,
+			EventID:   eventID,
+			EventName: eventName,
+			Timestamp: now,
+		},
+		PendingWork: []store.RunForkPendingWork{{
+			EventID:        eventID,
+			EventName:      eventName,
+			DeliveryID:     uuid.NewString(),
+			SubscriberType: subscriberType,
+			SubscriberID:   subscriberID,
+			Classification: classification,
+			Status:         "pending",
+			CreatedAt:      now,
+		}},
+		PendingWorkCount: 1,
+	}
+}
+
+func testContractFrontierSource(nodeID string) semanticview.Source {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "producer",
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			nodeID: {
+				ID:           nodeID,
+				SubscribesTo: []string{"scan.requested"},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, consumer}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "test-workflow",
+			Version: "v-test",
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"consumer": &root.Children[1],
+			},
+		},
+	})
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBlocker(blockers []store.RunForkUnsupportedBlocker, code string) bool {
+	for _, blocker := range blockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -101,12 +101,81 @@ func TestAdmitContractFrontier_DeliveredCompletedHistoryIsNotFrontierWork(t *tes
 	}
 }
 
+func TestAdmitContractFrontier_CommittedReplayScopeMarkersAreNotFrontierWork(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationCommittedReplay, "platform", "replay-scope")
+	source := testContractFrontierSource("consumer-node")
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.FrontierEventCount != 0 || len(admission.FrontierEvents) != 0 {
+		t.Fatalf("frontier events = %#v, want none for replay-scope marker", admission.FrontierEvents)
+	}
+	if len(admission.UnsupportedBlockers) != 0 {
+		t.Fatalf("blockers = %#v, want none without executable frontier work", admission.UnsupportedBlockers)
+	}
+}
+
+func TestAdmitContractFrontier_MaterializesSourceFlowInstanceRoutes(t *testing.T) {
+	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "review/inst-1"
+	source := testContractFrontierTemplateSource()
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v, want one instantiated frontier event", admission.FrontierEvents)
+	}
+	event := admission.FrontierEvents[0]
+	if !hasString(event.SourceFlowInstances, "review/inst-1") {
+		t.Fatalf("source flow instances = %v, want review/inst-1", event.SourceFlowInstances)
+	}
+	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "reviewer-inst-1" {
+		t.Fatalf("derived recipients = %#v, want materialized reviewer-inst-1", event.DerivedRecipients)
+	}
+	if event.DerivedRecipients[0].Path != "review/inst-1" {
+		t.Fatalf("recipient path = %q, want review/inst-1", event.DerivedRecipients[0].Path)
+	}
+	if hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want no unresolved-route blocker for materialized instance route", admission.UnsupportedBlockers)
+	}
+}
+
 func TestAdmitContractFrontier_FailsClosedWithoutSelectedSource(t *testing.T) {
 	_, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan: testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node"),
 	})
 	if err == nil {
 		t.Fatal("AdmitContractFrontier error = nil, want selected source failure")
+	}
+}
+
+func TestAdmitContractFrontier_InfersFlowInstanceRouteFromEventName(t *testing.T) {
+	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
+	source := testContractFrontierTemplateSource()
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	event := admission.FrontierEvents[0]
+	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "reviewer-inst-1" {
+		t.Fatalf("derived recipients = %#v, want inferred materialized reviewer-inst-1", event.DerivedRecipients)
 	}
 }
 
@@ -171,6 +240,39 @@ func testContractFrontierSource(nodeID string) semanticview.Source {
 			ByID: map[string]*runtimecontracts.FlowContractView{
 				"producer": &root.Children[0],
 				"consumer": &root.Children[1],
+			},
+		},
+	})
+}
+
+func testContractFrontierTemplateSource() semanticview.Source {
+	review := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+		},
+		Path: "review",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"reviewer": {
+				ID:           "reviewer-{instance_id}",
+				SubscribesTo: []string{"task.started"},
+				Produces:     []string{"task.started"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"task.started": {},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{review}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "test-workflow",
+			Version: "v-test",
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review": &root.Children[0],
 			},
 		},
 	})

--- a/internal/store/run_fork_contract_frontier_admission.go
+++ b/internal/store/run_fork_contract_frontier_admission.go
@@ -28,6 +28,7 @@ type RunForkContractFrontierEvent struct {
 	SourceEventID           string                             `json:"source_event_id"`
 	EventName               string                             `json:"event_name"`
 	SourceClassifications   []string                           `json:"source_classifications,omitempty"`
+	SourceFlowInstances     []string                           `json:"source_flow_instances,omitempty"`
 	SourceSubscriberTypes   []string                           `json:"source_subscriber_types,omitempty"`
 	SourceSubscriberIDs     []string                           `json:"source_subscriber_ids,omitempty"`
 	RuntimeEventOwners      []string                           `json:"runtime_event_owners,omitempty"`

--- a/internal/store/run_fork_contract_frontier_admission.go
+++ b/internal/store/run_fork_contract_frontier_admission.go
@@ -1,0 +1,43 @@
+package store
+
+const (
+	RunForkContractFrontierAdmissionOwner = "runtime.run_fork.contract_frontier_admission"
+
+	RunForkBlockerContractFrontierExecutionUnsupported = "contract_frontier_execution_unsupported"
+	RunForkBlockerContractFrontierRouteUnresolved      = "contract_frontier_route_unresolved"
+)
+
+type RunForkContractSelection struct {
+	Mode            string `json:"mode"`
+	ContractsRoot   string `json:"contracts_root,omitempty"`
+	WorkflowName    string `json:"workflow_name,omitempty"`
+	WorkflowVersion string `json:"workflow_version,omitempty"`
+}
+
+type RunForkContractFrontierAdmission struct {
+	Owner                        string                         `json:"owner"`
+	ContractSelection            RunForkContractSelection       `json:"contract_selection"`
+	NonMutating                  bool                           `json:"non_mutating"`
+	HistoricalExecutionSupported bool                           `json:"historical_execution_supported"`
+	FrontierEventCount           int                            `json:"frontier_event_count"`
+	FrontierEvents               []RunForkContractFrontierEvent `json:"frontier_events,omitempty"`
+	UnsupportedBlockers          []RunForkUnsupportedBlocker    `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkContractFrontierEvent struct {
+	SourceEventID           string                             `json:"source_event_id"`
+	EventName               string                             `json:"event_name"`
+	SourceClassifications   []string                           `json:"source_classifications,omitempty"`
+	SourceSubscriberTypes   []string                           `json:"source_subscriber_types,omitempty"`
+	SourceSubscriberIDs     []string                           `json:"source_subscriber_ids,omitempty"`
+	RuntimeEventOwners      []string                           `json:"runtime_event_owners,omitempty"`
+	WorkflowNodeSubscribers []string                           `json:"workflow_node_subscribers,omitempty"`
+	DerivedRecipients       []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
+}
+
+type RunForkContractFrontierRecipient struct {
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	Path           string `json:"path,omitempty"`
+	RouteSource    string `json:"route_source,omitempty"`
+}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -30,20 +30,21 @@ type RunForkPlanRequest struct {
 }
 
 type RunForkPlan struct {
-	SourceRunID              string                       `json:"source_run_id"`
-	SourceRunStatus          string                       `json:"source_run_status,omitempty"`
-	SourceRunStartedAt       *time.Time                   `json:"source_run_started_at,omitempty"`
-	SourceRunEndedAt         *time.Time                   `json:"source_run_ended_at,omitempty"`
-	ForkPoint                RunForkPoint                 `json:"fork_point"`
-	EventCountAtFork         int                          `json:"event_count_at_fork"`
-	ReconstructedEntityCount int                          `json:"reconstructed_entity_count"`
-	PendingWorkCount         int                          `json:"pending_work_count"`
-	UnsupportedBlockerCount  int                          `json:"unsupported_blocker_count"`
-	ExecutionReady           bool                         `json:"execution_ready"`
-	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
-	Entities                 []RunForkEntityState         `json:"entities,omitempty"`
-	PendingWork              []RunForkPendingWork         `json:"pending_work,omitempty"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
+	SourceRunID               string                            `json:"source_run_id"`
+	SourceRunStatus           string                            `json:"source_run_status,omitempty"`
+	SourceRunStartedAt        *time.Time                        `json:"source_run_started_at,omitempty"`
+	SourceRunEndedAt          *time.Time                        `json:"source_run_ended_at,omitempty"`
+	ForkPoint                 RunForkPoint                      `json:"fork_point"`
+	EventCountAtFork          int                               `json:"event_count_at_fork"`
+	ReconstructedEntityCount  int                               `json:"reconstructed_entity_count"`
+	PendingWorkCount          int                               `json:"pending_work_count"`
+	UnsupportedBlockerCount   int                               `json:"unsupported_blocker_count"`
+	ExecutionReady            bool                              `json:"execution_ready"`
+	ReplayResumeAdmission     RunForkReplayResumeAdmission      `json:"replay_resume_admission"`
+	ContractFrontierAdmission *RunForkContractFrontierAdmission `json:"contract_frontier_admission,omitempty"`
+	Entities                  []RunForkEntityState              `json:"entities,omitempty"`
+	PendingWork               []RunForkPendingWork              `json:"pending_work,omitempty"`
+	UnsupportedBlockers       []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`
 }
 
 type RunForkPoint struct {

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -66,6 +66,7 @@ type RunForkEntityState struct {
 type RunForkPendingWork struct {
 	EventID         string     `json:"event_id"`
 	EventName       string     `json:"event_name"`
+	FlowInstance    string     `json:"flow_instance,omitempty"`
 	DeliveryID      string     `json:"delivery_id,omitempty"`
 	SubscriberType  string     `json:"subscriber_type,omitempty"`
 	SubscriberID    string     `json:"subscriber_id,omitempty"`
@@ -371,6 +372,7 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 			SELECT
 				e.event_id::text AS event_id,
 				e.event_name AS event_name,
+				COALESCE(e.flow_instance, '') AS flow_instance,
 				d.delivery_id::text AS delivery_id,
 				COALESCE(d.subscriber_type, '') AS subscriber_type,
 				COALESCE(d.subscriber_id, '') AS subscriber_id,
@@ -427,6 +429,7 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 			SELECT
 				e.event_id::text AS event_id,
 				e.event_name AS event_name,
+				COALESCE(e.flow_instance, '') AS flow_instance,
 				''::text AS delivery_id,
 				COALESCE(r.subscriber_type, '') AS subscriber_type,
 				COALESCE(r.subscriber_id, '') AS subscriber_id,
@@ -458,6 +461,7 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 		SELECT
 			event_id,
 			event_name,
+			flow_instance,
 			delivery_id,
 			subscriber_type,
 			subscriber_id,
@@ -491,6 +495,7 @@ func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string
 		if err := rows.Scan(
 			&item.EventID,
 			&item.EventName,
+			&item.FlowInstance,
 			&item.DeliveryID,
 			&item.SubscriberType,
 			&item.SubscriberID,

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -142,9 +142,9 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
-			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			run_id, event_id, event_name, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.work', 'global', '{}'::jsonb, 'test', 'platform', $3)
+		VALUES ($1::uuid, $2::uuid, 'fork.work', 'review/inst-1', 'global', '{}'::jsonb, 'test', 'platform', $3)
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -179,6 +179,9 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	got := map[string]string{}
 	for _, item := range plan.PendingWork {
 		got[item.SubscriberID] = item.Classification
+		if item.FlowInstance != "review/inst-1" {
+			t.Fatalf("pending item flow_instance = %q, want review/inst-1; item=%#v", item.FlowInstance, item)
+		}
 	}
 	want := map[string]string{
 		"done-agent":               RunForkPendingClassificationDeliveredCompleted,


### PR DESCRIPTION
## Summary

Closes #577.

Adds the canonical non-mutating fork contract/frontier admission slice approved by the #577 gate:

- introduces `runtime.run_fork.contract_frontier_admission` as the selected-contract frontier admission owner;
- models selected contract identity, unresolved at-T frontier events, source delivery evidence, runtime event owners, workflow subscribers, and selected-contract route recipients;
- wires `swarm fork --dry-run --contracts <path> --json` onto that owner;
- keeps `--contracts` fail-closed for `--materialize-only` and `--activate`;
- updates the fork spec and `timestamp_fork_replay_resume_ownership` watchlist mapping for #577.

## Governing References

Exact spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.command`
- `run_model.fork.planning_admission`
- `run_model.fork.materialize_only_admission`
- `run_model.fork.activation_admission`
- `run_model.fork.replay_resume_admission_taxonomy`
- `run_model.fork.semantics.4_boot`
- `run_model.fork.semantics.5_resume`
- `run_model.fork.contract_swap`
- `run_model.fork.isolation`

Binding issue context: #577 approved as first slice after #576 gate outcome `insufficient; escalate broad refactor`. Parents remain #564 and #549.

## Semantic Migration

New canonical owner: `runtime.run_fork.contract_frontier_admission` in `internal/runtime/runforkadmission`.

Old invalid paths now explicitly avoided:

- source node/system `event_deliveries` are evidence only, not copied executable fork work;
- CLI `--contracts` is only a consumer of the owner, not the semantic owner;
- route/subscription/node-recipient admission consumes runtime semantic/route owners instead of a local fork helper;
- mutating selected-contract fork execution remains unsupported.

Production paths checked for surviving old behavior:

- existing store planner/materializer/activation behavior remains unchanged without `--contracts`;
- `--contracts` is rejected for materialize/activate;
- safe pending agent replay and non-agent blockers remain in existing store taxonomy.

Migration complete for the approved non-mutating first slice. Full mutating replay/resume remains tracked under #564/#549.

## Proof

- `go test ./internal/runtime/runforkadmission ./cmd/swarm ./internal/store`
- `go test ./internal/runtime/... ./internal/store ./cmd/swarm`

No clear-run proof required by the approved gate; this is a non-mutating admission slice.