### PR TITLE
[agent-a][issue #590] Bind selected-contract fork source state

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -365,9 +365,9 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 2
 	}
-	if strings.TrimSpace(*contractsPath) != "" && !*dryRun {
+	if strings.TrimSpace(*contractsPath) != "" && !*dryRun && !*materializeOnly {
 		if out != nil {
-			fmt.Fprintln(out, "fork failed: --contracts is only supported for non-mutating --dry-run admission")
+			fmt.Fprintln(out, "fork failed: --contracts is only supported for non-mutating --dry-run admission or --materialize-only binding")
 		}
 		return 2
 	}
@@ -427,9 +427,30 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		return 0
 	}
 	if *materializeOnly {
+		var contractSelection *store.RunForkContractSelection
+		if contracts := strings.TrimSpace(*contractsPath); contracts != "" {
+			contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, contracts))
+			if err != nil {
+				if out != nil {
+					fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
+				}
+				return 1
+			}
+			_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
+			if err != nil {
+				if out != nil {
+					fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
+				}
+				return 1
+			}
+			source := semanticview.Wrap(bundle)
+			selection := runtimerunforkadmission.SelectedContractSelection(source, contractsRoot)
+			contractSelection = &selection
+		}
 		result, err := stores.Postgres.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
-			SourceRunID: strings.TrimSpace(*runID),
-			At:          strings.TrimSpace(*at),
+			SourceRunID:       strings.TrimSpace(*runID),
+			At:                strings.TrimSpace(*at),
+			ContractSelection: contractSelection,
 		})
 		if err != nil {
 			if out != nil {
@@ -532,6 +553,14 @@ func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
 			result.DeliveryEventReplay.Owner,
 		)
 	}
+	if result.SelectedContractBinding != nil {
+		fmt.Fprintf(w, "Selected Contract Binding: owner=%s contracts=%s workflow=%s@%s\n",
+			result.SelectedContractBinding.Owner,
+			result.SelectedContractBinding.ContractSelection.ContractsRoot,
+			result.SelectedContractBinding.ContractSelection.WorkflowName,
+			result.SelectedContractBinding.ContractSelection.WorkflowVersion,
+		)
+	}
 }
 
 func printRunForkMaterialization(w io.Writer, result store.RunForkMaterialization) {
@@ -546,6 +575,14 @@ func printRunForkMaterialization(w io.Writer, result store.RunForkMaterializatio
 		result.DeliveryResumeBlocked,
 		result.SourceRunStatusUnchanged,
 	)
+	if result.SelectedContractBinding != nil {
+		fmt.Fprintf(w, "Selected Contract Binding: owner=%s contracts=%s workflow=%s@%s\n",
+			result.SelectedContractBinding.Owner,
+			result.SelectedContractBinding.ContractSelection.ContractsRoot,
+			result.SelectedContractBinding.ContractSelection.WorkflowName,
+			result.SelectedContractBinding.ContractSelection.WorkflowVersion,
+		)
+	}
 }
 
 func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -543,19 +543,18 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 	}
 }
 
