### PR TITLE
[agent-a][issue #604] Add selected fork route admission model

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -551,8 +551,21 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			}
 			return 1
 		}
+		routeAdmission, err := runtimerunforkadmission.AdmitSelectedContractRouteHistory(runtimerunforkadmission.SelectedContractRouteHistoryRequest{
+			Plan:              plan,
+			Source:            source,
+			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
+			FrontierAdmission: admission,
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: admit selected contract routes: %v\n", err)
+			}
+			return 1
+		}
 		executionModel, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
-			Admission: admission,
+			Admission:      admission,
+			RouteAdmission: routeAdmission,
 		})
 		if err != nil {
 			if out != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -534,6 +534,18 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 		model.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly {
 		t.Fatalf("selected-contract execution admission use = %#v", model)
 	}
+	if model.RouteAdmission == nil ||
+		model.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner ||
+		!model.RouteAdmission.NonMutating ||
+		model.RouteAdmission.RouteReconstructionSupported {
+		t.Fatalf("selected-contract route admission = %#v", model.RouteAdmission)
+	}
+	if !runForkPlanHasBoundary(model.RouteAdmission.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("selected-contract route invalid paths = %#v", model.RouteAdmission.InvalidPaths)
+	}
+	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating) {
+		t.Fatalf("selected-contract execution blockers = %#v, want route admission non-mutating blocker", model.UnsupportedBlockers)
+	}
 	if !runForkPlanHasBoundary(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("selected-contract execution invalid paths = %#v", model.InvalidPaths)
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3281,6 +3281,14 @@ run_model:
       materialization or activation can create fork-local executable work. It MUST NOT copy source timers or
       routing_rules, fire or replay source timers, persist fork-local timer/route rows, derive selected-source recipients
       for execution, or use source timer/route outcomes as selected-fork suppressors in this policy slice.'
+    selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
+      non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
+      runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
+      derivation through internal/runtime/bus.DeriveRouteTable for historical route evidence, and treats source
+      routing_rules and flow_instance_routes as evidence-only fail-closed facts. It MUST NOT copy source route rows,
+      persist fork-local route rows, derive executable recipients, create event_deliveries, run handlers, or absorb
+      timer reconstruction, session/turn reconstruction, source-advanced policy, contract-swap ownership, or UI/API
+      route ownership.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3320,6 +3328,11 @@ run_model:
         activating, firing timers, copying routing rules, deriving selected-source recipients, or creating fork-local
         executable work. Timer reconstruction and route reconstruction are separately gated fork replay/resume
         children.'
+      3e_selected_contract_route_admission: 'For selected-contract mutating fork execution, selected route/subscription
+        admission is evidence-only and non-mutating. It distinguishes frontier recipient admission from historical
+        route reconstruction, uses the selected contract route table only as route evidence, and fails closed before
+        route persistence, executable recipient derivation, delivery writes, or handler execution. Source routing rows,
+        source flow-instance routes, and source recipients are never copied into the fork.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -162,6 +162,10 @@ active_issues:
     title: Gate source-advanced branch policy for selected-contract timestamp forks
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 604
+    title: Gate selected-contract fork route reconstruction and recipient ownership
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -269,6 +273,7 @@ nodes:
       - mutating selected-contract fork execution must consume durable selected-source binding/admission, execute handlers under the fork run_id, write fresh fork-local event/delivery/outcome rows with lineage, regenerate follow-ups, and not use source outcomes as suppressors
       - selected-contract timestamp forks from historical T need durable branch divergence evidence when the source advanced after T; post-T source rows remain source-run evidence only and must not freeze, rewind, execute, copy, or suppress fork-local selected work
       - selected-contract timestamp forks with source timer or route facts must keep those rows as evidence-only fail-closed blockers until separate timer and route reconstruction owners are approved; source timers, routing_rules, route recipients, and timer firings are not executable selected-fork work
+      - selected-contract route/subscription reconstruction needs a non-mutating route-history admission owner that consumes selected-source route derivation, distinguishes frontier route/recipient admission from historical route evidence, and keeps route persistence, executable recipients, delivery writes, and handler execution split
     representative_issues:
       - 564
       - 565
@@ -284,6 +289,7 @@ nodes:
       - 598
       - 600
       - 602
+      - 604
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -41,6 +41,9 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 	if err != nil {
 		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission routes: %w", err)
 	}
+	if err := installContractFrontierFlowInstanceRoutes(routeTable, req.Source, req.Plan.PendingWork); err != nil {
+		return store.RunForkSelectedContractRouteAdmission{}, err
+	}
 	routeEvents := selectedRouteHistoryEvents(routeTable, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
 	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -1,0 +1,248 @@
+package runforkadmission
+
+import (
+	"fmt"
+	"strings"
+
+	runtimebus "swarm/internal/runtime/bus"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+type SelectedContractRouteHistoryRequest struct {
+	Plan              store.RunForkPlan
+	Source            semanticview.Source
+	ContractSelection store.RunForkContractSelection
+	FrontierAdmission store.RunForkContractFrontierAdmission
+}
+
+func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) (store.RunForkSelectedContractRouteAdmission, error) {
+	if req.Source == nil {
+		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("selected route admission requires selected contract semantic source")
+	}
+	selection := req.ContractSelection
+	if strings.TrimSpace(selection.Mode) == "" {
+		selection = SelectedContractSelection(req.Source, selection.ContractsRoot)
+	}
+	if strings.TrimSpace(selection.WorkflowName) == "" {
+		selection.WorkflowName = strings.TrimSpace(req.Source.WorkflowName())
+	}
+	if strings.TrimSpace(selection.WorkflowVersion) == "" {
+		selection.WorkflowVersion = strings.TrimSpace(req.Source.WorkflowVersion())
+	}
+	if strings.TrimSpace(req.FrontierAdmission.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("selected route admission requires %s frontier admission; got %q", store.RunForkContractFrontierAdmissionOwner, req.FrontierAdmission.Owner)
+	}
+	if !req.FrontierAdmission.NonMutating {
+		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("selected route admission requires non-mutating frontier admission")
+	}
+
+	routeTable, err := runtimebus.DeriveRouteTable(req.Source)
+	if err != nil {
+		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission routes: %w", err)
+	}
+	routeEvents := selectedRouteHistoryEvents(routeTable, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
+	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Plan, req.FrontierAdmission)
+	blockers := []store.RunForkUnsupportedBlocker{{
+		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+		Message: "selected-contract route admission is non-mutating; route persistence, recipient delivery writes, and handler execution remain separately gated",
+	}}
+	if selectedRouteHistoryHasSourceRouteFacts(req.Plan) {
+		blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerFlowRouteHistoryUnproven,
+			Message: "source route rows are current operational state and remain evidence-only until selected route reconstruction is separately approved",
+		})
+	}
+
+	return store.RunForkSelectedContractRouteAdmission{
+		Owner:                          store.RunForkSelectedContractRouteAdmissionOwner,
+		FutureRouteReconstructionOwner: store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+		NonMutating:                    true,
+		RouteReconstructionSupported:   false,
+		ContractSelection:              selection,
+		SourceRouteFactsPresent:        selectedRouteHistoryHasSourceRouteFacts(req.Plan),
+		SelectedRouteEvents:            routeEvents,
+		DynamicFlowInstances:           dynamicFlowInstances,
+		FrontierAdmissionOwner:         req.FrontierAdmission.Owner,
+		RequiredConsumers:              selectedRouteHistoryRequiredConsumers(),
+		BlockedSiblings:                selectedRouteHistoryBlockedSiblings(),
+		InvalidPaths:                   selectedRouteHistoryInvalidPaths(),
+		UnsupportedBlockers:            blockers,
+	}, nil
+}
+
+func selectedRouteHistoryHasSourceRouteFacts(plan store.RunForkPlan) bool {
+	if hasUnsupportedBlocker(plan.UnsupportedBlockers, store.RunForkBlockerFlowRouteHistoryUnproven) {
+		return true
+	}
+	for _, blocker := range plan.ReplayResumeAdmission.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == store.RunForkBlockerFlowRouteHistoryUnproven {
+			return true
+		}
+	}
+	for _, disposition := range plan.ReplayResumeAdmission.Dispositions {
+		if strings.TrimSpace(disposition.Fact) == store.RunForkReplayResumeFactRouteHistory &&
+			strings.TrimSpace(disposition.Disposition) == store.RunForkReplayResumeDispositionFailClosedBlocker {
+			return true
+		}
+	}
+	return false
+}
+
+type selectedRouteHistoryEvent struct {
+	sourceEventID string
+	eventName     string
+}
+
+func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
+	frontierEventIDs := map[string]struct{}{}
+	for _, event := range frontier.FrontierEvents {
+		if sourceEventID := strings.TrimSpace(event.SourceEventID); sourceEventID != "" {
+			frontierEventIDs[sourceEventID] = struct{}{}
+		}
+	}
+	seen := map[string]selectedRouteHistoryEvent{}
+	add := func(sourceEventID, eventName string) {
+		sourceEventID = strings.TrimSpace(sourceEventID)
+		eventName = strings.TrimSpace(eventName)
+		if eventName == "" {
+			return
+		}
+		if _, isFrontier := frontierEventIDs[sourceEventID]; sourceEventID != "" && isFrontier {
+			return
+		}
+		key := sourceEventID
+		if key == "" {
+			key = eventName
+		}
+		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName}
+	}
+	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName)
+	for _, item := range plan.PendingWork {
+		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
+			add(item.EventID, item.EventName)
+		}
+	}
+	keys := make(map[string]struct{}, len(seen))
+	for key := range seen {
+		keys[key] = struct{}{}
+	}
+	ordered := sortedSet(keys)
+	out := make([]selectedRouteHistoryEvent, 0, len(ordered))
+	for _, key := range ordered {
+		out = append(out, seen[key])
+	}
+	return out
+}
+
+func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
+	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, store.RunForkSelectedContractRouteEvent{
+			SourceEventID:     event.sourceEventID,
+			EventName:         event.eventName,
+			DerivedRecipients: contractFrontierRecipients(routeTable.Resolve(event.eventName)),
+			Disposition:       store.RunForkSelectedContractDispositionEvidenceOnly,
+		})
+	}
+	return out
+}
+
+func selectedRouteHistoryDynamicFlowInstances(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []string {
+	seen := map[string]struct{}{}
+	add := func(value string) {
+		value = strings.Trim(strings.TrimSpace(value), "/")
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	for _, item := range plan.PendingWork {
+		add(item.FlowInstance)
+	}
+	for _, event := range frontier.FrontierEvents {
+		for _, flowInstance := range event.SourceFlowInstances {
+			add(flowInstance)
+		}
+	}
+	return sortedSet(seen)
+}
+
+func selectedRouteHistoryRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_source_route_derivation",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       "internal/runtime/bus.DeriveRouteTable",
+			Reason:      "route-history admission consumes selected-source route derivation instead of copying source route rows",
+		},
+		{
+			Concept:     "fork_local_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/runtime/bus.delivery_planner",
+			Reason:      "executable route reconstruction must feed an approved recipient planner before delivery rows can be created",
+		},
+	}
+}
+
+func selectedRouteHistoryBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "mutating_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+			Reason:      "this route admission model is non-mutating and does not persist fork-local route rows",
+		},
+		{
+			Concept:     "dynamic_flow_instance_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "internal/runtime/bus.RouteTable.AddFlowInstanceRoute",
+			Reason:      "dynamic flow-instance route reconstruction needs fork-local flow-instance ownership before route persistence",
+		},
+		{
+			Concept:     "recipient_delivery_writes",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "delivery_and_replay_ownership",
+			Reason:      "recipient derivation becomes executable only after a delivery owner approves fork-local delivery writes",
+		},
+		{
+			Concept:     "timer_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "timer reconstruction is scheduler lifecycle history, not route/subscription admission",
+		},
+	}
+}
+
+func selectedRouteHistoryInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "copy_source_routing_rules",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source routing_rules are current operational evidence, not selected-fork route truth",
+		},
+		{
+			Concept:     "copy_source_flow_instance_routes",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source materialized route rows lack selected-fork provenance and must not be copied",
+		},
+		{
+			Concept:     "reuse_source_recipients",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source recipient decisions were made under the source run and source contracts",
+		},
+		{
+			Concept:     "cli_api_dashboard_owned_routes",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "operator surfaces may consume route admission but must not own selected route reconstruction semantics",
+		},
+	}
+}
+
+func hasUnsupportedBlocker(blockers []store.RunForkUnsupportedBlocker, code string) bool {
+	code = strings.TrimSpace(code)
+	for _, blocker := range blockers {
+		if strings.TrimSpace(blocker.Code) == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -56,6 +56,7 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 			Message: "source route rows are current operational state and remain evidence-only until selected route reconstruction is separately approved",
 		})
 	}
