### PR TITLE
[agent-a][issue #596] Gate selected-contract fork activation

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -405,8 +405,13 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		return 1
 	}
 	if *activate {
-		result, err := stores.Postgres.ActivateRunFork(ctx, store.RunForkActivateRequest{
+		result, err := runtimerunforkexecution.ActivateSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractActivationGateRequest{
 			ForkRunID: strings.TrimSpace(*runID),
+			Store:     stores.Postgres,
+			SourceLoader: runtimerunforkexecution.ContractBundleSourceLoader{
+				RepoRoot:         repo,
+				PlatformSpecPath: resolvePath(repo, *platformSpecPath),
+			},
 		})
 		if err != nil {
 			if out != nil {
@@ -423,7 +428,7 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			}
 			return 0
 		}
-		printRunForkActivation(out, result)
+		printRunForkActivation(out, result.RunForkActivation)
 		return 0
 	}
 	if *materializeOnly {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -712,6 +712,138 @@ func TestRunForkCommand_ActivateUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	}
 }
 
+func TestRunForkCommand_ActivateSelectedBindingConsumesRuntimeAdmission(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000330, 0).UTC()
+	ctx := context.Background()
+	seedRunForkCLIActivationSource(t, db, runID, entityID, eventID, at)
+	repo := repoRoot()
+	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
+
+	var materializeOut bytes.Buffer
+	materializeCode := runForkCommand(ctx, repo, []string{
+		"--materialize-only",
+		"--run", runID,
+		"--at", eventID,
+		"--contracts", contractsRoot,
+		"--json",
+	}, &materializeOut)
+	if materializeCode != 0 {
+		t.Fatalf("materialize code=%d output=%s", materializeCode, materializeOut.String())
+	}
+	var materialized store.RunForkMaterialization
+	if err := json.Unmarshal(materializeOut.Bytes(), &materialized); err != nil {
+		t.Fatalf("decode materialization: %v\n%s", err, materializeOut.String())
+	}
+
+	var activateOut bytes.Buffer
+	activateCode := runForkCommand(ctx, repo, []string{
+		"--activate",
+		"--run", materialized.ForkRunID,
+		"--json",
+	}, &activateOut)
+	if activateCode != 0 {
+		t.Fatalf("activate code=%d output=%s", activateCode, activateOut.String())
+	}
+	var result struct {
+		store.RunForkActivation
+		Owner     string                                           `json:"selected_contract_activation_gate_owner"`
+		Admission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission"`
+	}
+	if err := json.Unmarshal(activateOut.Bytes(), &result); err != nil {
+		t.Fatalf("decode activation: %v\n%s", err, activateOut.String())
+	}
+	if !result.Activated || !result.SourceFrozen || result.ForkRunID != materialized.ForkRunID {
+		t.Fatalf("activation = %#v", result.RunForkActivation)
+	}
+	if result.Owner != store.RunForkSelectedContractExecutionActivationGateOwner {
+		t.Fatalf("selected activation owner = %q, want %q", result.Owner, store.RunForkSelectedContractExecutionActivationGateOwner)
+	}
+	if result.Admission == nil ||
+		result.Admission.Owner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		result.Admission.FrontierEventCount != 0 ||
+		result.Admission.ContractBindingOwner != store.RunForkSelectedContractBindingOwner {
+		t.Fatalf("selected admission = %#v", result.Admission)
+	}
+}
+
+func TestRunForkCommand_ActivateSelectedBindingBlocksSourceReplayBeforeMutation(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000340, 0).UTC()
+	ctx := context.Background()
+	seedRunForkCLIActivationSource(t, db, runID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'safe-agent', 'pending', 0, 'matched_agent_subscription', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed safe pending delivery: %v", err)
+	}
+	repo := repoRoot()
+	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
+
+	var materializeOut bytes.Buffer
+	materializeCode := runForkCommand(ctx, repo, []string{
+		"--materialize-only",
+		"--run", runID,
+		"--at", eventID,
+		"--contracts", contractsRoot,
+		"--json",
+	}, &materializeOut)
+	if materializeCode != 0 {
+		t.Fatalf("materialize code=%d output=%s", materializeCode, materializeOut.String())
+	}
+	var materialized store.RunForkMaterialization
+	if err := json.Unmarshal(materializeOut.Bytes(), &materialized); err != nil {
+		t.Fatalf("decode materialization: %v\n%s", err, materializeOut.String())
+	}
+
+	var activateOut bytes.Buffer
+	activateCode := runForkCommand(ctx, repo, []string{
+		"--activate",
+		"--run", materialized.ForkRunID,
+		"--json",
+	}, &activateOut)
+	if activateCode != 1 {
+		t.Fatalf("activate code=%d, want 1; output=%s", activateCode, activateOut.String())
+	}
+	if !strings.Contains(activateOut.String(), store.RunForkBlockerSelectedContractSourceReplayUnsupported) {
+		t.Fatalf("activate output = %q, want selected source replay blocker", activateOut.String())
+	}
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, runID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != "running" || forkStatus != store.RunForkMaterializedStatus {
+		t.Fatalf("source/fork status = %s/%s, want running/paused", sourceStatus, forkStatus)
+	}
+	var replayRows, forkEvents, forkDeliveries int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, materialized.ForkRunID).Scan(&replayRows); err != nil {
+		t.Fatalf("count replay rows: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkEvents); err != nil {
+		t.Fatalf("count fork events: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkDeliveries); err != nil {
+		t.Fatalf("count fork deliveries: %v", err)
+	}
+	if replayRows != 0 || forkEvents != 0 || forkDeliveries != 0 {
+		t.Fatalf("selected-bound replay mutation counts = replay:%d events:%d deliveries:%d, want 0/0/0", replayRows, forkEvents, forkDeliveries)
+	}
+}
+
 func TestRunForkCommand_NonDryRunWithoutMaterializeOnlyStaysFailClosed(t *testing.T) {
 	var buf bytes.Buffer
 	code := runForkCommand(context.Background(), t.TempDir(), []string{

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -712,6 +712,42 @@ func TestRunForkCommand_ActivateUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	}
 }
 
+func TestRunForkCommand_ActivateNonSelectedDoesNotRequireSelectedBindingSchema(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	pg := &store.PostgresStore{DB: db}
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000325, 0).UTC()
+	ctx := context.Background()
+	seedRunForkCLIActivationSource(t, db, runID, entityID, eventID, at)
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: runID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE run_fork_selected_contract_bindings`); err != nil {
+		t.Fatalf("drop selected binding table: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runForkCommand(ctx, t.TempDir(), []string{
+		"--activate",
+		"--run", materialized.ForkRunID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var result store.RunForkActivation
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode fork activation json: %v\n%s", err, buf.String())
+	}
+	if !result.Activated || !result.SourceFrozen || result.ForkRunID != materialized.ForkRunID {
+		t.Fatalf("activation result = %#v", result)
+	}
+}
+
 func TestRunForkCommand_ActivateSelectedBindingConsumesRuntimeAdmission(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3245,6 +3245,15 @@ run_model:
       events, timers, routes, sessions, turns, source-advanced policy, contract-swap state, or UI/API execution state.
       Missing, ambiguous, stale, incompatible, or unavailable binding/source/admission evidence is a hard admission
       failure before any selected-contract execution mutation.'
+    selected_contract_activation_gate: 'Selected-bound fork activation is owned by the runtime-side
+      runtime.run_fork.selected_contract_execution.activation_gate before store activation mutates lifecycle state.
+      The gate loads durable selected-contract binding, consumes selected_contract_execution_admission, and permits
+      activation to proceed only when the selected-bound fork has no selected executable frontier and no replayable source
+      delivery/event work. If selected-contract frontier evidence or source delivery/event replay would be required, the
+      gate fails closed before source freeze, fork activation, run_fork_delivery_event_replays insertion, fork event row
+      creation, or fork delivery row creation. This gate does not run handlers, create selected fork-local executable
+      event/delivery rows, write receipts, dead letters, idempotency state, emitted follow-up events, timers, routes,
+      sessions, turns, source-advanced policy, contract-swap state, or UI/API execution state.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -254,6 +254,7 @@ nodes:
       - selected-contract fork execution needs a non-mutating owner model before mutation; the model must consume frontier admission as evidence only and classify contract binding, fork run_id context, handler execution, receipts, dead letters, idempotency, emitted follow-ups, timers, routes, sessions, source-advanced policy, and contract-swap boot/resume
       - selected-contract fork execution needs a durable fork-run selected-source binding owner; CLI/API arguments, dry-run JSON, and local model output are not authoritative for future execution
       - selected-contract fork execution needs a runtime-side non-mutating admission/context owner that consumes the durable selected-source binding before any handler execution or fork-local delivery/outcome mutation
+      - selected-bound fork activation needs a runtime-side selected-contract activation gate that consumes selected-contract execution admission before store activation mutation and blocks source delivery/event replay from becoming selected-contract executable work by fall-through
     representative_issues:
       - 564
       - 565
@@ -265,6 +266,7 @@ nodes:
       - 585
       - 590
       - 594
+      - 596
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -1,0 +1,123 @@
+package runforkexecution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/runtime/runforkadmission"
+	"swarm/internal/store"
+)
+
+type SelectedContractActivationStore interface {
+	LoadRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, bool, error)
+	RequireRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, error)
+	PlanRunFork(context.Context, store.RunForkPlanRequest) (store.RunForkPlan, error)
+	ActivateRunFork(context.Context, store.RunForkActivateRequest) (store.RunForkActivation, error)
+}
+
+type SelectedContractActivationGateRequest struct {
+	ForkRunID    string
+	Store        SelectedContractActivationStore
+	SourceLoader SelectedContractSourceLoader
+}
+
+type SelectedContractActivationGateResult struct {
+	store.RunForkActivation
+	Owner                              string                                           `json:"selected_contract_activation_gate_owner,omitempty"`
+	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
+}
+
+func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractActivationGateRequest) (SelectedContractActivationGateResult, error) {
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("selected-contract activation gate requires fork run_id")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("selected-contract activation gate fork run_id must be a UUID: %w", err)
+	}
+	if req.Store == nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("selected-contract activation gate requires store")
+	}
+
+	binding, ok, err := req.Store.LoadRunForkSelectedContractBinding(ctx, forkRunID)
+	if err != nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("load selected-contract binding for activation gate: %w", err)
+	}
+	if !ok {
+		activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{ForkRunID: forkRunID})
+		return SelectedContractActivationGateResult{RunForkActivation: activation}, err
+	}
+	if req.SourceLoader == nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("selected-contract activation gate requires selected source loader")
+	}
+
+	loadedSource, err := req.SourceLoader.LoadRunForkSelectedContractSource(ctx, binding.ContractSelection)
+	if err != nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("load selected semantic source for activation gate: %w", err)
+	}
+	plan, err := req.Store.PlanRunFork(ctx, store.RunForkPlanRequest{SourceRunID: binding.SourceRunID, At: binding.ForkEventID})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("plan selected-contract activation gate: %w", err)
+	}
+	frontier, err := runforkadmission.AdmitContractFrontier(runforkadmission.ContractFrontierRequest{
+		Plan:              plan,
+		Source:            loadedSource.Source,
+		ContractSelection: binding.ContractSelection,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
+	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     req.Store,
+		SourceLoader:      req.SourceLoader,
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
+	result := SelectedContractActivationGateResult{
+		Owner:                              store.RunForkSelectedContractExecutionActivationGateOwner,
+		SelectedContractExecutionAdmission: &admission,
+	}
+	if !plan.ExecutionReady {
+		return result, fmt.Errorf("selected-contract activation gate requires execution-ready plan before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))
+	}
+	if plan.ReplayResumeAdmission.DeliveryEventReplayReady {
+		return result, fmt.Errorf("%s: selected-bound activation cannot consume source delivery/event replay as selected-contract executable work", store.RunForkBlockerSelectedContractSourceReplayUnsupported)
+	}
+	if plan.ReplayResumeAdmission.HistoricalReplayRequired {
+		return result, fmt.Errorf("selected-contract activation gate blocks historical replay before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))
+	}
+	if frontier.FrontierEventCount > 0 {
+		return result, fmt.Errorf("%s: selected-contract frontier execution remains non-mutating", store.RunForkBlockerContractFrontierExecutionUnsupported)
+	}
+
+	activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{ForkRunID: forkRunID})
+	result.RunForkActivation = activation
+	return result, err
+}
+
+func selectedContractBlockerCodes(blockers []store.RunForkUnsupportedBlocker) string {
+	if len(blockers) == 0 {
+		return "none"
+	}
+	codes := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		if code := strings.TrimSpace(blocker.Code); code != "" {
+			codes = append(codes, code)
+		}
+	}
+	if len(codes) == 0 {
+		return "none"
+	}
+	return strings.Join(codes, ",")
+}

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -1,0 +1,254 @@
+package runforkexecution
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/store"
+)
+
+func TestActivateSelectedContractRunForkDelegatesNonSelectedActivation(t *testing.T) {
+	forkRunID := uuid.NewString()
+	activation := store.RunForkActivation{
+		SourceRunID:     uuid.NewString(),
+		ForkRunID:       forkRunID,
+		ForkRunStatus:   store.RunForkActivatedStatus,
+		SourceRunStatus: store.RunForkSourceFrozenStatus,
+		Activated:       true,
+		SourceFrozen:    true,
+	}
+	fakeStore := &fakeSelectedContractActivationStore{activation: activation}
+
+	result, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID: forkRunID,
+		Store:     fakeStore,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSelectedContractRunFork: %v", err)
+	}
+	if !fakeStore.activateCalled || fakeStore.planCalled {
+		t.Fatalf("store calls = activate:%v plan:%v, want delegate activate without selected plan", fakeStore.activateCalled, fakeStore.planCalled)
+	}
+	if result.SelectedContractExecutionAdmission != nil || result.ForkRunID != forkRunID || !result.Activated {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestActivateSelectedContractRunForkConsumesAdmissionBeforeStateOnlyActivation(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	plan := testSelectedContractStateOnlyPlan(binding)
+	fakeStore := &fakeSelectedContractActivationStore{
+		binding:    binding,
+		bindingOK:  true,
+		plan:       plan,
+		activation: store.RunForkActivation{SourceRunID: binding.SourceRunID, ForkRunID: forkRunID, Activated: true, SourceFrozen: true},
+	}
+	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
+
+	result, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSelectedContractRunFork: %v", err)
+	}
+	if !fakeStore.planCalled || !fakeStore.requireCalled || !fakeStore.activateCalled {
+		t.Fatalf("store calls = plan:%v require:%v activate:%v, want admission before activation", fakeStore.planCalled, fakeStore.requireCalled, fakeStore.activateCalled)
+	}
+	if result.Owner != store.RunForkSelectedContractExecutionActivationGateOwner {
+		t.Fatalf("owner = %q, want %q", result.Owner, store.RunForkSelectedContractExecutionActivationGateOwner)
+	}
+	if result.SelectedContractExecutionAdmission == nil ||
+		result.SelectedContractExecutionAdmission.Owner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		result.SelectedContractExecutionAdmission.FrontierEventCount != 0 {
+		t.Fatalf("selected admission = %#v", result.SelectedContractExecutionAdmission)
+	}
+	if result.RunForkActivation.ForkRunID != forkRunID || !result.Activated {
+		t.Fatalf("activation = %#v", result.RunForkActivation)
+	}
+}
+
+func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMutation(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	plan := testSelectedContractStateOnlyPlan(binding)
+	plan.ExecutionReady = true
+	plan.PendingWorkCount = 1
+	plan.PendingWork = []store.RunForkPendingWork{{
+		EventID:        uuid.NewString(),
+		EventName:      "work.begin",
+		SubscriberType: "agent",
+		SubscriberID:   "safe-agent",
+		Classification: store.RunForkPendingClassificationPending,
+		CreatedAt:      time.Unix(1700001000, 0).UTC(),
+	}}
+	plan.ReplayResumeAdmission = store.RunForkReplayResumeAdmission{
+		Owner:                     store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady:  true,
+		HistoricalReplayRequired:  true,
+		HistoricalReplaySupported: true,
+	}
+	fakeStore := &fakeSelectedContractActivationStore{binding: binding, bindingOK: true, plan: plan}
+	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
+
+	result, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerSelectedContractSourceReplayUnsupported) {
+		t.Fatalf("err = %v, want selected source replay blocker", err)
+	}
+	if fakeStore.activateCalled {
+		t.Fatal("ActivateRunFork called, want fail closed before mutation")
+	}
+	if !fakeStore.requireCalled || result.SelectedContractExecutionAdmission == nil {
+		t.Fatalf("admission not consumed before block; require:%v result:%#v", fakeStore.requireCalled, result)
+	}
+}
+
+func TestActivateSelectedContractRunForkFailsBeforeMutationOnUnavailableSource(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	fakeStore := &fakeSelectedContractActivationStore{
+		binding:   binding,
+		bindingOK: true,
+		plan:      testSelectedContractStateOnlyPlan(binding),
+	}
+	loader := &fakeSelectedContractSourceLoader{err: errors.New("selected source unavailable")}
+
+	_, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected source unavailable") {
+		t.Fatalf("err = %v, want selected source failure", err)
+	}
+	if fakeStore.activateCalled {
+		t.Fatal("ActivateRunFork called, want fail closed before mutation")
+	}
+}
+
+func TestActivateSelectedContractRunForkFailsBeforeMutationOnStaleBindingAdmission(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	fakeStore := &fakeSelectedContractActivationStore{
+		binding:    binding,
+		bindingOK:  true,
+		requireErr: errors.New("selected contract binding disappeared"),
+		plan:       testSelectedContractStateOnlyPlan(binding),
+	}
+	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
+
+	_, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected contract binding disappeared") {
+		t.Fatalf("err = %v, want stale binding failure", err)
+	}
+	if fakeStore.activateCalled {
+		t.Fatal("ActivateRunFork called, want fail closed before mutation")
+	}
+}
+
+func TestActivateSelectedContractRunForkPreservesPlannerBlockersBeforeMutation(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	plan := testSelectedContractStateOnlyPlan(binding)
+	plan.ExecutionReady = false
+	plan.ReplayResumeAdmission.StateOnlyExecutionReady = false
+	plan.ReplayResumeAdmission.HistoricalReplayRequired = true
+	plan.UnsupportedBlockers = []store.RunForkUnsupportedBlocker{{
+		Code:    store.RunForkBlockerSessionHistoryUnproven,
+		Message: "session history is not reconstructable",
+	}}
+	fakeStore := &fakeSelectedContractActivationStore{binding: binding, bindingOK: true, plan: plan}
+	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
+
+	_, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerSessionHistoryUnproven) {
+		t.Fatalf("err = %v, want preserved planner blocker", err)
+	}
+	if fakeStore.activateCalled {
+		t.Fatal("ActivateRunFork called, want fail closed before mutation")
+	}
+}
+
+type fakeSelectedContractActivationStore struct {
+	binding       store.RunForkSelectedContractBinding
+	bindingOK     bool
+	bindingErr    error
+	requireErr    error
+	plan          store.RunForkPlan
+	planErr       error
+	activation    store.RunForkActivation
+	activationErr error
+
+	loadCalled     bool
+	requireCalled  bool
+	planCalled     bool
+	activateCalled bool
+}
+
+func (s *fakeSelectedContractActivationStore) LoadRunForkSelectedContractBinding(_ context.Context, _ string) (store.RunForkSelectedContractBinding, bool, error) {
+	s.loadCalled = true
+	if s.bindingErr != nil {
+		return store.RunForkSelectedContractBinding{}, false, s.bindingErr
+	}
+	return s.binding, s.bindingOK, nil
+}
+
+func (s *fakeSelectedContractActivationStore) RequireRunForkSelectedContractBinding(_ context.Context, _ string) (store.RunForkSelectedContractBinding, error) {
+	s.requireCalled = true
+	if s.requireErr != nil {
+		return store.RunForkSelectedContractBinding{}, s.requireErr
+	}
+	if !s.bindingOK {
+		return store.RunForkSelectedContractBinding{}, errors.New("selected contract binding not found")
+	}
+	return s.binding, nil
+}
+
+func (s *fakeSelectedContractActivationStore) PlanRunFork(_ context.Context, _ store.RunForkPlanRequest) (store.RunForkPlan, error) {
+	s.planCalled = true
+	if s.planErr != nil {
+		return store.RunForkPlan{}, s.planErr
+	}
+	return s.plan, nil
+}
+
+func (s *fakeSelectedContractActivationStore) ActivateRunFork(_ context.Context, _ store.RunForkActivateRequest) (store.RunForkActivation, error) {
+	s.activateCalled = true
+	if s.activationErr != nil {
+		return store.RunForkActivation{}, s.activationErr
+	}
+	return s.activation, nil
+}
+
+func testSelectedContractStateOnlyPlan(binding store.RunForkSelectedContractBinding) store.RunForkPlan {
+	return store.RunForkPlan{
+		SourceRunID:      binding.SourceRunID,
+		SourceRunStatus:  "running",
+		ForkPoint:        store.RunForkPoint{Input: binding.ForkEventID, EventID: binding.ForkEventID, EventName: "work.ready", Timestamp: binding.CreatedAt},
+		EventCountAtFork: 1,
+		ExecutionReady:   true,
+		ReplayResumeAdmission: store.RunForkReplayResumeAdmission{
+			Owner:                   store.RunForkReplayResumeAdmissionOwner,
+			StateOnlyExecutionReady: true,
+		},
+	}
+}

--- a/internal/store/run_fork_selected_contract_binding.go
+++ b/internal/store/run_fork_selected_contract_binding.go
@@ -79,8 +79,22 @@ func (s *PostgresStore) LoadRunForkSelectedContractBinding(ctx context.Context, 
 	if _, err := uuid.Parse(forkRunID); err != nil {
 		return RunForkSelectedContractBinding{}, false, fmt.Errorf("fork run_id must be a UUID: %w", err)
 	}
-	if err := s.requireRunForkSelectedContractBindingCapabilities(ctx); err != nil {
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
 		return RunForkSelectedContractBinding{}, false, err
+	}
+	if !catalog.hasColumns(
+		runForkSelectedContractBindingTable,
+		"fork_run_id",
+		"source_run_id",
+		"fork_event_id",
+		"mode",
+		"contracts_root",
+		"workflow_name",
+		"workflow_version",
+		"created_at",
+	) {
+		return RunForkSelectedContractBinding{}, false, nil
 	}
 	binding, err := loadRunForkSelectedContractBinding(ctx, s.DB, forkRunID)
 	if err == sql.ErrNoRows {
@@ -93,6 +107,9 @@ func (s *PostgresStore) LoadRunForkSelectedContractBinding(ctx context.Context, 
 }
 
 func (s *PostgresStore) RequireRunForkSelectedContractBinding(ctx context.Context, forkRunID string) (RunForkSelectedContractBinding, error) {
+	if err := s.requireRunForkSelectedContractBindingCapabilities(ctx); err != nil {
+		return RunForkSelectedContractBinding{}, err
+	}
 	binding, ok, err := s.LoadRunForkSelectedContractBinding(ctx, forkRunID)
 	if err != nil {
 		return RunForkSelectedContractBinding{}, err

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -1,9 +1,10 @@
 package store
 
 const (
-	RunForkSelectedContractExecutionModelOwner     = "runtime.run_fork.selected_contract_execution_model"
-	RunForkSelectedContractExecutionAdmissionOwner = "runtime.run_fork.selected_contract_execution_admission"
-	RunForkSelectedContractExecutionOwner          = "runtime.run_fork.selected_contract_execution"
+	RunForkSelectedContractExecutionModelOwner          = "runtime.run_fork.selected_contract_execution_model"
+	RunForkSelectedContractExecutionAdmissionOwner      = "runtime.run_fork.selected_contract_execution_admission"
+	RunForkSelectedContractExecutionActivationGateOwner = "runtime.run_fork.selected_contract_execution.activation_gate"
+	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
 	RunForkSelectedContractExecutionAdmissionUseDurableBinding = "durable_binding_and_frontier_evidence"
@@ -16,6 +17,7 @@ const (
 
 	RunForkBlockerSelectedContractExecutionModelNonMutating     = "selected_contract_execution_model_non_mutating"
 	RunForkBlockerSelectedContractExecutionAdmissionNonMutating = "selected_contract_execution_admission_non_mutating"
+	RunForkBlockerSelectedContractSourceReplayUnsupported       = "selected_contract_source_replay_unsupported"
 )
 
 type RunForkSelectedContractExecution struct {


### PR DESCRIPTION
## Summary

Closes #596.

Part of #588, #564, and #549.

This PR implements the approved first slice from the #588 gate: selected-bound fork activation now goes through a runtime-side selected-contract activation gate before any store activation mutation. Non-selected activation still delegates to the existing store owner unchanged.

## Governing Context

Exact spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.activation_admission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.replay_resume_admission_taxonomy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_execution_model`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_execution_admission`
- New spec entry in this PR: `run_model.fork.selected_contract_activation_gate`

Binding issue/gate context:

- #588 refreshed pre-audit after #594/#595
- #588 independent gate approving #596 as first slice
- #596 issue boundary and stop conditions

## Semantic Migration

New canonical owner:

- `runtime.run_fork.selected_contract_execution.activation_gate`

Old path now invalid/non-authoritative for selected-bound activation:

- Direct CLI-to-store selected-bound activation that bypasses selected-contract execution admission.
- Selected-bound activation falling through to #570 source delivery/event replay as selected-contract executable work.

Production paths checked:

- `cmd/swarm fork --activate` now consumes the runtime activation gate.
- Non-selected activation still delegates to `store.ActivateRunFork(...)`.
- Selected-bound state-only activation proceeds only after durable binding and selected admission succeed.
- Selected-bound source replay fails closed before source freeze, fork activation, replay lineage, fork event rows, or fork delivery rows.

Migration complete for this child: yes. #588 remains open for handler execution, fork-local selected event/delivery writes, outcomes/idempotency, emitted follow-ups, timers/routes/sessions/turns, source-advanced policy, contract swap, and UI/API execution.

## Proof

- `go test ./internal/runtime/runforkexecution -count=1`
- `go test ./cmd/swarm -run 'RunForkCommand_Activate|RunForkCommand_Materialize|RunForkCommand_ContractsRemainNonExecuting' -count=1`
- `go test ./internal/store -run 'RunFork.*(Activate|DeliveryEventReplay|Selected|Materialize)' -count=1`
- `go test ./internal/runtime/runforkexecution ./internal/store ./cmd/swarm -run 'SelectedContract|RunFork|Activate|DeliveryEventReplay|ContractFrontier' -count=1`
- `go test ./...`