### PR TITLE
[agent-a][issue #598] Execute selected-contract timestamp forks

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -332,7 +332,7 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 	fs := flag.NewFlagSet("fork", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
-	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for non-mutating dry-run admission")
+	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for fork planning or selected-contract execution")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	storeMode := fs.String("store", "postgres", "Store mode: postgres")
 	runID := fs.String("run", "", "Source run ID to plan from")
@@ -359,15 +359,10 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		}
 		return 2
 	}
-	if modeCount == 0 {
+	selectedContractsRequested := strings.TrimSpace(*contractsPath) != ""
+	if modeCount == 0 && !selectedContractsRequested {
 		if out != nil {
-			fmt.Fprintln(out, "fork failed: mutating fork execution is not implemented; use --dry-run, --materialize-only, or --activate")
-		}
-		return 2
-	}
-	if strings.TrimSpace(*contractsPath) != "" && !*dryRun && !*materializeOnly {
-		if out != nil {
-			fmt.Fprintln(out, "fork failed: --contracts is only supported for non-mutating --dry-run admission or --materialize-only binding")
+			fmt.Fprintln(out, "fork failed: mutating fork execution without --contracts is not implemented; use --dry-run, --materialize-only, --activate, or --contracts")
 		}
 		return 2
 	}
@@ -475,6 +470,50 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		printRunForkMaterialization(out, result)
 		return 0
 	}
+	if modeCount == 0 && selectedContractsRequested {
+		contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, *contractsPath))
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
+			}
+			return 1
+		}
+		_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
+			}
+			return 1
+		}
+		source := semanticview.Wrap(bundle)
+		result, err := runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
+			SourceRunID: strings.TrimSpace(*runID),
+			At:          strings.TrimSpace(*at),
+			Store:       stores.Postgres,
+			SourceLoader: runtimerunforkexecution.ContractBundleSourceLoader{
+				RepoRoot:         repo,
+				PlatformSpecPath: resolvePath(repo, *platformSpecPath),
+			},
+			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: %v\n", err)
+			}
+			return 1
+		}
+		if *asJSON {
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(result); err != nil {
+				fmt.Fprintf(out, "fork failed: encode json: %v\n", err)
+				return 1
+			}
+			return 0
+		}
+		printSelectedContractExecution(out, result)
+		return 0
+	}
 	plan, err := stores.Postgres.PlanRunFork(ctx, store.RunForkPlanRequest{
 		SourceRunID: strings.TrimSpace(*runID),
 		At:          strings.TrimSpace(*at),
@@ -565,6 +604,27 @@ func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
 			result.SelectedContractBinding.ContractSelection.WorkflowName,
 			result.SelectedContractBinding.ContractSelection.WorkflowVersion,
 		)
+	}
+}
+
+func printSelectedContractExecution(w io.Writer, result runtimerunforkexecution.SelectedContractExecutionResult) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "Selected-contract fork executed for source run %s\n", result.Materialization.SourceRunID)
+	fmt.Fprintf(w, "Fork Run: %s status=%s\n", result.Materialization.ForkRunID, result.Activation.ForkRunStatus)
+	fmt.Fprintf(w, "Source Run: %s status=%s\n", result.Activation.SourceRunID, result.Activation.SourceRunStatus)
+	fmt.Fprintf(w, "Owner: %s\n", result.Owner)
+	fmt.Fprintf(w, "Summary: executed_events=%d materialized_entities=%d source_frozen=%t\n",
+		result.ExecutedEventCount,
+		result.Materialization.MaterializedEntityCount,
+		result.Activation.SourceFrozen,
+	)
+	if len(result.ForkEvents) > 0 {
+		fmt.Fprintln(w, "Fork Events:")
+		for _, event := range result.ForkEvents {
+			fmt.Fprintf(w, "  %s -> %s %s\n", event.SourceEventID, event.ForkEventID, event.EventName)
+		}
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +27,7 @@ import (
 	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
@@ -543,18 +545,61 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 	}
 }
 
-func TestRunForkCommand_ContractsRemainNonExecuting(t *testing.T) {
+func TestRunForkCommand_ActivateWithContractsReachesSelectedActivationGate(t *testing.T) {
 	var buf bytes.Buffer
 	code := runForkCommand(context.Background(), t.TempDir(), []string{
 		"--activate",
 		"--contracts", t.TempDir(),
 		"--run", uuid.NewString(),
 	}, &buf)
-	if code != 2 {
-		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
+	if code != 1 {
+		t.Fatalf("runForkCommand code=%d, want runtime failure after parsing; output=%s", code, buf.String())
 	}
-	if !strings.Contains(buf.String(), "--contracts is only supported for non-mutating --dry-run admission or --materialize-only binding") {
-		t.Fatalf("output = %q, want non-executing contracts failure", buf.String())
+	if strings.Contains(buf.String(), "--contracts is only supported") {
+		t.Fatalf("output = %q, want --activate to consume canonical selected activation gate rather than parse-level contract rejection", buf.String())
+	}
+}
+
+func TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	repo := repoRoot()
+	contractsRoot := filepath.Join(repo, "tests/tier1-primitives/test-emits-multiple")
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700000312, 0).UTC()
+	seedRunForkCLISelectedExecutionSource(t, db, sourceRunID, entityID, sourceEventID, at)
+
+	var buf bytes.Buffer
+	code := runForkCommand(context.Background(), repo, []string{
+		"--contracts", contractsRoot,
+		"--run", sourceRunID,
+		"--at", sourceEventID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var result runtimerunforkexecution.SelectedContractExecutionResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode selected execution json: %v\n%s", err, buf.String())
+	}
+	if result.Owner != store.RunForkSelectedContractExecutionOwner || result.ExecutedEventCount != 1 || len(result.ForkEvents) != 1 {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	var lineageRows int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+		  AND source_event_id = $2::uuid
+		  AND fork_event_id = $3::uuid
+	`, result.Materialization.ForkRunID, sourceEventID, result.ForkEvents[0].ForkEventID).Scan(&lineageRows); err != nil {
+		t.Fatalf("count selected execution lineage: %v", err)
+	}
+	if lineageRows != 1 {
+		t.Fatalf("selected execution lineage rows = %d, want 1", lineageRows)
 	}
 }
 
@@ -889,7 +934,7 @@ func TestRunForkCommand_NonDryRunWithoutMaterializeOnlyStaysFailClosed(t *testin
 	if code != 2 {
 		t.Fatalf("runForkCommand code=%d, want 2; output=%s", code, buf.String())
 	}
-	if !strings.Contains(buf.String(), "mutating fork execution is not implemented; use --dry-run, --materialize-only, or --activate") {
+	if !strings.Contains(buf.String(), "mutating fork execution without --contracts is not implemented") {
 		t.Fatalf("output = %q, want fail-closed fork execution message", buf.String())
 	}
 }
@@ -932,6 +977,59 @@ func seedRunForkCLIActivationSource(t *testing.T, db interface {
 		VALUES (
 			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'CLI Entity',
 			'ready', '{}'::jsonb, '{"name":"CLI Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, runID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+}
+
+func seedRunForkCLISelectedExecutionSource(t *testing.T, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, runID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'item.received', $3::uuid, 'flow-a/1', 'entity', $4::jsonb, 'test', 'platform', $5)
+	`, runID, eventID, entityID, fmt.Sprintf(`{"entity_id":%q}`, entityID), at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'test-node', 'pending', 'source_pending_node_delivery', $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'cli-selected-execution-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"CLI Selected Execution Entity"'::jsonb, $3::uuid, 'platform', 'cli-selected-execution-test', 'seed', $4)
+	`, runID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'CLI Selected Execution Entity',
+			'pending', '{}'::jsonb, '{"name":"CLI Selected Execution Entity"}'::jsonb, '{}'::jsonb, 1,
 			$3, $3, $3
 		)
 	`, runID, entityID, at); err != nil {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2709,6 +2709,12 @@ platform_tables:
         does not authorize handler execution, event/delivery replay, timer, route, session, turn, source-advanced, or
         contract-swap mutation.
       ddl: "CREATE TABLE run_fork_selected_contract_bindings (\n    binding_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id      UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id    UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id    UUID NOT NULL REFERENCES events(event_id),\n    mode             TEXT NOT NULL CHECK (mode IN ('selected_contracts')),\n    contracts_root   TEXT NOT NULL,\n    workflow_name    TEXT NOT NULL,\n    workflow_version TEXT NOT NULL,\n    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_bindings_source (source_run_id, fork_event_id)\n);"
+    run_fork_selected_contract_executions:
+      description: Source-to-fork lineage table for mutating selected-contract timestamp-fork execution. The runtime
+        selected-contract execution owner publishes fresh fork-local events under the fork run_id and records which source
+        frontier event each fork event executed from. Source events, deliveries, receipts, dead letters, retry state, and
+        post-fork outcomes are lineage evidence only and must not be copied or used as fork suppressors.
+      ddl: "CREATE TABLE run_fork_selected_contract_executions (\n    execution_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id     UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id   UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id UUID NOT NULL REFERENCES events(event_id),\n    fork_event_id   UUID NOT NULL REFERENCES events(event_id),\n    event_name      TEXT NOT NULL,\n    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id, source_event_id),\n    UNIQUE (fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_fork (fork_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_source (source_run_id, source_event_id)\n);"
     event_deliveries:
       description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
         inherited from the parent event for run-scoped queries.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -153,6 +153,11 @@ active_issues:
     title: Define selected-contract fork execution admission from durable binding
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 598
+    title: Gate selected-contract fork handler execution and fork-local write ownership
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -216,6 +221,7 @@ nodes:
       - timestamp forks need fork-local delivery/event replay lineage and committed replay-scope proof rather than direct source delivery redelivery or markerless same-run outbox replay
       - timestamp-fork non-agent delivery facts are not safe to replay through the agent delivery primitive; node/system delivery execution requires a separate handler/idempotency/receipt owner
       - selected-contract fork execution must classify delivery-write boundaries before future mutation; source deliveries remain lineage/blocker evidence, not executable fork work
+      - selected-contract fork execution must write fresh fork-local event/delivery/outcome rows through the runtime selected-contract execution owner, with source rows used only as lineage evidence
     representative_issues:
       - 112
       - 144
@@ -226,6 +232,7 @@ nodes:
       - 574
       - 583
       - 585
+      - 598
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -255,6 +262,7 @@ nodes:
       - selected-contract fork execution needs a durable fork-run selected-source binding owner; CLI/API arguments, dry-run JSON, and local model output are not authoritative for future execution
       - selected-contract fork execution needs a runtime-side non-mutating admission/context owner that consumes the durable selected-source binding before any handler execution or fork-local delivery/outcome mutation
       - selected-bound fork activation needs a runtime-side selected-contract activation gate that consumes selected-contract execution admission before store activation mutation and blocks source delivery/event replay from becoming selected-contract executable work by fall-through
+      - mutating selected-contract fork execution must consume durable selected-source binding/admission, execute handlers under the fork run_id, write fresh fork-local event/delivery/outcome rows with lineage, regenerate follow-ups, and not use source outcomes as suppressors
     representative_issues:
       - 564
       - 565
@@ -267,6 +275,7 @@ nodes:
       - 590
       - 594
       - 596
+      - 598
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -154,6 +154,12 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
 
+	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), req.ExecutionModel.UnsupportedBlockers...)
+	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
+		Code:    store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating,
+		Message: "selected-contract execution admission is non-mutating; handler execution and fork-local writes remain separately gated",
+	})
+
 	return store.RunForkSelectedContractExecutionAdmission{
 		Owner:                 store.RunForkSelectedContractExecutionAdmissionOwner,
 		FutureExecutionOwner:  store.RunForkSelectedContractExecutionOwner,
@@ -177,13 +183,10 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 			Owner:       store.RunForkSelectedContractBindingOwner,
 			Reason:      "execution admission consumes the durable selected contract source bound to the fork run before any mutation",
 		},
