### PR TITLE
[agent-a][issue #594] Define selected-contract fork execution admission

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3235,6 +3235,16 @@ run_model:
       timers, routes, sessions, turns, source advancement, and contract-swap boot/resume. The model MUST NOT create
       fork-local executable work, run handlers, accept source outcomes as fork suppressors, or treat same-run outbox
       replay as timestamp-fork selected-contract execution.'
+    selected_contract_execution_admission: 'Selected-contract fork execution admission is a non-mutating runtime-side
+      prerequisite for future selected-contract execution. The canonical owner consumes the durable
+      store.run_fork.selected_contract_binding by fork run_id, loads and validates the selected semantic source from that
+      binding identity, combines it with contract_frontier_admission and selected_contract_execution_model evidence, and
+      returns fail-closed execution admission/context for the future runtime.run_fork.selected_contract_execution owner.
+      It MUST NOT run handlers, create fork-local events or event_deliveries, copy source events or source
+      event_deliveries, use same-run outbox replay, write receipts, dead letters, idempotency state, emitted follow-up
+      events, timers, routes, sessions, turns, source-advanced policy, contract-swap state, or UI/API execution state.
+      Missing, ambiguous, stale, incompatible, or unavailable binding/source/admission evidence is a hard admission
+      failure before any selected-contract execution mutation.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -149,6 +149,10 @@ active_issues:
     title: Gate non-mutating fork contract/frontier/route admission
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 594
+    title: Define selected-contract fork execution admission from durable binding
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -249,6 +253,7 @@ nodes:
       - selected-contract timestamp-fork re-admission needs a non-mutating contract/frontier/route admission owner before node/system delivery facts can become executable fork work
       - selected-contract fork execution needs a non-mutating owner model before mutation; the model must consume frontier admission as evidence only and classify contract binding, fork run_id context, handler execution, receipts, dead letters, idempotency, emitted follow-ups, timers, routes, sessions, source-advanced policy, and contract-swap boot/resume
       - selected-contract fork execution needs a durable fork-run selected-source binding owner; CLI/API arguments, dry-run JSON, and local model output are not authoritative for future execution
+      - selected-contract fork execution needs a runtime-side non-mutating admission/context owner that consumes the durable selected-source binding before any handler execution or fork-local delivery/outcome mutation
     representative_issues:
       - 564
       - 565
@@ -259,6 +264,7 @@ nodes:
       - 583
       - 585
       - 590
+      - 594
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 )
@@ -16,10 +17,49 @@ type SelectedContractBindingReader interface {
 	RequireRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, error)
 }
 
+type SelectedContractSourceLoader interface {
+	LoadRunForkSelectedContractSource(context.Context, store.RunForkContractSelection) (LoadedSelectedContractSource, error)
+}
+
+type LoadedSelectedContractSource struct {
+	Selection store.RunForkContractSelection
+	Source    semanticview.Source
+}
+
+type ContractBundleSourceLoader struct {
+	RepoRoot         string
+	PlatformSpecPath string
+}
+
+func (l ContractBundleSourceLoader) LoadRunForkSelectedContractSource(ctx context.Context, selection store.RunForkContractSelection) (LoadedSelectedContractSource, error) {
+	if err := ctx.Err(); err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
+	if err := validateSelectedContractSelection("selected source loader", selection); err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
+	repoRoot := strings.TrimSpace(l.RepoRoot)
+	if repoRoot == "" {
+		return LoadedSelectedContractSource{}, fmt.Errorf("selected-contract execution admission source loader requires repo root")
+	}
+	platformSpecPath := strings.TrimSpace(l.PlatformSpecPath)
+	if platformSpecPath == "" {
+		platformSpecPath = runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, strings.TrimSpace(selection.ContractsRoot), platformSpecPath)
+	if err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
+	return LoadedSelectedContractSource{
+		Selection: selection,
+		Source:    semanticview.Wrap(bundle),
+	}, nil
+}
+
 type SelectedContractExecutionAdmissionRequest struct {
 	ForkRunID         string
 	BindingReader     SelectedContractBindingReader
-	SelectedSource    semanticview.Source
+	SourceLoader      SelectedContractSourceLoader
 	FrontierAdmission store.RunForkContractFrontierAdmission
 	ExecutionModel    store.RunForkSelectedContractExecution
 }
