### PR TITLE
[agent-d][issue #605] Canonical event metadata namespace

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1752,7 +1752,8 @@ pins:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
 task.assigned:
-  _source: external (verify lint evidence test)
+  swarm:
+    source: external (verify lint evidence test)
   entity_id: string
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
@@ -1913,7 +1914,8 @@ states: [idle, done]
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
 task.assigned:
-  _source: external (state schema float verify test)
+  swarm:
+    source: external (state schema float verify test)
   entity_id: string
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
@@ -2266,7 +2268,7 @@ func TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface(t *testing
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"scan.corpus_dispatch": {
-				Source: "external",
+				Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"},
 				Payload: runtimecontracts.EventPayloadSpec{
 					Properties: map[string]runtimecontracts.EventFieldSpec{
 						"scan_id":   {Type: "string"},
@@ -2317,7 +2319,7 @@ func TestVerifyBundle_InputPinProducerPathReturnsWarningSurface(t *testing.T) {
 		"Root agent emit_events: not found",
 		"Root node handler emits: not found",
 		"Platform event catalog: not matched",
-		"External source annotation (_source): not found",
+		"External source metadata (swarm.source): not found",
 		"Same-flow timer declaration: not found",
 	} {
 		if !strings.Contains(err.Error(), want) {

--- a/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
+++ b/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
@@ -398,6 +398,7 @@ Every event has a typed payload schema in `events.yaml`. The platform validates 
 
 Events can be marked with reserved `swarm:` metadata:
 - `swarm.source: external` — produced by human/API, not by any agent or node
+- `swarm.producer: mailbox_human` — exceptional non-derivable producer proof
 - `swarm.consumer: external_ui` — consumed by UI/mailbox/operator, not by any agent
 - `swarm.status: planned` — future feature, not yet implemented
 

--- a/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
+++ b/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
@@ -396,10 +396,10 @@ Agent emits event → platform persists → system node handles → new event em
 
 Every event has a typed payload schema in `events.yaml`. The platform validates payloads at entry.
 
-Events can be marked with metadata:
-- `_source: external` — produced by human/API, not by any agent or node
-- `_consumer: mailbox_system` — consumed by UI, not by any agent
-- `_status: planned` — future feature, not yet implemented
+Events can be marked with reserved `swarm:` metadata:
+- `swarm.source: external` — produced by human/API, not by any agent or node
+- `swarm.consumer: external_ui` — consumed by UI/mailbox/operator, not by any agent
+- `swarm.status: planned` — future feature, not yet implemented
 
 ### Expressions (CEL)
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -177,15 +177,20 @@ contract_formats:
   event_schema:
     description: |
       Events in `events.yaml` use the Wave 1 flat payload form.
-      Event-level metadata is underscore-prefixed. Non-underscored keys
-      are producer-owned payload fields. The platform validates emit
-      calls against the declared payload contract and populates envelope
-      fields separately.
+      Event-level Swarm metadata lives under the reserved `swarm:`
+      namespace. Aside from reserved platform metadata fields such as
+      `emitter`, `runtime_handling`, `owning_node`, and
+      `delivery_channel`, other non-underscored top-level keys are
+      producer-owned payload fields.
+      The platform validates emit calls against the declared payload
+      contract and populates envelope fields separately.
     format:
       event_name: |
-        _note: Human-readable metadata (optional)
-        _source: Producer annotation (optional)
-        _consumer: Consumer annotation (optional)
+        swarm:
+          source: external (optional; non-derivable external/platform producer proof)
+          consumer: external_ui (optional; non-derivable external sink proof)
+          status: planned (optional; lifecycle suppression)
+          note: Human-readable metadata (optional)
         field_name: type
         nested_field:
           type: NamedType
@@ -264,10 +269,10 @@ contract_formats:
   underscore_prefix_convention:
     description: Fields starting with _ in contract YAML files.
     semantic_fields:
-      _source: 'Event producer type. Suppresses NO-PRODUCER verifier warnings. Values: external (...)'
-      _consumer: 'Event consumer type. Suppresses NO-CONSUMER warnings. Values: mailbox_system (...)'
-      _status: 'Event lifecycle. Values: planned (future feature).'
-      _producer: Event producer agent. Suppresses NO-PRODUCER warnings for agent-emitted events.
+      _source: 'Legacy migration input for event swarm.source. Do not author in new contracts.'
+      _consumer: 'Legacy migration input for event swarm.consumer. Do not author in new contracts.'
+      _status: 'Legacy migration input for event swarm.status. Do not author in new contracts.'
+      _producer: 'Legacy migration input for event swarm.producer for non-derivable producer proof only. Do not author for ordinary internal topology.'
     documentation_fields: Any other _-prefixed field (_note, _routing_note, _internal_events_note, etc.) is a human comment.
       The platform ignores them. The verifier ignores them. They are not part of the contract.
 rule:
@@ -1808,13 +1813,13 @@ engine:
       severity: warning
       scope: per-flow
       trigger: An event is emitted (by a node handler or agent emit_events) but no node or agent subscribes to it. Suppressed
-        if the event has _consumer or _status annotations.
+        if the event has swarm.consumer or swarm.status metadata.
       when: boot-only
     - id: event_producer_exists
       severity: warning
       scope: per-flow
-      trigger: An agent subscribes to an event that no node handler emits and no agent lists in emit_events. Suppressed if
-        the event has _source or _status annotations.
+      trigger: An agent subscribes to an event that no node handler emits and no agent lists in emit_events. Suppressed if the
+        event has swarm.source or swarm.status metadata.
       when: boot-only
     - id: payload_field_coverage
       severity: error
@@ -1990,15 +1995,15 @@ engine:
       scope: per-flow
       trigger: 'A flow''s required input event pin (from schema.yaml pins.inputs.events) has no satisfiable authored producer
         path on the static verify surface. The warning checks only sibling flow output pins, root agent emit_events, root
-        node handler emit sites, exact platform_events catalog matches, _source values starting with external, and same-flow
-        timer declarations. It does not use produces or _status: planned as proof.'
+        node handler emit sites, exact platform_events catalog matches, swarm.source values starting with external, and same-flow
+        timer declarations. It does not use produces or swarm.status: planned as input-pin proof.'
       when: boot-only
     - id: semantic_drift_dead_event_schema
       severity: warning
       scope: per-event
       trigger: A product-declared event schema entry in `events.yaml` has no active authored role on the static verify surface.
         Active roles are limited to intra-flow local usage, explicit cross-flow qualified usage, root-local usage for root-declared
-        events only, external `_source` / `_consumer` annotations, same-flow timer fire/start/cancel references, same-flow
+        events only, external `swarm.source` / `swarm.consumer` metadata, same-flow timer fire/start/cancel references, same-flow
         `fan_out.emit`, and same-flow `auto_emit_on_create`. It does not treat platform catalog membership, root-local
         references into child-flow declarations, or coincidental same local names in other flows as proof.
       when: boot-only
@@ -3463,7 +3468,8 @@ platform_events:
         source: string — who initiated the reset (admin_cli, builder_api, etc.)
         timestamp: string (ISO 8601)
       produced_by_type: platform
-      _source: external (platform admin CLI or builder API)
+      swarm:
+        source: external (platform admin CLI or builder API)
     platform.auth_required:
       description: Agent or tool call blocked pending authorization.
       scope: flow
@@ -3853,7 +3859,7 @@ static_analyzer:
       - payload compatibility
       - multi-hop reachability or liveness
       - produces-based proof
-      - _status-based lifecycle suppression
+      - swarm.status-based lifecycle suppression
     accepted_producer_paths:
       sibling_flow_output_pin:
         rule: Another flow declares the same local event name in schema.yaml pins.outputs.events.
@@ -3865,7 +3871,7 @@ static_analyzer:
       platform_event_catalog:
         rule: The input pin event exactly matches a platform_events.catalog key.
       external_source_annotation:
-        rule: The consuming flow or root event entry for the event has _source beginning with external.
+        rule: The consuming flow or root event entry for the event has swarm.source beginning with external.
       same_flow_timer_declaration:
         rule: A timer declared within the consuming flow fires the same event.
     rule: Emit warning when none of the accepted producer-path forms are found. The finding message must say no producer path
@@ -3943,7 +3949,7 @@ static_analyzer:
         rule: Another flow or root participant references the declaration via an explicitly qualified event name that resolves
           to the declaring flow.
       external_annotations:
-        rule: "`_source` beginning with external or `_consumer` metadata on the declared event entry counts as an active external role."
+        rule: "`swarm.source` beginning with external or `swarm.consumer` metadata on the declared event entry counts as an active external role."
       same_flow_timer_references:
         rule: "Timers in the same scope keep the declaration alive through `event`, `start_on: event:...`, or `cancel_on: event:...`."
       same_flow_fan_out_emit:

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -188,6 +188,7 @@ contract_formats:
       event_name: |
         swarm:
           source: external (optional; non-derivable external/platform producer proof)
+          producer: mailbox_human (optional; exceptional non-derivable producer proof)
           consumer: external_ui (optional; non-derivable external sink proof)
           status: planned (optional; lifecycle suppression)
           note: Human-readable metadata (optional)
@@ -1819,7 +1820,7 @@ engine:
       severity: warning
       scope: per-flow
       trigger: An agent subscribes to an event that no node handler emits and no agent lists in emit_events. Suppressed if the
-        event has swarm.source or swarm.status metadata.
+        event has swarm.source, swarm.producer, or swarm.status metadata.
       when: boot-only
     - id: payload_field_coverage
       severity: error

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -202,7 +202,7 @@ The spec also allows "empty" required agent declarations. A role may exist with 
 
 The contracts use two categories of `_`-prefixed fields:
 
-**Semantic fields** that the platform and verifier understand: `_source`, `_consumer`, `_status`, `_producer`. These suppress verifier warnings (like NO-PRODUCER or NO-CONSUMER) and carry meaning.
+**Semantic event metadata** that the platform and verifier understand lives under the reserved `swarm:` namespace: `swarm.source`, `swarm.consumer`, `swarm.status`, and exceptional `swarm.producer` for non-derivable producer proof. Legacy `_source`, `_consumer`, `_status`, and `_producer` are migration inputs only.
 
 **Documentation-only fields** that the platform ignores: anything else starting with `_` (like `_note`, `_routing_note`, `_internal_events_note`). These are human comments. The verifier skips them. They are not part of the contract.
 

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -269,10 +269,10 @@ hello.completed:
 
 - `description`: Fields starting with _ in contract YAML files.
 - `semantic_fields`:
-  - `_source`: Event producer type. Suppresses NO-PRODUCER verifier warnings. Values: external (...)
-  - `_consumer`: Event consumer type. Suppresses NO-CONSUMER warnings. Values: mailbox_system (...)
-  - `_status`: Event lifecycle. Values: planned (future feature).
-  - `_producer`: Event producer agent. Suppresses NO-PRODUCER warnings for agent-emitted events.
+  - `_source`: Legacy migration input for event swarm.source. Do not author in new contracts.
+  - `_consumer`: Legacy migration input for event swarm.consumer. Do not author in new contracts.
+  - `_status`: Legacy migration input for event swarm.status. Do not author in new contracts.
+  - `_producer`: Legacy migration input for event swarm.producer for non-derivable producer proof only. Do not author for ordinary internal topology.
 
 - `documentation_fields`: Any other _-prefixed field (_note, _routing_note, _internal_events_note, etc.) is a human comment. The platform ignores them. The verifier ignores them. They are not part of the contract.
 # handler_specification

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -102,11 +102,11 @@ events_defined = set(k for k, v in all_events.items() if isinstance(v, dict))
 # ============================================================
 # Helpers
 # ============================================================
-def flatten_payload(payload, prefix=''):
+def flatten_payload(payload, prefix='', skip_root_swarm=False):
     fields = set()
     if not isinstance(payload, dict): return fields
     for k, v in payload.items():
-        if k.startswith('_') or k == 'swarm': continue
+        if k.startswith('_') or (skip_root_swarm and not prefix and k == 'swarm'): continue
         full = (prefix + '.' + k) if prefix else k
         fields.add(full)
         if isinstance(v, dict) and not any(t in str(v) for t in ['string','integer','number','boolean','array','object','text','timestamp','uuid','numeric']):

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -106,7 +106,7 @@ def flatten_payload(payload, prefix=''):
     fields = set()
     if not isinstance(payload, dict): return fields
     for k, v in payload.items():
-        if k.startswith('_'): continue
+        if k.startswith('_') or k == 'swarm': continue
         full = (prefix + '.' + k) if prefix else k
         fields.add(full)
         if isinstance(v, dict) and not any(t in str(v) for t in ['string','integer','number','boolean','array','object','text','timestamp','uuid','numeric']):
@@ -119,9 +119,20 @@ def extract_payload_refs(s):
 def extract_policy_refs(s):
     return re.findall(r'policy\.([a-zA-Z_][a-zA-Z0-9_.]*)', str(s))
 
+def metadata_value_startswith(value, prefixes):
+    if isinstance(value, list):
+        return any(metadata_value_startswith(item, prefixes) for item in value)
+    return str(value).startswith(prefixes)
+
 def is_suppressed(ev_name):
     ev = all_events.get(ev_name, {})
     if isinstance(ev, dict):
+        swarm = ev.get('swarm', {})
+        if isinstance(swarm, dict):
+            if metadata_value_startswith(swarm.get('source', ''), ('external', 'platform')): return True
+            if metadata_value_startswith(swarm.get('consumer', ''), ('external', 'mailbox')): return True
+            if swarm.get('status') == 'planned': return True
+            if metadata_value_startswith(swarm.get('producer', ''), ('agent',)): return True
         if ev.get('_source', '').startswith('external'): return True
         if ev.get('_consumer', '').startswith('mailbox'): return True
         if ev.get('_status') == 'planned': return True

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -122,21 +122,40 @@ def extract_policy_refs(s):
 def metadata_value_startswith(value, prefixes):
     if isinstance(value, list):
         return any(metadata_value_startswith(item, prefixes) for item in value)
-    return str(value).startswith(prefixes)
+    return str(value).strip().startswith(prefixes)
 
-def is_suppressed(ev_name):
+def metadata_value_present(value):
+    if isinstance(value, list):
+        return any(metadata_value_present(item) for item in value)
+    return str(value or '').strip() != ''
+
+def event_swarm_metadata(ev):
+    swarm = ev.get('swarm', {}) if isinstance(ev, dict) else {}
+    return swarm if isinstance(swarm, dict) else {}
+
+def event_planned(ev, swarm):
+    return swarm.get('status') == 'planned' or ev.get('_status') == 'planned'
+
+def suppresses_event_consumer_warning(ev_name):
     ev = all_events.get(ev_name, {})
     if isinstance(ev, dict):
-        swarm = ev.get('swarm', {})
-        if isinstance(swarm, dict):
-            if metadata_value_startswith(swarm.get('source', ''), ('external', 'platform')): return True
-            if metadata_value_startswith(swarm.get('consumer', ''), ('external', 'mailbox')): return True
-            if swarm.get('status') == 'planned': return True
-            if metadata_value_startswith(swarm.get('producer', ''), ('agent',)): return True
-        if ev.get('_source', '').startswith('external'): return True
-        if ev.get('_consumer', '').startswith('mailbox'): return True
-        if ev.get('_status') == 'planned': return True
-        if ev.get('_producer', '').startswith('agent'): return True
+        swarm = event_swarm_metadata(ev)
+        if metadata_value_present(swarm.get('consumer', '')): return True
+        if metadata_value_present(ev.get('consumer', '')): return True
+        if metadata_value_present(ev.get('_consumer', '')): return True
+        if event_planned(ev, swarm): return True
+    return False
+
+def suppresses_event_producer_warning(ev_name):
+    ev = all_events.get(ev_name, {})
+    if isinstance(ev, dict):
+        swarm = event_swarm_metadata(ev)
+        if metadata_value_startswith(swarm.get('source', ''), ('external', 'platform')): return True
+        if metadata_value_startswith(ev.get('_source', ''), ('external', 'platform')): return True
+        if metadata_value_present(swarm.get('producer', '')): return True
+        if metadata_value_present(ev.get('producer', '')): return True
+        if metadata_value_present(ev.get('_producer', '')): return True
+        if event_planned(ev, swarm): return True
     return False
 
 def emit_event_name(spec):
@@ -323,7 +342,7 @@ for ev in events_emitted:
 # ============================================================
 for ev in events_emitted:
     if ev and ev in events_defined and ev not in events_subscribed and not ev.startswith('platform.'):
-        if not is_suppressed(ev):
+        if not suppresses_event_consumer_warning(ev):
             warn("event_consumer_exists", "'%s' emitted but nobody subscribes" % ev)
 
 # ============================================================
@@ -331,7 +350,7 @@ for ev in events_emitted:
 # ============================================================
 for ev in events_subscribed:
     if ev and ev in events_defined and ev not in events_emitted:
-        if not is_suppressed(ev) and ev not in fan_out_events and not ev.startswith('timer.') and not ev.startswith('platform.'):
+        if not suppresses_event_producer_warning(ev) and ev not in fan_out_events and not ev.startswith('timer.') and not ev.startswith('platform.'):
             warn("event_producer_exists", "'%s' subscribed but nobody emits" % ev)
 
 # ============================================================

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -388,6 +388,8 @@ nodes:
         - supported proof-harness allowlists and active prose/reference surfaces that still described payload_transform, fan_out.emit_per_item, or implicit passthrough as current behavior
       - adjacent split retained after this node:
         - generic post-publish canonical-event validation cleanup remains outside this migration class unless later promoted
+      - adjacent supporting migration tracked by #605:
+        - canonical event-level swarm metadata now owns non-derivable external/lifecycle topology proof so flat event payload fields and verifier metadata no longer share ambiguous underscore ownership
     representative_issues:
       - 455
       - 457
@@ -397,6 +399,7 @@ nodes:
       - 466
       - 468
       - 470
+      - 605
     common_framing_mistakes:
       too_broad:
         - land the entire strict event-schema migration in one PR

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -606,6 +606,10 @@ func TestRun_DoesNotWarnForEventProducerExistsWhenCatalogDeclaresExternalOrPlann
 			name:  "planned status",
 			entry: runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Status: "planned"}},
 		},
+		{
+			name:  "exceptional non-agent producer metadata",
+			entry: runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Producer: []string{"mailbox_human"}}},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -233,7 +233,7 @@ func TestRun_MapsDeadDeclaredEventSchemaToNamedWarning(t *testing.T) {
 	for _, want := range []string{
 		"has no active role in the authored bundle",
 		"Handler emits: 0",
-		"External source annotation (_source): no",
+		"External source metadata (swarm.source): no",
 	} {
 		if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", want) {
 			t.Fatalf("expected semantic_drift_dead_event_schema warning containing %q, got %#v", want, report.Warnings())
@@ -312,25 +312,25 @@ root-node:
 			},
 		},
 		{
-			name:   "external source annotation",
+			name:   "external source metadata",
 			target: "support/ticket.ready",
 			opts: deadEventSchemaFixtureOptions{
 				name: "dead-event-schema-external-source",
 				flows: map[string]deadEventSchemaFlowFiles{
 					"support": {
-						events: "ticket.ready:\n  _source: external (manual handoff)\n",
+						events: "ticket.ready:\n  swarm:\n    source: external (manual handoff)\n",
 					},
 				},
 			},
 		},
 		{
-			name:   "external consumer annotation",
+			name:   "external consumer metadata",
 			target: "support/ticket.ready",
 			opts: deadEventSchemaFixtureOptions{
 				name: "dead-event-schema-external-consumer",
 				flows: map[string]deadEventSchemaFlowFiles{
 					"support": {
-						events: "ticket.ready:\n  _consumer: mailbox_system\n",
+						events: "ticket.ready:\n  swarm:\n    consumer: mailbox_system\n",
 					},
 				},
 			},
@@ -576,8 +576,8 @@ func TestRun_DoesNotWarnForEventConsumerExistsWhenCatalogDeclaresConsumerMetadat
 			},
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
-			"task.start": {Source: "external"},
-			"task.done":  {ConsumerType: []string{"dashboard"}},
+			"task.start": {Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"}},
+			"task.done":  {Swarm: runtimecontracts.EventSwarmMetadata{Consumer: []string{"dashboard"}}},
 		},
 	}
 	bundle.Platform.Platform.Name = "test"
@@ -600,11 +600,11 @@ func TestRun_DoesNotWarnForEventProducerExistsWhenCatalogDeclaresExternalOrPlann
 	}{
 		{
 			name:  "external source",
-			entry: runtimecontracts.EventCatalogEntry{Source: "external system"},
+			entry: runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Source: "external system"}},
 		},
 		{
 			name:  "planned status",
-			entry: runtimecontracts.EventCatalogEntry{Status: "planned"},
+			entry: runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Status: "planned"}},
 		},
 	}
 