-		RequiredConsumers: append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.RequiredConsumers...),
-		BlockedSiblings:   append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.BlockedSiblings...),
-		InvalidPaths:      append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.InvalidPaths...),
-		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
-			Code:    store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating,
-			Message: "selected-contract execution admission is non-mutating; handler execution and fork-local writes remain separately gated",
-		}},
+		RequiredConsumers:   append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.RequiredConsumers...),
+		BlockedSiblings:     append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.BlockedSiblings...),
+		InvalidPaths:        append([]store.RunForkSelectedContractExecutionBoundary(nil), req.ExecutionModel.InvalidPaths...),
+		UnsupportedBlockers: unsupportedBlockers,
 	}, nil
 }
 

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 )
@@ -24,6 +25,35 @@ type SelectedContractSourceLoader interface {
 type LoadedSelectedContractSource struct {
 	Selection store.RunForkContractSelection
 	Source    semanticview.Source
+	Module    runtimepipeline.WorkflowModule
+}
+
+type selectedContractWorkflowModule struct {
+	source         semanticview.Source
+	workflow       *runtimepipeline.WorkflowDefinition
+	nodes          []runtimepipeline.WorkflowNode
+	guardRegistry  runtimepipeline.GuardRegistry
+	actionRegistry runtimepipeline.ActionRegistry
+}
+
+func (m selectedContractWorkflowModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func (m selectedContractWorkflowModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return m.workflow
+}
+
+func (m selectedContractWorkflowModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+
+func (m selectedContractWorkflowModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guardRegistry
+}
+
+func (m selectedContractWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actionRegistry
 }
 
 type ContractBundleSourceLoader struct {
@@ -35,7 +65,7 @@ func (l ContractBundleSourceLoader) LoadRunForkSelectedContractSource(ctx contex
 	if err := ctx.Err(); err != nil {
 		return LoadedSelectedContractSource{}, err
 	}
-	if err := validateSelectedContractSelection("selected source loader", selection); err != nil {
+	if err := validateSelectedSourceLoaderSelection(selection); err != nil {
 		return LoadedSelectedContractSource{}, err
 	}
 	repoRoot := strings.TrimSpace(l.RepoRoot)
@@ -50,9 +80,34 @@ func (l ContractBundleSourceLoader) LoadRunForkSelectedContractSource(ctx contex
 	if err != nil {
 		return LoadedSelectedContractSource{}, err
 	}
+	source := semanticview.Wrap(bundle)
+	if strings.TrimSpace(selection.WorkflowName) == "" {
+		selection.WorkflowName = strings.TrimSpace(source.WorkflowName())
+	}
+	if strings.TrimSpace(selection.WorkflowVersion) == "" {
+		selection.WorkflowVersion = strings.TrimSpace(source.WorkflowVersion())
+	}
+	if err := validateSelectedContractSelection("selected source loader", selection); err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
+	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
+	if err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		return LoadedSelectedContractSource{}, err
+	}
 	return LoadedSelectedContractSource{
 		Selection: selection,
-		Source:    semanticview.Wrap(bundle),
+		Source:    source,
+		Module: selectedContractWorkflowModule{
+			source:         source,
+			workflow:       workflow,
+			nodes:          nodes,
+			guardRegistry:  runtimepipeline.NewContractGuardRegistry(source),
+			actionRegistry: runtimepipeline.NewContractActionRegistry(source),
+		},
 	}, nil
 }
 
@@ -243,6 +298,16 @@ func validateSelectedContractSelection(label string, selection store.RunForkCont
 	}
 	if strings.TrimSpace(selection.WorkflowVersion) == "" {
 		return fmt.Errorf("selected-contract execution admission %s requires workflow_version", label)
+	}
+	return nil
+}
+
+func validateSelectedSourceLoaderSelection(selection store.RunForkContractSelection) error {
+	if strings.TrimSpace(selection.Mode) != "selected_contracts" {
+		return fmt.Errorf("selected-contract execution admission selected source loader requires mode selected_contracts; got %q", selection.Mode)
+	}
+	if strings.TrimSpace(selection.ContractsRoot) == "" {
+		return fmt.Errorf("selected-contract execution admission selected source loader requires contracts_root")
 	}
 	return nil
 }

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -77,6 +77,9 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if frontier.FrontierEventCount == 0 {
 		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires selected frontier events")
 	}
+	if err := validateSelectedContractExecutionFrontierForMutation(frontier); err != nil {
+		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner}, err
+	}
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
 	if err != nil {
 		return SelectedContractExecutionResult{}, err
@@ -139,6 +142,22 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		ForkEvents:                         published,
 	}
 	return result, err
+}
+
+func validateSelectedContractExecutionFrontierForMutation(frontier store.RunForkContractFrontierAdmission) error {
+	for _, blocker := range frontier.UnsupportedBlockers {
+		code := strings.TrimSpace(blocker.Code)
+		switch code {
+		case "", store.RunForkBlockerContractFrontierExecutionUnsupported:
+			continue
+		default:
+			if msg := strings.TrimSpace(blocker.Message); msg != "" {
+				return fmt.Errorf("%s: %s", code, msg)
+			}
+			return fmt.Errorf("%s", code)
+		}
+	}
+	return nil
 }
 
 func cleanupSelectedContractExecutionFailure(ctx context.Context, store *store.PostgresStore, forkRunID string, cause error) error {

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -1,0 +1,244 @@
+package runforkexecution
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/runforkadmission"
+	"swarm/internal/store"
+)
+
+type SelectedContractExecutionRequest struct {
+	SourceRunID       string
+	At                string
+	Store             *store.PostgresStore
+	SourceLoader      SelectedContractSourceLoader
+	ContractSelection store.RunForkContractSelection
+}
+
+type SelectedContractExecutionForkEvent struct {
+	SourceEventID string `json:"source_event_id"`
+	ForkEventID   string `json:"fork_event_id"`
+	EventName     string `json:"event_name"`
+}
+
+type SelectedContractExecutionResult struct {
+	Owner                              string                                           `json:"owner"`
+	Materialization                    store.RunForkMaterialization                     `json:"materialization"`
+	Activation                         store.RunForkActivation                          `json:"activation"`
+	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
+	ExecutedEventCount                 int                                              `json:"executed_event_count"`
+	ForkEvents                         []SelectedContractExecutionForkEvent             `json:"fork_events,omitempty"`
+}
+
+func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExecutionRequest) (SelectedContractExecutionResult, error) {
+	if req.Store == nil {
+		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires store")
+	}
+	if req.SourceLoader == nil {
+		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires selected source loader")
+	}
+	selection, err := normalizeSelectedContractExecutionSelection(req.ContractSelection)
+	if err != nil {
+		return SelectedContractExecutionResult{}, err
+	}
+	loadedSource, err := req.SourceLoader.LoadRunForkSelectedContractSource(ctx, selection)
+	if err != nil {
+		return SelectedContractExecutionResult{}, fmt.Errorf("load selected semantic source for execution: %w", err)
+	}
+	selection = loadedSource.Selection
+	if loadedSource.Module == nil {
+		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires executable selected workflow module")
+	}
+	plan, err := req.Store.PlanRunFork(ctx, store.RunForkPlanRequest{
+		SourceRunID: strings.TrimSpace(req.SourceRunID),
+		At:          strings.TrimSpace(req.At),
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{}, fmt.Errorf("plan selected-contract execution: %w", err)
+	}
+	frontier, err := runforkadmission.AdmitContractFrontier(runforkadmission.ContractFrontierRequest{
+		Plan:              plan,
+		Source:            loadedSource.Source,
+		ContractSelection: selection,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{}, err
+	}
+	if frontier.FrontierEventCount == 0 {
+		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires selected frontier events")
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	if err != nil {
+		return SelectedContractExecutionResult{}, err
+	}
+	sourceEventIDs := selectedContractExecutionFrontierEventIDs(frontier.FrontierEvents)
+	materialization, err := req.Store.MaterializeRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID:       plan.SourceRunID,
+		At:                plan.ForkPoint.EventID,
+		ContractSelection: selection,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
+	}
+	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         materialization.ForkRunID,
+		BindingReader:     req.Store,
+		SourceLoader:      req.SourceLoader,
+		FrontierAdmission: frontier,
+		ExecutionModel:    model,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
+	}
+	activation, err := req.Store.ActivateRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialization.ForkRunID,
+		AllowedSourceEventIDs: sourceEventIDs,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{
+			Owner:                              store.RunForkSelectedContractExecutionOwner,
+			Materialization:                    materialization,
+			Activation:                         activation,
+			SelectedContractExecutionAdmission: &admission,
+		}, err
+	}
+	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
+		Store:        req.Store,
+		LoadedSource: loadedSource,
+		SourceRunID:  plan.SourceRunID,
+		ForkRunID:    materialization.ForkRunID,
+		SourceEvents: sourceEventIDs,
+	})
+	result := SelectedContractExecutionResult{
+		Owner:                              store.RunForkSelectedContractExecutionOwner,
+		Materialization:                    materialization,
+		Activation:                         activation,
+		SelectedContractExecutionAdmission: &admission,
+		ExecutedEventCount:                 len(published),
+		ForkEvents:                         published,
+	}
+	return result, err
+}
+
+type publishSelectedContractForkEventsRequest struct {
+	Store        *store.PostgresStore
+	LoadedSource LoadedSelectedContractSource
+	SourceRunID  string
+	ForkRunID    string
+	SourceEvents []string
+}
+
+func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedContractForkEventsRequest) ([]SelectedContractExecutionForkEvent, error) {
+	sourceEvents, err := req.Store.LoadRunForkSelectedContractSourceEvents(ctx, req.SourceRunID, req.SourceEvents)
+	if err != nil {
+		return nil, err
+	}
+	bus, err := runtimebus.NewEventBusWithOptions(req.Store, runtimebus.EventBusOptions{
+		ContractBundle: req.LoadedSource.Source,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create selected-contract execution bus: %w", err)
+	}
+	pipeline := newSelectedContractPipeline(bus, req.Store, req.LoadedSource)
+	bus.SetInterceptors(pipeline)
+
+	runCtx := runtimecorrelation.WithRunID(ctx, req.ForkRunID)
+	out := make([]SelectedContractExecutionForkEvent, 0, len(sourceEvents))
+	for _, sourceEvent := range sourceEvents {
+		forkEventID := uuid.NewString()
+		evt := selectedContractForkEvent(req.ForkRunID, forkEventID, sourceEvent)
+		if err := bus.Publish(runCtx, evt); err != nil {
+			return out, fmt.Errorf("execute selected-contract fork event %s as %s: %w", sourceEvent.SourceEventID, forkEventID, err)
+		}
+		lineage := store.RunForkSelectedContractExecutionLineage{
+			Owner:         store.RunForkSelectedContractExecutionLineageOwner,
+			ForkRunID:     req.ForkRunID,
+			SourceRunID:   req.SourceRunID,
+			SourceEventID: sourceEvent.SourceEventID,
+			ForkEventID:   forkEventID,
+			EventName:     sourceEvent.EventName,
+			CreatedAt:     time.Now().UTC(),
+		}
+		if err := req.Store.RecordRunForkSelectedContractExecutionLineage(ctx, lineage); err != nil {
+			return out, err
+		}
+		out = append(out, SelectedContractExecutionForkEvent{
+			SourceEventID: sourceEvent.SourceEventID,
+			ForkEventID:   forkEventID,
+			EventName:     sourceEvent.EventName,
+		})
+	}
+	return out, nil
+}
+
+func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.RunForkSelectedContractSourceEvent) events.Event {
+	payload := json.RawMessage("{}")
+	if len(sourceEvent.Payload) > 0 && json.Valid(sourceEvent.Payload) {
+		payload = append(json.RawMessage(nil), sourceEvent.Payload...)
+	}
+	evt := events.Event{
+		ID:          strings.TrimSpace(forkEventID),
+		Type:        events.EventType(strings.TrimSpace(sourceEvent.EventName)),
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+		Payload:     payload,
+		RunID:       strings.TrimSpace(forkRunID),
+		CreatedAt:   time.Now().UTC(),
+	}
+	envelope := events.EventEnvelope{
+		EntityID:     strings.TrimSpace(sourceEvent.EntityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(sourceEvent.FlowInstance), "/"),
+		Scope:        events.EventScope(strings.TrimSpace(sourceEvent.Scope)),
+	}
+	return evt.WithEnvelope(envelope)
+}
+
+func newSelectedContractPipeline(bus *runtimebus.EventBus, store *store.PostgresStore, loaded LoadedSelectedContractSource) *runtimepipeline.PipelineCoordinator {
+	return runtimepipeline.NewPipelineCoordinatorWithOptions(bus, store.DB, runtimepipeline.PipelineCoordinatorOptions{
+		Module:                  loaded.Module,
+		EventReceiptsCapability: store.CanonicalEventReceiptsCapability,
+	})
+}
+
+func selectedContractExecutionFrontierEventIDs(events []store.RunForkContractFrontierEvent) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(events))
+	for _, event := range events {
+		eventID := strings.TrimSpace(event.SourceEventID)
+		if eventID == "" {
+			continue
+		}
+		if _, ok := seen[eventID]; ok {
+			continue
+		}
+		seen[eventID] = struct{}{}
+		out = append(out, eventID)
+	}
+	return out
+}
+
+func normalizeSelectedContractExecutionSelection(selection store.RunForkContractSelection) (store.RunForkContractSelection, error) {
+	selection.Mode = strings.TrimSpace(selection.Mode)
+	if selection.Mode == "" {
+		selection.Mode = "selected_contracts"
+	}
+	if selection.Mode != "selected_contracts" {
+		return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires mode selected_contracts; got %q", selection.Mode)
+	}
+	selection.ContractsRoot = strings.TrimSpace(selection.ContractsRoot)
+	selection.WorkflowName = strings.TrimSpace(selection.WorkflowName)
+	selection.WorkflowVersion = strings.TrimSpace(selection.WorkflowVersion)
+	if selection.ContractsRoot == "" {
+		return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires contracts_root")
+	}
+	return selection, nil
+}

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -100,6 +100,22 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
 	}