@@ -42,7 +82,14 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 	if err := validateSelectedContractExecutionBinding(forkRunID, binding); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionSource(binding, req.SelectedSource); err != nil {
+	if req.SourceLoader == nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("selected-contract execution admission requires selected source loader bound to %s", store.RunForkSelectedContractBindingOwner)
+	}
+	loadedSource, err := req.SourceLoader.LoadRunForkSelectedContractSource(ctx, binding.ContractSelection)
+	if err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("load selected semantic source for execution admission: %w", err)
+	}
+	if err := validateSelectedContractExecutionSource(binding, loadedSource); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
 	if err := validateSelectedContractExecutionFrontier(binding, req.FrontierAdmission); err != nil {
@@ -65,8 +112,8 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 		AdmissionOwner:        req.FrontierAdmission.Owner,
 		AdmissionUse:          store.RunForkSelectedContractExecutionAdmissionUseDurableBinding,
 		ExecutionModelOwner:   req.ExecutionModel.Owner,
-		SourceWorkflowName:    strings.TrimSpace(req.SelectedSource.WorkflowName()),
-		SourceWorkflowVersion: strings.TrimSpace(req.SelectedSource.WorkflowVersion()),
+		SourceWorkflowName:    strings.TrimSpace(loadedSource.Source.WorkflowName()),
+		SourceWorkflowVersion: strings.TrimSpace(loadedSource.Source.WorkflowVersion()),
 		FrontierEventCount:    req.ExecutionModel.FrontierEventCount,
 		FrontierEvents:        append([]store.RunForkSelectedContractFrontierEvent(nil), req.ExecutionModel.FrontierEvents...),
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
@@ -106,11 +153,15 @@ func validateSelectedContractExecutionBinding(forkRunID string, binding store.Ru
 	return validateSelectedContractSelection("binding", binding.ContractSelection)
 }
 
-func validateSelectedContractExecutionSource(binding store.RunForkSelectedContractBinding, source semanticview.Source) error {
+func validateSelectedContractExecutionSource(binding store.RunForkSelectedContractBinding, loaded LoadedSelectedContractSource) error {
+	if err := validateSelectionMatches("selected source", binding.ContractSelection, loaded.Selection); err != nil {
+		return err
+	}
+	source := loaded.Source
 	if source == nil {
 		return fmt.Errorf("selected-contract execution admission requires selected semantic source from durable binding")
 	}
-	selection := binding.ContractSelection
+	selection := loaded.Selection
 	sourceName := strings.TrimSpace(source.WorkflowName())
 	sourceVersion := strings.TrimSpace(source.WorkflowVersion())
 	if sourceName == "" || sourceVersion == "" {

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -3,6 +3,7 @@ package runforkexecution
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/google/uuid"
@@ -149,6 +150,12 @@ func validateSelectedContractExecutionModel(binding store.RunForkSelectedContrac
 	}
 	if strings.TrimSpace(model.AdmissionOwner) != frontier.Owner {
 		return fmt.Errorf("selected-contract execution admission model admission owner mismatch: got %q want %q", model.AdmissionOwner, frontier.Owner)
+	}
+	if model.FrontierEventCount != frontier.FrontierEventCount {
+		return fmt.Errorf("selected-contract execution admission model frontier count mismatch: got %d want %d", model.FrontierEventCount, frontier.FrontierEventCount)
+	}
+	if !reflect.DeepEqual(model.FrontierEvents, selectedContractFrontierEvents(frontier.FrontierEvents)) {
+		return fmt.Errorf("selected-contract execution admission model frontier events do not match durable frontier evidence")
 	}
 	if model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
 		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite {

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -1,0 +1,190 @@
+package runforkexecution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+type SelectedContractBindingReader interface {
+	RequireRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, error)
+}
+
+type SelectedContractExecutionAdmissionRequest struct {
+	ForkRunID         string
+	BindingReader     SelectedContractBindingReader
+	SelectedSource    semanticview.Source
+	FrontierAdmission store.RunForkContractFrontierAdmission
+	ExecutionModel    store.RunForkSelectedContractExecution
+}
+
+func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedContractExecutionAdmissionRequest) (store.RunForkSelectedContractExecutionAdmission, error) {
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("selected-contract execution admission requires fork run_id")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("selected-contract execution admission fork run_id must be a UUID: %w", err)
+	}
+	if req.BindingReader == nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("selected-contract execution admission requires %s reader", store.RunForkSelectedContractBindingOwner)
+	}
+	binding, err := req.BindingReader.RequireRunForkSelectedContractBinding(ctx, forkRunID)
+	if err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("load selected-contract binding for execution admission: %w", err)
+	}
+	if err := validateSelectedContractExecutionBinding(forkRunID, binding); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
+	if err := validateSelectedContractExecutionSource(binding, req.SelectedSource); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
+	if err := validateSelectedContractExecutionFrontier(binding, req.FrontierAdmission); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
+	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.ExecutionModel); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
+
+	return store.RunForkSelectedContractExecutionAdmission{
+		Owner:                 store.RunForkSelectedContractExecutionAdmissionOwner,
+		FutureExecutionOwner:  store.RunForkSelectedContractExecutionOwner,
+		NonMutating:           true,
+		ExecutionSupported:    false,
+		ForkRunID:             binding.ForkRunID,
+		SourceRunID:           binding.SourceRunID,
+		ForkEventID:           binding.ForkEventID,
+		ContractSelection:     binding.ContractSelection,
+		ContractBindingOwner:  binding.Owner,
+		AdmissionOwner:        req.FrontierAdmission.Owner,
+		AdmissionUse:          store.RunForkSelectedContractExecutionAdmissionUseDurableBinding,
+		ExecutionModelOwner:   req.ExecutionModel.Owner,
+		SourceWorkflowName:    strings.TrimSpace(req.SelectedSource.WorkflowName()),
+		SourceWorkflowVersion: strings.TrimSpace(req.SelectedSource.WorkflowVersion()),
+		FrontierEventCount:    req.ExecutionModel.FrontierEventCount,
+		FrontierEvents:        append([]store.RunForkSelectedContractFrontierEvent(nil), req.ExecutionModel.FrontierEvents...),
+		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "selected_contract_binding",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractBindingOwner,
+			Reason:      "execution admission consumes the durable selected contract source bound to the fork run before any mutation",
+		},
+		RequiredConsumers: append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.RequiredConsumers...),
+		BlockedSiblings:   append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.BlockedSiblings...),
+		InvalidPaths:      append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.InvalidPaths...),
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
+			Code:    store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating,
+			Message: "selected-contract execution admission is non-mutating; handler execution and fork-local writes remain separately gated",
+		}},
+	}, nil
+}
+
+func validateSelectedContractExecutionBinding(forkRunID string, binding store.RunForkSelectedContractBinding) error {
+	if strings.TrimSpace(binding.Owner) != store.RunForkSelectedContractBindingOwner {
+		return fmt.Errorf("selected-contract execution admission requires %s binding; got %q", store.RunForkSelectedContractBindingOwner, binding.Owner)
+	}
+	if strings.TrimSpace(binding.ForkRunID) != forkRunID {
+		return fmt.Errorf("selected-contract execution admission binding fork run_id mismatch: got %q want %q", binding.ForkRunID, forkRunID)
+	}
+	for label, value := range map[string]string{
+		"source run_id": binding.SourceRunID,
+		"fork event_id": binding.ForkEventID,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("selected-contract execution admission binding missing %s", label)
+		}
+		if _, err := uuid.Parse(strings.TrimSpace(value)); err != nil {
+			return fmt.Errorf("selected-contract execution admission binding %s must be a UUID: %w", label, err)
+		}
+	}
+	return validateSelectedContractSelection("binding", binding.ContractSelection)
+}
+
+func validateSelectedContractExecutionSource(binding store.RunForkSelectedContractBinding, source semanticview.Source) error {
+	if source == nil {
+		return fmt.Errorf("selected-contract execution admission requires selected semantic source from durable binding")
+	}
+	selection := binding.ContractSelection
+	sourceName := strings.TrimSpace(source.WorkflowName())
+	sourceVersion := strings.TrimSpace(source.WorkflowVersion())
+	if sourceName == "" || sourceVersion == "" {
+		return fmt.Errorf("selected-contract execution admission selected source must expose workflow name and version")
+	}
+	if strings.TrimSpace(selection.WorkflowName) != sourceName {
+		return fmt.Errorf("selected-contract execution admission workflow name mismatch: binding %q source %q", selection.WorkflowName, sourceName)
+	}
+	if strings.TrimSpace(selection.WorkflowVersion) != sourceVersion {
+		return fmt.Errorf("selected-contract execution admission workflow version mismatch: binding %q source %q", selection.WorkflowVersion, sourceVersion)
+	}
+	return nil
+}
+
+func validateSelectedContractExecutionFrontier(binding store.RunForkSelectedContractBinding, admission store.RunForkContractFrontierAdmission) error {
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return fmt.Errorf("selected-contract execution admission requires %s frontier admission; got %q", store.RunForkContractFrontierAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return fmt.Errorf("selected-contract execution admission requires non-mutating frontier admission")
+	}
+	if admission.HistoricalExecutionSupported {
+		return fmt.Errorf("selected-contract execution admission frontier unexpectedly supports historical execution")
+	}
+	return validateSelectionMatches("frontier admission", binding.ContractSelection, admission.ContractSelection)
+}
+
+func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, model store.RunForkSelectedContractExecution) error {
+	if strings.TrimSpace(model.Owner) != store.RunForkSelectedContractExecutionModelOwner {
+		return fmt.Errorf("selected-contract execution admission requires %s model; got %q", store.RunForkSelectedContractExecutionModelOwner, model.Owner)
+	}
+	if strings.TrimSpace(model.FutureExecutionOwner) != store.RunForkSelectedContractExecutionOwner {
+		return fmt.Errorf("selected-contract execution admission model must point to %s; got %q", store.RunForkSelectedContractExecutionOwner, model.FutureExecutionOwner)
+	}
+	if !model.NonMutating || model.ExecutionSupported {
+		return fmt.Errorf("selected-contract execution admission requires non-mutating unsupported execution model")
+	}
+	if strings.TrimSpace(model.AdmissionOwner) != frontier.Owner {
+		return fmt.Errorf("selected-contract execution admission model admission owner mismatch: got %q want %q", model.AdmissionOwner, frontier.Owner)
+	}
+	if model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
+		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite {
+		return fmt.Errorf("selected-contract execution admission model must consume %s as prerequisite", store.RunForkSelectedContractBindingOwner)
+	}
+	return validateSelectionMatches("execution model", binding.ContractSelection, model.ContractSelection)
+}
+
+func validateSelectionMatches(label string, want, got store.RunForkContractSelection) error {
+	if err := validateSelectedContractSelection("binding", want); err != nil {
+		return err
+	}
+	if err := validateSelectedContractSelection(label, got); err != nil {
+		return err
+	}
+	if strings.TrimSpace(want.Mode) != strings.TrimSpace(got.Mode) ||
+		strings.TrimSpace(want.ContractsRoot) != strings.TrimSpace(got.ContractsRoot) ||
+		strings.TrimSpace(want.WorkflowName) != strings.TrimSpace(got.WorkflowName) ||
+		strings.TrimSpace(want.WorkflowVersion) != strings.TrimSpace(got.WorkflowVersion) {
+		return fmt.Errorf("selected-contract execution admission %s selection does not match durable binding", label)
+	}
+	return nil
+}
+
+func validateSelectedContractSelection(label string, selection store.RunForkContractSelection) error {
+	if strings.TrimSpace(selection.Mode) != "selected_contracts" {
+		return fmt.Errorf("selected-contract execution admission %s requires mode selected_contracts; got %q", label, selection.Mode)
+	}
+	if strings.TrimSpace(selection.ContractsRoot) == "" {
+		return fmt.Errorf("selected-contract execution admission %s requires contracts_root", label)
+	}
+	if strings.TrimSpace(selection.WorkflowName) == "" {
+		return fmt.Errorf("selected-contract execution admission %s requires workflow_name", label)
+	}
+	if strings.TrimSpace(selection.WorkflowVersion) == "" {
+		return fmt.Errorf("selected-contract execution admission %s requires workflow_version", label)
+	}
+	return nil
+}

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -19,13 +19,14 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
 	reader := &fakeSelectedContractBindingReader{binding: binding}
