### PR TITLE
[agent-a][issue #609] Define fork route topology owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -563,9 +563,19 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			}
 			return 1
 		}
-		executionModel, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
+		routeTopology, err := runtimerunforkexecution.BuildSelectedContractRouteTopology(runtimerunforkexecution.SelectedContractRouteTopologyRequest{
 			Admission:      admission,
 			RouteAdmission: routeAdmission,
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: classify selected contract route topology: %v\n", err)
+			}
+			return 1
+		}
+		executionModel, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
+			Admission:     admission,
+			RouteTopology: routeTopology,
 		})
 		if err != nil {
 			if out != nil {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -574,8 +574,9 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			return 1
 		}
 		executionModel, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
-			Admission:     admission,
-			RouteTopology: routeTopology,
+			Admission:      admission,
+			RouteAdmission: routeAdmission,
+			RouteTopology:  routeTopology,
 		})
 		if err != nil {
 			if out != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -534,14 +534,19 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 		model.AdmissionUse != store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly {
 		t.Fatalf("selected-contract execution admission use = %#v", model)
 	}
-	if model.RouteAdmission == nil ||
-		model.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner ||
-		!model.RouteAdmission.NonMutating ||
-		model.RouteAdmission.RouteReconstructionSupported {
-		t.Fatalf("selected-contract route admission = %#v", model.RouteAdmission)
+	if model.RouteTopology == nil ||
+		model.RouteTopology.Owner != store.RunForkSelectedContractRouteTopologyOwner ||
+		model.RouteTopology.RouteAdmissionOwner != store.RunForkSelectedContractRouteAdmissionOwner ||
+		!model.RouteTopology.NonMutating ||
+		model.RouteTopology.RoutePersistenceSupported ||
+		model.RouteTopology.ExecutableRecipientsSupported {
+		t.Fatalf("selected-contract route topology = %#v", model.RouteTopology)
 	}
-	if !runForkPlanHasBoundary(model.RouteAdmission.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
-		t.Fatalf("selected-contract route invalid paths = %#v", model.RouteAdmission.InvalidPaths)
+	if !runForkPlanHasBoundary(model.RouteTopology.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("selected-contract route invalid paths = %#v", model.RouteTopology.InvalidPaths)
+	}
+	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteTopologyNonMutating) {
+		t.Fatalf("selected-contract execution blockers = %#v, want route topology non-mutating blocker", model.UnsupportedBlockers)
 	}
 	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating) {
 		t.Fatalf("selected-contract execution blockers = %#v, want route admission non-mutating blocker", model.UnsupportedBlockers)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3295,6 +3295,14 @@ run_model:
       persist fork-local route rows, derive executable recipients, create event_deliveries, run handlers, or absorb
       timer reconstruction, session/turn reconstruction, source-advanced policy, contract-swap ownership, or UI/API
       route ownership.'
+    selected_contract_route_topology: 'Selected-contract route/topology truth is owned by
+      runtime.run_fork.selected_contract_route_topology after route admission. It consumes
+      runtime.run_fork.selected_contract_route_admission as prerequisite evidence, classifies selected-source static
+      route topology as fork-local truth only through internal/runtime/bus.DeriveRouteTable and the durable selected
+      contract/frontier binding, and classifies dynamic flow-instance topology as fork-local-proven or fail-closed with
+      a named blocker. It MUST NOT copy source routing_rules or materialized flow-instance route rows, persist
+      fork-local route rows, derive executable recipients, invoke the delivery planner for fork work, create
+      event_deliveries, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3339,6 +3347,13 @@ run_model:
         route reconstruction, uses the selected contract route table only as route evidence, and fails closed before
         route persistence, executable recipient derivation, delivery writes, or handler execution. Source routing rows,
         source flow-instance routes, and source recipients are never copied into the fork.'
+      3f_selected_contract_route_topology: 'For selected-contract mutating fork execution, fork-local route/topology
+        truth is a separate owner beyond route admission. The selected execution model and admission consume
+        runtime.run_fork.selected_contract_route_topology rather than treating route admission as final truth. Static
+        selected-source topology is classified from selected-source route derivation and selected binding/frontier
+        evidence only. Dynamic flow-instance topology requires explicit fork-local topology proof and otherwise
+        remains fail-closed. This owner is still non-mutating: it does not persist route rows, derive executable
+        recipients, write deliveries, or run handlers.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -274,6 +274,7 @@ nodes:
       - selected-contract timestamp forks from historical T need durable branch divergence evidence when the source advanced after T; post-T source rows remain source-run evidence only and must not freeze, rewind, execute, copy, or suppress fork-local selected work
       - selected-contract timestamp forks with source timer or route facts must keep those rows as evidence-only fail-closed blockers until separate timer and route reconstruction owners are approved; source timers, routing_rules, route recipients, and timer firings are not executable selected-fork work
       - selected-contract route/subscription reconstruction needs a non-mutating route-history admission owner that consumes selected-source route derivation, distinguishes frontier route/recipient admission from historical route evidence, and keeps route persistence, executable recipients, delivery writes, and handler execution split
+      - selected-contract route/topology truth needs a canonical owner beyond route admission before recipient delivery; route admission is prerequisite evidence, static selected-source topology is fork-local truth only through the selected route derivation owner, and dynamic flow-instance topology must be fork-local-proven or fail-closed without copying source routing rows
     representative_issues:
       - 564
       - 565
@@ -290,6 +291,7 @@ nodes:
       - 600
       - 602
       - 604
+      - 609
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -79,9 +79,16 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+	routeTopology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
 		Admission:      frontier,
 		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:     frontier,
+		RouteTopology: routeTopology,
 	})
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
@@ -91,7 +98,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err != nil {

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -87,8 +87,9 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		return SelectedContractActivationGateResult{}, err
 	}
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     frontier,
-		RouteTopology: routeTopology,
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
@@ -98,6 +99,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -116,7 +116,7 @@ type SelectedContractExecutionAdmissionRequest struct {
 	BindingReader     SelectedContractBindingReader
 	SourceLoader      SelectedContractSourceLoader
 	FrontierAdmission store.RunForkContractFrontierAdmission
-	RouteAdmission    store.RunForkSelectedContractRouteAdmission
+	RouteTopology     store.RunForkSelectedContractRouteTopology
 	ExecutionModel    store.RunForkSelectedContractExecution
 }
 
@@ -151,10 +151,10 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 	if err := validateSelectedContractExecutionFrontier(binding, req.FrontierAdmission); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionRouteAdmission(binding, req.FrontierAdmission, req.RouteAdmission); err != nil {
+	if err := validateSelectedContractExecutionRouteTopology(binding, req.FrontierAdmission, req.RouteTopology); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteAdmission, req.ExecutionModel); err != nil {
+	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteTopology, req.ExecutionModel); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
 
