### PR TITLE
[agent-d][issue #581] Add role-scoped entity tools

### DIFF
--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -672,7 +672,7 @@ func emitToolDefinitions(cfg models.AgentConfig, authority runtimeauthority.Prov
 func filterTools(in []llm.ToolDefinition, allowed map[string]struct{}, constrained bool) []llm.ToolDefinition {
 	out := make([]llm.ToolDefinition, 0, len(in))
 	for _, t := range in {
-		if runtimetools.IsUniversal(t.Name) {
+		if runtimetools.IsUniversal(t.Name) || runtimetools.IsRoleScopedEntityTool(t.Name) {
 			out = append(out, t)
 			continue
 		}

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -44,6 +44,10 @@ type actorScopedToolExecutor interface {
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
 }
 
+type roleScopedEntityToolCatalog interface {
+	RoleScopedEntityToolNamesForActor(models.AgentConfig) map[string]struct{}
+}
+
 func NewLLMAgentWithOptions(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition, opts LLMAgentOptions) (*LLMAgent, error) {
 	return newLLMAgent(cfg, modelRuntime, toolExecutor, tools, false, opts)
 }
@@ -68,7 +72,7 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 	if emitRegistry == nil {
 		emitRegistry = runtimetools.NewEmitRegistry(nil, authority)
 	}
-	tools = composeConversationTools(cfg, modelRuntime, tools, precomposed, authority, emitRegistry)
+	tools = composeConversationTools(cfg, modelRuntime, toolExecutor, tools, precomposed, authority, emitRegistry)
 
 	maxTurns := 100
 	mode := llm.TaskScoped
@@ -116,12 +120,16 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 	}, nil
 }
 
-func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, tools []llm.ToolDefinition, precomposed bool, authority runtimeauthority.Provider, emitRegistry *runtimetools.EmitRegistry) []llm.ToolDefinition {
+func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor actorScopedToolExecutor, tools []llm.ToolDefinition, precomposed bool, authority runtimeauthority.Provider, emitRegistry *runtimetools.EmitRegistry) []llm.ToolDefinition {
 	if precomposed {
 		return tools
 	}
 	allowedToolSet, constrained := extractAllowedToolSet(cfg)
-	tools = mergeTools(filterTools(tools, allowedToolSet, constrained), emitToolDefinitions(cfg, authority, emitRegistry))
+	roleScopedToolSet := map[string]struct{}{}
+	if catalog, ok := toolExecutor.(roleScopedEntityToolCatalog); ok {
+		roleScopedToolSet = catalog.RoleScopedEntityToolNamesForActor(cfg)
+	}
+	tools = mergeTools(filterTools(tools, allowedToolSet, constrained, roleScopedToolSet), emitToolDefinitions(cfg, authority, emitRegistry))
 	tools = mergeTools(tools, nativeFallbackToolDefinitions(cfg, modelRuntime))
 	return tools
 }
@@ -669,10 +677,14 @@ func emitToolDefinitions(cfg models.AgentConfig, authority runtimeauthority.Prov
 	return emitRegistry.GenerateEmitToolsForRole(cfg.Role, processWarnOnce)
 }
 
-func filterTools(in []llm.ToolDefinition, allowed map[string]struct{}, constrained bool) []llm.ToolDefinition {
+func filterTools(in []llm.ToolDefinition, allowed map[string]struct{}, constrained bool, roleScoped map[string]struct{}) []llm.ToolDefinition {
 	out := make([]llm.ToolDefinition, 0, len(in))
 	for _, t := range in {
-		if runtimetools.IsUniversal(t.Name) || runtimetools.IsRoleScopedEntityTool(t.Name) {
+		if runtimetools.IsUniversal(t.Name) {
+			out = append(out, t)
+			continue
+		}
+		if _, ok := roleScoped[strings.TrimSpace(t.Name)]; ok {
 			out = append(out, t)
 			continue
 		}

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -135,7 +135,7 @@ func TestFilterTools_RetainsUniversalEntityToolsWhenConstrained(t *testing.T) {
 		{Name: "agent_message"},
 		{Name: "non_universal"},
 	}
-	filtered := filterTools(tools, allowed, constrained)
+	filtered := filterTools(tools, allowed, constrained, nil)
 	names := make([]string, 0, len(filtered))
 	for _, tool := range filtered {
 		names = append(names, tool.Name)
@@ -161,7 +161,7 @@ func TestFilterTools_DefaultDeniesNonUniversalToolsWhenNoToolList(t *testing.T) 
 		{Name: "agent_message"},
 		{Name: "schedule"},
 	}
-	filtered := filterTools(tools, allowed, constrained)
+	filtered := filterTools(tools, allowed, constrained, nil)
 	names := make([]string, 0, len(filtered))
 	for _, tool := range filtered {
 		names = append(names, tool.Name)
@@ -183,9 +183,14 @@ func TestFilterTools_RetainsRoleScopedEntityToolsOnNonPrecomposedPath(t *testing
 		{Name: "read_validation_case"},
 		{Name: "save_validation_case_business_brief"},
 		{Name: "update_validation_case_business_brief_summary"},
+		{Name: "read_unrelated_prefix_tool"},
 		{Name: "schedule"},
 	}
-	filtered := filterTools(tools, allowed, constrained)
+	filtered := filterTools(tools, allowed, constrained, map[string]struct{}{
+		"read_validation_case":                          {},
+		"save_validation_case_business_brief":           {},
+		"update_validation_case_business_brief_summary": {},
+	})
 	names := make([]string, 0, len(filtered))
 	for _, tool := range filtered {
 		names = append(names, tool.Name)
@@ -198,8 +203,8 @@ func TestFilterTools_RetainsRoleScopedEntityToolsOnNonPrecomposedPath(t *testing
 	if containsString(names, "schedule") {
 		t.Fatalf("expected unrelated non-universal tool filtered out, got %v", names)
 	}
-	if runtimetools.IsRoleScopedEntityTool("read_file") {
-		t.Fatal("read_file must not be classified as a role-scoped entity tool")
+	if containsString(names, "read_unrelated_prefix_tool") {
+		t.Fatalf("expected unproven read_* tool filtered out, got %v", names)
 	}
 }
 

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -174,6 +174,35 @@ func TestFilterTools_DefaultDeniesNonUniversalToolsWhenNoToolList(t *testing.T) 
 	}
 }
 
+func TestFilterTools_RetainsRoleScopedEntityToolsOnNonPrecomposedPath(t *testing.T) {
+	allowed, constrained := extractAllowedToolSet(models.AgentConfig{})
+	if constrained {
+		t.Fatal("expected unconstrained tool set when no tools are configured")
+	}
+	tools := []llm.ToolDefinition{
+		{Name: "read_validation_case"},
+		{Name: "save_validation_case_business_brief"},
+		{Name: "update_validation_case_business_brief_summary"},
+		{Name: "schedule"},
+	}
+	filtered := filterTools(tools, allowed, constrained)
+	names := make([]string, 0, len(filtered))
+	for _, tool := range filtered {
+		names = append(names, tool.Name)
+	}
+	for _, want := range []string{"read_validation_case", "save_validation_case_business_brief", "update_validation_case_business_brief_summary"} {
+		if !containsString(names, want) {
+			t.Fatalf("expected role-scoped entity tool %s preserved, got %v", want, names)
+		}
+	}
+	if containsString(names, "schedule") {
+		t.Fatalf("expected unrelated non-universal tool filtered out, got %v", names)
+	}
+	if runtimetools.IsRoleScopedEntityTool("read_file") {
+		t.Fatal("read_file must not be classified as a role-scoped entity tool")
+	}
+}
+
 func TestResolvePromptForMode_ExpandsConfigVariables(t *testing.T) {
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	bundleRoot := writeAgentPromptTestBundle(t, repoRoot)

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -587,9 +587,13 @@ type FlowSchemaDocument struct {
 	TerminalStates    []string                 `yaml:"terminal_states"`
 	States            []string                 `yaml:"states"`
 	Pins              FlowPins                 `yaml:"pins"`
+	ToolSurface       FlowToolSurfaceContract  `yaml:"tool_surface"`
 	RequiredAgents    []FlowRequiredAgent      `yaml:"required_agents"`
 	InstanceVariables FlowInstanceVariables    `yaml:"instance_variables"`
 	AutoEmitOnCreate  AutoEmitOnCreateContract `yaml:"auto_emit_on_create"`
+}
+type FlowToolSurfaceContract struct {
+	RoleScopedEntityTools bool `yaml:"role_scoped_entity_tools"`
 }
 type FlowInstanceVariables struct {
 	Description string                  `yaml:"description"`

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -52,6 +52,10 @@ type runtimeGatewayExecutor interface {
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
 }
 
+type roleScopedEntityToolSurfaceReporter interface {
+	RoleScopedEntityToolsEnabledForActor(models.AgentConfig) bool
+}
+
 func NewGateway(executor runtimeGatewayExecutor, authToken string, hooks GatewayHooks) *Gateway {
 	return &Gateway{
 		executor:  executor,
@@ -621,7 +625,7 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string
 			}
 		}
 	}
-	if g.executor != nil && len(catalog) == 0 {
+	if g.executor != nil && len(catalog) == 0 && !g.roleScopedEntityToolsEnabledForActor(actor) {
 		for _, def := range g.executor.ToolDefinitions() {
 			name := normalizeGatewayToolName(def.Name)
 			if name != "" {
@@ -652,6 +656,14 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string
 		}
 	}
 	return catalog
+}
+
+func (g *Gateway) roleScopedEntityToolsEnabledForActor(actor models.AgentConfig) bool {
+	if g == nil || g.executor == nil {
+		return false
+	}
+	reporter, ok := g.executor.(roleScopedEntityToolSurfaceReporter)
+	return ok && reporter.RoleScopedEntityToolsEnabledForActor(actor)
 }
 
 func (g *Gateway) requestToolCapabilities(actor models.AgentConfig, actorOK bool, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -159,8 +159,9 @@ func (s *relayAwareToolExecutorStub) PersistOversizedToolResultRelay(_ context.C
 }
 
 type actorScopedToolExecutorStub struct {
-	defs      []llm.ToolDefinition
-	actorDefs []llm.ToolDefinition
+	defs       []llm.ToolDefinition
+	actorDefs  []llm.ToolDefinition
+	roleScoped bool
 }
 
 func (s actorScopedToolExecutorStub) Execute(context.Context, string, any) (any, error) {
@@ -173,6 +174,10 @@ func (s actorScopedToolExecutorStub) ToolDefinitions() []llm.ToolDefinition {
 
 func (s actorScopedToolExecutorStub) ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition {
 	return append([]llm.ToolDefinition(nil), s.actorDefs...)
+}
+
+func (s actorScopedToolExecutorStub) RoleScopedEntityToolsEnabledForActor(models.AgentConfig) bool {
+	return s.roleScoped
 }
 
 func (s actorScopedToolExecutorStub) ToolCapabilitiesForActor(_ models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
@@ -564,6 +569,34 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 	}
 	if !strings.Contains(tools[0].Description, "actor scoped\n\nUsage:\nUse CEL equality with ==.") {
 		t.Fatalf("tool description = %q, want usage appended", tools[0].Description)
+	}
+}
+
+func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForRoleScopedActor(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	g := NewGateway(actorScopedToolExecutorStub{
+		defs: []llm.ToolDefinition{
+			{Name: "get_entity", Description: "runtime-wide legacy entity tool"},
+		},
+		actorDefs:  nil,
+		roleScoped: true,
+	}, "", GatewayHooks{
+		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
+			return models.AgentConfig{ID: agentID, Role: "validation_orchestrator"}, true
+		},
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	putTestTurnContext(t, registry, "ctx-role-scoped-empty", TurnContext{
+		Actor:     models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"},
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := withContextToken(httptest.NewRequest("POST", "/mcp", nil), "ctx-role-scoped-empty")
+	tools := mustMCPToolsForRequest(t, g, req)
+	if len(tools) != 0 {
+		t.Fatalf("role-scoped empty actor catalog fell back to runtime-wide tools: %#v", tools)
 	}
 }
 

--- a/internal/runtime/tools/authorizer.go
+++ b/internal/runtime/tools/authorizer.go
@@ -29,6 +29,7 @@ const (
 	toolAuthorizationPermission  toolAuthorizationClass = "permission"
 	toolAuthorizationEmitAllowed toolAuthorizationClass = "emit_allowed"
 	toolAuthorizationNativeTool  toolAuthorizationClass = "native_tool"
+	toolAuthorizationRoleScoped  toolAuthorizationClass = "role_scoped_entity_tool"
 	toolAuthorizationActorConfig toolAuthorizationClass = "actor_config"
 	toolAuthorizationDenied      toolAuthorizationClass = "denied"
 )

--- a/internal/runtime/tools/dispatcher.go
+++ b/internal/runtime/tools/dispatcher.go
@@ -13,17 +13,19 @@ type ToolHandler func(ctx context.Context, actor models.AgentConfig, input any) 
 type EmitToolHandler func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error)
 type HTTPToolHandler func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error)
 type MCPToolHandler func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error)
+type RoleScopedEntityToolHandler func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error)
 type ToolResolver func(actor models.AgentConfig, name string) (RegisteredTool, bool, error)
 
 type ToolDispatcher struct {
-	emitHandler EmitToolHandler
-	resolver    ToolResolver
-	httpHandler HTTPToolHandler
-	mcpHandler  MCPToolHandler
-	handlers    map[string]ToolHandler
+	emitHandler             EmitToolHandler
+	resolver                ToolResolver
+	httpHandler             HTTPToolHandler
+	mcpHandler              MCPToolHandler
+	roleScopedEntityHandler RoleScopedEntityToolHandler
+	handlers                map[string]ToolHandler
 }
 
-func NewToolDispatcher(emitHandler EmitToolHandler, resolver ToolResolver, httpHandler HTTPToolHandler, mcpHandler MCPToolHandler, handlers map[string]ToolHandler) *ToolDispatcher {
+func NewToolDispatcher(emitHandler EmitToolHandler, resolver ToolResolver, httpHandler HTTPToolHandler, mcpHandler MCPToolHandler, roleScopedEntityHandler RoleScopedEntityToolHandler, handlers map[string]ToolHandler) *ToolDispatcher {
 	copied := make(map[string]ToolHandler, len(handlers))
 	for name, handler := range handlers {
 		if strings.TrimSpace(name) == "" || handler == nil {
@@ -32,11 +34,12 @@ func NewToolDispatcher(emitHandler EmitToolHandler, resolver ToolResolver, httpH
 		copied[strings.TrimSpace(name)] = handler
 	}
 	return &ToolDispatcher{
-		emitHandler: emitHandler,
-		resolver:    resolver,
-		httpHandler: httpHandler,
-		mcpHandler:  mcpHandler,
-		handlers:    copied,
+		emitHandler:             emitHandler,
+		resolver:                resolver,
+		httpHandler:             httpHandler,
+		mcpHandler:              mcpHandler,
+		roleScopedEntityHandler: roleScopedEntityHandler,
+		handlers:                copied,
 	}
 }
 
@@ -65,6 +68,9 @@ func (d *ToolDispatcher) Dispatch(ctx context.Context, actor models.AgentConfig,
 	case implementationPlatformBuiltin:
 		handler, ok := d.handlers[name]
 		if !ok || handler == nil {
+			if IsRoleScopedEntityTool(name) && d.roleScopedEntityHandler != nil {
+				return d.roleScopedEntityHandler(ctx, actor, name, input)
+			}
 			return nil, fmt.Errorf("missing platform builtin handler: %s", name)
 		}
 		return handler(ctx, actor, input)

--- a/internal/runtime/tools/dispatcher.go
+++ b/internal/runtime/tools/dispatcher.go
@@ -13,7 +13,7 @@ type ToolHandler func(ctx context.Context, actor models.AgentConfig, input any) 
 type EmitToolHandler func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error)
 type HTTPToolHandler func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error)
 type MCPToolHandler func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error)
-type RoleScopedEntityToolHandler func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error)
+type RoleScopedEntityToolHandler func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, bool, error)
 type ToolResolver func(actor models.AgentConfig, name string) (RegisteredTool, bool, error)
 
 type ToolDispatcher struct {
@@ -68,8 +68,11 @@ func (d *ToolDispatcher) Dispatch(ctx context.Context, actor models.AgentConfig,
 	case implementationPlatformBuiltin:
 		handler, ok := d.handlers[name]
 		if !ok || handler == nil {
-			if IsRoleScopedEntityTool(name) && d.roleScopedEntityHandler != nil {
-				return d.roleScopedEntityHandler(ctx, actor, name, input)
+			if d.roleScopedEntityHandler != nil {
+				out, handled, err := d.roleScopedEntityHandler(ctx, actor, name, input)
+				if handled {
+					return out, err
+				}
 			}
 			return nil, fmt.Errorf("missing platform builtin handler: %s", name)
 		}

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -110,7 +110,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 			return exec.execMCPTool(ctx, actor, tool, input)
 		},
-		exec.execRoleScopedEntityTool,
+		exec.dispatchRoleScopedEntityTool,
 		exec.buildToolHandlers(),
 	)
 	return exec

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -95,9 +95,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 			processWarn("tool-executor", "mcp discovery warning: %v", err)
 		}
 	}
-	exec.authorizer = NewToolAuthorizer(bus, func(actor models.AgentConfig, toolName string) toolAuthorizationDecision {
-		return classifyToolAuthorization(actor, toolName, exec.authority, exec.emitRegistry)
-	})
+	exec.authorizer = NewToolAuthorizer(bus, exec.toolAuthorizationDecision)
 	exec.validator = NewToolInputValidator(exec.contractDefinitionsForActor)
 	exec.dispatcher = NewToolDispatcher(
 		func(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error) {
@@ -112,6 +110,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		func(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 			return exec.execMCPTool(ctx, actor, tool, input)
 		},
+		exec.execRoleScopedEntityTool,
 		exec.buildToolHandlers(),
 	)
 	return exec
@@ -188,7 +187,7 @@ func (e *Executor) ToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 	filtered := make([]llm.ToolDefinition, 0, len(names))
 	for _, name := range names {
 		entry := entries[name]
-		if !classifyToolAuthorization(actor, name, e.authority, e.emitRegistry).allowed {
+		if !e.toolAuthorizationDecision(actor, name).allowed {
 			continue
 		}
 		filtered = append(filtered, llm.ToolDefinition{
@@ -207,7 +206,86 @@ func (e *Executor) ToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 }
 
 func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
-	return capabilitySetForActorWithDeps(actor, names, requestAllowed, e.authority, e.emitRegistry)
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	seen := map[string]struct{}{}
+	for _, raw := range names {
+		name := normalizeNativeToolName(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		decision := e.toolAuthorizationDecision(actor, name)
+		cap := toolcapabilities.Capability{
+			Name:               name,
+			Kind:               toolKindPolicy(name),
+			Visible:            decision.allowed,
+			Callable:           decision.allowed,
+			ContextRequirement: toolContextRequirementPolicy(name),
+			AuthorizationClass: string(decision.class),
+		}
+		if len(requestAllowed) > 0 {
+			if _, ok := requestAllowed[name]; !ok {
+				cap.Visible = false
+				cap.Callable = false
+				cap.DenialReason = "request_not_allowed"
+				caps = append(caps, cap)
+				continue
+			}
+		}
+		if !decision.allowed {
+			cap.DenialReason = "tool_not_allowed"
+		}
+		caps = append(caps, cap)
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func (e *Executor) toolAuthorizationDecision(actor models.AgentConfig, toolName string) toolAuthorizationDecision {
+	toolName = normalizeNativeToolName(toolName)
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	if roleScopedEntityToolsEnabledForActor(source, actor) {
+		if _, legacy := legacyEntityToolSurfaceNames[toolName]; legacy {
+			return toolAuthorizationDecision{
+				ownership: toolOwnershipPlatformBuiltin,
+				class:     toolAuthorizationDenied,
+				allowed:   false,
+			}
+		}
+		if _, _, ok := roleScopedEntityToolSpecForActor(source, actor, toolName); ok {
+			return toolAuthorizationDecision{
+				ownership: toolOwnershipPlatformBuiltin,
+				class:     toolAuthorizationRoleScoped,
+				allowed:   true,
+			}
+		}
+	}
+	decision := classifyToolAuthorization(actor, toolName, e.authority, e.emitRegistry)
+	if decision.allowed {
+		return decision
+	}
+	if _, _, ok := roleScopedEntityToolSpecForActor(source, actor, toolName); ok {
+		return toolAuthorizationDecision{
+			ownership: toolOwnershipPlatformBuiltin,
+			class:     toolAuthorizationRoleScoped,
+			allowed:   true,
+		}
+	}
+	return decision
+}
+
+func (e *Executor) RoleScopedEntityToolsEnabledForActor(actor models.AgentConfig) bool {
+	if e == nil {
+		return false
+	}
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	return roleScopedEntityToolsEnabledForActor(source, actor)
 }
 
 func (e *Executor) Execute(ctx context.Context, name string, input any) (any, error) {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -13,9 +13,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	llm "swarm/internal/runtime/llm"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
@@ -243,6 +246,144 @@ func TestEntityTools_CreateEntityAcceptsAnnotatedJSONBFields(t *testing.T) {
 	checklist, ok := kit["checklist"].([]any)
 	if !ok || len(checklist) != 2 {
 		t.Fatalf("validation_kit.checklist = %#v, want persisted array", kit["checklist"])
+	}
+}
+
+func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{
+		"create_entity",
+		"get_entity",
+		"save_entity_field",
+		"query_entities",
+	}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	_, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+
+	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
+	for _, name := range []string{
+		"read_validation_case",
+		"read_validation_case_status",
+		"read_validation_case_business_brief",
+		"save_validation_case_business_brief",
+		"update_validation_case_business_brief_summary",
+		"update_validation_case_business_brief_confidence",
+	} {
+		if _, ok := names[name]; !ok {
+			t.Fatalf("expected generated role-scoped tool %q in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
+	for _, name := range []string{
+		"create_entity",
+		"get_entity",
+		"get_subject_status",
+		"query_entities",
+		"query_metrics",
+		"save_entity_field",
+		"search_entities",
+	} {
+		if _, ok := names[name]; ok {
+			t.Fatalf("legacy entity tool %q remained visible in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
+
+	saveSchema := names["save_validation_case_business_brief"].Schema.(map[string]any)
+	props, _ := saveSchema["properties"].(map[string]any)
+	if _, ok := props["entity_id"]; ok {
+		t.Fatalf("generated save schema exposes entity_id: %#v", saveSchema)
+	}
+	if _, ok := props["value"]; !ok {
+		t.Fatalf("generated save schema missing value: %#v", saveSchema)
+	}
+
+	caps := exec.ToolCapabilitiesForActor(actor, []string{"read_validation_case", "get_entity"}, nil)
+	if cap, ok := caps.Capability("read_validation_case"); !ok || !cap.Visible || !cap.Callable {
+		t.Fatalf("read_validation_case capability = %#v, ok=%v; want visible/callable", cap, ok)
+	}
+	if cap, ok := caps.Capability("get_entity"); !ok || cap.Visible || cap.Callable {
+		t.Fatalf("get_entity capability = %#v, ok=%v; want denied for opted-in actor", cap, ok)
+	}
+}
+
+func TestRoleScopedEntityTools_NonOptedActorKeepsLegacySurface(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"get_entity", "query_entities"}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, false)
+	_, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+
+	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
+	for _, name := range []string{"get_entity", "query_entities"} {
+		if _, ok := names[name]; !ok {
+			t.Fatalf("expected legacy entity tool %q without opt-in in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
+	if _, ok := names["read_validation_case"]; ok {
+		t.Fatalf("generated role-scoped tool was visible without opt-in in %#v", sortedRoleScopedToolNames(names))
+	}
+}
+
+func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{
+		"create_entity",
+		"get_entity",
+		"save_entity_field",
+		"query_entities",
+	}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	currentID := uuid.NewString()
+	siblingID := uuid.NewString()
+	foreignID := uuid.NewString()
+	seedEntityStateRow(t, db, currentID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
+		"status":         "open",
+		"business_brief": map[string]any{"summary": "before", "confidence": 1},
+	}, time.Now().UTC())
+	seedEntityStateRow(t, db, siblingID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
+		"status":         "open",
+		"business_brief": map[string]any{"summary": "sibling", "confidence": 2},
+	}, time.Now().UTC())
+	seedEntityStateRow(t, db, foreignID, "", "other/inst-1", "other_case", "queued", map[string]any{
+		"status": "foreign",
+	}, time.Now().UTC())
+	currentCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-current",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(currentID).WithFlowInstance("validation/inst-1"))
+
+	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
+		"value": map[string]any{"summary": "after", "confidence": 9},
+	}); err != nil {
+		t.Fatalf("save_validation_case_business_brief: %v", err)
+	}
+	got, err := exec.Execute(currentCtx, "read_validation_case_business_brief", map[string]any{})
+	if err != nil {
+		t.Fatalf("read_validation_case_business_brief: %v", err)
+	}
+	brief, ok := got.(map[string]any)
+	if !ok || strings.TrimSpace(asString(brief["summary"])) != "after" {
+		t.Fatalf("read current business_brief = %#v, want updated current entity", got)
+	}
+	if got := persistedEntityField(t, db, siblingID, "business_brief"); strings.Contains(got, "after") {
+		t.Fatalf("generated save touched sibling entity: %s", got)
+	}
+
+	if _, err := exec.Execute(currentCtx, "read_validation_case", map[string]any{"entity_id": siblingID}); err == nil {
+		t.Fatalf("read_validation_case accepted caller-supplied entity_id")
+	}
+	if _, err := exec.Execute(ctx, "read_validation_case", map[string]any{}); err == nil {
+		t.Fatalf("read_validation_case succeeded without current inbound entity")
+	}
+	foreignCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-foreign",
+		Type:  events.EventType("other.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(foreignID).WithFlowInstance("other/inst-1"))
+	if _, err := exec.Execute(foreignCtx, "read_validation_case", map[string]any{}); err == nil {
+		t.Fatalf("read_validation_case accepted foreign current entity")
+	}
+	for _, legacy := range []string{"get_entity", "create_entity"} {
+		if _, err := exec.Execute(currentCtx, legacy, map[string]any{"entity_id": currentID}); err == nil {
+			t.Fatalf("legacy tool %s remained callable for opted-in actor", legacy)
+		}
 	}
 }
 
@@ -2266,6 +2407,96 @@ terminal_states: [closed]
 	return bundle
 }
 
+func loadRoleScopedEntityToolBundle(t *testing.T, actor models.AgentConfig, optIn bool) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	toolSurface := ""
+	if optIn {
+		toolSurface = `
+tool_surface:
+  role_scoped_entity_tools: true
+`
+	}
+	return loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"validation": {
+			SchemaYAML: fmt.Sprintf(`
+name: validation
+mode: static
+initial_state: queued
+states: [queued, ready, closed]
+terminal_states: [closed]
+%s`, toolSurface),
+			TypesYAML: `
+types:
+  business_brief:
+    summary: text
+    confidence: integer
+`,
+			EntitiesYAML: `
+validation_case:
+  status: text
+  business_brief: business_brief
+`,
+			AgentsYAML: roleScopedEntityToolAgentYAML(actor),
+		},
+		"other": {
+			EntitiesYAML: `
+other_case:
+  status: text
+`,
+		},
+	})
+}
+
+func roleScopedEntityToolAgentYAML(actor models.AgentConfig) string {
+	var builder strings.Builder
+	builder.WriteString(strings.TrimSpace(actor.ID))
+	builder.WriteString(":\n")
+	builder.WriteString("  id: ")
+	builder.WriteString(strings.TrimSpace(actor.ID))
+	builder.WriteString("\n")
+	if role := strings.TrimSpace(actor.Role); role != "" {
+		builder.WriteString("  role: ")
+		builder.WriteString(role)
+		builder.WriteString("\n")
+	}
+	if len(actor.Tools) > 0 {
+		builder.WriteString("  tools:\n")
+		for _, tool := range actor.Tools {
+			tool = strings.TrimSpace(tool)
+			if tool == "" {
+				continue
+			}
+			builder.WriteString("    - ")
+			builder.WriteString(tool)
+			builder.WriteString("\n")
+		}
+	}
+	builder.WriteString("  entity_writes:\n")
+	builder.WriteString("    validation_case:\n")
+	builder.WriteString("      save:\n")
+	builder.WriteString("        - business_brief\n")
+	return builder.String()
+}
+
+func roleScopedToolDefinitionMap(defs []llm.ToolDefinition) map[string]llm.ToolDefinition {
+	out := make(map[string]llm.ToolDefinition, len(defs))
+	for _, def := range defs {
+		if name := strings.TrimSpace(def.Name); name != "" {
+			out[name] = def
+		}
+	}
+	return out
+}
+
+func sortedRoleScopedToolNames(defs map[string]llm.ToolDefinition) []string {
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 type entityToolFlowFixture struct {
 	SchemaYAML   string
 	TypesYAML    string
@@ -2360,6 +2591,19 @@ func seedEntityStateRow(t *testing.T, db *sql.DB, entityID, _ string, flowInstan
 	`, entityToolTestRunID, entityID, flowInstance, entityType, currentState, string(fieldsJSON), enteredAt); err != nil {
 		t.Fatalf("seed entity_state(%s): %v", entityID, err)
 	}
+}
+
+func persistedEntityField(t *testing.T, db *sql.DB, entityID, field string) string {
+	t.Helper()
+	var raw []byte
+	if err := db.QueryRow(`
+		SELECT COALESCE(fields -> $2, 'null'::jsonb)
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $3::uuid
+	`, entityToolTestRunID, field, entityID).Scan(&raw); err != nil {
+		t.Fatalf("read persisted entity field %s.%s: %v", entityID, field, err)
+	}
+	return strings.TrimSpace(string(raw))
 }
 
 func entityToolAgentYAML(actor models.AgentConfig) string {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -272,6 +272,11 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 			t.Fatalf("expected generated role-scoped tool %q in %#v", name, sortedRoleScopedToolNames(names))
 		}
 	}
+	for _, name := range []string{"save_validation_case_status", "update_validation_case_status_value"} {
+		if _, ok := names[name]; ok {
+			t.Fatalf("create-only field produced mutation tool %q in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
 	for _, name := range []string{
 		"create_entity",
 		"get_entity",
@@ -2473,6 +2478,8 @@ func roleScopedEntityToolAgentYAML(actor models.AgentConfig) string {
 	}
 	builder.WriteString("  entity_writes:\n")
 	builder.WriteString("    validation_case:\n")
+	builder.WriteString("      create:\n")
+	builder.WriteString("        - status\n")
 	builder.WriteString("      save:\n")
 	builder.WriteString("        - business_brief\n")
 	return builder.String()

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -26,6 +26,13 @@ func builtinRegisteredTools(source semanticview.Source, actor *models.AgentConfi
 }
 
 func builtinRuntimeContractSchemas(source semanticview.Source, actor *models.AgentConfig) map[string]ContractSchemaEntry {
+	if actor != nil && roleScopedEntityToolsEnabledForActor(source, *actor) {
+		contract, ok := resolveEntityToolContract(source, actor)
+		if !ok {
+			return map[string]ContractSchemaEntry{}
+		}
+		return roleScopedEntityToolSchemaEntriesForActor(source, *actor, contract)
+	}
 	readContracts := actorOwnedReadTargetContracts(source, actor)
 	readTargetSchema := entityReadTargetInputSchemaForContracts(readContracts)
 	out := genericEntityRuntimeContractSchemas(readTargetSchema)

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -137,6 +137,10 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
+	roleScopedEntitySurface := roleScopedEntityToolsEnabledForActor(source, actor)
+	if roleScopedEntitySurface {
+		removeLegacyEntityToolSurface(entries)
+	}
 	for name, entry := range builtinRegisteredTools(source, &actor) {
 		entries[name] = entry
 	}
@@ -178,6 +182,9 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 			continue
 		}
 		entries[name] = tool
+	}
+	if roleScopedEntitySurface {
+		removeLegacyEntityToolSurface(entries)
 	}
 	removeUnavailableEntityScopedUniversalTools(entries, source, actor)
 	return entries, nil

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -65,27 +65,6 @@ func roleScopedEntityToolsEnabledForActor(source semanticview.Source, actor mode
 	return schema.ToolSurface.RoleScopedEntityTools
 }
 
-func IsRoleScopedEntityTool(toolName string) bool {
-	return roleScopedEntityToolNameKind(toolName) != ""
-}
-
-func roleScopedEntityToolNameKind(toolName string) roleScopedEntityToolKind {
-	toolName = strings.TrimSpace(toolName)
-	if toolName == "read_file" {
-		return ""
-	}
-	switch {
-	case strings.HasPrefix(toolName, "read_"):
-		return roleScopedEntityToolReadWhole
-	case strings.HasPrefix(toolName, "save_"):
-		return roleScopedEntityToolSaveField
-	case strings.HasPrefix(toolName, "update_"):
-		return roleScopedEntityToolUpdatePath
-	default:
-		return ""
-	}
-}
-
 func roleScopedEntityToolSchemaEntriesForActor(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) map[string]ContractSchemaEntry {
 	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
 	out := make(map[string]ContractSchemaEntry, len(specs))
@@ -216,7 +195,6 @@ func roleScopedWritableFields(source semanticview.Source, actor models.AgentConf
 			}
 		}
 	}
-	add(decl.Create)
 	add(decl.Save)
 	out := make([]string, 0, len(seen))
 	for field := range seen {
@@ -304,6 +282,44 @@ func roleScopedEntityToolSpecForActor(source semanticview.Source, actor models.A
 	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
 	spec, ok := specs[strings.TrimSpace(toolName)]
 	return spec, contract, ok
+}
+
+func (e *Executor) RoleScopedEntityToolNamesForActor(actor models.AgentConfig) map[string]struct{} {
+	if e == nil {
+		return nil
+	}
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	if !roleScopedEntityToolsEnabledForActor(source, actor) {
+		return nil
+	}
+	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	if !ok {
+		return nil
+	}
+	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
+	out := make(map[string]struct{}, len(specs))
+	for name := range specs {
+		if name = strings.TrimSpace(name); name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func (e *Executor) dispatchRoleScopedEntityTool(ctx context.Context, actor models.AgentConfig, name string, input any) (any, bool, error) {
+	if e == nil {
+		return nil, false, nil
+	}
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	if _, _, ok := roleScopedEntityToolSpecForActor(source, actor, name); !ok {
+		return nil, false, nil
+	}
+	out, err := e.execRoleScopedEntityTool(ctx, actor, name, input)
+	return out, true, err
 }
 
 func (e *Executor) execRoleScopedEntityTool(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error) {

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -1,0 +1,390 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/entityruntime"
+	"swarm/internal/runtime/semanticview"
+)
+
+type roleScopedEntityToolKind string
+
+const (
+	roleScopedEntityToolReadWhole  roleScopedEntityToolKind = "read_whole"
+	roleScopedEntityToolReadField  roleScopedEntityToolKind = "read_field"
+	roleScopedEntityToolSaveField  roleScopedEntityToolKind = "save_field"
+	roleScopedEntityToolUpdatePath roleScopedEntityToolKind = "update_path"
+)
+
+type roleScopedEntityToolSpec struct {
+	Kind       roleScopedEntityToolKind
+	EntityType string
+	Field      string
+	Subpath    string
+}
+
+var legacyEntityToolSurfaceNames = map[string]struct{}{
+	"create_entity":      {},
+	"get_entity":         {},
+	"get_subject_status": {},
+	"query_entities":     {},
+	"query_metrics":      {},
+	"save_entity_field":  {},
+	"search_entities":    {},
+}
+
+func removeLegacyEntityToolSurface(entries map[string]RegisteredTool) {
+	for name := range legacyEntityToolSurfaceNames {
+		delete(entries, name)
+	}
+}
+
+func roleScopedEntityToolsEnabledForActor(source semanticview.Source, actor models.AgentConfig) bool {
+	if source == nil {
+		return false
+	}
+	contractSource, ok := source.AgentContractSource(strings.TrimSpace(actor.ID))
+	if !ok {
+		return false
+	}
+	flowID := strings.TrimSpace(contractSource.FlowID)
+	if flowID == "" {
+		return false
+	}
+	schema, ok := source.FlowSchemaByID(flowID)
+	if !ok {
+		return false
+	}
+	return schema.ToolSurface.RoleScopedEntityTools
+}
+
+func IsRoleScopedEntityTool(toolName string) bool {
+	return roleScopedEntityToolNameKind(toolName) != ""
+}
+
+func roleScopedEntityToolNameKind(toolName string) roleScopedEntityToolKind {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "read_file" {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(toolName, "read_"):
+		return roleScopedEntityToolReadWhole
+	case strings.HasPrefix(toolName, "save_"):
+		return roleScopedEntityToolSaveField
+	case strings.HasPrefix(toolName, "update_"):
+		return roleScopedEntityToolUpdatePath
+	default:
+		return ""
+	}
+}
+
+func roleScopedEntityToolSchemaEntriesForActor(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) map[string]ContractSchemaEntry {
+	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
+	out := make(map[string]ContractSchemaEntry, len(specs))
+	names := make([]string, 0, len(specs))
+	for name := range specs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		spec := specs[name]
+		out[name] = roleScopedEntityToolSchemaEntry(contract, spec)
+	}
+	return out
+}
+
+func roleScopedEntityToolSchemaEntry(contract entityruntime.Contract, spec roleScopedEntityToolSpec) ContractSchemaEntry {
+	entry := ContractSchemaEntry{
+		Category:    "entity_persistence",
+		Description: roleScopedEntityToolDescription(spec),
+		InputSchema: ObjectSchema(map[string]any{}),
+	}
+	if spec.Kind == roleScopedEntityToolSaveField || spec.Kind == roleScopedEntityToolUpdatePath {
+		typeRef := ""
+		if spec.Subpath == "" {
+			if decl, err := entityruntime.FieldDecl(contract, spec.Field); err == nil {
+				typeRef = decl.Type
+			}
+		} else if typeRefForSubpath, ok := roleScopedEntitySubpathTypeRef(contract, spec.Field, spec.Subpath); ok {
+			typeRef = typeRefForSubpath
+		}
+		entry.InputSchema = ObjectSchema(map[string]any{
+			"value": entityContractJSONSchema(contract, typeRef, map[string]struct{}{}),
+		}, "value")
+	}
+	return entry
+}
+
+func roleScopedEntityToolDescription(spec roleScopedEntityToolSpec) string {
+	switch spec.Kind {
+	case roleScopedEntityToolReadWhole:
+		return fmt.Sprintf("Read the current turn %s entity. The target entity is resolved from the trigger event; no entity_id is accepted.", spec.EntityType)
+	case roleScopedEntityToolReadField:
+		return fmt.Sprintf("Read %s from the current turn %s entity. The target entity is resolved from the trigger event; no entity_id is accepted.", spec.Field, spec.EntityType)
+	case roleScopedEntityToolSaveField:
+		return fmt.Sprintf("Save %s on the current turn %s entity. The target entity is resolved from the trigger event; no entity_id is accepted.", spec.Field, spec.EntityType)
+	case roleScopedEntityToolUpdatePath:
+		return fmt.Sprintf("Update %s.%s on the current turn %s entity. The target entity is resolved from the trigger event; no entity_id is accepted.", spec.Field, spec.Subpath, spec.EntityType)
+	default:
+		return "Role-scoped entity tool."
+	}
+}
+
+func roleScopedEntityToolSpecsForActor(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) map[string]roleScopedEntityToolSpec {
+	entityName := roleScopedToolNamePart(contract.EntityType)
+	if entityName == "" {
+		return nil
+	}
+	out := map[string]roleScopedEntityToolSpec{
+		"read_" + entityName: {
+			Kind:       roleScopedEntityToolReadWhole,
+			EntityType: contract.EntityType,
+		},
+	}
+	for _, field := range entityruntime.FieldNames(contract) {
+		fieldName := roleScopedToolNamePart(field)
+		if fieldName == "" {
+			continue
+		}
+		out["read_"+entityName+"_"+fieldName] = roleScopedEntityToolSpec{
+			Kind:       roleScopedEntityToolReadField,
+			EntityType: contract.EntityType,
+			Field:      field,
+		}
+	}
+	for _, field := range roleScopedWritableFields(source, actor, contract) {
+		fieldName := roleScopedToolNamePart(field)
+		if fieldName == "" {
+			continue
+		}
+		out["save_"+entityName+"_"+fieldName] = roleScopedEntityToolSpec{
+			Kind:       roleScopedEntityToolSaveField,
+			EntityType: contract.EntityType,
+			Field:      field,
+		}
+		for _, subpath := range roleScopedTopLevelSubpaths(contract, field) {
+			subpathName := roleScopedToolNamePart(subpath)
+			if subpathName == "" {
+				continue
+			}
+			out["update_"+entityName+"_"+fieldName+"_"+subpathName] = roleScopedEntityToolSpec{
+				Kind:       roleScopedEntityToolUpdatePath,
+				EntityType: contract.EntityType,
+				Field:      field,
+				Subpath:    subpath,
+			}
+		}
+	}
+	return out
+}
+
+func roleScopedWritableFields(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) []string {
+	if source == nil {
+		return nil
+	}
+	_, entry, ok := semanticview.ResolveAgentRegistryEntry(source, actor)
+	if !ok {
+		return nil
+	}
+	decl, ok := roleScopedEntityWriteDecl(entry, contract)
+	if !ok {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	add := func(rule runtimecontracts.AgentEntityWriteRule) {
+		if rule.All {
+			for _, field := range entityruntime.FieldNames(contract) {
+				seen[field] = struct{}{}
+			}
+			return
+		}
+		for _, field := range rule.Fields {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			if _, err := entityruntime.FieldDecl(contract, field); err == nil {
+				seen[field] = struct{}{}
+			}
+		}
+	}
+	add(decl.Create)
+	add(decl.Save)
+	out := make([]string, 0, len(seen))
+	for field := range seen {
+		out = append(out, field)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func roleScopedEntityWriteDecl(entry runtimecontracts.AgentRegistryEntry, contract entityruntime.Contract) (runtimecontracts.AgentEntityWriteDecl, bool) {
+	if len(entry.EntityWrites) == 0 {
+		return runtimecontracts.AgentEntityWriteDecl{}, false
+	}
+	if contract.FlowID != "" {
+		if decl, ok := entry.EntityWrites[contract.FlowID+"."+contract.EntityType]; ok {
+			return decl, true
+		}
+	}
+	decl, ok := entry.EntityWrites[contract.EntityType]
+	return decl, ok
+}
+
+func roleScopedTopLevelSubpaths(contract entityruntime.Contract, field string) []string {
+	decl, err := entityruntime.FieldDecl(contract, field)
+	if err != nil || !deliveryNamedType(contract, decl.Type) {
+		return nil
+	}
+	named := contract.Types.Types[deliveryTypeName(contract, decl.Type)]
+	out := make([]string, 0, len(named.Fields))
+	for name := range named.Fields {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func roleScopedEntitySubpathTypeRef(contract entityruntime.Contract, field, subpath string) (string, bool) {
+	decl, err := entityruntime.FieldDecl(contract, field)
+	if err != nil || !deliveryNamedType(contract, decl.Type) {
+		return "", false
+	}
+	named := contract.Types.Types[deliveryTypeName(contract, decl.Type)]
+	subDecl, ok := named.Fields[strings.TrimSpace(subpath)]
+	if !ok {
+		return "", false
+	}
+	return subDecl.Type, true
+}
+
+func roleScopedToolNamePart(raw string) string {
+	raw = strings.TrimSpace(raw)
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range raw {
+		switch {
+		case r == '_' || r == '-' || r == '.' || r == '/':
+			if !lastUnderscore && b.Len() > 0 {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+			lastUnderscore = false
+		default:
+			if !lastUnderscore && b.Len() > 0 {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func roleScopedEntityToolSpecForActor(source semanticview.Source, actor models.AgentConfig, toolName string) (roleScopedEntityToolSpec, entityruntime.Contract, bool) {
+	if !roleScopedEntityToolsEnabledForActor(source, actor) {
+		return roleScopedEntityToolSpec{}, entityruntime.Contract{}, false
+	}
+	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	if !ok {
+		return roleScopedEntityToolSpec{}, entityruntime.Contract{}, false
+	}
+	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
+	spec, ok := specs[strings.TrimSpace(toolName)]
+	return spec, contract, ok
+}
+
+func (e *Executor) execRoleScopedEntityTool(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error) {
+	db, source, payload, err := e.entityToolDependencies(input)
+	if err != nil {
+		return nil, err
+	}
+	forbidden := []string{"entity_id", "flow_instance", "field"}
+	for _, key := range forbidden {
+		if value, ok := payload[key]; ok && value != nil {
+			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.identity", false, "%s is resolved by the runtime and must not be supplied", key)
+		}
+	}
+	spec, contract, ok := roleScopedEntityToolSpecForActor(source, actor, name)
+	if !ok {
+		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.resolve", false, "role-scoped entity tool is not available for actor %s: %s", strings.TrimSpace(actor.ID), strings.TrimSpace(name))
+	}
+	entityID := roleScopedCurrentEntityID(ctx)
+	if entityID == "" {
+		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.current_entity", false, "current turn entity_id is required for %s", strings.TrimSpace(name))
+	}
+	row, found, err := loadEntityState(ctx, db, entityID)
+	if err != nil {
+		return nil, WrapRuntimeError("query_failed", "tool-executor", "role_scoped_entity_tool.lookup", true, err, "load current entity %s", entityID)
+	}
+	if !found {
+		return nil, NewRuntimeError("not_found", "tool-executor", "role_scoped_entity_tool.lookup", false, "current entity %s not found", entityID)
+	}
+	if err := roleScopedEntityMatchesContract(source, row, contract); err != nil {
+		return nil, err
+	}
+	switch spec.Kind {
+	case roleScopedEntityToolReadWhole:
+		return materializeEntityStateRow(source, row)
+	case roleScopedEntityToolReadField:
+		materialized, err := materializeEntityStateRow(source, row)
+		if err != nil {
+			return nil, WrapRuntimeError("query_failed", "tool-executor", "role_scoped_entity_tool.materialize", false, err, "materialize current entity %s", entityID)
+		}
+		fields, _ := materialized["fields"].(map[string]any)
+		return fields[spec.Field], nil
+	case roleScopedEntityToolSaveField:
+		value, ok := payload["value"]
+		if !ok {
+			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.value", false, "value is required")
+		}
+		return e.execSaveEntityField(ctx, actor, map[string]any{
+			"entity_id": entityID,
+			"field":     spec.Field,
+			"value":     value,
+		})
+	case roleScopedEntityToolUpdatePath:
+		value, ok := payload["value"]
+		if !ok {
+			return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.value", false, "value is required")
+		}
+		return e.execSaveEntityField(ctx, actor, map[string]any{
+			"entity_id": entityID,
+			"field":     spec.Field + "." + spec.Subpath,
+			"value":     value,
+		})
+	default:
+		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.kind", false, "unsupported role-scoped entity tool: %s", strings.TrimSpace(name))
+	}
+}
+
+func roleScopedCurrentEntityID(ctx context.Context) string {
+	inbound, ok := runtimebus.InboundEventFromContext(ctx)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(inbound.EntityID())
+}
+
+func roleScopedEntityMatchesContract(source semanticview.Source, row map[string]any, contract entityruntime.Contract) error {
+	actual, ok := entityruntime.ResolveForEntityRow(source, row)
+	if !ok {
+		return NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.contract", false, "current entity does not resolve to a flow-owned entity contract")
+	}
+	if strings.TrimSpace(actual.FlowID) != strings.TrimSpace(contract.FlowID) || strings.TrimSpace(actual.EntityType) != strings.TrimSpace(contract.EntityType) {
+		return NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.contract", false, "current entity does not match actor entity contract")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements the approved #581 first-slice runtime boundary for alpha role-scoped typed entity tools.

- Adds per-flow opt-in `tool_surface.role_scoped_entity_tools: true`.
- Generates typed current-entity tools for opted-in actors: `read_<entity_type>`, `read_<entity_type>_<field>`, `save_<entity_type>_<field>`, and depth-1 `update_<entity_type>_<field>_<subpath>` from the flow-owned entity contract and `entity_writes`.
- Removes/denies the legacy agent entity surface for opted-in actors: `create_entity`, `get_entity`, `query_entities`, `search_entities`, `query_metrics`, `save_entity_field`, and `get_subject_status`.
- Routes generated tools through actor tool definitions, MCP tools/list, gateway fallback protection, capability policy, agent non-precomposed filtering, dispatcher routing, input validation, and current inbound-event entity binding.

Closes #581.

## Governing Refs / Context

- Binding issue/gate: #581 and the approved implementation gate comment on #581.
- Parent/background: #568 role-scoped tool-contract direction.
- Draft spec context referenced by the gate is not present on current `origin/master`; this PR documents the serialized alpha key as `tool_surface.role_scoped_entity_tools`.
- Explicit non-closure: this does not claim #580 non-lossy read closure, #582 provider schema closure, #579 full legacy retirement, Empire prompt cleanup, or emit-tool closure.

## Semantic Migration

- New canonical owner: opted-in flow schema plus generated runtime platform builtins derived from the flow-owned entity contract and actor `entity_writes`.
- Current entity owner: inbound event envelope/entity context; generated read/save/update tools accept no `entity_id` and fail closed when current entity context is absent, foreign, invalid, or mismatched.
- Old producer/reader/writer path now invalid for opted-in actors: agent-visible/callable legacy universal entity tools listed above.
- Production paths checked for surviving old behavior: `ToolDefinitionsForActor`, MCP `tools/list`, gateway runtime-wide fallback, capability policy, direct dispatcher routing, direct forged calls, and `agent_llm.go::filterTools`.
- Migration completeness: complete for the #581 alpha opt-in slice only.

## Validation

- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/agents`
- `go test ./internal/runtime/...`