+	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(req.FrontierAdmission)
 
 	return store.RunForkSelectedContractRouteAdmission{
 		Owner:                          store.RunForkSelectedContractRouteAdmissionOwner,
@@ -67,6 +68,9 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 		SelectedRouteEvents:            routeEvents,
 		DynamicFlowInstances:           dynamicFlowInstances,
 		FrontierAdmissionOwner:         req.FrontierAdmission.Owner,
+		FrontierEventCount:             frontierEventCount,
+		FrontierSourceEventIDs:         frontierSourceEventIDs,
+		FrontierEvidenceFingerprint:    frontierFingerprint,
 		RequiredConsumers:              selectedRouteHistoryRequiredConsumers(),
 		BlockedSiblings:                selectedRouteHistoryBlockedSiblings(),
 		InvalidPaths:                   selectedRouteHistoryInvalidPaths(),

--- a/internal/runtime/runforkadmission/selected_route_history_test.go
+++ b/internal/runtime/runforkadmission/selected_route_history_test.go
@@ -1,0 +1,171 @@
+package runforkadmission
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/store"
+)
+
+func TestAdmitSelectedContractRouteHistoryDerivesSelectedRoutesWithoutMutating(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	plan.UnsupportedBlockers = []store.RunForkUnsupportedBlocker{{
+		Code: store.RunForkBlockerFlowRouteHistoryUnproven,
+	}}
+	source := testContractFrontierSource("consumer-node")
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if admission.Owner != store.RunForkSelectedContractRouteAdmissionOwner {
+		t.Fatalf("owner = %q, want %q", admission.Owner, store.RunForkSelectedContractRouteAdmissionOwner)
+	}
+	if !admission.NonMutating || admission.RouteReconstructionSupported {
+		t.Fatalf("mutation flags = non_mutating:%v route_supported:%v", admission.NonMutating, admission.RouteReconstructionSupported)
+	}
+	if !admission.SourceRouteFactsPresent {
+		t.Fatalf("source route facts present = false, want true")
+	}
+	if len(admission.SelectedRouteEvents) != 1 {
+		t.Fatalf("selected route events = %#v, want one historical route event", admission.SelectedRouteEvents)
+	}
+	event := admission.SelectedRouteEvents[0]
+	if event.EventName != "producer/scan.requested" ||
+		event.SourceEventID == "" ||
+		event.Disposition != store.RunForkSelectedContractDispositionEvidenceOnly ||
+		len(event.DerivedRecipients) != 1 ||
+		event.DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("selected route event = %#v, want evidence-only selected consumer-node", event)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating) {
+		t.Fatalf("blockers = %#v, want non-mutating route admission blocker", admission.UnsupportedBlockers)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerFlowRouteHistoryUnproven) {
+		t.Fatalf("blockers = %#v, want source route history blocker", admission.UnsupportedBlockers)
+	}
+	if !routeBoundaryHas(admission.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source routing_rules copy invalid", admission.InvalidPaths)
+	}
+	if !routeBoundaryHas(admission.BlockedSiblings, "mutating_route_reconstruction", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("blocked siblings = %#v, want mutating route reconstruction blocked", admission.BlockedSiblings)
+	}
+}
+
+func TestAdmitSelectedContractRouteHistoryDoesNotDuplicateFrontierRecipients(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	historyEventID := uuid.NewString()
+	plan.PendingWork = append(plan.PendingWork, store.RunForkPendingWork{
+		EventID:        historyEventID,
+		EventName:      "producer/scan.requested",
+		DeliveryID:     uuid.NewString(),
+		SubscriberType: "node",
+		SubscriberID:   "completed-node",
+		Classification: store.RunForkPendingClassificationDeliveredCompleted,
+		Status:         "completed",
+		CreatedAt:      plan.ForkPoint.Timestamp,
+		DeliveredAt:    &plan.ForkPoint.Timestamp,
+		ReceiptAt:      &plan.ForkPoint.Timestamp,
+	})
+	plan.PendingWorkCount = len(plan.PendingWork)
+	source := testContractFrontierSource("consumer-node")
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if frontier.FrontierEventCount != 1 {
+		t.Fatalf("frontier events = %#v, want selected frontier work", frontier.FrontierEvents)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(admission.SelectedRouteEvents) != 1 {
+		t.Fatalf("selected route events = %#v, want only same-name historical event", admission.SelectedRouteEvents)
+	}
+	if admission.SelectedRouteEvents[0].SourceEventID != historyEventID {
+		t.Fatalf("route source event = %q, want historical event %q", admission.SelectedRouteEvents[0].SourceEventID, historyEventID)
+	}
+	if admission.FrontierAdmissionOwner != store.RunForkContractFrontierAdmissionOwner {
+		t.Fatalf("frontier owner = %q", admission.FrontierAdmissionOwner)
+	}
+}
+
+func TestAdmitSelectedContractRouteHistoryClassifiesDynamicFlowInstances(t *testing.T) {
+	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "review/inst-1"
+	source := testContractFrontierTemplateSource()
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if !hasString(admission.DynamicFlowInstances, "review/inst-1") {
+		t.Fatalf("dynamic flow instances = %v, want review/inst-1", admission.DynamicFlowInstances)
+	}
+	if !routeBoundaryHas(admission.BlockedSiblings, "dynamic_flow_instance_route_reconstruction", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("blocked siblings = %#v, want dynamic route reconstruction blocked", admission.BlockedSiblings)
+	}
+}
+
+func TestAdmitSelectedContractRouteHistoryRequiresCanonicalFrontier(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	source := testContractFrontierSource("consumer-node")
+	_, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:   plan,
+		Source: source,
+		FrontierAdmission: store.RunForkContractFrontierAdmission{
+			Owner:       "cmd.swarm.local_frontier",
+			NonMutating: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("AdmitSelectedContractRouteHistory error = nil, want canonical frontier failure")
+	}
+}
+
+func routeBoundaryHas(items []store.RunForkSelectedContractExecutionBoundary, concept, disposition string) bool {
+	for _, item := range items {
+		if item.Concept == concept && item.Disposition == disposition {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/runforkadmission/selected_route_history_test.go
+++ b/internal/runtime/runforkadmission/selected_route_history_test.go
@@ -116,7 +116,7 @@ func TestAdmitSelectedContractRouteHistoryDoesNotDuplicateFrontierRecipients(t *
 }
 
 func TestAdmitSelectedContractRouteHistoryClassifiesDynamicFlowInstances(t *testing.T) {
-	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
+	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
 	plan.PendingWork[0].FlowInstance = "review/inst-1"
 	source := testContractFrontierTemplateSource()
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
@@ -139,6 +139,12 @@ func TestAdmitSelectedContractRouteHistoryClassifiesDynamicFlowInstances(t *test
 	}
 	if !hasString(admission.DynamicFlowInstances, "review/inst-1") {
 		t.Fatalf("dynamic flow instances = %v, want review/inst-1", admission.DynamicFlowInstances)
+	}
+	if len(admission.SelectedRouteEvents) != 1 ||
+		len(admission.SelectedRouteEvents[0].DerivedRecipients) != 1 ||
+		admission.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "reviewer-inst-1" ||
+		admission.SelectedRouteEvents[0].DerivedRecipients[0].Path != "review/inst-1" {
+		t.Fatalf("selected route events = %#v, want materialized dynamic recipient reviewer-inst-1", admission.SelectedRouteEvents)
 	}
 	if !routeBoundaryHas(admission.BlockedSiblings, "dynamic_flow_instance_route_reconstruction", store.RunForkSelectedContractDispositionBlockedSibling) {
 		t.Fatalf("blocked siblings = %#v, want dynamic route reconstruction blocked", admission.BlockedSiblings)

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -70,7 +70,19 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	routeAdmission, err := runforkadmission.AdmitSelectedContractRouteHistory(runforkadmission.SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            loadedSource.Source,
+		ContractSelection: binding.ContractSelection,
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+	})
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
@@ -79,6 +91,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		ExecutionModel:    model,
 	})
 	if err != nil {

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -116,6 +116,7 @@ type SelectedContractExecutionAdmissionRequest struct {
 	BindingReader     SelectedContractBindingReader
 	SourceLoader      SelectedContractSourceLoader
 	FrontierAdmission store.RunForkContractFrontierAdmission
+	RouteAdmission    store.RunForkSelectedContractRouteAdmission
 	ExecutionModel    store.RunForkSelectedContractExecution
 }
 
@@ -150,7 +151,10 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 	if err := validateSelectedContractExecutionFrontier(binding, req.FrontierAdmission); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.ExecutionModel); err != nil {
+	if err := validateSelectedContractExecutionRouteAdmission(binding, req.FrontierAdmission, req.RouteAdmission); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
+	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteAdmission, req.ExecutionModel); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
 
@@ -177,6 +181,7 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 		SourceWorkflowVersion: strings.TrimSpace(loadedSource.Source.WorkflowVersion()),
 		FrontierEventCount:    req.ExecutionModel.FrontierEventCount,
 		FrontierEvents:        append([]store.RunForkSelectedContractFrontierEvent(nil), req.ExecutionModel.FrontierEvents...),
+		RouteAdmission:        &req.RouteAdmission,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -247,7 +252,14 @@ func validateSelectedContractExecutionFrontier(binding store.RunForkSelectedCont
 	return validateSelectionMatches("frontier admission", binding.ContractSelection, admission.ContractSelection)
 }
 
-func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, model store.RunForkSelectedContractExecution) error {
+func validateSelectedContractExecutionRouteAdmission(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) error {
+	if err := validateSelectedContractRouteAdmission(frontier, routeAdmission); err != nil {
+		return err
+	}
+	return validateSelectionMatches("route admission", binding.ContractSelection, routeAdmission.ContractSelection)
+}
+
+func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, model store.RunForkSelectedContractExecution) error {
 	if strings.TrimSpace(model.Owner) != store.RunForkSelectedContractExecutionModelOwner {
 		return fmt.Errorf("selected-contract execution admission requires %s model; got %q", store.RunForkSelectedContractExecutionModelOwner, model.Owner)
 	}
@@ -265,6 +277,12 @@ func validateSelectedContractExecutionModel(binding store.RunForkSelectedContrac
 	}
 	if !reflect.DeepEqual(model.FrontierEvents, selectedContractFrontierEvents(frontier.FrontierEvents)) {
 		return fmt.Errorf("selected-contract execution admission model frontier events do not match durable frontier evidence")
+	}
+	if model.RouteAdmission == nil {
+		return fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRouteAdmissionOwner)
+	}
+	if !reflect.DeepEqual(*model.RouteAdmission, routeAdmission) {
+		return fmt.Errorf("selected-contract execution admission model route admission does not match canonical route admission evidence")
 	}
 	if model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
 		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite {

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -21,6 +21,7 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	reader := &fakeSelectedContractBindingReader{binding: binding}
 	sourceLoader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 	model := testSelectedContractExecutionModel(t, frontier)
 
 	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -28,6 +29,7 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 		BindingReader:     reader,
 		SourceLoader:      sourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		ExecutionModel:    model,
 	})
 	if err != nil {
@@ -63,6 +65,9 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
 		t.Fatalf("frontier events = %#v", admission.FrontierEvents)
 	}
+	if admission.RouteAdmission == nil || admission.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner {
+		t.Fatalf("route admission = %#v, want canonical selected-contract route admission", admission.RouteAdmission)
+	}
 	if !executionBoundaryHas(admission.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copy invalid", admission.InvalidPaths)
 	}
@@ -74,6 +79,9 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	}
 	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating) {
 		t.Fatalf("unsupported blockers = %#v, want non-mutating admission blocker", admission.UnsupportedBlockers)
+	}
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want non-mutating route admission blocker", admission.UnsupportedBlockers)
 	}
 }
 