@@ -181,7 +181,7 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 		SourceWorkflowVersion: strings.TrimSpace(loadedSource.Source.WorkflowVersion()),
 		FrontierEventCount:    req.ExecutionModel.FrontierEventCount,
 		FrontierEvents:        append([]store.RunForkSelectedContractFrontierEvent(nil), req.ExecutionModel.FrontierEvents...),
-		RouteAdmission:        &req.RouteAdmission,
+		RouteTopology:         &req.RouteTopology,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -252,14 +252,14 @@ func validateSelectedContractExecutionFrontier(binding store.RunForkSelectedCont
 	return validateSelectionMatches("frontier admission", binding.ContractSelection, admission.ContractSelection)
 }
 
-func validateSelectedContractExecutionRouteAdmission(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) error {
-	if err := validateSelectedContractRouteAdmission(frontier, routeAdmission); err != nil {
+func validateSelectedContractExecutionRouteTopology(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeTopology store.RunForkSelectedContractRouteTopology) error {
+	if err := validateSelectedContractRouteTopology(frontier, routeTopology); err != nil {
 		return err
 	}
-	return validateSelectionMatches("route admission", binding.ContractSelection, routeAdmission.ContractSelection)
+	return validateSelectionMatches("route topology", binding.ContractSelection, routeTopology.ContractSelection)
 }
 
-func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, model store.RunForkSelectedContractExecution) error {
+func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeTopology store.RunForkSelectedContractRouteTopology, model store.RunForkSelectedContractExecution) error {
 	if strings.TrimSpace(model.Owner) != store.RunForkSelectedContractExecutionModelOwner {
 		return fmt.Errorf("selected-contract execution admission requires %s model; got %q", store.RunForkSelectedContractExecutionModelOwner, model.Owner)
 	}
@@ -278,11 +278,11 @@ func validateSelectedContractExecutionModel(binding store.RunForkSelectedContrac
 	if !reflect.DeepEqual(model.FrontierEvents, selectedContractFrontierEvents(frontier.FrontierEvents)) {
 		return fmt.Errorf("selected-contract execution admission model frontier events do not match durable frontier evidence")
 	}
-	if model.RouteAdmission == nil {
-		return fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRouteAdmissionOwner)
+	if model.RouteTopology == nil {
+		return fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRouteTopologyOwner)
 	}
-	if !reflect.DeepEqual(*model.RouteAdmission, routeAdmission) {
-		return fmt.Errorf("selected-contract execution admission model route admission does not match canonical route admission evidence")
+	if !reflect.DeepEqual(*model.RouteTopology, routeTopology) {
+		return fmt.Errorf("selected-contract execution admission model route topology does not match canonical route topology truth")
 	}
 	if model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
 		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite {

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -116,6 +116,7 @@ type SelectedContractExecutionAdmissionRequest struct {
 	BindingReader     SelectedContractBindingReader
 	SourceLoader      SelectedContractSourceLoader
 	FrontierAdmission store.RunForkContractFrontierAdmission
+	RouteAdmission    store.RunForkSelectedContractRouteAdmission
 	RouteTopology     store.RunForkSelectedContractRouteTopology
 	ExecutionModel    store.RunForkSelectedContractExecution
 }
@@ -151,10 +152,10 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 	if err := validateSelectedContractExecutionFrontier(binding, req.FrontierAdmission); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionRouteTopology(binding, req.FrontierAdmission, req.RouteTopology); err != nil {
+	if err := validateSelectedContractExecutionRouteTopology(binding, req.FrontierAdmission, req.RouteAdmission, req.RouteTopology); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
-	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteTopology, req.ExecutionModel); err != nil {
+	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteAdmission, req.RouteTopology, req.ExecutionModel); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
 
@@ -252,14 +253,17 @@ func validateSelectedContractExecutionFrontier(binding store.RunForkSelectedCont
 	return validateSelectionMatches("frontier admission", binding.ContractSelection, admission.ContractSelection)
 }
 
-func validateSelectedContractExecutionRouteTopology(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeTopology store.RunForkSelectedContractRouteTopology) error {
-	if err := validateSelectedContractRouteTopology(frontier, routeTopology); err != nil {
+func validateSelectedContractExecutionRouteTopology(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, routeTopology store.RunForkSelectedContractRouteTopology) error {
+	if err := validateSelectedContractRouteAdmission(frontier, routeAdmission); err != nil {
+		return err
+	}
+	if err := validateSelectedContractRouteTopology(frontier, routeAdmission, routeTopology); err != nil {
 		return err
 	}
 	return validateSelectionMatches("route topology", binding.ContractSelection, routeTopology.ContractSelection)
 }
 
-func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeTopology store.RunForkSelectedContractRouteTopology, model store.RunForkSelectedContractExecution) error {
+func validateSelectedContractExecutionModel(binding store.RunForkSelectedContractBinding, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, routeTopology store.RunForkSelectedContractRouteTopology, model store.RunForkSelectedContractExecution) error {
 	if strings.TrimSpace(model.Owner) != store.RunForkSelectedContractExecutionModelOwner {
 		return fmt.Errorf("selected-contract execution admission requires %s model; got %q", store.RunForkSelectedContractExecutionModelOwner, model.Owner)
 	}
@@ -280,6 +284,9 @@ func validateSelectedContractExecutionModel(binding store.RunForkSelectedContrac
 	}
 	if model.RouteTopology == nil {
 		return fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRouteTopologyOwner)
+	}
+	if err := validateSelectedContractRouteTopology(frontier, routeAdmission, *model.RouteTopology); err != nil {
+		return err
 	}
 	if !reflect.DeepEqual(*model.RouteTopology, routeTopology) {
 		return fmt.Errorf("selected-contract execution admission model route topology does not match canonical route topology truth")

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -21,7 +21,8 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	reader := &fakeSelectedContractBindingReader{binding: binding}
 	sourceLoader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
-	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 	model := testSelectedContractExecutionModel(t, frontier)
 
 	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -29,6 +30,7 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 		BindingReader:     reader,
 		SourceLoader:      sourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
@@ -91,13 +93,15 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnMissingBinding(t *t
 	selection := testContractSelection()
 	frontier := testContractFrontierAdmission(selection)
 	model := testSelectedContractExecutionModel(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{err: errors.New("selected contract binding not found")},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(selection)},
 		FrontierAdmission: frontier,
-		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "load selected-contract binding") {
@@ -111,13 +115,15 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnUnavailableSelected
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection}},
 		FrontierAdmission: frontier,
-		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected semantic source") {
@@ -131,6 +137,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *t
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 	mismatched := binding.ContractSelection
 	mismatched.WorkflowVersion = "other-version"
 
@@ -139,7 +146,8 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *t
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection, Source: testSelectedSource(mismatched)}},
 		FrontierAdmission: frontier,
-		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workflow version mismatch") {
@@ -153,6 +161,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnWrongContractsRoot(
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 	wrongRoot := binding.ContractSelection
 	wrongRoot.ContractsRoot = "/tmp/other-selected-contracts"
 
@@ -161,7 +170,8 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnWrongContractsRoot(
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(wrongRoot)},
 		FrontierAdmission: frontier,
-		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected source selection does not match durable binding") {
@@ -175,7 +185,8 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
-	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 	frontier.Owner = "cmd.swarm.local_frontier"
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -183,6 +194,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
@@ -198,13 +210,16 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
 	frontier.FrontierEvents[0].EventName = "work.changed"
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier events do not match") {
@@ -218,7 +233,8 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteTopology(t
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
-	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 	routeTopology.Owner = "cmd.swarm.route_helper"
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -226,6 +242,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteTopology(t
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
@@ -239,7 +256,8 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyF
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
-	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 	model := testSelectedContractExecutionModel(t, frontier)
 	frontier.FrontierEvents[0].EventName = "work.changed"
 
@@ -248,6 +266,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyF
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
@@ -266,7 +285,8 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyF
 	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-1"}
 	frontier.FrontierEvents[0].SourceSubscriberTypes = []string{"node"}
 	frontier.FrontierEvents[0].SourceSubscriberIDs = []string{"source-node"}
-	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
 	model := testSelectedContractExecutionModel(t, frontier)
 	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
 
@@ -275,11 +295,52 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyF
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
 		t.Fatalf("error = %v, want stale route topology flow-instance failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionRejectsForgedRouteTopology(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	frontier.FrontierEvents[0].EventName = "review/inst-1/task.started"
+	frontier.FrontierEvents[0].SourceClassifications = []string{store.RunForkPendingClassificationPending}
+	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-1"}
+	frontier.FrontierEvents[0].SourceSubscriberTypes = []string{"node"}
+	frontier.FrontierEvents[0].SourceSubscriberIDs = []string{"source-node"}
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	routeTopology.DynamicFlowInstances = nil
+	routeTopology.DynamicTopologySupported = true
+	routeTopology.DynamicTopologyDisposition = store.RunForkSelectedContractDispositionForkLocalTruth
+	routeTopology.UnsupportedBlockers = removeUnsupportedBlocker(routeTopology.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven)
+
+	_, err = BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
+		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical route-admission evidence") {
+		t.Fatalf("error = %v, want forged route topology admission failure", err)
 	}
 }
 
@@ -407,9 +468,11 @@ func testSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAd
 
 func testSelectedContractExecutionModel(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractExecution {
 	t.Helper()
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     frontier,
-		RouteTopology: testSelectedContractRouteTopology(t, frontier),
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission),
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
@@ -419,9 +482,14 @@ func testSelectedContractExecutionModel(t *testing.T, frontier store.RunForkCont
 
 func testSelectedContractRouteTopology(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractRouteTopology {
 	t.Helper()
+	return testSelectedContractRouteTopologyFromAdmission(t, frontier, testSelectedContractRouteAdmission(frontier))
+}
+
+func testSelectedContractRouteTopologyFromAdmission(t *testing.T, frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) store.RunForkSelectedContractRouteTopology {
+	t.Helper()
 	routeTopology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
 		Admission:      frontier,
-		RouteAdmission: testSelectedContractRouteAdmission(frontier),
+		RouteAdmission: routeAdmission,
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -21,7 +21,7 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	reader := &fakeSelectedContractBindingReader{binding: binding}
 	sourceLoader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
-	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopology(t, frontier)
 	model := testSelectedContractExecutionModel(t, frontier)
 
 	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -29,7 +29,7 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 		BindingReader:     reader,
 		SourceLoader:      sourceLoader,
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err != nil {
@@ -65,8 +65,8 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
 		t.Fatalf("frontier events = %#v", admission.FrontierEvents)
 	}
-	if admission.RouteAdmission == nil || admission.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner {
-		t.Fatalf("route admission = %#v, want canonical selected-contract route admission", admission.RouteAdmission)
+	if admission.RouteTopology == nil || admission.RouteTopology.Owner != store.RunForkSelectedContractRouteTopologyOwner {
+		t.Fatalf("route topology = %#v, want canonical selected-contract route topology", admission.RouteTopology)
 	}
 	if !executionBoundaryHas(admission.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copy invalid", admission.InvalidPaths)
@@ -97,7 +97,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnMissingBinding(t *t
 		BindingReader:     &fakeSelectedContractBindingReader{err: errors.New("selected contract binding not found")},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(selection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "load selected-contract binding") {
@@ -117,7 +117,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnUnavailableSelected
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection}},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected semantic source") {
@@ -139,7 +139,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnSourceMismatch(t *t
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: LoadedSelectedContractSource{Selection: binding.ContractSelection, Source: testSelectedSource(mismatched)}},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workflow version mismatch") {
@@ -161,7 +161,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnWrongContractsRoot(
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(wrongRoot)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "selected source selection does not match durable binding") {
@@ -175,6 +175,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
+	routeTopology := testSelectedContractRouteTopology(t, frontier)
 	frontier.Owner = "cmd.swarm.local_frontier"
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
@@ -182,7 +183,7 @@ func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalEvidence(t *tes
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), store.RunForkContractFrontierAdmissionOwner) {
@@ -203,7 +204,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    testSelectedContractRouteAdmission(frontier),
+		RouteTopology:     testSelectedContractRouteTopology(t, frontier),
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier events do not match") {
@@ -211,34 +212,34 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleModelFrontier(
 	}
 }
 
-func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteAdmission(t *testing.T) {
+func TestBuildSelectedContractExecutionAdmissionRequiresCanonicalRouteTopology(t *testing.T) {
 	ctx := context.Background()
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
 	model := testSelectedContractExecutionModel(t, frontier)
-	routeAdmission := testSelectedContractRouteAdmission(frontier)
-	routeAdmission.Owner = "cmd.swarm.route_helper"
+	routeTopology := testSelectedContractRouteTopology(t, frontier)
+	routeTopology.Owner = "cmd.swarm.route_helper"
 
 	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
-	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteAdmissionOwner) {
-		t.Fatalf("error = %v, want canonical route admission failure", err)
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteTopologyOwner) {
+		t.Fatalf("error = %v, want canonical route topology failure", err)
 	}
 }
 
-func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmissionFrontier(t *testing.T) {
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyFrontier(t *testing.T) {
 	ctx := context.Background()
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
 	frontier := testContractFrontierAdmission(binding.ContractSelection)
-	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopology(t, frontier)
 	model := testSelectedContractExecutionModel(t, frontier)
 	frontier.FrontierEvents[0].EventName = "work.changed"
 
@@ -247,15 +248,15 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmission
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
-		t.Fatalf("error = %v, want stale route admission frontier failure", err)
+		t.Fatalf("error = %v, want stale route topology frontier failure", err)
 	}
 }
 
-func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmissionFlowInstances(t *testing.T) {
+func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteTopologyFlowInstances(t *testing.T) {
 	ctx := context.Background()
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
@@ -265,7 +266,7 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmission
 	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-1"}
 	frontier.FrontierEvents[0].SourceSubscriberTypes = []string{"node"}
 	frontier.FrontierEvents[0].SourceSubscriberIDs = []string{"source-node"}
-	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopology(t, frontier)
 	model := testSelectedContractExecutionModel(t, frontier)
 	frontier.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
 
@@ -274,11 +275,11 @@ func TestBuildSelectedContractExecutionAdmissionFailsClosedOnStaleRouteAdmission
 		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
 		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
-		t.Fatalf("error = %v, want stale route admission flow-instance failure", err)
+		t.Fatalf("error = %v, want stale route topology flow-instance failure", err)
 	}
 }
 
@@ -407,11 +408,23 @@ func testSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAd
 func testSelectedContractExecutionModel(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractExecution {
 	t.Helper()
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:      frontier,
-		RouteAdmission: testSelectedContractRouteAdmission(frontier),
+		Admission:     frontier,
+		RouteTopology: testSelectedContractRouteTopology(t, frontier),
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
 	}
 	return model
+}
+
+func testSelectedContractRouteTopology(t *testing.T, frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractRouteTopology {
+	t.Helper()
+	routeTopology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission:      frontier,
+		RouteAdmission: testSelectedContractRouteAdmission(frontier),
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	return routeTopology
 }

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -97,8 +97,9 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		return SelectedContractExecutionResult{}, err
 	}
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     frontier,
-		RouteTopology: routeTopology,
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err != nil {
 		return SelectedContractExecutionResult{}, err
@@ -117,6 +118,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
 		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -89,9 +89,16 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if err := validateSelectedContractExecutionFrontierForMutation(frontier); err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner}, err
 	}
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+	routeTopology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
 		Admission:      frontier,
 		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		return SelectedContractExecutionResult{}, err
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:     frontier,
+		RouteTopology: routeTopology,
 	})
 	if err != nil {
 		return SelectedContractExecutionResult{}, err
@@ -110,7 +117,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,
-		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
 		ExecutionModel:    model,
 	})
 	if err != nil {

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -2,15 +2,78 @@ package runforkexecution
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"swarm/internal/store"
 )
 
 type SelectedContractExecutionModelRequest struct {
+	Admission     store.RunForkContractFrontierAdmission
+	RouteTopology store.RunForkSelectedContractRouteTopology
+}
+
+type SelectedContractRouteTopologyRequest struct {
 	Admission      store.RunForkContractFrontierAdmission
 	RouteAdmission store.RunForkSelectedContractRouteAdmission
+}
+
+func BuildSelectedContractRouteTopology(req SelectedContractRouteTopologyRequest) (store.RunForkSelectedContractRouteTopology, error) {
+	admission := req.Admission
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return store.RunForkSelectedContractRouteTopology{}, fmt.Errorf("selected-contract route topology requires %s admission; got %q", store.RunForkContractFrontierAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return store.RunForkSelectedContractRouteTopology{}, fmt.Errorf("selected-contract route topology requires non-mutating frontier admission")
+	}
+	if admission.HistoricalExecutionSupported {
+		return store.RunForkSelectedContractRouteTopology{}, fmt.Errorf("selected-contract route topology unexpectedly supports historical execution")
+	}
+	routeAdmission := req.RouteAdmission
+	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
+		return store.RunForkSelectedContractRouteTopology{}, err
+	}
+
+	blockers := []store.RunForkUnsupportedBlocker{{
+		Code:    store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
+		Message: "selected-contract route topology is non-mutating; route persistence, recipient delivery writes, and handler execution remain separately gated",
+	}}
+	dynamicDisposition := store.RunForkSelectedContractDispositionForkLocalTruth
+	if len(routeAdmission.DynamicFlowInstances) > 0 {
+		dynamicDisposition = store.RunForkSelectedContractDispositionFailClosed
+		blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven,
+			Message: "selected-contract dynamic flow-instance topology requires fork-local topology evidence before route reconstruction",
+		})
+	}
+	for _, blocker := range routeAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+
+	staticEvents := selectedContractRouteTopologyEvents(routeAdmission.SelectedRouteEvents)
+	return store.RunForkSelectedContractRouteTopology{
+		Owner:                          store.RunForkSelectedContractRouteTopologyOwner,
+		RouteAdmissionOwner:            routeAdmission.Owner,
+		FutureRouteReconstructionOwner: routeAdmission.FutureRouteReconstructionOwner,
+		NonMutating:                    true,
+		RoutePersistenceSupported:      false,
+		ExecutableRecipientsSupported:  false,
+		ContractSelection:              routeAdmission.ContractSelection,
+		StaticTopologySupported:        true,
+		DynamicTopologySupported:       len(routeAdmission.DynamicFlowInstances) == 0,
+		SourceRouteFactsPresent:        routeAdmission.SourceRouteFactsPresent,
+		StaticRouteEvents:              staticEvents,
+		DynamicFlowInstances:           append([]string(nil), routeAdmission.DynamicFlowInstances...),
+		DynamicTopologyDisposition:     dynamicDisposition,
+		FrontierAdmissionOwner:         routeAdmission.FrontierAdmissionOwner,
+		FrontierEventCount:             routeAdmission.FrontierEventCount,
+		FrontierSourceEventIDs:         append([]string(nil), routeAdmission.FrontierSourceEventIDs...),
+		FrontierEvidenceFingerprint:    routeAdmission.FrontierEvidenceFingerprint,
+		RequiredEvidence:               selectedContractRouteTopologyRequiredEvidence(routeAdmission),
+		RequiredConsumers:              selectedContractRouteTopologyRequiredConsumers(),
+		BlockedSiblings:                selectedContractRouteTopologyBlockedSiblings(),
+		InvalidPaths:                   selectedContractRouteTopologyInvalidPaths(),
+		UnsupportedBlockers:            blockers,
+	}, nil
 }
 
 func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelRequest) (store.RunForkSelectedContractExecution, error) {
@@ -24,13 +87,13 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 	if admission.HistoricalExecutionSupported {
 		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission unexpectedly supports historical execution")
 	}
-	routeAdmission := req.RouteAdmission
-	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
+	routeTopology := req.RouteTopology
+	if err := validateSelectedContractRouteTopology(admission, routeTopology); err != nil {
 		return store.RunForkSelectedContractExecution{}, err
 	}
 
 	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), admission.UnsupportedBlockers...)
-	for _, blocker := range routeAdmission.UnsupportedBlockers {
+	for _, blocker := range routeTopology.UnsupportedBlockers {
 		unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, blocker)
 	}
 	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
@@ -48,7 +111,7 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		AdmissionUse:         store.RunForkSelectedContractExecutionAdmissionUseEvidenceOnly,
 		FrontierEventCount:   admission.FrontierEventCount,
 		FrontierEvents:       selectedContractFrontierEvents(admission.FrontierEvents),
-		RouteAdmission:       &routeAdmission,
+		RouteTopology:        &routeTopology,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -60,6 +123,41 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		InvalidPaths:        selectedContractExecutionInvalidPaths(),
 		UnsupportedBlockers: unsupportedBlockers,
 	}, nil
+}
+
+func validateSelectedContractRouteTopology(frontier store.RunForkContractFrontierAdmission, topology store.RunForkSelectedContractRouteTopology) error {
+	if strings.TrimSpace(topology.Owner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return fmt.Errorf("selected-contract execution model requires %s route topology; got %q", store.RunForkSelectedContractRouteTopologyOwner, topology.Owner)
+	}
+	if strings.TrimSpace(topology.RouteAdmissionOwner) != store.RunForkSelectedContractRouteAdmissionOwner {
+		return fmt.Errorf("selected-contract route topology must consume %s; got %q", store.RunForkSelectedContractRouteAdmissionOwner, topology.RouteAdmissionOwner)
+	}
+	if !topology.NonMutating {
+		return fmt.Errorf("selected-contract route topology must be non-mutating")
+	}
+	if topology.RoutePersistenceSupported {
+		return fmt.Errorf("selected-contract route topology unexpectedly supports route persistence")
+	}
+	if topology.ExecutableRecipientsSupported {
+		return fmt.Errorf("selected-contract route topology unexpectedly supports executable recipients")
+	}
+	if strings.TrimSpace(topology.FrontierAdmissionOwner) != store.RunForkContractFrontierAdmissionOwner {
+		return fmt.Errorf("selected-contract route topology must consume %s; got %q", store.RunForkContractFrontierAdmissionOwner, topology.FrontierAdmissionOwner)
+	}
+	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(frontier)
+	if topology.FrontierEventCount != frontierEventCount {
+		return fmt.Errorf("selected-contract route topology frontier count mismatch: got %d want %d", topology.FrontierEventCount, frontierEventCount)
+	}
+	if !equalStringSlices(topology.FrontierSourceEventIDs, frontierSourceEventIDs) {
+		return fmt.Errorf("selected-contract route topology frontier source event IDs do not match current frontier evidence")
+	}
+	if strings.TrimSpace(topology.FrontierEvidenceFingerprint) != frontierFingerprint {
+		return fmt.Errorf("selected-contract route topology frontier fingerprint mismatch")
+	}
+	if err := validateSelectionMatches("route topology", frontier.ContractSelection, topology.ContractSelection); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateSelectedContractRouteAdmission(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) error {
@@ -79,7 +177,7 @@ func validateSelectedContractRouteAdmission(frontier store.RunForkContractFronti
 	if routeAdmission.FrontierEventCount != frontierEventCount {
 		return fmt.Errorf("selected-contract route admission frontier count mismatch: got %d want %d", routeAdmission.FrontierEventCount, frontierEventCount)
 	}
-	if !reflect.DeepEqual(routeAdmission.FrontierSourceEventIDs, frontierSourceEventIDs) {
+	if !equalStringSlices(routeAdmission.FrontierSourceEventIDs, frontierSourceEventIDs) {
 		return fmt.Errorf("selected-contract route admission frontier source event IDs do not match current frontier evidence")
 	}
 	if strings.TrimSpace(routeAdmission.FrontierEvidenceFingerprint) != frontierFingerprint {
@@ -89,6 +187,121 @@ func validateSelectedContractRouteAdmission(frontier store.RunForkContractFronti
 		return err
 	}
 	return nil
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if strings.TrimSpace(left[i]) != strings.TrimSpace(right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func selectedContractRouteTopologyEvents(events []store.RunForkSelectedContractRouteEvent) []store.RunForkSelectedContractRouteEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, store.RunForkSelectedContractRouteEvent{
+			SourceEventID:     event.SourceEventID,
+			EventName:         event.EventName,
+			DerivedRecipients: append([]store.RunForkContractFrontierRecipient(nil), event.DerivedRecipients...),
+			Disposition:       store.RunForkSelectedContractDispositionForkLocalTruth,
+		})
+	}
+	return out
+}
+
+func selectedContractRouteTopologyRequiredEvidence(routeAdmission store.RunForkSelectedContractRouteAdmission) []store.RunForkSelectedContractExecutionBoundary {
+	evidence := []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_contract_route_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRouteAdmissionOwner,
+			Reason:      "route topology consumes route admission as prerequisite evidence and does not duplicate its admission class",
+		},
+	}
+	for _, item := range routeAdmission.RequiredConsumers {
+		if strings.TrimSpace(item.Disposition) == store.RunForkSelectedContractDispositionPrerequisite {
+			evidence = append(evidence, item)
+		}
+	}
+	return evidence
+}
+
+func selectedContractRouteTopologyRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_contract_execution_model",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractExecutionModelOwner,
+			Reason:      "selected-contract execution must consume route topology truth before future execution can derive recipients",
+		},
+		{
+			Concept:     "fork_local_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/runtime/bus.delivery_planner",
+			Reason:      "recipient planning is a future consumer and is not invoked by the route topology owner",
+		},
+	}
+}
+
+func selectedContractRouteTopologyBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "mutating_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".route_reconstruction",
+			Reason:      "route topology is a non-mutating truth owner and does not persist fork-local route rows",
+		},
+		{
+			Concept:     "dynamic_flow_instance_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "internal/runtime/bus.RouteTable.AddFlowInstanceRoute",
+			Reason:      "dynamic flow-instance route reconstruction needs fork-local topology evidence before route persistence",
+		},
+		{
+			Concept:     "recipient_delivery_writes",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "delivery_and_replay_ownership",
+			Reason:      "route topology does not derive executable recipients or create delivery rows",
+		},
+		{
+			Concept:     "timer_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "timer reconstruction remains a separate scheduler lifecycle owner",
+		},
+	}
+}
+
+func selectedContractRouteTopologyInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "copy_source_routing_rules",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source routing_rules are current operational evidence, not fork-local topology truth",
+		},
+		{
+			Concept:     "copy_source_flow_instance_routes",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source materialized route rows lack fork-local topology provenance",
+		},
+		{
+			Concept:     "reuse_source_recipients",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source recipient decisions were made under source-run contracts and are not executable fork truth",
+		},
+		{
+			Concept:     "delivery_planner_as_topology_owner",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "delivery planning is a future consumer and must not own route topology semantics",
+		},
+	}
 }
 
 func appendRunForkUnsupportedBlocker(blockers []store.RunForkUnsupportedBlocker, blocker store.RunForkUnsupportedBlocker) []store.RunForkUnsupportedBlocker {

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -2,14 +2,16 @@ package runforkexecution
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"swarm/internal/store"
 )
 
 type SelectedContractExecutionModelRequest struct {
-	Admission     store.RunForkContractFrontierAdmission
-	RouteTopology store.RunForkSelectedContractRouteTopology
+	Admission      store.RunForkContractFrontierAdmission
+	RouteAdmission store.RunForkSelectedContractRouteAdmission
+	RouteTopology  store.RunForkSelectedContractRouteTopology
 }
 
 type SelectedContractRouteTopologyRequest struct {
@@ -32,7 +34,10 @@ func BuildSelectedContractRouteTopology(req SelectedContractRouteTopologyRequest
 	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
 		return store.RunForkSelectedContractRouteTopology{}, err
 	}
+	return canonicalSelectedContractRouteTopology(routeAdmission), nil
+}
 