+	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
+		Store:        req.Store,
+		LoadedSource: loadedSource,
+		SourceRunID:  plan.SourceRunID,
+		ForkRunID:    materialization.ForkRunID,
+		SourceEvents: sourceEventIDs,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{
+			Owner:                              store.RunForkSelectedContractExecutionOwner,
+			Materialization:                    materialization,
+			SelectedContractExecutionAdmission: &admission,
+			ExecutedEventCount:                 len(published),
+			ForkEvents:                         published,
+		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
+	}
 	activation, err := req.Store.ActivateRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID:             materialization.ForkRunID,
 		AllowedSourceEventIDs: sourceEventIDs,
@@ -110,15 +126,10 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 			Materialization:                    materialization,
 			Activation:                         activation,
 			SelectedContractExecutionAdmission: &admission,
-		}, err
+			ExecutedEventCount:                 len(published),
+			ForkEvents:                         published,
+		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
 	}
-	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
-		Store:        req.Store,
-		LoadedSource: loadedSource,
-		SourceRunID:  plan.SourceRunID,
-		ForkRunID:    materialization.ForkRunID,
-		SourceEvents: sourceEventIDs,
-	})
 	result := SelectedContractExecutionResult{
 		Owner:                              store.RunForkSelectedContractExecutionOwner,
 		Materialization:                    materialization,
@@ -128,6 +139,19 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		ForkEvents:                         published,
 	}
 	return result, err
