### PR TITLE
[agent-a][issue #600] Add selected fork source-advanced branch policy

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -620,6 +620,15 @@ func printSelectedContractExecution(w io.Writer, result runtimerunforkexecution.
 		result.Materialization.MaterializedEntityCount,
 		result.Activation.SourceFrozen,
 	)
+	if result.Activation.BranchDivergence != nil {
+		fmt.Fprintf(w, "Selected Contract Branch: owner=%s policy=%s source_frozen=%t source_status=%s facts=%s\n",
+			result.Activation.BranchDivergence.Owner,
+			result.Activation.BranchDivergence.Policy,
+			result.Activation.BranchDivergence.SourceFrozen,
+			result.Activation.BranchDivergence.SourceRunStatusAfterActivation,
+			strings.Join(result.Activation.BranchDivergence.SourceAdvancedFacts, ","),
+		)
+	}
 	if len(result.ForkEvents) > 0 {
 		fmt.Fprintln(w, "Fork Events:")
 		for _, event := range result.ForkEvents {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -603,6 +603,56 @@ func TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *tes
 	}
 }
 
+func TestRunForkCommand_SelectedContractsExecuteReportsSourceAdvancedBranchJSON(t *testing.T) {
+	dsn, db, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	repo := repoRoot()
+	contractsRoot := filepath.Join(repo, "tests/tier1-primitives/test-emits-multiple")
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	afterEventID := uuid.NewString()
+	at := time.Unix(1700000313, 0).UTC()
+	seedRunForkCLISelectedExecutionSource(t, db, sourceRunID, entityID, sourceEventID, at)
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'source.after', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed post-fork source event: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runForkCommand(context.Background(), repo, []string{
+		"--contracts", contractsRoot,
+		"--run", sourceRunID,
+		"--at", sourceEventID,
+		"--json",
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runForkCommand code=%d output=%s", code, buf.String())
+	}
+	var result runtimerunforkexecution.SelectedContractExecutionResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode selected branch execution json: %v\n%s", err, buf.String())
+	}
+	if result.Activation.BranchDivergence == nil || result.Activation.SourceFrozen {
+		t.Fatalf("branch activation = %#v", result.Activation)
+	}
+	if result.Activation.BranchDivergence.Owner != store.RunForkSelectedContractBranchDivergenceOwner ||
+		result.Activation.BranchDivergence.Policy != store.RunForkSelectedContractSourceAdvancedBranchPolicy {
+		t.Fatalf("branch divergence = %#v", result.Activation.BranchDivergence)
+	}
+	var sourceStatus string
+	if err := db.QueryRowContext(context.Background(), `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if sourceStatus != "running" {
+		t.Fatalf("source status = %q, want unchanged running", sourceStatus)
+	}
+}
+
 func TestRunForkCommand_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2715,6 +2715,12 @@ platform_tables:
         frontier event each fork event executed from. Source events, deliveries, receipts, dead letters, retry state, and
         post-fork outcomes are lineage evidence only and must not be copied or used as fork suppressors.
       ddl: "CREATE TABLE run_fork_selected_contract_executions (\n    execution_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id     UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id   UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id UUID NOT NULL REFERENCES events(event_id),\n    fork_event_id   UUID NOT NULL REFERENCES events(event_id),\n    event_name      TEXT NOT NULL,\n    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id, source_event_id),\n    UNIQUE (fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_fork (fork_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_source (source_run_id, source_event_id)\n);"
+    run_fork_selected_contract_branch_divergences:
+      description: Durable source/fork branch divergence evidence for selected-contract timestamp-fork execution. This
+        table is written only by the selected-contract execution owner when the source has advanced after the fork point
+        and selected execution proceeds as a branch rather than freezing or rewinding the source. Source post-fork facts
+        remain source-run evidence only; fork-local work is regenerated under the fork run_id.
+      ddl: "CREATE TABLE run_fork_selected_contract_branch_divergences (\n    divergence_id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                     UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                   UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                   UUID NOT NULL REFERENCES events(event_id),\n    owner                           TEXT NOT NULL,\n    policy                          TEXT NOT NULL CHECK (policy IN ('selected_contract_source_advanced_branch')),\n    source_run_status_at_activation TEXT NOT NULL,\n    source_run_status_after_activation TEXT NOT NULL,\n    source_frozen                   BOOLEAN NOT NULL DEFAULT FALSE,\n    source_advanced_facts           TEXT[] NOT NULL DEFAULT '{}',\n    created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_branch_divergences_source (source_run_id, fork_event_id)\n);"
     event_deliveries:
       description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
         inherited from the parent event for run-scoped queries.
@@ -3260,6 +3266,14 @@ run_model:
       creation, or fork delivery row creation. This gate does not run handlers, create selected fork-local executable
       event/delivery rows, write receipts, dead letters, idempotency state, emitted follow-up events, timers, routes,
       sessions, turns, source-advanced policy, contract-swap state, or UI/API execution state.'
+    selected_contract_source_advanced_branch: 'Mutating selected-contract timestamp-fork execution treats a source run
+      that advanced after the fork point as branch divergence evidence, not as executable fork work and not as a fork
+      suppressor. This policy is owned by runtime.run_fork.selected_contract_execution and its store-owned durable branch
+      divergence evidence. It is selected-contract execution only: generic/state-only activation still requires no source
+      advancement and may freeze the source run. A selected-contract branch must not freeze or rewind an already-advanced
+        source run, must record terminal source status at activation as divergence evidence, must not copy post-fork source
+        events or event_deliveries, and must continue to regenerate fork-local events, deliveries, receipts, dead letters,
+        idempotency effects, and emitted follow-ups under the fork run_id.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3287,6 +3301,12 @@ run_model:
         lineage, then atomically mark the source run forked and the fork run running. Future runtime work uses the fork
         run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
         unsupported outside the gated delivery/event primitive.'
+      3c_selected_contract_source_advanced_branch: 'For selected-contract mutating fork execution, source advancement
+        after the fork point is explicit branch divergence evidence when the selected execution owner can regenerate
+        fork-local work under the fork run_id. The source run remains in its current status and is not frozen or rewound.
+        Post-fork source events, deliveries, receipts, dead letters, retry state, outcomes, current state, and mutations
+        remain source-run evidence only; they are not copied into the fork and do not suppress fork-local selected
+        execution. Generic/state-only activation continues to use 3b no-source-advancement/freeze semantics.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -158,6 +158,10 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 600
+    title: Gate source-advanced branch policy for selected-contract timestamp forks
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -263,6 +267,7 @@ nodes:
       - selected-contract fork execution needs a runtime-side non-mutating admission/context owner that consumes the durable selected-source binding before any handler execution or fork-local delivery/outcome mutation
       - selected-bound fork activation needs a runtime-side selected-contract activation gate that consumes selected-contract execution admission before store activation mutation and blocks source delivery/event replay from becoming selected-contract executable work by fall-through
       - mutating selected-contract fork execution must consume durable selected-source binding/admission, execute handlers under the fork run_id, write fresh fork-local event/delivery/outcome rows with lineage, regenerate follow-ups, and not use source outcomes as suppressors
+      - selected-contract timestamp forks from historical T need durable branch divergence evidence when the source advanced after T; post-T source rows remain source-run evidence only and must not freeze, rewind, execute, copy, or suppress fork-local selected work
     representative_issues:
       - 564
       - 565
@@ -276,6 +281,7 @@ nodes:
       - 594
       - 596
       - 598
+      - 600
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -306,7 +306,7 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(
 	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
 }
 
-func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testing.T) {
+func TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
@@ -326,6 +326,7 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testin
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	afterEventID := uuid.NewString()
+	afterDeliveryID := uuid.NewString()
 	at := time.Unix(1700002350, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
 	if _, err := db.ExecContext(ctx, `
@@ -335,6 +336,22 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testin
 		VALUES ($1::uuid, $2::uuid, 'source.after', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4)
 	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
 		t.Fatalf("seed post-fork source event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, 'node', 'source-post-t-node', 'delivered', 'source_post_t_delivery', $4)
+	`, afterDeliveryID, sourceRunID, afterEventID, at.Add(1500*time.Millisecond)); err != nil {
+		t.Fatalf("seed post-fork source delivery: %v", err)
+	}
+	seedSourceOutcomeThatMustNotSuppressFork(t, db, afterEventID, entityID, at.Add(2*time.Second))
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET status = 'completed', ended_at = $2
+		WHERE run_id = $1::uuid
+	`, sourceRunID, at.Add(3*time.Second)); err != nil {
+		t.Fatalf("mark source complete after fork point: %v", err)
 	}
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
@@ -347,13 +364,97 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationFailure(t *testin
 			contractsRoot,
 		),
 	})
-	if err == nil || !strings.Contains(err.Error(), "source_events_advanced_after_fork_point") {
-		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want source-advanced activation failure", err)
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
 	}
-	if result.Activation.SourceFrozen || result.Activation.ForkRunStatus == store.RunForkActivatedStatus {
-		t.Fatalf("activation mutated before publish failure cleanup: %#v", result.Activation)
+	if !result.Activation.Activated || result.Activation.ForkRunStatus != store.RunForkActivatedStatus {
+		t.Fatalf("activation = %#v, want activated fork", result.Activation)
 	}
-	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
+	if result.Activation.SourceFrozen || !result.Activation.SourceAdvancedAfterFork {
+		t.Fatalf("branch activation flags = frozen:%v advanced:%v", result.Activation.SourceFrozen, result.Activation.SourceAdvancedAfterFork)
+	}
+	if result.Activation.BranchDivergence == nil {
+		t.Fatalf("branch divergence missing from result: %#v", result.Activation)
+	}
+	if result.Activation.BranchDivergence.Owner != store.RunForkSelectedContractBranchDivergenceOwner ||
+		result.Activation.BranchDivergence.Policy != store.RunForkSelectedContractSourceAdvancedBranchPolicy ||
+		result.Activation.BranchDivergence.SourceFrozen {
+		t.Fatalf("branch divergence = %#v", result.Activation.BranchDivergence)
+	}
+	for _, fact := range []string{
+		"source_events_advanced_after_fork_point",
+		"source_run_terminal_at_activation",
+		"source_deliveries_advanced_after_fork_point",
+		"source_receipts_advanced_after_fork_point",
+		"source_dead_letters_advanced_after_fork_point",
+	} {
+		if !containsString(result.Activation.BranchDivergence.SourceAdvancedFacts, fact) {
+			t.Fatalf("branch facts = %#v, want %s", result.Activation.BranchDivergence.SourceAdvancedFacts, fact)
+		}
+	}
+
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, result.Materialization.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != "completed" || forkStatus != store.RunForkActivatedStatus {
+		t.Fatalf("branch statuses source/fork = %s/%s, want completed/running", sourceStatus, forkStatus)
+	}
+
+	var branchRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_branch_divergences
+		WHERE fork_run_id = $1::uuid
+		  AND source_run_id = $2::uuid
+		  AND fork_event_id = $3::uuid
+		  AND policy = $4
+		  AND source_frozen = false
+		  AND source_run_status_at_activation = 'completed'
+		  AND source_run_status_after_activation = 'completed'
+		  AND source_advanced_facts @> ARRAY[
+				'source_events_advanced_after_fork_point',
+				'source_run_terminal_at_activation',
+				'source_deliveries_advanced_after_fork_point',
+				'source_receipts_advanced_after_fork_point',
+				'source_dead_letters_advanced_after_fork_point'
+		  ]::text[]
+	`, result.Materialization.ForkRunID, sourceRunID, sourceEventID, store.RunForkSelectedContractSourceAdvancedBranchPolicy).Scan(&branchRows); err != nil {
+		t.Fatalf("count branch divergence rows: %v", err)
+	}
+	if branchRows != 1 {
+		t.Fatalf("branch divergence rows = %d, want 1", branchRows)
+	}
+
+	forkEventID := result.ForkEvents[0].ForkEventID
+	var copiedPostTEvents, copiedPostTDeliveries, forkReceipts, emittedFollowUps int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_id = $2::uuid`, result.Materialization.ForkRunID, afterEventID).Scan(&copiedPostTEvents); err != nil {
+		t.Fatalf("count copied post-T source event: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid AND event_id = $2::uuid`, result.Materialization.ForkRunID, afterEventID).Scan(&copiedPostTDeliveries); err != nil {
+		t.Fatalf("count copied post-T source delivery: %v", err)
+	}
+	if copiedPostTEvents != 0 || copiedPostTDeliveries != 0 {
+		t.Fatalf("copied post-T source rows into fork events=%d deliveries=%d", copiedPostTEvents, copiedPostTDeliveries)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, forkEventID).Scan(&forkReceipts); err != nil {
+		t.Fatalf("count fork receipts: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'item.processed'
+		  AND source_event_id = $2::uuid
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&emittedFollowUps); err != nil {
+		t.Fatalf("count branch follow-ups: %v", err)
+	}
+	if forkReceipts == 0 || emittedFollowUps != 1 {
+		t.Fatalf("branch fork-local outcomes receipts=%d followUps=%d, want receipts and one follow-up", forkReceipts, emittedFollowUps)
+	}
 }
 
 func assertSelectedContractExecutionCleanup(t *testing.T, db *sql.DB, sourceRunID, forkRunID string) {
@@ -479,4 +580,13 @@ func seedSourceOutcomeThatMustNotSuppressFork(t *testing.T, db *sql.DB, sourceEv
 	`, sourceEventID, entityID, at); err != nil {
 		t.Fatalf("seed source dead letter: %v", err)
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -22,21 +22,22 @@ type RunForkActivateRequest struct {
 }
 
 type RunForkActivation struct {
-	SourceRunID              string                            `json:"source_run_id"`
-	ForkRunID                string                            `json:"fork_run_id"`
-	ForkRunStatus            string                            `json:"fork_run_status"`
-	SourceRunStatus          string                            `json:"source_run_status"`
-	ForkPoint                RunForkPoint                      `json:"fork_point"`
-	Activated                bool                              `json:"activated"`
-	SourceFrozen             bool                              `json:"source_frozen"`
-	HistoricalReplayBlocked  bool                              `json:"historical_replay_blocked"`
-	ReplayResumeAdmission    RunForkReplayResumeAdmission      `json:"replay_resume_admission"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`
-	MaterializedEntityCount  int                               `json:"materialized_entity_count"`
-	DeliveryEventReplay      *RunForkDeliveryEventReplayResult `json:"delivery_event_replay,omitempty"`
-	SelectedContractBinding  *RunForkSelectedContractBinding   `json:"selected_contract_binding,omitempty"`
-	SourceAdvancedAfterFork  bool                              `json:"source_advanced_after_fork_point,omitempty"`
-	RepeatedActivationFailed bool                              `json:"repeated_activation_failed,omitempty"`
+	SourceRunID              string                                   `json:"source_run_id"`
+	ForkRunID                string                                   `json:"fork_run_id"`
+	ForkRunStatus            string                                   `json:"fork_run_status"`
+	SourceRunStatus          string                                   `json:"source_run_status"`
+	ForkPoint                RunForkPoint                             `json:"fork_point"`
+	Activated                bool                                     `json:"activated"`
+	SourceFrozen             bool                                     `json:"source_frozen"`
+	HistoricalReplayBlocked  bool                                     `json:"historical_replay_blocked"`
+	ReplayResumeAdmission    RunForkReplayResumeAdmission             `json:"replay_resume_admission"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker              `json:"unsupported_blockers,omitempty"`
+	MaterializedEntityCount  int                                      `json:"materialized_entity_count"`
+	DeliveryEventReplay      *RunForkDeliveryEventReplayResult        `json:"delivery_event_replay,omitempty"`
+	SelectedContractBinding  *RunForkSelectedContractBinding          `json:"selected_contract_binding,omitempty"`
+	BranchDivergence         *RunForkSelectedContractBranchDivergence `json:"selected_contract_branch_divergence,omitempty"`
+	SourceAdvancedAfterFork  bool                                     `json:"source_advanced_after_fork_point,omitempty"`
+	RepeatedActivationFailed bool                                     `json:"repeated_activation_failed,omitempty"`
 }
 
 type runForkActivationLineage struct {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -5,6 +5,7 @@ const (
 	RunForkSelectedContractExecutionAdmissionOwner      = "runtime.run_fork.selected_contract_execution_admission"
 	RunForkSelectedContractExecutionActivationGateOwner = "runtime.run_fork.selected_contract_execution.activation_gate"
 	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
+	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
 	RunForkSelectedContractExecutionAdmissionUseDurableBinding = "durable_binding_and_frontier_evidence"
@@ -18,6 +19,8 @@ const (
 	RunForkBlockerSelectedContractExecutionModelNonMutating     = "selected_contract_execution_model_non_mutating"
 	RunForkBlockerSelectedContractExecutionAdmissionNonMutating = "selected_contract_execution_admission_non_mutating"
 	RunForkBlockerSelectedContractSourceReplayUnsupported       = "selected_contract_source_replay_unsupported"
+
+	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
 )
 
 type RunForkSelectedContractExecution struct {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -72,7 +72,7 @@ func RequireRunForkSelectedContractExecutionCapabilities(caps StoreSchemaCapabil
 		columns []string
 	}{
 		{runForkSelectedContractExecutionLineageTable, []string{"fork_run_id", "source_run_id", "source_event_id", "fork_event_id", "event_name", "created_at"}},
-		{runForkSelectedContractBranchDivergenceTable, []string{"fork_run_id", "source_run_id", "fork_event_id", "policy", "source_run_status_at_activation", "source_run_status_after_activation", "source_frozen", "source_advanced_facts", "created_at"}},
+		{runForkSelectedContractBranchDivergenceTable, []string{"fork_run_id", "source_run_id", "fork_event_id", "owner", "policy", "source_run_status_at_activation", "source_run_status_after_activation", "source_frozen", "source_advanced_facts", "created_at"}},
 	}
 	for _, requirement := range required {
 		if catalog.hasColumns(requirement.table, requirement.columns...) {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -17,6 +17,7 @@ import (
 const (
 	RunForkSelectedContractExecutionLineageOwner = "store.run_fork.selected_contract_execution_lineage"
 	runForkSelectedContractExecutionLineageTable = "run_fork_selected_contract_executions"
+	runForkSelectedContractBranchDivergenceTable = "run_fork_selected_contract_branch_divergences"
 )
 
 type RunForkSelectedContractExecutionMaterializeRequest struct {
@@ -49,18 +50,35 @@ type RunForkSelectedContractExecutionLineage struct {
 	CreatedAt     time.Time `json:"created_at"`
 }
 
+type RunForkSelectedContractBranchDivergence struct {
+	Owner                          string    `json:"owner"`
+	ForkRunID                      string    `json:"fork_run_id"`
+	SourceRunID                    string    `json:"source_run_id"`
+	ForkEventID                    string    `json:"fork_event_id"`
+	Policy                         string    `json:"policy"`
+	SourceRunStatusAtActivation    string    `json:"source_run_status_at_activation"`
+	SourceRunStatusAfterActivation string    `json:"source_run_status_after_activation"`
+	SourceFrozen                   bool      `json:"source_frozen"`
+	SourceAdvancedFacts            []string  `json:"source_advanced_facts,omitempty"`
+	CreatedAt                      time.Time `json:"created_at"`
+}
+
 func RequireRunForkSelectedContractExecutionCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
 	if err := RequireRunForkActivationCapabilities(caps, catalog); err != nil {
 		return err
 	}
-	required := map[string][]string{
-		runForkSelectedContractExecutionLineageTable: {"fork_run_id", "source_run_id", "source_event_id", "fork_event_id", "event_name", "created_at"},
+	required := []struct {
+		table   string
+		columns []string
+	}{
+		{runForkSelectedContractExecutionLineageTable, []string{"fork_run_id", "source_run_id", "source_event_id", "fork_event_id", "event_name", "created_at"}},
+		{runForkSelectedContractBranchDivergenceTable, []string{"fork_run_id", "source_run_id", "fork_event_id", "policy", "source_run_status_at_activation", "source_run_status_after_activation", "source_frozen", "source_advanced_facts", "created_at"}},
 	}
-	for tableName, columns := range required {
-		if catalog.hasColumns(tableName, columns...) {
+	for _, requirement := range required {
+		if catalog.hasColumns(requirement.table, requirement.columns...) {
 			continue
 		}
-		return fmt.Errorf("selected-contract fork execution requires %s columns %v", tableName, columns)
+		return fmt.Errorf("selected-contract fork execution requires %s columns %v", requirement.table, requirement.columns)
 	}
 	return nil
 }
@@ -223,8 +241,8 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		result.RepeatedActivationFailed = lineage.ForkStatus == RunForkActivatedStatus
 		return result, fmt.Errorf("selected-contract fork activation requires materialized fork status %q; got %q", RunForkMaterializedStatus, lineage.ForkStatus)
 	}
-	if lineage.SourceRunStatus != "running" && lineage.SourceRunStatus != "paused" {
-		return result, fmt.Errorf("selected-contract fork activation requires source run status running or paused before freeze; got %q", lineage.SourceRunStatus)
+	if !runForkSelectedContractBranchSourceStatusSupported(lineage.SourceRunStatus) {
+		return result, fmt.Errorf("selected-contract fork activation requires source run status running, paused, completed, failed, or cancelled for branch lineage; got %q", lineage.SourceRunStatus)
 	}
 	if len(lineage.EntityIDs) == 0 {
 		return result, fmt.Errorf("selected-contract fork activation requires materialized fork entity_state rows")
@@ -247,8 +265,21 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		result.UnsupportedBlockers = blockers
 		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
 	}
-	if err := ensureRunForkSourceNotAdvanced(ctx, tx, catalog, lineage); err != nil {
+	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, catalog, lineage)
+	if err != nil {
+		return result, err
+	}
+	if len(sourceAdvancedFacts) > 0 {
 		result.SourceAdvancedAfterFork = true
+	}
+	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, catalog, lineage); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
+		return result, err
+	}
+	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, catalog, lineage); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
 			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
@@ -264,6 +295,48 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	}
 
 	now := time.Now().UTC()
+	if len(sourceAdvancedFacts) > 0 {
+		forkResult, err := tx.ExecContext(ctx, `
+			UPDATE runs
+			SET status = $2, ended_at = NULL
+			WHERE run_id = $1::uuid
+			  AND status = $3
+		`, lineage.ForkRunID, RunForkActivatedStatus, RunForkMaterializedStatus)
+		if err != nil {
+			return result, fmt.Errorf("activate selected-contract branch fork run: %w", err)
+		}
+		if affected, err := forkResult.RowsAffected(); err != nil {
+			return result, fmt.Errorf("confirm selected-contract branch fork activation: %w", err)
+		} else if affected != 1 {
+			return result, fmt.Errorf("selected-contract branch activation blocked: fork_run_activation_not_applied")
+		}
+		divergence := RunForkSelectedContractBranchDivergence{
+			Owner:                          RunForkSelectedContractBranchDivergenceOwner,
+			ForkRunID:                      lineage.ForkRunID,
+			SourceRunID:                    lineage.SourceRunID,
+			ForkEventID:                    lineage.ForkEventID,
+			Policy:                         RunForkSelectedContractSourceAdvancedBranchPolicy,
+			SourceRunStatusAtActivation:    lineage.SourceRunStatus,
+			SourceRunStatusAfterActivation: lineage.SourceRunStatus,
+			SourceFrozen:                   false,
+			SourceAdvancedFacts:            sourceAdvancedFacts,
+			CreatedAt:                      now,
+		}
+		if err := insertRunForkSelectedContractBranchDivergence(ctx, tx, divergence); err != nil {
+			return result, err
+		}
+		if err := tx.Commit(); err != nil {
+			return result, fmt.Errorf("commit selected-contract branch activation: %w", err)
+		}
+		committed = true
+		result.ForkRunStatus = RunForkActivatedStatus
+		result.SourceRunStatus = lineage.SourceRunStatus
+		result.Activated = true
+		result.SourceFrozen = false
+		result.BranchDivergence = &divergence
+		return result, nil
+	}
+
 	sourceResult, err := tx.ExecContext(ctx, `
 		UPDATE runs
 		SET status = $2, ended_at = COALESCE(ended_at, $3)
@@ -354,6 +427,12 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_sessions WHERE run_id = $1::uuid`, forkRunID); err != nil {
 			return fmt.Errorf("delete selected-contract fork sessions: %w", err)
 		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM run_fork_selected_contract_branch_divergences
+		WHERE fork_run_id = $1::uuid
+	`, forkRunID); err != nil {
+		return fmt.Errorf("delete selected-contract branch divergence: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM run_fork_selected_contract_executions
@@ -476,6 +555,171 @@ func (s *PostgresStore) RecordRunForkSelectedContractExecutionLineage(ctx contex
 	`, lineage.ForkRunID, lineage.SourceRunID, lineage.SourceEventID, lineage.ForkEventID, lineage.EventName, createdAt)
 	if err != nil {
 		return fmt.Errorf("record selected-contract execution lineage: %w", err)
+	}
+	return nil
+}
+
+func runForkSelectedContractBranchSourceStatusSupported(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "running", "paused", "completed", "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectRunForkSelectedContractSourceAdvancedFacts(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) ([]string, error) {
+	checks := []struct {
+		code    string
+		enabled bool
+		query   string
+		args    []any
+	}{
+		{
+			code:    "source_events_advanced_after_fork_point",
+			enabled: true,
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM events
+					WHERE run_id = $1::uuid
+					  AND (created_at, event_id) > ($2::timestamptz, $3::uuid)
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
+		},
+		{
+			code:    "source_mutations_advanced_after_fork_point",
+			enabled: true,
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM entity_mutations
+					WHERE run_id = $1::uuid
+					  AND created_at > $2::timestamptz
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+		{
+			code:    "source_current_state_advanced_after_fork_point",
+			enabled: true,
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM entity_state
+					WHERE run_id = $1::uuid
+					  AND updated_at > $2::timestamptz
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+		{
+			code:    "source_deliveries_advanced_after_fork_point",
+			enabled: true,
+			query: `
+				SELECT EXISTS (
+					SELECT 1 FROM event_deliveries d
+					WHERE d.run_id = $1::uuid
+					  AND (
+							d.created_at > $2::timestamptz
+							OR d.started_at > $2::timestamptz
+							OR d.delivered_at > $2::timestamptz
+					  )
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
+		},
+		{
+			code:    "source_receipts_advanced_after_fork_point",
+			enabled: catalog.hasColumns("event_receipts", "event_id", "processed_at") && catalog.hasColumns("events", "event_id", "run_id", "created_at"),
+			query: `
+				SELECT EXISTS (
+					SELECT 1
+					FROM event_receipts r
+					INNER JOIN events e ON e.event_id = r.event_id
+					WHERE e.run_id = $1::uuid
+					  AND (
+							r.processed_at > $2::timestamptz
+							OR (e.created_at, e.event_id) > ($2::timestamptz, $3::uuid)
+					  )
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
+		},
+		{
+			code:    "source_dead_letters_advanced_after_fork_point",
+			enabled: catalog.hasColumns("dead_letters", "original_event_id", "created_at") && catalog.hasColumns("events", "event_id", "run_id", "created_at"),
+			query: `
+				SELECT EXISTS (
+					SELECT 1
+					FROM dead_letters dl
+					INNER JOIN events e ON e.event_id = dl.original_event_id
+					WHERE e.run_id = $1::uuid
+					  AND (
+							dl.created_at > $2::timestamptz
+							OR (e.created_at, e.event_id) > ($2::timestamptz, $3::uuid)
+					  )
+				)
+			`,
+			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
+		},
+	}
+	facts := []string{}
+	switch strings.TrimSpace(lineage.SourceRunStatus) {
+	case "completed", "failed", "cancelled":
+		facts = append(facts, "source_run_terminal_at_activation")
+	}
+	for _, check := range checks {
+		if !check.enabled {
+			continue
+		}
+		var exists bool
+		if err := tx.QueryRowContext(ctx, check.query, check.args...).Scan(&exists); err != nil {
+			return nil, fmt.Errorf("check selected-contract branch %s: %w", check.code, err)
+		}
+		if exists {
+			facts = append(facts, check.code)
+		}
+	}
+	return uniqueNonEmptyStrings(facts), nil
+}
+
+func insertRunForkSelectedContractBranchDivergence(ctx context.Context, tx *sql.Tx, divergence RunForkSelectedContractBranchDivergence) error {
+	if divergence.CreatedAt.IsZero() {
+		divergence.CreatedAt = time.Now().UTC()
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO run_fork_selected_contract_branch_divergences (
+			fork_run_id,
+			source_run_id,
+			fork_event_id,
+			owner,
+			policy,
+			source_run_status_at_activation,
+			source_run_status_after_activation,
+			source_frozen,
+			source_advanced_facts,
+			created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7, $8, $9::text[], $10)
+		ON CONFLICT (fork_run_id) DO UPDATE
+		SET owner = EXCLUDED.owner,
+		    policy = EXCLUDED.policy,
+		    source_run_status_at_activation = EXCLUDED.source_run_status_at_activation,
+		    source_run_status_after_activation = EXCLUDED.source_run_status_after_activation,
+		    source_frozen = EXCLUDED.source_frozen,
+		    source_advanced_facts = EXCLUDED.source_advanced_facts,
+		    created_at = EXCLUDED.created_at
+	`, divergence.ForkRunID,
+		divergence.SourceRunID,
+		divergence.ForkEventID,
+		divergence.Owner,
+		divergence.Policy,
+		divergence.SourceRunStatusAtActivation,
+		divergence.SourceRunStatusAfterActivation,
+		divergence.SourceFrozen,
+		pq.Array(divergence.SourceAdvancedFacts),
+		divergence.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("record selected-contract branch divergence: %w", err)
 	}
 	return nil
 }

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -89,6 +89,45 @@ func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *
 	}
 }
 
+func TestSelectedContractExecutionMaterializationPreflightsBranchDivergenceOwnerCapability(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002475, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `ALTER TABLE run_fork_selected_contract_branch_divergences DROP COLUMN owner`); err != nil {
+		t.Fatalf("drop branch divergence owner column: %v", err)
+	}
+
+	_, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "run_fork_selected_contract_branch_divergences") || !strings.Contains(err.Error(), "owner") {
+		t.Fatalf("materialization error = %v, want branch divergence owner capability failure", err)
+	}
+	var strayForks int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE forked_from_run_id = $1::uuid
+	`, sourceRunID).Scan(&strayForks); err != nil {
+		t.Fatalf("count stray forks: %v", err)
+	}
+	if strayForks != 0 {
+		t.Fatalf("stray materialized forks = %d, want 0", strayForks)
+	}
+}
+
 func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -319,6 +319,8 @@ func platformTableOrder(name string) int {
 		return 15
 	case "run_fork_selected_contract_executions":
 		return 18
+	case "run_fork_selected_contract_branch_divergences":
+		return 19
 	case "dead_letters":
 		return 20
 	case "agents":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -497,6 +497,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 15
 	case "run_fork_selected_contract_executions":
 		return 18
+	case "run_fork_selected_contract_branch_divergences":
+		return 19
 	case "dead_letters":
 		return 20
 	case "agents":


### PR DESCRIPTION
## Summary

Closes #600.
Part of #588, #564, and #549.

This PR implements the approved first slice: selected-contract source-advanced branch policy for mutating timestamp-fork execution. A selected-contract fork can now proceed when the source run advanced after fork point T by recording durable branch divergence evidence, leaving the source run unchanged, and continuing selected execution under the fork `run_id`.

It does not implement full replay/resume, timers/routes/session/turn reconstruction, contract swap, or UI/API-owned branch semantics.

## Governing Context

Exact governing spec was incomplete before this PR. Binding context is issue #600 plus the independent gate outcome `approved as first slice` in https://github.com/yazzaoui/Swarm/issues/600#issuecomment-4348264774, constrained by adjacent platform spec sections for selected-contract execution and fork activation.

This PR updates `platform-spec.yaml` with:

- `run_model.fork.selected_contract_source_advanced_branch`
- `run_model.fork.semantics.3c_selected_contract_source_advanced_branch`
- `platform_tables.run_fork_selected_contract_branch_divergences`

## Semantic Migration

New canonical owner:

- `store.run_fork.selected_contract_branch_divergence`, consumed by `runtime.run_fork.selected_contract_execution`.

Old invalid path:

- selected-contract activation treating `ensureRunForkSourceNotAdvanced(...)` as a permanent blocker;
- freezing or rewinding an already-advanced source run for selected-contract branch execution;
- copying post-T source events/deliveries as fork executable work;
- using source receipts/dead letters/outcomes as fork suppressors.

Production paths checked:

- selected-contract execution activation;
- generic/state-only activation fail-closed behavior;
- fork-local bus/pipeline event, delivery, receipt, and follow-up writes;
- CLI JSON/text reporting;
- spec/watchlist mapping.

Migration completeness:

- Complete for #600 chosen first-slice class.
- Parent classes #588/#564/#549 remain open for timers/routes/sessions/turns/contract swap/UI/API and broader replay/resume.

## Proof

```bash
go test ./internal/runtime/runforkexecution -run 'TestExecuteSelectedContractRunFork(WritesForkLocalExecutionAndLineage|BranchesWhenSourceAdvancedAfterForkPoint|PreservesSessionBlocker)' -count=1
```

```bash
go test ./internal/store -run 'TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat|TestGeneratePlatformTableDDLs|TestSelectedContractExecution' -count=1
```

```bash
go test ./cmd/swarm -run 'TestRunForkCommand_SelectedContractsExecute(ThroughCanonicalOwnerJSON|ReportsSourceAdvancedBranchJSON)|TestRunForkCommand_ActivateSelectedBindingConsumesRuntimeAdmission' -count=1
```

```bash
go test ./internal/runtime/runforkexecution ./internal/store ./cmd/swarm -count=1
```

```bash
go test ./... -count=1
```