+func canonicalSelectedContractRouteTopology(routeAdmission store.RunForkSelectedContractRouteAdmission) store.RunForkSelectedContractRouteTopology {
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
 		Message: "selected-contract route topology is non-mutating; route persistence, recipient delivery writes, and handler execution remain separately gated",
@@ -73,7 +78,7 @@ func BuildSelectedContractRouteTopology(req SelectedContractRouteTopologyRequest
 		BlockedSiblings:                selectedContractRouteTopologyBlockedSiblings(),
 		InvalidPaths:                   selectedContractRouteTopologyInvalidPaths(),
 		UnsupportedBlockers:            blockers,
-	}, nil
+	}
 }
 
 func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelRequest) (store.RunForkSelectedContractExecution, error) {
@@ -88,7 +93,11 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		return store.RunForkSelectedContractExecution{}, fmt.Errorf("selected-contract frontier admission unexpectedly supports historical execution")
 	}
 	routeTopology := req.RouteTopology
-	if err := validateSelectedContractRouteTopology(admission, routeTopology); err != nil {
+	routeAdmission := req.RouteAdmission
+	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
+		return store.RunForkSelectedContractExecution{}, err
+	}
+	if err := validateSelectedContractRouteTopology(admission, routeAdmission, routeTopology); err != nil {
 		return store.RunForkSelectedContractExecution{}, err
 	}
 