+}
+
+func cleanupSelectedContractExecutionFailure(ctx context.Context, store *store.PostgresStore, forkRunID string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if store == nil || strings.TrimSpace(forkRunID) == "" {
+		return cause
+	}
+	if err := store.DiscardMaterializedSelectedContractExecutionFork(ctx, forkRunID); err != nil {
+		return fmt.Errorf("%w; cleanup selected-contract fork %s: %v", cause, forkRunID, err)
+	}
+	return cause
 }
 
 type publishSelectedContractForkEventsRequest struct {

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -246,6 +246,66 @@ func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterializ
 	}
 }
 
+func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION fail_selected_contract_execution_lineage_insert()
+		RETURNS trigger AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced selected execution lineage failure';
+		END;
+		$$ LANGUAGE plpgsql;
+
+		CREATE TRIGGER fail_selected_contract_execution_lineage_insert
+		BEFORE INSERT ON run_fork_selected_contract_executions
+		FOR EACH ROW EXECUTE FUNCTION fail_selected_contract_execution_lineage_insert();
+	`); err != nil {
+		t.Fatalf("install lineage failure trigger: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002335, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err == nil || !strings.Contains(err.Error(), "forced selected execution lineage failure") {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want forced lineage publish failure", err)
+	}
+	if result.Materialization.ForkRunID == "" {
+		t.Fatalf("expected materialization before publish failure, got %#v", result.Materialization)
+	}
+	if result.Activation.SourceFrozen || result.Activation.ForkRunStatus == store.RunForkActivatedStatus {
+		t.Fatalf("activation mutated before publish failure cleanup: %#v", result.Activation)
+	}
+
+	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
+}
+
 func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -293,6 +353,12 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testin
 	if result.Activation.SourceFrozen || result.Activation.ForkRunStatus == store.RunForkActivatedStatus {
 		t.Fatalf("activation mutated before publish failure cleanup: %#v", result.Activation)
 	}
+	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
+}
+
+func assertSelectedContractExecutionCleanup(t *testing.T, db *sql.DB, sourceRunID, forkRunID string) {
+	t.Helper()
+	ctx := context.Background()
 	var sourceStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
 		t.Fatalf("load source status: %v", err)
@@ -300,23 +366,36 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testin
 	if sourceStatus != "running" {
 		t.Fatalf("source status = %q, want running", sourceStatus)
 	}
-	var forkRows, forkEvents, forkState, lineageRows int
+	var forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE forked_from_run_id = $1::uuid`, sourceRunID).Scan(&forkRows); err != nil {
 		t.Fatalf("count fork rows: %v", err)
 	}
-	if result.Materialization.ForkRunID != "" {
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkEvents); err != nil {
+	if forkRunID != "" {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, forkRunID).Scan(&forkEvents); err != nil {
 			t.Fatalf("count fork events: %v", err)
 		}
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_state WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkState); err != nil {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`, forkRunID).Scan(&forkDeliveries); err != nil {
+			t.Fatalf("count fork deliveries: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts`).Scan(&forkReceipts); err != nil {
+			t.Fatalf("count event receipts after cleanup: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_state WHERE run_id = $1::uuid`, forkRunID).Scan(&forkState); err != nil {
 			t.Fatalf("count fork state: %v", err)
 		}
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_executions WHERE fork_run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&lineageRows); err != nil {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, forkRunID).Scan(&forkMutations); err != nil {
+			t.Fatalf("count fork mutations: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_bindings WHERE fork_run_id = $1::uuid`, forkRunID).Scan(&bindingRows); err != nil {
+			t.Fatalf("count fork binding: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_executions WHERE fork_run_id = $1::uuid`, forkRunID).Scan(&lineageRows); err != nil {
 			t.Fatalf("count fork lineage: %v", err)
 		}
 	}
-	if forkRows != 0 || forkEvents != 0 || forkState != 0 || lineageRows != 0 {
-		t.Fatalf("cleanup left fork rows runs:%d events:%d state:%d lineage:%d", forkRows, forkEvents, forkState, lineageRows)
+	if forkRows != 0 || forkEvents != 0 || forkDeliveries != 0 || forkReceipts != 0 || forkState != 0 || forkMutations != 0 || bindingRows != 0 || lineageRows != 0 {
+		t.Fatalf("cleanup left fork rows runs:%d events:%d deliveries:%d receipts:%d state:%d mutations:%d bindings:%d lineage:%d",
+			forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows)
 	}
 }
 

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -198,7 +198,7 @@ func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 	}
 }
 
-func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(t *testing.T) {
+func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterialization(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
@@ -217,8 +217,8 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	at := time.Unix(1700002350, 0).UTC()
-	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "invalid event name", at)
+	at := time.Unix(1700002325, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "ghost.event", at)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -230,8 +230,65 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(
 			contractsRoot,
 		),
 	})