-func TestRunForkCommand_ContractsRemainDryRunOnly(t *testing.T) {
+func TestRunForkCommand_ContractsRemainNonExecuting(t *testing.T) {
 	var buf bytes.Buffer
 	code := runForkCommand(context.Background(), t.TempDir(), []string{
-		"--materialize-only",
+		"--activate",
 		"--contracts", t.TempDir(),
 		"--run", uuid.NewString(),
-		"--at", uuid.NewString(),
 	}, &buf)
 	if code != 2 {
 		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
 	}
-	if !strings.Contains(buf.String(), "--contracts is only supported for non-mutating --dry-run admission") {
-		t.Fatalf("output = %q, want dry-run-only contracts failure", buf.String())
+	if !strings.Contains(buf.String(), "--contracts is only supported for non-mutating --dry-run admission or --materialize-only binding") {
+		t.Fatalf("output = %q, want non-executing contracts failure", buf.String())
 	}
 }
 
@@ -605,11 +604,14 @@ func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T)
 	`, runID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
+	repo := repoRoot()
+	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
 	var buf bytes.Buffer
-	code := runForkCommand(ctx, t.TempDir(), []string{
+	code := runForkCommand(ctx, repo, []string{
 		"--materialize-only",
 		"--run", runID,
 		"--at", eventID,
+		"--contracts", contractsRoot,
 		"--json",
 	}, &buf)
 	if code != 0 {
@@ -625,6 +627,16 @@ func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T)
 	if result.ReplayResumeAdmission.Owner != store.RunForkReplayResumeAdmissionOwner || !result.ReplayResumeAdmission.StateOnlyExecutionReady {
 		t.Fatalf("materialization taxonomy = %#v, want canonical owner and state-only ready", result.ReplayResumeAdmission)
 	}
+	if result.SelectedContractBinding == nil {
+		t.Fatalf("SelectedContractBinding = nil; output=%s", buf.String())
+	}
+	if result.SelectedContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
+		result.SelectedContractBinding.ForkRunID != result.ForkRunID ||
+		result.SelectedContractBinding.SourceRunID != runID ||
+		result.SelectedContractBinding.ForkEventID != eventID ||
+		result.SelectedContractBinding.ContractSelection.ContractsRoot != contractsRoot {
+		t.Fatalf("selected contract binding = %#v", result.SelectedContractBinding)
+	}
 	var forkState string
 	if err := db.QueryRowContext(ctx, `
 		SELECT current_state
@@ -635,6 +647,19 @@ func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T)
 	}
 	if forkState != "ready" {
 		t.Fatalf("fork state = %q, want ready", forkState)
+	}
+	var persistedBindingMode string
+	if err := db.QueryRowContext(ctx, `
+		SELECT mode
+		FROM run_fork_selected_contract_bindings
+		WHERE fork_run_id = $1::uuid
+		  AND source_run_id = $2::uuid
+		  AND fork_event_id = $3::uuid
+	`, result.ForkRunID, runID, eventID).Scan(&persistedBindingMode); err != nil {
+		t.Fatalf("load selected contract binding row: %v", err)
+	}
+	if persistedBindingMode != "selected_contracts" {
+		t.Fatalf("binding mode = %q, want selected_contracts", persistedBindingMode)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2702,6 +2702,13 @@ platform_tables:
         \ idx_events_flow (flow_instance, event_name) WHERE flow_instance IS NOT NULL,\n    INDEX idx_events_global (event_name,\
         \ created_at) WHERE scope = 'global',\n    INDEX idx_events_idempotency (idempotency_key) WHERE idempotency_key\
         \ IS NOT NULL,\n    INDEX idx_events_source (source_event_id) WHERE source_event_id IS NOT NULL\n);"
+    run_fork_selected_contract_bindings:
+      description: Durable selected-contract source binding for timestamp forks. One row binds a fork run to the selected
+        contract source identity that was admitted before materialization. This is prerequisite fork-run state for future
+        selected-contract execution; CLI/API arguments, dry-run JSON, and local model output are not semantic owners. It
+        does not authorize handler execution, event/delivery replay, timer, route, session, turn, source-advanced, or
+        contract-swap mutation.
+      ddl: "CREATE TABLE run_fork_selected_contract_bindings (\n    binding_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id      UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id    UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id    UUID NOT NULL REFERENCES events(event_id),\n    mode             TEXT NOT NULL CHECK (mode IN ('selected_contracts')),\n    contracts_root   TEXT NOT NULL,\n    workflow_name    TEXT NOT NULL,\n    workflow_version TEXT NOT NULL,\n    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_bindings_source (source_run_id, fork_event_id)\n);"
     event_deliveries:
       description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
         inherited from the parent event for run-scoped queries.
@@ -3184,6 +3191,8 @@ run_model:
     materialize_only_admission: 'The materialize-only form is the first supported mutating fork slice. It
       consumes the canonical read-only planner, requires execution_ready=true, creates a fork run with
       status=paused and fork lineage, and writes reconstructed entity_state rows under the fork run_id.
+      When selected contracts are provided, it may also persist a durable selected-contract source binding under the
+      fork run_id after loading and validating that selected source, but that binding is prerequisite metadata only.
       It does not mark the source run forked, freeze the source run, redeliver pending work, resume event
       processing, change contracts, or mutate delivery/session/timer/route state. Materialized fork current-state
       rows start a new fork-local revision sequence at revision=1; source-at-T entity_state.revision is not
@@ -3219,7 +3228,8 @@ run_model:
       is ready.'
     selected_contract_execution_model: 'Selected-contract fork execution ownership is a non-mutating model until
       separately approved for runtime mutation. The canonical owner consumes contract_frontier_admission output only as
