### PR TITLE
[agent-d][issue #580] Preserve non-lossy typed reads

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -149,6 +149,14 @@ active_issues:
     title: Gate non-mutating fork contract/frontier/route admission
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 571
+    title: get_entity truncates large current-entity reads and hides required fields
+    maps_to:
+      - transport_policy_and_surface_parity
+  - id: 580
+    title: Implement non-lossy typed read tools for current-entity access
+    maps_to:
+      - transport_policy_and_surface_parity
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -166,6 +174,7 @@ nodes:
       - oversized file-backed tool results on supported Claude helper turns can leak provider scratch paths back into later runtime read_file calls
       - CLI native tools can still use mixed provider-plus-platform fallback semantics, so visible turn surface does not equal callable provider-native truth for bash, web_search, and file_io
       - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
+      - generated role-scoped typed reads can be silently downgraded by generic transport projection into preview/truncated shapes instead of complete typed values or explicit typed-read errors
     representative_issues:
       - 111
       - 136
@@ -175,6 +184,8 @@ nodes:
       - 381
       - 444
       - 544
+      - 571
+      - 580
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent

--- a/internal/runtime/core/toolresultpolicy/toolresultpolicy.go
+++ b/internal/runtime/core/toolresultpolicy/toolresultpolicy.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	// Keep this above the #571 40KB proof target while still bounding a single
-	// inline typed read result before the LLM turn envelope becomes unsafe.
-	MaxCompleteTypedReadResultBytes = 64 * 1024
+	// inline typed read result with enough room for the LLM tool-call envelope.
+	MaxCompleteTypedReadResultBytes = 56 * 1024
 
 	RoleScopedEntityToolAuthorizationClass = "role_scoped_entity_tool"
 

--- a/internal/runtime/core/toolresultpolicy/toolresultpolicy.go
+++ b/internal/runtime/core/toolresultpolicy/toolresultpolicy.go
@@ -1,0 +1,72 @@
+package toolresultpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/runtime/core/toolcapabilities"
+	"swarm/internal/runtime/core/toolidentity"
+	runtimerterr "swarm/internal/runtime/rterrors"
+)
+
+const (
+	// Keep this above the #571 40KB proof target while still bounding a single
+	// inline typed read result before the LLM turn envelope becomes unsafe.
+	MaxCompleteTypedReadResultBytes = 64 * 1024
+
+	RoleScopedEntityToolAuthorizationClass = "role_scoped_entity_tool"
+
+	TypedReadResultTooLargeCode     = "typed_read_result_too_large"
+	TypedReadResultMarshalErrorCode = "typed_read_result_marshal_failed"
+)
+
+func IsRoleScopedTypedReadCapability(cap toolcapabilities.Capability) bool {
+	if strings.TrimSpace(cap.AuthorizationClass) != RoleScopedEntityToolAuthorizationClass {
+		return false
+	}
+	return IsRoleScopedTypedReadName(cap.Name)
+}
+
+func IsRoleScopedTypedReadName(name string) bool {
+	name = toolidentity.CanonicalName(name)
+	if name == "" || name == "read_file" {
+		return false
+	}
+	return strings.HasPrefix(name, "read_")
+}
+
+func IsRoleScopedTypedReadInContext(set toolcapabilities.Set, name string) bool {
+	cap, ok := set.Capability(name)
+	if !ok {
+		return false
+	}
+	return IsRoleScopedTypedReadCapability(cap)
+}
+
+func NewTypedReadResultTooLargeError(component, operation, toolName string, bytes int) error {
+	return runtimerterr.NewRuntimeError(
+		TypedReadResultTooLargeCode,
+		component,
+		operation,
+		false,
+		"role-scoped typed read %s produced %d bytes, exceeding the complete delivery limit of %d bytes",
+		strings.TrimSpace(toolName),
+		bytes,
+		MaxCompleteTypedReadResultBytes,
+	)
+}
+
+func NewTypedReadResultMarshalError(component, operation, toolName string, cause error) error {
+	if cause == nil {
+		cause = fmt.Errorf("marshal typed read result")
+	}
+	return runtimerterr.WrapRuntimeError(
+		TypedReadResultMarshalErrorCode,
+		component,
+		operation,
+		false,
+		cause,
+		"role-scoped typed read %s result cannot be serialized completely",
+		strings.TrimSpace(toolName),
+	)
+}

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -10,6 +10,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
 	"swarm/internal/runtime/core/toolidentity"