-	if err == nil || !strings.Contains(err.Error(), "invalid event type") {
-		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want publish event type validation failure", err)
+	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want unresolved frontier blocker", err)
+	}
+	if result.Materialization.ForkRunID != "" || result.ExecutedEventCount != 0 {
+		t.Fatalf("result mutated before unresolved frontier rejection: %#v", result)
+	}
+
+	var forkRows int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE forked_from_run_id = $1::uuid`, sourceRunID).Scan(&forkRows); err != nil {
+		t.Fatalf("count fork rows: %v", err)
+	}
+	if forkRows != 0 {
+		t.Fatalf("fork rows after unresolved frontier rejection = %d, want 0", forkRows)
+	}
+}
+
+func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	afterEventID := uuid.NewString()
+	at := time.Unix(1700002350, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'source.after', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4)
+	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed post-fork source event: %v", err)
+	}
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_events_advanced_after_fork_point") {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want source-advanced activation failure", err)
 	}
 	if result.Activation.SourceFrozen || result.Activation.ForkRunStatus == store.RunForkActivatedStatus {
 		t.Fatalf("activation mutated before publish failure cleanup: %#v", result.Activation)

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -1,0 +1,281 @@
+package runforkexecution
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/runtime/runforkadmission"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002200, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.Owner != store.RunForkSelectedContractExecutionOwner || result.ExecutedEventCount != 1 || len(result.ForkEvents) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	forkEventID := result.ForkEvents[0].ForkEventID
+	if forkEventID == "" || forkEventID == sourceEventID {
+		t.Fatalf("fork event id = %q, source = %q", forkEventID, sourceEventID)
+	}
+
+	var forkEventRun, forkEventName, forkSourceEvent string
+	if err := db.QueryRowContext(ctx, `
+		SELECT run_id::text, event_name, COALESCE(source_event_id::text, '')
+		FROM events
+		WHERE event_id = $1::uuid
+	`, forkEventID).Scan(&forkEventRun, &forkEventName, &forkSourceEvent); err != nil {
+		t.Fatalf("load fork event: %v", err)
+	}
+	if forkEventRun != result.Materialization.ForkRunID || forkEventName != "item.received" {
+		t.Fatalf("fork event = run:%s name:%s", forkEventRun, forkEventName)
+	}
+	if forkSourceEvent == sourceEventID {
+		t.Fatalf("fork event source_event_id copied source event %s; lineage must be explicit table evidence", sourceEventID)
+	}
+
+	var lineageCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+		  AND source_run_id = $2::uuid
+		  AND source_event_id = $3::uuid
+		  AND fork_event_id = $4::uuid
+	`, result.Materialization.ForkRunID, sourceRunID, sourceEventID, forkEventID).Scan(&lineageCount); err != nil {
+		t.Fatalf("count selected execution lineage: %v", err)
+	}
+	if lineageCount != 1 {
+		t.Fatalf("selected execution lineage rows = %d, want 1", lineageCount)
+	}
+
+	var sourceCopiedEvents int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, result.Materialization.ForkRunID, sourceEventID).Scan(&sourceCopiedEvents); err != nil {
+		t.Fatalf("count copied source event ids: %v", err)
+	}
+	if sourceCopiedEvents != 0 {
+		t.Fatalf("copied source event ids into fork run = %d, want 0", sourceCopiedEvents)
+	}
+
+	var forkReceipts, forkDeliveries int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, forkEventID).Scan(&forkReceipts); err != nil {
+		t.Fatalf("count fork receipts: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid AND event_id = $2::uuid`, result.Materialization.ForkRunID, forkEventID).Scan(&forkDeliveries); err != nil {
+		t.Fatalf("count fork deliveries: %v", err)
+	}
+	if forkReceipts == 0 || forkDeliveries == 0 {
+		t.Fatalf("fork outcomes = receipts:%d deliveries:%d, want fork-local writes", forkReceipts, forkDeliveries)
+	}
+
+	var emittedFollowUps int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'item.processed'
+		  AND source_event_id = $2::uuid
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&emittedFollowUps); err != nil {
+		t.Fatalf("count emitted follow-ups: %v", err)
+	}
+	if emittedFollowUps != 1 {
+		t.Fatalf("fork follow-up events = %d, want 1", emittedFollowUps)
+	}
+
+	var sourceStatus, forkStatus, forkEntityState string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT current_state FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, result.Materialization.ForkRunID, entityID).Scan(&forkEntityState); err != nil {
+		t.Fatalf("load fork entity state: %v", err)
+	}
+	if sourceStatus != store.RunForkSourceFrozenStatus || forkStatus != store.RunForkActivatedStatus || forkEntityState == "" {
+		t.Fatalf("post execution = source:%s fork:%s entity:%s", sourceStatus, forkStatus, forkEntityState)
+	}
+}
+
+func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	at := time.Unix(1700002300, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, conversation_mode, status, created_at)
+		VALUES ('agent-a', 'test-agent', 'tier1', 'session_per_entity', 'active', $1)
+		ON CONFLICT (agent_id) DO NOTHING
+	`, at); err != nil {
+		t.Fatalf("seed source session agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'session_per_entity', 'active', $4, $4)
+	`, sessionID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source session: %v", err)
+	}
+
+	_, err = ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerSessionHistoryUnproven) {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want session blocker", err)
+	}
+}
+
+func runForkExecutionRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	return root
+}
+
+func seedSelectedExecutionSourceRun(t *testing.T, db *sql.DB, sourceRunID, entityID, sourceEventID, eventName string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	payload, _ := json.Marshal(map[string]any{"entity_id": entityID})
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3, $4::uuid, 'flow-a/1', 'entity', $5::jsonb, 'source-runtime', 'platform', $6)
+	`, sourceRunID, sourceEventID, eventName, entityID, string(payload), at); err != nil {
+		t.Fatalf("seed source event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'test-node', 'pending', 'source_pending_node_delivery', $3)
+	`, sourceRunID, sourceEventID, at); err != nil {
+		t.Fatalf("seed source delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'selected-execution-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Selected Execution Entity"'::jsonb, $3::uuid, 'platform', 'selected-execution-test', 'seed', $4)
+	`, sourceRunID, entityID, sourceEventID, at); err != nil {
+		t.Fatalf("seed source mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'Selected Execution Entity',
+			'pending', '{}'::jsonb, '{"name":"Selected Execution Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+}
+
+func seedSourceOutcomeThatMustNotSuppressFork(t *testing.T, db *sql.DB, sourceEventID, entityID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES ($1::uuid, 'node', 'old-source-node', $2::uuid, 'flow-a/1', 'success', 'source_outcome_must_not_suppress_fork', '{}'::jsonb, $3)
+	`, sourceEventID, entityID, at); err != nil {
+		t.Fatalf("seed source receipt: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dead_letters (
+			original_event_id, original_event, entity_id, flow_instance, failure_type, error_message, handler_node, created_at
+		)
+		VALUES ($1::uuid, 'item.received', $2::uuid, 'flow-a/1', 'handler_error', 'source dead letter must not suppress fork', 'old-source-node', $3)
+	`, sourceEventID, entityID, at); err != nil {
+		t.Fatalf("seed source dead letter: %v", err)
+	}
+}

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -198,6 +198,71 @@ func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 	}
 }
 
+func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002350, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "invalid event name", at)
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid event type") {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want publish event type validation failure", err)
+	}
+	if result.Activation.SourceFrozen || result.Activation.ForkRunStatus == store.RunForkActivatedStatus {
+		t.Fatalf("activation mutated before publish failure cleanup: %#v", result.Activation)
+	}
+	var sourceStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if sourceStatus != "running" {
+		t.Fatalf("source status = %q, want running", sourceStatus)
+	}
+	var forkRows, forkEvents, forkState, lineageRows int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE forked_from_run_id = $1::uuid`, sourceRunID).Scan(&forkRows); err != nil {
+		t.Fatalf("count fork rows: %v", err)
+	}
+	if result.Materialization.ForkRunID != "" {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkEvents); err != nil {
+			t.Fatalf("count fork events: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_state WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkState); err != nil {
+			t.Fatalf("count fork state: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_executions WHERE fork_run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&lineageRows); err != nil {
+			t.Fatalf("count fork lineage: %v", err)
+		}
+	}
+	if forkRows != 0 || forkEvents != 0 || forkState != 0 || lineageRows != 0 {
+		t.Fatalf("cleanup left fork rows runs:%d events:%d state:%d lineage:%d", forkRows, forkEvents, forkState, lineageRows)
+	}
+}
+
 func runForkExecutionRepoRoot(t *testing.T) string {
 	t.Helper()
 	root, err := filepath.Abs("../../..")

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -23,6 +23,12 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission unexpectedly supports historical execution")
 	}
 
+	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), admission.UnsupportedBlockers...)
+	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
+		Code:    store.RunForkBlockerSelectedContractExecutionModelNonMutating,
+		Message: "selected-contract fork execution is model-only; executable fork work remains separately gated",
+	})
+
 	return store.RunForkSelectedContractExecution{
 		Owner:                store.RunForkSelectedContractExecutionModelOwner,
 		FutureExecutionOwner: store.RunForkSelectedContractExecutionOwner,
@@ -39,14 +45,25 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 			Owner:       store.RunForkSelectedContractBindingOwner,
 			Reason:      "future execution must consume the durable selected contract source bound to the fork run before handlers run",
 		},
-		RequiredConsumers: selectedContractExecutionRequiredConsumers(),
-		BlockedSiblings:   selectedContractExecutionBlockedSiblings(),
-		InvalidPaths:      selectedContractExecutionInvalidPaths(),
-		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
-			Code:    store.RunForkBlockerSelectedContractExecutionModelNonMutating,
-			Message: "selected-contract fork execution is model-only; executable fork work remains separately gated",
-		}},
+		RequiredConsumers:   selectedContractExecutionRequiredConsumers(),
+		BlockedSiblings:     selectedContractExecutionBlockedSiblings(),
+		InvalidPaths:        selectedContractExecutionInvalidPaths(),
+		UnsupportedBlockers: unsupportedBlockers,
 	}, nil
+}
+
+func appendRunForkUnsupportedBlocker(blockers []store.RunForkUnsupportedBlocker, blocker store.RunForkUnsupportedBlocker) []store.RunForkUnsupportedBlocker {
+	code := strings.TrimSpace(blocker.Code)
+	if code == "" {
+		return blockers
+	}
+	for _, existing := range blockers {
+		if strings.TrimSpace(existing.Code) == code {
+			return blockers
+		}
+	}
+	blocker.Code = code
+	return append(blockers, blocker)
 }
 
 func selectedContractFrontierEvents(events []store.RunForkContractFrontierEvent) []store.RunForkSelectedContractFrontierEvent {

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -75,6 +75,43 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 	}
 }
 
+func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID: "source-event",
+			EventName:     "ghost.event",
+		}},
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{
+			{Code: store.RunForkBlockerContractFrontierExecutionUnsupported},
+			{Code: store.RunForkBlockerContractFrontierRouteUnresolved},
+		},
+	}
+
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: admission})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	for _, code := range []string{
+		store.RunForkBlockerContractFrontierExecutionUnsupported,
+		store.RunForkBlockerContractFrontierRouteUnresolved,
+		store.RunForkBlockerSelectedContractExecutionModelNonMutating,
+	} {
+		if !unsupportedBlockerHas(model.UnsupportedBlockers, code) {
+			t.Fatalf("unsupported blockers = %#v, want %s", model.UnsupportedBlockers, code)
+		}
+	}
+}
+
 func TestBuildSelectedContractExecutionModelFailsClosedOnExecutableAdmission(t *testing.T) {
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
 		Admission: store.RunForkContractFrontierAdmission{

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -81,6 +81,9 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if s == nil || s.DB == nil {
 		return RunForkMaterialization{}, fmt.Errorf("postgres store is required")
 	}
+	if _, err := s.requireRunForkSelectedContractExecutionCapabilities(ctx); err != nil {
+		return RunForkMaterialization{}, err
+	}
 	if err := s.requireRunForkMaterializerCapabilities(ctx); err != nil {
 		return RunForkMaterialization{}, err
 	}
@@ -252,7 +255,7 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		}
 		return result, err
 	}
