### PR TITLE
[agent-a][issue #615] Gate dynamic route topology proof

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3339,6 +3339,15 @@ run_model:
       a named blocker. It MUST NOT copy source routing_rules or materialized flow-instance route rows, persist
       fork-local route rows, derive executable recipients, invoke the delivery planner for fork work, create
       event_deliveries, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
+    selected_contract_dynamic_route_topology: 'Selected-contract dynamic route topology proof is a non-mutating
+      child owned by runtime.run_fork.selected_contract_dynamic_route_topology under
+      runtime.run_fork.selected_contract_route_topology. It may clear selected_contract_dynamic_route_topology_unproven
+      only when each dynamic flow-instance topology item is proven from fork-local selected-contract evidence:
+      selected-source route derivation, contract frontier evidence, route-admission evidence, and fork-local
+      flow-instance identity/topology evidence. If proof is incomplete, dynamic topology remains fail-closed. This
+      owner MUST NOT copy source routing_rules or materialized flow-instance route rows, persist fork-local route rows,
+      derive executable recipients outside runtime.run_fork.selected_contract_recipient_planning, invoke delivery
+      writes, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
     selected_contract_recipient_planning: 'Selected-contract recipient planning for mutating fork execution is owned by
       runtime.run_fork.selected_contract_recipient_planning after selected route topology. It consumes the durable
       selected-contract binding, runtime.run_fork.contract_frontier_admission, runtime.run_fork.selected_contract_route_admission,
@@ -3403,6 +3412,14 @@ run_model:
         evidence only. Dynamic flow-instance topology requires explicit fork-local topology proof and otherwise
         remains fail-closed. This owner is still non-mutating: it does not persist route rows, derive executable
         recipients, write deliveries, or run handlers.'
+      3f1_selected_contract_dynamic_route_topology: 'For selected-contract mutating fork execution, dynamic
+        flow-instance route topology is proven by runtime.run_fork.selected_contract_dynamic_route_topology as a
+        non-mutating extension of runtime.run_fork.selected_contract_route_topology. Dynamic proof is valid only when
+        selected-source route derivation and frontier/route-admission evidence identify fork-local flow-instance
+        topology and derived recipients for every dynamic instance. Missing, stale, source-row-only, or partial proof
+        keeps selected_contract_dynamic_route_topology_unproven fail-closed. This owner does not persist routes,
+        copy source routing rows, create deliveries, run handlers, reconstruct timers/sessions/turns, change
+        source-advanced policy, own contract-swap behavior, or own UI/API execution state.'
       3g_selected_contract_recipient_planning: 'For selected-contract mutating fork execution, fork-local recipient
         planning is a separate owner beyond route topology. The selected execution model, admission, publish path, and
         EventBus.Publish recipient guard consume runtime.run_fork.selected_contract_recipient_planning before selected

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -295,6 +295,7 @@ nodes:
       - selected-contract timestamp forks with source timer or route facts must keep those rows as evidence-only fail-closed blockers until separate timer and route reconstruction owners are approved; source timers, routing_rules, route recipients, and timer firings are not executable selected-fork work
       - selected-contract route/subscription reconstruction needs a non-mutating route-history admission owner that consumes selected-source route derivation, distinguishes frontier route/recipient admission from historical route evidence, and keeps route persistence, executable recipients, delivery writes, and handler execution split
       - selected-contract route/topology truth needs a canonical owner beyond route admission before recipient delivery; route admission is prerequisite evidence, static selected-source topology is fork-local truth only through the selected route derivation owner, and dynamic flow-instance topology must be fork-local-proven or fail-closed without copying source routing rows
+      - selected-contract dynamic route topology proof is a non-mutating child under route topology; it may clear selected_contract_dynamic_route_topology_unproven only from fork-local selected-contract route/frontier/admission/flow-instance evidence and must keep route persistence, delivery writes, handlers, timers, sessions, source-advanced policy, contract swap, and UI/API split
       - selected-contract recipient planning needs a canonical owner beyond route topology before selected execution publishes fork-local events; selected execution and EventBus.Publish must consume that owner before recipient derivation, while delivery writes, route persistence, handlers, timers, sessions, turns, source-advanced policy, contract swap, and UI/API remain separately gated siblings
     representative_issues:
       - 564
@@ -314,6 +315,7 @@ nodes:
       - 604
       - 609
       - 611
+      - 615
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -263,7 +263,7 @@ func selectedContractDynamicRouteTopologyProofs(frontier store.RunForkContractFr
 	proofs := make([]store.RunForkSelectedContractDynamicTopologyProof, 0, len(instances))
 	for _, instance := range instances {
 		item, ok := evidence[instance]
-		if !ok || len(item.recipients) == 0 || len(item.eventNames) == 0 {
+		if !ok || !item.hasFrontierFlowInstance || len(item.recipients) == 0 || len(item.eventNames) == 0 {
 			continue
 		}
 		recipients := sortedFrontierRecipients(item.recipients)
@@ -282,14 +282,15 @@ func selectedContractDynamicRouteTopologyProofs(frontier store.RunForkContractFr
 }
 
 type selectedContractDynamicTopologyEvidenceItem struct {
-	sourceEventIDs map[string]struct{}
-	eventNames     map[string]struct{}
-	recipients     []store.RunForkContractFrontierRecipient
+	hasFrontierFlowInstance bool
+	sourceEventIDs          map[string]struct{}
+	eventNames              map[string]struct{}
+	recipients              []store.RunForkContractFrontierRecipient
 }
 
 func selectedContractDynamicTopologyEvidence(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) map[string]*selectedContractDynamicTopologyEvidenceItem {
 	out := map[string]*selectedContractDynamicTopologyEvidenceItem{}
-	add := func(instance, sourceEventID, eventName string, recipients []store.RunForkContractFrontierRecipient) {
+	add := func(instance, sourceEventID, eventName string, hasFrontierFlowInstance bool, recipients []store.RunForkContractFrontierRecipient) {
 		instance = normalizeRouteInstance(instance)
 		eventName = strings.TrimSpace(eventName)
 		if instance == "" || eventName == "" {
@@ -306,6 +307,9 @@ func selectedContractDynamicTopologyEvidence(frontier store.RunForkContractFront
 		if sourceEventID = strings.TrimSpace(sourceEventID); sourceEventID != "" {
 			item.sourceEventIDs[sourceEventID] = struct{}{}
 		}
+		if hasFrontierFlowInstance {
+			item.hasFrontierFlowInstance = true
+		}
 		item.eventNames[eventName] = struct{}{}
 		for _, recipient := range recipients {
 			if normalizeRouteInstance(recipient.Path) != instance {
@@ -321,12 +325,12 @@ func selectedContractDynamicTopologyEvidence(frontier store.RunForkContractFront
 	}
 	for _, event := range frontier.FrontierEvents {
 		for _, instance := range event.SourceFlowInstances {
-			add(instance, event.SourceEventID, event.EventName, event.DerivedRecipients)
+			add(instance, event.SourceEventID, event.EventName, true, event.DerivedRecipients)
 		}
 	}
 	for _, event := range routeAdmission.SelectedRouteEvents {
 		for _, recipient := range event.DerivedRecipients {
-			add(recipient.Path, event.SourceEventID, event.EventName, event.DerivedRecipients)
+			add(recipient.Path, event.SourceEventID, event.EventName, false, event.DerivedRecipients)
 		}
 	}
 	return out

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -3,6 +3,7 @@ package runforkexecution
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"swarm/internal/store"
@@ -34,16 +35,19 @@ func BuildSelectedContractRouteTopology(req SelectedContractRouteTopologyRequest
 	if err := validateSelectedContractRouteAdmission(admission, routeAdmission); err != nil {
 		return store.RunForkSelectedContractRouteTopology{}, err
 	}
-	return canonicalSelectedContractRouteTopology(routeAdmission), nil
+	return canonicalSelectedContractRouteTopology(admission, routeAdmission), nil
 }
 
-func canonicalSelectedContractRouteTopology(routeAdmission store.RunForkSelectedContractRouteAdmission) store.RunForkSelectedContractRouteTopology {
+func canonicalSelectedContractRouteTopology(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) store.RunForkSelectedContractRouteTopology {
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
 		Message: "selected-contract route topology is non-mutating; route persistence, recipient delivery writes, and handler execution remain separately gated",
 	}}
 	dynamicDisposition := store.RunForkSelectedContractDispositionForkLocalTruth
-	if len(routeAdmission.DynamicFlowInstances) > 0 {
+	dynamicFlowInstances := sortedTrimmedStrings(routeAdmission.DynamicFlowInstances)
+	dynamicProofs := selectedContractDynamicRouteTopologyProofs(frontier, routeAdmission, dynamicFlowInstances)
+	dynamicSupported := len(dynamicFlowInstances) == 0 || len(dynamicProofs) == len(dynamicFlowInstances)
+	if len(dynamicFlowInstances) > 0 && !dynamicSupported {
 		dynamicDisposition = store.RunForkSelectedContractDispositionFailClosed
 		blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
 			Code:    store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven,
@@ -64,10 +68,12 @@ func canonicalSelectedContractRouteTopology(routeAdmission store.RunForkSelected
 		ExecutableRecipientsSupported:  false,
 		ContractSelection:              routeAdmission.ContractSelection,
 		StaticTopologySupported:        true,
-		DynamicTopologySupported:       len(routeAdmission.DynamicFlowInstances) == 0,
+		DynamicTopologySupported:       dynamicSupported,
+		DynamicTopologyOwner:           selectedContractDynamicRouteTopologyOwner(dynamicFlowInstances),
 		SourceRouteFactsPresent:        routeAdmission.SourceRouteFactsPresent,
 		StaticRouteEvents:              staticEvents,
-		DynamicFlowInstances:           append([]string(nil), routeAdmission.DynamicFlowInstances...),
+		DynamicFlowInstances:           dynamicFlowInstances,
+		DynamicTopologyProofs:          dynamicProofs,
 		DynamicTopologyDisposition:     dynamicDisposition,
 		FrontierAdmissionOwner:         routeAdmission.FrontierAdmissionOwner,
 		FrontierEventCount:             routeAdmission.FrontierEventCount,
@@ -178,7 +184,7 @@ func validateSelectedContractRouteTopology(frontier store.RunForkContractFrontie
 	if err := validateSelectionMatches("route topology", frontier.ContractSelection, topology.ContractSelection); err != nil {
 		return err
 	}
-	canonical := canonicalSelectedContractRouteTopology(routeAdmission)
+	canonical := canonicalSelectedContractRouteTopology(frontier, routeAdmission)
 	if !reflect.DeepEqual(topology, canonical) {
 		return fmt.Errorf("selected-contract route topology does not match canonical route-admission evidence")
 	}
@@ -242,6 +248,120 @@ func selectedContractRouteTopologyEvents(events []store.RunForkSelectedContractR
 	return out
 }
 
+func selectedContractDynamicRouteTopologyOwner(instances []string) string {
+	if len(instances) == 0 {
+		return ""
+	}
+	return store.RunForkSelectedContractDynamicRouteTopologyOwner
+}
+
+func selectedContractDynamicRouteTopologyProofs(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission, instances []string) []store.RunForkSelectedContractDynamicTopologyProof {
+	if len(instances) == 0 {
+		return nil
+	}
+	evidence := selectedContractDynamicTopologyEvidence(frontier, routeAdmission)
+	proofs := make([]store.RunForkSelectedContractDynamicTopologyProof, 0, len(instances))
+	for _, instance := range instances {
+		item, ok := evidence[instance]
+		if !ok || len(item.recipients) == 0 || len(item.eventNames) == 0 {
+			continue
+		}
+		recipients := sortedFrontierRecipients(item.recipients)
+		if len(recipients) == 0 {
+			continue
+		}
+		proofs = append(proofs, store.RunForkSelectedContractDynamicTopologyProof{
+			FlowInstance:      instance,
+			SourceEventIDs:    sortedStringSet(item.sourceEventIDs),
+			EventNames:        sortedStringSet(item.eventNames),
+			DerivedRecipients: recipients,
+			Disposition:       store.RunForkSelectedContractDispositionForkLocalTruth,
+		})
+	}
+	return proofs
+}
+
+type selectedContractDynamicTopologyEvidenceItem struct {
+	sourceEventIDs map[string]struct{}
+	eventNames     map[string]struct{}
+	recipients     []store.RunForkContractFrontierRecipient
+}
+
+func selectedContractDynamicTopologyEvidence(frontier store.RunForkContractFrontierAdmission, routeAdmission store.RunForkSelectedContractRouteAdmission) map[string]*selectedContractDynamicTopologyEvidenceItem {
+	out := map[string]*selectedContractDynamicTopologyEvidenceItem{}
+	add := func(instance, sourceEventID, eventName string, recipients []store.RunForkContractFrontierRecipient) {
+		instance = normalizeRouteInstance(instance)
+		eventName = strings.TrimSpace(eventName)
+		if instance == "" || eventName == "" {
+			return
+		}
+		item := out[instance]
+		if item == nil {
+			item = &selectedContractDynamicTopologyEvidenceItem{
+				sourceEventIDs: map[string]struct{}{},
+				eventNames:     map[string]struct{}{},
+			}
+			out[instance] = item
+		}
+		if sourceEventID = strings.TrimSpace(sourceEventID); sourceEventID != "" {
+			item.sourceEventIDs[sourceEventID] = struct{}{}
+		}
+		item.eventNames[eventName] = struct{}{}
+		for _, recipient := range recipients {
+			if normalizeRouteInstance(recipient.Path) != instance {
+				continue
+			}
+			item.recipients = append(item.recipients, store.RunForkContractFrontierRecipient{
+				SubscriberType: strings.TrimSpace(recipient.SubscriberType),
+				SubscriberID:   strings.TrimSpace(recipient.SubscriberID),
+				Path:           strings.TrimSpace(recipient.Path),
+				RouteSource:    strings.TrimSpace(recipient.RouteSource),
+			})
+		}
+	}
+	for _, event := range frontier.FrontierEvents {
+		for _, instance := range event.SourceFlowInstances {
+			add(instance, event.SourceEventID, event.EventName, event.DerivedRecipients)
+		}
+	}
+	for _, event := range routeAdmission.SelectedRouteEvents {
+		for _, recipient := range event.DerivedRecipients {
+			add(recipient.Path, event.SourceEventID, event.EventName, event.DerivedRecipients)
+		}
+	}
+	return out
+}
+
+func normalizeRouteInstance(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "/")
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedTrimmedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = normalizeRouteInstance(value)
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	return sortedStringSet(seen)
+}
+
 func selectedContractRouteTopologyRequiredEvidence(routeAdmission store.RunForkSelectedContractRouteAdmission) []store.RunForkSelectedContractExecutionBoundary {
 	evidence := []store.RunForkSelectedContractExecutionBoundary{
 		{
@@ -255,6 +375,14 @@ func selectedContractRouteTopologyRequiredEvidence(routeAdmission store.RunForkS
 		if strings.TrimSpace(item.Disposition) == store.RunForkSelectedContractDispositionPrerequisite {
 			evidence = append(evidence, item)
 		}
+	}
+	if len(routeAdmission.DynamicFlowInstances) > 0 {
+		evidence = append(evidence, store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "selected_contract_dynamic_route_topology",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractDynamicRouteTopologyOwner,
+			Reason:      "dynamic flow-instance topology must be proven from fork-local selected-contract route evidence or remain fail-closed",
+		})
 	}
 	return evidence
 }

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -109,6 +109,61 @@ func TestBuildSelectedContractRouteTopologyFailsClosedOnDynamicFlowInstances(t *
 	}
 }
 
+func TestBuildSelectedContractRouteTopologyRequiresFrontierCorroborationForDynamicProof(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID: "source-event",
+			EventName:     "review/inst-1/task.started",
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "reviewer-inst-1",
+				Path:           "review/inst-1",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeAdmission.SelectedRouteEvents = []store.RunForkSelectedContractRouteEvent{{
+		SourceEventID: "source-event",
+		EventName:     "review/inst-1/task.started",
+		DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+			SubscriberType: "node",
+			SubscriberID:   "reviewer-inst-1",
+			Path:           "review/inst-1",
+			RouteSource:    "selected_contracts",
+		}},
+		Disposition: store.RunForkSelectedContractDispositionEvidenceOnly,
+	}}
+
+	topology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	if topology.DynamicTopologySupported {
+		t.Fatalf("DynamicTopologySupported = true, want false without frontier flow-instance proof")
+	}
+	if len(topology.DynamicTopologyProofs) != 0 {
+		t.Fatalf("dynamic proofs = %#v, want none without frontier flow-instance proof", topology.DynamicTopologyProofs)
+	}
+	if !unsupportedBlockerHas(topology.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven) {
+		t.Fatalf("unsupported blockers = %#v, want dynamic topology blocker", topology.UnsupportedBlockers)
+	}
+}
+
 func TestBuildSelectedContractRouteTopologyProvesDynamicFlowInstancesFromForkLocalEvidence(t *testing.T) {
 	admission := store.RunForkContractFrontierAdmission{
 		Owner:                        store.RunForkContractFrontierAdmissionOwner,

--- a/internal/runtime/runforkexecution/model_test.go
+++ b/internal/runtime/runforkexecution/model_test.go
@@ -109,6 +109,78 @@ func TestBuildSelectedContractRouteTopologyFailsClosedOnDynamicFlowInstances(t *
 	}
 }
 
+func TestBuildSelectedContractRouteTopologyProvesDynamicFlowInstancesFromForkLocalEvidence(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:       "source-event",
+			EventName:           "review/inst-1/task.started",
+			SourceFlowInstances: []string{"review/inst-1"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "reviewer-inst-1",
+				Path:           "review/inst-1",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeAdmission.SelectedRouteEvents = []store.RunForkSelectedContractRouteEvent{{
+		SourceEventID: "source-event",
+		EventName:     "review/inst-1/task.started",
+		DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+			SubscriberType: "node",
+			SubscriberID:   "reviewer-inst-1",
+			Path:           "review/inst-1",
+			RouteSource:    "selected_contracts",
+		}},
+		Disposition: store.RunForkSelectedContractDispositionEvidenceOnly,
+	}}
+
+	topology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	if !topology.DynamicTopologySupported {
+		t.Fatalf("DynamicTopologySupported = false, want fork-local dynamic topology proof")
+	}
+	if topology.DynamicTopologyOwner != store.RunForkSelectedContractDynamicRouteTopologyOwner {
+		t.Fatalf("dynamic topology owner = %q", topology.DynamicTopologyOwner)
+	}
+	if topology.DynamicTopologyDisposition != store.RunForkSelectedContractDispositionForkLocalTruth {
+		t.Fatalf("dynamic disposition = %q", topology.DynamicTopologyDisposition)
+	}
+	if len(topology.DynamicTopologyProofs) != 1 {
+		t.Fatalf("dynamic proofs = %#v, want one proof", topology.DynamicTopologyProofs)
+	}
+	proof := topology.DynamicTopologyProofs[0]
+	if proof.FlowInstance != "review/inst-1" ||
+		proof.Disposition != store.RunForkSelectedContractDispositionForkLocalTruth ||
+		len(proof.DerivedRecipients) != 1 ||
+		proof.DerivedRecipients[0].SubscriberID != "reviewer-inst-1" {
+		t.Fatalf("dynamic proof = %#v", proof)
+	}
+	if !executionBoundaryHas(topology.RequiredEvidence, "selected_contract_dynamic_route_topology", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required evidence = %#v, want dynamic topology prerequisite", topology.RequiredEvidence)
+	}
+	if unsupportedBlockerHas(topology.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven) {
+		t.Fatalf("unsupported blockers = %#v, want dynamic topology proof to clear blocker", topology.UnsupportedBlockers)
+	}
+}
+
 func TestBuildSelectedContractRecipientPlanningConsumesRouteTopology(t *testing.T) {
 	admission := store.RunForkContractFrontierAdmission{
 		Owner:                        store.RunForkContractFrontierAdmissionOwner,
@@ -170,6 +242,64 @@ func TestBuildSelectedContractRecipientPlanningConsumesRouteTopology(t *testing.
 	}
 	if !unsupportedBlockerHas(planning.UnsupportedBlockers, store.RunForkBlockerSelectedContractRecipientPlanningNonMutating) {
 		t.Fatalf("unsupported blockers = %#v, want recipient-planning non-mutating blocker", planning.UnsupportedBlockers)
+	}
+}
+
+func TestBuildSelectedContractRecipientPlanningConsumesProvenDynamicTopology(t *testing.T) {
+	admission := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID:       "source-event",
+			EventName:           "review/inst-1/task.started",
+			SourceFlowInstances: []string{"review/inst-1"},
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "reviewer-inst-1",
+				Path:           "review/inst-1",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(admission)
+	routeAdmission.DynamicFlowInstances = []string{"review/inst-1"}
+	routeAdmission.SelectedRouteEvents = []store.RunForkSelectedContractRouteEvent{{
+		SourceEventID: "source-event",
+		EventName:     "review/inst-1/task.started",
+		DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+			SubscriberType: "node",
+			SubscriberID:   "reviewer-inst-1",
+			Path:           "review/inst-1",
+			RouteSource:    "selected_contracts",
+		}},
+		Disposition: store.RunForkSelectedContractDispositionEvidenceOnly,
+	}}
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, admission, routeAdmission)
+
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      admission,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	if !planning.RecipientPlanningSupported {
+		t.Fatalf("RecipientPlanningSupported = false, want proven dynamic topology to allow planning; blockers=%#v", planning.UnsupportedBlockers)
+	}
+	if unsupportedBlockerHas(planning.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven) {
+		t.Fatalf("unsupported blockers = %#v, want dynamic blocker cleared", planning.UnsupportedBlockers)
+	}
+	if !executionBoundaryHas(planning.RequiredEvidence, "selected_contract_dynamic_route_topology", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("required evidence = %#v, want dynamic topology evidence consumed", planning.RequiredEvidence)
 	}
 }
 

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -15,6 +15,7 @@ const (
 	RunForkSelectedContractExecutionOwner               = "runtime.run_fork.selected_contract_execution"
 	RunForkSelectedContractRouteAdmissionOwner          = "runtime.run_fork.selected_contract_route_admission"
 	RunForkSelectedContractRouteTopologyOwner           = "runtime.run_fork.selected_contract_route_topology"
+	RunForkSelectedContractDynamicRouteTopologyOwner    = "runtime.run_fork.selected_contract_dynamic_route_topology"
 	RunForkSelectedContractRecipientPlanningOwner       = "runtime.run_fork.selected_contract_recipient_planning"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
@@ -114,28 +115,38 @@ type RunForkSelectedContractRouteAdmission struct {
 }
 
 type RunForkSelectedContractRouteTopology struct {
-	Owner                          string                                     `json:"owner"`
-	RouteAdmissionOwner            string                                     `json:"route_admission_owner"`
-	FutureRouteReconstructionOwner string                                     `json:"future_route_reconstruction_owner"`
-	NonMutating                    bool                                       `json:"non_mutating"`
-	RoutePersistenceSupported      bool                                       `json:"route_persistence_supported"`
-	ExecutableRecipientsSupported  bool                                       `json:"executable_recipients_supported"`
-	ContractSelection              RunForkContractSelection                   `json:"contract_selection"`
-	StaticTopologySupported        bool                                       `json:"static_topology_supported"`
-	DynamicTopologySupported       bool                                       `json:"dynamic_topology_supported"`
-	SourceRouteFactsPresent        bool                                       `json:"source_route_facts_present"`
-	StaticRouteEvents              []RunForkSelectedContractRouteEvent        `json:"static_route_events,omitempty"`
-	DynamicFlowInstances           []string                                   `json:"dynamic_flow_instances,omitempty"`
-	DynamicTopologyDisposition     string                                     `json:"dynamic_topology_disposition,omitempty"`
-	FrontierAdmissionOwner         string                                     `json:"frontier_admission_owner,omitempty"`
-	FrontierEventCount             int                                        `json:"frontier_event_count"`
-	FrontierSourceEventIDs         []string                                   `json:"frontier_source_event_ids,omitempty"`
-	FrontierEvidenceFingerprint    string                                     `json:"frontier_evidence_fingerprint"`
-	RequiredEvidence               []RunForkSelectedContractExecutionBoundary `json:"required_evidence,omitempty"`
-	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
-	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
-	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
-	UnsupportedBlockers            []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+	Owner                          string                                        `json:"owner"`
+	RouteAdmissionOwner            string                                        `json:"route_admission_owner"`
+	FutureRouteReconstructionOwner string                                        `json:"future_route_reconstruction_owner"`
+	NonMutating                    bool                                          `json:"non_mutating"`
+	RoutePersistenceSupported      bool                                          `json:"route_persistence_supported"`
+	ExecutableRecipientsSupported  bool                                          `json:"executable_recipients_supported"`
+	ContractSelection              RunForkContractSelection                      `json:"contract_selection"`
+	StaticTopologySupported        bool                                          `json:"static_topology_supported"`
+	DynamicTopologySupported       bool                                          `json:"dynamic_topology_supported"`
+	DynamicTopologyOwner           string                                        `json:"dynamic_topology_owner,omitempty"`
+	SourceRouteFactsPresent        bool                                          `json:"source_route_facts_present"`
+	StaticRouteEvents              []RunForkSelectedContractRouteEvent           `json:"static_route_events,omitempty"`
+	DynamicFlowInstances           []string                                      `json:"dynamic_flow_instances,omitempty"`
+	DynamicTopologyProofs          []RunForkSelectedContractDynamicTopologyProof `json:"dynamic_topology_proofs,omitempty"`
+	DynamicTopologyDisposition     string                                        `json:"dynamic_topology_disposition,omitempty"`
+	FrontierAdmissionOwner         string                                        `json:"frontier_admission_owner,omitempty"`
+	FrontierEventCount             int                                           `json:"frontier_event_count"`
+	FrontierSourceEventIDs         []string                                      `json:"frontier_source_event_ids,omitempty"`
+	FrontierEvidenceFingerprint    string                                        `json:"frontier_evidence_fingerprint"`
+	RequiredEvidence               []RunForkSelectedContractExecutionBoundary    `json:"required_evidence,omitempty"`
+	RequiredConsumers              []RunForkSelectedContractExecutionBoundary    `json:"required_consumers,omitempty"`
+	BlockedSiblings                []RunForkSelectedContractExecutionBoundary    `json:"blocked_siblings,omitempty"`
+	InvalidPaths                   []RunForkSelectedContractExecutionBoundary    `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers            []RunForkUnsupportedBlocker                   `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractDynamicTopologyProof struct {
+	FlowInstance      string                             `json:"flow_instance"`
+	SourceEventIDs    []string                           `json:"source_event_ids,omitempty"`
+	EventNames        []string                           `json:"event_names,omitempty"`
+	DerivedRecipients []RunForkContractFrontierRecipient `json:"derived_recipients,omitempty"`
+	Disposition       string                             `json:"disposition"`
 }
 
 type RunForkSelectedContractRouteEvent struct {


### PR DESCRIPTION
## Summary

Implements the approved #615 first slice: a non-mutating selected-contract dynamic route-topology proof/fail-closed extension under `runtime.run_fork.selected_contract_route_topology`.

This PR does not implement route persistence, delivery writes, handler execution, timers, sessions/turns, source-advanced behavior, contract swap, or UI/API ownership.

Closes #615

## Governing refs / context

Exact spec refs treated as binding and updated in this PR:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_timer_route_policy`
- `run_model.fork.selected_contract_route_admission`
- `run_model.fork.selected_contract_route_topology`
- `run_model.fork.selected_contract_dynamic_route_topology`
- `run_model.fork.selected_contract_recipient_planning`
- semantics `3d_selected_contract_timer_route_policy`
- semantics `3e_selected_contract_route_admission`
- semantics `3f_selected_contract_route_topology`
- semantics `3f1_selected_contract_dynamic_route_topology`
- semantics `3g_selected_contract_recipient_planning`
- `platform_tables.routing_rules`

Binding issue/thread context:

- #615 Pre-Implementation Coverage Audit
- #615 independent gate outcome: `approved as first slice`
- Parents: #608, #588, #564, #549
- Prerequisites: #604/#606 route admission, #609/#610 route topology, #611/#614 recipient planning / publish-path guard
- Watchlist node: `timestamp_fork_replay_resume_ownership`

## Semantic migration

New canonical owner:

- `runtime.run_fork.selected_contract_dynamic_route_topology`

Old producer / reader / writer paths now invalid or non-authoritative:

- Source `routing_rules` rows are not executable fork route truth.
- Source materialized flow-instance route rows are not copied or used as fork-local proof.
- `internal/runtime/bus.RouteTable.AddFlowInstanceRoute` remains a current-runtime helper, not the canonical fork owner.
- `internal/runtime/bus.EventBus.AddFlowInstanceRoute` and `internal/store/flow_instance_routes.go` remain current operational persistence paths, not fork-local route persistence.
- `delivery_planner` / `EventBus.Publish` remain downstream guarded recipient consumers, not topology owners.

Production paths checked for surviving old behavior:

- `internal/runtime/runforkexecution` route topology, admission, recipient planning, selected execution publish guard.
- `internal/runtime/runforkadmission` contract frontier and selected route-history admission.
- `internal/runtime/bus` route derivation, flow-instance route materialization, publish/recipient planning seams.
- `internal/runtime/manager` flow activation and route recovery seams.
- `internal/store` route persistence, routing_rules, run-fork planner/admission/activation surfaces.
- `cmd/swarm` supported surface tests.

Migration completeness:

- Complete for the approved first slice: dynamic topology is now either fork-local-proven through the canonical non-mutating proof owner or remains fail-closed.
- Incomplete by design for the parent: route persistence, delivery writes, handlers, outcomes, timers, sessions/turns, source-advanced, contract swap, and UI/API remain split siblings.

## Tests

- `go test ./internal/runtime/runforkexecution -run 'SelectedContract.*(RouteTopology|RecipientPlanning|ExecutionModel|ExecutionAdmission)' -count=1`
- `go test ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/store ./cmd/swarm -run 'RunFork|SelectedContract|Route|Routing|DeliveryPlanner|FlowInstance|RecipientPlanning' -count=1`
- `go test ./...`