### PR TITLE
[agent-d][issue #579] Prove role-scoped legacy tool retirement

### DIFF
--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -223,6 +223,54 @@ func TestCLIExecutionToolSurface_CanonicalizesProviderBuiltins(t *testing.T) {
 	}
 }
 
+func TestCLIExecutionToolSurface_DoesNotInjectRetiredLegacyEntityTools(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"}
+	tools := []ToolDefinition{
+		{Name: "read_validation_case"},
+		{Name: "read_validation_case_business_brief"},
+		{Name: "save_validation_case_business_brief"},
+		{Name: "update_validation_case_business_brief_summary"},
+		{Name: "emit_validation_package_ready"},
+	}
+
+	surface := cliExecutionToolSurfaceForActor(actor, tools)
+	allowed := strings.Split(claudeAllowedToolsArgForActor(actor, tools), ",")
+	summary := AgentVisibleToolSummaryLinesForActor(actor, tools)
+	legacyNames := []string{
+		"create_entity",
+		"get_entity",
+		"get_subject_status",
+		"query_entities",
+		"query_metrics",
+		"save_entity_field",
+		"search_entities",
+	}
+	for _, name := range legacyNames {
+		if slices.Contains(surface.RuntimeToolNames, name) || slices.Contains(surface.CanonicalVisibleTools, name) {
+			t.Fatalf("legacy entity tool %q appeared in CLI runtime surface: %#v", name, surface)
+		}
+		if slices.Contains(allowed, "mcp__runtime-tools__"+name) || slices.Contains(allowed, name) {
+			t.Fatalf("legacy entity tool %q appeared in Claude allowed tools: %#v", name, allowed)
+		}
+		for _, line := range summary {
+			if strings.Contains(line, name) {
+				t.Fatalf("legacy entity tool %q appeared in prompt tool summary line %q", name, line)
+			}
+		}
+	}
+	for _, name := range []string{"read_validation_case", "save_validation_case_business_brief", "emit_validation_package_ready"} {
+		if !slices.Contains(surface.RuntimeToolNames, name) {
+			t.Fatalf("generated/runtime tool %q missing from CLI runtime surface: %#v", name, surface.RuntimeToolNames)
+		}
+		if !slices.Contains(allowed, "mcp__runtime-tools__"+name) {
+			t.Fatalf("generated/runtime tool %q missing from Claude allowed tools: %#v", name, allowed)
+		}
+	}
+	if len(AgentVisibleToolSurfaceForActor(actor, tools).WritableEntityPaths) != 0 {
+		t.Fatalf("save_entity_field writable paths should not be advertised for generated save tools")
+	}
+}
+
 func TestCLIExecutionToolSurface_FileIONativeSurfaceRemovesFallbackRuntimeTools(t *testing.T) {
 	surface := cliExecutionToolSurfaceForActor(models.AgentConfig{
 		NativeTools: models.NativeToolConfig{

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -202,9 +202,13 @@ type actorScopedToolExecutorStub struct {
 	defs       []llm.ToolDefinition
 	actorDefs  []llm.ToolDefinition
 	roleScoped bool
+	callCount  *int
 }
 
 func (s actorScopedToolExecutorStub) Execute(context.Context, string, any) (any, error) {
+	if s.callCount != nil {
+		*s.callCount++
+	}
 	return map[string]any{"ok": true}, nil
 }
 
@@ -642,6 +646,7 @@ func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForRoleScope
 
 func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing.T) {
 	registry := newTestTurnContextRegistry()
+	executeCount := 0
 	legacyDefs := []llm.ToolDefinition{
 		{Name: "create_entity", Description: "legacy create"},
 		{Name: "get_entity", Description: "legacy get"},
@@ -659,6 +664,7 @@ func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing
 		defs:       legacyDefs,
 		actorDefs:  generatedDefs,
 		roleScoped: true,
+		callCount:  &executeCount,
 	}, testGatewayToken, GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			return models.AgentConfig{ID: agentID, Role: "validation_orchestrator"}, true
@@ -729,6 +735,29 @@ func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing
 		if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
 			t.Fatalf("%s response = %s, want tool-not-allowed", def.Name, rec.Body.String())
 		}
+	}
+	if executeCount != 0 {
+		t.Fatalf("MCP denied legacy tool calls reached executor %d times, want 0", executeCount)
+	}
+
+	for _, def := range legacyDefs {
+		body, err := json.Marshal(ToolGatewayRequest{Input: map[string]any{}})
+		if err != nil {
+			t.Fatalf("marshal direct tool request for %s: %v", def.Name, err)
+		}
+		toolReq := withContextToken(httptest.NewRequest(http.MethodPost, "/tools/"+def.Name, strings.NewReader(string(body))), "ctx-role-scoped-generated")
+		authorizeGatewayRequest(toolReq)
+		rec := httptest.NewRecorder()
+		g.Handler().ServeHTTP(rec, toolReq)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("direct %s status = %d, want 400", def.Name, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
+			t.Fatalf("direct %s response = %s, want tool-not-allowed", def.Name, rec.Body.String())
+		}
+	}
+	if executeCount != 0 {
+		t.Fatalf("direct denied legacy tool calls reached executor %d times, want 0", executeCount)
 	}
 }
 

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -640,6 +640,98 @@ func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForRoleScope
 	}
 }
 