@@ -125,7 +134,7 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 	}, nil
 }
 
-func validateSelectedContractRouteTopology(frontier store.RunForkContractFrontierAdmission, topology store.RunForkSelectedContractRouteTopology) error {
+func validateSelectedContractRouteTopology(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, topology store.RunForkSelectedContractRouteTopology) error {
 	if strings.TrimSpace(topology.Owner) != store.RunForkSelectedContractRouteTopologyOwner {
 		return fmt.Errorf("selected-contract execution model requires %s route topology; got %q", store.RunForkSelectedContractRouteTopologyOwner, topology.Owner)
 	}
@@ -156,6 +165,10 @@ func validateSelectedContractRouteTopology(frontier store.RunForkContractFrontie
 	}
 	if err := validateSelectionMatches("route topology", frontier.ContractSelection, topology.ContractSelection); err != nil {
 		return err
+	}
+	canonical := canonicalSelectedContractRouteTopology(routeAdmission)
+	if !reflect.DeepEqual(topology, canonical) {
+		return fmt.Errorf("selected-contract route topology does not match canonical route-admission evidence")
 	}
 	return nil
 }

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -7,7 +7,7 @@ import (
 	"swarm/internal/store"
 )
 
-func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *testing.T) {
+func TestBuildSelectedContractRouteTopologyConsumesRouteAdmissionAsPrerequisite(t *testing.T) {
 	admission := store.RunForkContractFrontierAdmission{
 		Owner:                        store.RunForkContractFrontierAdmissionOwner,
 		NonMutating:                  true,
@@ -34,9 +34,118 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 	}
 
 	routeAdmission := testSelectedContractRouteAdmission(admission)
-	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+	topology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
 		Admission:      admission,
 		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	if topology.Owner != store.RunForkSelectedContractRouteTopologyOwner ||
+		topology.RouteAdmissionOwner != store.RunForkSelectedContractRouteAdmissionOwner ||
+		!topology.NonMutating ||
+		topology.RoutePersistenceSupported ||
+		topology.ExecutableRecipientsSupported {
+		t.Fatalf("topology ownership = %#v", topology)
+	}
+	if !topology.StaticTopologySupported || !topology.DynamicTopologySupported {
+		t.Fatalf("topology support = static:%v dynamic:%v", topology.StaticTopologySupported, topology.DynamicTopologySupported)
+	}
+	if len(topology.StaticRouteEvents) != len(routeAdmission.SelectedRouteEvents) {
+		t.Fatalf("static route events = %#v, want route admission evidence", topology.StaticRouteEvents)
+	}
+	if !executionBoundaryHas(topology.RequiredEvidence, "selected_contract_route_admission", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required evidence = %#v, want route admission prerequisite", topology.RequiredEvidence)
+	}
+	if !executionBoundaryHas(topology.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source routing_rules copy invalid", topology.InvalidPaths)
+	}
+	if !executionBoundaryHas(topology.BlockedSiblings, "recipient_delivery_writes", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("blocked siblings = %#v, want recipient delivery writes blocked", topology.BlockedSiblings)
+	}
+	if !unsupportedBlockerHas(topology.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteTopologyNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want topology non-mutating blocker", topology.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractRouteTopologyFailsClosedOnDynamicFlowInstances(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:         "source-event",
+			EventName:             "review/inst-1/task.started",
+			SourceFlowInstances:   []string{"review/inst-1"},
+			SourceSubscriberTypes: []string{"node"},
+			SourceSubscriberIDs:   []string{"source-node"},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+
+	topology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	if topology.DynamicTopologySupported {
+		t.Fatalf("DynamicTopologySupported = true, want false for source dynamic topology")
+	}
+	if topology.DynamicTopologyDisposition != store.RunForkSelectedContractDispositionFailClosed {
+		t.Fatalf("dynamic disposition = %q", topology.DynamicTopologyDisposition)
+	}
+	if !unsupportedBlockerHas(topology.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven) {
+		t.Fatalf("unsupported blockers = %#v, want dynamic topology blocker", topology.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractExecutionModelConsumesRouteTopologyAsTruth(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:           "source-event",
+			EventName:               "work.begin",
+			RuntimeEventOwners:      []string{"alpha-intake"},
+			WorkflowNodeSubscribers: []string{"beta-intake"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "alpha-intake",
+				Path:           "flow-a/alpha-intake",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:     admission,
+		RouteTopology: routeTopology,
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
@@ -62,8 +171,8 @@ func TestBuildSelectedContractExecutionModelConsumesAdmissionAsEvidenceOnly(t *t
 	if model.FrontierEvents[0].Disposition != store.RunForkSelectedContractDispositionEvidenceOnly {
 		t.Fatalf("frontier disposition = %q", model.FrontierEvents[0].Disposition)
 	}
-	if model.RouteAdmission == nil || model.RouteAdmission.Owner != store.RunForkSelectedContractRouteAdmissionOwner {
-		t.Fatalf("route admission = %#v, want canonical selected-contract route admission", model.RouteAdmission)
+	if model.RouteTopology == nil || model.RouteTopology.Owner != store.RunForkSelectedContractRouteTopologyOwner {
+		t.Fatalf("route topology = %#v, want canonical selected-contract route topology", model.RouteTopology)
 	}
 	if !executionBoundaryHas(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copying invalid", model.InvalidPaths)
@@ -108,8 +217,8 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 	}
 
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:      admission,
-		RouteAdmission: testSelectedContractRouteAdmission(admission),
+		Admission:     admission,
+		RouteTopology: testSelectedContractRouteTopology(t, admission),
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
@@ -118,6 +227,7 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 		store.RunForkBlockerContractFrontierExecutionUnsupported,
 		store.RunForkBlockerContractFrontierRouteUnresolved,
 		store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+		store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
 		store.RunForkBlockerSelectedContractExecutionModelNonMutating,
 	} {
 		if !unsupportedBlockerHas(model.UnsupportedBlockers, code) {
@@ -126,7 +236,7 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 	}
 }
 
-func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteAdmission(t *testing.T) {
+func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteTopology(t *testing.T) {
 	admission := store.RunForkContractFrontierAdmission{
 		Owner:                        store.RunForkContractFrontierAdmissionOwner,
 		NonMutating:                  true,
@@ -138,15 +248,15 @@ func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteAdmission(t *t
 			WorkflowVersion: "v1",
 		},
 	}
-	routeAdmission := testSelectedContractRouteAdmission(admission)
-	routeAdmission.Owner = "cmd.swarm.local_route_admission"
+	routeTopology := testSelectedContractRouteTopology(t, admission)
+	routeTopology.Owner = "cmd.swarm.local_route_topology"
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:      admission,
-		RouteAdmission: routeAdmission,
+		Admission:     admission,
+		RouteTopology: routeTopology,
 	})
-	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteAdmissionOwner) {
-		t.Fatalf("error = %v, want canonical route admission failure", err)
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteTopologyOwner) {
+		t.Fatalf("error = %v, want canonical route topology failure", err)
 	}
 }
 
@@ -167,15 +277,15 @@ func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFron
 			EventName:     "work.begin",
 		}},
 	}
-	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopology(t, admission)
 	admission.FrontierEvents[0].EventName = "work.changed"
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:      admission,
-		RouteAdmission: routeAdmission,
+		Admission:     admission,
+		RouteTopology: routeTopology,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
-		t.Fatalf("error = %v, want stale route admission frontier failure", err)
+		t.Fatalf("error = %v, want stale route topology frontier failure", err)
 	}
 }
 
@@ -200,15 +310,15 @@ func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFlow
 			SourceSubscriberIDs:   []string{"source-node"},
 		}},
 	}