+	"swarm/internal/runtime/core/toolresultpolicy"
 	"swarm/internal/runtime/sessions"
 )
 
@@ -256,6 +257,18 @@ func (c *Conversation) executeToolCalls(ctx context.Context, calls []ToolCall) (
 		return fmt.Sprintf(`[%q]`, err.Error()), executed
 	}
 	if len(b) > toolRelayMessageLimit(calls) {
+		if toolCallBatchHasRoleScopedTypedRead(ctx, calls) {
+			overflow := []map[string]any{{
+				"name":  "__runtime_guardrail__",
+				"ok":    false,
+				"error": fmt.Sprintf("%s: role-scoped typed read results exceeded the complete delivery limit of %d bytes", toolresultpolicy.TypedReadResultTooLargeCode, toolresultpolicy.MaxCompleteTypedReadResultBytes),
+			}}
+			guarded, gerr := json.Marshal(overflow)
+			if gerr != nil {
+				return fmt.Sprintf(`[{"name":"__runtime_guardrail__","ok":false,"error":%q}]`, toolresultpolicy.TypedReadResultTooLargeCode), executed
+			}
+			return strings.TrimSpace(string(guarded)), executed
+		}
 		overflow := []map[string]any{{
 			"name":  "__runtime_guardrail__",
 			"ok":    false,
@@ -276,10 +289,19 @@ func (c *Conversation) projectToolResult(ctx context.Context, name string, input
 	}
 	b, err := json.Marshal(result)
 	if err != nil {
+		if toolIsRoleScopedTypedReadInContext(ctx, name) {
+			return nil, toolresultpolicy.NewTypedReadResultMarshalError("llm-conversation", "tool_result.project", name, err)
+		}
 		return map[string]any{
 			"truncated": false,
 			"error":     "marshal tool result",
 		}, nil
+	}
+	if toolIsRoleScopedTypedReadInContext(ctx, name) {
+		if len(b) > toolresultpolicy.MaxCompleteTypedReadResultBytes {
+			return nil, toolresultpolicy.NewTypedReadResultTooLargeError("llm-conversation", "tool_result.project", name, len(b))
+		}
+		return result, nil
 	}
 	limit := toolRelayResultLimitForRuntime(ctx, c.runtime, c.turnToolDefinitions(), name, input)
 	if len(b) <= limit {
@@ -392,6 +414,23 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 		return ctx
 	}
 	return toolcapabilities.WithContext(ctx, c.toolExecutor.ToolCapabilitiesForActor(actor, names, nil))
+}
+
+func toolIsRoleScopedTypedReadInContext(ctx context.Context, name string) bool {
+	set, ok := toolcapabilities.FromContext(ctx)
+	if !ok {
+		return false
+	}
+	return toolresultpolicy.IsRoleScopedTypedReadInContext(set, name)
+}
+
+func toolCallBatchHasRoleScopedTypedRead(ctx context.Context, calls []ToolCall) bool {
+	for _, call := range calls {
+		if toolIsRoleScopedTypedReadInContext(ctx, call.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 func runtimeReadFileFollowUpAllowedForTurn(ctx context.Context, tools []ToolDefinition) bool {

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -9,6 +9,7 @@ import (
 
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
+	"swarm/internal/runtime/core/toolresultpolicy"
 )
 
 type fakeRuntime struct {
@@ -139,6 +140,57 @@ func (l largeToolExec) ToolCapabilitiesForActor(_ models.AgentConfig, names []st
 		caps = append(caps, toolcapabilities.Capability{Name: name, Visible: true, Callable: true})
 	}
 	return toolcapabilities.NewSet(caps)
+}
+
+type roleScopedTypedReadExec struct {
+	payload any
+}
+
+func (r roleScopedTypedReadExec) Execute(context.Context, string, any) (any, error) {
+	return r.payload, nil
+}
+
+func (r roleScopedTypedReadExec) ToolCapabilitiesForActor(_ models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, name := range names {
+		caps = append(caps, toolcapabilities.Capability{
+			Name:               name,
+			Visible:            true,
+			Callable:           true,
+			AuthorizationClass: toolresultpolicy.RoleScopedEntityToolAuthorizationClass,
+		})
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func largeValidationCasePayloadForConversationTest() map[string]any {
+	problem := strings.Repeat("problem statement ", 350)
+	return map[string]any{
+		"entity_id":              "validation-case-1",
+		"entity_type":            "validation_case",
+		"flow_instance":          "validation/inst-1",
+		"mvp_problem_statement":  problem,
+		"current_state":          "mvp_speccing",
+		"revision":               float64(3),
+		"business_brief_padding": strings.Repeat("business brief ", 900),
+		"fields": map[string]any{
+			"business_brief": map[string]any{
+				"summary":    strings.Repeat("business brief ", 900),
+				"confidence": float64(10),
+			},
+			"mvp_spec": map[string]any{
+				"problem_statement":  problem,
+				"technical_approach": strings.Repeat("technical approach ", 350),
+			},
+		},
+	}
+}
+
+func asStringForConversationTest(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return ""
 }
 
 type relayRuntime struct {
@@ -345,6 +397,100 @@ func TestConversation_ExecuteToolCalls_TruncatesLargeResult(t *testing.T) {
 	resultMap, _ := arr[0]["result"].(map[string]any)
 	if resultMap == nil || resultMap["truncated"] != true {
 		t.Fatalf("expected truncated result metadata, got %#v", arr[0]["result"])
+	}
+}
+
+func TestConversation_ExecuteToolCalls_RoleScopedTypedReadPreservesLargeValidationCase(t *testing.T) {
+	payload := largeValidationCasePayloadForConversationTest()
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if len(rawPayload) < 40*1024 || len(rawPayload) > toolresultpolicy.MaxCompleteTypedReadResultBytes {
+		t.Fatalf("payload size = %d, want >=40KB and <=%d", len(rawPayload), toolresultpolicy.MaxCompleteTypedReadResultBytes)
+	}
+	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_validation_case"}}, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(roleScopedTypedReadExec{payload: payload})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_validation_case", Arguments: map[string]any{}}})
+	if strings.Contains(raw, `"truncated"`) || strings.Contains(raw, `"preview"`) || strings.Contains(raw, `"follow_up"`) {
+		t.Fatalf("typed read projection used lossy metadata: %s", raw)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != true {
+		t.Fatalf("expected successful typed read payload, got %#v", arr)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	fields, _ := resultMap["fields"].(map[string]any)
+	mvp, _ := fields["mvp_spec"].(map[string]any)
+	if got := asStringForConversationTest(mvp["problem_statement"]); got != asStringForConversationTest(payload["mvp_problem_statement"]) {
+		t.Fatalf("mvp_spec.problem_statement length = %d, want %d", len(got), len(asStringForConversationTest(payload["mvp_problem_statement"])))
+	}
+}
+
+func TestConversation_ExecuteToolCalls_RoleScopedTypedReadFieldPreservesCompleteField(t *testing.T) {
+	field := map[string]any{
+		"problem_statement":  strings.Repeat("problem statement ", 900),
+		"technical_approach": strings.Repeat("technical approach ", 900),
+	}
+	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_validation_case_mvp_spec"}}, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(roleScopedTypedReadExec{payload: field})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_validation_case_mvp_spec", Arguments: map[string]any{}}})
+	if strings.Contains(raw, `"truncated"`) || strings.Contains(raw, `"preview"`) || strings.Contains(raw, `"follow_up"`) {
+		t.Fatalf("typed field read projection used lossy metadata: %s", raw)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	if got := asStringForConversationTest(resultMap["technical_approach"]); got != field["technical_approach"].(string) {
+		t.Fatalf("technical_approach length = %d, want %d", len(got), len(field["technical_approach"].(string)))
+	}
+}
+
+func TestConversation_ExecuteToolCalls_RoleScopedTypedReadFailsClosedWhenTooLarge(t *testing.T) {
+	payload := map[string]any{"blob": strings.Repeat("x", toolresultpolicy.MaxCompleteTypedReadResultBytes+1024)}
+	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_validation_case"}}, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(roleScopedTypedReadExec{payload: payload})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_validation_case", Arguments: map[string]any{}}})
+	if strings.Contains(raw, `"truncated"`) || strings.Contains(raw, `"preview"`) || strings.Contains(raw, `"follow_up"`) {
+		t.Fatalf("typed read oversize emitted lossy metadata: %s", raw)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != false {
+		t.Fatalf("expected fail-closed typed read payload, got %#v", arr)
+	}
+	if !strings.Contains(asStringForConversationTest(arr[0]["error"]), toolresultpolicy.TypedReadResultTooLargeCode) {
+		t.Fatalf("error = %#v, want %s", arr[0]["error"], toolresultpolicy.TypedReadResultTooLargeCode)
+	}
+}
+
+func TestConversation_ExecuteToolCalls_ReadPrefixedNonRoleScopedToolKeepsLegacyProjection(t *testing.T) {
+	huge := strings.Repeat("x", maxToolResultBytes+1024)
+	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_custom_report"}}, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(largeToolExec{payload: map[string]any{"blob": huge}})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_custom_report", Arguments: map[string]any{}}})
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	resultMap, _ := arr[0]["result"].(map[string]any)
+	if truncated, _ := resultMap["truncated"].(bool); !truncated {
+		t.Fatalf("truncated = %#v, want legacy projection for non-role-scoped read-prefixed tool", resultMap["truncated"])
 	}
 }
 

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -477,6 +477,29 @@ func TestConversation_ExecuteToolCalls_RoleScopedTypedReadFailsClosedWhenTooLarg
 	}
 }
 