@@ -89,6 +97,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnMissingBinding(t *t
 		BindingReader:     &fakeSelectedContractBindingReader{err: errors.New("selected contract binding not found")},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(selection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "load selected-contract binding") {
@@ -108,6 +117,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnUnavailableSelected
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection}},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected semantic source") {
@@ -129,6 +139,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *t
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection, Source: testSelectedSource(mismatched)}},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workflow version mismatch") {
@@ -150,6 +161,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnWrongContractsRoot(
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(wrongRoot)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected source selection does not match durable binding") {
@@ -170,6 +182,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), store.RunForkContractFrontierAdmissionOwner) {
@@ -190,10 +203,33 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier events do not match") {
 		t.Fatalf("error = %v, want stale frontier model failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteAdmission(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	model := testSelectedContractExecutionModel(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeAdmission.Owner = "cmd.swarm.route_helper"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
+		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical route admission failure", err)
 	}
 }
 
@@ -283,9 +319,44 @@ func testContractFrontierAdmission(selection store.RunForkContractSelection) sto
 	}
 }
 
+func testSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractRouteAdmission {
+	return store.RunForkSelectedContractRouteAdmission{
+		Owner:                          store.RunForkSelectedContractRouteAdmissionOwner,
+		FutureRouteReconstructionOwner: store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+		NonMutating:                    true,
+		RouteReconstructionSupported:   false,
+		ContractSelection:              frontier.ContractSelection,
+		FrontierAdmissionOwner:         frontier.Owner,
+		RequiredConsumers: []store.RunForkSelectedContractExecutionBoundary{{
+			Concept:     "selected_source_route_derivation",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       "internal/runtime/bus.DeriveRouteTable",
+			Reason:      "test route admission consumes selected-source route derivation",
+		}},
+		BlockedSiblings: []store.RunForkSelectedContractExecutionBoundary{{
+			Concept:     "mutating_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+			Reason:      "test route admission remains non-mutating",
+		}},
+		InvalidPaths: []store.RunForkSelectedContractExecutionBoundary{{
+			Concept:     "copy_source_routing_rules",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "test route admission rejects source route row copy",
+		}},
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
+			Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+			Message: "selected-contract route admission is non-mutating",
+		}},
+	}
+}
+
 func testSelectedContractExecutionModel(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractExecution {
 	t.Helper()
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: testSelectedContractRouteAdmission(frontier),
+	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
 	}

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -233,6 +233,28 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteAdmission(
 	}
 }
 
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmissionFrontier(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	model := testSelectedContractExecutionModel(t, frontier)
+	frontier.FrontierEvents[0].EventName = "work.changed"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
+		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
+		t.Fatalf("error = %v, want stale route admission frontier failure", err)
+	}
+}
+
 type fakeSelectedContractBindingReader struct {
 	binding            store.RunForkSelectedContractBinding
 	err                error
@@ -320,6 +342,7 @@ func testContractFrontierAdmission(selection store.RunForkContractSelection) sto
 }
 
 func testSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractRouteAdmission {
+	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(frontier)
 	return store.RunForkSelectedContractRouteAdmission{
 		Owner:                          store.RunForkSelectedContractRouteAdmissionOwner,
 		FutureRouteReconstructionOwner: store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
@@ -327,6 +350,9 @@ func testSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAd
 		RouteReconstructionSupported:   false,
 		ContractSelection:              frontier.ContractSelection,
 		FrontierAdmissionOwner:         frontier.Owner,
+		FrontierEventCount:             frontierEventCount,
+		FrontierSourceEventIDs:         frontierSourceEventIDs,
+		FrontierEvidenceFingerprint:    frontierFingerprint,
 		RequiredConsumers: []store.RunForkSelectedContractExecutionBoundary{{
 			Concept:     "selected_source_route_derivation",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -255,6 +255,33 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmission
 	}
 }
 
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmissionFlowInstances(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	frontier.FrontierEvents[0].EventName = "review/inst-1/task.started"
+	frontier.FrontierEvents[0].SourceClassifications = []string{store.RunForkPendingClassificationPending}
+	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-1"}
+	frontier.FrontierEvents[0].SourceSubscriberTypes = []string{"node"}
+	frontier.FrontierEvents[0].SourceSubscriberIDs = []string{"source-node"}
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	model := testSelectedContractExecutionModel(t, frontier)
+	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
+		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
+		t.Fatalf("error = %v, want stale route admission flow-instance failure", err)
+	}
+}
+
 type fakeSelectedContractBindingReader struct {
 	binding            store.RunForkSelectedContractBinding
 	err                error

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -77,10 +77,22 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if frontier.FrontierEventCount == 0 {
 		return SelectedContractExecutionResult{}, fmt.Errorf("selected-contract execution requires selected frontier events")
 	}
+	routeAdmission, err := runforkadmission.AdmitSelectedContractRouteHistory(runforkadmission.SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            loadedSource.Source,
+		ContractSelection: selection,
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{}, err
+	}
 	if err := validateSelectedContractExecutionFrontierForMutation(frontier); err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner}, err
 	}
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: frontier})
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+	})
 	if err != nil {
 		return SelectedContractExecutionResult{}, err
 	}
