### PR TITLE
[agent-a][issue #585] Define selected-contract fork execution model

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -35,6 +35,7 @@ import (
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimerunforkadmission "swarm/internal/runtime/runforkadmission"
+	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -485,7 +486,17 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			}
 			return 1
 		}
+		executionModel, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
+			Admission: admission,
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: model selected contract execution: %v\n", err)
+			}
+			return 1
+		}
 		plan.ContractFrontierAdmission = &admission
+		plan.SelectedContractExecution = &executionModel
 	}
 	if *asJSON {
 		enc := json.NewEncoder(out)
@@ -579,6 +590,15 @@ func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {
 			admission.NonMutating,
 			admission.FrontierEventCount,
 			admission.HistoricalExecutionSupported,
+		)
+	}
+	if plan.SelectedContractExecution != nil {
+		model := plan.SelectedContractExecution
+		fmt.Fprintf(w, "Selected Contract Execution Model: owner=%s non_mutating=%t execution_supported=%t future_owner=%s\n",
+			model.Owner,
+			model.NonMutating,
+			model.ExecutionSupported,
+			model.FutureExecutionOwner,
 		)
 	}
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -518,6 +518,29 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 	if !runForkPlanHasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierExecutionUnsupported) {
 		t.Fatalf("contract frontier blockers = %#v, want execution unsupported", admission.UnsupportedBlockers)
 	}