+func TestConversation_ExecuteToolCalls_RoleScopedTypedReadNearCapFitsEnvelope(t *testing.T) {
+	overhead := len(`{"blob":""}`)
+	payload := map[string]any{"blob": strings.Repeat("x", toolresultpolicy.MaxCompleteTypedReadResultBytes-overhead)}
+	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_validation_case"}}, SessionScoped, 4, &fakeRuntime{})
+	c.SetToolExecutor(roleScopedTypedReadExec{payload: payload})
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "a1"})
+	raw, _ := c.executeToolCalls(ctx, []ToolCall{{Name: "read_validation_case", Arguments: map[string]any{}}})
+	if strings.Contains(raw, "__runtime_guardrail__") {
+		t.Fatalf("near-cap typed read tripped batch guardrail: %s", raw)
+	}
+	if len(raw) > maxToolMessageBytes {
+		t.Fatalf("tool message size = %d, want <= %d", len(raw), maxToolMessageBytes)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("unmarshal tool payload: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["ok"] != true {
+		t.Fatalf("expected successful near-cap typed read payload, got %#v", arr)
+	}
+}
+
 func TestConversation_ExecuteToolCalls_ReadPrefixedNonRoleScopedToolKeepsLegacyProjection(t *testing.T) {
 	huge := strings.Repeat("x", maxToolResultBytes+1024)
 	c := NewConversation("a1", "t1", "sys", []ToolDefinition{{Name: "read_custom_report"}}, SessionScoped, 4, &fakeRuntime{})

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -14,6 +14,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
 	"swarm/internal/runtime/core/toolidentity"
+	"swarm/internal/runtime/core/toolresultpolicy"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	llm "swarm/internal/runtime/llm"
 	runtimerterr "swarm/internal/runtime/rterrors"
@@ -358,6 +359,15 @@ func projectToolCallSuccessText(ctx context.Context, executor runtimeGatewayExec
 	}
 	raw, err := json.Marshal(out)
 	if err != nil {
+		if toolIsRoleScopedTypedReadInContext(ctx, toolName) {
+			return "", toolresultpolicy.NewTypedReadResultMarshalError("mcp-gateway", "mcp.tools.call.result_project", toolName, err)
+		}
+		return ToolResultText(out), nil
+	}
+	if toolIsRoleScopedTypedReadInContext(ctx, toolName) {
+		if len(raw) > toolresultpolicy.MaxCompleteTypedReadResultBytes {
+			return "", toolresultpolicy.NewTypedReadResultTooLargeError("mcp-gateway", "mcp.tools.call.result_project", toolName, len(raw))
+		}
 		return ToolResultText(out), nil
 	}
 	if len(raw) <= toolCallRelayResultLimit(toolName, input) {
@@ -398,6 +408,14 @@ func projectToolCallSuccessText(ctx context.Context, executor runtimeGatewayExec
 		"preview":   clampRunes(string(raw), maxToolResultPreviewRunes),
 		"follow_up": followUp,
 	}), nil
+}
+
+func toolIsRoleScopedTypedReadInContext(ctx context.Context, name string) bool {
+	set, ok := toolcapabilities.FromContext(ctx)
+	if !ok {
+		return false
+	}
+	return toolresultpolicy.IsRoleScopedTypedReadInContext(set, name)
 }
 
 func toolCallRelayResultLimit(toolName string, input any) int {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -15,6 +15,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
 	"swarm/internal/runtime/core/toolidentity"
+	"swarm/internal/runtime/core/toolresultpolicy"
 	llm "swarm/internal/runtime/llm"
 	runtimerterr "swarm/internal/runtime/rterrors"
 )