-	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopology(t, admission)
 	admission.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:      admission,
-		RouteAdmission: routeAdmission,
+		Admission:     admission,
+		RouteTopology: routeTopology,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
-		t.Fatalf("error = %v, want stale route admission flow-instance failure", err)
+		t.Fatalf("error = %v, want stale route topology flow-instance failure", err)
 	}
 }
 

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -144,8 +144,9 @@ func TestBuildSelectedContractExecutionModelConsumesRouteTopologyAsTruth(t *test
 		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
 	}
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     admission,
-		RouteTopology: routeTopology,
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
@@ -216,9 +217,11 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 		},
 	}
 
+	routeAdmission := testSelectedContractRouteAdmission(admission)
 	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     admission,
-		RouteTopology: testSelectedContractRouteTopology(t, admission),
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission),
 	})
 	if err != nil {
 		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
@@ -248,15 +251,82 @@ func TestBuildSelectedContractExecutionModelRequiresCanonicalRouteTopology(t *te
 			WorkflowVersion: "v1",
 		},
 	}
-	routeTopology := testSelectedContractRouteTopology(t, admission)
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
 	routeTopology.Owner = "cmd.swarm.local_route_topology"
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     admission,
-		RouteTopology: routeTopology,
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRouteTopologyOwner) {
 		t.Fatalf("error = %v, want canonical route topology failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionModelRejectsForgedDynamicRouteTopology(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:         "source-event",
+			EventName:             "review/inst-1/task.started",
+			SourceClassifications: []string{store.RunForkPendingClassificationPending},
+			SourceFlowInstances:   []string{"review/inst-1"},
+			SourceSubscriberTypes: []string{"node"},
+			SourceSubscriberIDs:   []string{"source-node"},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
+	routeTopology.DynamicFlowInstances = nil
+	routeTopology.DynamicTopologySupported = true
+	routeTopology.DynamicTopologyDisposition = store.RunForkSelectedContractDispositionForkLocalTruth
+	routeTopology.UnsupportedBlockers = removeUnsupportedBlocker(routeTopology.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven)
+
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical route-admission evidence") {
+		t.Fatalf("error = %v, want forged dynamic route topology failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionModelRejectsForgedRouteAdmissionBlockerTopology(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
+	routeTopology.UnsupportedBlockers = removeUnsupportedBlocker(routeTopology.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteAdmissionNonMutating)
+
+	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonical route-admission evidence") {
+		t.Fatalf("error = %v, want forged route-admission blocker topology failure", err)
 	}
 }
 
@@ -277,12 +347,14 @@ func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFron
 			EventName:     "work.begin",
 		}},
 	}
