### PR TITLE
[agent-d][issue #617] Retire legacy entity tools from agent catalogs

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -233,8 +233,10 @@ contract_formats:
       authoritative flow-owned entity contracts in entities.yaml, agents.yaml entity_writes declarations, and the shared
       type system. This ensures all data access is permissioned, auditable, and storage-backend agnostic.
     role_scoped_entity_tools:
-      opt_in: 'A flow opts into the Path alpha entity-tool model with tool_surface.role_scoped_entity_tools: true in
-        schema.yaml. The opt-in applies to agents authored in that flow.'
+      default_surface: 'For normal agents, the Path alpha entity-tool model is mandatory. If an actor resolves to a
+        flow-owned entity contract, the platform generates role-scoped current-entity tools for that actor by default;
+        no schema.yaml opt-in flag is required or honored as a compatibility boundary.'
+      no_contract_surface: Normal agents that do not resolve to a flow-owned entity contract receive no entity tools.
       current_entity_binding: 'Generated role-scoped entity tools operate on the current entity resolved from the triggering
         event/session context. Agent-supplied entity_id, entity_type, or flow_instance arguments are not accepted.'
       generated_reads:
@@ -249,17 +251,18 @@ contract_formats:
         update_path: 'update_{entity_type}_{field}_{subpath}({value}) updates one generated top-level subpath for a writable
           named-object field. The value schema is the exact declared subpath type.'
         create_rule: 'create authorization in entity_writes is author evidence for prompt/boot coverage. Path alpha does not
-          expose a generic agent-facing create_entity replacement for opted-in current-entity tools.'
+          expose a generic agent-facing create_entity replacement for current-entity tools.'
       generated_schema_closure: 'Generated entity-tool input and output schemas are closed recursively: additionalProperties
         is false for object schemas, required fields are explicit, and enum values come from the shared type system. Provider-visible
         schemas, runtime validation, and bootverify schema-closure checks must agree. Provider schema enforcement is a first
         validation layer when honored; runtime validation remains mandatory defense-in-depth.'
-      legacy_surface_retirement: 'For fully opted-in role-scoped actors, the legacy universal entity surface is removed from
-        the provider-visible/callable agent surface, not merely denied after selection. Retired names are create_entity,
-        get_entity, get_subject_status, query_entities, search_entities, query_metrics, and save_entity_field.'
-      compatibility_boundary: 'Non-opted flows, operator/system surfaces, and explicitly tracked rollout compatibility may
-        continue to expose legacy platform entity tools until their parent rollout issues close. That compatibility is not
-        the valid surface for fully opted-in role-scoped agents.'
+      legacy_surface_retirement: 'For normal agents, the legacy universal entity surface is removed from the
+        provider-visible/callable agent surface, not merely denied after selection. Retired names are create_entity,
+        get_entity, get_subject_status, query_entities, search_entities, query_metrics, and save_entity_field. allowed_tools,
+        runtime-wide fallback, MCP tools/list, provider summaries, and executor authorization MUST NOT reintroduce these
+        names for ordinary agents.'
+      compatibility_boundary: 'Retained legacy platform entity handlers are non-agent internal/operator compatibility only.
+        They are not a valid normal-agent provider-visible or callable surface.'
     schema_source: entities.yaml + types.yaml
   required_agents:
     description: required_agents in schema.yaml declares agents the flow needs.
@@ -1367,8 +1370,8 @@ engine:
       - Timers are cancelled
       - Agent sessions are terminated
       - All persisted state remains in the database
-      - Entity remains queryable through explicit read/query surfaces; for fully opted-in role-scoped agents this means generated
-        current-entity reads, while legacy query_entities remains a non-opted/operator/system compatibility surface.
+      - Entity remains queryable through explicit read/query surfaces; for normal agents this means generated current-entity
+        reads, while legacy query_entities remains a non-agent internal/operator/system compatibility surface.
       archival: Future concern — retention policy and cold storage are not specified in v1.1.0.
       event_rejection: 'When an event arrives targeting an entity in a terminal state, the platform rejects it before handler
         execution. No guard runs, no handler runs, no state changes. The event is marked as rejected with reason: terminal_entity.
@@ -2221,22 +2224,22 @@ tool_model:
       agent_fire: Terminate an agent session. Requires agent_fire permission.
       agent_hire: Spawn a new agent session. Requires agent_hire permission.
       agent_reconfigure: Modify an agent's prompt, tools, or subscriptions. Requires agent_reconfigure permission.
-      create_entity: Create a new entity row in entity_state. Legacy/operator/system compatibility surface; removed from
-        fully opted-in role-scoped agent surfaces.
-      get_entity: Read an entity by ID. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped
-        agent surfaces in favor of generated read_{entity_type} tools.
+      create_entity: Create a new entity row in entity_state. Legacy internal/operator/system compatibility surface; not
+        provider-visible or callable for normal agents.
+      get_entity: Read an entity by ID. Legacy internal/operator/system compatibility surface; not provider-visible or
+        callable for normal agents in favor of generated read_{entity_type} tools.
       human_task_decide: Record a human decision on a pending task. Requires human_task_decide permission.
       human_task_request: Create a task for human execution. Requires human_task_request permission.
       mailbox_send: Send an item to the human mailbox for decision. Auto-granted to all agents (universal tool).
-      query_entities: Query entities by state, fields, or aggregation. Legacy/operator/system compatibility surface; removed
-        from fully opted-in role-scoped agent surfaces.
-      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Legacy/operator/system compatibility
-        surface; removed from fully opted-in role-scoped agent surfaces.
-      save_entity_field: Write a specific field on an entity. Legacy/operator/system compatibility surface; removed from
-        fully opted-in role-scoped agent surfaces in favor of generated save/update tools.
+      query_entities: Query entities by state, fields, or aggregation. Legacy internal/operator/system compatibility surface;
+        not provider-visible or callable for normal agents.
+      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Legacy internal/operator/system
+        compatibility surface; not provider-visible or callable for normal agents.
+      save_entity_field: Write a specific field on an entity. Legacy internal/operator/system compatibility surface; not
+        provider-visible or callable for normal agents in favor of generated save/update tools.
       schedule: Schedule a future action or timer. Requires schedule permission.
-      search_entities: Query entities by stage, field values, or metadata. Legacy/operator/system compatibility surface;
-        removed from fully opted-in role-scoped agent surfaces.
+      search_entities: Query entities by stage, field values, or metadata. Legacy internal/operator/system compatibility
+        surface; not provider-visible or callable for normal agents.
     handler_actions:
       description: These are handler ACTION field values, not agent-callable tools. They are invoked via the action field in
         node handlers. The platform ships the handler code. They are listed separately from the tool catalog because agents
@@ -2255,8 +2258,8 @@ tool_model:
       description: All entity tools operate on the generic entity_state table. They read/write entity_state.fields (JSONB),
         entity_state.current_state, entity_state.gates, and entity_state.accumulator. They do NOT operate on product-specific
         typed tables. Product-specific tables are optional query-performance optimizations — the entity tools always use the
-        generic entity_state interface. For fully opted-in role-scoped agents, these legacy schemas are compatibility surfaces;
-        the valid provider-visible surface is the generated role-scoped tool set from
+        generic entity_state interface. For normal agents, these legacy schemas are non-provider-visible internal/operator
+        compatibility surfaces; the valid provider-visible surface is the generated role-scoped tool set from
         contract_formats.persistence_model.role_scoped_entity_tools.
       create_entity:
         description: Create a new entity row in entity_state.
@@ -2345,16 +2348,16 @@ tool_model:
     universal_tools: 'The following tools are included in every agent session without listing in tools: agent_message
       and mailbox_send. Emit tools (emit_{event_name}) are auto-generated from emit_events. Neither universal communication
       tools nor emit tools require explicit tools entry.'
-    role_scoped_entity_tools: 'When the actor''s owning flow declares tool_surface.role_scoped_entity_tools: true, the platform
-      generates current-entity read/save/update tools from the actor''s flow-owned entity contract and entity_writes declaration.
-      The generated tools are included in the agent-visible/provider-visible surface without explicit tools entries. In the
-      same opted-in surface, the legacy entity names create_entity, get_entity, get_subject_status, query_entities,
-      search_entities, query_metrics, and save_entity_field are removed before provider delivery and remain denied by runtime
-      authorization as defense-in-depth.'
+    role_scoped_entity_tools: 'When a normal actor resolves to a flow-owned entity contract, the platform generates
+      current-entity read/save/update tools from that contract and the actor''s entity_writes declaration. The generated
+      tools are included in the agent-visible/provider-visible surface without explicit tools entries. The legacy entity
+      names create_entity, get_entity, get_subject_status, query_entities, search_entities, query_metrics, and
+      save_entity_field are removed before provider delivery and remain denied by runtime authorization as defense-in-depth.
+      Normal actors without an entity contract receive no entity tools.'
     context_cost: An agent with 4 tools in tools pays for 4 tool schemas in LLM context, regardless of how many tools
       exist in the registry or how many tools an MCP server exposes. The filter is the contract, not the source.
     default_deny: If an agent calls a tool that is not in its tools list, not a universal communication tool, not an emit
-      tool, not a generated role-scoped entity tool for an opted-in actor, and not a native_tools capability — the call is
+      tool, not a generated role-scoped entity tool for an actor with an entity contract, and not a native_tools capability — the call is
       rejected. There is no default-allow policy for unrecognized tools.
   mcp_client:
     description: The platform acts as an MCP client, connecting to external MCP servers to discover and invoke tools. MCP

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -261,8 +261,9 @@ contract_formats:
         get_entity, get_subject_status, query_entities, search_entities, query_metrics, and save_entity_field. allowed_tools,
         runtime-wide fallback, MCP tools/list, provider summaries, and executor authorization MUST NOT reintroduce these
         names for ordinary agents.'
-      compatibility_boundary: 'Retained legacy platform entity handlers are non-agent internal/operator compatibility only.
-        They are not a valid normal-agent provider-visible or callable surface.'
+      compatibility_boundary: 'Retained legacy platform entity handlers are trusted runtime-internal compatibility only.
+        A normal agent MUST NOT regain them by setting agent-authored type/role/config fields; they are not a valid normal-agent
+        provider-visible or callable surface.'
     schema_source: entities.yaml + types.yaml
   required_agents:
     description: required_agents in schema.yaml declares agents the flow needs.
@@ -1371,7 +1372,7 @@ engine:
       - Agent sessions are terminated
       - All persisted state remains in the database
       - Entity remains queryable through explicit read/query surfaces; for normal agents this means generated current-entity
-        reads, while legacy query_entities remains a non-agent internal/operator/system compatibility surface.
+        reads, while legacy query_entities remains a trusted runtime-internal compatibility surface.
       archival: Future concern — retention policy and cold storage are not specified in v1.1.0.
       event_rejection: 'When an event arrives targeting an entity in a terminal state, the platform rejects it before handler
         execution. No guard runs, no handler runs, no state changes. The event is marked as rejected with reason: terminal_entity.
@@ -2224,21 +2225,21 @@ tool_model:
       agent_fire: Terminate an agent session. Requires agent_fire permission.
       agent_hire: Spawn a new agent session. Requires agent_hire permission.
       agent_reconfigure: Modify an agent's prompt, tools, or subscriptions. Requires agent_reconfigure permission.
-      create_entity: Create a new entity row in entity_state. Legacy internal/operator/system compatibility surface; not
+      create_entity: Create a new entity row in entity_state. Legacy trusted runtime-internal compatibility surface; not
         provider-visible or callable for normal agents.
-      get_entity: Read an entity by ID. Legacy internal/operator/system compatibility surface; not provider-visible or
+      get_entity: Read an entity by ID. Legacy trusted runtime-internal compatibility surface; not provider-visible or
         callable for normal agents in favor of generated read_{entity_type} tools.
       human_task_decide: Record a human decision on a pending task. Requires human_task_decide permission.
       human_task_request: Create a task for human execution. Requires human_task_request permission.
       mailbox_send: Send an item to the human mailbox for decision. Auto-granted to all agents (universal tool).
-      query_entities: Query entities by state, fields, or aggregation. Legacy internal/operator/system compatibility surface;
+      query_entities: Query entities by state, fields, or aggregation. Legacy trusted runtime-internal compatibility surface;
         not provider-visible or callable for normal agents.
-      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Legacy internal/operator/system
+      query_metrics: Read aggregated metrics (counts, sums, averages) across entities. Legacy trusted runtime-internal
         compatibility surface; not provider-visible or callable for normal agents.
-      save_entity_field: Write a specific field on an entity. Legacy internal/operator/system compatibility surface; not
+      save_entity_field: Write a specific field on an entity. Legacy trusted runtime-internal compatibility surface; not
         provider-visible or callable for normal agents in favor of generated save/update tools.
       schedule: Schedule a future action or timer. Requires schedule permission.
-      search_entities: Query entities by stage, field values, or metadata. Legacy internal/operator/system compatibility
+      search_entities: Query entities by stage, field values, or metadata. Legacy trusted runtime-internal compatibility
         surface; not provider-visible or callable for normal agents.
     handler_actions:
       description: These are handler ACTION field values, not agent-callable tools. They are invoked via the action field in
@@ -2258,7 +2259,7 @@ tool_model:
       description: All entity tools operate on the generic entity_state table. They read/write entity_state.fields (JSONB),
         entity_state.current_state, entity_state.gates, and entity_state.accumulator. They do NOT operate on product-specific
         typed tables. Product-specific tables are optional query-performance optimizations — the entity tools always use the
-        generic entity_state interface. For normal agents, these legacy schemas are non-provider-visible internal/operator
+        generic entity_state interface. For normal agents, these legacy schemas are non-provider-visible runtime-internal
         compatibility surfaces; the valid provider-visible surface is the generated role-scoped tool set from
         contract_formats.persistence_model.role_scoped_entity_tools.
       create_entity:

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -194,6 +194,10 @@ active_issues:
     title: Land Path alpha role-scoped tool-contract model in canonical platform spec
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 617
+    title: Aggressively retire legacy universal entity tools from agent catalogs
+    maps_to:
+      - transport_policy_and_surface_parity
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -208,12 +212,13 @@ nodes:
       - supported agent turns can persist a canonical visible tool surface that is broader than the provider-callable surface actually available on that turn
       - fallback relay on a supported turn can degrade file-backed work by clamping large relayed tool results to preview-only text
       - supported no-read_file turns can emit runtime_read_file follow-up artifacts for oversized tool results even though the same turn surface cannot call read_file
+      - legacy universal entity tools can remain normal-agent provider-visible/callable beside generated role-scoped typed tools
       - oversized file-backed tool results on supported Claude helper turns can leak provider scratch paths back into later runtime read_file calls
       - CLI native tools can still use mixed provider-plus-platform fallback semantics, so visible turn surface does not equal callable provider-native truth for bash, web_search, and file_io
       - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
       - generated role-scoped typed reads can be silently downgraded by generic transport projection into preview/truncated shapes instead of complete typed values or explicit typed-read errors
       - generated typed tool and emit schemas can drift between provider-visible delivery, runtime validation, and bootverify, allowing undeclared payload keys or missing required/enum constraints to survive one surface
-      - canonical platform specs and generated docs can lag runtime Path alpha tool delivery, re-authorizing legacy universal entity-tool semantics after opted-in actors have moved to generated role-scoped tools
+      - canonical platform specs and generated docs can lag runtime Path alpha tool delivery, re-authorizing legacy universal entity-tool semantics after normal agents have moved to generated role-scoped tools
     representative_issues:
       - 111
       - 136

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -680,6 +680,9 @@ func emitToolDefinitions(cfg models.AgentConfig, authority runtimeauthority.Prov
 func filterTools(in []llm.ToolDefinition, allowed map[string]struct{}, constrained bool, roleScoped map[string]struct{}) []llm.ToolDefinition {
 	out := make([]llm.ToolDefinition, 0, len(in))
 	for _, t := range in {
+		if runtimetools.IsLegacyEntityToolSurfaceName(t.Name) {
+			continue
+		}
 		if runtimetools.IsUniversal(t.Name) {
 			out = append(out, t)
 			continue

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -122,9 +122,9 @@ func TestFormatEventForAgent_DoesNotAdvertiseCLIOnlyControlTools(t *testing.T) {
 	}
 }
 
-func TestFilterTools_RetainsUniversalEntityToolsWhenConstrained(t *testing.T) {
+func TestFilterTools_RemovesLegacyEntityToolsWhenConstrained(t *testing.T) {
 	allowed, constrained := extractAllowedToolSet(models.AgentConfig{
-		Tools: []string{"emit_example"},
+		Tools: []string{"emit_example", "get_entity"},
 	})
 	if !constrained {
 		t.Fatal("expected constrained tool set")
@@ -140,18 +140,21 @@ func TestFilterTools_RetainsUniversalEntityToolsWhenConstrained(t *testing.T) {
 	for _, tool := range filtered {
 		names = append(names, tool.Name)
 	}
-	if !containsString(names, "get_entity") || !containsString(names, "search_entities") || !containsString(names, "agent_message") {
-		t.Fatalf("expected universal tools preserved, got %v", names)
+	if containsString(names, "get_entity") || containsString(names, "search_entities") {
+		t.Fatalf("legacy entity tools should not be preserved by constrained filtering, got %v", names)
+	}
+	if !containsString(names, "agent_message") {
+		t.Fatalf("expected non-entity universal tool preserved, got %v", names)
 	}
 	if containsString(names, "non_universal") {
 		t.Fatalf("expected non-universal tool filtered out, got %v", names)
 	}
-	if !runtimetools.IsUniversal("get_entity") {
-		t.Fatal("expected get_entity to be universal")
+	if runtimetools.IsUniversal("get_entity") {
+		t.Fatal("get_entity must not remain universal")
 	}
 }
 
-func TestFilterTools_DefaultDeniesNonUniversalToolsWhenNoToolList(t *testing.T) {
+func TestFilterTools_DefaultDeniesLegacyEntityToolsWhenNoToolList(t *testing.T) {
 	allowed, constrained := extractAllowedToolSet(models.AgentConfig{})
 	if constrained {
 		t.Fatal("expected unconstrained tool set when no tools are configured")
@@ -166,8 +169,11 @@ func TestFilterTools_DefaultDeniesNonUniversalToolsWhenNoToolList(t *testing.T) 
 	for _, tool := range filtered {
 		names = append(names, tool.Name)
 	}
-	if !containsString(names, "get_entity") || !containsString(names, "agent_message") {
-		t.Fatalf("expected universal tools preserved, got %v", names)
+	if containsString(names, "get_entity") {
+		t.Fatalf("legacy entity tool should not be preserved by default filtering, got %v", names)
+	}
+	if !containsString(names, "agent_message") {
+		t.Fatalf("expected non-entity universal tool preserved, got %v", names)
 	}
 	if containsString(names, "schedule") {
 		t.Fatalf("expected non-universal tool filtered out, got %v", names)

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -2319,7 +2319,8 @@ func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetoo
 		t.Fatalf("seed run: %v", err)
 	}
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB: db,
+		SQLDB:                          db,
+		AllowInternalLegacyEntityTools: true,
 		WorkflowSource: runtimesemanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 			RootEntities: runtimecontracts.EntityContractsDocument{
 				"accounts": {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -2338,6 +2338,7 @@ func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetoo
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimetools.WithActor(ctx, runtimeactors.AgentConfig{
 		ID:    "tester",
+		Type:  "internal",
 		Role:  "operator",
 		Tools: []string{"create_entity", "save_entity_field"},
 	})

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -53,10 +53,6 @@ type runtimeGatewayExecutor interface {
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
 }
 
-type roleScopedEntityToolSurfaceReporter interface {
-	RoleScopedEntityToolsEnabledForActor(models.AgentConfig) bool
-}
-
 func NewGateway(executor runtimeGatewayExecutor, authToken string, hooks GatewayHooks) *Gateway {
 	return &Gateway{
 		executor:  executor,
@@ -643,15 +639,6 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string
 			}
 		}
 	}
-	if g.executor != nil && len(catalog) == 0 && !g.roleScopedEntityToolsEnabledForActor(actor) {
-		for _, def := range g.executor.ToolDefinitions() {
-			name := normalizeGatewayToolName(def.Name)
-			if name != "" {
-				def.Name = name
-				catalog[name] = def
-			}
-		}
-	}
 	if g.hooks.EmitToolsForActor != nil {
 		for _, def := range g.hooks.EmitToolsForActor(actor) {
 			name := normalizeGatewayToolName(def.Name)
@@ -674,14 +661,6 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string
 		}
 	}
 	return catalog
-}
-
-func (g *Gateway) roleScopedEntityToolsEnabledForActor(actor models.AgentConfig) bool {
-	if g == nil || g.executor == nil {
-		return false
-	}
-	reporter, ok := g.executor.(roleScopedEntityToolSurfaceReporter)
-	return ok && reporter.RoleScopedEntityToolsEnabledForActor(actor)
 }
 
 func (g *Gateway) requestToolCapabilities(actor models.AgentConfig, actorOK bool, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -199,10 +199,9 @@ func (s *relayAwareToolExecutorStub) PersistOversizedToolResultRelay(_ context.C
 }
 
 type actorScopedToolExecutorStub struct {
-	defs       []llm.ToolDefinition
-	actorDefs  []llm.ToolDefinition
-	roleScoped bool
-	callCount  *int
+	defs      []llm.ToolDefinition
+	actorDefs []llm.ToolDefinition
+	callCount *int
 }
 
 func (s actorScopedToolExecutorStub) Execute(context.Context, string, any) (any, error) {
@@ -218,10 +217,6 @@ func (s actorScopedToolExecutorStub) ToolDefinitions() []llm.ToolDefinition {
 
 func (s actorScopedToolExecutorStub) ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition {
 	return append([]llm.ToolDefinition(nil), s.actorDefs...)
-}
-
-func (s actorScopedToolExecutorStub) RoleScopedEntityToolsEnabledForActor(models.AgentConfig) bool {
-	return s.roleScoped
 }
 
 func (s actorScopedToolExecutorStub) ToolCapabilitiesForActor(_ models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
@@ -616,14 +611,13 @@ func TestGatewayMCPToolsForRequest_PrefersActorScopedToolDefinitions(t *testing.
 	}
 }
 
-func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForRoleScopedActor(t *testing.T) {
+func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForEmptyActorCatalog(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	g := NewGateway(actorScopedToolExecutorStub{
 		defs: []llm.ToolDefinition{
 			{Name: "get_entity", Description: "runtime-wide legacy entity tool"},
 		},
-		actorDefs:  nil,
-		roleScoped: true,
+		actorDefs: nil,
 	}, "", GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			return models.AgentConfig{ID: agentID, Role: "validation_orchestrator"}, true
@@ -640,7 +634,7 @@ func TestGatewayMCPToolsForRequest_DoesNotFallbackToRuntimeWideToolsForRoleScope
 	req := withContextToken(httptest.NewRequest("POST", "/mcp", nil), "ctx-role-scoped-empty")
 	tools := mustMCPToolsForRequest(t, g, req)
 	if len(tools) != 0 {
-		t.Fatalf("role-scoped empty actor catalog fell back to runtime-wide tools: %#v", tools)
+		t.Fatalf("empty actor catalog fell back to runtime-wide tools: %#v", tools)
 	}
 }
 
@@ -661,10 +655,9 @@ func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing
 		{Name: "save_validation_case_business_brief", Description: "role scoped save"},
 	}
 	g := NewGateway(actorScopedToolExecutorStub{
-		defs:       legacyDefs,
-		actorDefs:  generatedDefs,
-		roleScoped: true,
-		callCount:  &executeCount,
+		defs:      legacyDefs,
+		actorDefs: generatedDefs,
+		callCount: &executeCount,
 	}, testGatewayToken, GatewayHooks{
 		ResolveActorConfig: func(agentID string) (models.AgentConfig, bool) {
 			return models.AgentConfig{ID: agentID, Role: "validation_orchestrator"}, true

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -13,7 +13,9 @@ import (
 
 func TestToolDefinitionsForActor_DeriveRoleScopedEntitySchemasFromActorContract(t *testing.T) {
 	actor := models.AgentConfig{
-		ID:    "analyzer",
+		ID: "analyzer",
+		// Type is config-authored; it must not be trusted to restore legacy tools.
+		Type:  "internal",
 		Role:  "analyzer",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
 	}

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -1,6 +1,7 @@
 package tools_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -10,7 +11,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 )
 
-func TestToolDefinitionsForActor_DeriveWave1EntitySchemasFromActorContract(t *testing.T) {
+func TestToolDefinitionsForActor_DeriveRoleScopedEntitySchemasFromActorContract(t *testing.T) {
 	actor := models.AgentConfig{
 		ID:    "analyzer",
 		Role:  "analyzer",
@@ -41,104 +42,42 @@ review_subject:
 		defByName[def.Name] = schema
 	}
 
-	createSchema := defByName["create_entity"]
-	if createSchema == nil {
-		t.Fatal("expected create_entity definition")
+	for _, legacy := range []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"} {
+		if _, ok := defByName[legacy]; ok {
+			t.Fatalf("legacy entity tool %q remained visible in %#v", legacy, toolDefinitionNames(defs))
+		}
 	}
-	props, _ := createSchema["properties"].(map[string]any)
-	if _, ok := props["entity_id"]; ok {
-		t.Fatalf("create_entity schema should not expose entity_id: %#v", props)
-	}
-	if _, ok := props["entity_type"]; ok {
-		t.Fatalf("create_entity schema should not expose entity_type: %#v", props)
-	}
-	if _, ok := props["subject_id"]; ok {
-		t.Fatalf("create_entity schema should not expose subject_id: %#v", props)
-	}
-	fields, _ := props["fields"].(map[string]any)
-	fieldProps, _ := fields["properties"].(map[string]any)
-	if _, ok := fieldProps["status"]; !ok {
-		t.Fatalf("create_entity fields schema missing status: %#v", fieldProps)
-	}
-	if _, ok := fieldProps["metadata"]; !ok {
-		t.Fatalf("create_entity fields schema missing metadata: %#v", fieldProps)
-	}
-	if additional, ok := fields["additionalProperties"].(bool); !ok || additional {
-		t.Fatalf("create_entity fields additionalProperties = %#v, want false", fields["additionalProperties"])
+	caps := exec.ToolCapabilitiesForActor(actor, []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"}, nil)
+	for _, legacy := range []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"} {
+		cap, ok := caps.Capability(legacy)
+		if !ok || cap.Visible || cap.Callable {
+			t.Fatalf("legacy entity tool %q capability = %#v ok=%v, want denied", legacy, cap, ok)
+		}
+		if _, err := exec.Execute(runtimetools.WithActor(context.Background(), actor), legacy, map[string]any{}); err == nil || !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("direct legacy %s execution error = %v, want not allowed", legacy, err)
+		}
 	}
 
-	saveSchema := defByName["save_entity_field"]
-	saveProps, _ := saveSchema["properties"].(map[string]any)
-	fieldEnum, _ := saveProps["field"].(map[string]any)
-	values, _ := fieldEnum["enum"].([]any)
-	if !containsAnyString(values, "status") {
-		t.Fatalf("save_entity_field field enum = %#v, want status", values)
+	readSchema := defByName["read_review_subject"]
+	if readSchema == nil {
+		t.Fatalf("expected read_review_subject definition, got %v", toolDefinitionNames(defs))
 	}
-	if !containsAnyString(values, "metadata") {
-		t.Fatalf("save_entity_field field enum = %#v, want metadata", values)
+	props, _ := readSchema["properties"].(map[string]any)
+	if len(props) != 0 {
+		t.Fatalf("read_review_subject should not accept selector/entity_id input, got schema %#v", readSchema)
 	}
-	if !containsAnyString(values, "metadata.region") {
-		t.Fatalf("save_entity_field field enum = %#v, want metadata.region", values)
+
+	metadataSchema := defByName["read_review_subject_metadata"]
+	if metadataSchema == nil {
+		t.Fatalf("expected read_review_subject_metadata definition, got %v", toolDefinitionNames(defs))
 	}
-	if containsAnyString(values, "entity_id") {
-		t.Fatalf("save_entity_field field enum = %#v, should not include envelope field entity_id", values)
+	metadataProps, _ := metadataSchema["properties"].(map[string]any)
+	if len(metadataProps) != 0 {
+		t.Fatalf("read_review_subject_metadata should not accept selector/entity_id input, got schema %#v", metadataSchema)
 	}
 	summaryLines := llm.AgentVisibleToolSummaryLinesForActor(actor, defs)
-	wantWritablePathLine := "Writable entity paths for save_entity_field in this turn: " + strings.Join(anyStrings(values), ", ")
-	if !containsString(summaryLines, wantWritablePathLine) {
-		t.Fatalf("agent-visible writable path summary = %#v, want %q", summaryLines, wantWritablePathLine)
-	}
-
-	searchSchema := defByName["search_entities"]
-	searchProps, _ := searchSchema["properties"].(map[string]any)
-	searchTarget, _ := searchProps["entity_type"].(map[string]any)
-	searchTargets, _ := searchTarget["enum"].([]any)
-	if !containsAnyString(searchTargets, "review.review_subject") {
-		t.Fatalf("search_entities entity_type enum = %#v, want review.review_subject", searchTargets)
-	}
-	filterSchema, _ := searchProps["filter"].(map[string]any)
-	filterProps, _ := filterSchema["properties"].(map[string]any)
-	if _, ok := filterProps["metadata.region"]; !ok {
-		t.Fatalf("search_entities filter schema missing metadata.region: %#v", filterProps)
-	}
-	if _, ok := filterProps["status"]; !ok {
-		t.Fatalf("search_entities filter schema missing status: %#v", filterProps)
-	}
-	if additional, ok := filterSchema["additionalProperties"].(bool); !ok || additional {
-		t.Fatalf("search_entities filter additionalProperties = %#v, want false", filterSchema["additionalProperties"])
-	}
-
-	querySchema := defByName["query_entities"]
-	queryProps, _ := querySchema["properties"].(map[string]any)
-	queryTarget, _ := queryProps["entity_type"].(map[string]any)
-	queryTargets, _ := queryTarget["enum"].([]any)
-	if !containsAnyString(queryTargets, "review.review_subject") {
-		t.Fatalf("query_entities entity_type enum = %#v, want review.review_subject", queryTargets)
-	}
-	selectSchema, _ := queryProps["select"].(map[string]any)
-	selectItems, _ := selectSchema["items"].(map[string]any)
-	selectEnum, _ := selectItems["enum"].([]any)
-	if !containsAnyString(selectEnum, "metadata.region") {
-		t.Fatalf("query_entities select enum = %#v, want metadata.region", selectEnum)
-	}
-	if !containsAnyString(selectEnum, "entity_id") {
-		t.Fatalf("query_entities select enum = %#v, want entity_id", selectEnum)
-	}
-
-	metricSchema := defByName["query_metrics"]
-	metricProps, _ := metricSchema["properties"].(map[string]any)
-	metricTarget, _ := metricProps["entity_type"].(map[string]any)
-	metricTargets, _ := metricTarget["enum"].([]any)
-	if !containsAnyString(metricTargets, "review.review_subject") {
-		t.Fatalf("query_metrics entity_type enum = %#v, want review.review_subject", metricTargets)
-	}
-	metricField, _ := metricProps["field"].(map[string]any)
-	metricFieldEnum, _ := metricField["enum"].([]any)
-	if !containsAnyString(metricFieldEnum, "status") {
-		t.Fatalf("query_metrics field enum = %#v, want status", metricFieldEnum)
-	}
-	if containsAnyString(metricFieldEnum, "metadata") {
-		t.Fatalf("query_metrics field enum = %#v, should not include composite metadata", metricFieldEnum)
+	if containsString(summaryLines, "Writable entity paths for save_entity_field") {
+		t.Fatalf("legacy save_entity_field writable path summary remained visible: %#v", summaryLines)
 	}
 }
 
@@ -175,29 +114,21 @@ signal:
 		defByName[def.Name] = schema
 	}
 
-	for _, toolName := range []string{"search_entities", "query_entities", "query_metrics"} {
-		schema := defByName[toolName]
-		if schema == nil {
-			t.Fatalf("expected %s definition", toolName)
+	for _, legacy := range []string{"search_entities", "query_entities", "query_metrics"} {
+		if _, ok := defByName[legacy]; ok {
+			t.Fatalf("legacy query tool %q remained visible in %#v", legacy, toolDefinitionNames(defs))
 		}
-		props, _ := schema["properties"].(map[string]any)
-		target, _ := props["entity_type"].(map[string]any)
-		targets, _ := target["enum"].([]any)
-		if !containsAnyString(targets, "discovery.campaign") {
-			t.Fatalf("%s entity_type enum = %#v, want discovery.campaign", toolName, targets)
-		}
-		if containsAnyString(targets, "signal-search.signal") {
-			t.Fatalf("%s entity_type enum = %#v, should not expose foreign read target", toolName, targets)
-		}
+	}
+	if _, ok := defByName["read_campaign"]; !ok {
+		t.Fatalf("expected read_campaign role-scoped definition, got %#v", toolDefinitionNames(defs))
 	}
 }
 
 func TestToolDefinitionsForActor_HideEntityScopedUniversalToolsWithoutActorContract(t *testing.T) {
 	lifecycle := models.AgentConfig{
-		ID:           "lifecycle-coordinator",
-		Role:         "lifecycle-coordinator",
-		SessionScope: "global",
-		Tools:        []string{"schedule"},
+		ID:    "lifecycle-coordinator",
+		Role:  "lifecycle-coordinator",
+		Tools: []string{"schedule"},
 	}
 	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
 		"validation": {
@@ -221,14 +152,14 @@ vertical:
 	})
 	defs := exec.ToolDefinitionsForActor(lifecycle)
 	names := toolDefinitionNames(defs)
-	for _, toolName := range []string{"get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"} {
+	for _, toolName := range []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"} {
 		if containsString(names, toolName) {
 			t.Fatalf("expected %s to be hidden for actor with no entity contract/read scope, got %v", toolName, names)
 		}
 	}
 }
 
-func TestToolDefinitionsForActor_PreserveNonPlatformEntityToolNameOverrideWithoutActorContract(t *testing.T) {
+func TestToolDefinitionsForActor_RetireSameNameEntityToolOverrideWithoutActorContract(t *testing.T) {
 	lifecycle := models.AgentConfig{
 		ID:           "lifecycle-coordinator",
 		Role:         "lifecycle-coordinator",
@@ -270,40 +201,9 @@ validation_case:
 	for _, def := range defs {
 		defByName[def.Name] = def
 	}
-	def, ok := defByName["get_entity"]
-	if !ok {
-		t.Fatalf("expected non-platform get_entity override to remain visible, got %v", toolDefinitionNames(defs))
+	if _, ok := defByName["get_entity"]; ok {
+		t.Fatalf("same-name get_entity override remained visible, got %v", toolDefinitionNames(defs))
 	}
-	if got := strings.TrimSpace(def.Description); got != "Lifecycle-owned external lookup override." {
-		t.Fatalf("get_entity description = %q, want scoped override", got)
-	}
-	schema, _ := def.Schema.(map[string]any)
-	props, _ := schema["properties"].(map[string]any)
-	if _, ok := props["query"]; !ok {
-		t.Fatalf("get_entity override schema = %#v, want query property", schema)
-	}
-	if _, ok := props["entity_id"]; ok {
-		t.Fatalf("get_entity override schema = %#v, should not be platform entity schema", schema)
-	}
-}
-
-func containsAnyString(values []any, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}
-
-func anyStrings(values []any) []string {
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		if got, ok := value.(string); ok {
-			out = append(out, got)
-		}
-	}
-	return out
 }
 
 func toolDefinitionNames(defs []llm.ToolDefinition) []string {

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -50,4 +50,7 @@ type ExecutorOptions struct {
 	WorkspaceResolver workspace.Resolver
 	AuthorityProvider runtimeauthority.Provider
 	EmitRegistry      *EmitRegistry
+	// Trusted runtime/test escape hatch for exercising retained legacy handlers.
+	// Actor-authored config must never enable legacy entity tools for normal agents.
+	AllowInternalLegacyEntityTools bool
 }

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -26,27 +26,28 @@ import (
 )
 
 type Executor struct {
-	mu              sync.RWMutex
-	manager         Manager
-	managerProvider ManagerProvider
-	sqlDB           *sql.DB
-	bus             EventPublisher
-	scheduler       Scheduler
-	scheduleStore   SchedulePersistence
-	mailboxStore    MailboxPersistence
-	cfg             *config.Config
-	credentials     runtimecredentials.Store
-	httpClient      *http.Client
-	mcpClient       *runtimemcp.Client
-	workflowSource  semanticview.Source
-	workspaces      workspace.Resolver
-	authority       runtimeauthority.Provider
-	emitRegistry    *EmitRegistry
-	authorizer      *ToolAuthorizer
-	validator       *ToolInputValidator
-	dispatcher      *ToolDispatcher
-	oneShotMu       sync.Mutex
-	oneShotEmits    map[string]struct{}
+	mu                             sync.RWMutex
+	manager                        Manager
+	managerProvider                ManagerProvider
+	sqlDB                          *sql.DB
+	bus                            EventPublisher
+	scheduler                      Scheduler
+	scheduleStore                  SchedulePersistence
+	mailboxStore                   MailboxPersistence
+	cfg                            *config.Config
+	credentials                    runtimecredentials.Store
+	httpClient                     *http.Client
+	mcpClient                      *runtimemcp.Client
+	workflowSource                 semanticview.Source
+	workspaces                     workspace.Resolver
+	authority                      runtimeauthority.Provider
+	emitRegistry                   *EmitRegistry
+	authorizer                     *ToolAuthorizer
+	validator                      *ToolInputValidator
+	dispatcher                     *ToolDispatcher
+	allowInternalLegacyEntityTools bool
+	oneShotMu                      sync.Mutex
+	oneShotEmits                   map[string]struct{}
 }
 
 type runtimeToolLogSink interface {
@@ -63,21 +64,22 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		scheduleStore = stores[0]
 	}
 	exec := &Executor{
-		manager:         opts.Manager,
-		managerProvider: opts.ManagerProvider,
-		bus:             bus,
-		scheduler:       scheduler,
-		scheduleStore:   scheduleStore,
-		mailboxStore:    opts.MailboxStore,
-		sqlDB:           opts.SQLDB,
-		cfg:             opts.Config,
-		credentials:     opts.Credentials,
-		httpClient:      &http.Client{Timeout: 30 * time.Second},
-		mcpClient:       opts.MCPClient,
-		workflowSource:  opts.WorkflowSource,
-		workspaces:      opts.WorkspaceResolver,
-		authority:       runtimeauthority.ProviderOrNoop(opts.AuthorityProvider),
-		oneShotEmits:    make(map[string]struct{}),
+		manager:                        opts.Manager,
+		managerProvider:                opts.ManagerProvider,
+		bus:                            bus,
+		scheduler:                      scheduler,
+		scheduleStore:                  scheduleStore,
+		mailboxStore:                   opts.MailboxStore,
+		sqlDB:                          opts.SQLDB,
+		cfg:                            opts.Config,
+		credentials:                    opts.Credentials,
+		httpClient:                     &http.Client{Timeout: 30 * time.Second},
+		mcpClient:                      opts.MCPClient,
+		workflowSource:                 opts.WorkflowSource,
+		workspaces:                     opts.WorkspaceResolver,
+		authority:                      runtimeauthority.ProviderOrNoop(opts.AuthorityProvider),
+		allowInternalLegacyEntityTools: opts.AllowInternalLegacyEntityTools,
+		oneShotEmits:                   make(map[string]struct{}),
 	}
 	if opts.EmitRegistry != nil {
 		exec.emitRegistry = opts.EmitRegistry
@@ -148,10 +150,19 @@ func (e *Executor) resolveRegisteredTool(actor models.AgentConfig, name string) 
 	e.mu.RLock()
 	source := e.workflowSource
 	client := e.mcpClient
+	allowInternalLegacy := e.allowInternalLegacyEntityTools
 	e.mu.RUnlock()
 	var discovered map[string]runtimemcp.DiscoveredTool
 	if client != nil {
 		discovered = client.DiscoveredTools()
+	}
+	if allowInternalLegacy && IsLegacyEntityToolSurfaceName(name) {
+		entries, err := registeredToolsForRuntime(source, discovered)
+		if err != nil {
+			return RegisteredTool{}, false, err
+		}
+		tool, ok := entries[name]
+		return tool, ok, nil
 	}
 	return resolveRegisteredToolForActor(source, actor, name, discovered)
 }
@@ -247,8 +258,9 @@ func (e *Executor) toolAuthorizationDecision(actor models.AgentConfig, toolName 
 	toolName = normalizeNativeToolName(toolName)
 	e.mu.RLock()
 	source := e.workflowSource
+	allowInternalLegacy := e.allowInternalLegacyEntityTools
 	e.mu.RUnlock()
-	if _, legacy := legacyEntityToolSurfaceNames[toolName]; legacy && !actorAllowsInternalLegacyEntityTools(actor) {
+	if _, legacy := legacyEntityToolSurfaceNames[toolName]; legacy && !allowInternalLegacy {
 		return toolAuthorizationDecision{
 			ownership: toolOwnershipPlatformBuiltin,
 			class:     toolAuthorizationDenied,

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -248,14 +248,14 @@ func (e *Executor) toolAuthorizationDecision(actor models.AgentConfig, toolName 
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
-	if roleScopedEntityToolsEnabledForActor(source, actor) {
-		if _, legacy := legacyEntityToolSurfaceNames[toolName]; legacy {
-			return toolAuthorizationDecision{
-				ownership: toolOwnershipPlatformBuiltin,
-				class:     toolAuthorizationDenied,
-				allowed:   false,
-			}
+	if _, legacy := legacyEntityToolSurfaceNames[toolName]; legacy && !actorAllowsInternalLegacyEntityTools(actor) {
+		return toolAuthorizationDecision{
+			ownership: toolOwnershipPlatformBuiltin,
+			class:     toolAuthorizationDenied,
+			allowed:   false,
 		}
+	}
+	if roleScopedEntityToolsEnabledForActor(source, actor) {
 		if _, _, ok := roleScopedEntityToolSpecForActor(source, actor, toolName); ok {
 			return toolAuthorizationDecision{
 				ownership: toolOwnershipPlatformBuiltin,

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -374,19 +374,19 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 	}
 }
 
-func TestRoleScopedEntityTools_NonOptedActorKeepsLegacySurface(t *testing.T) {
+func TestRoleScopedEntityTools_NonOptedActorReceivesGeneratedSurfaceByDefault(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"get_entity", "query_entities"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, false)
 	_, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
 
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
 	for _, name := range []string{"get_entity", "query_entities"} {
-		if _, ok := names[name]; !ok {
-			t.Fatalf("expected legacy entity tool %q without opt-in in %#v", name, sortedRoleScopedToolNames(names))
+		if _, ok := names[name]; ok {
+			t.Fatalf("legacy entity tool %q remained visible without opt-in in %#v", name, sortedRoleScopedToolNames(names))
 		}
 	}
-	if _, ok := names["read_validation_case"]; ok {
-		t.Fatalf("generated role-scoped tool was visible without opt-in in %#v", sortedRoleScopedToolNames(names))
+	if _, ok := names["read_validation_case"]; !ok {
+		t.Fatalf("generated role-scoped tool was not visible by default in %#v", sortedRoleScopedToolNames(names))
 	}
 }
 
@@ -1027,6 +1027,7 @@ func TestEntityTools_GetEntityReturnsStoredCurrentState(t *testing.T) {
 func TestEntityTools_GetEntityReturnsForkLocalMaterializedRevision(t *testing.T) {
 	actor := models.AgentConfig{
 		ID:    "tester",
+		Type:  "internal",
 		Role:  "operator",
 		Tools: []string{"get_entity"},
 	}
@@ -1122,6 +1123,7 @@ accounts:
 func TestEntityTools_SaveEntityFieldAfterForkActivationUsesForkRunID(t *testing.T) {
 	actor := models.AgentConfig{
 		ID:    "tester",
+		Type:  "internal",
 		Role:  "operator",
 		Tools: []string{"get_entity", "save_entity_field"},
 	}
@@ -1807,7 +1809,7 @@ func TestEntityTools_InvalidField(t *testing.T) {
 		"field":     "unknown_field",
 		"value":     "x",
 	})
-	if err == nil || !strings.Contains(err.Error(), "invalid enum value unknown_field") {
+	if err == nil || !strings.Contains(err.Error(), "unknown entity field") {
 		t.Fatalf("expected delivery-boundary invalid field rejection, got %v", err)
 	}
 }
@@ -1867,7 +1869,7 @@ func TestEntityTools_CreateEntityRejectsCallerSuppliedSubjectID(t *testing.T) {
 	}
 }
 
-func TestEntityTools_ConstrainedAllowedToolsStillPermitOnlyUniversalEntityTools(t *testing.T) {
+func TestEntityTools_ConstrainedAllowedToolsDoNotPermitLegacyEntityTools(t *testing.T) {
 	ctx, exec := newEntityToolTestExecutorWithActor(t, models.AgentConfig{
 		ID:    "tester",
 		Role:  "operator",
@@ -1885,8 +1887,8 @@ func TestEntityTools_ConstrainedAllowedToolsStillPermitOnlyUniversalEntityTools(
 	}); err == nil {
 		t.Fatalf("expected create_entity to be denied when not listed in tools")
 	}
-	if _, err := exec.Execute(ctx, "query_entities", map[string]any{}); err != nil {
-		t.Fatalf("query_entities with constrained tools: %v", err)
+	if _, err := exec.Execute(ctx, "query_entities", map[string]any{}); err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("query_entities with constrained tools error = %v, want not allowed", err)
 	}
 }
 
@@ -2349,6 +2351,7 @@ func newAnnotatedEntityToolExecutor(t *testing.T) (context.Context, *runtimetool
 	t.Helper()
 	return newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
 		ID:    "tester",
+		Type:  "internal",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities"},
 	}, loadWave1EntityToolBundle(t, models.AgentConfig{
@@ -2383,6 +2386,9 @@ func newEntityToolTestHarness(t *testing.T) (context.Context, *runtimetools.Exec
 
 func newEntityToolTestHarnessWithActor(t *testing.T, actor models.AgentConfig) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
+	if strings.TrimSpace(actor.Type) == "" {
+		actor.Type = "internal"
+	}
 	bundle := loadWave1EntityToolBundle(t, actor, "review", "accounts", `
 types:
   Metadata:
@@ -2413,6 +2419,11 @@ accounts:
 
 func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
+	if strings.TrimSpace(actor.Type) == "" && strings.TrimSpace(actor.ID) != "validation-orchestrator" {
+		// These legacy handler tests exercise retained internal/operator paths,
+		// not normal agent provider-visible tool delivery.
+		actor.Type = "internal"
+	}
 	_, db, _ := testutil.StartPostgres(t)
 	ensureEntityToolTestRun(t, db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -260,7 +260,7 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 		"search_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
 
 	defs := exec.ToolDefinitionsForActor(actor)
 	names := roleScopedToolDefinitionMap(defs)
@@ -337,7 +337,7 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 	if errs := runtimetools.ValidateGeneratedToolSchemaClosureForSource(source); len(errs) > 0 {
 		t.Fatalf("ValidateGeneratedToolSchemaClosureForSource errors = %#v", errs)
 	}
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
 	saveSchema := names["save_validation_case_business_brief"].Schema.(map[string]any)
 	if err := runtimetools.ValidatePayloadAgainstSchema(saveSchema, map[string]any{
@@ -377,7 +377,7 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 func TestRoleScopedEntityTools_NonOptedActorReceivesGeneratedSurfaceByDefault(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"get_entity", "query_entities"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, false)
-	_, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	_, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
 
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
 	for _, name := range []string{"get_entity", "query_entities"} {
@@ -398,7 +398,7 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 		"query_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
 	currentID := uuid.NewString()
 	siblingID := uuid.NewString()
 	foreignID := uuid.NewString()
@@ -460,7 +460,7 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
 	entityID := uuid.NewString()
 	brief := strings.Repeat("business brief ", 1800)
 	specProblem := strings.Repeat("problem statement ", 900)
@@ -1089,8 +1089,9 @@ accounts:
 		t.Fatalf("MaterializeRunFork: %v", err)
 	}
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:          db,
-		WorkflowSource: semanticview.Wrap(bundle),
+		SQLDB:                          db,
+		WorkflowSource:                 semanticview.Wrap(bundle),
+		AllowInternalLegacyEntityTools: true,
 	})
 	forkCtx := runtimetools.WithActor(runtimecorrelation.WithRunID(context.Background(), result.ForkRunID), actor)
 	out, err := exec.Execute(forkCtx, "get_entity", map[string]any{"entity_id": entityID})
@@ -1193,8 +1194,9 @@ accounts:
 	}
 
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:          db,
-		WorkflowSource: semanticview.Wrap(bundle),
+		SQLDB:                          db,
+		WorkflowSource:                 semanticview.Wrap(bundle),
+		AllowInternalLegacyEntityTools: true,
 	})
 	forkCtx := runtimetools.WithActor(runtimecorrelation.WithRunID(context.Background(), materialized.ForkRunID), actor)
 	if _, err := exec.Execute(forkCtx, "save_entity_field", map[string]any{
@@ -2419,17 +2421,18 @@ accounts:
 
 func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
-	if strings.TrimSpace(actor.Type) == "" && strings.TrimSpace(actor.ID) != "validation-orchestrator" {
-		// These legacy handler tests exercise retained internal/operator paths,
-		// not normal agent provider-visible tool delivery.
-		actor.Type = "internal"
-	}
+	return newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, true)
+}
+
+func newEntityToolTestHarnessWithBundleAndLegacyAccess(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, allowInternalLegacy bool) (context.Context, *runtimetools.Executor, *sql.DB) {
+	t.Helper()
 	_, db, _ := testutil.StartPostgres(t)
 	ensureEntityToolTestRun(t, db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:          db,
-		WorkflowSource: semanticview.Wrap(bundle),
+		SQLDB:                          db,
+		WorkflowSource:                 semanticview.Wrap(bundle),
+		AllowInternalLegacyEntityTools: allowInternalLegacy,
 	})
 	return runtimetools.WithActor(ctx, actor), exec, db
 }

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -28,7 +28,7 @@ func builtinRegisteredTools(source semanticview.Source, actor *models.AgentConfi
 }
 
 func builtinRuntimeContractSchemas(source semanticview.Source, actor *models.AgentConfig) map[string]ContractSchemaEntry {
-	if actor != nil && roleScopedEntityToolsEnabledForActor(source, *actor) {
+	if actor != nil {
 		contract, ok := resolveEntityToolContract(source, actor)
 		if !ok {
 			return map[string]ContractSchemaEntry{}

--- a/internal/runtime/tools/policy.go
+++ b/internal/runtime/tools/policy.go
@@ -3,21 +3,8 @@ package tools
 import "strings"
 
 var universalRuntimeTools = map[string]struct{}{
-	"agent_message":     {},
-	"mailbox_send":      {},
-	"get_entity":        {},
-	"save_entity_field": {},
-	"query_entities":    {},
-	"search_entities":   {},
-	"query_metrics":     {},
-}
-
-var entityScopedUniversalRuntimeTools = map[string]struct{}{
-	"get_entity":        {},
-	"save_entity_field": {},
-	"query_entities":    {},
-	"search_entities":   {},
-	"query_metrics":     {},
+	"agent_message": {},
+	"mailbox_send":  {},
 }
 
 func IsUniversal(toolName string) bool {
@@ -26,14 +13,5 @@ func IsUniversal(toolName string) bool {
 		return false
 	}
 	_, ok := universalRuntimeTools[toolName]
-	return ok
-}
-
-func isEntityScopedUniversalRuntimeTool(toolName string) bool {
-	toolName = strings.TrimSpace(toolName)
-	if toolName == "" {
-		return false
-	}
-	_, ok := entityScopedUniversalRuntimeTools[toolName]
 	return ok
 }

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -139,9 +139,7 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
-	if !actorAllowsInternalLegacyEntityTools(actor) {
-		removeLegacyEntityToolSurface(entries)
-	}
+	removeLegacyEntityToolSurface(entries)
 	for name, entry := range builtinRegisteredTools(source, &actor) {
 		entries[name] = entry
 	}
@@ -184,9 +182,7 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 		}
 		entries[name] = tool
 	}
-	if !actorAllowsInternalLegacyEntityTools(actor) {
-		removeLegacyEntityToolSurface(entries)
-	}
+	removeLegacyEntityToolSurface(entries)
 	return entries, nil
 }
 

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -6,7 +6,6 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
-	"swarm/internal/runtime/entityruntime"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	"swarm/internal/runtime/semanticview"
@@ -140,8 +139,7 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
-	roleScopedEntitySurface := roleScopedEntityToolsEnabledForActor(source, actor)
-	if roleScopedEntitySurface {
+	if !actorAllowsInternalLegacyEntityTools(actor) {
 		removeLegacyEntityToolSurface(entries)
 	}
 	for name, entry := range builtinRegisteredTools(source, &actor) {
@@ -186,33 +184,10 @@ func registeredToolsForActor(source semanticview.Source, actor models.AgentConfi
 		}
 		entries[name] = tool
 	}
-	if roleScopedEntitySurface {
+	if !actorAllowsInternalLegacyEntityTools(actor) {
 		removeLegacyEntityToolSurface(entries)
 	}
-	removeUnavailableEntityScopedUniversalTools(entries, source, actor)
 	return entries, nil
-}
-
-func removeUnavailableEntityScopedUniversalTools(entries map[string]RegisteredTool, source semanticview.Source, actor models.AgentConfig) {
-	if len(entries) == 0 || source == nil {
-		return
-	}
-	if !strings.EqualFold(strings.TrimSpace(actor.SessionScope), "global") {
-		return
-	}
-	actorID := strings.TrimSpace(actor.ID)
-	if actorID == "" {
-		return
-	}
-	if _, ok := entityruntime.ResolveForActor(source, actorID); ok {
-		return
-	}
-	for name := range entries {
-		tool := entries[name]
-		if tool.HandlerType == implementationPlatformBuiltin && isEntityScopedUniversalRuntimeTool(name) {
-			delete(entries, name)
-		}
-	}
 }
 
 func resolveRegisteredToolForActor(source semanticview.Source, actor models.AgentConfig, toolName string, discovered map[string]runtimemcp.DiscoveredTool) (RegisteredTool, bool, error) {

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -46,23 +46,32 @@ func removeLegacyEntityToolSurface(entries map[string]RegisteredTool) {
 	}
 }
 
+func IsLegacyEntityToolSurfaceName(name string) bool {
+	_, ok := legacyEntityToolSurfaceNames[strings.TrimSpace(name)]
+	return ok
+}
+
 func roleScopedEntityToolsEnabledForActor(source semanticview.Source, actor models.AgentConfig) bool {
-	if source == nil {
+	return actorHasEntityContract(source, actor)
+}
+
+func actorHasEntityContract(source semanticview.Source, actor models.AgentConfig) bool {
+	if source == nil || strings.TrimSpace(actor.ID) == "" {
 		return false
 	}
-	contractSource, ok := source.AgentContractSource(strings.TrimSpace(actor.ID))
-	if !ok {
+	_, ok := entityruntime.ResolveForActor(source, actor.ID)
+	return ok
+}
+
+func actorAllowsInternalLegacyEntityTools(actor models.AgentConfig) bool {
+	// Legacy entity handlers remain available only to non-agent internal/operator
+	// paths. Normal agent configs do not set these execution types.
+	switch strings.ToLower(strings.TrimSpace(actor.Type)) {
+	case "internal", "operator", "system", "system_node":
+		return true
+	default:
 		return false
 	}
-	flowID := strings.TrimSpace(contractSource.FlowID)
-	if flowID == "" {
-		return false
-	}
-	schema, ok := source.FlowSchemaByID(flowID)
-	if !ok {
-		return false
-	}
-	return schema.ToolSurface.RoleScopedEntityTools
 }
 
 func roleScopedEntityToolSchemaEntriesForActor(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) map[string]ContractSchemaEntry {
@@ -305,9 +314,6 @@ func roleScopedToolNamePart(raw string) string {
 }
 
 func roleScopedEntityToolSpecForActor(source semanticview.Source, actor models.AgentConfig, toolName string) (roleScopedEntityToolSpec, entityruntime.Contract, bool) {
-	if !roleScopedEntityToolsEnabledForActor(source, actor) {
-		return roleScopedEntityToolSpec{}, entityruntime.Contract{}, false
-	}
 	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
 	if !ok {
 		return roleScopedEntityToolSpec{}, entityruntime.Contract{}, false
@@ -324,9 +330,6 @@ func (e *Executor) RoleScopedEntityToolNamesForActor(actor models.AgentConfig) m
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
-	if !roleScopedEntityToolsEnabledForActor(source, actor) {
-		return nil
-	}
 	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
 	if !ok {
 		return nil

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -63,17 +63,6 @@ func actorHasEntityContract(source semanticview.Source, actor models.AgentConfig
 	return ok
 }
 
-func actorAllowsInternalLegacyEntityTools(actor models.AgentConfig) bool {
-	// Legacy entity handlers remain available only to non-agent internal/operator
-	// paths. Normal agent configs do not set these execution types.
-	switch strings.ToLower(strings.TrimSpace(actor.Type)) {
-	case "internal", "operator", "system", "system_node":
-		return true
-	default:
-		return false
-	}
-}
-
 func roleScopedEntityToolSchemaEntriesForActor(source semanticview.Source, actor models.AgentConfig, contract entityruntime.Contract) map[string]ContractSchemaEntry {
 	specs := roleScopedEntityToolSpecsForActor(source, actor, contract)
 	out := make(map[string]ContractSchemaEntry, len(specs))


### PR DESCRIPTION
## Summary

Closes #617.

This PR makes generated role-scoped typed entity tools the default normal-agent entity surface and retires legacy generic entity tools from normal-agent catalogs/callability.

## Governing Context

- Pre-Implementation Coverage Audit: #617 issue thread.
- Gate outcome: approved.
- Authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Related tracker context: #568, #579, #580, #581, #582, #571, #556.

## Semantic Migration

- New canonical owner: runtime role-scoped entity tool catalog/authorization plus `platform-spec.yaml`.
- Old producer/reader/writer path now invalid for normal agents: provider/MCP catalogs and allowed-tools authorization for `create_entity`, `get_entity`, `get_subject_status`, `query_entities`, `search_entities`, `query_metrics`, and `save_entity_field`.
- Production paths checked: `ToolDefinitionsForActor`, registry construction, MCP `tools/list` fallback, LLM filter path, executor authorization, capability projection, startup/transport tests, and runtime-wide internal definitions.
- Migration completeness: complete for normal-agent catalog/callability. Retained legacy handlers are trusted runtime-internal compatibility only; actor-authored `type`/`role`/YAML config cannot re-enable them.

## Verification

- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/agents -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./...`
- `git diff --check`

## Notes

- #579 is superseded as the active implementation boundary for this normal-agent runtime class.
- #571/#556 remain adjacent residual trackers only for runtime-internal or root/run identity reclassification after this runtime surface removal.