@@ -50,6 +51,45 @@ func mustMCPToolsForRequest(t *testing.T, g *Gateway, req *http.Request) []ToolD
 		t.Fatalf("mcpToolsForRequest: %v", err)
 	}
 	return tools
+}
+
+func roleScopedTypedReadContext(name string) context.Context {
+	return toolcapabilities.WithContext(context.Background(), toolcapabilities.NewSet([]toolcapabilities.Capability{{
+		Name:               name,
+		Visible:            true,
+		Callable:           true,
+		AuthorizationClass: toolresultpolicy.RoleScopedEntityToolAuthorizationClass,
+	}}))
+}
+
+func largeValidationCasePayloadForTypedReadTest() map[string]any {
+	problem := strings.Repeat("problem statement ", 350)
+	return map[string]any{
+		"entity_id":              "validation-case-1",
+		"entity_type":            "validation_case",
+		"flow_instance":          "validation/inst-1",
+		"mvp_problem_statement":  problem,
+		"current_state":          "mvp_speccing",
+		"revision":               float64(3),
+		"business_brief_padding": strings.Repeat("business brief ", 900),
+		"fields": map[string]any{
+			"business_brief": map[string]any{
+				"summary":    strings.Repeat("business brief ", 900),
+				"confidence": float64(10),
+			},
+			"mvp_spec": map[string]any{
+				"problem_statement":  problem,
+				"technical_approach": strings.Repeat("technical approach ", 350),
+			},
+		},
+	}
+}
+
+func asStringForGatewayTest(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return ""
 }
 
 type testToolExecutor func(context.Context, string, any) (any, error)