-      prerequisite evidence, names the future selected-contract execution owner, classifies invalid paths such as copying
+      prerequisite evidence, names the durable selected-contract binding owner that future execution must consume,
+      names the future selected-contract execution owner, classifies invalid paths such as copying
       source event_deliveries or source events, and records the required future consumers for fork-local run_id context,
       handler execution, fork-local event/delivery writes, receipts, dead letters, idempotency, emitted follow-up events,
       timers, routes, sessions, turns, source advancement, and contract-swap boot/resume. The model MUST NOT create

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -242,6 +242,7 @@ nodes:
       - non-agent delivery replay remains admission-policy only; source node/system/platform/internal delivery facts and committed replay-scope markers are lineage-only or named fail-closed blockers until runtime handler replay ownership is approved
       - selected-contract timestamp-fork re-admission needs a non-mutating contract/frontier/route admission owner before node/system delivery facts can become executable fork work
       - selected-contract fork execution needs a non-mutating owner model before mutation; the model must consume frontier admission as evidence only and classify contract binding, fork run_id context, handler execution, receipts, dead letters, idempotency, emitted follow-ups, timers, routes, sessions, source-advanced policy, and contract-swap boot/resume
+      - selected-contract fork execution needs a durable fork-run selected-source binding owner; CLI/API arguments, dry-run JSON, and local model output are not authoritative for future execution
     representative_issues:
       - 564
       - 565
@@ -251,6 +252,7 @@ nodes:
       - 577
       - 583
       - 585
+      - 590
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -35,9 +35,9 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		FrontierEvents:       selectedContractFrontierEvents(admission.FrontierEvents),
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
-			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
-			Owner:       store.RunForkSelectedContractExecutionOwner,
-			Reason:      "future execution must bind the selected contract source to the fork before handlers run",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractBindingOwner,
+			Reason:      "future execution must consume the durable selected contract source bound to the fork run before handlers run",
 		},
 		RequiredConsumers: selectedContractExecutionRequiredConsumers(),
 		BlockedSiblings:   selectedContractExecutionBlockedSiblings(),

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -47,6 +47,11 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 		model.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly {
 		t.Fatalf("admission use = owner:%q use:%q", model.AdmissionOwner, model.AdmissionUse)
 	}
