### PR TITLE
[agent-a][issue #611] Gate selected fork recipient planning

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -545,6 +545,16 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 	if !runForkPlanHasBoundary(model.RouteTopology.InvalidPaths, "copy_source_routing_rules", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("selected-contract route invalid paths = %#v", model.RouteTopology.InvalidPaths)
 	}
+	if model.RecipientPlanning == nil ||
+		model.RecipientPlanning.Owner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		!model.RecipientPlanning.NonMutating ||
+		!model.RecipientPlanning.RecipientPlanningSupported ||
+		model.RecipientPlanning.DeliveryWritesSupported {
+		t.Fatalf("selected-contract recipient planning = %#v", model.RecipientPlanning)
+	}
+	if !runForkPlanHasBoundary(model.RecipientPlanning.RequiredConsumers, "eventbus_publish_recipient_guard", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("selected-contract recipient planning consumers = %#v", model.RecipientPlanning.RequiredConsumers)
+	}
 	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractRouteTopologyNonMutating) {
 		t.Fatalf("selected-contract execution blockers = %#v, want route topology non-mutating blocker", model.UnsupportedBlockers)
 	}
@@ -604,6 +614,11 @@ func TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *tes
 	}
 	if result.Owner != store.RunForkSelectedContractExecutionOwner || result.ExecutedEventCount != 1 || len(result.ForkEvents) != 1 {
 		t.Fatalf("selected execution result = %#v", result)
+	}
+	if result.SelectedContractExecutionAdmission == nil ||
+		result.SelectedContractExecutionAdmission.RecipientPlanning == nil ||
+		result.SelectedContractExecutionAdmission.RecipientPlanning.Owner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("selected execution recipient planning admission = %#v", result.SelectedContractExecutionAdmission)
 	}
 	var lineageRows int
 	if err := db.QueryRowContext(context.Background(), `

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3303,6 +3303,19 @@ run_model:
       a named blocker. It MUST NOT copy source routing_rules or materialized flow-instance route rows, persist
       fork-local route rows, derive executable recipients, invoke the delivery planner for fork work, create
       event_deliveries, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
+    selected_contract_recipient_planning: 'Selected-contract recipient planning for mutating fork execution is owned by
+      runtime.run_fork.selected_contract_recipient_planning after selected route topology. It consumes the durable
+      selected-contract binding, runtime.run_fork.contract_frontier_admission, runtime.run_fork.selected_contract_route_admission,
+      and runtime.run_fork.selected_contract_route_topology, then produces deterministic fork-local recipient-plan
+      evidence for selected frontier events before selected execution publishes fork-local events. The selected execution
+      publish path and EventBus.Publish MUST consume/gate on this owner before deriving recipients for selected-fork work.
+      internal/runtime/bus.deliveryPlanner.Plan MAY be a downstream helper or isolated pure primitive, but it is not the
+      canonical owner and MUST NOT bypass this owner. Dynamic flow-instance topology remains fail-closed unless explicit
+      fork-local topology proof exists. Source route rows, source flow-instance route rows, source event_deliveries,
+      source recipients, source receipts, source dead letters, and post-fork source outcomes are invalid as executable
+      fork truth or fork suppressors. This owner MUST NOT persist fork-local route rows, write event_deliveries, run
+      handlers, write receipts, dead letters, idempotency state, emitted follow-ups, timers, sessions, turns,
+      source-advanced policy, contract-swap state, or UI/API execution state.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3354,6 +3367,15 @@ run_model:
         evidence only. Dynamic flow-instance topology requires explicit fork-local topology proof and otherwise
         remains fail-closed. This owner is still non-mutating: it does not persist route rows, derive executable
         recipients, write deliveries, or run handlers.'
+      3g_selected_contract_recipient_planning: 'For selected-contract mutating fork execution, fork-local recipient
+        planning is a separate owner beyond route topology. The selected execution model, admission, publish path, and
+        EventBus.Publish recipient guard consume runtime.run_fork.selected_contract_recipient_planning before selected
+        fork recipient derivation. The owner plans recipients from selected binding, frontier evidence, route admission,
+        and route topology evidence only; source deliveries, source route rows, source recipients, source receipts,
+        source dead letters, and post-fork source outcomes are not executable fork truth or suppressors. This owner is
+        still non-mutating: it does not persist route rows, write deliveries, run handlers, or own receipts, dead
+        letters, idempotency, emitted follow-ups, timers, sessions, turns, source-advanced policy, contract swap, or
+        UI/API execution state.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -166,6 +166,10 @@ active_issues:
     title: Gate selected-contract fork route reconstruction and recipient ownership
     maps_to:
       - timestamp_fork_replay_resume_ownership
+  - id: 611
+    title: Gate selected-contract recipient planning owner and publish-path consumer migration
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -275,6 +279,7 @@ nodes:
       - selected-contract timestamp forks with source timer or route facts must keep those rows as evidence-only fail-closed blockers until separate timer and route reconstruction owners are approved; source timers, routing_rules, route recipients, and timer firings are not executable selected-fork work
       - selected-contract route/subscription reconstruction needs a non-mutating route-history admission owner that consumes selected-source route derivation, distinguishes frontier route/recipient admission from historical route evidence, and keeps route persistence, executable recipients, delivery writes, and handler execution split
       - selected-contract route/topology truth needs a canonical owner beyond route admission before recipient delivery; route admission is prerequisite evidence, static selected-source topology is fork-local truth only through the selected route derivation owner, and dynamic flow-instance topology must be fork-local-proven or fail-closed without copying source routing rows
+      - selected-contract recipient planning needs a canonical owner beyond route topology before selected execution publishes fork-local events; selected execution and EventBus.Publish must consume that owner before recipient derivation, while delivery writes, route persistence, handlers, timers, sessions, turns, source-advanced policy, contract swap, and UI/API remain separately gated siblings
     representative_issues:
       - 564
       - 565
@@ -292,6 +297,7 @@ nodes:
       - 602
       - 604
       - 609
+      - 611
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -24,31 +24,45 @@ type EventInterceptor interface {
 type PayloadValidator func(eventType string, payload []byte) error
 
 type EventBus struct {
-	mu                  sync.RWMutex
-	channels            map[events.EventType]map[string]chan events.Event
-	agentChans          map[string]chan events.Event
-	subscriptions       map[string][]events.EventType
-	subscriptionKinds   map[string]inMemorySubscriberKind
-	pendingInternalByID map[string][]string
-	routeTable          *RouteTable
-	deliveryPlanner     deliveryPlanner
-	interceptors        []EventInterceptor
-	interceptorProvider func() []EventInterceptor
-	store               EventStore
-	logger              LoggerHook
-	semanticSource      semanticview.Source
-	payloadValidator    PayloadValidator
-	outboxSweeperActive bool
-	inFlightPublishes   atomic.Int64
+	mu                          sync.RWMutex
+	channels                    map[events.EventType]map[string]chan events.Event
+	agentChans                  map[string]chan events.Event
+	subscriptions               map[string][]events.EventType
+	subscriptionKinds           map[string]inMemorySubscriberKind
+	pendingInternalByID         map[string][]string
+	routeTable                  *RouteTable
+	deliveryPlanner             deliveryPlanner
+	interceptors                []EventInterceptor
+	interceptorProvider         func() []EventInterceptor
+	store                       EventStore
+	logger                      LoggerHook
+	semanticSource              semanticview.Source
+	payloadValidator            PayloadValidator
+	recipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
+	recipientPlanGuard          PublishRecipientPlanGuard
+	outboxSweeperActive         bool
+	inFlightPublishes           atomic.Int64
 }
 
+type PublishRecipientPlan struct {
+	Recipients             []string
+	PersistedRecipients    []string
+	RoutedRecipients       []PublishDiagnosticRecipient
+	SubscriptionRecipients []string
+}
+
+type PublishRecipientPlanAdmissionGuard func(context.Context, events.Event) error
+type PublishRecipientPlanGuard func(context.Context, events.Event, PublishRecipientPlan) error
+
 type EventBusOptions struct {
-	Logger              LoggerHook
-	Interceptors        []EventInterceptor
-	InterceptorProvider func() []EventInterceptor
-	ContractBundle      semanticview.Source
-	RouteTable          *RouteTable
-	PayloadValidator    PayloadValidator
+	Logger                      LoggerHook
+	Interceptors                []EventInterceptor
+	InterceptorProvider         func() []EventInterceptor
+	ContractBundle              semanticview.Source
+	RouteTable                  *RouteTable
+	PayloadValidator            PayloadValidator
+	RecipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
+	RecipientPlanGuard          PublishRecipientPlanGuard
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -98,18 +112,20 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		routeTable = derived
 	}
 	eb := &EventBus{
-		channels:            make(map[events.EventType]map[string]chan events.Event),
-		agentChans:          make(map[string]chan events.Event),
-		subscriptions:       make(map[string][]events.EventType),
-		subscriptionKinds:   make(map[string]inMemorySubscriberKind),
-		pendingInternalByID: make(map[string][]string),
-		routeTable:          routeTable,
-		store:               store,
-		logger:              opts.Logger,
-		interceptors:        filtered,
-		interceptorProvider: opts.InterceptorProvider,
-		semanticSource:      semanticSource,
-		payloadValidator:    opts.PayloadValidator,
+		channels:                    make(map[events.EventType]map[string]chan events.Event),
+		agentChans:                  make(map[string]chan events.Event),
+		subscriptions:               make(map[string][]events.EventType),
+		subscriptionKinds:           make(map[string]inMemorySubscriberKind),
+		pendingInternalByID:         make(map[string][]string),
+		routeTable:                  routeTable,
+		store:                       store,
+		logger:                      opts.Logger,
+		interceptors:                filtered,
+		interceptorProvider:         opts.InterceptorProvider,
+		semanticSource:              semanticSource,
+		payloadValidator:            opts.PayloadValidator,
+		recipientPlanAdmissionGuard: opts.RecipientPlanAdmissionGuard,
+		recipientPlanGuard:          opts.RecipientPlanGuard,
 	}
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -177,8 +177,14 @@ func (eb *EventBus) publishTransactional(
 		return fmt.Errorf("persist event: %w", err)
 	}
 
+	if err := eb.authorizePublishRecipientPlanning(txctx, evt); err != nil {
+		return err
+	}
 	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
 	if err != nil {
+		return err
+	}
+	if err := eb.authorizePublishRecipientPlan(txctx, evt, inboundPlan); err != nil {
 		return err
 	}
 	eb.recordPublishDiagnostic(txctx, evt, inboundPlan)
@@ -367,12 +373,37 @@ func (eb *EventBus) publishSubscribedNonTransactional(ctx context.Context, evt e
 }
 
 func (eb *EventBus) planSubscribedPublish(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
+	if err := eb.authorizePublishRecipientPlanning(ctx, evt); err != nil {
+		return eventDeliveryPlan{}, err
+	}
 	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
+	if err := eb.authorizePublishRecipientPlan(ctx, evt, plan); err != nil {
+		return eventDeliveryPlan{}, err
+	}
 	eb.recordPublishDiagnostic(ctx, evt, plan)
 	return plan, nil
+}
+
+func (eb *EventBus) authorizePublishRecipientPlanning(ctx context.Context, evt events.Event) error {
+	if eb == nil || eb.recipientPlanAdmissionGuard == nil {
+		return nil
+	}
+	return eb.recipientPlanAdmissionGuard(ctx, evt)
+}
+
+func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
+	if eb == nil || eb.recipientPlanGuard == nil {
+		return nil
+	}
+	return eb.recipientPlanGuard(ctx, evt, PublishRecipientPlan{
+		Recipients:             uniqueStrings(plan.Recipients),
+		PersistedRecipients:    uniqueStrings(plan.PersistedRecipients),
+		RoutedRecipients:       eb.describeSubscribersForEvent(string(evt.Type), plan.RoutedRecipients),
+		SubscriptionRecipients: uniqueStrings(plan.SubscribedRecipients),
+	})
 }
 
 func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -45,7 +45,7 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 		return store.RunForkSelectedContractRouteAdmission{}, err
 	}
 	routeEvents := selectedRouteHistoryEvents(routeTable, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
-	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Plan, req.FrontierAdmission)
+	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Source, req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
 		Message: "selected-contract route admission is non-mutating; route persistence, recipient delivery writes, and handler execution remain separately gated",
@@ -155,11 +155,11 @@ func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, events []sele
 	return out
 }
 
-func selectedRouteHistoryDynamicFlowInstances(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []string {
+func selectedRouteHistoryDynamicFlowInstances(source semanticview.Source, plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []string {
 	seen := map[string]struct{}{}
 	add := func(value string) {
 		value = strings.Trim(strings.TrimSpace(value), "/")
-		if value != "" {
+		if value != "" && isContractFrontierTemplateInstancePath(source, value) {
 			seen[value] = struct{}{}
 		}
 	}
@@ -185,8 +185,8 @@ func selectedRouteHistoryRequiredConsumers() []store.RunForkSelectedContractExec
 		{
 			Concept:     "fork_local_recipient_planning",
 			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
-			Owner:       "internal/runtime/bus.delivery_planner",
-			Reason:      "executable route reconstruction must feed an approved recipient planner before delivery rows can be created",
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "executable route reconstruction must feed the canonical recipient-planning owner before delivery rows can be created",
 		},
 	}
 }

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -158,6 +158,13 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 	if err := validateSelectedContractExecutionModel(binding, req.FrontierAdmission, req.RouteAdmission, req.RouteTopology, req.ExecutionModel); err != nil {
 		return store.RunForkSelectedContractExecutionAdmission{}, err
 	}
+	recipientPlanning := req.ExecutionModel.RecipientPlanning
+	if recipientPlanning == nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRecipientPlanningOwner)
+	}
+	if err := validateSelectedContractRecipientPlanning(req.FrontierAdmission, req.RouteAdmission, req.RouteTopology, *recipientPlanning); err != nil {
+		return store.RunForkSelectedContractExecutionAdmission{}, err
+	}
 
 	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), req.ExecutionModel.UnsupportedBlockers...)
 	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
@@ -183,6 +190,7 @@ func BuildSelectedContractExecutionAdmission(ctx context.Context, req SelectedCo
 		FrontierEventCount:    req.ExecutionModel.FrontierEventCount,
 		FrontierEvents:        append([]store.RunForkSelectedContractFrontierEvent(nil), req.ExecutionModel.FrontierEvents...),
 		RouteTopology:         &req.RouteTopology,
+		RecipientPlanning:     recipientPlanning,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -290,6 +298,12 @@ func validateSelectedContractExecutionModel(binding store.RunForkSelectedContrac
 	}
 	if !reflect.DeepEqual(*model.RouteTopology, routeTopology) {
 		return fmt.Errorf("selected-contract execution admission model route topology does not match canonical route topology truth")
+	}
+	if model.RecipientPlanning == nil {
+		return fmt.Errorf("selected-contract execution admission model must carry %s", store.RunForkSelectedContractRecipientPlanningOwner)
+	}
+	if err := validateSelectedContractRecipientPlanning(frontier, routeAdmission, routeTopology, *model.RecipientPlanning); err != nil {
+		return err
 	}
 	if model.ContractBinding.Owner != store.RunForkSelectedContractBindingOwner ||
 		model.ContractBinding.Disposition != store.RunForkSelectedContractDispositionPrerequisite {

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -70,6 +70,9 @@ func TestBuildSelectedContractExecutionAdmissionConsumesDurableBinding(t *testin
 	if admission.RouteTopology == nil || admission.RouteTopology.Owner != store.RunForkSelectedContractRouteTopologyOwner {
 		t.Fatalf("route topology = %#v, want canonical selected-contract route topology", admission.RouteTopology)
 	}
+	if admission.RecipientPlanning == nil || admission.RecipientPlanning.Owner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("recipient planning = %#v, want canonical selected-contract recipient planning", admission.RecipientPlanning)
+	}
 	if !executionBoundaryHas(admission.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copy invalid", admission.InvalidPaths)
 	}
@@ -341,6 +344,30 @@ func TestBuildSelectedContractExecutionAdmissionRejectsForgedRouteTopology(t *te
 	})
 	if err == nil || !strings.Contains(err.Error(), "canonical route-admission evidence") {
 		t.Fatalf("error = %v, want forged route topology admission failure", err)
+	}
+}
+
+func TestBuildSelectedContractExecutionAdmissionRejectsForgedRecipientPlanning(t *testing.T) {
+	ctx := context.Background()
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	frontier := testContractFrontierAdmission(binding.ContractSelection)
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	model := testSelectedContractExecutionModel(t, frontier)
+	model.RecipientPlanning.Owner = "cmd.swarm.local_recipient_plan"
+
+	_, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
+		ForkRunID:         forkRunID,
+		BindingReader:     &fakeSelectedContractBindingReader{binding: binding},
+		SourceLoader:      &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)},
+		FrontierAdmission: frontier,
+		RouteAdmission:    routeAdmission,
+		RouteTopology:     routeTopology,
+		ExecutionModel:    model,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRecipientPlanningOwner) {
+		t.Fatalf("error = %v, want canonical recipient planning failure", err)
 	}
 }
 

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -126,11 +126,12 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
 	}
 	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
-		Store:        req.Store,
-		LoadedSource: loadedSource,
-		SourceRunID:  plan.SourceRunID,
-		ForkRunID:    materialization.ForkRunID,
-		SourceEvents: sourceEventIDs,
+		Store:             req.Store,
+		LoadedSource:      loadedSource,
+		RecipientPlanning: *model.RecipientPlanning,
+		SourceRunID:       plan.SourceRunID,
+		ForkRunID:         materialization.ForkRunID,
+		SourceEvents:      sourceEventIDs,
 	})
 	if err != nil {
 		return SelectedContractExecutionResult{
@@ -196,11 +197,12 @@ func cleanupSelectedContractExecutionFailure(ctx context.Context, store *store.P
 }
 
 type publishSelectedContractForkEventsRequest struct {
-	Store        *store.PostgresStore
-	LoadedSource LoadedSelectedContractSource
-	SourceRunID  string
-	ForkRunID    string
-	SourceEvents []string
+	Store             *store.PostgresStore
+	LoadedSource      LoadedSelectedContractSource
+	RecipientPlanning store.RunForkSelectedContractRecipientPlanning
+	SourceRunID       string
+	ForkRunID         string
+	SourceEvents      []string
 }
 
 func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedContractForkEventsRequest) ([]SelectedContractExecutionForkEvent, error) {
@@ -208,8 +210,14 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	if err != nil {
 		return nil, err
 	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(req.RecipientPlanning)
+	if err != nil {
+		return nil, err
+	}
 	bus, err := runtimebus.NewEventBusWithOptions(req.Store, runtimebus.EventBusOptions{
-		ContractBundle: req.LoadedSource.Source,
+		ContractBundle:              req.LoadedSource.Source,
+		RecipientPlanAdmissionGuard: guard.AuthorizeEvent,
+		RecipientPlanGuard:          guard.Authorize,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create selected-contract execution bus: %w", err)
@@ -222,6 +230,7 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	for _, sourceEvent := range sourceEvents {
 		forkEventID := uuid.NewString()
 		evt := selectedContractForkEvent(req.ForkRunID, forkEventID, sourceEvent)
+		guard.ExpectForkEvent(forkEventID, sourceEvent.SourceEventID)
 		if err := bus.Publish(runCtx, evt); err != nil {
 			return out, fmt.Errorf("execute selected-contract fork event %s as %s: %w", sourceEvent.SourceEventID, forkEventID, err)
 		}

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"swarm/internal/events"
+	"swarm/internal/runtime/bus"
 	"swarm/internal/runtime/runforkadmission"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -54,6 +56,12 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 	}
 	if result.Owner != store.RunForkSelectedContractExecutionOwner || result.ExecutedEventCount != 1 || len(result.ForkEvents) != 1 {
 		t.Fatalf("result = %#v", result)
+	}
+	if result.SelectedContractExecutionAdmission.RecipientPlanning == nil ||
+		result.SelectedContractExecutionAdmission.RecipientPlanning.Owner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		!result.SelectedContractExecutionAdmission.RecipientPlanning.RecipientPlanningSupported ||
+		len(result.SelectedContractExecutionAdmission.RecipientPlanning.RecipientPlanEvents) != 1 {
+		t.Fatalf("recipient planning admission = %#v", result.SelectedContractExecutionAdmission.RecipientPlanning)
 	}
 	forkEventID := result.ForkEvents[0].ForkEventID
 	if forkEventID == "" || forkEventID == sourceEventID {
@@ -454,6 +462,121 @@ func TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint(
 	}
 	if forkReceipts == 0 || emittedFollowUps != 1 {
 		t.Fatalf("branch fork-local outcomes receipts=%d followUps=%d, want receipts and one follow-up", forkReceipts, emittedFollowUps)
+	}
+}
+
+func TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan(t *testing.T) {
+	frontier := testContractFrontierAdmission(testContractSelection())
+	sourceEventID := frontier.FrontierEvents[0].SourceEventID
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(planning)
+	if err != nil {
+		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
+	}
+	guard.ExpectForkEvent("fork-event", sourceEventID)
+
+	err = guard.AuthorizeEvent(context.Background(), events.Event{
+		ID:          "fork-event",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeEvent canonical recipient plan: %v", err)
+	}
+
+	err = guard.Authorize(context.Background(), events.Event{
+		ID:          "fork-event",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "alpha-intake",
+			Path:        "flow-a/alpha-intake",
+			RouteSource: "selected_contracts",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Authorize canonical recipient plan: %v", err)
+	}
+}
+
+func TestSelectedContractRecipientPlanPublishGuardRejectsBypassAndSubscriptions(t *testing.T) {
+	frontier := testContractFrontierAdmission(testContractSelection())
+	sourceEventID := frontier.FrontierEvents[0].SourceEventID
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(planning)
+	if err != nil {
+		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
+	}
+
+	err = guard.Authorize(context.Background(), events.Event{
+		ID:          "fork-event",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "alpha-intake",
+			Path:        "flow-a/alpha-intake",
+			RouteSource: "selected_contracts",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRecipientPlanningOwner) {
+		t.Fatalf("Authorize without expectation error = %v, want recipient-planning evidence failure", err)
+	}
+
+	guard.ExpectForkEvent("fork-event-subscription", sourceEventID)
+	err = guard.Authorize(context.Background(), events.Event{
+		ID:          "fork-event-subscription",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "alpha-intake",
+			Path:        "flow-a/alpha-intake",
+			RouteSource: "selected_contracts",
+		}},
+		SubscriptionRecipients: []string{"legacy-subscription"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "live subscription") {
+		t.Fatalf("Authorize subscription recipient error = %v, want live subscription rejection", err)
+	}
+
+	guard.ExpectForkEvent("fork-event-wrong-recipient", sourceEventID)
+	err = guard.Authorize(context.Background(), events.Event{
+		ID:          "fork-event-wrong-recipient",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "other-node",
+			Path:        "flow-a/other-node",
+			RouteSource: "selected_contracts",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "routed recipients do not match") {
+		t.Fatalf("Authorize wrong recipient error = %v, want recipient-plan mismatch", err)
 	}
 }
 

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -100,9 +100,20 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 	if err := validateSelectedContractRouteTopology(admission, routeAdmission, routeTopology); err != nil {
 		return store.RunForkSelectedContractExecution{}, err
 	}
+	recipientPlanning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		return store.RunForkSelectedContractExecution{}, err
+	}
 
 	unsupportedBlockers := append([]store.RunForkUnsupportedBlocker(nil), admission.UnsupportedBlockers...)
 	for _, blocker := range routeTopology.UnsupportedBlockers {
+		unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, blocker)
+	}
+	for _, blocker := range recipientPlanning.UnsupportedBlockers {
 		unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, blocker)
 	}
 	unsupportedBlockers = appendRunForkUnsupportedBlocker(unsupportedBlockers, store.RunForkUnsupportedBlocker{
@@ -121,6 +132,7 @@ func BuildSelectedContractExecutionModel(req SelectedContractExecutionModelReque
 		FrontierEventCount:   admission.FrontierEventCount,
 		FrontierEvents:       selectedContractFrontierEvents(admission.FrontierEvents),
 		RouteTopology:        &routeTopology,
+		RecipientPlanning:    &recipientPlanning,
 		ContractBinding: store.RunForkSelectedContractExecutionBoundary{
 			Concept:     "selected_contract_binding",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
@@ -258,8 +270,8 @@ func selectedContractRouteTopologyRequiredConsumers() []store.RunForkSelectedCon
 		{
 			Concept:     "fork_local_recipient_planning",
 			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
-			Owner:       "internal/runtime/bus.delivery_planner",
-			Reason:      "recipient planning is a future consumer and is not invoked by the route topology owner",
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "recipient planning is a future consumer and must own executable selected-fork recipient evidence before delivery planning",
 		},
 	}
 }
@@ -351,6 +363,12 @@ func selectedContractFrontierEvents(events []store.RunForkContractFrontierEvent)
 
 func selectedContractExecutionRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
 	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "fork_local_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "selected execution must consume canonical recipient-plan evidence before publish-path recipient derivation",
+		},
 		{
 			Concept:     "fork_run_id_runtime_context",
 			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -109,6 +109,110 @@ func TestBuildSelectedContractRouteTopologyFailsClosedOnDynamicFlowInstances(t *
 	}
 }
 
+func TestBuildSelectedContractRecipientPlanningConsumesRouteTopology(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:           "source-event",
+			EventName:               "work.begin",
+			RuntimeEventOwners:      []string{"alpha-intake"},
+			WorkflowNodeSubscribers: []string{"beta-intake"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "alpha-intake",
+				Path:           "flow-a/alpha-intake",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
+
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	if planning.Owner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		planning.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		!planning.NonMutating ||
+		!planning.RecipientPlanningSupported ||
+		planning.DeliveryWritesSupported {
+		t.Fatalf("recipient planning ownership = %#v", planning)
+	}
+	if len(planning.RecipientPlanEvents) != 1 ||
+		planning.RecipientPlanEvents[0].SourceEventID != "source-event" ||
+		planning.RecipientPlanEvents[0].EventName != "work.begin" ||
+		len(planning.RecipientPlanEvents[0].Recipients) != 1 ||
+		planning.RecipientPlanEvents[0].Recipients[0].SubscriberID != "alpha-intake" {
+		t.Fatalf("recipient plan events = %#v", planning.RecipientPlanEvents)
+	}
+	if !executionBoundaryHas(planning.RequiredEvidence, "selected_contract_route_topology", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required evidence = %#v, want route topology prerequisite", planning.RequiredEvidence)
+	}
+	if !executionBoundaryHas(planning.RequiredConsumers, "selected_execution_publish_path", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required consumers = %#v, want selected execution publish-path consumer", planning.RequiredConsumers)
+	}
+	if !executionBoundaryHas(planning.InvalidPaths, "source_event_deliveries_as_recipient_truth", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source deliveries invalid", planning.InvalidPaths)
+	}
+	if !unsupportedBlockerHas(planning.UnsupportedBlockers, store.RunForkBlockerSelectedContractRecipientPlanningNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want recipient-planning non-mutating blocker", planning.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractRecipientPlanningKeepsDynamicTopologyBlocked(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:         "source-event",
+			EventName:             "review/inst-1/task.started",
+			SourceFlowInstances:   []string{"review/inst-1"},
+			SourceSubscriberTypes: []string{"node"},
+			SourceSubscriberIDs:   []string{"source-node"},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
+
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	if planning.RecipientPlanningSupported {
+		t.Fatalf("RecipientPlanningSupported = true, want false for unproven dynamic topology")
+	}
+	if !unsupportedBlockerHas(planning.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven) {
+		t.Fatalf("unsupported blockers = %#v, want dynamic topology blocker", planning.UnsupportedBlockers)
+	}
+}
+
 func TestBuildSelectedContractExecutionModelConsumesRouteTopologyAsTruth(t *testing.T) {
 	admission := store.RunForkContractFrontierAdmission{
 		Owner:                        store.RunForkContractFrontierAdmissionOwner,
@@ -175,6 +279,12 @@ func TestBuildSelectedContractExecutionModelConsumesRouteTopologyAsTruth(t *test
 	if model.RouteTopology == nil || model.RouteTopology.Owner != store.RunForkSelectedContractRouteTopologyOwner {
 		t.Fatalf("route topology = %#v, want canonical selected-contract route topology", model.RouteTopology)
 	}
+	if model.RecipientPlanning == nil || model.RecipientPlanning.Owner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("recipient planning = %#v, want canonical selected-contract recipient planning", model.RecipientPlanning)
+	}
+	if !executionBoundaryHas(model.RequiredConsumers, "fork_local_recipient_planning", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required consumers = %#v, want recipient planning prerequisite", model.RequiredConsumers)
+	}
 	if !executionBoundaryHas(model.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("invalid paths = %#v, want source delivery copying invalid", model.InvalidPaths)
 	}
@@ -231,6 +341,7 @@ func TestBuildSelectedContractExecutionModelCarriesFrontierBlockers(t *testing.T
 		store.RunForkBlockerContractFrontierRouteUnresolved,
 		store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
 		store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
+		store.RunForkBlockerSelectedContractRecipientPlanningNonMutating,
 		store.RunForkBlockerSelectedContractExecutionModelNonMutating,
 	} {
 		if !unsupportedBlockerHas(model.UnsupportedBlockers, code) {

--- a/internal/runtime/runforkexecution/recipient_planning.go
+++ b/internal/runtime/runforkexecution/recipient_planning.go
@@ -1,0 +1,440 @@
+package runforkexecution
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	"swarm/internal/store"
+)
+
+type SelectedContractRecipientPlanningRequest struct {
+	Admission      store.RunForkContractFrontierAdmission
+	RouteAdmission store.RunForkSelectedContractRouteAdmission
+	RouteTopology  store.RunForkSelectedContractRouteTopology
+}
+
+func BuildSelectedContractRecipientPlanning(req SelectedContractRecipientPlanningRequest) (store.RunForkSelectedContractRecipientPlanning, error) {
+	admission := req.Admission
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return store.RunForkSelectedContractRecipientPlanning{}, fmt.Errorf("selected-contract recipient planning requires %s admission; got %q", store.RunForkContractFrontierAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return store.RunForkSelectedContractRecipientPlanning{}, fmt.Errorf("selected-contract recipient planning requires non-mutating frontier admission")
+	}
+	if admission.HistoricalExecutionSupported {
+		return store.RunForkSelectedContractRecipientPlanning{}, fmt.Errorf("selected-contract recipient planning unexpectedly supports historical execution")
+	}
+	routeAdmission := req.RouteAdmission
+	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
+		return store.RunForkSelectedContractRecipientPlanning{}, err
+	}
+	routeTopology := req.RouteTopology
+	if err := validateSelectedContractRouteTopology(admission, routeAdmission, routeTopology); err != nil {
+		return store.RunForkSelectedContractRecipientPlanning{}, err
+	}
+	return canonicalSelectedContractRecipientPlanning(admission, routeTopology), nil
+}
+
+func canonicalSelectedContractRecipientPlanning(frontier store.RunForkContractFrontierAdmission, routeTopology store.RunForkSelectedContractRouteTopology) store.RunForkSelectedContractRecipientPlanning {
+	blockers := []store.RunForkUnsupportedBlocker{{
+		Code:    store.RunForkBlockerSelectedContractRecipientPlanningNonMutating,
+		Message: "selected-contract recipient planning is non-mutating; event append, delivery writes, and handler execution remain separately gated",
+	}}
+	for _, blocker := range routeTopology.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	return store.RunForkSelectedContractRecipientPlanning{
+		Owner:                       store.RunForkSelectedContractRecipientPlanningOwner,
+		RouteTopologyOwner:          routeTopology.Owner,
+		RouteAdmissionOwner:         routeTopology.RouteAdmissionOwner,
+		FutureExecutionOwner:        store.RunForkSelectedContractExecutionOwner,
+		NonMutating:                 true,
+		RecipientPlanningSupported:  selectedContractRecipientPlanningSupported(blockers),
+		DeliveryWritesSupported:     false,
+		ContractSelection:           routeTopology.ContractSelection,
+		FrontierEventCount:          routeTopology.FrontierEventCount,
+		FrontierSourceEventIDs:      append([]string(nil), routeTopology.FrontierSourceEventIDs...),
+		FrontierEvidenceFingerprint: routeTopology.FrontierEvidenceFingerprint,
+		RecipientPlanEvents:         selectedContractRecipientPlanEvents(frontier.FrontierEvents),
+		RequiredEvidence:            selectedContractRecipientPlanningRequiredEvidence(routeTopology),
+		RequiredConsumers:           selectedContractRecipientPlanningRequiredConsumers(),
+		BlockedSiblings:             selectedContractRecipientPlanningBlockedSiblings(),
+		InvalidPaths:                selectedContractRecipientPlanningInvalidPaths(),
+		UnsupportedBlockers:         blockers,
+	}
+}
+
+func selectedContractRecipientPlanningSupported(blockers []store.RunForkUnsupportedBlocker) bool {
+	for _, blocker := range blockers {
+		switch strings.TrimSpace(blocker.Code) {
+		case "", store.RunForkBlockerSelectedContractRecipientPlanningNonMutating,
+			store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+			store.RunForkBlockerSelectedContractRouteTopologyNonMutating:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func selectedContractRecipientPlanEvents(events []store.RunForkContractFrontierEvent) []store.RunForkSelectedContractRecipientPlanEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]store.RunForkSelectedContractRecipientPlanEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, store.RunForkSelectedContractRecipientPlanEvent{
+			SourceEventID: strings.TrimSpace(event.SourceEventID),
+			EventName:     strings.TrimSpace(event.EventName),
+			Recipients:    sortedFrontierRecipients(event.DerivedRecipients),
+			Disposition:   store.RunForkSelectedContractDispositionForkLocalTruth,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := strings.Join([]string{out[i].SourceEventID, out[i].EventName}, "\x00")
+		right := strings.Join([]string{out[j].SourceEventID, out[j].EventName}, "\x00")
+		return left < right
+	})
+	return out
+}
+
+func sortedFrontierRecipients(in []store.RunForkContractFrontierRecipient) []store.RunForkContractFrontierRecipient {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]store.RunForkContractFrontierRecipient, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, recipient := range in {
+		recipient = store.RunForkContractFrontierRecipient{
+			SubscriberType: strings.TrimSpace(recipient.SubscriberType),
+			SubscriberID:   strings.TrimSpace(recipient.SubscriberID),
+			Path:           strings.TrimSpace(recipient.Path),
+			RouteSource:    strings.TrimSpace(recipient.RouteSource),
+		}
+		if recipient.SubscriberType == "" || recipient.SubscriberID == "" {
+			continue
+		}
+		key := recipientKey(recipient)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, recipient)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return recipientKey(out[i]) < recipientKey(out[j])
+	})
+	return out
+}
+
+func selectedContractRecipientPlanningRequiredEvidence(routeTopology store.RunForkSelectedContractRouteTopology) []store.RunForkSelectedContractExecutionBoundary {
+	evidence := []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_contract_route_topology",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRouteTopologyOwner,
+			Reason:      "recipient planning consumes canonical fork-local route topology before selected execution can publish fork work",
+		},
+		{
+			Concept:     "selected_contract_binding",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractBindingOwner,
+			Reason:      "recipient planning is selected-source specific and must remain bound to durable selected contract evidence",
+		},
+	}
+	for _, item := range routeTopology.RequiredEvidence {
+		if strings.TrimSpace(item.Disposition) == store.RunForkSelectedContractDispositionPrerequisite {
+			evidence = append(evidence, item)
+		}
+	}
+	return evidence
+}
+
+func selectedContractRecipientPlanningRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_execution_publish_path",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "selected execution must consume recipient-plan evidence before EventBus.Publish can derive selected-fork recipients",
+		},
+		{
+			Concept:     "eventbus_publish_recipient_guard",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       "internal/runtime/bus.EventBus.Publish",
+			Reason:      "the live publish path remains a downstream consumer and must validate routed recipients against this owner before delivery writes",
+		},
+	}
+}
+
+func selectedContractRecipientPlanningBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "fork_local_event_delivery_writes",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "recipient planning does not append events or create event_deliveries",
+		},
+		{
+			Concept:     "handler_execution",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "internal/runtime/pipeline",
+			Reason:      "recipient planning evidence is computed before handler execution",
+		},
+		{
+			Concept:     "receipts_dead_letters_idempotency",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "outcome writes and suppressors remain separately gated",
+		},
+		{
+			Concept:     "dynamic_flow_instance_route_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       "internal/runtime/bus.RouteTable.AddFlowInstanceRoute",
+			Reason:      "dynamic topology remains fail-closed without fork-local topology proof",
+		},
+		{
+			Concept:     "timer_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "timer reconstruction remains a separate scheduler lifecycle owner",
+		},
+		{
+			Concept:     "sessions_turns_audits",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "session, turn, and audit reconstruction remain separately gated",
+		},
+	}
+}
+
+func selectedContractRecipientPlanningInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "source_route_rows_as_recipient_truth",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source routing_rules and flow_instance_routes are not executable selected-fork recipient truth",
+		},
+		{
+			Concept:     "source_event_deliveries_as_recipient_truth",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source event_deliveries are source-run history and must not define selected-fork recipients",
+		},
+		{
+			Concept:     "delivery_planner_as_canonical_owner",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "generic delivery planning may only be a downstream consumer guarded by recipient-plan evidence",
+		},
+		{
+			Concept:     "source_outcome_suppression",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source receipts, dead letters, retry state, and post-T outcomes cannot suppress selected-fork work",
+		},
+	}
+}
+
+func validateSelectedContractRecipientPlanning(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, routeTopology store.RunForkSelectedContractRouteTopology, planning store.RunForkSelectedContractRecipientPlanning) error {
+	if strings.TrimSpace(planning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return fmt.Errorf("selected-contract execution requires %s; got %q", store.RunForkSelectedContractRecipientPlanningOwner, planning.Owner)
+	}
+	if strings.TrimSpace(planning.RouteTopologyOwner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return fmt.Errorf("selected-contract recipient planning must consume %s; got %q", store.RunForkSelectedContractRouteTopologyOwner, planning.RouteTopologyOwner)
+	}
+	if strings.TrimSpace(planning.RouteAdmissionOwner) != store.RunForkSelectedContractRouteAdmissionOwner {
+		return fmt.Errorf("selected-contract recipient planning must consume %s; got %q", store.RunForkSelectedContractRouteAdmissionOwner, planning.RouteAdmissionOwner)
+	}
+	if strings.TrimSpace(planning.FutureExecutionOwner) != store.RunForkSelectedContractExecutionOwner {
+		return fmt.Errorf("selected-contract recipient planning must point to %s; got %q", store.RunForkSelectedContractExecutionOwner, planning.FutureExecutionOwner)
+	}
+	if !planning.NonMutating {
+		return fmt.Errorf("selected-contract recipient planning must be non-mutating")
+	}
+	if planning.DeliveryWritesSupported {
+		return fmt.Errorf("selected-contract recipient planning unexpectedly supports delivery writes")
+	}
+	if err := validateSelectionMatches("recipient planning", routeTopology.ContractSelection, planning.ContractSelection); err != nil {
+		return err
+	}
+	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(frontier)
+	if planning.FrontierEventCount != frontierEventCount {
+		return fmt.Errorf("selected-contract recipient planning frontier count mismatch: got %d want %d", planning.FrontierEventCount, frontierEventCount)
+	}
+	if !equalStringSlices(planning.FrontierSourceEventIDs, frontierSourceEventIDs) {
+		return fmt.Errorf("selected-contract recipient planning frontier source event IDs do not match current frontier evidence")
+	}
+	if strings.TrimSpace(planning.FrontierEvidenceFingerprint) != frontierFingerprint {
+		return fmt.Errorf("selected-contract recipient planning frontier fingerprint mismatch")
+	}
+	canonical := canonicalSelectedContractRecipientPlanning(frontier, routeTopology)
+	if !reflect.DeepEqual(planning, canonical) {
+		return fmt.Errorf("selected-contract recipient planning does not match canonical route-topology evidence")
+	}
+	return validateSelectedContractRouteTopology(frontier, routeAdmission, routeTopology)
+}
+
+func validateSelectedContractRecipientPlanningForPublish(planning store.RunForkSelectedContractRecipientPlanning) error {
+	if strings.TrimSpace(planning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return fmt.Errorf("selected-contract publish path requires %s; got %q", store.RunForkSelectedContractRecipientPlanningOwner, planning.Owner)
+	}
+	if !planning.NonMutating || planning.DeliveryWritesSupported {
+		return fmt.Errorf("selected-contract publish path requires non-mutating recipient planning without delivery writes")
+	}
+	if !planning.RecipientPlanningSupported {
+		return fmt.Errorf("selected-contract recipient planning is not supported for publish; blockers: %s", selectedContractBlockerCodes(planning.UnsupportedBlockers))
+	}
+	for _, blocker := range planning.UnsupportedBlockers {
+		switch strings.TrimSpace(blocker.Code) {
+		case "", store.RunForkBlockerSelectedContractRecipientPlanningNonMutating,
+			store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+			store.RunForkBlockerSelectedContractRouteTopologyNonMutating:
+			continue
+		default:
+			if msg := strings.TrimSpace(blocker.Message); msg != "" {
+				return fmt.Errorf("%s: %s", blocker.Code, msg)
+			}
+			return fmt.Errorf("%s", blocker.Code)
+		}
+	}
+	return nil
+}
+
+type selectedContractRecipientPlanPublishGuard struct {
+	plansBySourceEvent map[string]store.RunForkSelectedContractRecipientPlanEvent
+	sourceByForkEvent  map[string]string
+}
+
+func newSelectedContractRecipientPlanPublishGuard(planning store.RunForkSelectedContractRecipientPlanning) (*selectedContractRecipientPlanPublishGuard, error) {
+	if err := validateSelectedContractRecipientPlanningForPublish(planning); err != nil {
+		return nil, err
+	}
+	plans := map[string]store.RunForkSelectedContractRecipientPlanEvent{}
+	for _, event := range planning.RecipientPlanEvents {
+		sourceEventID := strings.TrimSpace(event.SourceEventID)
+		if sourceEventID == "" {
+			continue
+		}
+		plans[sourceEventID] = event
+	}
+	return &selectedContractRecipientPlanPublishGuard{
+		plansBySourceEvent: plans,
+		sourceByForkEvent:  map[string]string{},
+	}, nil
+}
+
+func (g *selectedContractRecipientPlanPublishGuard) ExpectForkEvent(forkEventID, sourceEventID string) {
+	if g == nil {
+		return
+	}
+	forkEventID = strings.TrimSpace(forkEventID)
+	sourceEventID = strings.TrimSpace(sourceEventID)
+	if forkEventID == "" || sourceEventID == "" {
+		return
+	}
+	g.sourceByForkEvent[forkEventID] = sourceEventID
+}
+
+func (g *selectedContractRecipientPlanPublishGuard) AuthorizeEvent(ctx context.Context, evt events.Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(evt.SourceAgent) != store.RunForkSelectedContractExecutionOwner {
+		return nil
+	}
+	_, _, err := g.expectedRecipientPlanEvent(evt)
+	return err
+}
+
+func (g *selectedContractRecipientPlanPublishGuard) Authorize(ctx context.Context, evt events.Event, actual runtimebus.PublishRecipientPlan) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(evt.SourceAgent) != store.RunForkSelectedContractExecutionOwner {
+		return nil
+	}
+	sourceEventID, expected, err := g.expectedRecipientPlanEvent(evt)
+	if err != nil {
+		return err
+	}
+	if len(actual.SubscriptionRecipients) > 0 {
+		return fmt.Errorf("selected-contract publish path cannot use live subscriptions as fork recipient truth")
+	}
+	if !recipientKeysEqual(expectedRecipientKeys(expected.Recipients), actualRecipientKeys(actual.RoutedRecipients)) {
+		return fmt.Errorf("selected-contract publish routed recipients do not match %s for source event %s", store.RunForkSelectedContractRecipientPlanningOwner, sourceEventID)
+	}
+	return nil
+}
+
+func (g *selectedContractRecipientPlanPublishGuard) expectedRecipientPlanEvent(evt events.Event) (string, store.RunForkSelectedContractRecipientPlanEvent, error) {
+	forkEventID := strings.TrimSpace(evt.ID)
+	sourceEventID := strings.TrimSpace(g.sourceByForkEvent[forkEventID])
+	if sourceEventID == "" {
+		return "", store.RunForkSelectedContractRecipientPlanEvent{}, fmt.Errorf("selected-contract publish path missing %s evidence for fork event %s", store.RunForkSelectedContractRecipientPlanningOwner, forkEventID)
+	}
+	expected, ok := g.plansBySourceEvent[sourceEventID]
+	if !ok {
+		return "", store.RunForkSelectedContractRecipientPlanEvent{}, fmt.Errorf("selected-contract publish path has no recipient plan for source event %s", sourceEventID)
+	}
+	if strings.TrimSpace(expected.EventName) != strings.TrimSpace(string(evt.Type)) {
+		return "", store.RunForkSelectedContractRecipientPlanEvent{}, fmt.Errorf("selected-contract publish event type mismatch for source event %s: got %q want %q", sourceEventID, evt.Type, expected.EventName)
+	}
+	return sourceEventID, expected, nil
+}
+
+func expectedRecipientKeys(in []store.RunForkContractFrontierRecipient) []string {
+	out := make([]string, 0, len(in))
+	for _, recipient := range in {
+		recipient = store.RunForkContractFrontierRecipient{
+			SubscriberType: strings.TrimSpace(recipient.SubscriberType),
+			SubscriberID:   strings.TrimSpace(recipient.SubscriberID),
+			Path:           strings.TrimSpace(recipient.Path),
+			RouteSource:    strings.TrimSpace(recipient.RouteSource),
+		}
+		if recipient.SubscriberType == "" || recipient.SubscriberID == "" {
+			continue
+		}
+		out = append(out, recipientKey(recipient))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func actualRecipientKeys(in []runtimebus.PublishDiagnosticRecipient) []string {
+	out := make([]string, 0, len(in))
+	for _, recipient := range in {
+		if strings.TrimSpace(recipient.Type) == "" || strings.TrimSpace(recipient.ID) == "" {
+			continue
+		}
+		out = append(out, recipientKey(store.RunForkContractFrontierRecipient{
+			SubscriberType: recipient.Type,
+			SubscriberID:   recipient.ID,
+			Path:           recipient.Path,
+			RouteSource:    recipient.RouteSource,
+		}))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func recipientKeysEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func recipientKey(recipient store.RunForkContractFrontierRecipient) string {
+	return strings.Join([]string{
+		strings.TrimSpace(recipient.SubscriberType),
+		strings.TrimSpace(recipient.SubscriberID),
+		strings.TrimSpace(recipient.Path),
+		strings.TrimSpace(recipient.RouteSource),
+	}, "\x00")
+}

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -15,6 +15,7 @@ const (
 	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
 	RunForkSelectedContractRouteAdmissionOwner          = "runtime.run_fork.selected_contract_route_admission"
 	RunForkSelectedContractRouteTopologyOwner           = "runtime.run_fork.selected_contract_route_topology"
+	RunForkSelectedContractRecipientPlanningOwner       = "runtime.run_fork.selected_contract_recipient_planning"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -34,6 +35,7 @@ const (
 	RunForkBlockerSelectedContractRouteAdmissionNonMutating     = "selected_contract_route_admission_non_mutating"
 	RunForkBlockerSelectedContractRouteTopologyNonMutating      = "selected_contract_route_topology_non_mutating"
 	RunForkBlockerSelectedContractDynamicRouteTopologyUnproven  = "selected_contract_dynamic_route_topology_unproven"
+	RunForkBlockerSelectedContractRecipientPlanningNonMutating  = "selected_contract_recipient_planning_non_mutating"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
 )
@@ -49,6 +51,7 @@ type RunForkSelectedContractExecution struct {
 	FrontierEventCount   int                                        `json:"frontier_event_count"`
 	FrontierEvents       []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
 	RouteTopology        *RunForkSelectedContractRouteTopology      `json:"route_topology,omitempty"`
+	RecipientPlanning    *RunForkSelectedContractRecipientPlanning  `json:"recipient_planning,omitempty"`
 	ContractBinding      RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers    []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings      []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -74,6 +77,7 @@ type RunForkSelectedContractExecutionAdmission struct {
 	FrontierEventCount    int                                        `json:"frontier_event_count"`
 	FrontierEvents        []RunForkSelectedContractFrontierEvent     `json:"frontier_events,omitempty"`
 	RouteTopology         *RunForkSelectedContractRouteTopology      `json:"route_topology,omitempty"`
+	RecipientPlanning     *RunForkSelectedContractRecipientPlanning  `json:"recipient_planning,omitempty"`
 	ContractBinding       RunForkSelectedContractExecutionBoundary   `json:"contract_binding"`
 	RequiredConsumers     []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings       []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
@@ -139,6 +143,33 @@ type RunForkSelectedContractRouteEvent struct {
 	EventName         string                             `json:"event_name"`
 	DerivedRecipients []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
 	Disposition       string                             `json:"disposition"`
+}
+
+type RunForkSelectedContractRecipientPlanning struct {
+	Owner                       string                                      `json:"owner"`
+	RouteTopologyOwner          string                                      `json:"route_topology_owner"`
+	RouteAdmissionOwner         string                                      `json:"route_admission_owner"`
+	FutureExecutionOwner        string                                      `json:"future_execution_owner"`
+	NonMutating                 bool                                        `json:"non_mutating"`
+	RecipientPlanningSupported  bool                                        `json:"recipient_planning_supported"`
+	DeliveryWritesSupported     bool                                        `json:"delivery_writes_supported"`
+	ContractSelection           RunForkContractSelection                    `json:"contract_selection"`
+	FrontierEventCount          int                                         `json:"frontier_event_count"`
+	FrontierSourceEventIDs      []string                                    `json:"frontier_source_event_ids,omitempty"`
+	FrontierEvidenceFingerprint string                                      `json:"frontier_evidence_fingerprint"`
+	RecipientPlanEvents         []RunForkSelectedContractRecipientPlanEvent `json:"recipient_plan_events,omitempty"`
+	RequiredEvidence            []RunForkSelectedContractExecutionBoundary  `json:"required_evidence,omitempty"`
+	RequiredConsumers           []RunForkSelectedContractExecutionBoundary  `json:"required_consumers,omitempty"`
+	BlockedSiblings             []RunForkSelectedContractExecutionBoundary  `json:"blocked_siblings,omitempty"`
+	InvalidPaths                []RunForkSelectedContractExecutionBoundary  `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers         []RunForkUnsupportedBlocker                 `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractRecipientPlanEvent struct {
+	SourceEventID string                             `json:"source_event_id,omitempty"`
+	EventName     string                             `json:"event_name"`
+	Recipients    []RunForkContractFrontierRecipient `json:"recipients,omitempty"`
+	Disposition   string                             `json:"disposition"`
 }
 
 type RunForkSelectedContractExecutionBoundary struct {


### PR DESCRIPTION
## Summary

Closes #611.

This PR adds the canonical `runtime.run_fork.selected_contract_recipient_planning` owner and migrates selected-contract fork publish consumers to gate on it before recipient derivation. The selected execution path now builds deterministic fork-local recipient-plan evidence from durable selected binding, contract frontier evidence, route admission, and route topology, then `EventBus.Publish` uses a pre-plan admission guard and post-plan recipient comparison so `deliveryPlanner.Plan` cannot become a selected-fork owner or bypass.

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_route_admission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_route_topology`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` new `run_model.fork.selected_contract_recipient_planning`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` new `run_model.fork.semantics.3g_selected_contract_recipient_planning`
- Gate outcome on #611: `approved as first slice`

## Semantic migration

- New canonical owner: `runtime.run_fork.selected_contract_recipient_planning`.
- Old non-authoritative path now invalid/non-authoritative: selected execution calling `EventBus.Publish -> deliveryPlanner.Plan` as the first selected-fork recipient interpreter.
- Production paths checked/migrated: selected execution model/admission, `ExecuteSelectedContractRunFork`, `publishSelectedContractForkEvents`, `EventBus.Publish`, route admission future consumer metadata, CLI JSON proof surfaces, platform spec, and runtime watchlist evidence.
- Migration completeness: complete for the approved #611 child. Delivery rows, handler execution, receipts/dead letters/idempotency, emitted follow-ups, timers, sessions/turns, route persistence, source-advanced policy, contract swap, and UI/API ownership remain blocked/split siblings.

## Validation

- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/store ./cmd/swarm -run 'RunFork|SelectedContract|Route|Routing|DeliveryPlanner|FlowInstance' -count=1`
- `git diff --check`
- `go test ./...`