@@ -1154,6 +1194,96 @@ func TestGatewayHandleMCP_ToolsCallSuppressesRuntimeReadFileFollowUpWithoutReadF
 	}
 	if len(exec.relayRaw) != 0 {
 		t.Fatalf("relay raw = %q, want no relay payload write", string(exec.relayRaw))
+	}
+}
+
+func TestProjectToolCallSuccessText_RoleScopedTypedReadPreservesLargeValidationCase(t *testing.T) {
+	payload := largeValidationCasePayloadForTypedReadTest()
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if len(rawPayload) < 40*1024 || len(rawPayload) > toolresultpolicy.MaxCompleteTypedReadResultBytes {
+		t.Fatalf("payload size = %d, want >=40KB and <=%d", len(rawPayload), toolresultpolicy.MaxCompleteTypedReadResultBytes)
+	}
+	ctx := roleScopedTypedReadContext("read_validation_case")
+
+	text, err := projectToolCallSuccessText(ctx, testToolExecutor(func(context.Context, string, any) (any, error) {
+		return payload, nil
+	}), "read_validation_case", map[string]any{}, payload)
+	if err != nil {
+		t.Fatalf("projectToolCallSuccessText: %v", err)
+	}
+	if strings.Contains(text, `"truncated"`) || strings.Contains(text, `"preview"`) || strings.Contains(text, `"follow_up"`) {
+		t.Fatalf("typed read projection used lossy metadata: %s", text)
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(text), &projected); err != nil {
+		t.Fatalf("unmarshal projected text: %v", err)
+	}
+	fields, _ := projected["fields"].(map[string]any)
+	mvp, _ := fields["mvp_spec"].(map[string]any)
+	if got := asStringForGatewayTest(mvp["problem_statement"]); got != asStringForGatewayTest(payload["mvp_problem_statement"]) {
+		t.Fatalf("mvp_spec.problem_statement length = %d, want %d", len(got), len(asStringForGatewayTest(payload["mvp_problem_statement"])))
+	}
+}
+
+func TestProjectToolCallSuccessText_RoleScopedTypedReadFieldPreservesCompleteField(t *testing.T) {
+	field := map[string]any{
+		"problem_statement":  strings.Repeat("problem statement ", 900),
+		"technical_approach": strings.Repeat("technical approach ", 900),
+	}
+	ctx := roleScopedTypedReadContext("read_validation_case_mvp_spec")
+
+	text, err := projectToolCallSuccessText(ctx, testToolExecutor(func(context.Context, string, any) (any, error) {
+		return field, nil
+	}), "read_validation_case_mvp_spec", map[string]any{}, field)
+	if err != nil {
+		t.Fatalf("projectToolCallSuccessText: %v", err)
+	}
+	if strings.Contains(text, `"truncated"`) || strings.Contains(text, `"preview"`) || strings.Contains(text, `"follow_up"`) {
+		t.Fatalf("typed field read projection used lossy metadata: %s", text)
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(text), &projected); err != nil {
+		t.Fatalf("unmarshal projected text: %v", err)
+	}
+	if got := asStringForGatewayTest(projected["technical_approach"]); got != field["technical_approach"].(string) {
+		t.Fatalf("technical_approach length = %d, want %d", len(got), len(field["technical_approach"].(string)))
+	}
+}
+
+func TestProjectToolCallSuccessText_RoleScopedTypedReadFailsClosedWhenTooLarge(t *testing.T) {
+	payload := map[string]any{"blob": strings.Repeat("x", toolresultpolicy.MaxCompleteTypedReadResultBytes+1024)}
+	ctx := roleScopedTypedReadContext("read_validation_case")
+
+	text, err := projectToolCallSuccessText(ctx, testToolExecutor(func(context.Context, string, any) (any, error) {
+		return payload, nil
+	}), "read_validation_case", map[string]any{}, payload)
+	if err == nil {
+		t.Fatalf("projectToolCallSuccessText returned nil error and text %s", text)
+	}
+	runtimeErr, ok := runtimerterr.AsRuntimeError(err)
+	if !ok || runtimeErr.Code != toolresultpolicy.TypedReadResultTooLargeCode {
+		t.Fatalf("error = %#v, want runtime code %s", err, toolresultpolicy.TypedReadResultTooLargeCode)
+	}
+}
+
+func TestProjectToolCallSuccessText_ReadPrefixedNonRoleScopedToolKeepsLegacyProjection(t *testing.T) {
+	payload := map[string]any{"blob": strings.Repeat("x", maxToolResultBytes+1024)}
+
+	text, err := projectToolCallSuccessText(context.Background(), testToolExecutor(func(context.Context, string, any) (any, error) {
+		return payload, nil
+	}), "read_custom_report", map[string]any{}, payload)
+	if err != nil {
+		t.Fatalf("projectToolCallSuccessText: %v", err)
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(text), &projected); err != nil {
+		t.Fatalf("unmarshal projected text: %v", err)
+	}
+	if truncated, _ := projected["truncated"].(bool); !truncated {
+		t.Fatalf("truncated = %#v, want legacy projection for non-role-scoped read-prefixed tool", projected["truncated"])
 	}
 }
 