+func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	legacyDefs := []llm.ToolDefinition{
+		{Name: "create_entity", Description: "legacy create"},
+		{Name: "get_entity", Description: "legacy get"},
+		{Name: "get_subject_status", Description: "legacy subject"},
+		{Name: "query_entities", Description: "legacy query"},
+		{Name: "query_metrics", Description: "legacy metrics"},
+		{Name: "save_entity_field", Description: "legacy save"},
+		{Name: "search_entities", Description: "legacy search"},
+	}
+	generatedDefs := []llm.ToolDefinition{
+		{Name: "read_validation_case", Description: "role scoped read"},
+		{Name: "save_validation_case_business_brief", Description: "role scoped save"},
+	}
+	g := NewGateway(actorScopedToolExecutorStub{
+		defs:       legacyDefs,
+		actorDefs:  generatedDefs,
+		roleScoped: true,
+	}, testGatewayToken, GatewayHooks{
+		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
+			return models.AgentConfig{ID: agentID, Role: "validation_orchestrator"}, true
+		},
+		ResolveTurnContext: registry.ResolveTurnContext,
+	})
+
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"}
+	putTestTurnContext(t, registry, "ctx-role-scoped-generated", TurnContext{
+		Actor:     actor,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+
+	req := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-role-scoped-generated")
+	tools := mustMCPToolsForRequest(t, g, req)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+	if !slices.Equal(names, []string{"read_validation_case", "save_validation_case_business_brief"}) {
+		t.Fatalf("role-scoped tool catalog = %#v, want generated-only tools", names)
+	}
+
+	legacyAllowed := map[string]struct{}{}
+	for _, def := range legacyDefs {
+		legacyAllowed[def.Name] = struct{}{}
+	}
+	putTestTurnContext(t, registry, "ctx-role-scoped-legacy-allowed", TurnContext{
+		Actor:     actor,
+		Allowed:   legacyAllowed,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	allowedReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-role-scoped-legacy-allowed")
+	if tools := mustMCPToolsForRequest(t, g, allowedReq); len(tools) != 0 {
+		t.Fatalf("legacy allowed_tools reintroduced role-scoped catalog entries: %#v", tools)
+	}
+
+	for _, def := range legacyDefs {
+		body, err := json.Marshal(map[string]any{
+			"id":     "req-" + def.Name,
+			"method": "tools/call",
+			"params": map[string]any{
+				"name":      def.Name,
+				"arguments": map[string]any{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal request for %s: %v", def.Name, err)
+		}
+		callReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-role-scoped-generated")
+		authorizeGatewayRequest(callReq)
+		rec := httptest.NewRecorder()
+		g.Handler().ServeHTTP(rec, callReq)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", def.Name, rec.Code)
+		}
+		resp := mustRPCResponse(t, rec)
+		result, ok := resp.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("%s result type = %T, want map", def.Name, resp.Result)
+		}
+		if isError, _ := result["isError"].(bool); !isError {
+			t.Fatalf("%s isError = %#v, want true", def.Name, result["isError"])
+		}
+		if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
+			t.Fatalf("%s response = %s, want tool-not-allowed", def.Name, rec.Body.String())
+		}
+	}
+}
+
 func TestGatewayMCPToolsForRequest_IgnoresCallerAllowlist(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	g := NewGateway(actorScopedToolExecutorStub{

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -253,13 +253,17 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{
 		"create_entity",
 		"get_entity",
+		"get_subject_status",
 		"save_entity_field",
 		"query_entities",
+		"query_metrics",
+		"search_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	_, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
 
-	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
+	defs := exec.ToolDefinitionsForActor(actor)
+	names := roleScopedToolDefinitionMap(defs)
 	for _, name := range []string{
 		"read_validation_case",
 		"read_validation_case_status",
@@ -277,7 +281,7 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 			t.Fatalf("create-only field produced mutation tool %q in %#v", name, sortedRoleScopedToolNames(names))
 		}
 	}
-	for _, name := range []string{
+	legacyNames := []string{
 		"create_entity",
 		"get_entity",
 		"get_subject_status",
@@ -285,7 +289,8 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 		"query_metrics",
 		"save_entity_field",
 		"search_entities",
-	} {
+	}
+	for _, name := range legacyNames {
 		if _, ok := names[name]; ok {
 			t.Fatalf("legacy entity tool %q remained visible in %#v", name, sortedRoleScopedToolNames(names))
 		}
@@ -300,12 +305,28 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 		t.Fatalf("generated save schema missing value: %#v", saveSchema)
 	}
 
-	caps := exec.ToolCapabilitiesForActor(actor, []string{"read_validation_case", "get_entity"}, nil)
+	surface := llm.AgentVisibleToolSurfaceForActor(actor, defs)
+	for _, name := range legacyNames {
+		if containsString(surface.RuntimeToolNames, name) || containsString(surface.NonEmitToolNames, name) {
+			t.Fatalf("legacy entity tool %q remained in agent-visible surface: %#v", name, surface)
+		}
+	}
+	if len(surface.WritableEntityPaths) != 0 {
+		t.Fatalf("save_entity_field writable path summary remained visible for role-scoped actor: %#v", surface.WritableEntityPaths)
+	}
+
+	capabilityNames := append([]string{"read_validation_case"}, legacyNames...)
+	caps := exec.ToolCapabilitiesForActor(actor, capabilityNames, nil)
 	if cap, ok := caps.Capability("read_validation_case"); !ok || !cap.Visible || !cap.Callable {
 		t.Fatalf("read_validation_case capability = %#v, ok=%v; want visible/callable", cap, ok)
 	}
-	if cap, ok := caps.Capability("get_entity"); !ok || cap.Visible || cap.Callable {
-		t.Fatalf("get_entity capability = %#v, ok=%v; want denied for opted-in actor", cap, ok)
+	for _, name := range legacyNames {
+		if cap, ok := caps.Capability(name); !ok || cap.Visible || cap.Callable || cap.DenialReason != "tool_not_allowed" {
+			t.Fatalf("%s capability = %#v, ok=%v; want denied for opted-in actor", name, cap, ok)
+		}
+		if _, err := exec.Execute(ctx, name, map[string]any{}); err == nil || !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("direct %s execution error = %v, want tool-not-allowed", name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the approved #579 first-slice boundary: fully opted-in role-scoped actors must not receive or call the retired legacy entity-tool surface.

This is a proof-only Swarm-side slice. It does not claim broad #579 closure because Empire #27/#32/#33/#34 still block final supported-run rollout.

Part of #579.

## Governing refs / context

- #579 Pre-Implementation Coverage Audit and independent gate outcome.
- #568 Path alpha role-scoped typed tool-contract tracker.
- Prior runtime prerequisites: #581/#584, #580/#587, #582/#591.
- Path alpha draft was cited in the issue/gate record, but the draft file is not present on current `origin/master`; this PR relies on the issue/gate record as the binding implementation boundary.

## Semantic migration accounting

- Canonical owner after this slice: per-flow `tool_surface.role_scoped_entity_tools` consumed by actor-scoped runtime tool delivery and `legacyEntityToolSurfaceNames` for retired legacy entity-tool names.
- Old producer/reader path now invalid for opted-in actors: provider/MCP/catalog exposure of `create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `query_metrics`, `save_entity_field`, and `search_entities`.
- Production paths checked by focused tests: actor definitions, CLI/provider allowed-tools surface, prompt tool summaries, MCP catalog, malicious `allowed_tools`, gateway direct calls, executor direct calls, and capabilities.
- Migration completeness: complete for the approved Swarm first slice covering fully opted-in actors; broad #579 final closure remains pending Empire prerequisites and supported-run proof.

## Validation

- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/llm ./internal/runtime/agents -run 'RoleScoped|ToolDefinitionsForActor|HideEntityScoped|allowed_tools|AllowedTools|ToolCatalog|Writable|Legacy|Universal|CurrentEntity|Fallback|RetiresLegacy|DoesNotInjectRetired' -count=1`
- `go test ./...`