### PR TITLE
[agent-d][issue #582] Enforce generated schema closure

### DIFF
--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -157,6 +157,10 @@ active_issues:
     title: Implement non-lossy typed read tools for current-entity access
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 582
+    title: Enforce closed generated schemas for typed tools and emits
+    maps_to:
+      - transport_policy_and_surface_parity
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -175,6 +179,7 @@ nodes:
       - CLI native tools can still use mixed provider-plus-platform fallback semantics, so visible turn surface does not equal callable provider-native truth for bash, web_search, and file_io
       - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
       - generated role-scoped typed reads can be silently downgraded by generic transport projection into preview/truncated shapes instead of complete typed values or explicit typed-read errors
+      - generated typed tool and emit schemas can drift between provider-visible delivery, runtime validation, and bootverify, allowing undeclared payload keys or missing required/enum constraints to survive one surface
     representative_issues:
       - 111
       - 136
@@ -186,6 +191,7 @@ nodes:
       - 544
       - 571
       - 580
+      - 582
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -57,6 +57,9 @@ type checkerContext struct {
 	toolUsageLoaded   bool
 	toolUsageFindings []Finding
 
+	generatedToolSchemaClosureLoaded   bool
+	generatedToolSchemaClosureFindings []Finding
+
 	runtimeToolNamesLoaded bool
 	runtimeToolNames       map[string]struct{}
 
@@ -201,6 +204,7 @@ var bootCheckRegistry = []Check{
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},
+	{ID: "generated_tool_schema_closure", Severity: SeverityHardInvalidity, Run: checkGeneratedToolSchemaClosure},
 	{ID: "prompt_exists", Severity: "warning", Run: checkPromptExists},
 	{ID: "produces_drift", Severity: "warning", Run: checkProducesDrift},
 	{ID: "invalid_field_detection", Severity: "error", Run: checkInvalidFieldDetection},
@@ -252,10 +256,13 @@ func checkStateMachineCoherence(c *checkerContext) []Finding { return c.stateMac
 func checkNodeStateSchemaTypedCounterpart(c *checkerContext) []Finding {
 	return c.nodeStateSchemaTypedCounterpart()
 }
-func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.requiredAgentsMatch() }
-func checkHandlerFieldCompliance(c *checkerContext) []Finding     { return c.handlerFieldCompliance() }
-func checkToolResolution(c *checkerContext) []Finding             { return c.toolResolution() }
-func checkPlatformToolUsageHints(c *checkerContext) []Finding     { return c.platformToolUsageHints() }
+func checkRequiredAgentsMatch(c *checkerContext) []Finding    { return c.requiredAgentsMatch() }
+func checkHandlerFieldCompliance(c *checkerContext) []Finding { return c.handlerFieldCompliance() }
+func checkToolResolution(c *checkerContext) []Finding         { return c.toolResolution() }
+func checkPlatformToolUsageHints(c *checkerContext) []Finding { return c.platformToolUsageHints() }
+func checkGeneratedToolSchemaClosure(c *checkerContext) []Finding {
+	return c.generatedToolSchemaClosure()
+}
 func checkPromptExists(c *checkerContext) []Finding               { return c.promptExists() }
 func checkInvalidFieldDetection(c *checkerContext) []Finding      { return c.invalidFieldDetection() }
 func checkPolicyConflictDetection(c *checkerContext) []Finding    { return c.policyConflicts() }
@@ -531,6 +538,22 @@ func (c *checkerContext) platformToolUsageHints() []Finding {
 		})
 	}
 	return c.toolUsageFindings