@@ -98,6 +110,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		ExecutionModel:    model,
 	})
 	if err != nil {

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -8,7 +8,8 @@ import (
 )
 
 type SelectedContractExecutionModelRequest struct {
-	Admission store.RunForkContractFrontierAdmission
+	Admission      store.RunForkContractFrontierAdmission
+	RouteAdmission store.RunForkSelectedContractRouteAdmission
 }
 
 func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelRequest) (store.RunForkSelectedContractExecution, error) {
@@ -22,8 +23,15 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 	if admission.HistoricalExecutionSupported {
 		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission unexpectedly supports historical execution")
 	}
+	routeAdmission := req.RouteAdmission
+	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
+		return store.RunForkSelectedContractExecution{}, err
+	}
 
 	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), admission.UnsupportedBlockers...)
+	for _, blocker := range routeAdmission.UnsupportedBlockers {
+		unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, blocker)
+	}
 	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
 		Code:    store.RunForkBlockerSelectedContractExecutionModelNonMutating,
 		Message: "selected-contract fork execution is model-only; executable fork work remains separately gated",
@@ -39,6 +47,7 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		AdmissionUse:         store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly,
 		FrontierEventCount:   admission.FrontierEventCount,
 		FrontierEvents:       selectedContractFrontierEvents(admission.FrontierEvents),