--- a/internal/runtime/tools/authorizer.go
+++ b/internal/runtime/tools/authorizer.go
@@ -8,6 +8,7 @@ import (
 
 	runtimeauthority "swarm/internal/runtime/authority"
 	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolresultpolicy"
 )
 
 type ToolAuthorizer struct {
@@ -29,7 +30,7 @@ const (
 	toolAuthorizationPermission  toolAuthorizationClass = "permission"
 	toolAuthorizationEmitAllowed toolAuthorizationClass = "emit_allowed"
 	toolAuthorizationNativeTool  toolAuthorizationClass = "native_tool"
-	toolAuthorizationRoleScoped  toolAuthorizationClass = "role_scoped_entity_tool"
+	toolAuthorizationRoleScoped  toolAuthorizationClass = toolresultpolicy.RoleScopedEntityToolAuthorizationClass
 	toolAuthorizationActorConfig toolAuthorizationClass = "actor_config"
 	toolAuthorizationDenied      toolAuthorizationClass = "denied"
 )

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -392,6 +392,68 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 	}
 }
 
+func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	entityID := uuid.NewString()
+	brief := strings.Repeat("business brief ", 1800)
+	specProblem := strings.Repeat("problem statement ", 900)
+	specApproach := strings.Repeat("technical approach ", 900)
+	seedEntityStateRow(t, db, entityID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
+		"status": "open",
+		"business_brief": map[string]any{
+			"summary":    brief,
+			"confidence": 10,
+		},
+		"mvp_spec": map[string]any{
+			"problem_statement":  specProblem,
+			"technical_approach": specApproach,
+		},
+	}, time.Now().UTC())
+	currentCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-current",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(entityID).WithFlowInstance("validation/inst-1"))
+
+	whole, err := exec.Execute(currentCtx, "read_validation_case", map[string]any{})
+	if err != nil {
+		t.Fatalf("read_validation_case: %v", err)
+	}
+	rawWhole, err := json.Marshal(whole)
+	if err != nil {
+		t.Fatalf("marshal whole read: %v", err)
+	}
+	if len(rawWhole) < 40*1024 {
+		t.Fatalf("whole read fixture size = %d, want >= 40KB", len(rawWhole))
+	}
+	if strings.Contains(string(rawWhole), `"truncated"`) || strings.Contains(string(rawWhole), `"preview"`) || strings.Contains(string(rawWhole), `"follow_up"`) {
+		t.Fatalf("whole typed read contains lossy projection markers")
+	}
+	wholeMap, ok := whole.(map[string]any)
+	if !ok {
+		t.Fatalf("whole read = %T, want map", whole)
+	}
+	fields, _ := wholeMap["fields"].(map[string]any)
+	mvp, _ := fields["mvp_spec"].(map[string]any)
+	if asString(mvp["problem_statement"]) != specProblem {
+		t.Fatalf("whole read mvp_spec.problem_statement length = %d, want %d", len(asString(mvp["problem_statement"])), len(specProblem))
+	}
+
+	field, err := exec.Execute(currentCtx, "read_validation_case_mvp_spec", map[string]any{})
+	if err != nil {
+		t.Fatalf("read_validation_case_mvp_spec: %v", err)
+	}
+	fieldMap, ok := field.(map[string]any)
+	if !ok {
+		t.Fatalf("field read = %T, want map", field)
+	}
+	if asString(fieldMap["technical_approach"]) != specApproach {
+		t.Fatalf("field read technical_approach length = %d, want %d", len(asString(fieldMap["technical_approach"])), len(specApproach))
+	}
+}
+
 func TestEntityTools_SaveEntityFieldAcceptsAnnotatedJSONBFields(t *testing.T) {
 	ctx, exec := newAnnotatedEntityToolExecutor(t)
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{"flow_instance": "validation/inst-1"})
@@ -2435,11 +2497,15 @@ types:
   business_brief:
     summary: text
     confidence: integer