+}
+
+func (c *checkerContext) generatedToolSchemaClosure() []Finding {
+	if c.generatedToolSchemaClosureLoaded {
+		return c.generatedToolSchemaClosureFindings
+	}
+	c.generatedToolSchemaClosureLoaded = true
+	for _, err := range runtimetools.ValidateGeneratedToolSchemaClosureForSource(c.source) {
+		c.generatedToolSchemaClosureFindings = append(c.generatedToolSchemaClosureFindings, Finding{
+			CheckID:  "generated_tool_schema_closure",
+			Severity: SeverityHardInvalidity,
+			Message:  err.Error(),
+			Location: "generated-tools",
+		})
+	}
+	return c.generatedToolSchemaClosureFindings
 }
 
 func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3284,8 +3284,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 46 {
-		t.Fatalf("bootCheckRegistry count = %d, want 46", got)
+	if got := len(bootCheckRegistry); got != 47 {
+		t.Fatalf("bootCheckRegistry count = %d, want 47", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -441,7 +441,11 @@ func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen 
 	}
 	if namedName, ok := eventNamedTypeName(types, typeRef); ok {
 		if _, ok := seen[namedName]; ok {
-			return map[string]any{"type": "object"}
+			return map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": false,
+			}
 		}
 		seen[namedName] = struct{}{}
 		defer delete(seen, namedName)

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -8,10 +8,11 @@ import (
 )
 
 type ToolDefinition struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Schema      any    `json:"schema,omitempty"`
-	Usage       string `json:"-"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Schema          any    `json:"schema,omitempty"`
+	Usage           string `json:"-"`
+	GeneratedSchema bool   `json:"-"`
 }
 
 func DeliveredToolDescription(def ToolDefinition) string {

--- a/internal/runtime/tools/contracts.go
+++ b/internal/runtime/tools/contracts.go
@@ -10,9 +10,11 @@ import (
 )
 
 type ContractSchemaEntry struct {
-	Category    string         `yaml:"category"`
-	Description string         `yaml:"description"`
-	InputSchema map[string]any `yaml:"input_schema"`
+	Category        string         `yaml:"category"`
+	Description     string         `yaml:"description"`
+	InputSchema     map[string]any `yaml:"input_schema"`
+	OutputSchema    map[string]any `yaml:"output_schema,omitempty"`
+	GeneratedSchema bool           `yaml:"-"`
 }
 
 var supportedRuntimeToolNames = map[string]struct{}{

--- a/internal/runtime/tools/emit.go
+++ b/internal/runtime/tools/emit.go
@@ -59,11 +59,13 @@ func GenerateEmitTools(
 			}
 			continue
 		}
+		schema = closeGeneratedEmitSchema(schema)
 		tools = append(tools, llm.ToolDefinition{
-			Name:        EmitToolName(eventType),
-			Description: schema.Description,
-			Usage:       EmitToolUsage(),
-			Schema:      schema.Schema,
+			Name:            EmitToolName(eventType),
+			Description:     schema.Description,
+			Usage:           EmitToolUsage(),
+			Schema:          schema.Schema,
+			GeneratedSchema: true,
 		})
 	}
 	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -428,7 +428,7 @@ func (r *EmitRegistry) EventSchemaForActorTool(actor models.AgentConfig, toolNam
 	if !ok {
 		return "", EmitSchema{}, false
 	}
-	return eventType, schema, true
+	return eventType, closeGeneratedEmitSchema(schema), true
 }
 
 func (r *EmitRegistry) IsEmitToolAllowedForRole(role, toolName string) bool {

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -136,11 +136,13 @@ func (r *EmitRegistry) GenerateEmitToolsForEvents(eventTypes []string, warn func
 			}
 			continue
 		}
+		schema = closeGeneratedEmitSchema(schema)
 		tools = append(tools, llm.ToolDefinition{
-			Name:        toolName,
-			Description: schema.Description,
-			Usage:       EmitToolUsage(),
-			Schema:      schema.Schema,
+			Name:            toolName,
+			Description:     schema.Description,
+			Usage:           EmitToolUsage(),
+			Schema:          schema.Schema,
+			GeneratedSchema: true,
 		})
 	}
 	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
@@ -184,11 +186,13 @@ func (r *EmitRegistry) GenerateEmitToolsForActor(actor models.AgentConfig, warn 
 				}
 				continue
 			}
+			schema = closeGeneratedEmitSchema(schema)
 			tools = append(tools, llm.ToolDefinition{
-				Name:        toolName,
-				Description: schema.Description,
-				Usage:       EmitToolUsage(),
-				Schema:      schema.Schema,
+				Name:            toolName,
+				Description:     schema.Description,
+				Usage:           EmitToolUsage(),
+				Schema:          schema.Schema,
+				GeneratedSchema: true,
 			})
 		}
 		sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
@@ -218,13 +222,13 @@ func (r *EmitRegistry) schemaForActorEvent(actor models.AgentConfig, eventType s
 	}
 	if bundle, ok := semanticview.Bundle(r.source); ok && bundle != nil {
 		if schema, _, ok := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); ok {
-			return schema, true
+			return closeGeneratedEmitSchema(schema), true
 		}
 	}
 	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
 		proof.CatalogKey: proof.Entry,
 	})
-	schema, ok := registry[proof.CatalogKey]
+	schema, ok := closeGeneratedEmitSchemaRegistry(registry)[proof.CatalogKey]
 	return schema, ok
 }
 
@@ -242,6 +246,22 @@ func (r *EmitRegistry) GeneratedEmitSchemasForAgentRoles() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func closeGeneratedEmitSchemaRegistry(in map[string]EmitSchema) map[string]EmitSchema {
+	if len(in) == 0 {
+		return map[string]EmitSchema{}
+	}
+	out := make(map[string]EmitSchema, len(in))
+	for eventType, schema := range in {
+		out[eventType] = closeGeneratedEmitSchema(schema)
+	}
+	return out
+}
+
+func closeGeneratedEmitSchema(schema EmitSchema) EmitSchema {
+	schema.Schema = closeGeneratedJSONSchema(schema.Schema)
+	return schema
 }
 
 func ValidateGeneratedEmitToolSchemasForSource(source semanticview.Source) []error {

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -306,6 +306,120 @@ func TestGenerateEmitToolsForActor_ProviderSchemaNormalizesPrecisionRefs(t *test
 	}
 }
 
+func TestGenerateEmitToolsForActor_GeneratedSchemaIsClosedRequiredAndRejectsUndeclaredPayload(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Enums: map[string]runtimecontracts.EnumTypeDecl{
+				"SignalStrength": {Values: []string{"weak", "strong"}},
+			},
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DiscoveryContext": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"source": {Type: "text"},
+						"score":  {Type: "numeric(5,2)"},
+					},
+				},
+			},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"analysis-agent": {
+				ID:         "analysis-agent",
+				Role:       "analysis",
+				EmitEvents: []string{"vertical.derived"},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"vertical.derived": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"opportunity_name":     {Type: "text"},
+						"signal_strength":      {Type: "SignalStrength"},
+						"discovery_context":    {Type: "DiscoveryContext"},
+						"derivation_rationale": {Type: "text"},
+					},
+				},
+			},
+		},
+	})
+	if errs := ValidateGeneratedToolSchemaClosureForSource(source); len(errs) > 0 {
+		t.Fatalf("ValidateGeneratedToolSchemaClosureForSource errors = %#v", errs)
+	}
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+	defs := registry.GenerateEmitToolsForActor(models.AgentConfig{
+		ID:         "analysis-agent",
+		Role:       "analysis",
+		EmitEvents: []string{"vertical.derived"},
+	}, nil)
+	if len(defs) != 1 {
+		t.Fatalf("tool count = %d, want 1 (%#v)", len(defs), defs)
+	}
+	schema := defs[0].Schema.(map[string]any)
+	required := requiredSchemaSet(schema["required"])
+	for _, field := range []string{"opportunity_name", "signal_strength", "discovery_context", "derivation_rationale"} {
+		if _, ok := required[field]; !ok {
+			t.Fatalf("generated emit schema missing required field %s in %#v", field, schema["required"])
+		}
+	}
+	props := schema["properties"].(map[string]any)
+	if got := props["signal_strength"].(map[string]any)["enum"]; len(schemaEnumValues(got)) != 2 {
+		t.Fatalf("signal_strength enum = %#v, want two values", got)
+	}
+	contextSchema := props["discovery_context"].(map[string]any)
+	if got := contextSchema["additionalProperties"]; got != false {
+		t.Fatalf("discovery_context additionalProperties = %#v, want false", got)
+	}
+	if err := ValidatePayloadAgainstSchema(schema, map[string]any{
+		"opportunity_name":     "AP automation",
+		"signal_strength":      "strong",
+		"discovery_context":    map[string]any{"source": "call", "score": 98.5},
+		"derivation_rationale": "evidence",
+		"vertical_id":          "parent-vertical",
+	}); err == nil {
+		t.Fatal("generated emit schema accepted undeclared vertical_id")
+	}
+	if err := ValidatePayloadAgainstSchema(schema, map[string]any{
+		"opportunity_name":     "AP automation",
+		"discovery_context":    map[string]any{"source": "call", "score": 98.5},
+		"derivation_rationale": "evidence",
+	}); err == nil {
+		t.Fatal("generated emit schema accepted missing declared signal_strength")
+	}
+}
+
+func TestGeneratedToolSchemaClosureRejectsOpenOrPartialObjectSchemas(t *testing.T) {
+	errs := validateGeneratedJSONSchema("tool.input", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"value": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"mode": map[string]any{"type": "string", "enum": []any{}},
+				},
+				"additionalProperties": false,
+			},
+		},
+		"additionalProperties": false,
+	})
+	got := strings.Join(generatedSchemaClosureErrorStrings(errs), "\n")
+	for _, want := range []string{
+		"tool.input object schema must require declared property value",
+		"tool.input.properties.value object schema must require declared property mode",
+		"tool.input.properties.value.properties.mode enum schema must declare at least one allowed value",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("errors = %q, want %q", got, want)
+		}
+	}
+}
+
+func generatedSchemaClosureErrorStrings(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, err.Error())
+	}
+	return out
+}
+
 func TestValidateGeneratedEmitToolSchemasForSourceRejectsUnloweredContractRefs(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -44,11 +44,12 @@ func TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent(t *testing.
 		},
 	})
 	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
-
-	tools := registry.GenerateEmitToolsForActor(models.AgentConfig{
+	actor := models.AgentConfig{
 		ID:   "campaign-coordinator",
 		Role: "campaign_coordinator",
-	}, nil)
+	}
+
+	tools := registry.GenerateEmitToolsForActor(actor, nil)
 	for _, def := range tools {
 		if def.Name == "emit_scan_requested" {
 			if strings.TrimSpace(def.Usage) == "" {
@@ -56,6 +57,23 @@ func TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent(t *testing.
 			}
 			if strings.Contains(strings.ToLower(def.Usage), "cel") {
 				t.Fatalf("emit usage should not mention CEL: %q", def.Usage)
+			}
+			schema := def.Schema.(map[string]any)
+			if err := ValidatePayloadAgainstSchema(schema, map[string]any{
+				"entity_id": "scan-1",
+				"extra":     "must fail provider-visible schema",
+			}); err == nil {
+				t.Fatal("role-fallback delivered emit schema accepted undeclared field")
+			}
+			_, runtimeSchema, ok := registry.EventSchemaForActorTool(actor, "emit_scan_requested")
+			if !ok {
+				t.Fatal("role-fallback runtime schema not found")
+			}
+			if err := ValidatePayloadAgainstSchema(runtimeSchema.Schema, map[string]any{
+				"entity_id": "scan-1",
+				"extra":     "must fail runtime schema",
+			}); err == nil {
+				t.Fatal("role-fallback runtime emit schema accepted undeclared field")
 			}
 			return
 		}

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -341,23 +341,6 @@ func runtimeToolSchemaForName(defs []llm.ToolDefinition, name string) (map[strin
 	return nil, false
 }
 
-func pruneSchemaUnknownKeys(payload map[string]any, schema map[string]any) map[string]any {
-	if payload == nil {
-		return map[string]any{}
-	}
-	props := schemaProperties(schema["properties"])
-	if len(props) == 0 {
-		return payload
-	}
-	out := make(map[string]any, len(payload))
-	for key, value := range payload {
-		if _, ok := props[key]; ok {
-			out[key] = value
-		}
-	}
-	return out
-}
-
 func payloadTouchesSchemaProps(payload map[string]any, schema map[string]any) bool {
 	if len(payload) == 0 || schema == nil {
 		return false

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -309,6 +309,50 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 	}
 }
 
+func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"save_entity_field"}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	source := semanticview.Wrap(bundle)
+	if errs := runtimetools.ValidateGeneratedToolSchemaClosureForSource(source); len(errs) > 0 {
+		t.Fatalf("ValidateGeneratedToolSchemaClosureForSource errors = %#v", errs)
+	}
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
+	saveSchema := names["save_validation_case_business_brief"].Schema.(map[string]any)
+	if err := runtimetools.ValidatePayloadAgainstSchema(saveSchema, map[string]any{
+		"value": map[string]any{
+			"summary":    "provider-side",
+			"confidence": 7,
+			"notes":      "undeclared",
+		},
+	}); err == nil {
+		t.Fatal("provider-visible generated save schema accepted undeclared nested key")
+	}
+
+	entityID := uuid.NewString()
+	seedEntityStateRow(t, db, entityID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
+		"status":         "open",
+		"business_brief": map[string]any{"summary": "before", "confidence": 1},
+	}, time.Now().UTC())
+	currentCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-current",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(entityID).WithFlowInstance("validation/inst-1"))
+	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
+		"value": map[string]any{
+			"summary":    "after",
+			"confidence": 9,
+			"notes":      "runtime bypass must reject",
+		},
+	}); err == nil {
+		t.Fatal("runtime execution accepted undeclared nested key")
+	}
+	if got := persistedEntityField(t, db, entityID, "business_brief"); strings.Contains(got, "after") || strings.Contains(got, "runtime bypass") {
+		t.Fatalf("runtime validation failure still mutated entity: %s", got)
+	}
+}
+
 func TestRoleScopedEntityTools_NonOptedActorKeepsLegacySurface(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"get_entity", "query_entities"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, false)

--- a/internal/runtime/tools/generated_schema_closure.go
+++ b/internal/runtime/tools/generated_schema_closure.go
@@ -1,0 +1,179 @@
+package tools
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimeauthority "swarm/internal/runtime/authority"
+	models "swarm/internal/runtime/core/actors"
+	llm "swarm/internal/runtime/llm"
+	"swarm/internal/runtime/semanticview"
+	runtimesharedjson "swarm/internal/runtime/sharedjson"
+)
+
+// ValidateGeneratedToolSchemaClosureForSource enforces the Path alpha generated
+// tool-schema invariants at the boot/static boundary. It intentionally covers
+// generated role-scoped entity tools and generated emit tools, not transitional
+// legacy generic entity tools.
+func ValidateGeneratedToolSchemaClosureForSource(source semanticview.Source) []error {
+	if source == nil {
+		return nil
+	}
+	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
+	actors := providerSchemaValidationActors(source)
+	var errs []error
+	for _, actor := range actors {
+		errs = append(errs, validateGeneratedRoleScopedEntitySchemasForActor(source, actor)...)
+		for _, tool := range registry.GenerateEmitToolsForActor(actor, nil) {
+			errs = append(errs, validateGeneratedToolDefinitionSchema("agent "+strings.TrimSpace(actor.ID), tool)...)
+		}
+	}
+	return errs
+}
+
+func validateGeneratedRoleScopedEntitySchemasForActor(source semanticview.Source, actor models.AgentConfig) []error {
+	if !roleScopedEntityToolsEnabledForActor(source, actor) {
+		return nil
+	}
+	contract, ok := resolveEntityToolContract(source, &actor)
+	if !ok {
+		return nil
+	}
+	entries := roleScopedEntityToolSchemaEntriesForActor(source, actor, contract)
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var errs []error
+	for _, name := range names {
+		entry := entries[name]
+		location := fmt.Sprintf("agent %s tool %s", strings.TrimSpace(actor.ID), strings.TrimSpace(name))
+		errs = append(errs, validateGeneratedJSONSchema(location+" input", entry.InputSchema)...)
+		if len(entry.OutputSchema) > 0 {
+			errs = append(errs, validateGeneratedJSONSchema(location+" output", entry.OutputSchema)...)
+		}
+	}
+	return errs
+}
+
+func validateGeneratedToolDefinitionSchema(location string, tool llm.ToolDefinition) []error {
+	if err := llm.ValidateProviderToolSchema(tool.Name, tool.Schema); err != nil {
+		return []error{fmt.Errorf("%s: %w", strings.TrimSpace(location), err)}
+	}
+	schema, ok := tool.Schema.(map[string]any)
+	if !ok {
+		if tool.Schema == nil {
+			return nil
+		}
+		return []error{fmt.Errorf("%s tool %s input schema must be an object, got %T", strings.TrimSpace(location), strings.TrimSpace(tool.Name), tool.Schema)}
+	}
+	return validateGeneratedJSONSchema(fmt.Sprintf("%s tool %s input", strings.TrimSpace(location), strings.TrimSpace(tool.Name)), schema)
+}
+
+func validateGeneratedJSONSchema(location string, schema map[string]any) []error {
+	var errs []error
+	validateGeneratedJSONSchemaNode(strings.TrimSpace(location), schema, &errs)
+	return errs
+}
+
+func closeGeneratedJSONSchema(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	closed := deepCloneMap(schema)
+	closeGeneratedJSONSchemaNode(closed)
+	return closed
+}
+
+func closeGeneratedJSONSchemaNode(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+	props := schemaProperties(schema["properties"])
+	required := make([]string, 0, len(props))
+	for name, child := range props {
+		required = append(required, name)
+		closeGeneratedJSONSchemaNode(child)
+	}
+	sort.Strings(required)
+	schemaType := strings.TrimSpace(asString(schema["type"]))
+	isObject := schemaType == "object" || len(props) > 0 || len(required) > 0
+	if isObject {
+		if _, ok := schema["type"]; !ok {
+			schema["type"] = "object"
+		}
+		schema["additionalProperties"] = false
+		if len(required) > 0 {
+			schema["required"] = required
+		} else {
+			delete(schema, "required")
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		closeGeneratedJSONSchemaNode(items)
+	}
+}
+
+func validateGeneratedJSONSchemaNode(path string, schema map[string]any, errs *[]error) {
+	if schema == nil {
+		return
+	}
+	schemaType := strings.TrimSpace(asString(schema["type"]))
+	props := schemaProperties(schema["properties"])
+	required := requiredSchemaSet(schema["required"])
+	isObject := schemaType == "object" || len(props) > 0 || len(required) > 0
+	if isObject {
+		if schema["additionalProperties"] != false {
+			*errs = append(*errs, fmt.Errorf("%s object schema must set additionalProperties=false", path))
+		}
+		for name := range props {
+			if _, ok := required[name]; !ok {
+				*errs = append(*errs, fmt.Errorf("%s object schema must require declared property %s", path, name))
+			}
+		}
+		for name := range required {
+			if _, ok := props[name]; !ok {
+				*errs = append(*errs, fmt.Errorf("%s required property %s is not declared", path, name))
+			}
+		}
+	}
+	if enumRaw, ok := schema["enum"]; ok {
+		if len(schemaEnumValues(enumRaw)) == 0 {
+			*errs = append(*errs, fmt.Errorf("%s enum schema must declare at least one allowed value", path))
+		}
+	}
+	for name, child := range props {
+		validateGeneratedJSONSchemaNode(path+".properties."+name, child, errs)
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		validateGeneratedJSONSchemaNode(path+".items", items, errs)
+	}
+}
+
+func requiredSchemaSet(raw any) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range runtimesharedjson.RequiredList(raw) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func schemaEnumValues(raw any) []any {
+	switch values := raw.(type) {
+	case []any:
+		return values
+	case []string:
+		out := make([]any, 0, len(values))
+		for _, value := range values {
+			out = append(out, value)
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -14,12 +14,14 @@ func builtinRegisteredTools(source semanticview.Source, actor *models.AgentConfi
 	out := make(map[string]RegisteredTool, len(entries))
 	for name, entry := range entries {
 		out[name] = RegisteredTool{
-			Name:        strings.TrimSpace(name),
-			Category:    strings.TrimSpace(entry.Category),
-			Description: strings.TrimSpace(entry.Description),
-			Usage:       runtimeOwnedToolUsage(name),
-			HandlerType: implementationPlatformBuiltin,
-			InputSchema: deepCloneMap(entry.InputSchema),
+			Name:            strings.TrimSpace(name),
+			Category:        strings.TrimSpace(entry.Category),
+			Description:     strings.TrimSpace(entry.Description),
+			Usage:           runtimeOwnedToolUsage(name),
+			HandlerType:     implementationPlatformBuiltin,
+			InputSchema:     deepCloneMap(entry.InputSchema),
+			OutputSchema:    deepCloneMap(entry.OutputSchema),
+			GeneratedSchema: entry.GeneratedSchema,
 		}
 	}
 	return out
@@ -482,7 +484,7 @@ func entityContractJSONSchema(contract entityruntime.Contract, typeRef string, s
 	case deliveryNamedType(contract, typeRef):
 		typeName := deliveryTypeName(contract, typeRef)
 		if _, ok := seen[typeName]; ok {
-			return map[string]any{"type": "object"}
+			return ObjectSchema(map[string]any{})
 		}
 		seen[typeName] = struct{}{}
 		named := contract.Types.Types[typeName]

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -29,6 +29,7 @@ type RegisteredTool struct {
 	HandlerType        implementationClass
 	InputSchema        map[string]any
 	OutputSchema       map[string]any
+	GeneratedSchema    bool
 	HTTP               *runtimecontracts.HTTPToolSpec
 	ResponseMapping    map[string]any
 	Credentials        []string
@@ -53,10 +54,11 @@ func toolDefinitionsForRuntime(source semanticview.Source, discovered map[string
 	for _, name := range names {
 		entry := entries[name]
 		defs = append(defs, llm.ToolDefinition{
-			Name:        name,
-			Description: strings.TrimSpace(entry.Description),
-			Usage:       strings.TrimSpace(entry.Usage),
-			Schema:      deepCloneJSONValue(entry.InputSchema),
+			Name:            name,
+			Description:     strings.TrimSpace(entry.Description),
+			Usage:           strings.TrimSpace(entry.Usage),
+			Schema:          deepCloneJSONValue(entry.InputSchema),
+			GeneratedSchema: entry.GeneratedSchema,
 		})
 	}
 	return defs, nil
@@ -79,10 +81,11 @@ func toolDefinitionsForActor(source semanticview.Source, actor models.AgentConfi
 	for _, name := range names {
 		entry := entries[name]
 		defs = append(defs, llm.ToolDefinition{
-			Name:        name,
-			Description: strings.TrimSpace(entry.Description),
-			Usage:       strings.TrimSpace(entry.Usage),
-			Schema:      deepCloneJSONValue(entry.InputSchema),
+			Name:            name,
+			Description:     strings.TrimSpace(entry.Description),
+			Usage:           strings.TrimSpace(entry.Usage),
+			Schema:          deepCloneJSONValue(entry.InputSchema),
+			GeneratedSchema: entry.GeneratedSchema,
 		})
 	}
 	return defs, nil

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -82,11 +82,19 @@ func roleScopedEntityToolSchemaEntriesForActor(source semanticview.Source, actor
 
 func roleScopedEntityToolSchemaEntry(contract entityruntime.Contract, spec roleScopedEntityToolSpec) ContractSchemaEntry {
 	entry := ContractSchemaEntry{
-		Category:    "entity_persistence",
-		Description: roleScopedEntityToolDescription(spec),
-		InputSchema: ObjectSchema(map[string]any{}),
+		Category:        "entity_persistence",
+		Description:     roleScopedEntityToolDescription(spec),
+		InputSchema:     ObjectSchema(map[string]any{}),
+		GeneratedSchema: true,
 	}
-	if spec.Kind == roleScopedEntityToolSaveField || spec.Kind == roleScopedEntityToolUpdatePath {
+	switch spec.Kind {
+	case roleScopedEntityToolReadWhole:
+		entry.OutputSchema = roleScopedEntityWholeReadOutputSchema(contract)
+	case roleScopedEntityToolReadField:
+		if decl, err := entityruntime.FieldDecl(contract, spec.Field); err == nil {
+			entry.OutputSchema = entityContractJSONSchema(contract, decl.Type, map[string]struct{}{})
+		}
+	case roleScopedEntityToolSaveField, roleScopedEntityToolUpdatePath:
 		typeRef := ""
 		if spec.Subpath == "" {
 			if decl, err := entityruntime.FieldDecl(contract, spec.Field); err == nil {
@@ -98,8 +106,33 @@ func roleScopedEntityToolSchemaEntry(contract entityruntime.Contract, spec roleS
 		entry.InputSchema = ObjectSchema(map[string]any{
 			"value": entityContractJSONSchema(contract, typeRef, map[string]struct{}{}),
 		}, "value")
+		entry.OutputSchema = ObjectSchema(map[string]any{
+			"entity_id": map[string]any{"type": "string"},
+			"field":     map[string]any{"type": "string"},
+			"revision":  map[string]any{"type": "integer"},
+		}, "entity_id", "field", "revision")
 	}
 	return entry
+}
+
+func roleScopedEntityWholeReadOutputSchema(contract entityruntime.Contract) map[string]any {
+	fieldProps := make(map[string]any, len(contract.Entity.Fields))
+	requiredFields := make([]string, 0, len(contract.Entity.Fields))
+	for _, field := range entityruntime.FieldNames(contract) {
+		decl, err := entityruntime.FieldDecl(contract, field)
+		if err != nil {
+			continue
+		}
+		fieldProps[field] = entityContractJSONSchema(contract, decl.Type, map[string]struct{}{})
+		requiredFields = append(requiredFields, field)
+	}
+	return ObjectSchema(map[string]any{
+		"entity_id":     map[string]any{"type": "string"},
+		"flow_instance": map[string]any{"type": "string"},
+		"entity_type":   map[string]any{"type": "string"},
+		"current_state": map[string]any{"type": "string"},
+		"fields":        ObjectSchema(fieldProps, requiredFields...),
+	}, "entity_id", "flow_instance", "entity_type", "current_state", "fields")
 }
 
 func roleScopedEntityToolDescription(spec roleScopedEntityToolSpec) string {

--- a/internal/runtime/tools/validator.go
+++ b/internal/runtime/tools/validator.go
@@ -46,23 +46,26 @@ func (v *ToolInputValidator) Validate(actor *models.AgentConfig, name string, in
 		return defsErr
 	}
 
-	contractSchema, foundContract := validatorToolSchemaForName(defs, name)
+	contractSchema, generatedSchema, foundContract := validatorToolSchemaForName(defs, name)
 	if foundContract && contractSchema != nil {
-		return ValidatePayloadAgainstSchema(contractSchema, validatorPruneSchemaUnknownKeys(payload, contractSchema))
+		if !generatedSchema {
+			payload = validatorPruneSchemaUnknownKeys(payload, contractSchema)
+		}
+		return ValidatePayloadAgainstSchema(contractSchema, payload)
 	}
 	return nil
 }
 
-func validatorToolSchemaForName(defs []llm.ToolDefinition, name string) (map[string]any, bool) {
+func validatorToolSchemaForName(defs []llm.ToolDefinition, name string) (map[string]any, bool, bool) {
 	name = normalizeNativeToolName(name)
 	for _, def := range defs {
 		if strings.TrimSpace(def.Name) != name {
 			continue
 		}
 		schema, ok := def.Schema.(map[string]any)
-		return schema, ok
+		return schema, def.GeneratedSchema, ok
 	}
-	return nil, false
+	return nil, false, false
 }
 
 func validatorPruneSchemaUnknownKeys(payload map[string]any, schema map[string]any) map[string]any {

--- a/internal/runtime/tools/validator_test.go
+++ b/internal/runtime/tools/validator_test.go
@@ -86,3 +86,39 @@ func TestToolInputValidator_UsesActorScopedDefinitionsWhenAvailable(t *testing.T
 		t.Fatal("Validate(nil actor) succeeded, want schema rejection for child_only")
 	}
 }
+
+func TestToolInputValidator_RejectsUnknownKeysAgainstClosedSchema(t *testing.T) {
+	validator := NewToolInputValidator(func(*models.AgentConfig) ([]llm.ToolDefinition, error) {
+		return []llm.ToolDefinition{{
+			Name:            "save_validation_case_business_brief",
+			GeneratedSchema: true,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"summary":    map[string]any{"type": "string"},
+							"confidence": map[string]any{"type": "integer"},
+						},
+						"required":             []any{"summary", "confidence"},
+						"additionalProperties": false,
+					},
+				},
+				"required":             []any{"value"},
+				"additionalProperties": false,
+			},
+		}}, nil
+	})
+
+	err := validator.Validate(nil, "save_validation_case_business_brief", map[string]any{
+		"value": map[string]any{
+			"summary":    "ok",
+			"confidence": 8,
+			"notes":      "must not be silently pruned",
+		},
+	})
+	if err == nil {
+		t.Fatal("Validate() succeeded, want undeclared nested key rejection")
+	}
+}

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -22,10 +22,11 @@ type WorkflowContractValidationOptions struct {
 }
 
 type WorkflowContractValidationResult struct {
-	BootReport                  runtimebootverify.Report
-	ToolImplementationWarnings  []error
-	MissingEmitSchemaEventTypes []string
-	GeneratedEmitSchemaErrors   []error
+	BootReport                       runtimebootverify.Report
+	ToolImplementationWarnings       []error
+	MissingEmitSchemaEventTypes      []string
+	GeneratedEmitSchemaErrors        []error
+	GeneratedToolSchemaClosureErrors []error
 }
 
 func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Store) WorkflowContractValidationOptions {
@@ -82,6 +83,10 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	result.GeneratedEmitSchemaErrors = runtimetools.ValidateGeneratedEmitToolSchemasForSource(source)
 	if len(result.GeneratedEmitSchemaErrors) > 0 {
 		return result, fmt.Errorf("generated emit tool schema validation failed:\n%s", formatValidationErrors(result.GeneratedEmitSchemaErrors))
+	}
+	result.GeneratedToolSchemaClosureErrors = runtimetools.ValidateGeneratedToolSchemaClosureForSource(source)
+	if len(result.GeneratedToolSchemaClosureErrors) > 0 {
+		return result, fmt.Errorf("generated tool schema closure validation failed:\n%s", formatValidationErrors(result.GeneratedToolSchemaClosureErrors))
 	}
 
 	return result, nil

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -133,14 +133,14 @@ func TestValidateWorkflowContractSurfaceRejectsInvalidGeneratedEmitToolSchema(t 
 	source := semanticview.Wrap(bundle)
 
 	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(nil))
-	if err == nil || !strings.Contains(err.Error(), "generated emit tool schema validation failed") {
-		t.Fatalf("ValidateWorkflowContractSurface error = %v, want generated schema failure", err)
+	if err == nil || !strings.Contains(err.Error(), "generated_tool_schema_closure") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want boot generated schema closure failure", err)
 	}
-	if len(result.GeneratedEmitSchemaErrors) != 1 {
-		t.Fatalf("GeneratedEmitSchemaErrors = %#v, want one error", result.GeneratedEmitSchemaErrors)
+	if len(result.BootReport.Errors()) != 1 {
+		t.Fatalf("BootReport errors = %#v, want one error", result.BootReport.Errors())
 	}
-	if got := result.GeneratedEmitSchemaErrors[0].Error(); !strings.Contains(got, "unsupported JSON Schema type \"NotDeclared\"") {
-		t.Fatalf("GeneratedEmitSchemaErrors[0] = %q, want unsupported type", got)
+	if got := result.BootReport.Errors()[0].Message; !strings.Contains(got, "unsupported JSON Schema type \"NotDeclared\"") {
+		t.Fatalf("BootReport error = %q, want unsupported type", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #582.

Part of #568.

This PR enforces the approved #582 first-slice boundary for generated Path alpha schemas:

- Generated role-scoped entity tool schemas and generated emit tool schemas are recursively closed with `additionalProperties: false`.
- Generated schemas require every declared property and preserve enum constraints.
- Runtime validation no longer prunes unknown keys for generated closed schemas, while legacy/non-generated tools retain their existing validation behavior.
- Bootverify/workflow validation now fails generated schema closure drift before runtime launch.

## Governing refs/context

Exact governing spec references from the approved gate:

- `docs/specs/swarm-platform/platform/contracts/review/platform-spec.role-scoped-tool-contracts.yaml`
- `proposal.schema_closure_rules`
- `resolved_decisions.q6_emit_alignment`

Binding tracker/gate context:

- #582 issue body and Pre-Implementation Coverage Audit.
- Parent #568 Path alpha role-scoped typed tool contract migration.
- Approved gate result: `approved as first slice`.

## Semantic migration

New canonical enforcement points:

- Generated schema closure/static validation: `ValidateGeneratedToolSchemaClosureForSource`.
- Generated role-scoped entity schema production: role-scoped entity tool schema entries, including generated input and output schemas.
- Generated emit schema production/runtime lookup: generated emit schemas are closed before provider-visible delivery and runtime emit validation.
- Runtime validation parity: `ToolInputValidator` uses strict no-prune validation only for `GeneratedSchema` tools.

Old non-authoritative paths now invalid for this slice:

- Unknown-key pruning for generated closed schemas.
- Provider-schema compatibility checks that only prove schema syntax, not closure/required/enum invariants.
- Open or partially required generated emit/entity schemas passing boot validation.

Production paths checked:

- Role-scoped save/update/read schema generation.
- Generated emit tool schema generation and runtime emit schema lookup.
- Provider-visible `ToolDefinition` schema delivery metadata.
- Runtime bypass validation for generated tools.
- Bootverify and workflow contract validation.

Migration status: complete for the approved #582 generated schema closure first slice. #579 final universal retirement, Empire #25 prompt residue, and Empire #26/#29 orchestration/authored-contract work remain split.

## Validation

- `go test ./...`