+		RouteAdmission:       &routeAdmission,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -50,6 +59,25 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		InvalidPaths:        selectedContractExecutionInvalidPaths(),
 		UnsupportedBlockers: unsupportedBlockers,
 	}, nil
+}
+
+func validateSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) error {
+	if strings.TrimSpace(routeAdmission.Owner) != store.RunForkSelectedContractRouteAdmissionOwner {
+		return fmt.Errorf("selected-contract execution model requires %s route admission; got %q", store.RunForkSelectedContractRouteAdmissionOwner, routeAdmission.Owner)
+	}
+	if !routeAdmission.NonMutating {
+		return fmt.Errorf("selected-contract route admission must be non-mutating")
+	}
+	if routeAdmission.RouteReconstructionSupported {
+		return fmt.Errorf("selected-contract route admission unexpectedly supports route reconstruction")
+	}
+	if strings.TrimSpace(routeAdmission.FrontierAdmissionOwner) != store.RunForkContractFrontierAdmissionOwner {
+		return fmt.Errorf("selected-contract route admission must consume %s; got %q", store.RunForkContractFrontierAdmissionOwner, routeAdmission.FrontierAdmissionOwner)
+	}
+	if err := validateSelectionMatches("route admission", frontier.ContractSelection, routeAdmission.ContractSelection); err != nil {
+		return err
+	}
+	return nil
 }
 
 func appendRunForkUnsupportedBlocker(blockers []store.RunForkUnsupportedBlocker, blocker store.RunForkUnsupportedBlocker) []store.RunForkUnsupportedBlocker {
@@ -134,9 +162,15 @@ func selectedContractExecutionBlockedSiblings() []store.RunForkSelectedContractE
 			Reason:      "node/system execution requires a later mutating owner and remains blocked here",
 		},
 		{
-			Concept:     "timers_routes",
+			Concept:     "timer_reconstruction",
 			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
-			Reason:      "timer and route reconstruction remain separate fork replay/resume blockers",
+			Reason:      "timer reconstruction remains a separate fork replay/resume blocker",
+		},
+		{
+			Concept:     "mutating_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+			Reason:      "route-history admission is non-mutating and must not persist routes or create executable recipients in this slice",
 		},
 		{
 			Concept:     "sessions_turns_audits",

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -2,6 +2,7 @@ package runforkexecution
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"swarm/internal/store"
@@ -73,6 +74,16 @@ func validateSelectedContractRouteAdmission(frontier store.RunForkContractFronti
 	}
 	if strings.TrimSpace(routeAdmission.FrontierAdmissionOwner) != store.RunForkContractFrontierAdmissionOwner {
 		return fmt.Errorf("selected-contract route admission must consume %s; got %q", store.RunForkContractFrontierAdmissionOwner, routeAdmission.FrontierAdmissionOwner)
+	}
+	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(frontier)
+	if routeAdmission.FrontierEventCount != frontierEventCount {
+		return fmt.Errorf("selected-contract route admission frontier count mismatch: got %d want %d", routeAdmission.FrontierEventCount, frontierEventCount)
+	}
+	if !reflect.DeepEqual(routeAdmission.FrontierSourceEventIDs, frontierSourceEventIDs) {
+		return fmt.Errorf("selected-contract route admission frontier source event IDs do not match current frontier evidence")
+	}
+	if strings.TrimSpace(routeAdmission.FrontierEvidenceFingerprint) != frontierFingerprint {
+		return fmt.Errorf("selected-contract route admission frontier fingerprint mismatch")
 	}
 	if err := validateSelectionMatches("route admission", frontier.ContractSelection, routeAdmission.ContractSelection); err != nil {
 		return err

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -179,6 +179,39 @@ func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFron
 	}
 }
 