-	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, lineage.ForkRunID); err != nil {
+	if err := ensureRunForkSelectedContractExecutionForkState(ctx, tx, catalog, lineage.ForkRunID, req.AllowedSourceEventIDs); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
 			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
@@ -298,6 +301,110 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	result.Activated = true
 	result.SourceFrozen = true
 	return result, nil
+}
+
+func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx context.Context, forkRunID string) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	forkRunID = strings.TrimSpace(forkRunID)
+	if forkRunID == "" {
+		return fmt.Errorf("fork run_id is required")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return fmt.Errorf("fork run_id must be a UUID: %w", err)
+	}
+	catalog, err := s.requireRunForkSelectedContractExecutionCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin selected-contract fork discard: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var status string
+	if err := tx.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, forkRunID).Scan(&status); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("load fork run for discard: %w", err)
+	}
+	if status != RunForkMaterializedStatus {
+		return fmt.Errorf("selected-contract fork discard requires materialized fork status %q; got %q", RunForkMaterializedStatus, status)
+	}
+
+	if catalog.hasColumns("agent_turns", "run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_turns WHERE run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork turns: %w", err)
+		}
+	}
+	if catalog.hasColumns("agent_conversation_audits", "run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_conversation_audits WHERE run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork conversation audits: %w", err)
+		}
+	}
+	if catalog.hasColumns("agent_sessions", "run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_sessions WHERE run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork sessions: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+	`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract execution lineage: %w", err)
+	}
+	if catalog.hasColumns(runForkDeliveryEventReplayTable, "fork_run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork replay lineage: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM event_receipts
+		WHERE event_id IN (SELECT event_id FROM events WHERE run_id = $1::uuid)
+	`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork receipts: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM dead_letters
+		WHERE original_event_id IN (SELECT event_id FROM events WHERE run_id = $1::uuid)
+	`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork dead letters: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM event_deliveries
+		WHERE run_id = $1::uuid
+		   OR event_id IN (SELECT event_id FROM events WHERE run_id = $1::uuid)
+	`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork deliveries: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM entity_mutations WHERE run_id = $1::uuid`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork mutations: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE run_id = $1::uuid`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork events: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM entity_state WHERE run_id = $1::uuid`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork entity state: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM run_fork_selected_contract_bindings WHERE fork_run_id = $1::uuid`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract fork binding: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM runs WHERE run_id = $1::uuid AND status = $2`, forkRunID, RunForkMaterializedStatus); err != nil {
+		return fmt.Errorf("delete selected-contract fork run: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit selected-contract fork discard: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (s *PostgresStore) LoadRunForkSelectedContractSourceEvents(ctx context.Context, sourceRunID string, sourceEventIDs []string) ([]RunForkSelectedContractSourceEvent, error) {
@@ -409,6 +516,95 @@ func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourc
 		}
 	}
 	return blockers