+	sourceLoader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
 
 	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     reader,
-		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		SourceLoader:      sourceLoader,
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
@@ -34,6 +35,9 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	}
 	if reader.requestedForkRunID != forkRunID {
 		t.Fatalf("binding reader fork_run_id = %q, want %q", reader.requestedForkRunID, forkRunID)
+	}
+	if sourceLoader.requestedSelection != binding.ContractSelection {
+		t.Fatalf("source loader selection = %#v, want binding selection %#v", sourceLoader.requestedSelection, binding.ContractSelection)
 	}
 	if admission.Owner != store.RunForkSelectedContractExecutionAdmissionOwner ||
 		admission.FutureExecutionOwner != store.RunForkSelectedContractExecutionOwner ||
@@ -83,7 +87,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnMissingBinding(t *t
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{err: errors.New("selected contract binding not found")},
-		SelectedSource:    testSelectedSource(selection),
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(selection)},
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
@@ -102,7 +106,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnUnavailableSelected
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
-		SelectedSource:    nil,
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection}},
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
@@ -123,12 +127,33 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *t
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
-		SelectedSource:    testSelectedSource(mismatched),
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection, Source: testSelectedSource(mismatched)}},
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workflow version mismatch") {
 		t.Fatalf("error = %v, want selected source mismatch", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnWrongContractsRoot(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+	wrongRoot := binding.ContractSelection
+	wrongRoot.ContractsRoot = "/tmp/other-selected-contracts"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(wrongRoot)},
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected source selection does not match durable binding") {
+		t.Fatalf("error = %v, want wrong contracts_root source failure", err)
 	}
 }
 