+func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFlowInstances(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:         "source-event",
+			EventName:             "review/inst-1/task.started",
+			SourceClassifications: []string{store.RunForkPendingClassificationPending},
+			SourceFlowInstances:   []string{"review/inst-1"},
+			SourceSubscriberTypes: []string{"node"},
+			SourceSubscriberIDs:   []string{"source-node"},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	admission.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
+
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
+		t.Fatalf("error = %v, want stale route admission flow-instance failure", err)
+	}
+}
+
 func TestBuildSelectedContractExecutionModelFailsClosedOnExecutableAdmission(t *testing.T) {
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
 		Admission: store.RunForkContractFrontierAdmission{

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -150,6 +150,35 @@ func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteAdmission(t *t
 	}
 }
 
+func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFrontier(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID: "source-event",
+			EventName:     "work.begin",
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	admission.FrontierEvents[0].EventName = "work.changed"
+
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
+		t.Fatalf("error = %v, want stale route admission frontier failure", err)
+	}
+}
+
 func TestBuildSelectedContractExecutionModelFailsClosedOnExecutableAdmission(t *testing.T) {
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
 		Admission: store.RunForkContractFrontierAdmission{

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -33,7 +33,11 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 		}},
 	}
 
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: admission})
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
 	}
@@ -58,6 +62,9 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 	if model.FrontierEvents[0].Disposition != store.RunForkSelectedContractDispositionEvidenceOnly {
 		t.Fatalf("frontier disposition = %q", model.FrontierEvents[0].Disposition)
 	}
+	if model.RouteAdmission == nil || model.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner {
+		t.Fatalf("route admission = %#v, want canonical selected-contract route admission", model.RouteAdmission)
+	}
 	if !executionBoundaryHas(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copying invalid", model.InvalidPaths)
 	}