-	routeTopology := testSelectedContractRouteTopology(t, admission)
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
 	admission.FrontierEvents[0].EventName = "work.changed"
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     admission,
-		RouteTopology: routeTopology,
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
 		t.Fatalf("error = %v, want stale route topology frontier failure", err)
@@ -310,12 +382,14 @@ func TestBuildSelectedContractExecutionModelFailsClosedOnStaleRouteAdmissionFlow
 			SourceSubscriberIDs:   []string{"source-node"},
 		}},
 	}
-	routeTopology := testSelectedContractRouteTopology(t, admission)
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
 	admission.FrontierEvents[0].SourceFlowInstances = []string{"review/inst-2"}
 
 	_, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
-		Admission:     admission,
-		RouteTopology: routeTopology,
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
 	})
 	if err == nil || !strings.Contains(err.Error(), "frontier fingerprint mismatch") {
 		t.Fatalf("error = %v, want stale route topology flow-instance failure", err)
@@ -363,4 +437,14 @@ func unsupportedBlockerHas(items []store.RunForkUnsupportedBlocker, code string)
 		}
 	}
 	return false
+}
+
+func removeUnsupportedBlocker(items []store.RunForkUnsupportedBlocker, code string) []store.RunForkUnsupportedBlocker {
+	out := make([]store.RunForkUnsupportedBlocker, 0, len(items))
+	for _, item := range items {
+		if item.Code != code {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -14,6 +14,7 @@ const (
 	RunForkSelectedContractExecutionActivationGateOwner = "runtime.run_fork.selected_contract_execution.activation_gate"
 	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
 	RunForkSelectedContractRouteAdmissionOwner          = "runtime.run_fork.selected_contract_route_admission"
+	RunForkSelectedContractRouteTopologyOwner           = "runtime.run_fork.selected_contract_route_topology"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -24,11 +25,15 @@ const (
 	RunForkSelectedContractDispositionBlockedSibling      = "blocked_sibling"
 	RunForkSelectedContractDispositionPrerequisite        = "prerequisite"
 	RunForkSelectedContractDispositionInvalid             = "invalid"
+	RunForkSelectedContractDispositionForkLocalTruth      = "fork_local_truth"
+	RunForkSelectedContractDispositionFailClosed          = "fail_closed"
 
 	RunForkBlockerSelectedContractExecutionModelNonMutating     = "selected_contract_execution_model_non_mutating"
 	RunForkBlockerSelectedContractExecutionAdmissionNonMutating = "selected_contract_execution_admission_non_mutating"
 	RunForkBlockerSelectedContractSourceReplayUnsupported       = "selected_contract_source_replay_unsupported"
 	RunForkBlockerSelectedContractRouteAdmissionNonMutating     = "selected_contract_route_admission_non_mutating"
+	RunForkBlockerSelectedContractRouteTopologyNonMutating      = "selected_contract_route_topology_non_mutating"
+	RunForkBlockerSelectedContractDynamicRouteTopologyUnproven  = "selected_contract_dynamic_route_topology_unproven"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
 )
@@ -43,7 +48,7 @@ type RunForkSelectedContractExecution struct {
 	AdmissionUse         string                                     `json:"admission_use"`
 	FrontierEventCount   int                                        `json:"frontier_event_count"`
 	FrontierEvents       []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
-	RouteAdmission       *RunForkSelectedContractRouteAdmission     `json:"route_admission,omitempty"`
+	RouteTopology        *RunForkSelectedContractRouteTopology      `json:"route_topology,omitempty"`
 	ContractBinding      RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers    []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings      []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -68,7 +73,7 @@ type RunForkSelectedContractExecutionAdmission struct {
 	SourceWorkflowVersion string                                     `json:"source_workflow_version"`
 	FrontierEventCount    int                                        `json:"frontier_event_count"`
 	FrontierEvents        []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
-	RouteAdmission        *RunForkSelectedContractRouteAdmission     `json:"route_admission,omitempty"`
+	RouteTopology         *RunForkSelectedContractRouteTopology      `json:"route_topology,omitempty"`
 	ContractBinding       RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers     []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings       []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -98,6 +103,31 @@ type RunForkSelectedContractRouteAdmission struct {
 	FrontierEventCount             int                                        `json:"frontier_event_count"`
 	FrontierSourceEventIDs         []string                                   `json:"frontier_source_event_ids,omitempty"`
 	FrontierEvidenceFingerprint    string                                     `json:"frontier_evidence_fingerprint"`
+	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers            []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractRouteTopology struct {
+	Owner                          string                                     `json:"owner"`
+	RouteAdmissionOwner            string                                     `json:"route_admission_owner"`
+	FutureRouteReconstructionOwner string                                     `json:"future_route_reconstruction_owner"`
+	NonMutating                    bool                                       `json:"non_mutating"`
+	RoutePersistenceSupported      bool                                       `json:"route_persistence_supported"`
+	ExecutableRecipientsSupported  bool                                       `json:"executable_recipients_supported"`
+	ContractSelection              RunForkContractSelection                   `json:"contract_selection"`
+	StaticTopologySupported        bool                                       `json:"static_topology_supported"`
+	DynamicTopologySupported       bool                                       `json:"dynamic_topology_supported"`
+	SourceRouteFactsPresent        bool                                       `json:"source_route_facts_present"`
+	StaticRouteEvents              []RunForkSelectedContractRouteEvent        `json:"static_route_events,omitempty"`
+	DynamicFlowInstances           []string                                   `json:"dynamic_flow_instances,omitempty"`
+	DynamicTopologyDisposition     string                                     `json:"dynamic_topology_disposition,omitempty"`
+	FrontierAdmissionOwner         string                                     `json:"frontier_admission_owner,omitempty"`
+	FrontierEventCount             int                                        `json:"frontier_event_count"`
+	FrontierSourceEventIDs         []string                                   `json:"frontier_source_event_ids,omitempty"`
+	FrontierEvidenceFingerprint    string                                     `json:"frontier_evidence_fingerprint"`
+	RequiredEvidence               []RunForkSelectedContractExecutionBoundary `json:"required_evidence,omitempty"`
 	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`


### PR DESCRIPTION
## Summary

Defines `runtime.run_fork.selected_contract_route_topology` as the canonical fork-local selected-contract route/topology truth owner beyond the existing #604 route admission evidence owner.

The selected execution model/admission/activation/execution path now consumes route topology, not route admission as final truth. Route admission remains prerequisite evidence only.

Closes #609

## Governing Context

Exact governing spec added/updated in this PR:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `selected_contract_route_topology`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `3f_selected_contract_route_topology`

Binding prior context:

- #609 approved gate: fork-local selected-contract route/topology truth ownership before executable recipient delivery.
- #608 blocked gate: direct route reconstruction plus executable recipients was too broad.
- #604/#606: route admission is already closed and is prerequisite evidence only.
- Existing spec sections `selected_contract_route_admission`, `3e_selected_contract_route_admission`, `selected_contract_timer_route_policy`, and `3d_selected_contract_timer_route_policy` remain binding.

## Semantic Migration

New canonical owner: `runtime.run_fork.selected_contract_route_topology`.

Old non-authoritative path now invalid: treating `runtime.run_fork.selected_contract_route_admission` as the final route/topology truth owner for selected execution. It is now consumed as prerequisite evidence by the topology owner.

Checked production paths for surviving old behavior:

- CLI dry-run selected-contract model building now builds route topology before selected execution model.
- Selected activation gate now builds route topology before selected execution admission.
- Selected mutating execution path now builds route topology before selected execution admission.
- Execution model/admission structs now carry `route_topology`, not direct `route_admission`.

Migration status: complete for the approved #609 child. Route persistence, executable recipient derivation, delivery writes, handler execution, timers, sessions/turns, source-advanced policy, contract swap, and UI/API ownership remain intentionally split.

## Validation

- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/store ./cmd/swarm -run 'RunFork|SelectedContract|Route|Routing|DeliveryPlanner|FlowInstance' -count=1`
- `go test ./...`