@@ -660,7 +660,7 @@ func TestRun_MapsMissingPromptToPromptExistsWarning(t *testing.T) {
 func TestEventProducedExternallyLocal_AllowsAnnotatedSourceText(t *testing.T) {
 	t.Parallel()
 
-	entry := runtimecontracts.EventCatalogEntry{Source: "platform (timer system)"}
+	entry := runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Source: "platform (timer system)"}}
 	if !eventProducedExternallyLocal(entry) {
 		t.Fatal("expected platform source annotation to count as externally produced")
 	}
@@ -2163,7 +2163,7 @@ func TestRun_ReportsInputPinWiringWarning(t *testing.T) {
 func TestRun_DoesNotWarnForExternalInputPinWithoutEmitter(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	entry := bundle.Events["task.feedback"]
-	entry.Source = "external"
+	entry.Swarm.Source = "external"
 	bundle.Events["task.feedback"] = entry
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
@@ -2305,7 +2305,7 @@ func TestRun_DoesNotUseProducesOrPlannedAsInputProducerPathProof(t *testing.T) {
 			name: "planned status",
 			mutate: func(bundle *runtimecontracts.WorkflowContractBundle) {
 				entry := bundle.Events["task.feedback"]
-				entry.Status = "planned"
+				entry.Swarm.Status = "planned"
 				bundle.Events["task.feedback"] = entry
 			},
 		},
@@ -3703,7 +3703,7 @@ pins:
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
 		entry := "ticket.ready:\n  payload:\n    entity_id: string\n"
 		if flowID == "external_consumer" {
-			entry = "ticket.ready:\n  _source: external (manual handoff)\n  entity_id: string\n"
+			entry = "ticket.ready:\n  swarm:\n    source: external (manual handoff)\n  entity_id: string\n"
 		} else {
 			entry = "ticket.ready:\n  entity_id: string\n"
 		}
@@ -4164,8 +4164,8 @@ func bootverifyDeclarationDriftBundle() *runtimecontracts.WorkflowContractBundle
 			},
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
-			"task.start": {Source: "external"},
-			"task.done":  {ConsumerType: []string{"dashboard"}},
+			"task.start": {Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"}},
+			"task.done":  {Swarm: runtimecontracts.EventSwarmMetadata{Consumer: []string{"dashboard"}}},
 		},
 	}
 	bundle.Platform.Platform.Name = "test"