+}
+
+func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID string, allowedSourceEventIDs []string) error {
+	allowedEvents := uniqueNonEmptyStrings(allowedSourceEventIDs)
+	if len(allowedEvents) == 0 {
+		return ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, forkRunID)
+	}
+	for _, check := range []struct {
+		code  string
+		table string
+		query string
+	}{
+		{"fork_sessions_already_exist", "agent_sessions", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`},
+		{"fork_conversation_audits_already_exist", "agent_conversation_audits", `SELECT EXISTS (SELECT 1 FROM agent_conversation_audits WHERE run_id = $1::uuid)`},
+		{"fork_turns_already_exist", "agent_turns", `SELECT EXISTS (SELECT 1 FROM agent_turns WHERE run_id = $1::uuid)`},
+	} {
+		if !catalog.hasColumns(check.table, "run_id") {
+			continue
+		}
+		var exists bool
+		if err := tx.QueryRowContext(ctx, check.query, forkRunID).Scan(&exists); err != nil {
+			return fmt.Errorf("check %s: %w", check.code, err)
+		}
+		if exists {
+			return runForkReplayResumeError(check.code, RunForkReplayResumeFactForkReplayState, fmt.Sprintf("fork activation blocked: %s", check.code))
+		}
+	}
+
+	var missingLineage int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM unnest($2::uuid[]) AS allowed(source_event_id)
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM run_fork_selected_contract_executions x
+			WHERE x.fork_run_id = $1::uuid
+			  AND x.source_event_id = allowed.source_event_id
+		)
+	`, forkRunID, pq.Array(allowedEvents)).Scan(&missingLineage); err != nil {
+		return fmt.Errorf("check selected-contract execution lineage completeness: %w", err)
+	}
+	if missingLineage > 0 {
+		return runForkReplayResumeError("fork_selected_contract_execution_lineage_missing", RunForkReplayResumeFactForkReplayState, "fork activation blocked: fork_selected_contract_execution_lineage_missing")
+	}
+
+	var strayEvents int
+	if err := tx.QueryRowContext(ctx, `
+		WITH RECURSIVE selected_tree AS (
+			SELECT e.event_id
+			FROM events e
+			INNER JOIN run_fork_selected_contract_executions x
+				ON x.fork_event_id = e.event_id
+			   AND x.fork_run_id = $1::uuid
+			   AND x.source_event_id = ANY($2::uuid[])
+			WHERE e.run_id = $1::uuid
+			UNION
+			SELECT child.event_id
+			FROM events child
+			INNER JOIN selected_tree parent ON child.source_event_id = parent.event_id
+			WHERE child.run_id = $1::uuid
+		)
+		SELECT COUNT(*)
+		FROM events e
+		WHERE e.run_id = $1::uuid
+		  AND NOT EXISTS (
+			SELECT 1 FROM selected_tree tree WHERE tree.event_id = e.event_id
+		  )
+	`, forkRunID, pq.Array(allowedEvents)).Scan(&strayEvents); err != nil {
+		return fmt.Errorf("check selected-contract fork event lineage: %w", err)
+	}
+	if strayEvents > 0 {
+		return runForkReplayResumeError("fork_events_not_selected_contract_lineage", RunForkReplayResumeFactForkReplayState, "fork activation blocked: fork_events_not_selected_contract_lineage")
+	}
+
+	var strayDeliveries int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries d
+		WHERE d.run_id = $1::uuid
+		  AND NOT EXISTS (
+			SELECT 1 FROM events e WHERE e.run_id = $1::uuid AND e.event_id = d.event_id
+		  )
+	`, forkRunID).Scan(&strayDeliveries); err != nil {
+		return fmt.Errorf("check selected-contract fork deliveries: %w", err)
+	}
+	if strayDeliveries > 0 {
+		return runForkReplayResumeError("fork_deliveries_not_selected_contract_lineage", RunForkReplayResumeFactForkReplayState, "fork activation blocked: fork_deliveries_not_selected_contract_lineage")
+	}
+	return nil
 }
 
 func uniqueNonEmptyStrings(in []string) []string {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -1,0 +1,430 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+const (
+	RunForkSelectedContractExecutionLineageOwner = "store.run_fork.selected_contract_execution_lineage"
+	runForkSelectedContractExecutionLineageTable = "run_fork_selected_contract_executions"
+)
+
+type RunForkSelectedContractExecutionMaterializeRequest struct {
+	SourceRunID       string
+	At                string
+	ContractSelection RunForkContractSelection
+}
+
+type RunForkSelectedContractExecutionActivateRequest struct {
+	ForkRunID             string
+	AllowedSourceEventIDs []string
+}
+
+type RunForkSelectedContractSourceEvent struct {
+	SourceEventID string          `json:"source_event_id"`
+	EventName     string          `json:"event_name"`
+	EntityID      string          `json:"entity_id,omitempty"`
+	FlowInstance  string          `json:"flow_instance,omitempty"`
+	Scope         string          `json:"scope,omitempty"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+}
+
+type RunForkSelectedContractExecutionLineage struct {
+	Owner         string    `json:"owner"`
+	ForkRunID     string    `json:"fork_run_id"`
+	SourceRunID   string    `json:"source_run_id"`
+	SourceEventID string    `json:"source_event_id"`
+	ForkEventID   string    `json:"fork_event_id"`
+	EventName     string    `json:"event_name"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+func RequireRunForkSelectedContractExecutionCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	if err := RequireRunForkActivationCapabilities(caps, catalog); err != nil {
+		return err
+	}
+	required := map[string][]string{
+		runForkSelectedContractExecutionLineageTable: {"fork_run_id", "source_run_id", "source_event_id", "fork_event_id", "event_name", "created_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("selected-contract fork execution requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireRunForkSelectedContractExecutionCapabilities(ctx context.Context) (schemaColumnCatalog, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return schemaColumnCatalog{}, err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return schemaColumnCatalog{}, err
+	}
+	return catalog, RequireRunForkSelectedContractExecutionCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx context.Context, req RunForkSelectedContractExecutionMaterializeRequest) (RunForkMaterialization, error) {
+	if s == nil || s.DB == nil {
+		return RunForkMaterialization{}, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunForkMaterializerCapabilities(ctx); err != nil {
+		return RunForkMaterialization{}, err
+	}
+	if err := s.requireRunForkSelectedContractBindingCapabilities(ctx); err != nil {
+		return RunForkMaterialization{}, err
+	}
+	selection, err := normalizeRunForkSelectedContractSelection(req.ContractSelection)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{
+		SourceRunID: strings.TrimSpace(req.SourceRunID),
+		At:          strings.TrimSpace(req.At),
+	})
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	if blockers := runForkSelectedContractExecutionPlanBlockers(plan, nil); len(blockers) > 0 {
+		return RunForkMaterialization{
+			SourceRunID:           plan.SourceRunID,
+			ForkPoint:             plan.ForkPoint,
+			ExecutionReady:        false,
+			ReplayResumeAdmission: plan.ReplayResumeAdmission,
+			UnsupportedBlockers:   blockers,
+			DeliveryResumeBlocked: true,
+		}, fmt.Errorf("selected-contract fork execution materialization blocked: %s", runForkBlockerCodes(blockers))
+	}
+
+	forkRunID := deterministicRunForkMaterializationID(plan.SourceRunID, plan.ForkPoint.EventID)
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("begin selected-contract fork materialization: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
+		return RunForkMaterialization{}, err
+	}
+	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, status, forked_from_run_id, forked_from_event_id,
+			entity_count, event_count, started_at
+		)
+		VALUES (
+			$1::uuid, $2, $3::uuid, $4::uuid,
+			$5, 0, $6
+		)
+	`, forkRunID, RunForkMaterializedStatus, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("insert selected-contract fork run: %w", err)
+	}
+
+	forkCtx := runtimecorrelation.WithRunID(ctx, forkRunID)
+	for _, entity := range plan.Entities {
+		if err := materializeRunForkEntityState(forkCtx, tx, forkRunID, plan, entity, metadata[entity.EntityID], now); err != nil {
+			return RunForkMaterialization{}, err
+		}
+	}
+	binding, err := insertRunForkSelectedContractBinding(ctx, tx, RunForkSelectedContractBindingRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       plan.SourceRunID,
+		ForkEventID:       plan.ForkPoint.EventID,
+		ContractSelection: selection,
+	}, now)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return RunForkMaterialization{}, fmt.Errorf("commit selected-contract fork materialization: %w", err)
+	}
+	committed = true
+	return RunForkMaterialization{
+		SourceRunID:              plan.SourceRunID,
+		ForkRunID:                forkRunID,
+		ForkRunStatus:            RunForkMaterializedStatus,
+		ForkPoint:                plan.ForkPoint,
+		MaterializedEntityCount:  len(plan.Entities),
+		ExecutionReady:           false,
+		ReplayResumeAdmission:    plan.ReplayResumeAdmission,
+		SelectedContractBinding:  &binding,
+		UnsupportedBlockers:      plan.UnsupportedBlockers,
+		DeliveryResumeBlocked:    true,
+		SourceRunStatusUnchanged: true,
+	}, nil
+}
+
+func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.Context, req RunForkSelectedContractExecutionActivateRequest) (RunForkActivation, error) {
+	if s == nil || s.DB == nil {
+		return RunForkActivation{}, fmt.Errorf("postgres store is required")
+	}
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return RunForkActivation{}, fmt.Errorf("fork run_id is required")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkActivation{}, fmt.Errorf("fork run_id must be a UUID: %w", err)
+	}
+	catalog, err := s.requireRunForkSelectedContractExecutionCapabilities(ctx)
+	if err != nil {
+		return RunForkActivation{}, err
+	}
+
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return RunForkActivation{}, fmt.Errorf("begin selected-contract fork activation: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	lineage, err := loadRunForkActivationLineage(ctx, tx, forkRunID)
+	if err != nil {
+		return RunForkActivation{}, err
+	}
+	result := RunForkActivation{
+		SourceRunID:             lineage.SourceRunID,
+		ForkRunID:               lineage.ForkRunID,
+		ForkRunStatus:           lineage.ForkStatus,
+		SourceRunStatus:         lineage.SourceRunStatus,
+		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
+		HistoricalReplayBlocked: true,
+		MaterializedEntityCount: len(lineage.EntityIDs),
+	}
+	if lineage.ForkStatus != RunForkMaterializedStatus {
+		result.RepeatedActivationFailed = lineage.ForkStatus == RunForkActivatedStatus
+		return result, fmt.Errorf("selected-contract fork activation requires materialized fork status %q; got %q", RunForkMaterializedStatus, lineage.ForkStatus)
+	}
+	if lineage.SourceRunStatus != "running" && lineage.SourceRunStatus != "paused" {
+		return result, fmt.Errorf("selected-contract fork activation requires source run status running or paused before freeze; got %q", lineage.SourceRunStatus)
+	}
+	if len(lineage.EntityIDs) == 0 {
+		return result, fmt.Errorf("selected-contract fork activation requires materialized fork entity_state rows")
+	}
+	binding, err := loadRunForkSelectedContractBinding(ctx, tx, lineage.ForkRunID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return result, fmt.Errorf("selected-contract fork activation requires selected contract binding")
+		}
+		return result, fmt.Errorf("load selected contract binding: %w", err)
+	}
+	result.SelectedContractBinding = &binding
+
+	plan, err := s.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: lineage.SourceRunID, At: lineage.ForkEventID})
+	if err != nil {
+		return result, err
+	}
+	result.ReplayResumeAdmission = plan.ReplayResumeAdmission
+	if blockers := runForkSelectedContractExecutionPlanBlockers(plan, req.AllowedSourceEventIDs); len(blockers) > 0 {
+		result.UnsupportedBlockers = blockers
+		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
+	}
+	if err := ensureRunForkSourceNotAdvanced(ctx, tx, catalog, lineage); err != nil {
+		result.SourceAdvancedAfterFork = true
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
+		return result, err
+	}
+	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, lineage.ForkRunID); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
+		return result, err
+	}
+
+	now := time.Now().UTC()
+	sourceResult, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2, ended_at = COALESCE(ended_at, $3)
+		WHERE run_id = $1::uuid
+		  AND status IN ('running', 'paused')
+	`, lineage.SourceRunID, RunForkSourceFrozenStatus, now)
+	if err != nil {
+		return result, fmt.Errorf("freeze source run: %w", err)
+	}
+	if affected, err := sourceResult.RowsAffected(); err != nil {
+		return result, fmt.Errorf("confirm source freeze: %w", err)
+	} else if affected != 1 {
+		return result, fmt.Errorf("selected-contract fork activation blocked: source_run_freeze_not_applied")
+	}
+	forkResult, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = $2, ended_at = NULL
+		WHERE run_id = $1::uuid
+		  AND status = $3
+	`, lineage.ForkRunID, RunForkActivatedStatus, RunForkMaterializedStatus)
+	if err != nil {
+		return result, fmt.Errorf("activate fork run: %w", err)
+	}
+	if affected, err := forkResult.RowsAffected(); err != nil {
+		return result, fmt.Errorf("confirm fork activation: %w", err)
+	} else if affected != 1 {
+		return result, fmt.Errorf("selected-contract fork activation blocked: fork_run_activation_not_applied")
+	}
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("commit selected-contract fork activation: %w", err)
+	}
+	committed = true
+	result.ForkRunStatus = RunForkActivatedStatus
+	result.SourceRunStatus = RunForkSourceFrozenStatus
+	result.Activated = true
+	result.SourceFrozen = true
+	return result, nil
+}
+
+func (s *PostgresStore) LoadRunForkSelectedContractSourceEvents(ctx context.Context, sourceRunID string, sourceEventIDs []string) ([]RunForkSelectedContractSourceEvent, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	sourceRunID = strings.TrimSpace(sourceRunID)
+	if sourceRunID == "" {
+		return nil, fmt.Errorf("source run_id is required")
+	}
+	ids := uniqueNonEmptyStrings(sourceEventIDs)
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			event_id::text,
+			event_name,
+			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
+			COALESCE(scope, ''),
+			COALESCE(payload, '{}'::jsonb)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_id = ANY($2::uuid[])
+		ORDER BY created_at ASC, event_id ASC
+	`, sourceRunID, pq.Array(ids))
+	if err != nil {
+		return nil, fmt.Errorf("load selected-contract source events: %w", err)
+	}
+	defer rows.Close()
+	out := make([]RunForkSelectedContractSourceEvent, 0, len(ids))
+	for rows.Next() {
+		var event RunForkSelectedContractSourceEvent
+		if err := rows.Scan(&event.SourceEventID, &event.EventName, &event.EntityID, &event.FlowInstance, &event.Scope, &event.Payload); err != nil {
+			return nil, fmt.Errorf("scan selected-contract source event: %w", err)
+		}
+		if !json.Valid(event.Payload) {
+			return nil, fmt.Errorf("selected-contract source event %s payload is not valid json", event.SourceEventID)
+		}
+		out = append(out, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read selected-contract source events: %w", err)
+	}
+	if len(out) != len(ids) {
+		return nil, fmt.Errorf("selected-contract source event lookup returned %d rows for %d requested events", len(out), len(ids))
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) RecordRunForkSelectedContractExecutionLineage(ctx context.Context, lineage RunForkSelectedContractExecutionLineage) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	if _, err := s.requireRunForkSelectedContractExecutionCapabilities(ctx); err != nil {
+		return err
+	}
+	createdAt := lineage.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO run_fork_selected_contract_executions (
+			fork_run_id, source_run_id, source_event_id, fork_event_id, event_name, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, $5, $6)
+		ON CONFLICT (fork_run_id, source_event_id) DO NOTHING
+	`, lineage.ForkRunID, lineage.SourceRunID, lineage.SourceEventID, lineage.ForkEventID, lineage.EventName, createdAt)
+	if err != nil {
+		return fmt.Errorf("record selected-contract execution lineage: %w", err)
+	}
+	return nil
+}
+
+func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourceEventIDs []string) []RunForkUnsupportedBlocker {
+	allowedEvents := map[string]struct{}{}
+	for _, eventID := range allowedSourceEventIDs {
+		if eventID = strings.TrimSpace(eventID); eventID != "" {
+			allowedEvents[eventID] = struct{}{}
+		}
+	}
+	blockers := []RunForkUnsupportedBlocker{}
+	for _, blocker := range plan.UnsupportedBlockers {
+		switch strings.TrimSpace(blocker.Code) {
+		case RunForkBlockerDeliveryHistoryUnproven, RunForkBlockerNonAgentDeliveryReplayUnsupported:
+			continue
+		default:
+			blockers = appendRunForkBlocker(blockers, blocker)
+		}
+	}
+	for _, item := range plan.PendingWork {
+		classification := strings.TrimSpace(item.Classification)
+		if classification == RunForkPendingClassificationDeliveredCompleted {
+			continue
+		}
+		if classification == RunForkPendingClassificationCommittedReplay {
+			blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(RunForkBlockerCommittedReplayScopeReplayUnsupported))
+			continue
+		}
+		if len(allowedEvents) == 0 {
+			continue
+		}
+		if _, ok := allowedEvents[strings.TrimSpace(item.EventID)]; !ok {
+			blockers = appendRunForkBlocker(blockers, RunForkUnsupportedBlocker{
+				Code:    RunForkBlockerDeliveryHistoryUnproven,
+				Message: "selected-contract execution cannot absorb pending source delivery outside selected frontier evidence",
+			})
+		}
+	}
+	return blockers
+}
+
+func uniqueNonEmptyStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -50,6 +50,45 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	}
 }
 