+	model := plan.SelectedContractExecution
+	if model == nil {
+		t.Fatalf("SelectedContractExecution = nil; output=%s", buf.String())
+	}
+	if model.Owner != store.RunForkSelectedContractExecutionModelOwner ||
+		model.FutureExecutionOwner != store.RunForkSelectedContractExecutionOwner ||
+		!model.NonMutating ||
+		model.ExecutionSupported {
+		t.Fatalf("selected-contract execution model = %#v", model)
+	}
+	if model.AdmissionOwner != store.RunForkContractFrontierAdmissionOwner ||
+		model.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly {
+		t.Fatalf("selected-contract execution admission use = %#v", model)
+	}
+	if !runForkPlanHasBoundary(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("selected-contract execution invalid paths = %#v", model.InvalidPaths)
+	}
+	if !runForkPlanHasBoundary(model.RequiredConsumers, "handler_execution", store.RunForkSelectedContractDispositionFutureOwnerRequired) {
+		t.Fatalf("selected-contract execution consumers = %#v", model.RequiredConsumers)
+	}
+	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionModelNonMutating) {
+		t.Fatalf("selected-contract execution blockers = %#v", model.UnsupportedBlockers)
+	}
 }
 
 func TestRunForkCommand_ContractsRemainDryRunOnly(t *testing.T) {
@@ -735,6 +758,15 @@ func runForkPlanHasBlocker(blockers []store.RunForkUnsupportedBlocker, code stri
 func runForkPlanHasString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkPlanHasBoundary(values []store.RunForkSelectedContractExecutionBoundary, concept, disposition string) bool {
+	for _, value := range values {
+		if value.Concept == concept && value.Disposition == disposition {
 			return true
 		}
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3217,6 +3217,14 @@ run_model:
       receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime replay
       mutation. Full historical resume remains separately gated even when state-only activation or delivery/event replay
       is ready.'
+    selected_contract_execution_model: 'Selected-contract fork execution ownership is a non-mutating model until
+      separately approved for runtime mutation. The canonical owner consumes contract_frontier_admission output only as
+      prerequisite evidence, names the future selected-contract execution owner, classifies invalid paths such as copying
+      source event_deliveries or source events, and records the required future consumers for fork-local run_id context,
+      handler execution, fork-local event/delivery writes, receipts, dead letters, idempotency, emitted follow-up events,
+      timers, routes, sessions, turns, source advancement, and contract-swap boot/resume. The model MUST NOT create
+      fork-local executable work, run handlers, accept source outcomes as fork suppressors, or treat same-run outbox
+      replay as timestamp-fork selected-contract execution.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -194,6 +194,7 @@ nodes:
       - markerless replay-eligible events can repeatedly fail committed replay-scope lookup on the supported outbox sweeper path
       - timestamp forks need fork-local delivery/event replay lineage and committed replay-scope proof rather than direct source delivery redelivery or markerless same-run outbox replay
       - timestamp-fork non-agent delivery facts are not safe to replay through the agent delivery primitive; node/system delivery execution requires a separate handler/idempotency/receipt owner
+      - selected-contract fork execution must classify delivery-write boundaries before future mutation; source deliveries remain lineage/blocker evidence, not executable fork work
     representative_issues:
       - 112
       - 144
@@ -202,6 +203,8 @@ nodes:
       - 564
       - 569
       - 574
+      - 583
+      - 585
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -227,6 +230,7 @@ nodes:
       - session/turn replay remains an admission-policy first slice; source active sessions, active turns, active task conversation audits, and fork-local pre-existing session/turn rows are permanent fail-closed blockers until a run-scoped reconstruction owner is approved
       - non-agent delivery replay remains admission-policy only; source node/system/platform/internal delivery facts and committed replay-scope markers are lineage-only or named fail-closed blockers until runtime handler replay ownership is approved
       - selected-contract timestamp-fork re-admission needs a non-mutating contract/frontier/route admission owner before node/system delivery facts can become executable fork work
+      - selected-contract fork execution needs a non-mutating owner model before mutation; the model must consume frontier admission as evidence only and classify contract binding, fork run_id context, handler execution, receipts, dead letters, idempotency, emitted follow-ups, timers, routes, sessions, source-advanced policy, and contract-swap boot/resume
     representative_issues:
       - 564
       - 565
@@ -234,6 +238,8 @@ nodes:
       - 572
       - 574
       - 577
+      - 583
+      - 585
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -1,0 +1,175 @@
+package runforkexecution
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type SelectedContractExecutionModelRequest struct {
+	Admission store.RunForkContractFrontierAdmission
+}
+
+func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelRequest) (store.RunForkSelectedContractExecution, error) {
+	admission := req.Admission
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract execution model requires %s admission; got %q", store.RunForkContractFrontierAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission must be non-mutating")
+	}
+	if admission.HistoricalExecutionSupported {
+		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission unexpectedly supports historical execution")
+	}
+
+	return store.RunForkSelectedContractExecution{
+		Owner:                store.RunForkSelectedContractExecutionModelOwner,
+		FutureExecutionOwner: store.RunForkSelectedContractExecutionOwner,
+		NonMutating:          true,
+		ExecutionSupported:   false,
+		ContractSelection:    admission.ContractSelection,
+		AdmissionOwner:       admission.Owner,
+		AdmissionUse:         store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly,
+		FrontierEventCount:   admission.FrontierEventCount,
+		FrontierEvents:       selectedContractFrontierEvents(admission.FrontierEvents),
+		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "selected_contract_binding",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "future execution must bind the selected contract source to the fork before handlers run",
+		},
+		RequiredConsumers: selectedContractExecutionRequiredConsumers(),
+		BlockedSiblings:   selectedContractExecutionBlockedSiblings(),
+		InvalidPaths:      selectedContractExecutionInvalidPaths(),
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
+			Code:    store.RunForkBlockerSelectedContractExecutionModelNonMutating,
+			Message: "selected-contract fork execution is model-only; executable fork work remains separately gated",
+		}},
+	}, nil
+}
+
+func selectedContractFrontierEvents(events []store.RunForkContractFrontierEvent) []store.RunForkSelectedContractFrontierEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]store.RunForkSelectedContractFrontierEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, store.RunForkSelectedContractFrontierEvent{
+			SourceEventID:           event.SourceEventID,
+			EventName:               event.EventName,
+			RuntimeEventOwners:      append([]string(nil), event.RuntimeEventOwners...),
+			WorkflowNodeSubscribers: append([]string(nil), event.WorkflowNodeSubscribers...),
+			DerivedRecipients:       append([]store.RunForkContractFrontierRecipient(nil), event.DerivedRecipients...),
+			Disposition:             store.RunForkSelectedContractDispositionEvidenceOnly,
+		})
+	}
+	return out
+}
+
+func selectedContractExecutionRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "fork_run_id_runtime_context",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "future handlers must execute with the fork run_id, not the source run_id",
+		},
+		{
+			Concept:     "fork_local_event_delivery_writes",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "future execution must create fresh fork-local IDs and lineage instead of copying source rows",
+		},
+		{
+			Concept:     "handler_execution",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/runtime/pipeline",
+			Reason:      "normal handler execution is a required future consumer, but this owner model does not run handlers",
+		},
+		{
+			Concept:     "receipts_dead_letters_idempotency",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/store/event_receipt_store.go+internal/runtime/deadletters",
+			Reason:      "future execution must write fork-local outcomes and must not use source outcomes as suppressors without an approved model",
+		},
+		{
+			Concept:     "emitted_follow_up_events",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/runtime/bus",
+			Reason:      "future follow-up events must be regenerated under the fork run_id through the runtime bus",
+		},
+		{
+			Concept:     "safe_agent_delivery_event_replay",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkDeliveryEventReplayOwner,
+			Reason:      "safe pending-agent replay remains a sibling pattern for fresh IDs and lineage, not the selected-contract execution owner",
+		},
+	}
+}
+
+func selectedContractExecutionBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "node_system_non_agent_execution",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "node/system execution requires a later mutating owner and remains blocked here",
+		},
+		{
+			Concept:     "timers_routes",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "timer and route reconstruction remain separate fork replay/resume blockers",
+		},
+		{
+			Concept:     "sessions_turns_audits",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "session, turn, and audit reconstruction remain separately gated",
+		},
+		{
+			Concept:     "source_advanced_after_fork_point",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "source advancement remains fail-closed until a branch/suppression policy is approved",
+		},
+		{
+			Concept:     "contract_swap_boot_resume",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "full selected-contract boot/resume execution remains outside this non-mutating model",
+		},
+		{
+			Concept:     "builder_dashboard_ui",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "operator UI is a later consumer and must not become the execution owner",
+		},
+	}
+}
+
+func selectedContractExecutionInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "copy_source_event_deliveries",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source deliveries are lineage/blocker evidence, not executable fork work",
+		},
+		{
+			Concept:     "copy_source_events",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "fork events require fresh fork-local event IDs and lineage",
+		},
+		{
+			Concept:     "cli_owned_execution",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "CLI may consume the model but must not own selected-contract execution semantics",
+		},
+		{
+			Concept:     "same_run_outbox_replay_as_fork_replay",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "same-run recovery does not define timestamp-fork selected-contract replay ownership",
+		},
+		{
+			Concept:     "source_outcome_suppression",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source receipts, dead letters, and post-T outcomes cannot suppress fork-local work without an approved model",
+		},
+	}
+}

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -1,0 +1,114 @@
+package runforkexecution
+
+import (
+	"strings"
+	"testing"
+
+	"swarm/internal/store"
+)
+
+func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:           "source-event",
+			EventName:               "work.begin",
+			RuntimeEventOwners:      []string{"alpha-intake"},
+			WorkflowNodeSubscribers: []string{"beta-intake"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "alpha-intake",
+				Path:           "flow-a/alpha-intake",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: admission})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	if model.Owner != store.RunForkSelectedContractExecutionModelOwner ||
+		model.FutureExecutionOwner != store.RunForkSelectedContractExecutionOwner ||
+		!model.NonMutating ||
+		model.ExecutionSupported {
+		t.Fatalf("model ownership = %#v", model)
+	}
+	if model.AdmissionOwner != store.RunForkContractFrontierAdmissionOwner ||
+		model.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly {
+		t.Fatalf("admission use = owner:%q use:%q", model.AdmissionOwner, model.AdmissionUse)
+	}
+	if model.FrontierEventCount != 1 || len(model.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v", model.FrontierEvents)
+	}
+	if model.FrontierEvents[0].Disposition != store.RunForkSelectedContractDispositionEvidenceOnly {
+		t.Fatalf("frontier disposition = %q", model.FrontierEvents[0].Disposition)
+	}
+	if !executionBoundaryHas(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source delivery copying invalid", model.InvalidPaths)
+	}
+	if !executionBoundaryHas(model.RequiredConsumers, "handler_execution", store.RunForkSelectedContractDispositionFutureOwnerRequired) {
+		t.Fatalf("required consumers = %#v, want handler execution future owner", model.RequiredConsumers)
+	}
+	if !executionBoundaryHas(model.RequiredConsumers, "safe_agent_delivery_event_replay", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required consumers = %#v, want safe-agent replay as prerequisite", model.RequiredConsumers)
+	}
+	if !executionBoundaryHas(model.BlockedSiblings, "sessions_turns_audits", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("blocked siblings = %#v, want sessions/turns blocked", model.BlockedSiblings)
+	}
+	if !unsupportedBlockerHas(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionModelNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want non-mutating model blocker", model.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractExecutionModelFailsClosedOnExecutableAdmission(t *testing.T) {
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission: store.RunForkContractFrontierAdmission{
+			Owner:                        store.RunForkContractFrontierAdmissionOwner,
+			NonMutating:                  true,
+			HistoricalExecutionSupported: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unexpectedly supports historical execution") {
+		t.Fatalf("error = %v, want executable-admission failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionModelRequiresCanonicalAdmissionOwner(t *testing.T) {
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission: store.RunForkContractFrontierAdmission{
+			Owner:       "cmd.swarm.local_contracts",
+			NonMutating: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkContractFrontierAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical admission owner failure", err)
+	}
+}
+
+func executionBoundaryHas(items []store.RunForkSelectedContractExecutionBoundary, concept, disposition string) bool {
+	for _, item := range items {
+		if item.Concept == concept && item.Disposition == disposition {
+			return true
+		}
+	}
+	return false
+}
+
+func unsupportedBlockerHas(items []store.RunForkUnsupportedBlocker, code string) bool {
+	for _, item := range items {
+		if item.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -42,6 +42,7 @@ type RunForkPlan struct {
 	ExecutionReady            bool                              `json:"execution_ready"`
 	ReplayResumeAdmission     RunForkReplayResumeAdmission      `json:"replay_resume_admission"`
 	ContractFrontierAdmission *RunForkContractFrontierAdmission `json:"contract_frontier_admission,omitempty"`
+	SelectedContractExecution *RunForkSelectedContractExecution `json:"selected_contract_execution,omitempty"`
 	Entities                  []RunForkEntityState              `json:"entities,omitempty"`
 	PendingWork               []RunForkPendingWork              `json:"pending_work,omitempty"`
 	UnsupportedBlockers       []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -1,0 +1,49 @@
+package store
+
+const (
+	RunForkSelectedContractExecutionModelOwner = "runtime.run_fork.selected_contract_execution_model"
+	RunForkSelectedContractExecutionOwner      = "runtime.run_fork.selected_contract_execution"
+
+	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly = "prerequisite_evidence_only"
+
+	RunForkSelectedContractDispositionEvidenceOnly        = "evidence_only"
+	RunForkSelectedContractDispositionFutureOwnerRequired = "future_owner_required"
+	RunForkSelectedContractDispositionBlockedSibling      = "blocked_sibling"
+	RunForkSelectedContractDispositionPrerequisite        = "prerequisite"
+	RunForkSelectedContractDispositionInvalid             = "invalid"
+
+	RunForkBlockerSelectedContractExecutionModelNonMutating = "selected_contract_execution_model_non_mutating"
+)
+
+type RunForkSelectedContractExecution struct {
+	Owner                string                                     `json:"owner"`
+	FutureExecutionOwner string                                     `json:"future_execution_owner"`
+	NonMutating          bool                                       `json:"non_mutating"`
+	ExecutionSupported   bool                                       `json:"execution_supported"`
+	ContractSelection    RunForkContractSelection                   `json:"contract_selection"`
+	AdmissionOwner       string                                     `json:"admission_owner"`
+	AdmissionUse         string                                     `json:"admission_use"`
+	FrontierEventCount   int                                        `json:"frontier_event_count"`
+	FrontierEvents       []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
+	ContractBinding      RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
+	RequiredConsumers    []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings      []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths         []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers  []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractFrontierEvent struct {
+	SourceEventID           string                             `json:"source_event_id"`
+	EventName               string                             `json:"event_name"`
+	RuntimeEventOwners      []string                           `json:"runtime_event_owners,omitempty"`
+	WorkflowNodeSubscribers []string                           `json:"workflow_node_subscribers,omitempty"`
+	DerivedRecipients       []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
+	Disposition             string                             `json:"disposition"`
+}
+
+type RunForkSelectedContractExecutionBoundary struct {
+	Concept     string `json:"concept"`
+	Disposition string `json:"disposition"`
+	Owner       string `json:"owner,omitempty"`
+	Reason      string `json:"reason"`
+}


### PR DESCRIPTION
## Summary

Closes #585.

Adds the approved non-mutating selected-contract fork execution owner-model slice:

- introduces `runtime.run_fork.selected_contract_execution_model` as the owner-model boundary;
- models the future mutating owner as `runtime.run_fork.selected_contract_execution` without creating executable fork work;
- consumes `runtime.run_fork.contract_frontier_admission` as prerequisite evidence only;
- exposes the model on `swarm fork --dry-run --contracts ...` output for operator proof;
- classifies invalid paths, required future consumers, blocked siblings, and non-mutating blockers;
- updates the platform spec and runtime watchlist mapping for #583/#585.

No fork-local event/delivery rows are created. No source events or source `event_deliveries` are copied. No selected-contract handlers are run.

## Governing References

Exact spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.description` / `run_id.present_on`
- `run_model.fork.command`
- `run_model.fork.planning_admission`
- `run_model.fork.materialize_only_admission`
- `run_model.fork.activation_admission`
- `run_model.fork.planning_owner`
- `run_model.fork.replay_resume_admission_taxonomy`
- `run_model.fork.selected_contract_execution_model`
- `run_model.fork.semantics.3a_materialize_only_run`
- `run_model.fork.semantics.3b_activate_materialized_fork`
- `run_model.fork.semantics.4_boot`
- `run_model.fork.semantics.5_resume`
- `run_model.fork.contract_swap`
- `run_model.fork.isolation`

Binding issue/gate context:

- #585 pre-audit approved as first slice.
- #583 gate outcome was `insufficient; escalate broad refactor` for mutating selected-contract execution.
- Parents remain #564 and #549.
- #577/#578 provide the non-mutating contract frontier admission prerequisite.

## Semantic Migration

New canonical owner-model: `runtime.run_fork.selected_contract_execution_model` in `internal/runtime/runforkexecution`.

Future mutating owner named but not implemented: `runtime.run_fork.selected_contract_execution`.

Old invalid paths now explicitly modeled as invalid:

- source `event_deliveries` copying;
- source event copying;
- CLI-owned execution semantics;
- same-run outbox replay treated as fork replay;
- source outcome suppression without an approved fork-local model.

Production paths checked for surviving old behavior:

- `swarm fork --dry-run --contracts ...` now reports the owner model alongside #578 admission.
- `swarm fork --materialize-only --contracts ...` and `swarm fork --activate --contracts ...` remain rejected by existing dry-run-only guardrails.
- `ActivateRunFork` still consumes only store replay taxonomy and safe pending-agent replay; selected-contract mutation remains unsupported.
- #570 safe pending-agent replay remains separate and unchanged.

Migration complete for the approved non-mutating owner-model class. Mutating selected-contract execution remains unimplemented and requires a new independent gate.

## Proof

Focused proof:

- `go test ./internal/runtime/runforkexecution`
- `go test ./cmd/swarm -run 'TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON|TestRunForkCommand_ContractsRemainDryRunOnly'`
- `go test ./internal/store -run 'TestRunForkPlanner|TestRunForkMaterializer'`

Affected package/spec proof:

- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./cmd/swarm ./internal/store`
- `python3 docs/specs/swarm-platform/verify.py docs/specs/swarm-platform/platform/contracts`

Relevant broad suite:

- `go test ./internal/runtime/... ./internal/store ./cmd/swarm`

No clear-run proof required by the approved gate; this is a non-mutating owner-model slice.