@@ -72,6 +79,9 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 	}
 	if !unsupportedBlockerHas(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionModelNonMutating) {
 		t.Fatalf("unsupported blockers = %#v, want non-mutating model blocker", model.UnsupportedBlockers)
+	}
+	if !unsupportedBlockerHas(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want non-mutating route admission blocker", model.UnsupportedBlockers)
 	}
 }
 
@@ -97,18 +107,46 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 		},
 	}
 
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{Admission: admission})
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: testSelectedContractRouteAdmission(admission),
+	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
 	}
 	for _, code := range []string{
 		store.RunForkBlockerContractFrontierExecutionUnsupported,
 		store.RunForkBlockerContractFrontierRouteUnresolved,
+		store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
 		store.RunForkBlockerSelectedContractExecutionModelNonMutating,
 	} {
 		if !unsupportedBlockerHas(model.UnsupportedBlockers, code) {
 			t.Fatalf("unsupported blockers = %#v, want %s", model.UnsupportedBlockers, code)
 		}
+	}
+}
+
+func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteAdmission(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.Owner = "cmd.swarm.local_route_admission"
+
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical route admission failure", err)
 	}
 }
 

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -128,6 +128,10 @@ func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmi
 	type frontierEvent struct {
 		SourceEventID           string           `json:"source_event_id,omitempty"`
 		EventName               string           `json:"event_name,omitempty"`
+		SourceClassifications   []string         `json:"source_classifications,omitempty"`
+		SourceFlowInstances     []string         `json:"source_flow_instances,omitempty"`
+		SourceSubscriberTypes   []string         `json:"source_subscriber_types,omitempty"`
+		SourceSubscriberIDs     []string         `json:"source_subscriber_ids,omitempty"`
 		RuntimeEventOwners      []string         `json:"runtime_event_owners,omitempty"`
 		WorkflowNodeSubscribers []string         `json:"workflow_node_subscribers,omitempty"`
 		DerivedRecipients       []routeRecipient `json:"derived_recipients,omitempty"`
@@ -158,6 +162,10 @@ func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmi
 		events = append(events, frontierEvent{
 			SourceEventID:           sourceEventID,
 			EventName:               eventName,
+			SourceClassifications:   sortedTrimmedStrings(event.SourceClassifications),
+			SourceFlowInstances:     sortedTrimmedStrings(event.SourceFlowInstances),
+			SourceSubscriberTypes:   sortedTrimmedStrings(event.SourceSubscriberTypes),
+			SourceSubscriberIDs:     sortedTrimmedStrings(event.SourceSubscriberIDs),
 			RuntimeEventOwners:      sortedTrimmedStrings(event.RuntimeEventOwners),
 			WorkflowNodeSubscribers: sortedTrimmedStrings(event.WorkflowNodeSubscribers),
 			DerivedRecipients:       recipients,

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -5,6 +5,7 @@ const (
 	RunForkSelectedContractExecutionAdmissionOwner      = "runtime.run_fork.selected_contract_execution_admission"
 	RunForkSelectedContractExecutionActivationGateOwner = "runtime.run_fork.selected_contract_execution.activation_gate"
 	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
+	RunForkSelectedContractRouteAdmissionOwner          = "runtime.run_fork.selected_contract_route_admission"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -19,6 +20,7 @@ const (
 	RunForkBlockerSelectedContractExecutionModelNonMutating     = "selected_contract_execution_model_non_mutating"
 	RunForkBlockerSelectedContractExecutionAdmissionNonMutating = "selected_contract_execution_admission_non_mutating"
 	RunForkBlockerSelectedContractSourceReplayUnsupported       = "selected_contract_source_replay_unsupported"
+	RunForkBlockerSelectedContractRouteAdmissionNonMutating     = "selected_contract_route_admission_non_mutating"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
 )
@@ -33,6 +35,7 @@ type RunForkSelectedContractExecution struct {
 	AdmissionUse         string                                     `json:"admission_use"`
 	FrontierEventCount   int                                        `json:"frontier_event_count"`
 	FrontierEvents       []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
+	RouteAdmission       *RunForkSelectedContractRouteAdmission     `json:"route_admission,omitempty"`
 	ContractBinding      RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers    []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings      []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -57,6 +60,7 @@ type RunForkSelectedContractExecutionAdmission struct {
 	SourceWorkflowVersion string                                     `json:"source_workflow_version"`
 	FrontierEventCount    int                                        `json:"frontier_event_count"`
 	FrontierEvents        []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
+	RouteAdmission        *RunForkSelectedContractRouteAdmission     `json:"route_admission,omitempty"`
 	ContractBinding       RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers     []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings       []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -71,6 +75,29 @@ type RunForkSelectedContractFrontierEvent struct {
 	WorkflowNodeSubscribers []string                           `json:"workflow_node_subscribers,omitempty"`
 	DerivedRecipients       []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
 	Disposition             string                             `json:"disposition"`
+}
+
+type RunForkSelectedContractRouteAdmission struct {
+	Owner                          string                                     `json:"owner"`
+	FutureRouteReconstructionOwner string                                     `json:"future_route_reconstruction_owner"`
+	NonMutating                    bool                                       `json:"non_mutating"`
+	RouteReconstructionSupported   bool                                       `json:"route_reconstruction_supported"`
+	ContractSelection              RunForkContractSelection                   `json:"contract_selection"`
+	SourceRouteFactsPresent        bool                                       `json:"source_route_facts_present"`
+	SelectedRouteEvents            []RunForkSelectedContractRouteEvent        `json:"selected_route_events,omitempty"`
+	DynamicFlowInstances           []string                                   `json:"dynamic_flow_instances,omitempty"`
+	FrontierAdmissionOwner         string                                     `json:"frontier_admission_owner,omitempty"`
+	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers            []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractRouteEvent struct {
+	SourceEventID     string                             `json:"source_event_id,omitempty"`
+	EventName         string                             `json:"event_name"`
+	DerivedRecipients []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
+	Disposition       string                             `json:"disposition"`
 }
 
 type RunForkSelectedContractExecutionBoundary struct {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -1,5 +1,13 @@
 package store
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
 const (
 	RunForkSelectedContractExecutionModelOwner          = "runtime.run_fork.selected_contract_execution_model"
 	RunForkSelectedContractExecutionAdmissionOwner      = "runtime.run_fork.selected_contract_execution_admission"
@@ -87,6 +95,9 @@ type RunForkSelectedContractRouteAdmission struct {
 	SelectedRouteEvents            []RunForkSelectedContractRouteEvent        `json:"selected_route_events,omitempty"`
 	DynamicFlowInstances           []string                                   `json:"dynamic_flow_instances,omitempty"`
 	FrontierAdmissionOwner         string                                     `json:"frontier_admission_owner,omitempty"`
+	FrontierEventCount             int                                        `json:"frontier_event_count"`
+	FrontierSourceEventIDs         []string                                   `json:"frontier_source_event_ids,omitempty"`
+	FrontierEvidenceFingerprint    string                                     `json:"frontier_evidence_fingerprint"`
 	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
@@ -105,4 +116,85 @@ type RunForkSelectedContractExecutionBoundary struct {
 	Disposition string `json:"disposition"`
 	Owner       string `json:"owner,omitempty"`
 	Reason      string `json:"reason"`
+}
+
+func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmission) (int, []string, string) {
+	type routeRecipient struct {
+		SubscriberType string `json:"subscriber_type,omitempty"`
+		SubscriberID   string `json:"subscriber_id,omitempty"`
+		Path           string `json:"path,omitempty"`
+		RouteSource    string `json:"route_source,omitempty"`
+	}
+	type frontierEvent struct {
+		SourceEventID           string           `json:"source_event_id,omitempty"`
+		EventName               string           `json:"event_name,omitempty"`
+		RuntimeEventOwners      []string         `json:"runtime_event_owners,omitempty"`
+		WorkflowNodeSubscribers []string         `json:"workflow_node_subscribers,omitempty"`
+		DerivedRecipients       []routeRecipient `json:"derived_recipients,omitempty"`
+	}
+
+	events := make([]frontierEvent, 0, len(frontier.FrontierEvents))
+	ids := map[string]struct{}{}
+	for _, event := range frontier.FrontierEvents {
+		sourceEventID := strings.TrimSpace(event.SourceEventID)
+		eventName := strings.TrimSpace(event.EventName)
+		if sourceEventID != "" {
+			ids[sourceEventID] = struct{}{}
+		}
+		recipients := make([]routeRecipient, 0, len(event.DerivedRecipients))
+		for _, recipient := range event.DerivedRecipients {
+			recipients = append(recipients, routeRecipient{
+				SubscriberType: strings.TrimSpace(recipient.SubscriberType),
+				SubscriberID:   strings.TrimSpace(recipient.SubscriberID),
+				Path:           strings.TrimSpace(recipient.Path),
+				RouteSource:    strings.TrimSpace(recipient.RouteSource),
+			})
+		}
+		sort.Slice(recipients, func(i, j int) bool {
+			left := strings.Join([]string{recipients[i].SubscriberType, recipients[i].SubscriberID, recipients[i].Path, recipients[i].RouteSource}, "\x00")
+			right := strings.Join([]string{recipients[j].SubscriberType, recipients[j].SubscriberID, recipients[j].Path, recipients[j].RouteSource}, "\x00")
+			return left < right
+		})
+		events = append(events, frontierEvent{
+			SourceEventID:           sourceEventID,
+			EventName:               eventName,
+			RuntimeEventOwners:      sortedTrimmedStrings(event.RuntimeEventOwners),
+			WorkflowNodeSubscribers: sortedTrimmedStrings(event.WorkflowNodeSubscribers),
+			DerivedRecipients:       recipients,
+		})
+	}
+	sort.Slice(events, func(i, j int) bool {
+		left := strings.Join([]string{events[i].SourceEventID, events[i].EventName}, "\x00")
+		right := strings.Join([]string{events[j].SourceEventID, events[j].EventName}, "\x00")
+		return left < right
+	})
+
+	sourceEventIDs := make([]string, 0, len(ids))
+	for id := range ids {
+		sourceEventIDs = append(sourceEventIDs, id)
+	}
+	sort.Strings(sourceEventIDs)
+
+	payload, _ := json.Marshal(events)
+	sum := sha256.Sum256(payload)
+	return len(frontier.FrontierEvents), sourceEventIDs, hex.EncodeToString(sum[:])
+}
+
+func sortedTrimmedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
Closes #604

## Summary
- Adds canonical non-mutating `runtime.run_fork.selected_contract_route_admission` evidence for selected-contract timestamp forks.
- Wires route admission into CLI dry-run JSON, selected-contract execution model, selected-contract execution admission, selected execution, and selected-bound activation gate.
- Keeps route reconstruction, route row persistence, executable recipient derivation, delivery writes, handler execution, timers, sessions/turns, source-advanced policy, contract swap, and UI/API ownership blocked or split.

## Governing refs / context
- #604 Pre-Implementation Coverage Audit and lead gate decision: approved as first slice.
- Platform spec: `run_model.fork.policy.selected_contract_route_admission` and `run_model.fork.policy.semantics.3e_selected_contract_route_admission`.
- Adjacent binding context: #577 contract/frontier admission, #602 timer/route blocker consumption, and #598 selected-contract execution model/admission.

## Semantic migration
- New canonical owner: `runtime.run_fork.selected_contract_route_admission`.
- Old paths invalid/non-authoritative: copying source `routing_rules`, copying source `flow_instance_routes`, reusing source recipients, CLI/API/dashboard-owned route semantics.
- Production paths checked: CLI dry-run selected contracts, activation gate, selected execution admission/model, selected execution, contract frontier admission, selected-source route derivation, delivery planner boundary, store planner blocker taxonomy.
- Migration completion: complete for the approved non-mutating route/subscription admission slice. Mutating route reconstruction, recipient/delivery writes, and handler execution remain explicitly blocked future siblings.

## Proof
- `go test ./cmd/swarm -run TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON -count=1`
- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/store ./internal/runtime/bus ./internal/runtime/manager ./cmd/swarm -run 'SelectedContract|RunForkPlanner|Route|Routing|DeliveryPlanner|FlowInstance|ContractFrontier|Fork' -count=1`
- `go test ./...`