@@ -143,7 +168,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
-		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
@@ -163,7 +188,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
-		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
 		ExecutionModel:    model,
 	})
@@ -176,6 +201,20 @@ type fakeSelectedContractBindingReader struct {
 	binding            store.RunForkSelectedContractBinding
 	err                error
 	requestedForkRunID string
+}
+
+type fakeSelectedContractSourceLoader struct {
+	loaded             LoadedSelectedContractSource
+	err                error
+	requestedSelection store.RunForkContractSelection
+}
+
+func (l *fakeSelectedContractSourceLoader) LoadRunForkSelectedContractSource(_ context.Context, selection store.RunForkContractSelection) (LoadedSelectedContractSource, error) {
+	l.requestedSelection = selection
+	if l.err != nil {
+		return LoadedSelectedContractSource{}, l.err
+	}
+	return l.loaded, nil
 }
 
 func (r *fakeSelectedContractBindingReader) RequireRunForkSelectedContractBinding(_ context.Context, forkRunID string) (store.RunForkSelectedContractBinding, error) {
@@ -213,6 +252,13 @@ func testSelectedSource(selection store.RunForkContractSelection) semanticview.S
 			Version: selection.WorkflowVersion,
 		},
 	})
+}
+
+func testLoadedSelectedSource(selection store.RunForkContractSelection) LoadedSelectedContractSource {
+	return LoadedSelectedContractSource{
+		Selection: selection,
+		Source:    testSelectedSource(selection),
+	}
 }
 
 func testContractFrontierAdmission(selection store.RunForkContractSelection) store.RunForkContractFrontierAdmission {

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -1,0 +1,227 @@
+package runforkexecution
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	reader := &fakeSelectedContractBindingReader{binding: binding}
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+
+	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     reader,
+		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionAdmission: %v", err)
+	}
+	if reader.requestedForkRunID != forkRunID {
+		t.Fatalf("binding reader fork_run_id = %q, want %q", reader.requestedForkRunID, forkRunID)
+	}
+	if admission.Owner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		admission.FutureExecutionOwner != store.RunForkSelectedContractExecutionOwner ||
+		!admission.NonMutating ||
+		admission.ExecutionSupported {
+		t.Fatalf("admission ownership = %#v", admission)
+	}
+	if admission.ForkRunID != forkRunID ||
+		admission.SourceRunID != binding.SourceRunID ||
+		admission.ForkEventID != binding.ForkEventID ||
+		admission.ContractBindingOwner != store.RunForkSelectedContractBindingOwner {
+		t.Fatalf("admission binding lineage = %#v", admission)
+	}
+	if admission.AdmissionOwner != store.RunForkContractFrontierAdmissionOwner ||
+		admission.ExecutionModelOwner != store.RunForkSelectedContractExecutionModelOwner ||
+		admission.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseDurableBinding {
+		t.Fatalf("admission evidence accounting = %#v", admission)
+	}
+	if admission.SourceWorkflowName != binding.ContractSelection.WorkflowName ||
+		admission.SourceWorkflowVersion != binding.ContractSelection.WorkflowVersion {
+		t.Fatalf("source workflow = %s@%s", admission.SourceWorkflowName, admission.SourceWorkflowVersion)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v", admission.FrontierEvents)
+	}
+	if !executionBoundaryHas(admission.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source delivery copy invalid", admission.InvalidPaths)
+	}
+	if !executionBoundaryHas(admission.RequiredConsumers, "handler_execution", store.RunForkSelectedContractDispositionFutureOwnerRequired) {
+		t.Fatalf("required consumers = %#v, want handler execution future owner", admission.RequiredConsumers)
+	}
+	if !executionBoundaryHas(admission.BlockedSiblings, "sessions_turns_audits", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("blocked siblings = %#v, want sessions/turns blocked", admission.BlockedSiblings)
+	}
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want non-mutating admission blocker", admission.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnMissingBinding(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	selection := testContractSelection()
+	frontier := testContractFrontierAdmission(selection)
+	model := testSelectedContractExecutionModel(t, frontier)
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{err: errors.New("selected contract binding not found")},
+		SelectedSource:    testSelectedSource(selection),
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "load selected-contract binding") {
+		t.Fatalf("error = %v, want binding load failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnUnavailableSelectedSource(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SelectedSource:    nil,
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected semantic source") {
+		t.Fatalf("error = %v, want selected source failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+	mismatched := binding.ContractSelection
+	mismatched.WorkflowVersion = "other-version"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SelectedSource:    testSelectedSource(mismatched),
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "workflow version mismatch") {
+		t.Fatalf("error = %v, want selected source mismatch", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+	frontier.Owner = "cmd.swarm.local_frontier"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkContractFrontierAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical frontier failure", err)
+	}
+}
+
+type fakeSelectedContractBindingReader struct {
+	binding            store.RunForkSelectedContractBinding
+	err                error
+	requestedForkRunID string
+}
+
+func (r *fakeSelectedContractBindingReader) RequireRunForkSelectedContractBinding(_ context.Context, forkRunID string) (store.RunForkSelectedContractBinding, error) {
+	r.requestedForkRunID = forkRunID
+	if r.err != nil {
+		return store.RunForkSelectedContractBinding{}, r.err
+	}
+	return r.binding, nil
+}
+
+func testSelectedContractBinding(forkRunID string) store.RunForkSelectedContractBinding {
+	return store.RunForkSelectedContractBinding{
+		Owner:       store.RunForkSelectedContractBindingOwner,
+		ForkRunID:   forkRunID,
+		SourceRunID: uuid.NewString(),
+		ForkEventID: uuid.NewString(),
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v2",
+		},
+		CreatedAt: time.Unix(1700000900, 0).UTC(),
+	}
+}
+
+func testContractSelection() store.RunForkContractSelection {
+	return testSelectedContractBinding(uuid.NewString()).ContractSelection
+}
+
+func testSelectedSource(selection store.RunForkContractSelection) semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    selection.WorkflowName,
+			Version: selection.WorkflowVersion,
+		},
+	})
+}
+
+func testContractFrontierAdmission(selection store.RunForkContractSelection) store.RunForkContractFrontierAdmission {
+	return store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		ContractSelection:            selection,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		FrontierEventCount:           1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:           uuid.NewString(),
+			EventName:               "work.begin",
+			RuntimeEventOwners:      []string{"alpha-intake"},
+			WorkflowNodeSubscribers: []string{"beta-intake"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "alpha-intake",
+				Path:           "flow-a/alpha-intake",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+}
+
+func testSelectedContractExecutionModel(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractExecution {
+	t.Helper()
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	return model
+}

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -152,6 +152,26 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 	}
 }
 
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+	frontier.FrontierEvents[0].EventName = "work.changed"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SelectedSource:    testSelectedSource(binding.ContractSelection),
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontier events do not match") {
+		t.Fatalf("error = %v, want stale frontier model failure", err)
+	}
+}
+
 type fakeSelectedContractBindingReader struct {
 	binding            store.RunForkSelectedContractBinding
 	err                error

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -1,10 +1,12 @@
 package store
 
 const (
-	RunForkSelectedContractExecutionModelOwner = "runtime.run_fork.selected_contract_execution_model"
-	RunForkSelectedContractExecutionOwner      = "runtime.run_fork.selected_contract_execution"
+	RunForkSelectedContractExecutionModelOwner     = "runtime.run_fork.selected_contract_execution_model"
+	RunForkSelectedContractExecutionAdmissionOwner = "runtime.run_fork.selected_contract_execution_admission"
+	RunForkSelectedContractExecutionOwner          = "runtime.run_fork.selected_contract_execution"
 
-	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly = "prerequisite_evidence_only"
+	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
+	RunForkSelectedContractExecutionAdmissionUseDurableBinding = "durable_binding_and_frontier_evidence"
 
 	RunForkSelectedContractDispositionEvidenceOnly        = "evidence_only"
 	RunForkSelectedContractDispositionFutureOwnerRequired = "future_owner_required"
@@ -12,7 +14,8 @@ const (
 	RunForkSelectedContractDispositionPrerequisite        = "prerequisite"
 	RunForkSelectedContractDispositionInvalid             = "invalid"
 
-	RunForkBlockerSelectedContractExecutionModelNonMutating = "selected_contract_execution_model_non_mutating"
+	RunForkBlockerSelectedContractExecutionModelNonMutating     = "selected_contract_execution_model_non_mutating"
+	RunForkBlockerSelectedContractExecutionAdmissionNonMutating = "selected_contract_execution_admission_non_mutating"
 )
 
 type RunForkSelectedContractExecution struct {
@@ -30,6 +33,30 @@ type RunForkSelectedContractExecution struct {
 	BlockedSiblings      []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths         []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
 	UnsupportedBlockers  []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractExecutionAdmission struct {
+	Owner                 string                                     `json:"owner"`
+	FutureExecutionOwner  string                                     `json:"future_execution_owner"`
+	NonMutating           bool                                       `json:"non_mutating"`
+	ExecutionSupported    bool                                       `json:"execution_supported"`
+	ForkRunID             string                                     `json:"fork_run_id"`
+	SourceRunID           string                                     `json:"source_run_id"`
+	ForkEventID           string                                     `json:"fork_event_id"`
+	ContractSelection     RunForkContractSelection                   `json:"contract_selection"`
+	ContractBindingOwner  string                                     `json:"contract_binding_owner"`
+	AdmissionOwner        string                                     `json:"admission_owner"`
+	AdmissionUse          string                                     `json:"admission_use"`
+	ExecutionModelOwner   string                                     `json:"execution_model_owner"`
+	SourceWorkflowName    string                                     `json:"source_workflow_name"`
+	SourceWorkflowVersion string                                     `json:"source_workflow_version"`
+	FrontierEventCount    int                                        `json:"frontier_event_count"`
+	FrontierEvents        []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
+	ContractBinding       RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
+	RequiredConsumers     []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings       []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths          []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers   []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
 }
 
 type RunForkSelectedContractFrontierEvent struct {


### PR DESCRIPTION
## Summary

Closes #594.

Part of #588.

This PR implements the approved first slice for selected-contract fork execution admission. It adds the non-mutating `runtime.run_fork.selected_contract_execution_admission` owner, consumes `store.run_fork.selected_contract_binding` through a fork-run binding reader, validates the selected semantic source against that durable binding, and combines the binding with existing frontier/model evidence without enabling handler execution or fork-local event/delivery/outcome mutation.

## Governing Context

Spec references:
- `platform_tables.run_fork_selected_contract_bindings`
- `run_model.fork.materialize_only_admission`
- `run_model.fork.activation_admission`
- `run_model.fork.replay_resume_admission_taxonomy`
- `run_model.fork.selected_contract_execution_model`
- New/updated: `run_model.fork.selected_contract_execution_admission`

Binding issue/gate context:
- #588 refreshed Pre-Implementation Coverage Audit
- #588 independent lead gate outcome: approved as first slice
- #594 issue body and approved boundary
- #590 / PR #592 durable selected-contract binding prerequisite

## Semantic Migration / Owner Accounting

New canonical owner:
- `runtime.run_fork.selected_contract_execution_admission`

Existing prerequisite owners consumed:
- `store.run_fork.selected_contract_binding`
- `runtime.run_fork.contract_frontier_admission`
- `runtime.run_fork.selected_contract_execution_model`

Old non-authoritative paths now invalid / still invalid:
- CLI/API `--contracts` arguments are not execution truth.
- Dry-run JSON and local model output are evidence only.
- Route/frontier helpers are not execution owners.
- Source events, source `event_deliveries`, source outcomes, and same-run outbox replay are not selected-contract fork execution.

Production paths checked for surviving old behavior:
- `cmd/swarm fork --contracts` remains non-executing outside dry-run/materialize-only binding.
- `MaterializeRunFork` remains state/binding materialization only.
- `ActivateRunFork` remains activation/source-freeze only.
- `runtime.run_fork.selected_contract_execution` remains the future mutating owner and is not implemented here.

Migration completeness:
- Complete for the approved #594 non-mutating admission/context slice.
- Full mutating selected-contract fork execution remains open under #588.

## Proofs

Focused:
- `go test ./internal/runtime/runforkexecution -count=1`
- `go test ./cmd/swarm -run 'TestRunForkCommand_(ContractsRemainNonExecuting|MaterializeOnlyUsesCanonicalStoreOwnerJSON|ActivateUsesCanonicalStoreOwnerJSON|DryRunContractsAddsContractFrontierAdmissionJSON)' -count=1`
- `go test ./internal/store -run 'TestRunForkSelectedContractBinding|TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming|TestGeneratePlatformTableDDLs' -count=1`

Relevant/full:
- `go test ./internal/runtime/... -count=1`
- `go test ./internal/store -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`