### PR TITLE
[agent-d][issue #612] Canonicalize Path alpha tool contracts

### DIFF
--- a/docs/specs/swarm-platform/platform/CHANGELOG.md
+++ b/docs/specs/swarm-platform/platform/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Clarified: Path alpha role-scoped entity-tool contracts are canonical
+Opted-in flows (`tool_surface.role_scoped_entity_tools: true`) now have a canonical platform-spec home for generated current-entity read/save/update tools, non-lossy typed reads, generated closed schemas, and legacy entity-tool retirement. Fully opted-in role-scoped actors do not receive the legacy entity surface names (`create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `search_entities`, `query_metrics`, `save_entity_field`). Older changelog entries describing those tools as universally auto-granted are historical records for the pre-Path alpha model, not current opted-in actor-surface truth.
+
 ### Clarified: CLI native_tools are provider-native only
 The platform spec now makes the shipped CLI rule explicit: `bash`, `web_search`, and `file_io` are provider-native capabilities only. The platform does not inject fallback tools to satisfy `native_tools` on CLI, unsupported capabilities fail closed, and visible native-tool surface must equal callable truth for the same turn.
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2353,8 +2353,9 @@ tool_model:
       authorization as defense-in-depth.'
     context_cost: An agent with 4 tools in tools pays for 4 tool schemas in LLM context, regardless of how many tools
       exist in the registry or how many tools an MCP server exposes. The filter is the contract, not the source.
-    default_deny: If an agent calls a tool that is not in its tools list, not a universal tool, not an emit tool, and not
-      a native_tools capability — the call is rejected. There is no default-allow policy for unrecognized tools.
+    default_deny: If an agent calls a tool that is not in its tools list, not a universal communication tool, not an emit
+      tool, not a generated role-scoped entity tool for an opted-in actor, and not a native_tools capability — the call is
+      rejected. There is no default-allow policy for unrecognized tools.
   mcp_client:
     description: The platform acts as an MCP client, connecting to external MCP servers to discover and invoke tools. MCP
       servers are registered in the product's policy.yaml under mcp_servers.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -229,14 +229,37 @@ contract_formats:
         consuming: If only a node subscribes → route to node only
         passthrough: If no node subscribes → pure agent delivery
   persistence_model:
-    description: Agents do not have raw database access. The platform provides typed persistence tools derived from the
-      authoritative entity contracts in entities.yaml and the shared type system. This ensures all data access is
-      permissioned, auditable, and storage-backend agnostic.
-    auto_generated_tools:
-      get_entity: Read entity by ID. Returns all fields the agent has permission to see.
-      save_entity_field: Write a specific field on an entity. Field must exist in the inferred entity contract.
-      search_entities: Query entities by stage, field values, or metadata.
-      query_metrics: Read aggregated metrics (counts, sums, averages) across entities.
+    description: Agents do not have raw database access. The platform derives agent-facing persistence tools from the
+      authoritative flow-owned entity contracts in entities.yaml, agents.yaml entity_writes declarations, and the shared
+      type system. This ensures all data access is permissioned, auditable, and storage-backend agnostic.
+    role_scoped_entity_tools:
+      opt_in: 'A flow opts into the Path alpha entity-tool model with tool_surface.role_scoped_entity_tools: true in
+        schema.yaml. The opt-in applies to agents authored in that flow.'
+      current_entity_binding: 'Generated role-scoped entity tools operate on the current entity resolved from the triggering
+        event/session context. Agent-supplied entity_id, entity_type, or flow_instance arguments are not accepted.'
+      generated_reads:
+        read_entity: 'read_{entity_type}() returns the complete current entity envelope and fields for the actor''s flow-owned
+          entity contract.'
+        read_field: 'read_{entity_type}_{field}() returns the complete typed value of one declared field.'
+        non_lossy_invariant: 'Generated typed reads return the complete typed value or fail closed with an explicit typed-read
+          error. They MUST NOT silently return preview, truncated, omitted, or follow-up-file placeholder shapes as the value.'
+      generated_writes:
+        save_field: 'save_{entity_type}_{field}({value}) writes exactly one top-level declared field authorized by agents.yaml
+          entity_writes.<entity_type>.save or entity_writes.<flow_id>.<entity_type>.save.'
+        update_path: 'update_{entity_type}_{field}_{subpath}({value}) updates one generated top-level subpath for a writable
+          named-object field. The value schema is the exact declared subpath type.'
+        create_rule: 'create authorization in entity_writes is author evidence for prompt/boot coverage. Path alpha does not
+          expose a generic agent-facing create_entity replacement for opted-in current-entity tools.'
+      generated_schema_closure: 'Generated entity-tool input and output schemas are closed recursively: additionalProperties
+        is false for object schemas, required fields are explicit, and enum values come from the shared type system. Provider-visible
+        schemas, runtime validation, and bootverify schema-closure checks must agree. Provider schema enforcement is a first
+        validation layer when honored; runtime validation remains mandatory defense-in-depth.'
+      legacy_surface_retirement: 'For fully opted-in role-scoped actors, the legacy universal entity surface is removed from
+        the provider-visible/callable agent surface, not merely denied after selection. Retired names are create_entity,
+        get_entity, get_subject_status, query_entities, search_entities, query_metrics, and save_entity_field.'
+      compatibility_boundary: 'Non-opted flows, operator/system surfaces, and explicitly tracked rollout compatibility may
+        continue to expose legacy platform entity tools until their parent rollout issues close. That compatibility is not
+        the valid surface for fully opted-in role-scoped agents.'
     schema_source: entities.yaml + types.yaml
   required_agents:
     description: required_agents in schema.yaml declares agents the flow needs.
@@ -244,8 +267,8 @@ contract_formats:
       if schema says role: classifier-agent, agents.yaml must have a top-level key classifier-agent. No separate fulfills:
       field.'
     note_on_empty: required_agents entries with empty subscriptions and emits are valid. They declare that the flow needs
-      this agent role to exist, even if the agent only uses universal tools (agent_message, mailbox_send). Common for managerial
-      roles that coordinate via messages rather than event subscriptions.
+      this agent role to exist, even if the agent only uses the universal communication/mailbox tools (agent_message,
+      mailbox_send). Common for managerial roles that coordinate via messages rather than event subscriptions.
   hello_world_example:
     description: Minimal flow that processes one event and advances state.
     package_yaml: 'name: hello
@@ -1344,7 +1367,8 @@ engine:
       - Timers are cancelled
       - Agent sessions are terminated
       - All persisted state remains in the database
-      - Entity is queryable via query_entities tool
+      - Entity remains queryable through explicit read/query surfaces; for fully opted-in role-scoped agents this means generated
+        current-entity reads, while legacy query_entities remains a non-opted/operator/system compatibility surface.
       archival: Future concern — retention policy and cold storage are not specified in v1.1.0.
       event_rejection: 'When an event arrives targeting an entity in a terminal state, the platform rejects it before handler
         execution. No guard runs, no handler runs, no state changes. The event is marked as rejected with reason: terminal_entity.
@@ -1430,9 +1454,9 @@ engine:
         → tool: emit_score_dimension_complete'
       behavior: Each emit tool accepts a payload object matching the event's schema in events.yaml. The platform validates
         the payload, attaches sender context, and publishes the event.
-      universal_tools: 'The following tools are auto-granted to all agents without explicit tools listing: agent_message,
-        mailbox_send, get_entity, save_entity_field, query_entities, query_metrics, search_entities. These are "universal"
-        tools. See tool_model.agent_tool_filtering.universal_tools for the authoritative list.'
+      universal_tools: 'The following tools are auto-granted to all agents without explicit tools listing: agent_message
+        and mailbox_send. Generated emit tools are derived from emit_events. Entity tools are governed by
+        contract_formats.persistence_model.role_scoped_entity_tools and tool_model.agent_tool_filtering, not by prompt prose.'
     task_mode_audit: 'Agents in task conversation_mode do NOT create agent_sessions rows. Task mode is
       stateless — no live session, no session lookup, no session persistence. The conversation transcript
       (reasoning, tool calls, results) is persisted after each invocation to agent_conversation_audits
@@ -2197,19 +2221,22 @@ tool_model:
       agent_fire: Terminate an agent session. Requires agent_fire permission.
       agent_hire: Spawn a new agent session. Requires agent_hire permission.
       agent_reconfigure: Modify an agent's prompt, tools, or subscriptions. Requires agent_reconfigure permission.
-      create_entity: Create a new entity row in entity_state.
-      get_entity: Read an entity by ID. Returns all fields the agent has permission to see. Auto-granted to all agents (universal
-        tool).
+      create_entity: Create a new entity row in entity_state. Legacy/operator/system compatibility surface; removed from
+        fully opted-in role-scoped agent surfaces.
+      get_entity: Read an entity by ID. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped
+        agent surfaces in favor of generated read_{entity_type} tools.
       human_task_decide: Record a human decision on a pending task. Requires human_task_decide permission.
       human_task_request: Create a task for human execution. Requires human_task_request permission.
       mailbox_send: Send an item to the human mailbox for decision. Auto-granted to all agents (universal tool).
-      query_entities: Query entities by state, fields, or aggregation. Auto-granted to all agents (universal tool).
-      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Auto-granted to all agents (universal
-        tool).
-      save_entity_field: Write a specific field on an entity. Field must exist in the inferred entity contract. Auto-granted to all agents
-        (universal tool).
+      query_entities: Query entities by state, fields, or aggregation. Legacy/operator/system compatibility surface; removed
+        from fully opted-in role-scoped agent surfaces.
+      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Legacy/operator/system compatibility
+        surface; removed from fully opted-in role-scoped agent surfaces.
+      save_entity_field: Write a specific field on an entity. Legacy/operator/system compatibility surface; removed from
+        fully opted-in role-scoped agent surfaces in favor of generated save/update tools.
       schedule: Schedule a future action or timer. Requires schedule permission.
-      search_entities: Query entities by stage, field values, or metadata. Auto-granted to all agents (universal tool).
+      search_entities: Query entities by stage, field values, or metadata. Legacy/operator/system compatibility surface;
+        removed from fully opted-in role-scoped agent surfaces.
     handler_actions:
       description: These are handler ACTION field values, not agent-callable tools. They are invoked via the action field in
         node handlers. The platform ships the handler code. They are listed separately from the tool catalog because agents
@@ -2228,7 +2255,9 @@ tool_model:
       description: All entity tools operate on the generic entity_state table. They read/write entity_state.fields (JSONB),
         entity_state.current_state, entity_state.gates, and entity_state.accumulator. They do NOT operate on product-specific
         typed tables. Product-specific tables are optional query-performance optimizations — the entity tools always use the
-        generic entity_state interface.
+        generic entity_state interface. For fully opted-in role-scoped agents, these legacy schemas are compatibility surfaces;
+        the valid provider-visible surface is the generated role-scoped tool set from
+        contract_formats.persistence_model.role_scoped_entity_tools.
       create_entity:
         description: Create a new entity row in entity_state.
         input:
@@ -2313,9 +2342,15 @@ tool_model:
     rule: When constructing an agent session, the platform resolves tools entries against the merged tool registry
       (platform_builtin + mcp + http). Only resolved tools are included in the LLM tool definitions. Unresolvable entries
       log a warning per the tool_resolution boot check.
-    universal_tools: 'The following tools are included in every agent session without listing in tools: agent_message,
-      mailbox_send, get_entity, save_entity_field, query_entities, query_metrics, search_entities. Emit tools
-      (emit_{event_name}) are auto-generated from emit_events. Neither universal nor emit tools require explicit tools entry.'
+    universal_tools: 'The following tools are included in every agent session without listing in tools: agent_message
+      and mailbox_send. Emit tools (emit_{event_name}) are auto-generated from emit_events. Neither universal communication
+      tools nor emit tools require explicit tools entry.'
+    role_scoped_entity_tools: 'When the actor''s owning flow declares tool_surface.role_scoped_entity_tools: true, the platform
+      generates current-entity read/save/update tools from the actor''s flow-owned entity contract and entity_writes declaration.
+      The generated tools are included in the agent-visible/provider-visible surface without explicit tools entries. In the
+      same opted-in surface, the legacy entity names create_entity, get_entity, get_subject_status, query_entities,
+      search_entities, query_metrics, and save_entity_field are removed before provider delivery and remain denied by runtime
+      authorization as defense-in-depth.'
     context_cost: An agent with 4 tools in tools pays for 4 tool schemas in LLM context, regardless of how many tools
       exist in the registry or how many tools an MCP server exposes. The filter is the contract, not the source.
     default_deny: If an agent calls a tool that is not in its tools list, not a universal tool, not an emit tool, and not

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -183,14 +183,18 @@ The routing consequences are:
 
 This separation means you can change who receives an event by editing subscriptions, without touching the event's payload schema.
 
-### Persistence Tools Derived From Entity Schema
+### Role-Scoped Persistence Tools Derived From Entity Contracts
 
-Agents do not get raw database access. Instead, the platform auto-generates typed persistence tools from `entity_schema`:
+Agents do not get raw database access. In Path alpha opted-in flows, the platform generates role-scoped current-entity tools from the flow-owned entity contract and the agent's `entity_writes` declaration.
 
-- `get_entity` — read an entity by ID
-- `save_entity_field` — write a specific field on an entity
-- `search_entities` — query entities by stage, field values, or metadata
-- `query_metrics` — read aggregated metrics across entities
+- `read_{entity_type}()` — read the complete current entity for this turn
+- `read_{entity_type}_{field}()` — read the complete typed value for one declared field
+- `save_{entity_type}_{field}({value})` — save one top-level field authorized by `entity_writes`
+- `update_{entity_type}_{field}_{subpath}({value})` — update one generated top-level subpath for a writable named-object field
+
+The generated tools do not accept `entity_id`, `entity_type`, or `flow_instance`. The runtime resolves the current entity from the event/session context. Generated typed reads are non-lossy: they return the complete typed value or fail closed with an explicit typed-read error.
+
+Legacy entity tools (`create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `search_entities`, `query_metrics`, `save_entity_field`) are compatibility surfaces for non-opted flows and operator/system contexts. They are not the valid agent surface for fully opted-in role-scoped flows.
 
 ### Required Agents
 
@@ -582,7 +586,7 @@ When an event arrives in an agent's inbox, the platform creates or resumes an ag
 7. Session completes when the agent signals done or hits `max_turns_per_task`.
 8. Session state is persisted for audit and debugging.
 
-The platform auto-generates emit tools from each agent's `emit_events` list. Agents do not need to list emit tools in `tools`. Universal tools (`agent_message`, `mailbox_send`) are also auto-granted.
+The platform auto-generates emit tools from each agent's `emit_events` list. Agents do not need to list emit tools in `tools`. Universal communication tools (`agent_message`, `mailbox_send`) are also auto-granted. Entity tools are delivered from the role-scoped entity-tool contract when the owning flow opts in with `tool_surface.role_scoped_entity_tools: true`.
 
 #### Conversation Modes
 
@@ -697,8 +701,12 @@ The platform-builtin tools are:
 
 - `create_flow_instance` — create a new dynamic flow instance from a template (**handler action only**, not directly callable by agents)
 - `record_evidence` — append payload to entity accumulator (also handler action only)
-- `create_entity` — create a new entity row
-- `query_entities` — query entities by state, fields, or aggregation
+- `create_entity` — create a new entity row (legacy/operator/system compatibility, not exposed to fully opted-in role-scoped agents)
+- `get_entity` — read an entity by ID (legacy/operator/system compatibility, replaced by generated `read_*` tools for opted-in actors)
+- `query_entities` — query entities by state, fields, or aggregation (legacy/operator/system compatibility)
+- `query_metrics` — read aggregated metrics across entities (legacy/operator/system compatibility)
+- `save_entity_field` — write a specific entity field (legacy/operator/system compatibility, replaced by generated save/update tools for opted-in actors)
+- `search_entities` — query entities by stage, field values, or metadata (legacy/operator/system compatibility)
 - `agent_message` — send a message to another agent (auto-granted)
 - `mailbox_send` — send an item to the human mailbox (auto-granted)
 

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -710,6 +710,8 @@ The platform-builtin tools are:
 - `agent_message` — send a message to another agent (auto-granted)
 - `mailbox_send` — send an item to the human mailbox (auto-granted)
 
+Default-deny still applies. A call is valid only when the tool is explicitly listed in `tools`, is a universal communication tool, is a generated emit tool, is a generated role-scoped entity tool for an opted-in actor, or is an authorized `native_tools` capability.
+
 Custom tool definitions in `tools.yaml` require a `description` field and optionally include `handler_type`, `input_schema`, `output_schema`, `parameters`, and `returns`. The fields `endpoint` and `type` are explicitly not accepted.
 
 ### Prompt Templating

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1293,6 +1293,7 @@ The platform owns ALL tool schema serving. It reads tool definition YAML, genera
 
 - `note`: create_flow_instance is a handler ACTION field value, not a tool agents can call. It is listed here for completeness but invoked via action: create_flow_instance in node handlers.
 - `handler_registration`: At bootstrap, the workflow module registers handlers for its tools. The platform provides the MCP gateway and schema validation. One tools file per workflow contains all tool schemas for the actor's visible surface: universal communication tools, generated emit tools, generated role-scoped entity tools for opted-in actors, and explicitly configured workflow-specific tools.
+- `default_deny`: If an agent calls a tool that is not in its `tools` list, not a universal communication tool, not an emit tool, not a generated role-scoped entity tool for an opted-in actor, and not an authorized `native_tools` capability, the call is rejected.
 ## custom_tool_schema
 
 - `description`: Accepted fields for tool definitions in tools.yaml.

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -199,19 +199,24 @@ entity_schema:
 
 ## persistence_model
 
-- `description`: Agents do not have raw database access. The platform provides typed persistence tools auto-generated from the entity_schema in package.yaml. For each field group in the entity schema, the platform generates save/get tools with validated input schemas. This ensures all data access is permissioned, auditable, and storage-backend agnostic.
-- `auto_generated_tools`:
-  - `get_entity`: Read entity by ID. Returns all fields the agent has permission to see.
-  - `save_entity_field`: Write a specific field on an entity. Field must exist in entity_schema.
-  - `search_entities`: Query entities by stage, field values, or metadata.
-  - `query_metrics`: Read aggregated metrics (counts, sums, averages) across entities.
+- `description`: Agents do not have raw database access. The platform derives agent-facing persistence tools from flow-owned entity contracts, `agents.yaml` `entity_writes`, and the shared type system. This keeps data access permissioned, auditable, and storage-backend agnostic.
+- `role_scoped_entity_tools`:
+  - `opt_in`: A flow opts into the Path alpha entity-tool model with `tool_surface.role_scoped_entity_tools: true` in `schema.yaml`.
+  - `current_entity_binding`: Generated role-scoped entity tools operate on the current entity resolved from the triggering event/session context. Agent-supplied `entity_id`, `entity_type`, or `flow_instance` arguments are not accepted.
+  - `generated_reads`: `read_{entity_type}()` returns the complete current entity. `read_{entity_type}_{field}()` returns the complete typed field value.
+  - `generated_writes`: `save_{entity_type}_{field}({value})` writes one authorized field. `update_{entity_type}_{field}_{subpath}({value})` updates one generated top-level subpath for a writable named-object field.
+  - `entity_writes`: `agents.yaml` `entity_writes.<entity_type>.save` or `entity_writes.<flow_id>.<entity_type>.save` is the canonical authorization source for generated save/update tools.
+  - `non_lossy_invariant`: Generated typed reads return the complete typed value or fail closed with an explicit typed-read error. They never silently return preview, truncated, omitted, or follow-up-file placeholder shapes as the value.
+  - `generated_schema_closure`: Generated entity-tool input and output schemas are closed recursively with explicit required fields, `additionalProperties: false`, and enum constraints. Provider-visible schemas, runtime validation, and bootverify must agree.
+  - `legacy_surface_retirement`: Fully opted-in role-scoped actors do not see or call the legacy entity surface names: `create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `search_entities`, `query_metrics`, and `save_entity_field`.
+  - `compatibility_boundary`: Non-opted flows, operator/system surfaces, and explicitly tracked rollout compatibility may continue to expose legacy entity tools until their parent rollout issues close.
 
-- `schema_source`: package.yaml → entity_schema
+- `schema_source`: entities.yaml + types.yaml
 ## required_agents
 
 - `description`: required_agents in schema.yaml declares agents the flow needs.
 - `fulfillment_rule`: The agent YAML map key must match the role field in required_agents. This is the canonical identity: if schema says role: classifier-agent, agents.yaml must have a top-level key classifier-agent. No separate fulfills: field.
-- `note_on_empty`: required_agents entries with empty subscriptions and emits are valid. They declare that the flow needs this agent role to exist, even if the agent only uses universal tools (agent_message, mailbox_send). Common for managerial roles that coordinate via messages rather than event subscriptions.
+- `note_on_empty`: required_agents entries with empty subscriptions and emits are valid. They declare that the flow needs this agent role to exist, even if the agent only uses universal communication/mailbox tools (`agent_message`, `mailbox_send`). Common for managerial roles that coordinate via messages rather than event subscriptions.
 ## hello_world_example
 
 - `description`: Minimal flow that processes one event and advances state.
@@ -891,7 +896,7 @@ Specification for the platform engine — how it loads, validates, and executes 
 - `Timers are cancelled`
 - `Agent sessions are terminated`
 - `All persisted state remains in the database`
-- `Entity is queryable via query_entities tool`
+- Entity remains queryable through explicit read/query surfaces. For fully opted-in role-scoped agents this means generated current-entity reads; legacy `query_entities` remains a non-opted/operator/system compatibility surface.
 
 - `archival`: Future concern — retention policy and cold storage are not specified in v1.1.0.
 - `event_rejection`: When an event arrives targeting an entity in a terminal state, the platform rejects it before handler execution. No guard runs, no handler runs, no state changes. The event is marked as rejected with reason: terminal_entity. This is unconditional — no configuration can override it. Terminal means terminal.
@@ -953,7 +958,7 @@ Specification for the platform engine — how it loads, validates, and executes 
   - `description`: The platform auto-generates emit tools from each agent's emit_events list. Agents do NOT need to list emit tools in tools_tier2.
   - `naming`: emit_{event_name} where dots are replaced with underscores. Example: emit_events: [score.dimension_complete] → tool: emit_score_dimension_complete
   - `behavior`: Each emit tool accepts a payload object matching the event's schema in events.yaml. The platform validates the payload, attaches sender context, and publishes the event.
-  - `universal_tools`: Some tools are auto-granted to all agents without explicit tools_tier2 listing: agent_message, mailbox_send. These are "universal" tools.
+  - `universal_tools`: `agent_message` and `mailbox_send` are auto-granted to all agents without explicit tool listing. Entity tools are governed by the role-scoped entity-tool contract, not by prompt prose.
 
 - `task_mode_audit`: Agents in task conversation_mode do NOT get an agent_sessions row. Each event invocation is independent at runtime, but the sanitized conversation snapshot and per-turn telemetry are still persisted for audit/debugging. Task-mode conversation snapshots live in a dedicated audit persistence surface and are never reloaded as live session state.
 - `provider_session_ids`: External LLM provider session IDs (e.g., Anthropic conversation ID) are stored in agent_sessions.runtime_state.provider_session_id, NOT in session_id. session_id is the platform-owned UUID primary key. The provider ID is an implementation detail that may change if the provider is swapped.
@@ -1277,13 +1282,17 @@ The platform owns ALL tool schema serving. It reads tool definition YAML, genera
 - `tools`:
   - `create_flow_instance`: Create a new dynamic flow instance from a template. Handler action only.
   - `record_evidence`: Append payload to entity accumulator. Requires evidence_target field on the handler specifying which accumulator key to write to.
-  - `create_entity`: Create a new entity row in entity_state.
-  - `query_entities`: Query entities by state, fields, or aggregation.
+  - `create_entity`: Create a new entity row in entity_state. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
+  - `get_entity`: Read an entity by ID. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces in favor of generated `read_{entity_type}` tools.
+  - `query_entities`: Query entities by state, fields, or aggregation. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
+  - `query_metrics`: Read aggregated metrics across entities. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
+  - `save_entity_field`: Write a specific field on an entity. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces in favor of generated save/update tools.
+  - `search_entities`: Query entities by stage, field values, or metadata. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
   - `agent_message`: Send a message to another agent (auto-granted to all agents).
   - `mailbox_send`: Send an item to the human mailbox (auto-granted to all agents).
 
 - `note`: create_flow_instance is a handler ACTION field value, not a tool agents can call. It is listed here for completeness but invoked via action: create_flow_instance in node handlers.
-- `handler_registration`: At bootstrap, the workflow module registers handlers for its tools. The platform provides the MCP gateway and schema validation. One tools file per workflow containing all tool schemas (universal + workflow-specific). The platform does not need separate tool files.
+- `handler_registration`: At bootstrap, the workflow module registers handlers for its tools. The platform provides the MCP gateway and schema validation. One tools file per workflow contains all tool schemas for the actor's visible surface: universal communication tools, generated emit tools, generated role-scoped entity tools for opted-in actors, and explicitly configured workflow-specific tools.
 ## custom_tool_schema
 
 - `description`: Accepted fields for tool definitions in tools.yaml.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -178,6 +178,18 @@ active_issues:
     title: Enforce closed generated schemas for typed tools and emits
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 568
+    title: Per-role entity tool contracts / provider-visible schemas
+    maps_to:
+      - transport_policy_and_surface_parity
+  - id: 579
+    title: Retire universal agent-surface entity tools for fully opted-in role-scoped flows
+    maps_to:
+      - transport_policy_and_surface_parity
+  - id: 612
+    title: Land Path alpha role-scoped tool-contract model in canonical platform spec
+    maps_to:
+      - transport_policy_and_surface_parity
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -197,6 +209,7 @@ nodes:
       - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
       - generated role-scoped typed reads can be silently downgraded by generic transport projection into preview/truncated shapes instead of complete typed values or explicit typed-read errors
       - generated typed tool and emit schemas can drift between provider-visible delivery, runtime validation, and bootverify, allowing undeclared payload keys or missing required/enum constraints to survive one surface
+      - canonical platform specs and generated docs can lag runtime Path alpha tool delivery, re-authorizing legacy universal entity-tool semantics after opted-in actors have moved to generated role-scoped tools
     representative_issues:
       - 111
       - 136
@@ -206,9 +219,12 @@ nodes:
       - 381
       - 444
       - 544
+      - 568
       - 571
+      - 579
       - 580
       - 582
+      - 612
     common_framing_mistakes:
       too_broad:
         - tool transport is inconsistent


### PR DESCRIPTION
## Summary

Closes #612.

This PR lands the Path alpha role-scoped entity-tool contract model in the authoritative platform spec and aligns adjacent current docs/watchlist state with the already-implemented runtime first slices.

## Governing Refs / Context

- Swarm #612 approved as first slice under #568/#579.
- Authoritative spec sections updated in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `contract_formats.persistence_model.role_scoped_entity_tools`
  - `engine.agent_specification.emit_tool_convention.universal_tools`
  - `tool_model.platform_builtin_tools`
  - `tool_model.agent_tool_filtering`
- Binding runtime evidence from prior children: #581/#584, #580/#587, #582/#591, #579/#593.

## Semantic Migration

- New canonical owner: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` Path alpha role-scoped entity-tool sections.
- Old non-authoritative path: issue-thread/review-draft-only Path alpha context plus stale universal entity-tool prose.
- Old producer/reader/writer path now invalid for fully opted-in actors: treating `create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `search_entities`, `query_metrics`, or `save_entity_field` as universal agent-visible entity tools.
- Production paths checked: runtime generator/registry/executor/schema-closure/typed-read tests are unchanged and pass.
- Migration completeness: complete for #612 spec/docs/watchlist first slice. This does not close #568/#579 final runtime rollout or Empire prerequisites.

## Validation

- `python3` YAML parse for `platform-spec.yaml` and `runtime-operations.yaml`
- Residue grep for stale universal entity-tool auto-grant claims
- `git diff --check`
- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/llm ./internal/runtime/agents -run 'RoleScoped|ToolDefinitionsForActor|HideEntityScoped|allowed_tools|AllowedTools|ToolCatalog|Writable|Legacy|Universal|CurrentEntity|Fallback|RetiresLegacy|DoesNotInjectRetired|TypedRead|GeneratedSchema|Closed|Emit' -count=1`
- `go test ./cmd/swarm -run 'Verify|BuiltinToolParity|WorkflowValidation|RoleScoped|Tool' -count=1`
- `go test ./...`

No broad #568/#579 runtime closure is claimed from this spec-doc alignment PR.