+	if model.ContractBinding.Concept != "selected_contract_binding" ||
+		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite ||
+		model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner {
+		t.Fatalf("contract binding boundary = %#v, want canonical selected-contract binding owner", model.ContractBinding)
+	}
 	if model.FrontierEventCount != 1 || len(model.FrontierEvents) != 1 {
 		t.Fatalf("frontier events = %#v", model.FrontierEvents)
 	}

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -34,6 +34,7 @@ type RunForkActivation struct {
 	UnsupportedBlockers      []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`
 	MaterializedEntityCount  int                               `json:"materialized_entity_count"`
 	DeliveryEventReplay      *RunForkDeliveryEventReplayResult `json:"delivery_event_replay,omitempty"`
+	SelectedContractBinding  *RunForkSelectedContractBinding   `json:"selected_contract_binding,omitempty"`
 	SourceAdvancedAfterFork  bool                              `json:"source_advanced_after_fork_point,omitempty"`
 	RepeatedActivationFailed bool                              `json:"repeated_activation_failed,omitempty"`
 }
@@ -130,6 +131,14 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	}
 	if len(lineage.EntityIDs) == 0 {
 		return result, fmt.Errorf("fork activation requires materialized fork entity_state rows")
+	}
+	if catalog.hasColumns(runForkSelectedContractBindingTable, "fork_run_id", "source_run_id", "fork_event_id", "mode", "contracts_root", "workflow_name", "workflow_version", "created_at") {
+		binding, err := loadRunForkSelectedContractBinding(ctx, tx, lineage.ForkRunID)
+		if err == nil {
+			result.SelectedContractBinding = &binding
+		} else if err != sql.ErrNoRows {
+			return result, fmt.Errorf("load selected contract binding: %w", err)
+		}
 	}
 
 	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: lineage.SourceRunID, At: lineage.ForkEventID})

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -18,21 +18,23 @@ const (
 )
 
 type RunForkMaterializeRequest struct {
-	SourceRunID string
-	At          string
+	SourceRunID       string
+	At                string
+	ContractSelection *RunForkContractSelection
 }
 
 type RunForkMaterialization struct {
-	SourceRunID              string                       `json:"source_run_id"`
-	ForkRunID                string                       `json:"fork_run_id"`
-	ForkRunStatus            string                       `json:"fork_run_status"`
-	ForkPoint                RunForkPoint                 `json:"fork_point"`
-	MaterializedEntityCount  int                          `json:"materialized_entity_count"`
-	ExecutionReady           bool                         `json:"execution_ready"`
-	ReplayResumeAdmission    RunForkReplayResumeAdmission `json:"replay_resume_admission"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker  `json:"unsupported_blockers,omitempty"`
-	DeliveryResumeBlocked    bool                         `json:"delivery_resume_blocked"`
-	SourceRunStatusUnchanged bool                         `json:"source_run_status_unchanged"`
+	SourceRunID              string                          `json:"source_run_id"`
+	ForkRunID                string                          `json:"fork_run_id"`
+	ForkRunStatus            string                          `json:"fork_run_status"`
+	ForkPoint                RunForkPoint                    `json:"fork_point"`
+	MaterializedEntityCount  int                             `json:"materialized_entity_count"`
+	ExecutionReady           bool                            `json:"execution_ready"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission    `json:"replay_resume_admission"`
+	SelectedContractBinding  *RunForkSelectedContractBinding `json:"selected_contract_binding,omitempty"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker     `json:"unsupported_blockers,omitempty"`
+	DeliveryResumeBlocked    bool                            `json:"delivery_resume_blocked"`
+	SourceRunStatusUnchanged bool                            `json:"source_run_status_unchanged"`
 }
 
 type runForkEntityMetadata struct {
@@ -77,6 +79,17 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 	}
 	if err := s.requireRunForkMaterializerCapabilities(ctx); err != nil {
 		return RunForkMaterialization{}, err
+	}
+	var selection *RunForkContractSelection
+	if req.ContractSelection != nil {
+		normalized, err := normalizeRunForkSelectedContractSelection(*req.ContractSelection)
+		if err != nil {
+			return RunForkMaterialization{}, err
+		}
+		selection = &normalized
+		if err := s.requireRunForkSelectedContractBindingCapabilities(ctx); err != nil {
+			return RunForkMaterialization{}, err
+		}
 	}
 	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{
 		SourceRunID: strings.TrimSpace(req.SourceRunID),
@@ -135,6 +148,19 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 			return RunForkMaterialization{}, err
 		}
 	}
+	var selectedContractBinding *RunForkSelectedContractBinding
+	if selection != nil {
+		binding, err := insertRunForkSelectedContractBinding(ctx, tx, RunForkSelectedContractBindingRequest{
+			ForkRunID:         forkRunID,
+			SourceRunID:       plan.SourceRunID,
+			ForkEventID:       plan.ForkPoint.EventID,
+			ContractSelection: *selection,
+		}, now)
+		if err != nil {
+			return RunForkMaterialization{}, err
+		}
+		selectedContractBinding = &binding
+	}
 	if err := tx.Commit(); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit fork materialization: %w", err)
 	}
@@ -147,6 +173,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 		MaterializedEntityCount:  len(plan.Entities),
 		ExecutionReady:           true,
 		ReplayResumeAdmission:    plan.ReplayResumeAdmission,
+		SelectedContractBinding:  selectedContractBinding,
 		DeliveryResumeBlocked:    true,
 		SourceRunStatusUnchanged: true,
 	}, nil

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -221,6 +221,130 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	}
 }
 