+func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002450, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `DROP TABLE run_fork_selected_contract_executions`); err != nil {
+		t.Fatalf("drop selected execution lineage table: %v", err)
+	}
+
+	_, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "run_fork_selected_contract_executions") {
+		t.Fatalf("materialization error = %v, want lineage capability failure", err)
+	}
+	var strayForks int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE forked_from_run_id = $1::uuid
+	`, sourceRunID).Scan(&strayForks); err != nil {
+		t.Fatalf("count stray forks: %v", err)
+	}
+	if strayForks != 0 {
+		t.Fatalf("stray materialized forks = %d, want 0", strayForks)
+	}
+}
+
 func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFrontier(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002400, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+
+	_, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("MaterializeRunFork error = %v, want non-agent blocker", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" || materialized.SelectedContractBinding == nil || !materialized.DeliveryResumeBlocked {
+		t.Fatalf("materialization = %#v", materialized)
+	}
+	var replayRows int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, materialized.ForkRunID).Scan(&replayRows); err != nil {
+		t.Fatalf("count replay rows: %v", err)
+	}
+	if replayRows != 0 {
+		t.Fatalf("delivery replay rows = %d, want selected execution materialization to avoid #570 replay", replayRows)
+	}
+}
+
+func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002500, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (timer_name, entity_id, flow_instance, fire_event, fire_at, status, created_at)
+		VALUES ('selected-timer', $1::uuid, 'flow-a/1', 'timer.selected', $2, 'active', $3)
+	`, entityID, at.Add(time.Hour), at); err != nil {
+		t.Fatalf("seed timer: %v", err)
+	}
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerTimerHistoryUnproven) {
+		t.Fatalf("materialization error = %v, want timer blocker", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite timer blocker: %#v", materialized)
+	}
+}
+
+func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'item.received', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed source event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'test-node', 'pending', $3)
+	`, sourceRunID, eventID, at); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'selected-store-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Selected Store Entity"'::jsonb, $3::uuid, 'platform', 'selected-store-test', 'seed', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'Selected Store Entity',
+			'pending', '{}'::jsonb, '{"name":"Selected Store Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -317,6 +317,8 @@ func platformTableOrder(name string) int {
 		return 10
 	case "run_fork_selected_contract_bindings":
 		return 15
+	case "run_fork_selected_contract_executions":
+		return 18
 	case "dead_letters":
 		return 20
 	case "agents":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -495,6 +495,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 10
 	case "run_fork_selected_contract_bindings":
 		return 15
+	case "run_fork_selected_contract_executions":
+		return 18
 	case "dead_letters":
 		return 20
 	case "agents":
@@ -511,6 +513,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 70
 	case "event_deliveries":
 		return 80
+	case "run_fork_delivery_event_replays":
+		return 85
 	case "event_receipts":
 		return 90
 	case "entity_mutations":


### PR DESCRIPTION
## Summary

Implements the lead-approved broad mutating selected-contract execution refactor for timestamp forks under the canonical owner `runtime.run_fork.selected_contract_execution`.

- Consumes durable selected-contract binding/admission and selected semantic source before execution.
- Materializes and activates the fork through selected-contract store primitives, then executes selected frontier events under the fork `run_id` through the runtime bus/pipeline path.
- Writes fresh fork-local event/delivery/outcome rows and records explicit source-to-fork lineage in `run_fork_selected_contract_executions`.
- Wires `swarm fork --contracts ...` mutating execution onto the canonical runtime owner; non-selected mutating fork execution remains fail-closed.
- Preserves split/fail-closed blockers for sessions, timers, routes, turns, source-advanced, contract-swap, and UI/API execution.

Closes #598.
Part of #588.
Part of #564.
Part of #549.

## Governing Context

Governing context is the #598 `Pre-Implementation Coverage Audit` and independent gate decision on the issue thread. The gate approved the broad mutating selected-contract execution refactor and rejected helper-shaped, row-copy, CLI-owned, handler-only, delivery-only, or receipt-only slices.

Adjacent contract/spec context used:
- `run_fork_selected_contract_bindings` platform table spec.
- new `run_fork_selected_contract_executions` platform table spec added here as explicit selected execution lineage.
- existing runtime/store event, delivery, receipt, dead-letter, run-fork materialization, activation, and selected-contract admission contracts.

No narrower exact governing spec section fully described this mutating selected-contract execution cluster before this PR; the binding issue/gate record is therefore the closure-bearing context.

## Semantic Migration

New canonical owner: `runtime.run_fork.selected_contract_execution`.

Supporting persistence owner: `store.run_fork.selected_contract_execution_lineage` for source-to-fork selected execution lineage only.

Old paths now invalid/non-authoritative:
- CLI-owned selected fork execution.
- Source `events` or source `event_deliveries` copied as executable fork work.
- Source receipts, source dead letters, source retry state, or source post-T outcomes used as fork suppressors.
- #570 safe pending-agent replay generalized as selected-contract execution proof.
- Same-run outbox replay or route-helper execution used as selected timestamp-fork execution.

Production paths checked for surviving old behavior:
- `cmd/swarm fork --contracts` now consumes the runtime owner.
- runtime bus/pipeline are consumers used for fork-local execution, not owners.
- store materialization/activation remains canonical lifecycle persistence.
- event/delivery/receipt/dead-letter/idempotency paths remain fork-local runtime consumers.
- #570/#573/#575/timer/route/session/turn/source-advanced/contract-swap blockers remain preserved or split.

Migration completeness: complete for the #598 selected-contract handler execution and fork-local write ownership cluster. Broader #588/#564/#549 blockers remain explicitly tracked/split.

## Proof

Focused selected-surface proof:

```bash
go test ./internal/runtime/runforkexecution ./internal/store ./cmd/swarm -run 'TestExecuteSelected|TestSelectedContractExecution|TestRunForkCommand_(ActivateWithContracts|SelectedContractsExecute|NonDryRun)|TestGeneratePlatformTableDDLs' -count=1
```

Affected package proof:

```bash
go test ./internal/runtime/runforkexecution ./internal/store ./cmd/swarm -count=1
```

Full suite:

```bash
go test ./... -count=1
```