@@ -4205,7 +4205,7 @@ func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBun
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"scan.corpus_dispatch": {
-				Source: "external",
+				Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"},
 				Payload: runtimecontracts.EventPayloadSpec{
 					Properties: map[string]runtimecontracts.EventFieldSpec{
 						"scan_id":   {Type: "string"},
@@ -4216,7 +4216,7 @@ func bootverifyPayloadCompletenessBundle() *runtimecontracts.WorkflowContractBun
 				Required: []string{"scan_id", "geography"},
 			},
 			"market_research.scan_assigned": {
-				ConsumerType: []string{"dashboard"},
+				Swarm: runtimecontracts.EventSwarmMetadata{Consumer: []string{"dashboard"}},
 				Payload: runtimecontracts.EventPayloadSpec{
 					Properties: map[string]runtimecontracts.EventFieldSpec{
 						"scan_id":   {Type: "string"},

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -58,7 +58,7 @@ func (c *checkerContext) deadEventSchema() []Finding {
 			CheckID:  "semantic_drift_dead_event_schema",
 			Severity: "warning",
 			Message: fmt.Sprintf(
-				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source annotation (_source): %s\n- External consumer annotation (_consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add _source: external (...) or _consumer: ... to document the external role.",
+				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source metadata (swarm.source): %s\n- External consumer metadata (swarm.consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add swarm.source: external or swarm.consumer: ... to document the external role.",
 				decl.Canonical,
 				fileLabel,
 				usage.handlerEmits,
@@ -351,12 +351,12 @@ func deadEventSameScope(a, b string) bool {
 }
 
 func deadEventExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
-	source := strings.ToLower(strings.TrimSpace(entry.Source))
+	source := strings.ToLower(strings.TrimSpace(entry.SwarmSource()))
 	return strings.HasPrefix(source, "external")
 }
 
 func deadEventExternalConsumer(entry runtimecontracts.EventCatalogEntry) bool {
-	return len(entry.Consumer) > 0 || len(entry.ConsumerType) > 0
+	return len(entry.SwarmConsumer()) > 0
 }
 
 func deadEventSchemaFileLabel(path, flowID string) string {

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -175,7 +175,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 		if eventRefProducedLocal(c.source, ref, emittedRefs) {
 			continue
 		}
-		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.Status), "planned") {
+		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.SwarmStatus()), "planned") {
 			continue
 		}
 		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
@@ -236,14 +236,14 @@ func eventRefProducedLocal(source semanticview.Source, ref semanticview.FlowEven
 }
 
 func eventHasExternalConsumerLocal(entry runtimecontracts.EventCatalogEntry) bool {
-	return len(entry.Consumer) > 0 || len(entry.ConsumerType) > 0
+	return len(entry.SwarmConsumer()) > 0
 }
 
 func eventProducedExternallyLocal(entry runtimecontracts.EventCatalogEntry) bool {
-	if len(entry.Producer) > 0 {
+	if len(entry.SwarmProducer()) > 0 {
 		return true
 	}
-	source := strings.ToLower(strings.TrimSpace(entry.Source))
+	source := strings.ToLower(strings.TrimSpace(entry.SwarmSource()))
 	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
 }
 

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -114,7 +114,7 @@ func (p inputPinProducerPaths) message(flowID, eventType string) string {
 	flowID = strings.TrimSpace(flowID)
 	eventType = strings.TrimSpace(eventType)
 	return fmt.Sprintf(
-		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source annotation (_source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add _source: external (...) to %s's events.yaml entry if produced externally",
+		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add swarm.source: external to %s's events.yaml entry if produced externally",
 		flowID,
 		eventType,
 		p.siblingFlowOutputPin,
@@ -259,10 +259,10 @@ func (c *checkerContext) inputPinExternalSourcePath(flowID, eventType string) st
 	if !ok || bundle == nil {
 		return "not found"
 	}
-	if entry, ok := inputPinRootEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.Source) {
+	if entry, ok := inputPinRootEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.SwarmSource()) {
 		return "found"
 	}
-	if entry, ok := inputPinFlowEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.Source) {
+	if entry, ok := inputPinFlowEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.SwarmSource()) {
 		return "found"
 	}
 	return "not found"

--- a/internal/runtime/contracts/phase1_foundation_test.go
+++ b/internal/runtime/contracts/phase1_foundation_test.go
@@ -46,6 +46,7 @@ func TestPhase1SemanticModelUsesTypedContracts(t *testing.T) {
 	expectFieldType(t, reflect.TypeOf(ToolSchemaEntry{}), "InputSchema", reflect.TypeOf(ToolInputSchema{}))
 	expectFieldType(t, reflect.TypeOf(SystemNodeContract{}), "StateSchema", reflect.TypeOf(NodeStateSchema{}))
 	expectFieldType(t, reflect.TypeOf(SystemNodeContract{}), "GateState", reflect.TypeOf(NodeGateStateSchema{}))
+	expectFieldType(t, reflect.TypeOf(EventCatalogEntry{}), "Swarm", reflect.TypeOf(EventSwarmMetadata{}))
 	expectFieldType(t, reflect.TypeOf(EventCatalogEntry{}), "Emitter", reflect.TypeOf(EventEmitterRef{}))
 	expectFieldType(t, reflect.TypeOf(EventCatalogEntry{}), "Producer", reflect.TypeOf([]string{}))
 	expectFieldType(t, reflect.TypeOf(EventCatalogEntry{}), "Consumer", reflect.TypeOf([]string{}))

--- a/internal/runtime/contracts/workflow_contract_merging.go
+++ b/internal/runtime/contracts/workflow_contract_merging.go
@@ -85,6 +85,14 @@ func mergeEventContracts(bundle *WorkflowContractBundle, entries map[string]Even
 func mergeEventCatalogEntry(existing EventCatalogEntry, incoming EventCatalogEntry) (EventCatalogEntry, bool) {
 	merged := existing
 	var ok bool
+	if merged.Swarm, ok = mergeEventSwarmMetadata(existing.Swarm, incoming.Swarm); !ok {
+		return EventCatalogEntry{}, false
+	}
+	merged.Note = strings.TrimSpace(merged.Swarm.Note)
+	merged.Producer = normalizeStrings(merged.Swarm.Producer)
+	merged.Consumer = normalizeStrings(merged.Swarm.Consumer)
+	merged.Source = strings.TrimSpace(merged.Swarm.Source)
+	merged.Status = strings.TrimSpace(merged.Swarm.Status)
 	if merged.Emitter, ok = mergeEventEmitterRef(existing.Emitter, incoming.Emitter); !ok {
 		return EventCatalogEntry{}, false
 	}
@@ -92,9 +100,6 @@ func mergeEventCatalogEntry(existing EventCatalogEntry, incoming EventCatalogEnt
 		return EventCatalogEntry{}, false
 	}
 	merged.AlternateEmitters = mergeStringLists(existing.AlternateEmitters, incoming.AlternateEmitters)
-	if merged.Consumer, ok = mergeStringSliceValue(existing.Consumer, incoming.Consumer); !ok {
-		return EventCatalogEntry{}, false
-	}
 	if merged.ConsumerType, ok = mergeStringSliceValue(existing.ConsumerType, incoming.ConsumerType); !ok {
 		return EventCatalogEntry{}, false
 	}
@@ -117,6 +122,27 @@ func mergeEventCatalogEntry(existing EventCatalogEntry, incoming EventCatalogEnt
 		return EventCatalogEntry{}, false
 	}
 	merged.Required = mergeStringLists(existing.Required, incoming.Required)
+	return merged, true
+}
+
+func mergeEventSwarmMetadata(existing, incoming EventSwarmMetadata) (EventSwarmMetadata, bool) {
+	merged := existing
+	var ok bool
+	if merged.Note, ok = mergeStringValue(existing.Note, incoming.Note); !ok {
+		return EventSwarmMetadata{}, false
+	}
+	if merged.Source, ok = mergeStringValue(existing.Source, incoming.Source); !ok {
+		return EventSwarmMetadata{}, false
+	}
+	if merged.Producer, ok = mergeStringSliceValue(existing.Producer, incoming.Producer); !ok {
+		return EventSwarmMetadata{}, false
+	}
+	if merged.Consumer, ok = mergeStringSliceValue(existing.Consumer, incoming.Consumer); !ok {
+		return EventSwarmMetadata{}, false
+	}
+	if merged.Status, ok = mergeStringValue(existing.Status, incoming.Status); !ok {
+		return EventSwarmMetadata{}, false
+	}
 	return merged, true
 }
 func mergeStringValue(existing, incoming string) (string, bool) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -840,23 +840,52 @@ type SystemNodeEventHandler struct {
 	Branch           []BranchSpec             `yaml:"branch"`
 }
 type EventCatalogEntry struct {
-	Note              string           `yaml:"_note"`
-	Emitter           EventEmitterRef  `yaml:"emitter"`
-	EmitterType       string           `yaml:"emitter_type"`
-	Producer          []string         `yaml:"producer"`
-	AlternateEmitters []string         `yaml:"alternate_emitters"`
-	Consumer          []string         `yaml:"consumer"`
-	ConsumerType      []string         `yaml:"consumer_type"`
-	Source            string           `yaml:"_source"`
-	Status            string           `yaml:"_status"`
-	Intercepted       bool             `yaml:"intercepted"`
-	Passthrough       bool             `yaml:"passthrough"`
-	RuntimeHandling   string           `yaml:"runtime_handling"`
-	OwningNode        string           `yaml:"owning_node"`
-	DeliveryChannel   string           `yaml:"delivery_channel"`
-	Payload           EventPayloadSpec `yaml:"payload"`
-	Required          []string         `yaml:"required"`
+	Swarm             EventSwarmMetadata `yaml:"swarm"`
+	Note              string             `yaml:"_note"`
+	Emitter           EventEmitterRef    `yaml:"emitter"`
+	EmitterType       string             `yaml:"emitter_type"`
+	Producer          []string           `yaml:"producer"`
+	AlternateEmitters []string           `yaml:"alternate_emitters"`
+	Consumer          []string           `yaml:"consumer"`
+	ConsumerType      []string           `yaml:"consumer_type"`
+	Source            string             `yaml:"_source"`
+	Status            string             `yaml:"_status"`
+	Intercepted       bool               `yaml:"intercepted"`
+	Passthrough       bool               `yaml:"passthrough"`
+	RuntimeHandling   string             `yaml:"runtime_handling"`
+	OwningNode        string             `yaml:"owning_node"`
+	DeliveryChannel   string             `yaml:"delivery_channel"`
+	Payload           EventPayloadSpec   `yaml:"payload"`
+	Required          []string           `yaml:"required"`
 }
+type EventSwarmMetadata struct {
+	Note     string   `yaml:"note,omitempty"`
+	Source   string   `yaml:"source,omitempty"`
+	Producer []string `yaml:"producer,omitempty"`
+	Consumer []string `yaml:"consumer,omitempty"`
+	Status   string   `yaml:"status,omitempty"`
+}
+
+func (e EventCatalogEntry) SwarmNote() string {
+	return strings.TrimSpace(e.Swarm.Note)
+}
+
+func (e EventCatalogEntry) SwarmSource() string {
+	return strings.TrimSpace(e.Swarm.Source)
+}
+
+func (e EventCatalogEntry) SwarmProducer() []string {
+	return normalizeStrings(e.Swarm.Producer)
+}
+
+func (e EventCatalogEntry) SwarmConsumer() []string {
+	return normalizeStrings(e.Swarm.Consumer)
+}
+
+func (e EventCatalogEntry) SwarmStatus() string {
+	return strings.TrimSpace(e.Swarm.Status)
+}
+
 type AgentRegistryEntry struct {
 	ID                     string                          `yaml:"id"`
 	Type                   string                          `yaml:"type"`

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -325,8 +325,9 @@ flows: []
 func TestEventCatalogEntryDecode_AcceptsFlatWave1PayloadGrammar(t *testing.T) {
 	var entry EventCatalogEntry
 	if err := yaml.Unmarshal([]byte(`
-_note: root handoff
-_source: scoring
+swarm:
+  note: root handoff
+  source: scoring
 vertical_name: text
 composite_score:
   type: numeric

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -301,25 +301,26 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	var aux struct {
-		Note               string    `yaml:"_note"`
-		Emitter            yaml.Node `yaml:"emitter"`
-		EmitterType        string    `yaml:"emitter_type"`
-		Producer           yaml.Node `yaml:"producer"`
-		ProducerLegacy     yaml.Node `yaml:"_producer"`
-		AlternateEmitters  []string  `yaml:"alternate_emitters"`
-		Consumer           yaml.Node `yaml:"consumer"`
-		ConsumerLegacy     yaml.Node `yaml:"_consumer"`
-		ConsumerType       yaml.Node `yaml:"consumer_type"`
-		ConsumerTypeLegacy yaml.Node `yaml:"_consumer_type"`
-		Source             string    `yaml:"_source"`
-		Status             string    `yaml:"_status"`
-		Intercepted        yaml.Node `yaml:"intercepted"`
-		Passthrough        yaml.Node `yaml:"passthrough"`
-		RuntimeHandling    string    `yaml:"runtime_handling"`
-		OwningNode         string    `yaml:"owning_node"`
-		DeliveryChannel    yaml.Node `yaml:"delivery_channel"`
-		Payload            yaml.Node `yaml:"payload"`
-		Required           []string  `yaml:"required"`
+		Swarm              eventSwarmMetadataYAML `yaml:"swarm"`
+		Note               string                 `yaml:"_note"`
+		Emitter            yaml.Node              `yaml:"emitter"`
+		EmitterType        string                 `yaml:"emitter_type"`
+		Producer           yaml.Node              `yaml:"producer"`
+		ProducerLegacy     yaml.Node              `yaml:"_producer"`
+		AlternateEmitters  []string               `yaml:"alternate_emitters"`
+		Consumer           yaml.Node              `yaml:"consumer"`
+		ConsumerLegacy     yaml.Node              `yaml:"_consumer"`
+		ConsumerType       yaml.Node              `yaml:"consumer_type"`
+		ConsumerTypeLegacy yaml.Node              `yaml:"_consumer_type"`
+		Source             string                 `yaml:"_source"`
+		Status             string                 `yaml:"_status"`
+		Intercepted        yaml.Node              `yaml:"intercepted"`
+		Passthrough        yaml.Node              `yaml:"passthrough"`
+		RuntimeHandling    string                 `yaml:"runtime_handling"`
+		OwningNode         string                 `yaml:"owning_node"`
+		DeliveryChannel    yaml.Node              `yaml:"delivery_channel"`
+		Payload            yaml.Node              `yaml:"payload"`
+		Required           []string               `yaml:"required"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
@@ -336,11 +337,19 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if err != nil {
 		return err
 	}
+	swarmProducer, err := decodeStringListNode(&aux.Swarm.Producer)
+	if err != nil {
+		return err
+	}
 	consumer, err := decodeStringListNode(&aux.Consumer)
 	if err != nil {
 		return err
 	}
 	legacyConsumer, err := decodeStringListNode(&aux.ConsumerLegacy)
+	if err != nil {
+		return err
+	}
+	swarmConsumer, err := decodeStringListNode(&aux.Swarm.Consumer)
 	if err != nil {
 		return err
 	}
@@ -368,15 +377,43 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if len(payload.Required) == 0 {
 		payload.Required = normalizeStrings(aux.Required)
 	}
-	e.Note = strings.TrimSpace(aux.Note)
+	note, err := mergeCanonicalLegacyString(aux.Swarm.Note, aux.Note, "swarm.note", "_note")
+	if err != nil {
+		return err
+	}
+	source, err := mergeCanonicalLegacyString(aux.Swarm.Source, aux.Source, "swarm.source", "_source")
+	if err != nil {
+		return err
+	}
+	status, err := mergeCanonicalLegacyString(aux.Swarm.Status, aux.Status, "swarm.status", "_status")
+	if err != nil {
+		return err
+	}
+	producer, err = mergeCanonicalLegacyStringLists(swarmProducer, mergeStringLists(producer, legacyProducer), "swarm.producer", "producer/_producer")
+	if err != nil {
+		return err
+	}
+	consumer, err = mergeCanonicalLegacyStringLists(swarmConsumer, mergeStringLists(consumer, legacyConsumer), "swarm.consumer", "consumer/_consumer")
+	if err != nil {
+		return err
+	}
+	consumerType = mergeStringLists(consumerType, legacyConsumerType)
+	e.Swarm = EventSwarmMetadata{
+		Note:     note,
+		Source:   source,
+		Producer: producer,
+		Consumer: consumer,
+		Status:   status,
+	}
+	e.Note = e.SwarmNote()
 	e.Emitter = emitter
 	e.EmitterType = strings.TrimSpace(aux.EmitterType)
-	e.Producer = mergeStringLists(producer, legacyProducer)
+	e.Producer = e.SwarmProducer()
 	e.AlternateEmitters = mergeStringLists(aux.AlternateEmitters, alternates)
-	e.Consumer = mergeStringLists(consumer, legacyConsumer)
-	e.ConsumerType = mergeStringLists(consumerType, legacyConsumerType)
-	e.Source = strings.TrimSpace(aux.Source)
-	e.Status = strings.TrimSpace(aux.Status)
+	e.Consumer = e.SwarmConsumer()
+	e.ConsumerType = consumerType
+	e.Source = e.SwarmSource()
+	e.Status = e.SwarmStatus()
 	e.Intercepted = intercepted
 	e.Passthrough = passthrough
 	e.RuntimeHandling = strings.TrimSpace(aux.RuntimeHandling)
@@ -385,6 +422,63 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	e.Payload = payload
 	e.Required = normalizeStrings(aux.Required)
 	return nil
+}
+
+type eventSwarmMetadataYAML struct {
+	Note     string    `yaml:"note"`
+	Source   string    `yaml:"source"`
+	Producer yaml.Node `yaml:"producer"`
+	Consumer yaml.Node `yaml:"consumer"`
+	Status   string    `yaml:"status"`
+}
+
+func mergeCanonicalLegacyString(canonical, legacy, canonicalKey, legacyKey string) (string, error) {
+	canonical = strings.TrimSpace(canonical)
+	legacy = strings.TrimSpace(legacy)
+	switch {
+	case canonical == "":
+		return legacy, nil
+	case legacy == "":
+		return canonical, nil
+	case canonical == legacy:
+		return canonical, nil
+	default:
+		return "", fmt.Errorf("event metadata fields %s and %s conflict: %q != %q", canonicalKey, legacyKey, canonical, legacy)
+	}
+}
+
+func mergeCanonicalLegacyStringLists(canonical, legacy []string, canonicalKey, legacyKey string) ([]string, error) {
+	canonical = normalizeStrings(canonical)
+	legacy = normalizeStrings(legacy)
+	switch {
+	case len(canonical) == 0:
+		return legacy, nil
+	case len(legacy) == 0:
+		return canonical, nil
+	case sameStringSet(canonical, legacy):
+		return canonical, nil
+	default:
+		return nil, fmt.Errorf("event metadata fields %s and %s conflict: %v != %v", canonicalKey, legacyKey, canonical, legacy)
+	}
+}
+
+func sameStringSet(a, b []string) bool {
+	a = normalizeStrings(a)
+	b = normalizeStrings(b)
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, value := range a {
+		seen[value]++
+	}
+	for _, value := range b {
+		if seen[value] == 0 {
+			return false
+		}
+		seen[value]--
+	}
+	return true
 }
 
 func decodeGuardSpecNode(node *yaml.Node) (*GuardSpec, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -452,7 +452,7 @@ func buildFlatEventPayloadSpec(node *yaml.Node) (EventPayloadSpec, error) {
 			continue
 		}
 		switch key {
-		case "description", "emitter", "emitter_type", "producer", "_producer", "alternate_emitters", "consumer", "_consumer", "consumer_type", "_consumer_type", "_source", "_status", "_note", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "payload", "required":
+		case "description", "swarm", "emitter", "emitter_type", "producer", "_producer", "alternate_emitters", "consumer", "_consumer", "consumer_type", "_consumer_type", "_source", "_status", "_note", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "payload", "required":
 			continue
 		}
 		var field EventFieldSpec

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -442,28 +442,89 @@ gate_state:
 	}
 }
 
-func TestEventCatalogEntry_ConsumerAliasesAndSourceAnnotations(t *testing.T) {
+func TestEventCatalogEntry_SwarmMetadataOwnsTopologyAndLifecycle(t *testing.T) {
+	var entry EventCatalogEntry
+	if err := loadYAMLBytes([]byte(`
+swarm:
+  source: external (human board interface)
+  producer: mailbox_human
+  consumer: mailbox_system (external UI, not agent-subscribed)
+  status: planned
+  note: Human board handoff
+consumer_type: external_ui
+entity_id: string
+`), &entry); err != nil {
+		t.Fatalf("load event catalog entry: %v", err)
+	}
+	if got := entry.SwarmSource(); got != "external (human board interface)" {
+		t.Fatalf("expected source annotation preserved, got %q", got)
+	}
+	if got := entry.SwarmConsumer(); len(got) != 1 || strings.TrimSpace(got[0]) == "" {
+		t.Fatalf("expected swarm.consumer to populate canonical consumer, got %#v", got)
+	}
+	if got := entry.ConsumerType; len(got) != 1 || strings.TrimSpace(got[0]) != "external_ui" {
+		t.Fatalf("expected sibling consumer_type to remain runtime delivery metadata, got %#v", got)
+	}
+	if got := entry.SwarmProducer(); len(got) != 1 || strings.TrimSpace(got[0]) != "mailbox_human" {
+		t.Fatalf("expected swarm.producer to populate canonical producer, got %#v", got)
+	}
+	if got := entry.SwarmStatus(); got != "planned" {
+		t.Fatalf("expected swarm.status preserved, got %q", got)
+	}
+	if got := entry.SwarmNote(); got != "Human board handoff" {
+		t.Fatalf("expected swarm.note preserved, got %q", got)
+	}
+	if _, ok := entry.Payload.Properties["source"]; ok {
+		t.Fatalf("did not expect metadata source to become a payload field")
+	}
+}
+
+func TestEventCatalogEntry_LegacyMetadataNormalizesIntoSwarmOwner(t *testing.T) {
 	var entry EventCatalogEntry
 	if err := loadYAMLBytes([]byte(`
 _source: external (human board interface)
 _producer: mailbox_human
 _consumer: mailbox_system (external UI, not agent-subscribed)
 _consumer_type: external_ui
-entity_id: string
+_status: planned
+_note: Human board handoff
+source: text
 `), &entry); err != nil {
 		t.Fatalf("load event catalog entry: %v", err)
 	}
-	if got := strings.TrimSpace(entry.Source); got != "external (human board interface)" {
-		t.Fatalf("expected source annotation preserved, got %q", got)
+	if got := entry.SwarmSource(); got != "external (human board interface)" {
+		t.Fatalf("expected legacy _source to normalize into swarm.source, got %q", got)
 	}
-	if got := len(entry.Consumer); got != 1 || strings.TrimSpace(entry.Consumer[0]) == "" {
-		t.Fatalf("expected _consumer alias to populate consumer, got %#v", entry.Consumer)
+	if got := entry.SwarmProducer(); len(got) != 1 || got[0] != "mailbox_human" {
+		t.Fatalf("expected legacy _producer to normalize into swarm.producer, got %#v", got)
 	}
-	if got := len(entry.ConsumerType); got != 1 || strings.TrimSpace(entry.ConsumerType[0]) != "external_ui" {
-		t.Fatalf("expected _consumer_type alias to populate consumer_type, got %#v", entry.ConsumerType)
+	if got := entry.SwarmConsumer(); len(got) != 1 || got[0] == "" {
+		t.Fatalf("expected legacy _consumer to normalize into swarm.consumer, got %#v", got)
 	}
-	if got := len(entry.Producer); got != 1 || strings.TrimSpace(entry.Producer[0]) != "mailbox_human" {
-		t.Fatalf("expected _producer alias to populate producer, got %#v", entry.Producer)
+	if got := entry.ConsumerType; len(got) != 1 || got[0] != "external_ui" {
+		t.Fatalf("expected legacy _consumer_type to normalize into sibling consumer_type, got %#v", got)
+	}
+	if got := entry.SwarmStatus(); got != "planned" {
+		t.Fatalf("expected legacy _status to normalize into swarm.status, got %q", got)
+	}
+	if got := entry.SwarmNote(); got != "Human board handoff" {
+		t.Fatalf("expected legacy _note to normalize into swarm.note, got %q", got)
+	}
+	if _, ok := entry.Payload.Properties["source"]; !ok {
+		t.Fatalf("expected bare source to remain payload field, not metadata")
+	}
+}
+
+func TestEventCatalogEntry_ConflictingSwarmAndLegacyMetadataFailsClosed(t *testing.T) {
+	var entry EventCatalogEntry
+	err := loadYAMLBytes([]byte(`
+swarm:
+  source: external (operator)
+_source: platform (timer)
+entity_id: string
+`), &entry)
+	if err == nil || !strings.Contains(err.Error(), "swarm.source") || !strings.Contains(err.Error(), "_source") {
+		t.Fatalf("load event catalog entry error = %v, want swarm/_source conflict", err)
 	}
 }
 

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -79,7 +79,8 @@ item:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  _source: external (bootstrap fixture)
+  swarm:
+    source: external (bootstrap fixture)
   entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
@@ -148,7 +149,8 @@ item:
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "events.yaml"), `
 item.created:
-  _source: external (bootstrap fixture)
+  swarm:
+    source: external (bootstrap fixture)
   entity_id: string
 `)
 	writeRuntimeSessionScopeFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1836,6 +1836,16 @@ func TestCatalogDefinedHandlerField_RejectsRetiredEmitCarriers(t *testing.T) {
 
 func catalogIsSuppressedEvent(events map[string]any, ev string) bool {
 	eventDef := catalogMap(events[ev])
+	swarm := catalogMap(eventDef["swarm"])
+	if catalogMetadataHasPrefix(swarm["source"], "external", "platform") {
+		return true
+	}
+	if catalogMetadataHasPrefix(swarm["consumer"], "external", "mailbox") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(asStringForCatalog(swarm["status"])), "planned") {
+		return true
+	}
 	if source := strings.TrimSpace(asStringForCatalog(eventDef["_source"])); strings.HasPrefix(source, "external") {
 		return true
 	}
@@ -1843,6 +1853,21 @@ func catalogIsSuppressedEvent(events map[string]any, ev string) bool {
 		return true
 	}
 	return strings.EqualFold(strings.TrimSpace(asStringForCatalog(eventDef["_status"])), "planned")
+}
+
+func catalogMetadataHasPrefix(value any, prefixes ...string) bool {
+	for _, item := range catalogAnySlice(value) {
+		if catalogMetadataHasPrefix(item, prefixes...) {
+			return true
+		}
+	}
+	text := strings.TrimSpace(asStringForCatalog(value))
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(text, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func catalogFindEventCycles(graph map[string]map[string]struct{}) [][]string {

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1840,19 +1840,34 @@ func catalogIsSuppressedEvent(events map[string]any, ev string) bool {
 	if catalogMetadataHasPrefix(swarm["source"], "external", "platform") {
 		return true
 	}
-	if catalogMetadataHasPrefix(swarm["consumer"], "external", "mailbox") {
+	if catalogMetadataPresent(swarm["consumer"]) {
+		return true
+	}
+	if catalogMetadataPresent(swarm["producer"]) {
 		return true
 	}
 	if strings.EqualFold(strings.TrimSpace(asStringForCatalog(swarm["status"])), "planned") {
 		return true
 	}
-	if source := strings.TrimSpace(asStringForCatalog(eventDef["_source"])); strings.HasPrefix(source, "external") {
+	if source := strings.TrimSpace(asStringForCatalog(eventDef["_source"])); strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform") {
 		return true
 	}
-	if consumer := strings.TrimSpace(asStringForCatalog(eventDef["_consumer"])); strings.HasPrefix(consumer, "mailbox") {
+	if catalogMetadataPresent(eventDef["consumer"]) || catalogMetadataPresent(eventDef["_consumer"]) {
+		return true
+	}
+	if catalogMetadataPresent(eventDef["producer"]) || catalogMetadataPresent(eventDef["_producer"]) {
 		return true
 	}
 	return strings.EqualFold(strings.TrimSpace(asStringForCatalog(eventDef["_status"])), "planned")
+}
+
+func catalogMetadataPresent(value any) bool {
+	for _, item := range catalogAnySlice(value) {
+		if catalogMetadataPresent(item) {
+			return true
+		}
+	}
+	return strings.TrimSpace(asStringForCatalog(value)) != ""
 }
 
 func catalogMetadataHasPrefix(value any, prefixes ...string) bool {

--- a/tests/tier8-boot-verification/test-boot-event-no-consumer/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-no-consumer/events.yaml
@@ -1,5 +1,6 @@
 task.requested:
-  _source: external
+  swarm:
+    source: external
   entity_id: string
 orphan.unconsumed:
   entity_id: string

--- a/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/events.yaml
@@ -1,5 +1,6 @@
 task.requested:
-  _source: external
+  swarm:
+    source: external
   entity_id: string
 task.completed:
   entity_id: string

--- a/tests/tier8-boot-verification/test-boot-success/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-success/events.yaml
@@ -1,6 +1,8 @@
 task.requested:
-  _source: external
+  swarm:
+    source: external
   entity_id: string
 task.completed:
-  _source: external
+  swarm:
+    source: external
   entity_id: string


### PR DESCRIPTION
## Summary

Closes #605.

Related to yazzaoui/empire#45. This is the approved Swarm-side first slice only; it does not close the Empire contract migration.

This PR adds the canonical event-level `swarm:` metadata namespace for non-derivable topology/lifecycle proof, normalizes legacy underscore annotations into that owner during parsing, and moves Swarm verifier/static consumers to the canonical accessors. It also preserves runtime-delivery sibling metadata such as `consumer_type`, `runtime_handling`, `owning_node`, and `delivery_channel` outside `swarm:`.

## Governing refs / context

- Swarm #605 issue body, Pre-Implementation Coverage Audit, and lead gate outcome/refinement comments.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` event schema and boot verification sections.
- `docs/IMPLEMENTER_GUIDELINES.md`.
- `docs/SEMANTIC_DRIFT.md`.

## Semantic migration

- New canonical owner: `EventCatalogEntry.Swarm` / authored `swarm:` event metadata for `source`, `producer`, `consumer`, `status`, and `note`.
- Old non-authoritative paths now invalid as steady-state authoring: `_source`, `_producer`, `_consumer`, `_status`, `_note`; top-level `producer` / `consumer` remain migration inputs for exceptional non-derivable proof, not routine internal topology ownership.
- Runtime sibling metadata remains outside the migration: `consumer_type`, `runtime_handling`, `intercepted`, `passthrough`, `owning_node`, `delivery_channel`.
- Production paths checked: parser, payload classifier, merge semantics, bootverify producer/consumer/input-pin/dead-event checks, `docs/specs/swarm-platform/verify.py`, `internal/runtime/swarmflowtest/catalog_runner_test.go`, tier8 fixtures, docs/spec text, and watchlist mapping.
- Migration complete for Swarm #605 first slice. Empire #45 remains open for contract cleanup and any later hard-ban lint.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/semanticview ./internal/runtime/swarmflowtest ./cmd/swarm`
- `go test ./...`
- `python3 -m py_compile docs/specs/swarm-platform/verify.py`