+func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000510, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+
+	selection := RunForkContractSelection{
+		Mode:            "selected_contracts",
+		ContractsRoot:   "/tmp/selected-contracts",
+		WorkflowName:    "selected-workflow",
+		WorkflowVersion: "v2",
+	}
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                eventID,
+		ContractSelection: &selection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if materialized.SelectedContractBinding == nil {
+		t.Fatalf("SelectedContractBinding = nil")
+	}
+	if materialized.SelectedContractBinding.Owner != RunForkSelectedContractBindingOwner ||
+		materialized.SelectedContractBinding.ForkRunID != materialized.ForkRunID ||
+		materialized.SelectedContractBinding.SourceRunID != sourceRunID ||
+		materialized.SelectedContractBinding.ForkEventID != eventID {
+		t.Fatalf("materialized selected binding = %#v", materialized.SelectedContractBinding)
+	}
+
+	loaded, err := pg.RequireRunForkSelectedContractBinding(ctx, materialized.ForkRunID)
+	if err != nil {
+		t.Fatalf("RequireRunForkSelectedContractBinding: %v", err)
+	}
+	if loaded.Owner != RunForkSelectedContractBindingOwner ||
+		loaded.ContractSelection.ContractsRoot != selection.ContractsRoot ||
+		loaded.ContractSelection.WorkflowName != selection.WorkflowName ||
+		loaded.ContractSelection.WorkflowVersion != selection.WorkflowVersion {
+		t.Fatalf("loaded selected binding = %#v", loaded)
+	}
+
+	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if activated.SelectedContractBinding == nil ||
+		activated.SelectedContractBinding.Owner != RunForkSelectedContractBindingOwner ||
+		activated.SelectedContractBinding.ForkRunID != materialized.ForkRunID {
+		t.Fatalf("activated selected binding = %#v", activated.SelectedContractBinding)
+	}
+
+	var forkEventCount, forkDeliveryCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkEventCount); err != nil {
+		t.Fatalf("count fork events: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkDeliveryCount); err != nil {
+		t.Fatalf("count fork deliveries: %v", err)
+	}
+	if forkEventCount != 0 || forkDeliveryCount != 0 {
+		t.Fatalf("fork executable work = events:%d deliveries:%d, want 0/0", forkEventCount, forkDeliveryCount)
+	}
+}
+
+func TestRunForkSelectedContractBinding_FailsClosedOnMissingDuplicateAndInvalidSelection(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := pg.RequireRunForkSelectedContractBinding(ctx, uuid.NewString()); err == nil || !strings.Contains(err.Error(), "selected contract binding") {
+		t.Fatalf("RequireRunForkSelectedContractBinding error = %v, want missing binding failure", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000520, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	invalidSelection := RunForkContractSelection{
+		Mode:            "selected_contracts",
+		WorkflowName:    "selected-workflow",
+		WorkflowVersion: "v2",
+	}
+	if _, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                eventID,
+		ContractSelection: &invalidSelection,
+	}); err == nil || !strings.Contains(err.Error(), "contracts_root") {
+		t.Fatalf("MaterializeRunFork invalid selection error = %v, want contracts_root failure", err)
+	}
+
+	validSelection := RunForkContractSelection{
+		Mode:            "selected_contracts",
+		ContractsRoot:   "/tmp/selected-contracts",
+		WorkflowName:    "selected-workflow",
+		WorkflowVersion: "v2",
+	}
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                eventID,
+		ContractSelection: &validSelection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO run_fork_selected_contract_bindings (
+			fork_run_id, source_run_id, fork_event_id,
+			mode, contracts_root, workflow_name, workflow_version
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid,
+			'selected_contracts', '/tmp/duplicate', 'workflow', 'v1'
+		)
+	`, materialized.ForkRunID, sourceRunID, eventID)
+	if err == nil {
+		t.Fatalf("duplicate selected contract binding insert succeeded, want unique failure")
+	}
+}
+
 func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_selected_contract_binding.go
+++ b/internal/store/run_fork_selected_contract_binding.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	RunForkSelectedContractBindingOwner = "store.run_fork.selected_contract_binding"
+
+	runForkSelectedContractBindingTable = "run_fork_selected_contract_bindings"
+)
+
+type RunForkSelectedContractBindingRequest struct {
+	ForkRunID         string
+	SourceRunID       string
+	ForkEventID       string
+	ContractSelection RunForkContractSelection
+}
+
+type RunForkSelectedContractBinding struct {
+	Owner             string                   `json:"owner"`
+	ForkRunID         string                   `json:"fork_run_id"`
+	SourceRunID       string                   `json:"source_run_id"`
+	ForkEventID       string                   `json:"fork_event_id"`
+	ContractSelection RunForkContractSelection `json:"contract_selection"`
+	CreatedAt         time.Time                `json:"created_at"`
+}
+
+func RequireRunForkSelectedContractBindingCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	_ = caps
+	required := map[string][]string{
+		runForkSelectedContractBindingTable: {
+			"binding_id",
+			"fork_run_id",
+			"source_run_id",
+			"fork_event_id",
+			"mode",
+			"contracts_root",
+			"workflow_name",
+			"workflow_version",
+			"created_at",
+		},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run fork selected contract binding requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunForkSelectedContractBindingCapabilities(ctx context.Context) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return RequireRunForkSelectedContractBindingCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) LoadRunForkSelectedContractBinding(ctx context.Context, forkRunID string) (RunForkSelectedContractBinding, bool, error) {
+	if s == nil || s.DB == nil {
+		return RunForkSelectedContractBinding{}, false, fmt.Errorf("postgres store is required")
+	}
+	forkRunID = strings.TrimSpace(forkRunID)
+	if forkRunID == "" {
+		return RunForkSelectedContractBinding{}, false, fmt.Errorf("fork run_id is required")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkSelectedContractBinding{}, false, fmt.Errorf("fork run_id must be a UUID: %w", err)
+	}
+	if err := s.requireRunForkSelectedContractBindingCapabilities(ctx); err != nil {
+		return RunForkSelectedContractBinding{}, false, err
+	}
+	binding, err := loadRunForkSelectedContractBinding(ctx, s.DB, forkRunID)
+	if err == sql.ErrNoRows {
+		return RunForkSelectedContractBinding{}, false, nil
+	}
+	if err != nil {
+		return RunForkSelectedContractBinding{}, false, err
+	}
+	return binding, true, nil
+}
+
+func (s *PostgresStore) RequireRunForkSelectedContractBinding(ctx context.Context, forkRunID string) (RunForkSelectedContractBinding, error) {
+	binding, ok, err := s.LoadRunForkSelectedContractBinding(ctx, forkRunID)
+	if err != nil {
+		return RunForkSelectedContractBinding{}, err
+	}
+	if !ok {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding for fork run %s not found", strings.TrimSpace(forkRunID))
+	}
+	return binding, nil
+}
+
+func insertRunForkSelectedContractBinding(ctx context.Context, tx *sql.Tx, req RunForkSelectedContractBindingRequest, createdAt time.Time) (RunForkSelectedContractBinding, error) {
+	if tx == nil {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding transaction is required")
+	}
+	binding, err := normalizeRunForkSelectedContractBinding(req, createdAt)
+	if err != nil {
+		return RunForkSelectedContractBinding{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_fork_selected_contract_bindings (
+			fork_run_id, source_run_id, fork_event_id,
+			mode, contracts_root, workflow_name, workflow_version, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid,
+			$4, $5, $6, $7, $8
+		)
+	`, binding.ForkRunID, binding.SourceRunID, binding.ForkEventID,
+		binding.ContractSelection.Mode,
+		binding.ContractSelection.ContractsRoot,
+		binding.ContractSelection.WorkflowName,
+		binding.ContractSelection.WorkflowVersion,
+		binding.CreatedAt); err != nil {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("insert selected contract binding: %w", err)
+	}
+	return binding, nil
+}
+
+func loadRunForkSelectedContractBinding(ctx context.Context, querier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, forkRunID string) (RunForkSelectedContractBinding, error) {
+	var binding RunForkSelectedContractBinding
+	var selection RunForkContractSelection
+	err := querier.QueryRowContext(ctx, `
+		SELECT
+			fork_run_id::text,
+			source_run_id::text,
+			fork_event_id::text,
+			mode,
+			contracts_root,
+			workflow_name,
+			workflow_version,
+			created_at
+		FROM run_fork_selected_contract_bindings
+		WHERE fork_run_id = $1::uuid
+	`, forkRunID).Scan(
+		&binding.ForkRunID,
+		&binding.SourceRunID,
+		&binding.ForkEventID,
+		&selection.Mode,
+		&selection.ContractsRoot,
+		&selection.WorkflowName,
+		&selection.WorkflowVersion,
+		&binding.CreatedAt,
+	)
+	if err != nil {
+		return RunForkSelectedContractBinding{}, err
+	}
+	binding.Owner = RunForkSelectedContractBindingOwner
+	binding.ContractSelection = selection
+	return binding, nil
+}
+
+func normalizeRunForkSelectedContractBinding(req RunForkSelectedContractBindingRequest, createdAt time.Time) (RunForkSelectedContractBinding, error) {
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding requires fork run_id")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding fork run_id must be a UUID: %w", err)
+	}
+	sourceRunID := strings.TrimSpace(req.SourceRunID)
+	if sourceRunID == "" {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding requires source run_id")
+	}
+	if _, err := uuid.Parse(sourceRunID); err != nil {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding source run_id must be a UUID: %w", err)
+	}
+	forkEventID := strings.TrimSpace(req.ForkEventID)
+	if forkEventID == "" {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding requires fork event_id")
+	}
+	if _, err := uuid.Parse(forkEventID); err != nil {
+		return RunForkSelectedContractBinding{}, fmt.Errorf("selected contract binding fork event_id must be a UUID: %w", err)
+	}
+	selection, err := normalizeRunForkSelectedContractSelection(req.ContractSelection)
+	if err != nil {
+		return RunForkSelectedContractBinding{}, err
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	return RunForkSelectedContractBinding{
+		Owner:             RunForkSelectedContractBindingOwner,
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       forkEventID,
+		ContractSelection: selection,
+		CreatedAt:         createdAt.UTC(),
+	}, nil
+}
+
+func normalizeRunForkSelectedContractSelection(selection RunForkContractSelection) (RunForkContractSelection, error) {
+	selection.Mode = strings.TrimSpace(selection.Mode)
+	if selection.Mode == "" {
+		selection.Mode = "selected_contracts"
+	}
+	if selection.Mode != "selected_contracts" {
+		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires mode selected_contracts; got %q", selection.Mode)
+	}
+	selection.ContractsRoot = strings.TrimSpace(selection.ContractsRoot)
+	selection.WorkflowName = strings.TrimSpace(selection.WorkflowName)
+	selection.WorkflowVersion = strings.TrimSpace(selection.WorkflowVersion)
+	if selection.ContractsRoot == "" {
+		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires contracts_root")
+	}
+	if selection.WorkflowName == "" {
+		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires workflow_name")
+	}
+	if selection.WorkflowVersion == "" {
+		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires workflow_version")
+	}
+	return selection, nil
+}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -315,6 +315,8 @@ func platformTableOrder(name string) int {
 		return 5
 	case "events":
 		return 10
+	case "run_fork_selected_contract_bindings":
+		return 15
 	case "dead_letters":
 		return 20
 	case "agents":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -493,6 +493,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 5
 	case "events":
 		return 10
+	case "run_fork_selected_contract_bindings":
+		return 15
 	case "dead_letters":
 		return 20
 	case "agents":


### PR DESCRIPTION
## Summary

Closes #590.

This PR implements the approved first slice for non-mutating selected-contract timestamp-fork source binding. It adds a store-backed selected-contract binding owner keyed by fork run/source lineage, persists that binding during `--materialize-only --contracts`, and exposes the binding through materialization/activation JSON without enabling handler execution, delivery replay, source event copying, receipts, timers, routes, sessions, turns, source-advanced policy, contract swap, or UI work.

## Governing Context

Spec references:
- `run_model.fork.materialize_only_admission`
- `run_model.fork.selected_contract_execution_model`
- `run_model.fork.planning_admission`
- `run_model.fork.replay_resume_admission_taxonomy`
- `platform_tables.run_fork_selected_contract_bindings`

Binding issue/gate context:
- #590 Pre-Implementation Coverage Audit
- Gate outcome: approved as first slice
- Parent: #588 mutating selected-contract fork execution remains open

Semantic migration/accounting:
- New canonical owner: `store.run_fork.selected_contract_binding`
- New durable table: `run_fork_selected_contract_bindings`
- Old non-authoritative paths: CLI/API arguments, dry-run JSON, and `runtime.run_fork.selected_contract_execution_model` output are not semantic owners for future execution.
- Checked surviving production paths: `cmd/swarm fork --contracts`, `MaterializeRunFork`, `ActivateRunFork`, and `BuildSelectedContractExecutionModel` now either persist, expose, or reference the store owner.
- Migration completeness: complete for the approved non-mutating binding slice; mutating execution remains blocked/split under #588.

## Proofs

Focused:
- `go test ./internal/store -run 'TestRunForkSelectedContractBinding|TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming'`
- `go test ./cmd/swarm -run 'TestRunForkCommand_(ContractsRemainNonExecuting|MaterializeOnlyUsesCanonicalStoreOwnerJSON|DryRunContractsAddsContractFrontierAdmissionJSON)'`
- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution`

Affected/full relevant:
- `go test ./internal/store`
- `go test ./cmd/swarm`
- `go test ./internal/runtime/...`
- `go test ./...`