+  mvp_spec:
+    problem_statement: text
+    technical_approach: text
 `,
 			EntitiesYAML: `
 validation_case:
   status: text
   business_brief: business_brief
+  mvp_spec: mvp_spec
 `,
 			AgentsYAML: roleScopedEntityToolAgentYAML(actor),
 		},


### PR DESCRIPTION
## Summary

Closes #580.
Part of #568.
Addresses #571 evidence without claiming legacy `get_entity` closure.

Implements the approved #580 gate boundary: generated role-scoped typed reads now bypass generic lossy preview/follow-up projection and either deliver the complete typed value or fail closed with an explicit typed-read error.

## Governing Context

- Binding issue/gate: #580 pre-audit and independent gate comment.
- Evidence: #571 large validation_case `get_entity` truncation hiding `mvp_spec`.
- Parent tracker: #568 Path alpha role-scoped typed tool contracts.
- Spec context: `proposal.generated_tools_per_agent.read_tools_pattern_1` in the role-scoped tool contracts review draft, as cited by #580/#568.

## Semantic Migration

- New canonical owner: `internal/runtime/core/toolresultpolicy` for role-scoped typed-read result classification and complete-delivery limits.
- Old producer/reader path now invalid for generated typed reads: generic MCP/LLM oversized projection returning `{preview, truncated:true}` or runtime-read-file `follow_up` as the apparent read value.
- Production paths checked: MCP `projectToolCallSuccessText`, LLM `Conversation.projectToolResult`, LLM batch guardrail, role-scoped executor materialization.
- Migration completeness: complete for generated role-scoped typed read tools; legacy `get_entity` remains split/non-authoritative for this issue.

## Proof

- `go test ./internal/runtime/core/toolresultpolicy ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/llm`
- `go test ./...`

No `make run-clear` run; the approved gate requested focused Go proof for this child.