### PR TITLE
[agent-a][issue #602] Preserve selected fork timer route blockers

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3274,6 +3274,13 @@ run_model:
         source run, must record terminal source status at activation as divergence evidence, must not copy post-fork source
         events or event_deliveries, and must continue to regenerate fork-local events, deliveries, receipts, dead letters,
         idempotency effects, and emitted follow-ups under the fork run_id.'
+    selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source timer and
+      route facts as evidence-only fail-closed blockers until separately approved timer and route reconstruction owners
+      exist. The runtime.run_fork.selected_contract_execution owner consumes the canonical
+      store.run_fork.replay_resume_admission timer_history and flow_route_history blockers before selected-contract
+      materialization or activation can create fork-local executable work. It MUST NOT copy source timers or
+      routing_rules, fire or replay source timers, persist fork-local timer/route rows, derive selected-source recipients
+      for execution, or use source timer/route outcomes as selected-fork suppressors in this policy slice.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3307,6 +3314,12 @@ run_model:
         Post-fork source events, deliveries, receipts, dead letters, retry state, outcomes, current state, and mutations
         remain source-run evidence only; they are not copied into the fork and do not suppress fork-local selected
         execution. Generic/state-only activation continues to use 3b no-source-advancement/freeze semantics.'
+      3d_selected_contract_timer_route_policy: 'For selected-contract mutating fork execution, source timer and route
+        facts remain evidence-only blockers. The selected execution owner consumes timer_history_unproven and
+        flow_route_history_unproven from the canonical replay/resume taxonomy and fails before materializing,
+        activating, firing timers, copying routing rules, deriving selected-source recipients, or creating fork-local
+        executable work. Timer reconstruction and route reconstruction are separately gated fork replay/resume
+        children.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -268,6 +268,7 @@ nodes:
       - selected-bound fork activation needs a runtime-side selected-contract activation gate that consumes selected-contract execution admission before store activation mutation and blocks source delivery/event replay from becoming selected-contract executable work by fall-through
       - mutating selected-contract fork execution must consume durable selected-source binding/admission, execute handlers under the fork run_id, write fresh fork-local event/delivery/outcome rows with lineage, regenerate follow-ups, and not use source outcomes as suppressors
       - selected-contract timestamp forks from historical T need durable branch divergence evidence when the source advanced after T; post-T source rows remain source-run evidence only and must not freeze, rewind, execute, copy, or suppress fork-local selected work
+      - selected-contract timestamp forks with source timer or route facts must keep those rows as evidence-only fail-closed blockers until separate timer and route reconstruction owners are approved; source timers, routing_rules, route recipients, and timer firings are not executable selected-fork work
     representative_issues:
       - 564
       - 565
@@ -282,6 +283,7 @@ nodes:
       - 596
       - 598
       - 600
+      - 602
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 	"time"
@@ -159,6 +160,44 @@ func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) 
 	if materialized.ForkRunID != "" {
 		t.Fatalf("materialized fork despite timer blocker: %#v", materialized)
 	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
+}
+
+func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002525, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow,
+			is_materialized, status, created_at
+		)
+		VALUES ('item.received', 'node', 'selected-route-node', 'flow-a/2', 'flow-a', true, 'active', $1)
+	`, at); err != nil {
+		t.Fatalf("seed routing rule: %v", err)
+	}
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerFlowRouteHistoryUnproven) {
+		t.Fatalf("materialization error = %v, want route blocker", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite route blocker: %#v", materialized)
+	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
 func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
@@ -209,5 +248,40 @@ func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, so
 		)
 	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
+	}
+}
+
+func assertNoSelectedContractForkRows(t *testing.T, db *sql.DB, sourceRunID string) {
+	t.Helper()
+	ctx := context.Background()
+	for name, query := range map[string]string{
+		"runs": `
+			SELECT COUNT(*)
+			FROM runs
+			WHERE forked_from_run_id = $1::uuid
+		`,
+		"selected_contract_bindings": `
+			SELECT COUNT(*)
+			FROM run_fork_selected_contract_bindings
+			WHERE source_run_id = $1::uuid
+		`,
+		"selected_contract_executions": `
+			SELECT COUNT(*)
+			FROM run_fork_selected_contract_executions
+			WHERE source_run_id = $1::uuid
+		`,
+		"selected_contract_branch_divergences": `
+			SELECT COUNT(*)
+			FROM run_fork_selected_contract_branch_divergences
+			WHERE source_run_id = $1::uuid
+		`,
+	} {
+		var count int
+		if err := db.QueryRowContext(ctx, query, sourceRunID).Scan(&count); err != nil {
+			t.Fatalf("count %s rows: %v", name, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows for blocked selected-contract fork = %d, want 0", name, count)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #602.

This PR implements the approved first slice for selected-contract timestamp-fork timer/route policy: timer and route facts remain evidence-only fail-closed blockers under selected-contract execution until separate reconstruction owners are approved.

It does not implement timer reconstruction, route reconstruction, source `timers` row copying, source `routing_rules` row copying, source timer replay/firing, selected-source recipient derivation for execution, delivery ownership changes, sessions/turns, contract swap, UI/API ownership, or full replay/resume.

## Governing refs / context

- #602 pre-audit and independent gate: approved as first slice.
- Spec refs updated in this PR: `run_model.fork.policy.selected_contract_timer_route_policy` and `run_model.fork.semantics.3d_selected_contract_timer_route_policy` in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Adjacent binding context: `selected_contract_source_advanced_branch`, `selected_contract_execution_admission`, `selected_contract_activation_gate`, and `replay_resume_admission_taxonomy` in the same spec file.
- Watchlist node: `timestamp_fork_replay_resume_ownership` in `docs/watchlists/runtime-operations.yaml`.

## Semantic migration note

New explicit policy owner: `runtime.run_fork.selected_contract_execution` consuming `store.run_fork.replay_resume_admission` timer/route blockers.

Old invalid paths remain invalid and now have explicit proof/spec coverage: source `timers` rows, source `routing_rules` rows, source route recipients, and source timer firings are evidence-only blockers, not executable fork work.

Production paths checked: selected-contract materialization, canonical fork planner/replay taxonomy, generic planner timer/route blockers, selected source-advanced branch adjacency, and runtime execution package focused tests. Migration complete for this fail-closed policy slice; actual timer/route reconstruction remains split.

## Proof

```bash
go test ./internal/store -run 'TestRunForkPlanner_(StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables|RelevantTimerAndRouteRemainBlockers)|TestSelectedContractExecution(ActivationPreservesTimerBlocker|MaterializationPreservesRouteBlocker)' -count=1
```

```bash
go test ./internal/runtime/runforkexecution ./internal/store ./cmd/swarm -run 'SelectedContract|RunForkPlanner|RunForkActivation|SourceAdvanced|DeliveryEventReplay|ContractFrontier' -count=1
```

```bash
go test ./...
```
