### PR TITLE
[agent-a][issue #618] Persist selected route recovery

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2771,8 +2771,10 @@ platform_tables:
       description: Durable fork-local selected-contract route/topology recovery evidence. This table is owned by
         store.run_fork.selected_contract_route_persistence and consumed by runtime.run_fork.selected_contract_route_recovery
         after restart. Rows are keyed by fork run_id and selected binding/topology/recipient evidence; they are not copied
-        source routing_rules rows and are not current operational flow-instance route rows. Runtime recovery must consume
-        these rows as route truth for selected-contract forks and must continue to gate recipients through
+        source routing_rules rows and are not current operational flow-instance route rows. The topology and recipient
+        fingerprints are computed over canonical JSON semantics so JSONB storage normalization cannot invalidate honest
+        rows while tampered payloads still fail closed. Runtime recovery must consume these rows as route truth for
+        selected-contract forks and must continue to gate recipients through
         runtime.run_fork.selected_contract_recipient_planning before publish. This table does not authorize delivery
         replay, handler execution, receipts, dead letters, idempotency, timers, sessions, contract swap, or UI/API
         ownership.
@@ -3366,7 +3368,8 @@ run_model:
       store.run_fork.selected_contract_route_persistence and runtime recovery consumption is owned by
       runtime.run_fork.selected_contract_route_recovery. The store owner persists selected route topology, dynamic
       topology proof or fail-closed state, recipient-plan evidence, selected binding identity, and evidence
-      fingerprints under the fork run_id. Runtime recovery MUST read this owner after restart for selected-contract
+      fingerprints under the fork run_id. Topology and recipient-planning fingerprints MUST be computed and verified
+      over canonical JSON semantics rather than raw JSONB storage bytes. Runtime recovery MUST read this owner after restart for selected-contract
       fork route truth and MUST NOT read source/current routing_rules, source flow_instance_routes, current
       ListFlowInstanceRoutes output, or source event_deliveries as executable fork route or recipient truth. Recipient
       planning and EventBus.Publish recipient-plan guards remain authoritative before publish. This owner MUST NOT write

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2767,6 +2767,16 @@ platform_tables:
         and selected execution proceeds as a branch rather than freezing or rewinding the source. Source post-fork facts
         remain source-run evidence only; fork-local work is regenerated under the fork run_id.
       ddl: "CREATE TABLE run_fork_selected_contract_branch_divergences (\n    divergence_id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                     UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                   UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                   UUID NOT NULL REFERENCES events(event_id),\n    owner                           TEXT NOT NULL,\n    policy                          TEXT NOT NULL CHECK (policy IN ('selected_contract_source_advanced_branch')),\n    source_run_status_at_activation TEXT NOT NULL,\n    source_run_status_after_activation TEXT NOT NULL,\n    source_frozen                   BOOLEAN NOT NULL DEFAULT FALSE,\n    source_advanced_facts           TEXT[] NOT NULL DEFAULT '{}',\n    created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_branch_divergences_source (source_run_id, fork_event_id)\n);"
+    run_fork_selected_contract_route_recoveries:
+      description: Durable fork-local selected-contract route/topology recovery evidence. This table is owned by
+        store.run_fork.selected_contract_route_persistence and consumed by runtime.run_fork.selected_contract_route_recovery
+        after restart. Rows are keyed by fork run_id and selected binding/topology/recipient evidence; they are not copied
+        source routing_rules rows and are not current operational flow-instance route rows. Runtime recovery must consume
+        these rows as route truth for selected-contract forks and must continue to gate recipients through
+        runtime.run_fork.selected_contract_recipient_planning before publish. This table does not authorize delivery
+        replay, handler execution, receipts, dead letters, idempotency, timers, sessions, contract swap, or UI/API
+        ownership.
+      ddl: "CREATE TABLE run_fork_selected_contract_route_recoveries (\n    recovery_id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                    UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                  UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                  UUID NOT NULL REFERENCES events(event_id),\n    owner                          TEXT NOT NULL,\n    runtime_recovery_owner         TEXT NOT NULL,\n    mode                           TEXT NOT NULL CHECK (mode IN ('selected_contracts')),\n    contracts_root                 TEXT NOT NULL,\n    workflow_name                  TEXT NOT NULL,\n    workflow_version               TEXT NOT NULL,\n    route_topology_owner           TEXT NOT NULL,\n    dynamic_topology_owner         TEXT,\n    recipient_planning_owner       TEXT NOT NULL,\n    frontier_evidence_fingerprint  TEXT NOT NULL,\n    route_topology_fingerprint     TEXT NOT NULL,\n    recipient_planning_fingerprint TEXT NOT NULL,\n    static_route_event_count       INTEGER NOT NULL DEFAULT 0,\n    dynamic_topology_proof_count   INTEGER NOT NULL DEFAULT 0,\n    recipient_plan_event_count     INTEGER NOT NULL DEFAULT 0,\n    route_topology                 JSONB NOT NULL,\n    recipient_planning             JSONB NOT NULL,\n    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_source (source_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_owner (owner, runtime_recovery_owner)\n);"
     event_deliveries:
       description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
         inherited from the parent event for run-scoped queries.
@@ -3352,6 +3362,16 @@ run_model:
       owner MUST NOT copy source routing_rules or materialized flow-instance route rows, persist fork-local route rows,
       derive executable recipients outside runtime.run_fork.selected_contract_recipient_planning, invoke delivery
       writes, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
+    selected_contract_route_persistence_recovery: 'Fork-local selected-contract route persistence is owned by
+      store.run_fork.selected_contract_route_persistence and runtime recovery consumption is owned by
+      runtime.run_fork.selected_contract_route_recovery. The store owner persists selected route topology, dynamic
+      topology proof or fail-closed state, recipient-plan evidence, selected binding identity, and evidence
+      fingerprints under the fork run_id. Runtime recovery MUST read this owner after restart for selected-contract
+      fork route truth and MUST NOT read source/current routing_rules, source flow_instance_routes, current
+      ListFlowInstanceRoutes output, or source event_deliveries as executable fork route or recipient truth. Recipient
+      planning and EventBus.Publish recipient-plan guards remain authoritative before publish. This owner MUST NOT write
+      event_deliveries, run handlers, replay timers, reconstruct sessions/turns/audits, replay non-agent work,
+      implement contract-swap boot/resume, or own UI/API behavior.'
     selected_contract_recipient_planning: 'Selected-contract recipient planning for mutating fork execution is owned by
       runtime.run_fork.selected_contract_recipient_planning after selected route topology. It consumes the durable
       selected-contract binding, runtime.run_fork.contract_frontier_admission, runtime.run_fork.selected_contract_route_admission,

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -171,7 +171,7 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
   - id: 618
-    title: Gate fork-local selected-contract route persistence owner before delivery writes
+    title: Gate fork-local selected-contract route persistence/runtime recovery
     maps_to:
       - timestamp_fork_replay_resume_ownership
   - id: 619
@@ -321,6 +321,7 @@ nodes:
       - selected-contract recipient planning needs a canonical owner beyond route topology before selected execution publishes fork-local events; selected execution and EventBus.Publish must consume that owner before recipient derivation, while delivery writes, route persistence, handlers, timers, sessions, turns, source-advanced policy, contract swap, and UI/API remain separately gated siblings
       - selected-contract delivery writes are now closed for the supported swarm fork --contracts path through runtime.run_fork.selected_contract_execution consuming runtime.run_fork.selected_contract_recipient_planning; source deliveries remain lineage/blocker evidence and route persistence remains split
       - selected-contract parent-tail rebaseline must close or narrow stale #588/#608 tracker state while keeping #564/#549 open for full replay/resume and fork architecture siblings
+      - selected-contract route persistence/runtime recovery needs a fork-local owner keyed by fork run_id and selected binding/topology/recipient evidence; current routing_rules, flow_instance_routes, and startup ListFlowInstanceRoutes recovery remain current-route infrastructure and must not become selected-fork route truth
     representative_issues:
       - 564
       - 565

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -37,7 +37,7 @@ type AgentManager struct {
 	inFlightMu                      sync.Mutex
 	inFlight                        map[string]struct{}
 	workflowInstances               flowInstancePersistence
-	selectedContractRouteRecoveries map[string]SelectedContractRouteRecoveryRecord
+	selectedContractRouteRecoveries map[string]SelectedContractRouteRecoveryTruth
 
 	runMu              sync.Mutex
 	running            bool
@@ -105,7 +105,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		semanticSource:                  opts.SemanticSource,
 		promptResolver:                  opts.PromptResolver,
 		workflowInstances:               opts.WorkflowInstances,
-		selectedContractRouteRecoveries: map[string]SelectedContractRouteRecoveryRecord{},
+		selectedContractRouteRecoveries: map[string]SelectedContractRouteRecoveryTruth{},
 		runtimeMode:                     strings.TrimSpace(opts.RuntimeMode),
 		budget:                          opts.Budget,
 		resetRuntimeOwnedState:          opts.ResetRuntimeOwnedState,

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -18,25 +18,26 @@ import (
 )
 
 type AgentManager struct {
-	mu                             sync.RWMutex
-	agents                         map[string]Agent
-	agentCfg                       map[string]models.AgentConfig
-	agentUpAt                      map[string]time.Time
-	workspaces                     workspace.Lifecycle
-	bus                            Bus
-	factory                        AgentFactory
-	store                          ManagerPersistence
-	sessions                       sessions.Registry
-	semanticSource                 semanticview.Source
-	promptResolver                 runtimecontracts.PromptResolver
-	budget                         BudgetGuard
-	resetRuntimeOwnedState         func()
-	runtimeShutdownAdmissionClosed func() bool
-	runtimeMode                    string
-	throttleSuppressPrefixes       []string
-	inFlightMu                     sync.Mutex
-	inFlight                       map[string]struct{}
-	workflowInstances              flowInstancePersistence
+	mu                              sync.RWMutex
+	agents                          map[string]Agent
+	agentCfg                        map[string]models.AgentConfig
+	agentUpAt                       map[string]time.Time
+	workspaces                      workspace.Lifecycle
+	bus                             Bus
+	factory                         AgentFactory
+	store                           ManagerPersistence
+	sessions                        sessions.Registry
+	semanticSource                  semanticview.Source
+	promptResolver                  runtimecontracts.PromptResolver
+	budget                          BudgetGuard
+	resetRuntimeOwnedState          func()
+	runtimeShutdownAdmissionClosed  func() bool
+	runtimeMode                     string
+	throttleSuppressPrefixes        []string
+	inFlightMu                      sync.Mutex
+	inFlight                        map[string]struct{}
+	workflowInstances               flowInstancePersistence
+	selectedContractRouteRecoveries map[string]SelectedContractRouteRecoveryRecord
 
 	runMu              sync.Mutex
 	running            bool
@@ -93,29 +94,30 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		}
 	}
 	return &AgentManager{
-		agents:                         make(map[string]Agent),
-		agentCfg:                       make(map[string]models.AgentConfig),
-		agentUpAt:                      make(map[string]time.Time),
-		bus:                            bus,
-		factory:                        factory,
-		store:                          store,
-		workspaces:                     opts.Workspaces,
-		sessions:                       opts.Sessions,
-		semanticSource:                 opts.SemanticSource,
-		promptResolver:                 opts.PromptResolver,
-		workflowInstances:              opts.WorkflowInstances,
-		runtimeMode:                    strings.TrimSpace(opts.RuntimeMode),
-		budget:                         opts.Budget,
-		resetRuntimeOwnedState:         opts.ResetRuntimeOwnedState,
-		runtimeShutdownAdmissionClosed: opts.RuntimeShutdownAdmissionClosed,
-		throttleSuppressPrefixes:       throttleSuppressPrefixes,
-		inFlight:                       make(map[string]struct{}),
-		loopCancel:                     make(map[string]context.CancelFunc),
-		poisonPanicCounts:              make(map[string]int),
-		poisonEventEntities:            make(map[string]map[string]struct{}),
-		poisonEventEmitted:             make(map[string]bool),
-		deadLetterWindows:              make(map[string][]deadLetterEscalationSample),
-		deadLetterLastRaised:           make(map[string]time.Time),
+		agents:                          make(map[string]Agent),
+		agentCfg:                        make(map[string]models.AgentConfig),
+		agentUpAt:                       make(map[string]time.Time),
+		bus:                             bus,
+		factory:                         factory,
+		store:                           store,
+		workspaces:                      opts.Workspaces,
+		sessions:                        opts.Sessions,
+		semanticSource:                  opts.SemanticSource,
+		promptResolver:                  opts.PromptResolver,
+		workflowInstances:               opts.WorkflowInstances,
+		selectedContractRouteRecoveries: map[string]SelectedContractRouteRecoveryRecord{},
+		runtimeMode:                     strings.TrimSpace(opts.RuntimeMode),
+		budget:                          opts.Budget,
+		resetRuntimeOwnedState:          opts.ResetRuntimeOwnedState,
+		runtimeShutdownAdmissionClosed:  opts.RuntimeShutdownAdmissionClosed,
+		throttleSuppressPrefixes:        throttleSuppressPrefixes,
+		inFlight:                        make(map[string]struct{}),
+		loopCancel:                      make(map[string]context.CancelFunc),
+		poisonPanicCounts:               make(map[string]int),
+		poisonEventEntities:             make(map[string]map[string]struct{}),
+		poisonEventEmitted:              make(map[string]bool),
+		deadLetterWindows:               make(map[string][]deadLetterEscalationSample),
+		deadLetterLastRaised:            make(map[string]time.Time),
 	}
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 type recoveryTestBus struct {
-	storedRoutes []runtimebus.FlowInstanceRouteRecord
-	restored     []string
-	replayable   []events.PersistedReplayEvent
-	deliveries   map[string][]string
-	runtimeLogs  []runtimepipeline.RuntimeLogEntry
-	direct       []events.Event
+	storedRoutes            []runtimebus.FlowInstanceRouteRecord
+	selectedRouteRecoveries []SelectedContractRouteRecoveryRecord
+	restored                []string
+	replayable              []events.PersistedReplayEvent
+	deliveries              map[string][]string
+	runtimeLogs             []runtimepipeline.RuntimeLogEntry
+	direct                  []events.Event
 }
 
 func (*recoveryTestBus) Publish(context.Context, events.Event) error                 { return nil }
@@ -65,6 +66,9 @@ func (b *recoveryTestBus) ListFlowInstanceRoutes(context.Context) ([]runtimeflow
 		out = append(out, route.Identity)
 	}
 	return out, nil
+}
+func (b *recoveryTestBus) ListSelectedContractRouteRecoveryRecords(context.Context) ([]SelectedContractRouteRecoveryRecord, error) {
+	return append([]SelectedContractRouteRecoveryRecord(nil), b.selectedRouteRecoveries...), nil
 }
 func (b *recoveryTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
 	b.restored = append(b.restored, identity.InstancePath)
@@ -154,6 +158,79 @@ func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
 	}
 	if len(bus.restored) != 1 || bus.restored[0] != "review/inst-1" {
 		t.Fatalf("restored routes = %#v, want [review/inst-1]", bus.restored)
+	}
+}
+
+func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *testing.T) {
+	forkRunID := "00000000-0000-0000-0000-000000000601"
+	bus := &recoveryTestBus{
+		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{{
+			Owner:                        SelectedContractRoutePersistenceOwner,
+			RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
+			ForkRunID:                    forkRunID,
+			SourceRunID:                  "00000000-0000-0000-0000-000000000501",
+			ForkEventID:                  "00000000-0000-0000-0000-000000000701",
+			RouteTopologyOwner:           "runtime.run_fork.selected_contract_route_topology",
+			DynamicTopologyOwner:         "runtime.run_fork.selected_contract_dynamic_route_topology",
+			RecipientPlanningOwner:       "runtime.run_fork.selected_contract_recipient_planning",
+			FrontierEvidenceFingerprint:  "frontier-fp",
+			RouteTopologyFingerprint:     "topology-fp",
+			RecipientPlanningFingerprint: "recipient-fp",
+			StaticRouteEventCount:        1,
+			DynamicTopologyProofCount:    1,
+			RecipientPlanEventCount:      1,
+			CreatedAt:                    time.Now().UTC(),
+		}},
+	}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, &recoveryTestStore{})
+
+	if err := am.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	snapshot := am.SelectedContractRouteRecoverySnapshot()
+	if len(snapshot) != 1 {
+		t.Fatalf("selected route recovery snapshot len = %d, want 1", len(snapshot))
+	}
+	if got := snapshot[forkRunID]; got.Owner != SelectedContractRoutePersistenceOwner || got.RuntimeRecoveryOwner != SelectedContractRouteRecoveryOwner {
+		t.Fatalf("selected route recovery owner = (%q, %q), want canonical owners", got.Owner, got.RuntimeRecoveryOwner)
+	}
+	if len(bus.restored) != 0 {
+		t.Fatalf("current route restore was used for selected route recovery: %#v", bus.restored)
+	}
+	state, err := am.RecoverableStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("RecoverableStateSnapshot: %v", err)
+	}
+	if state.PersistedSelectedContractRouteRecoveryCount != 1 {
+		t.Fatalf("selected route recovery count = %d, want 1", state.PersistedSelectedContractRouteRecoveryCount)
+	}
+}
+
+func TestRecoverRejectsSelectedContractRouteRecoveryFromCurrentRouteOwner(t *testing.T) {
+	bus := &recoveryTestBus{
+		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{{
+			Owner:                        "routing_rules",
+			RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
+			ForkRunID:                    "00000000-0000-0000-0000-000000000602",
+			SourceRunID:                  "00000000-0000-0000-0000-000000000502",
+			ForkEventID:                  "00000000-0000-0000-0000-000000000702",
+			RouteTopologyOwner:           "runtime.run_fork.selected_contract_route_topology",
+			RecipientPlanningOwner:       "runtime.run_fork.selected_contract_recipient_planning",
+			FrontierEvidenceFingerprint:  "frontier-fp",
+			RouteTopologyFingerprint:     "topology-fp",
+			RecipientPlanningFingerprint: "recipient-fp",
+			CreatedAt:                    time.Now().UTC(),
+		}},
+	}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, &recoveryTestStore{})
+
+	err := am.Recover(context.Background())
+	if err == nil || !strings.Contains(err.Error(), SelectedContractRoutePersistenceOwner) {
+		t.Fatalf("Recover error = %v, want canonical owner rejection", err)
 	}
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -164,23 +164,9 @@ func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
 func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *testing.T) {
 	forkRunID := "00000000-0000-0000-0000-000000000601"
 	bus := &recoveryTestBus{
-		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{{
-			Owner:                        SelectedContractRoutePersistenceOwner,
-			RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
-			ForkRunID:                    forkRunID,
-			SourceRunID:                  "00000000-0000-0000-0000-000000000501",
-			ForkEventID:                  "00000000-0000-0000-0000-000000000701",
-			RouteTopologyOwner:           "runtime.run_fork.selected_contract_route_topology",
-			DynamicTopologyOwner:         "runtime.run_fork.selected_contract_dynamic_route_topology",
-			RecipientPlanningOwner:       "runtime.run_fork.selected_contract_recipient_planning",
-			FrontierEvidenceFingerprint:  "frontier-fp",
-			RouteTopologyFingerprint:     "topology-fp",
-			RecipientPlanningFingerprint: "recipient-fp",
-			StaticRouteEventCount:        1,
-			DynamicTopologyProofCount:    1,
-			RecipientPlanEventCount:      1,
-			CreatedAt:                    time.Now().UTC(),
-		}},
+		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{
+			selectedContractRouteRecoveryRecord(t, forkRunID),
+		},
 	}
 	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
 		return recoveryTestAgent{id: cfg.ID}, nil
@@ -193,8 +179,40 @@ func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *tes
 	if len(snapshot) != 1 {
 		t.Fatalf("selected route recovery snapshot len = %d, want 1", len(snapshot))
 	}
-	if got := snapshot[forkRunID]; got.Owner != SelectedContractRoutePersistenceOwner || got.RuntimeRecoveryOwner != SelectedContractRouteRecoveryOwner {
-		t.Fatalf("selected route recovery owner = (%q, %q), want canonical owners", got.Owner, got.RuntimeRecoveryOwner)
+	if got := snapshot[forkRunID]; got.Record.Owner != SelectedContractRoutePersistenceOwner ||
+		got.Record.RuntimeRecoveryOwner != SelectedContractRouteRecoveryOwner ||
+		got.RouteTopology.Owner != selectedContractRouteTopologyOwner ||
+		got.RecipientPlanning.Owner != selectedContractRecipientPlanningOwner ||
+		len(got.RecipientPlanning.RecipientPlanEvents) != 1 {
+		t.Fatalf("selected route recovery truth = %#v, want canonical recovered topology and recipient planning", got)
+	}
+	guard, ok := am.SelectedContractRouteRecoveryRecipientGuard(forkRunID)
+	if !ok {
+		t.Fatalf("missing selected route recovery recipient guard for %s", forkRunID)
+	}
+	guard.ExpectForkEvent("fork-event-1", "source-event-1")
+	evt := events.Event{
+		ID:          "fork-event-1",
+		Type:        events.EventType("work.ready"),
+		SourceAgent: selectedContractExecutionOwner,
+	}
+	if err := guard.AuthorizeEvent(context.Background(), evt); err != nil {
+		t.Fatalf("AuthorizeEvent recovered guard: %v", err)
+	}
+	if err := guard.Authorize(context.Background(), evt, runtimebus.PublishRecipientPlan{
+		RoutedRecipients: []runtimebus.PublishDiagnosticRecipient{{
+			Type:        "agent",
+			ID:          "agent-a",
+			Path:        "review/inst-1",
+			RouteSource: "selected_contract_route_topology",
+		}},
+	}); err != nil {
+		t.Fatalf("Authorize recovered recipients: %v", err)
+	}
+	if err := guard.Authorize(context.Background(), evt, runtimebus.PublishRecipientPlan{
+		SubscriptionRecipients: []string{"agent-a"},
+	}); err == nil || !strings.Contains(err.Error(), "live subscriptions") {
+		t.Fatalf("Authorize subscription bypass error = %v, want live subscription rejection", err)
 	}
 	if len(bus.restored) != 0 {
 		t.Fatalf("current route restore was used for selected route recovery: %#v", bus.restored)
@@ -209,20 +227,10 @@ func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *tes
 }
 
 func TestRecoverRejectsSelectedContractRouteRecoveryFromCurrentRouteOwner(t *testing.T) {
+	record := selectedContractRouteRecoveryRecord(t, "00000000-0000-0000-0000-000000000602")
+	record.Owner = "routing_rules"
 	bus := &recoveryTestBus{
-		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{{
-			Owner:                        "routing_rules",
-			RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
-			ForkRunID:                    "00000000-0000-0000-0000-000000000602",
-			SourceRunID:                  "00000000-0000-0000-0000-000000000502",
-			ForkEventID:                  "00000000-0000-0000-0000-000000000702",
-			RouteTopologyOwner:           "runtime.run_fork.selected_contract_route_topology",
-			RecipientPlanningOwner:       "runtime.run_fork.selected_contract_recipient_planning",
-			FrontierEvidenceFingerprint:  "frontier-fp",
-			RouteTopologyFingerprint:     "topology-fp",
-			RecipientPlanningFingerprint: "recipient-fp",
-			CreatedAt:                    time.Now().UTC(),
-		}},
+		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{record},
 	}
 	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
 		return recoveryTestAgent{id: cfg.ID}, nil
@@ -231,6 +239,76 @@ func TestRecoverRejectsSelectedContractRouteRecoveryFromCurrentRouteOwner(t *tes
 	err := am.Recover(context.Background())
 	if err == nil || !strings.Contains(err.Error(), SelectedContractRoutePersistenceOwner) {
 		t.Fatalf("Recover error = %v, want canonical owner rejection", err)
+	}
+}
+
+func selectedContractRouteRecoveryRecord(t *testing.T, forkRunID string) SelectedContractRouteRecoveryRecord {
+	t.Helper()
+	return SelectedContractRouteRecoveryRecord{
+		Owner:                        SelectedContractRoutePersistenceOwner,
+		RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
+		ForkRunID:                    forkRunID,
+		SourceRunID:                  "00000000-0000-0000-0000-000000000501",
+		ForkEventID:                  "00000000-0000-0000-0000-000000000701",
+		RouteTopologyOwner:           selectedContractRouteTopologyOwner,
+		DynamicTopologyOwner:         "runtime.run_fork.selected_contract_dynamic_route_topology",
+		RecipientPlanningOwner:       selectedContractRecipientPlanningOwner,
+		FrontierEvidenceFingerprint:  "frontier-fp",
+		RouteTopologyFingerprint:     "topology-fp",
+		RecipientPlanningFingerprint: "recipient-fp",
+		StaticRouteEventCount:        1,
+		DynamicTopologyProofCount:    1,
+		RecipientPlanEventCount:      1,
+		RouteTopology: mustRecoveryJSON(t, map[string]any{
+			"owner":                           selectedContractRouteTopologyOwner,
+			"non_mutating":                    true,
+			"route_persistence_supported":     false,
+			"executable_recipients_supported": false,
+			"frontier_evidence_fingerprint":   "frontier-fp",
+			"static_route_events": []map[string]any{{
+				"source_event_id": "source-event-1",
+				"event_name":      "work.ready",
+				"derived_recipients": []map[string]any{{
+					"subscriber_type": "agent",
+					"subscriber_id":   "agent-a",
+					"path":            "review/inst-1",
+					"route_source":    "selected_contract_route_topology",
+				}},
+				"disposition": "selected_contract_route_topology",
+			}},
+			"dynamic_topology_proofs": []map[string]any{{
+				"flow_instance":    "review/inst-1",
+				"source_event_ids": []string{"source-event-1"},
+				"event_names":      []string{"work.ready"},
+				"derived_recipients": []map[string]any{{
+					"subscriber_type": "agent",
+					"subscriber_id":   "agent-a",
+					"path":            "review/inst-1",
+					"route_source":    "selected_contract_route_topology",
+				}},
+				"disposition": "selected_contract_dynamic_route_topology",
+			}},
+		}),
+		RecipientPlanning: mustRecoveryJSON(t, map[string]any{
+			"owner":                         selectedContractRecipientPlanningOwner,
+			"route_topology_owner":          selectedContractRouteTopologyOwner,
+			"non_mutating":                  true,
+			"recipient_planning_supported":  true,
+			"delivery_writes_supported":     false,
+			"frontier_evidence_fingerprint": "frontier-fp",
+			"recipient_plan_events": []map[string]any{{
+				"source_event_id": "source-event-1",
+				"event_name":      "work.ready",
+				"recipients": []map[string]any{{
+					"subscriber_type": "agent",
+					"subscriber_id":   "agent-a",
+					"path":            "review/inst-1",
+					"route_source":    "selected_contract_route_topology",
+				}},
+				"disposition": "selected_contract_recipient_planning",
+			}},
+		}),
+		CreatedAt: time.Now().UTC(),
 	}
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -242,8 +244,91 @@ func TestRecoverRejectsSelectedContractRouteRecoveryFromCurrentRouteOwner(t *tes
 	}
 }
 
+func TestRecoverRejectsSelectedContractRouteRecoveryFingerprintMismatch(t *testing.T) {
+	record := selectedContractRouteRecoveryRecord(t, "00000000-0000-0000-0000-000000000603")
+	record.RecipientPlanning = mustRecoveryJSON(t, map[string]any{
+		"owner":                         selectedContractRecipientPlanningOwner,
+		"route_topology_owner":          selectedContractRouteTopologyOwner,
+		"non_mutating":                  true,
+		"recipient_planning_supported":  true,
+		"delivery_writes_supported":     false,
+		"frontier_evidence_fingerprint": "frontier-fp",
+		"recipient_plan_events": []map[string]any{{
+			"source_event_id": "source-event-1",
+			"event_name":      "work.ready",
+			"recipients": []map[string]any{{
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-tampered",
+				"path":            "review/inst-1",
+				"route_source":    "selected_contract_route_topology",
+			}},
+			"disposition": "selected_contract_recipient_planning",
+		}},
+	})
+	bus := &recoveryTestBus{
+		selectedRouteRecoveries: []SelectedContractRouteRecoveryRecord{record},
+	}
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, &recoveryTestStore{})
+
+	err := am.Recover(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "recipient planning fingerprint mismatch") {
+		t.Fatalf("Recover error = %v, want recipient planning fingerprint mismatch", err)
+	}
+}
+
 func selectedContractRouteRecoveryRecord(t *testing.T, forkRunID string) SelectedContractRouteRecoveryRecord {
 	t.Helper()
+	routeTopology := mustRecoveryJSON(t, map[string]any{
+		"owner":                           selectedContractRouteTopologyOwner,
+		"non_mutating":                    true,
+		"route_persistence_supported":     false,
+		"executable_recipients_supported": false,
+		"frontier_evidence_fingerprint":   "frontier-fp",
+		"static_route_events": []map[string]any{{
+			"source_event_id": "source-event-1",
+			"event_name":      "work.ready",
+			"derived_recipients": []map[string]any{{
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-a",
+				"path":            "review/inst-1",
+				"route_source":    "selected_contract_route_topology",
+			}},
+			"disposition": "selected_contract_route_topology",
+		}},
+		"dynamic_topology_proofs": []map[string]any{{
+			"flow_instance":    "review/inst-1",
+			"source_event_ids": []string{"source-event-1"},
+			"event_names":      []string{"work.ready"},
+			"derived_recipients": []map[string]any{{
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-a",
+				"path":            "review/inst-1",
+				"route_source":    "selected_contract_route_topology",
+			}},
+			"disposition": "selected_contract_dynamic_route_topology",
+		}},
+	})
+	recipientPlanning := mustRecoveryJSON(t, map[string]any{
+		"owner":                         selectedContractRecipientPlanningOwner,
+		"route_topology_owner":          selectedContractRouteTopologyOwner,
+		"non_mutating":                  true,
+		"recipient_planning_supported":  true,
+		"delivery_writes_supported":     false,
+		"frontier_evidence_fingerprint": "frontier-fp",
+		"recipient_plan_events": []map[string]any{{
+			"source_event_id": "source-event-1",
+			"event_name":      "work.ready",
+			"recipients": []map[string]any{{
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-a",
+				"path":            "review/inst-1",
+				"route_source":    "selected_contract_route_topology",
+			}},
+			"disposition": "selected_contract_recipient_planning",
+		}},
+	})
 	return SelectedContractRouteRecoveryRecord{
 		Owner:                        SelectedContractRoutePersistenceOwner,
 		RuntimeRecoveryOwner:         SelectedContractRouteRecoveryOwner,
@@ -254,62 +339,20 @@ func selectedContractRouteRecoveryRecord(t *testing.T, forkRunID string) Selecte
 		DynamicTopologyOwner:         "runtime.run_fork.selected_contract_dynamic_route_topology",
 		RecipientPlanningOwner:       selectedContractRecipientPlanningOwner,
 		FrontierEvidenceFingerprint:  "frontier-fp",
-		RouteTopologyFingerprint:     "topology-fp",
-		RecipientPlanningFingerprint: "recipient-fp",
+		RouteTopologyFingerprint:     recoveryJSONFingerprint(routeTopology),
+		RecipientPlanningFingerprint: recoveryJSONFingerprint(recipientPlanning),
 		StaticRouteEventCount:        1,
 		DynamicTopologyProofCount:    1,
 		RecipientPlanEventCount:      1,
-		RouteTopology: mustRecoveryJSON(t, map[string]any{
-			"owner":                           selectedContractRouteTopologyOwner,
-			"non_mutating":                    true,
-			"route_persistence_supported":     false,
-			"executable_recipients_supported": false,
-			"frontier_evidence_fingerprint":   "frontier-fp",
-			"static_route_events": []map[string]any{{
-				"source_event_id": "source-event-1",
-				"event_name":      "work.ready",
-				"derived_recipients": []map[string]any{{
-					"subscriber_type": "agent",
-					"subscriber_id":   "agent-a",
-					"path":            "review/inst-1",
-					"route_source":    "selected_contract_route_topology",
-				}},
-				"disposition": "selected_contract_route_topology",
-			}},
-			"dynamic_topology_proofs": []map[string]any{{
-				"flow_instance":    "review/inst-1",
-				"source_event_ids": []string{"source-event-1"},
-				"event_names":      []string{"work.ready"},
-				"derived_recipients": []map[string]any{{
-					"subscriber_type": "agent",
-					"subscriber_id":   "agent-a",
-					"path":            "review/inst-1",
-					"route_source":    "selected_contract_route_topology",
-				}},
-				"disposition": "selected_contract_dynamic_route_topology",
-			}},
-		}),
-		RecipientPlanning: mustRecoveryJSON(t, map[string]any{
-			"owner":                         selectedContractRecipientPlanningOwner,
-			"route_topology_owner":          selectedContractRouteTopologyOwner,
-			"non_mutating":                  true,
-			"recipient_planning_supported":  true,
-			"delivery_writes_supported":     false,
-			"frontier_evidence_fingerprint": "frontier-fp",
-			"recipient_plan_events": []map[string]any{{
-				"source_event_id": "source-event-1",
-				"event_name":      "work.ready",
-				"recipients": []map[string]any{{
-					"subscriber_type": "agent",
-					"subscriber_id":   "agent-a",
-					"path":            "review/inst-1",
-					"route_source":    "selected_contract_route_topology",
-				}},
-				"disposition": "selected_contract_recipient_planning",
-			}},
-		}),
-		CreatedAt: time.Now().UTC(),
+		RouteTopology:                routeTopology,
+		RecipientPlanning:            recipientPlanning,
+		CreatedAt:                    time.Now().UTC(),
 	}
+}
+
+func recoveryJSONFingerprint(raw json.RawMessage) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
 }
 
 func TestRecover_UsesCanonicalLoadedAgentMetadata(t *testing.T) {

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -500,6 +500,9 @@ func (am *AgentManager) recover(ctx context.Context, startupReplayDiagnostics bo
 	if err := am.restoreFlowInstanceRoutes(ctx); err != nil {
 		return summary, err
 	}
+	if err := am.restoreSelectedContractRouteRecoveries(ctx); err != nil {
+		return summary, err
+	}
 
 	if err := runtimepipeline.NewRecoveryManagerWith(am.bus.Store(), am.bus).Recover(ctx); err != nil {
 		return summary, fmt.Errorf("recover pipeline receipts: %w", err)
@@ -514,13 +517,17 @@ func (am *AgentManager) recover(ctx context.Context, startupReplayDiagnostics bo
 }
 
 type RecoverableStateSnapshot struct {
-	PersistedAgentCount             int
-	PersistedFlowInstanceRouteCount int
-	ReplayEligibleEventPresent      bool
+	PersistedAgentCount                         int
+	PersistedFlowInstanceRouteCount             int
+	PersistedSelectedContractRouteRecoveryCount int
+	ReplayEligibleEventPresent                  bool
 }
 
 func (s RecoverableStateSnapshot) HasRecoverableWork() bool {
-	return s.PersistedAgentCount > 0 || s.PersistedFlowInstanceRouteCount > 0 || s.ReplayEligibleEventPresent
+	return s.PersistedAgentCount > 0 ||
+		s.PersistedFlowInstanceRouteCount > 0 ||
+		s.PersistedSelectedContractRouteRecoveryCount > 0 ||
+		s.ReplayEligibleEventPresent
 }
 
 func (s RecoverableStateSnapshot) Classes() []string {
@@ -531,6 +538,9 @@ func (s RecoverableStateSnapshot) Classes() []string {
 	if s.PersistedFlowInstanceRouteCount > 0 {
 		classes = append(classes, "persisted flow instance routes")
 	}
+	if s.PersistedSelectedContractRouteRecoveryCount > 0 {
+		classes = append(classes, "selected-contract route recoveries")
+	}
 	if s.ReplayEligibleEventPresent {
 		classes = append(classes, "events missing pipeline receipts")
 	}
@@ -540,9 +550,10 @@ func (s RecoverableStateSnapshot) Classes() []string {
 
 func (s RecoverableStateSnapshot) Detail() map[string]any {
 	return map[string]any{
-		"persisted_agent_count":               s.PersistedAgentCount,
-		"persisted_flow_instance_route_count": s.PersistedFlowInstanceRouteCount,
-		"replay_eligible_event_present":       s.ReplayEligibleEventPresent,
+		"persisted_agent_count":                            s.PersistedAgentCount,
+		"persisted_flow_instance_route_count":              s.PersistedFlowInstanceRouteCount,
+		"persisted_selected_contract_route_recovery_count": s.PersistedSelectedContractRouteRecoveryCount,
+		"replay_eligible_event_present":                    s.ReplayEligibleEventPresent,
 	}
 }
 
@@ -571,6 +582,13 @@ func (am *AgentManager) RecoverableStateSnapshot(ctx context.Context) (Recoverab
 			return RecoverableStateSnapshot{}, fmt.Errorf("list persisted flow instance routes: %w", err)
 		}
 		snapshot.PersistedFlowInstanceRouteCount = len(routes)
+	}
+	if routeRecoveryStore, ok := store.(selectedContractRouteRecoveryLister); ok && routeRecoveryStore != nil {
+		recoveries, err := routeRecoveryStore.ListSelectedContractRouteRecoveryRecords(ctx)
+		if err != nil {
+			return RecoverableStateSnapshot{}, fmt.Errorf("list selected-contract route recoveries: %w", err)
+		}
+		snapshot.PersistedSelectedContractRouteRecoveryCount = len(recoveries)
 	}
 	replayStore, ok := store.(runtimereplayclaim.Lister)
 	if ok && replayStore != nil {

--- a/internal/runtime/manager/selected_contract_route_recovery.go
+++ b/internal/runtime/manager/selected_contract_route_recovery.go
@@ -1,0 +1,99 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	SelectedContractRoutePersistenceOwner = "store.run_fork.selected_contract_route_persistence"
+	SelectedContractRouteRecoveryOwner    = "runtime.run_fork.selected_contract_route_recovery"
+)
+
+type SelectedContractRouteRecoveryRecord struct {
+	Owner                        string
+	RuntimeRecoveryOwner         string
+	ForkRunID                    string
+	SourceRunID                  string
+	ForkEventID                  string
+	RouteTopologyOwner           string
+	DynamicTopologyOwner         string
+	RecipientPlanningOwner       string
+	FrontierEvidenceFingerprint  string
+	RouteTopologyFingerprint     string
+	RecipientPlanningFingerprint string
+	StaticRouteEventCount        int
+	DynamicTopologyProofCount    int
+	RecipientPlanEventCount      int
+	CreatedAt                    time.Time
+}
+
+type selectedContractRouteRecoveryLister interface {
+	ListSelectedContractRouteRecoveryRecords(ctx context.Context) ([]SelectedContractRouteRecoveryRecord, error)
+}
+
+func (am *AgentManager) restoreSelectedContractRouteRecoveries(ctx context.Context) error {
+	if am == nil || am.bus == nil || am.bus.Store() == nil {
+		return nil
+	}
+	lister, ok := am.bus.Store().(selectedContractRouteRecoveryLister)
+	if !ok || lister == nil {
+		return nil
+	}
+	records, err := lister.ListSelectedContractRouteRecoveryRecords(ctx)
+	if err != nil {
+		return fmt.Errorf("list selected-contract route recoveries: %w", err)
+	}
+	recovered := make(map[string]SelectedContractRouteRecoveryRecord, len(records))
+	for _, record := range records {
+		if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
+			return err
+		}
+		recovered[strings.TrimSpace(record.ForkRunID)] = record
+	}
+	am.mu.Lock()
+	am.selectedContractRouteRecoveries = recovered
+	am.mu.Unlock()
+	return nil
+}
+
+func validateSelectedContractRouteRecoveryRecord(record SelectedContractRouteRecoveryRecord) error {
+	if strings.TrimSpace(record.Owner) != SelectedContractRoutePersistenceOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s owner; got %q", SelectedContractRoutePersistenceOwner, record.Owner)
+	}
+	if strings.TrimSpace(record.RuntimeRecoveryOwner) != SelectedContractRouteRecoveryOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s runtime owner; got %q", SelectedContractRouteRecoveryOwner, record.RuntimeRecoveryOwner)
+	}
+	if strings.TrimSpace(record.ForkRunID) == "" ||
+		strings.TrimSpace(record.SourceRunID) == "" ||
+		strings.TrimSpace(record.ForkEventID) == "" {
+		return fmt.Errorf("selected-contract route recovery requires fork/source/event identity")
+	}
+	if strings.TrimSpace(record.RouteTopologyOwner) != "runtime.run_fork.selected_contract_route_topology" {
+		return fmt.Errorf("selected-contract route recovery requires route topology owner; got %q", record.RouteTopologyOwner)
+	}
+	if strings.TrimSpace(record.RecipientPlanningOwner) != "runtime.run_fork.selected_contract_recipient_planning" {
+		return fmt.Errorf("selected-contract route recovery requires recipient planning owner; got %q", record.RecipientPlanningOwner)
+	}
+	if strings.TrimSpace(record.FrontierEvidenceFingerprint) == "" ||
+		strings.TrimSpace(record.RouteTopologyFingerprint) == "" ||
+		strings.TrimSpace(record.RecipientPlanningFingerprint) == "" {
+		return fmt.Errorf("selected-contract route recovery requires evidence fingerprints")
+	}
+	return nil
+}
+
+func (am *AgentManager) SelectedContractRouteRecoverySnapshot() map[string]SelectedContractRouteRecoveryRecord {
+	if am == nil {
+		return nil
+	}
+	am.mu.RLock()
+	defer am.mu.RUnlock()
+	out := make(map[string]SelectedContractRouteRecoveryRecord, len(am.selectedContractRouteRecoveries))
+	for forkRunID, record := range am.selectedContractRouteRecoveries {
+		out[forkRunID] = record
+	}
+	return out
+}

--- a/internal/runtime/manager/selected_contract_route_recovery.go
+++ b/internal/runtime/manager/selected_contract_route_recovery.go
@@ -1,11 +1,13 @@
 package manager
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -163,10 +165,18 @@ func decodeSelectedContractRouteRecoveryTruth(record SelectedContractRouteRecove
 	if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
 		return SelectedContractRouteRecoveryTruth{}, err
 	}
-	if got := selectedContractRecoveredJSONFingerprint(record.RouteTopology); got != strings.TrimSpace(record.RouteTopologyFingerprint) {
+	got, err := selectedContractRecoveredJSONFingerprint(record.RouteTopology)
+	if err != nil {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("fingerprint selected-contract recovered route topology: %w", err)
+	}
+	if got != strings.TrimSpace(record.RouteTopologyFingerprint) {
 		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered route topology fingerprint mismatch")
 	}
-	if got := selectedContractRecoveredJSONFingerprint(record.RecipientPlanning); got != strings.TrimSpace(record.RecipientPlanningFingerprint) {
+	got, err = selectedContractRecoveredJSONFingerprint(record.RecipientPlanning)
+	if err != nil {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("fingerprint selected-contract recovered recipient planning: %w", err)
+	}
+	if got != strings.TrimSpace(record.RecipientPlanningFingerprint) {
 		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning fingerprint mismatch")
 	}
 	var topology selectedContractRecoveredRouteTopology
@@ -206,9 +216,23 @@ func decodeSelectedContractRouteRecoveryTruth(record SelectedContractRouteRecove
 	}, nil
 }
 
-func selectedContractRecoveredJSONFingerprint(raw json.RawMessage) string {
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
+func selectedContractRecoveredJSONFingerprint(raw json.RawMessage) (string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return "", fmt.Errorf("unexpected trailing JSON")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func newSelectedContractRecoveredRecipientGuard(planning selectedContractRecoveredRecipientPlanning) selectedContractRecoveredRecipientGuard {

--- a/internal/runtime/manager/selected_contract_route_recovery.go
+++ b/internal/runtime/manager/selected_contract_route_recovery.go
@@ -2,14 +2,23 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 )
 
 const (
 	SelectedContractRoutePersistenceOwner = "store.run_fork.selected_contract_route_persistence"
 	SelectedContractRouteRecoveryOwner    = "runtime.run_fork.selected_contract_route_recovery"
+
+	selectedContractExecutionOwner         = "runtime.run_fork.selected_contract_execution"
+	selectedContractRouteTopologyOwner     = "runtime.run_fork.selected_contract_route_topology"
+	selectedContractRecipientPlanningOwner = "runtime.run_fork.selected_contract_recipient_planning"
 )
 
 type SelectedContractRouteRecoveryRecord struct {
@@ -27,7 +36,66 @@ type SelectedContractRouteRecoveryRecord struct {
 	StaticRouteEventCount        int
 	DynamicTopologyProofCount    int
 	RecipientPlanEventCount      int
+	RouteTopology                json.RawMessage
+	RecipientPlanning            json.RawMessage
 	CreatedAt                    time.Time
+}
+
+type SelectedContractRouteRecoveryTruth struct {
+	Record            SelectedContractRouteRecoveryRecord
+	RouteTopology     selectedContractRecoveredRouteTopology
+	RecipientPlanning selectedContractRecoveredRecipientPlanning
+	recipientGuard    selectedContractRecoveredRecipientGuard
+}
+
+type selectedContractRecoveredRouteTopology struct {
+	Owner                         string `json:"owner"`
+	NonMutating                   bool   `json:"non_mutating"`
+	RoutePersistenceSupported     bool   `json:"route_persistence_supported"`
+	ExecutableRecipientsSupported bool   `json:"executable_recipients_supported"`
+	FrontierEvidenceFingerprint   string `json:"frontier_evidence_fingerprint"`
+	StaticRouteEvents             []struct {
+		SourceEventID     string                               `json:"source_event_id,omitempty"`
+		EventName         string                               `json:"event_name"`
+		DerivedRecipients []selectedContractRecoveredRecipient `json:"derived_recipients,omitempty"`
+		Disposition       string                               `json:"disposition"`
+	} `json:"static_route_events,omitempty"`
+	DynamicTopologyProofs []struct {
+		FlowInstance      string                               `json:"flow_instance"`
+		SourceEventIDs    []string                             `json:"source_event_ids,omitempty"`
+		EventNames        []string                             `json:"event_names,omitempty"`
+		DerivedRecipients []selectedContractRecoveredRecipient `json:"derived_recipients,omitempty"`
+		Disposition       string                               `json:"disposition"`
+	} `json:"dynamic_topology_proofs,omitempty"`
+}
+
+type selectedContractRecoveredRecipientPlanning struct {
+	Owner                       string                                        `json:"owner"`
+	RouteTopologyOwner          string                                        `json:"route_topology_owner"`
+	NonMutating                 bool                                          `json:"non_mutating"`
+	RecipientPlanningSupported  bool                                          `json:"recipient_planning_supported"`
+	DeliveryWritesSupported     bool                                          `json:"delivery_writes_supported"`
+	FrontierEvidenceFingerprint string                                        `json:"frontier_evidence_fingerprint"`
+	RecipientPlanEvents         []selectedContractRecoveredRecipientPlanEvent `json:"recipient_plan_events,omitempty"`
+}
+
+type selectedContractRecoveredRecipientPlanEvent struct {
+	SourceEventID string                               `json:"source_event_id,omitempty"`
+	EventName     string                               `json:"event_name"`
+	Recipients    []selectedContractRecoveredRecipient `json:"recipients,omitempty"`
+	Disposition   string                               `json:"disposition"`
+}
+
+type selectedContractRecoveredRecipient struct {
+	SubscriberType string `json:"subscriber_type,omitempty"`
+	SubscriberID   string `json:"subscriber_id,omitempty"`
+	Path           string `json:"path,omitempty"`
+	RouteSource    string `json:"route_source,omitempty"`
+}
+
+type selectedContractRecoveredRecipientGuard struct {
+	plansBySourceEvent map[string]selectedContractRecoveredRecipientPlanEvent
+	sourceByForkEvent  map[string]string
 }
 
 type selectedContractRouteRecoveryLister interface {
@@ -46,12 +114,13 @@ func (am *AgentManager) restoreSelectedContractRouteRecoveries(ctx context.Conte
 	if err != nil {
 		return fmt.Errorf("list selected-contract route recoveries: %w", err)
 	}
-	recovered := make(map[string]SelectedContractRouteRecoveryRecord, len(records))
+	recovered := make(map[string]SelectedContractRouteRecoveryTruth, len(records))
 	for _, record := range records {
-		if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
+		truth, err := decodeSelectedContractRouteRecoveryTruth(record)
+		if err != nil {
 			return err
 		}
-		recovered[strings.TrimSpace(record.ForkRunID)] = record
+		recovered[strings.TrimSpace(record.ForkRunID)] = truth
 	}
 	am.mu.Lock()
 	am.selectedContractRouteRecoveries = recovered
@@ -71,10 +140,10 @@ func validateSelectedContractRouteRecoveryRecord(record SelectedContractRouteRec
 		strings.TrimSpace(record.ForkEventID) == "" {
 		return fmt.Errorf("selected-contract route recovery requires fork/source/event identity")
 	}
-	if strings.TrimSpace(record.RouteTopologyOwner) != "runtime.run_fork.selected_contract_route_topology" {
+	if strings.TrimSpace(record.RouteTopologyOwner) != selectedContractRouteTopologyOwner {
 		return fmt.Errorf("selected-contract route recovery requires route topology owner; got %q", record.RouteTopologyOwner)
 	}
-	if strings.TrimSpace(record.RecipientPlanningOwner) != "runtime.run_fork.selected_contract_recipient_planning" {
+	if strings.TrimSpace(record.RecipientPlanningOwner) != selectedContractRecipientPlanningOwner {
 		return fmt.Errorf("selected-contract route recovery requires recipient planning owner; got %q", record.RecipientPlanningOwner)
 	}
 	if strings.TrimSpace(record.FrontierEvidenceFingerprint) == "" ||
@@ -82,18 +151,209 @@ func validateSelectedContractRouteRecoveryRecord(record SelectedContractRouteRec
 		strings.TrimSpace(record.RecipientPlanningFingerprint) == "" {
 		return fmt.Errorf("selected-contract route recovery requires evidence fingerprints")
 	}
+	if len(record.RouteTopology) == 0 || len(record.RecipientPlanning) == 0 {
+		return fmt.Errorf("selected-contract route recovery requires persisted topology and recipient planning evidence")
+	}
 	return nil
 }
 
-func (am *AgentManager) SelectedContractRouteRecoverySnapshot() map[string]SelectedContractRouteRecoveryRecord {
+func decodeSelectedContractRouteRecoveryTruth(record SelectedContractRouteRecoveryRecord) (SelectedContractRouteRecoveryTruth, error) {
+	if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
+		return SelectedContractRouteRecoveryTruth{}, err
+	}
+	var topology selectedContractRecoveredRouteTopology
+	if err := json.Unmarshal(record.RouteTopology, &topology); err != nil {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("decode selected-contract route topology recovery: %w", err)
+	}
+	if strings.TrimSpace(topology.Owner) != selectedContractRouteTopologyOwner {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered route topology requires %s owner; got %q", selectedContractRouteTopologyOwner, topology.Owner)
+	}
+	if !topology.NonMutating || topology.RoutePersistenceSupported || topology.ExecutableRecipientsSupported {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered route topology must be non-mutating evidence without current-route persistence or executable recipients")
+	}
+	if strings.TrimSpace(topology.FrontierEvidenceFingerprint) != strings.TrimSpace(record.FrontierEvidenceFingerprint) {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered route topology frontier fingerprint mismatch")
+	}
+	var planning selectedContractRecoveredRecipientPlanning
+	if err := json.Unmarshal(record.RecipientPlanning, &planning); err != nil {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("decode selected-contract recipient planning recovery: %w", err)
+	}
+	if strings.TrimSpace(planning.Owner) != selectedContractRecipientPlanningOwner {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning requires %s owner; got %q", selectedContractRecipientPlanningOwner, planning.Owner)
+	}
+	if strings.TrimSpace(planning.RouteTopologyOwner) != selectedContractRouteTopologyOwner {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning must consume %s; got %q", selectedContractRouteTopologyOwner, planning.RouteTopologyOwner)
+	}
+	if !planning.NonMutating || !planning.RecipientPlanningSupported || planning.DeliveryWritesSupported {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning must be supported non-mutating evidence without delivery-write ownership")
+	}
+	if strings.TrimSpace(planning.FrontierEvidenceFingerprint) != strings.TrimSpace(record.FrontierEvidenceFingerprint) {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning frontier fingerprint mismatch")
+	}
+	return SelectedContractRouteRecoveryTruth{
+		Record:            record,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+		recipientGuard:    newSelectedContractRecoveredRecipientGuard(planning),
+	}, nil
+}
+
+func newSelectedContractRecoveredRecipientGuard(planning selectedContractRecoveredRecipientPlanning) selectedContractRecoveredRecipientGuard {
+	plans := map[string]selectedContractRecoveredRecipientPlanEvent{}
+	for _, event := range planning.RecipientPlanEvents {
+		sourceEventID := strings.TrimSpace(event.SourceEventID)
+		if sourceEventID == "" {
+			continue
+		}
+		plans[sourceEventID] = event
+	}
+	return selectedContractRecoveredRecipientGuard{
+		plansBySourceEvent: plans,
+		sourceByForkEvent:  map[string]string{},
+	}
+}
+
+func (g *selectedContractRecoveredRecipientGuard) ExpectForkEvent(forkEventID, sourceEventID string) {
+	if g == nil {
+		return
+	}
+	forkEventID = strings.TrimSpace(forkEventID)
+	sourceEventID = strings.TrimSpace(sourceEventID)
+	if forkEventID == "" || sourceEventID == "" {
+		return
+	}
+	g.sourceByForkEvent[forkEventID] = sourceEventID
+}
+
+func (g *selectedContractRecoveredRecipientGuard) AuthorizeEvent(ctx context.Context, evt events.Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(evt.SourceAgent) != selectedContractExecutionOwner {
+		return nil
+	}
+	_, _, err := g.expectedRecipientPlanEvent(evt)
+	return err
+}
+
+func (g *selectedContractRecoveredRecipientGuard) Authorize(ctx context.Context, evt events.Event, actual runtimebus.PublishRecipientPlan) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(evt.SourceAgent) != selectedContractExecutionOwner {
+		return nil
+	}
+	sourceEventID, expected, err := g.expectedRecipientPlanEvent(evt)
+	if err != nil {
+		return err
+	}
+	if len(actual.SubscriptionRecipients) > 0 {
+		return fmt.Errorf("selected-contract recovered route truth cannot use live subscriptions as fork recipient truth")
+	}
+	if !selectedContractRecoveredRecipientKeysEqual(selectedContractRecoveredExpectedRecipientKeys(expected.Recipients), selectedContractRecoveredActualRecipientKeys(actual.RoutedRecipients)) {
+		return fmt.Errorf("selected-contract recovered routed recipients do not match %s for source event %s", selectedContractRecipientPlanningOwner, sourceEventID)
+	}
+	return nil
+}
+
+func (g *selectedContractRecoveredRecipientGuard) expectedRecipientPlanEvent(evt events.Event) (string, selectedContractRecoveredRecipientPlanEvent, error) {
+	if g == nil {
+		return "", selectedContractRecoveredRecipientPlanEvent{}, fmt.Errorf("selected-contract recovered recipient guard is required")
+	}
+	forkEventID := strings.TrimSpace(evt.ID)
+	sourceEventID := strings.TrimSpace(g.sourceByForkEvent[forkEventID])
+	if sourceEventID == "" {
+		return "", selectedContractRecoveredRecipientPlanEvent{}, fmt.Errorf("selected-contract recovered publish path missing %s evidence for fork event %s", selectedContractRecipientPlanningOwner, forkEventID)
+	}
+	expected, ok := g.plansBySourceEvent[sourceEventID]
+	if !ok {
+		return "", selectedContractRecoveredRecipientPlanEvent{}, fmt.Errorf("selected-contract recovered publish path has no recipient plan for source event %s", sourceEventID)
+	}
+	if strings.TrimSpace(expected.EventName) != strings.TrimSpace(string(evt.Type)) {
+		return "", selectedContractRecoveredRecipientPlanEvent{}, fmt.Errorf("selected-contract recovered publish event type mismatch for source event %s: got %q want %q", sourceEventID, evt.Type, expected.EventName)
+	}
+	return sourceEventID, expected, nil
+}
+
+func selectedContractRecoveredExpectedRecipientKeys(in []selectedContractRecoveredRecipient) []string {
+	out := make([]string, 0, len(in))
+	for _, recipient := range in {
+		if strings.TrimSpace(recipient.SubscriberType) == "" || strings.TrimSpace(recipient.SubscriberID) == "" {
+			continue
+		}
+		out = append(out, selectedContractRecoveredRecipientKey(recipient))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func selectedContractRecoveredActualRecipientKeys(in []runtimebus.PublishDiagnosticRecipient) []string {
+	out := make([]string, 0, len(in))
+	for _, recipient := range in {
+		if strings.TrimSpace(recipient.Type) == "" || strings.TrimSpace(recipient.ID) == "" {
+			continue
+		}
+		out = append(out, selectedContractRecoveredRecipientKey(selectedContractRecoveredRecipient{
+			SubscriberType: recipient.Type,
+			SubscriberID:   recipient.ID,
+			Path:           recipient.Path,
+			RouteSource:    recipient.RouteSource,
+		}))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func selectedContractRecoveredRecipientKeysEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func selectedContractRecoveredRecipientKey(recipient selectedContractRecoveredRecipient) string {
+	return strings.Join([]string{
+		strings.TrimSpace(recipient.SubscriberType),
+		strings.TrimSpace(recipient.SubscriberID),
+		strings.TrimSpace(recipient.Path),
+		strings.TrimSpace(recipient.RouteSource),
+	}, "\x00")
+}
+
+func (am *AgentManager) SelectedContractRouteRecoverySnapshot() map[string]SelectedContractRouteRecoveryTruth {
 	if am == nil {
 		return nil
 	}
 	am.mu.RLock()
 	defer am.mu.RUnlock()
-	out := make(map[string]SelectedContractRouteRecoveryRecord, len(am.selectedContractRouteRecoveries))
-	for forkRunID, record := range am.selectedContractRouteRecoveries {
-		out[forkRunID] = record
+	out := make(map[string]SelectedContractRouteRecoveryTruth, len(am.selectedContractRouteRecoveries))
+	for forkRunID, truth := range am.selectedContractRouteRecoveries {
+		out[forkRunID] = truth
 	}
 	return out
+}
+
+func (am *AgentManager) SelectedContractRouteRecoveryRecipientGuard(forkRunID string) (selectedContractRecoveredRecipientGuard, bool) {
+	if am == nil {
+		return selectedContractRecoveredRecipientGuard{}, false
+	}
+	am.mu.RLock()
+	defer am.mu.RUnlock()
+	truth, ok := am.selectedContractRouteRecoveries[strings.TrimSpace(forkRunID)]
+	if !ok {
+		return selectedContractRecoveredRecipientGuard{}, false
+	}
+	guard := selectedContractRecoveredRecipientGuard{
+		plansBySourceEvent: map[string]selectedContractRecoveredRecipientPlanEvent{},
+		sourceByForkEvent:  map[string]string{},
+	}
+	for sourceEventID, plan := range truth.recipientGuard.plansBySourceEvent {
+		guard.plansBySourceEvent[sourceEventID] = plan
+	}
+	return guard, true
 }

--- a/internal/runtime/manager/selected_contract_route_recovery.go
+++ b/internal/runtime/manager/selected_contract_route_recovery.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -161,6 +163,12 @@ func decodeSelectedContractRouteRecoveryTruth(record SelectedContractRouteRecove
 	if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
 		return SelectedContractRouteRecoveryTruth{}, err
 	}
+	if got := selectedContractRecoveredJSONFingerprint(record.RouteTopology); got != strings.TrimSpace(record.RouteTopologyFingerprint) {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered route topology fingerprint mismatch")
+	}
+	if got := selectedContractRecoveredJSONFingerprint(record.RecipientPlanning); got != strings.TrimSpace(record.RecipientPlanningFingerprint) {
+		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("selected-contract recovered recipient planning fingerprint mismatch")
+	}
 	var topology selectedContractRecoveredRouteTopology
 	if err := json.Unmarshal(record.RouteTopology, &topology); err != nil {
 		return SelectedContractRouteRecoveryTruth{}, fmt.Errorf("decode selected-contract route topology recovery: %w", err)
@@ -196,6 +204,11 @@ func decodeSelectedContractRouteRecoveryTruth(record SelectedContractRouteRecove
 		RecipientPlanning: planning,
 		recipientGuard:    newSelectedContractRecoveredRecipientGuard(planning),
 	}, nil
+}
+
+func selectedContractRecoveredJSONFingerprint(raw json.RawMessage) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
 }
 
 func newSelectedContractRecoveredRecipientGuard(planning selectedContractRecoveredRecipientPlanning) selectedContractRecoveredRecipientGuard {

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -125,6 +125,20 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
 	}
+	if _, err := req.Store.RecordRunForkSelectedContractRouteRecovery(ctx, store.RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         materialization.ForkRunID,
+		SourceRunID:       plan.SourceRunID,
+		ForkEventID:       plan.ForkPoint.EventID,
+		ContractSelection: selection,
+		RouteTopology:     routeTopology,
+		RecipientPlanning: *model.RecipientPlanning,
+	}); err != nil {
+		return SelectedContractExecutionResult{
+			Owner:                              store.RunForkSelectedContractExecutionOwner,
+			Materialization:                    materialization,
+			SelectedContractExecutionAdmission: &admission,
+		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
+	}
 	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
 		Store:             req.Store,
 		LoadedSource:      loadedSource,

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -97,6 +97,44 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 	if lineageCount != 1 {
 		t.Fatalf("selected execution lineage rows = %d, want 1", lineageCount)
 	}
+	routeRecovery, ok, err := pg.LoadRunForkSelectedContractRouteRecovery(ctx, result.Materialization.ForkRunID)
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if !ok {
+		t.Fatal("selected-contract route recovery row missing")
+	}
+	if routeRecovery.Owner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		routeRecovery.RuntimeRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner ||
+		routeRecovery.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		routeRecovery.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		routeRecovery.ForkRunID != result.Materialization.ForkRunID ||
+		routeRecovery.RecipientPlanEventCount != 1 ||
+		routeRecovery.FrontierEvidenceFingerprint == "" ||
+		routeRecovery.RouteTopologyFingerprint == "" ||
+		routeRecovery.RecipientPlanningFingerprint == "" {
+		t.Fatalf("route recovery = %#v", routeRecovery)
+	}
+	recoveredRoutes, err := RecoverSelectedContractRouteTruth(ctx, pg)
+	if err != nil {
+		t.Fatalf("RecoverSelectedContractRouteTruth: %v", err)
+	}
+	if len(recoveredRoutes) != 1 || recoveredRoutes[0].ForkRunID != result.Materialization.ForkRunID {
+		t.Fatalf("recovered route truth = %#v", recoveredRoutes)
+	}
+
+	var copiedCurrentRoutes int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM routing_rules
+		WHERE flow_instance = 'flow-a/1'
+		  AND is_materialized = true
+	`).Scan(&copiedCurrentRoutes); err != nil {
+		t.Fatalf("count current route rows: %v", err)
+	}
+	if copiedCurrentRoutes != 0 {
+		t.Fatalf("selected route recovery copied current routing_rules rows = %d, want 0", copiedCurrentRoutes)
+	}
 
 	var sourceCopiedEvents int
 	if err := db.QueryRowContext(ctx, `
@@ -590,7 +628,7 @@ func assertSelectedContractExecutionCleanup(t *testing.T, db *sql.DB, sourceRunI
 	if sourceStatus != "running" {
 		t.Fatalf("source status = %q, want running", sourceStatus)
 	}
-	var forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows int
+	var forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows, routeRecoveryRows int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE forked_from_run_id = $1::uuid`, sourceRunID).Scan(&forkRows); err != nil {
 		t.Fatalf("count fork rows: %v", err)
 	}
@@ -616,10 +654,13 @@ func assertSelectedContractExecutionCleanup(t *testing.T, db *sql.DB, sourceRunI
 		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_executions WHERE fork_run_id = $1::uuid`, forkRunID).Scan(&lineageRows); err != nil {
 			t.Fatalf("count fork lineage: %v", err)
 		}
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_selected_contract_route_recoveries WHERE fork_run_id = $1::uuid`, forkRunID).Scan(&routeRecoveryRows); err != nil {
+			t.Fatalf("count fork route recoveries: %v", err)
+		}
 	}
-	if forkRows != 0 || forkEvents != 0 || forkDeliveries != 0 || forkReceipts != 0 || forkState != 0 || forkMutations != 0 || bindingRows != 0 || lineageRows != 0 {
-		t.Fatalf("cleanup left fork rows runs:%d events:%d deliveries:%d receipts:%d state:%d mutations:%d bindings:%d lineage:%d",
-			forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows)
+	if forkRows != 0 || forkEvents != 0 || forkDeliveries != 0 || forkReceipts != 0 || forkState != 0 || forkMutations != 0 || bindingRows != 0 || lineageRows != 0 || routeRecoveryRows != 0 {
+		t.Fatalf("cleanup left fork rows runs:%d events:%d deliveries:%d receipts:%d state:%d mutations:%d bindings:%d lineage:%d route_recoveries:%d",
+			forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows, routeRecoveryRows)
 	}
 }
 

--- a/internal/runtime/runforkexecution/route_recovery.go
+++ b/internal/runtime/runforkexecution/route_recovery.go
@@ -1,0 +1,56 @@
+package runforkexecution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type SelectedContractRouteRecoveryReader interface {
+	ListRunForkSelectedContractRouteRecoveries(ctx context.Context) ([]store.RunForkSelectedContractRouteRecovery, error)
+}
+
+func RecoverSelectedContractRouteTruth(ctx context.Context, reader SelectedContractRouteRecoveryReader) ([]store.RunForkSelectedContractRouteRecovery, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("selected-contract route recovery requires persistence reader")
+	}
+	records, err := reader.ListRunForkSelectedContractRouteRecoveries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		if err := validateSelectedContractRouteRecoveryRecord(record); err != nil {
+			return nil, err
+		}
+	}
+	return records, nil
+}
+
+func validateSelectedContractRouteRecoveryRecord(record store.RunForkSelectedContractRouteRecovery) error {
+	if strings.TrimSpace(record.Owner) != store.RunForkSelectedContractRoutePersistenceOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s owner; got %q", store.RunForkSelectedContractRoutePersistenceOwner, record.Owner)
+	}
+	if strings.TrimSpace(record.RuntimeRecoveryOwner) != store.RunForkSelectedContractRouteRecoveryOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s runtime owner; got %q", store.RunForkSelectedContractRouteRecoveryOwner, record.RuntimeRecoveryOwner)
+	}
+	if strings.TrimSpace(record.ForkRunID) == "" || strings.TrimSpace(record.SourceRunID) == "" || strings.TrimSpace(record.ForkEventID) == "" {
+		return fmt.Errorf("selected-contract route recovery requires fork/source/event identity")
+	}
+	if strings.TrimSpace(record.RouteTopologyOwner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s topology; got %q", store.RunForkSelectedContractRouteTopologyOwner, record.RouteTopologyOwner)
+	}
+	if strings.TrimSpace(record.RecipientPlanningOwner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return fmt.Errorf("selected-contract route recovery requires %s recipient planning; got %q", store.RunForkSelectedContractRecipientPlanningOwner, record.RecipientPlanningOwner)
+	}
+	if strings.TrimSpace(record.FrontierEvidenceFingerprint) == "" ||
+		strings.TrimSpace(record.RouteTopologyFingerprint) == "" ||
+		strings.TrimSpace(record.RecipientPlanningFingerprint) == "" {
+		return fmt.Errorf("selected-contract route recovery requires evidence fingerprints")
+	}
+	if len(record.RouteTopology) == 0 || len(record.RecipientPlanning) == 0 {
+		return fmt.Errorf("selected-contract route recovery requires persisted topology and recipient planning evidence")
+	}
+	return nil
+}

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -67,6 +67,9 @@ func RequireRunForkSelectedContractExecutionCapabilities(caps StoreSchemaCapabil
 	if err := RequireRunForkActivationCapabilities(caps, catalog); err != nil {
 		return err
 	}
+	if err := RequireRunForkSelectedContractRouteRecoveryCapabilities(caps, catalog); err != nil {
+		return err
+	}
 	required := []struct {
 		table   string
 		columns []string
@@ -433,6 +436,14 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 		WHERE fork_run_id = $1::uuid
 	`, forkRunID); err != nil {
 		return fmt.Errorf("delete selected-contract branch divergence: %w", err)
+	}
+	if catalog.hasColumns(runForkSelectedContractRouteRecoveryTable, "fork_run_id") {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM run_fork_selected_contract_route_recoveries
+			WHERE fork_run_id = $1::uuid
+		`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract route recovery: %w", err)
+		}
 	}
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM run_fork_selected_contract_executions

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -129,6 +129,45 @@ func TestSelectedContractExecutionMaterializationPreflightsBranchDivergenceOwner
 	}
 }
 
+func TestSelectedContractExecutionMaterializationPreflightsRouteRecoveryCapability(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002485, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `DROP TABLE run_fork_selected_contract_route_recoveries`); err != nil {
+		t.Fatalf("drop selected route recovery table: %v", err)
+	}
+
+	_, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "run_fork_selected_contract_route_recoveries") {
+		t.Fatalf("materialization error = %v, want route recovery capability failure", err)
+	}
+	var strayForks int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE forked_from_run_id = $1::uuid
+	`, sourceRunID).Scan(&strayForks); err != nil {
+		t.Fatalf("count stray forks: %v", err)
+	}
+	if strayForks != 0 {
+		t.Fatalf("stray materialized forks = %d, want 0", strayForks)
+	}
+}
+
 func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_selected_contract_route_recovery.go
+++ b/internal/store/run_fork_selected_contract_route_recovery.go
@@ -230,6 +230,8 @@ func (s *PostgresStore) ListSelectedContractRouteRecoveryRecords(ctx context.Con
 			StaticRouteEventCount:        record.StaticRouteEventCount,
 			DynamicTopologyProofCount:    record.DynamicTopologyProofCount,
 			RecipientPlanEventCount:      record.RecipientPlanEventCount,
+			RouteTopology:                append([]byte(nil), record.RouteTopology...),
+			RecipientPlanning:            append([]byte(nil), record.RecipientPlanning...),
 			CreatedAt:                    record.CreatedAt,
 		})
 	}

--- a/internal/store/run_fork_selected_contract_route_recovery.go
+++ b/internal/store/run_fork_selected_contract_route_recovery.go
@@ -1,12 +1,14 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -352,8 +354,30 @@ func runForkSelectedContractRecoveryJSONFingerprint(value any) (json.RawMessage,
 	if err != nil {
 		return nil, "", err
 	}
-	sum := sha256.Sum256(payload)
-	return append(json.RawMessage(nil), payload...), hex.EncodeToString(sum[:]), nil
+	fingerprint, err := runForkSelectedContractRecoveryCanonicalJSONFingerprint(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return append(json.RawMessage(nil), payload...), fingerprint, nil
+}
+
+func runForkSelectedContractRecoveryCanonicalJSONFingerprint(raw json.RawMessage) (string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return "", fmt.Errorf("unexpected trailing JSON")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func runForkSelectedContractRouteRecoverySelect() string {

--- a/internal/store/run_fork_selected_contract_route_recovery.go
+++ b/internal/store/run_fork_selected_contract_route_recovery.go
@@ -1,0 +1,430 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimemanager "swarm/internal/runtime/manager"
+)
+
+const (
+	RunForkSelectedContractRoutePersistenceOwner = "store.run_fork.selected_contract_route_persistence"
+	RunForkSelectedContractRouteRecoveryOwner    = "runtime.run_fork.selected_contract_route_recovery"
+
+	runForkSelectedContractRouteRecoveryTable = "run_fork_selected_contract_route_recoveries"
+)
+
+type RunForkSelectedContractRouteRecoveryRequest struct {
+	ForkRunID         string
+	SourceRunID       string
+	ForkEventID       string
+	ContractSelection RunForkContractSelection
+	RouteTopology     RunForkSelectedContractRouteTopology
+	RecipientPlanning RunForkSelectedContractRecipientPlanning
+}
+
+type RunForkSelectedContractRouteRecovery struct {
+	Owner                        string                   `json:"owner"`
+	RuntimeRecoveryOwner         string                   `json:"runtime_recovery_owner"`
+	ForkRunID                    string                   `json:"fork_run_id"`
+	SourceRunID                  string                   `json:"source_run_id"`
+	ForkEventID                  string                   `json:"fork_event_id"`
+	ContractSelection            RunForkContractSelection `json:"contract_selection"`
+	RouteTopologyOwner           string                   `json:"route_topology_owner"`
+	DynamicTopologyOwner         string                   `json:"dynamic_topology_owner,omitempty"`
+	RecipientPlanningOwner       string                   `json:"recipient_planning_owner"`
+	FrontierEvidenceFingerprint  string                   `json:"frontier_evidence_fingerprint"`
+	RouteTopologyFingerprint     string                   `json:"route_topology_fingerprint"`
+	RecipientPlanningFingerprint string                   `json:"recipient_planning_fingerprint"`
+	StaticRouteEventCount        int                      `json:"static_route_event_count"`
+	DynamicTopologyProofCount    int                      `json:"dynamic_topology_proof_count"`
+	RecipientPlanEventCount      int                      `json:"recipient_plan_event_count"`
+	RouteTopology                json.RawMessage          `json:"route_topology"`
+	RecipientPlanning            json.RawMessage          `json:"recipient_planning"`
+	CreatedAt                    time.Time                `json:"created_at"`
+}
+
+func RequireRunForkSelectedContractRouteRecoveryCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	_ = caps
+	required := []string{
+		"recovery_id",
+		"fork_run_id",
+		"source_run_id",
+		"fork_event_id",
+		"owner",
+		"runtime_recovery_owner",
+		"mode",
+		"contracts_root",
+		"workflow_name",
+		"workflow_version",
+		"route_topology_owner",
+		"dynamic_topology_owner",
+		"recipient_planning_owner",
+		"frontier_evidence_fingerprint",
+		"route_topology_fingerprint",
+		"recipient_planning_fingerprint",
+		"static_route_event_count",
+		"dynamic_topology_proof_count",
+		"recipient_plan_event_count",
+		"route_topology",
+		"recipient_planning",
+		"created_at",
+	}
+	if catalog.hasColumns(runForkSelectedContractRouteRecoveryTable, required...) {
+		return nil
+	}
+	return fmt.Errorf("selected-contract route recovery requires %s columns %v", runForkSelectedContractRouteRecoveryTable, required)
+}
+
+func (s *PostgresStore) requireRunForkSelectedContractRouteRecoveryCapabilities(ctx context.Context) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return RequireRunForkSelectedContractRouteRecoveryCapabilities(caps, catalog)
+}
+
+func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.Context, req RunForkSelectedContractRouteRecoveryRequest) (RunForkSelectedContractRouteRecovery, error) {
+	if s == nil || s.DB == nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunForkSelectedContractRouteRecoveryCapabilities(ctx); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	record, err := normalizeRunForkSelectedContractRouteRecovery(req, time.Now().UTC())
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		INSERT INTO run_fork_selected_contract_route_recoveries (
+			fork_run_id, source_run_id, fork_event_id,
+			owner, runtime_recovery_owner,
+			mode, contracts_root, workflow_name, workflow_version,
+			route_topology_owner, dynamic_topology_owner, recipient_planning_owner,
+			frontier_evidence_fingerprint, route_topology_fingerprint, recipient_planning_fingerprint,
+			static_route_event_count, dynamic_topology_proof_count, recipient_plan_event_count,
+			route_topology, recipient_planning, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid,
+			$4, $5,
+			$6, $7, $8, $9,
+			$10, NULLIF($11, ''), $12,
+			$13, $14, $15,
+			$16, $17, $18,
+			$19::jsonb, $20::jsonb, $21
+		)
+		ON CONFLICT (fork_run_id) DO UPDATE
+		SET owner = EXCLUDED.owner,
+		    runtime_recovery_owner = EXCLUDED.runtime_recovery_owner,
+		    mode = EXCLUDED.mode,
+		    contracts_root = EXCLUDED.contracts_root,
+		    workflow_name = EXCLUDED.workflow_name,
+		    workflow_version = EXCLUDED.workflow_version,
+		    route_topology_owner = EXCLUDED.route_topology_owner,
+		    dynamic_topology_owner = EXCLUDED.dynamic_topology_owner,
+		    recipient_planning_owner = EXCLUDED.recipient_planning_owner,
+		    frontier_evidence_fingerprint = EXCLUDED.frontier_evidence_fingerprint,
+		    route_topology_fingerprint = EXCLUDED.route_topology_fingerprint,
+		    recipient_planning_fingerprint = EXCLUDED.recipient_planning_fingerprint,
+		    static_route_event_count = EXCLUDED.static_route_event_count,
+		    dynamic_topology_proof_count = EXCLUDED.dynamic_topology_proof_count,
+		    recipient_plan_event_count = EXCLUDED.recipient_plan_event_count,
+		    route_topology = EXCLUDED.route_topology,
+		    recipient_planning = EXCLUDED.recipient_planning,
+		    created_at = EXCLUDED.created_at
+	`, record.ForkRunID, record.SourceRunID, record.ForkEventID,
+		record.Owner, record.RuntimeRecoveryOwner,
+		record.ContractSelection.Mode, record.ContractSelection.ContractsRoot, record.ContractSelection.WorkflowName, record.ContractSelection.WorkflowVersion,
+		record.RouteTopologyOwner, record.DynamicTopologyOwner, record.RecipientPlanningOwner,
+		record.FrontierEvidenceFingerprint, record.RouteTopologyFingerprint, record.RecipientPlanningFingerprint,
+		record.StaticRouteEventCount, record.DynamicTopologyProofCount, record.RecipientPlanEventCount,
+		string(record.RouteTopology), string(record.RecipientPlanning), record.CreatedAt); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("record selected-contract route recovery: %w", err)
+	}
+	return record, nil
+}
+
+func (s *PostgresStore) LoadRunForkSelectedContractRouteRecovery(ctx context.Context, forkRunID string) (RunForkSelectedContractRouteRecovery, bool, error) {
+	if s == nil || s.DB == nil {
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("postgres store is required")
+	}
+	forkRunID = strings.TrimSpace(forkRunID)
+	if forkRunID == "" {
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("fork run_id is required")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("fork run_id must be a UUID: %w", err)
+	}
+	if err := s.requireRunForkSelectedContractRouteRecoveryCapabilities(ctx); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, false, err
+	}
+	record, err := loadRunForkSelectedContractRouteRecovery(ctx, s.DB, `WHERE fork_run_id = $1::uuid`, forkRunID)
+	if err == sql.ErrNoRows {
+		return RunForkSelectedContractRouteRecovery{}, false, nil
+	}
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s *PostgresStore) ListRunForkSelectedContractRouteRecoveries(ctx context.Context) ([]RunForkSelectedContractRouteRecovery, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunForkSelectedContractRouteRecoveryCapabilities(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.DB.QueryContext(ctx, runForkSelectedContractRouteRecoverySelect()+`
+		ORDER BY created_at ASC, fork_run_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list selected-contract route recoveries: %w", err)
+	}
+	defer rows.Close()
+	out := []RunForkSelectedContractRouteRecovery{}
+	for rows.Next() {
+		record, err := scanRunForkSelectedContractRouteRecovery(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read selected-contract route recoveries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) ListSelectedContractRouteRecoveryRecords(ctx context.Context) ([]runtimemanager.SelectedContractRouteRecoveryRecord, error) {
+	records, err := s.ListRunForkSelectedContractRouteRecoveries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]runtimemanager.SelectedContractRouteRecoveryRecord, 0, len(records))
+	for _, record := range records {
+		out = append(out, runtimemanager.SelectedContractRouteRecoveryRecord{
+			Owner:                        record.Owner,
+			RuntimeRecoveryOwner:         record.RuntimeRecoveryOwner,
+			ForkRunID:                    record.ForkRunID,
+			SourceRunID:                  record.SourceRunID,
+			ForkEventID:                  record.ForkEventID,
+			RouteTopologyOwner:           record.RouteTopologyOwner,
+			DynamicTopologyOwner:         record.DynamicTopologyOwner,
+			RecipientPlanningOwner:       record.RecipientPlanningOwner,
+			FrontierEvidenceFingerprint:  record.FrontierEvidenceFingerprint,
+			RouteTopologyFingerprint:     record.RouteTopologyFingerprint,
+			RecipientPlanningFingerprint: record.RecipientPlanningFingerprint,
+			StaticRouteEventCount:        record.StaticRouteEventCount,
+			DynamicTopologyProofCount:    record.DynamicTopologyProofCount,
+			RecipientPlanEventCount:      record.RecipientPlanEventCount,
+			CreatedAt:                    record.CreatedAt,
+		})
+	}
+	return out, nil
+}
+
+func normalizeRunForkSelectedContractRouteRecovery(req RunForkSelectedContractRouteRecoveryRequest, createdAt time.Time) (RunForkSelectedContractRouteRecovery, error) {
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	if forkRunID == "" {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires fork run_id")
+	}
+	if _, err := uuid.Parse(forkRunID); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery fork run_id must be a UUID: %w", err)
+	}
+	sourceRunID := strings.TrimSpace(req.SourceRunID)
+	if sourceRunID == "" {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires source run_id")
+	}
+	if _, err := uuid.Parse(sourceRunID); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery source run_id must be a UUID: %w", err)
+	}
+	forkEventID := strings.TrimSpace(req.ForkEventID)
+	if forkEventID == "" {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires fork event_id")
+	}
+	if _, err := uuid.Parse(forkEventID); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery fork event_id must be a UUID: %w", err)
+	}
+	selection, err := normalizeRunForkSelectedContractSelection(req.ContractSelection)
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	topology := req.RouteTopology
+	if strings.TrimSpace(topology.Owner) != RunForkSelectedContractRouteTopologyOwner {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires %s topology; got %q", RunForkSelectedContractRouteTopologyOwner, topology.Owner)
+	}
+	if !topology.NonMutating || topology.RoutePersistenceSupported || topology.ExecutableRecipientsSupported {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires non-mutating topology evidence without executable route persistence")
+	}
+	if strings.TrimSpace(topology.FrontierEvidenceFingerprint) == "" {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires topology frontier evidence fingerprint")
+	}
+	if err := validateRunForkSelectedContractRouteRecoverySelection("route recovery", selection, topology.ContractSelection); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	planning := req.RecipientPlanning
+	if strings.TrimSpace(planning.Owner) != RunForkSelectedContractRecipientPlanningOwner {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires %s recipient planning; got %q", RunForkSelectedContractRecipientPlanningOwner, planning.Owner)
+	}
+	if !planning.NonMutating || planning.DeliveryWritesSupported {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires non-mutating recipient planning evidence")
+	}
+	if !planning.RecipientPlanningSupported {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery requires supported recipient planning")
+	}
+	if strings.TrimSpace(planning.RouteTopologyOwner) != RunForkSelectedContractRouteTopologyOwner {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery recipient planning must consume %s; got %q", RunForkSelectedContractRouteTopologyOwner, planning.RouteTopologyOwner)
+	}
+	if strings.TrimSpace(planning.FrontierEvidenceFingerprint) != strings.TrimSpace(topology.FrontierEvidenceFingerprint) {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("selected-contract route recovery topology and recipient planning frontier fingerprints differ")
+	}
+	if err := validateRunForkSelectedContractRouteRecoverySelection("route recovery recipient planning", selection, planning.ContractSelection); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	topologyJSON, topologyFingerprint, err := runForkSelectedContractRecoveryJSONFingerprint(topology)
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("fingerprint route topology: %w", err)
+	}
+	planningJSON, planningFingerprint, err := runForkSelectedContractRecoveryJSONFingerprint(planning)
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("fingerprint recipient planning: %w", err)
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	return RunForkSelectedContractRouteRecovery{
+		Owner:                        RunForkSelectedContractRoutePersistenceOwner,
+		RuntimeRecoveryOwner:         RunForkSelectedContractRouteRecoveryOwner,
+		ForkRunID:                    forkRunID,
+		SourceRunID:                  sourceRunID,
+		ForkEventID:                  forkEventID,
+		ContractSelection:            selection,
+		RouteTopologyOwner:           topology.Owner,
+		DynamicTopologyOwner:         topology.DynamicTopologyOwner,
+		RecipientPlanningOwner:       planning.Owner,
+		FrontierEvidenceFingerprint:  topology.FrontierEvidenceFingerprint,
+		RouteTopologyFingerprint:     topologyFingerprint,
+		RecipientPlanningFingerprint: planningFingerprint,
+		StaticRouteEventCount:        len(topology.StaticRouteEvents),
+		DynamicTopologyProofCount:    len(topology.DynamicTopologyProofs),
+		RecipientPlanEventCount:      len(planning.RecipientPlanEvents),
+		RouteTopology:                topologyJSON,
+		RecipientPlanning:            planningJSON,
+		CreatedAt:                    createdAt.UTC(),
+	}, nil
+}
+
+func validateRunForkSelectedContractRouteRecoverySelection(context string, left, right RunForkContractSelection) error {
+	left, err := normalizeRunForkSelectedContractSelection(left)
+	if err != nil {
+		return err
+	}
+	right, err = normalizeRunForkSelectedContractSelection(right)
+	if err != nil {
+		return err
+	}
+	if left.Mode != right.Mode ||
+		left.ContractsRoot != right.ContractsRoot ||
+		left.WorkflowName != right.WorkflowName ||
+		left.WorkflowVersion != right.WorkflowVersion {
+		return fmt.Errorf("%s selected contract selection mismatch", strings.TrimSpace(context))
+	}
+	return nil
+}
+
+func runForkSelectedContractRecoveryJSONFingerprint(value any) (json.RawMessage, string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(payload)
+	return append(json.RawMessage(nil), payload...), hex.EncodeToString(sum[:]), nil
+}
+
+func runForkSelectedContractRouteRecoverySelect() string {
+	return `
+		SELECT
+			owner,
+			runtime_recovery_owner,
+			fork_run_id::text,
+			source_run_id::text,
+			fork_event_id::text,
+			mode,
+			contracts_root,
+			workflow_name,
+			workflow_version,
+			route_topology_owner,
+			COALESCE(dynamic_topology_owner, ''),
+			recipient_planning_owner,
+			frontier_evidence_fingerprint,
+			route_topology_fingerprint,
+			recipient_planning_fingerprint,
+			static_route_event_count,
+			dynamic_topology_proof_count,
+			recipient_plan_event_count,
+			route_topology,
+			recipient_planning,
+			created_at
+		FROM run_fork_selected_contract_route_recoveries
+	`
+}
+
+func loadRunForkSelectedContractRouteRecovery(ctx context.Context, querier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, where string, args ...any) (RunForkSelectedContractRouteRecovery, error) {
+	row := querier.QueryRowContext(ctx, runForkSelectedContractRouteRecoverySelect()+" "+where, args...)
+	return scanRunForkSelectedContractRouteRecovery(row)
+}
+
+type runForkSelectedContractRouteRecoveryScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRunForkSelectedContractRouteRecovery(row runForkSelectedContractRouteRecoveryScanner) (RunForkSelectedContractRouteRecovery, error) {
+	var record RunForkSelectedContractRouteRecovery
+	var selection RunForkContractSelection
+	var routeTopology, recipientPlanning []byte
+	err := row.Scan(
+		&record.Owner,
+		&record.RuntimeRecoveryOwner,
+		&record.ForkRunID,
+		&record.SourceRunID,
+		&record.ForkEventID,
+		&selection.Mode,
+		&selection.ContractsRoot,
+		&selection.WorkflowName,
+		&selection.WorkflowVersion,
+		&record.RouteTopologyOwner,
+		&record.DynamicTopologyOwner,
+		&record.RecipientPlanningOwner,
+		&record.FrontierEvidenceFingerprint,
+		&record.RouteTopologyFingerprint,
+		&record.RecipientPlanningFingerprint,
+		&record.StaticRouteEventCount,
+		&record.DynamicTopologyProofCount,
+		&record.RecipientPlanEventCount,
+		&routeTopology,
+		&recipientPlanning,
+		&record.CreatedAt,
+	)
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	record.ContractSelection = selection
+	record.RouteTopology = append(json.RawMessage(nil), routeTopology...)
+	record.RecipientPlanning = append(json.RawMessage(nil), recipientPlanning...)
+	return record, nil
+}

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestNormalizeRunForkSelectedContractRouteRecoveryRejectsCurrentRouteOwner(t *testing.T) {
+	selection := RunForkContractSelection{
+		Mode:            "selected_contracts",
+		ContractsRoot:   "/tmp/contracts",
+		WorkflowName:    "workflow",
+		WorkflowVersion: "v1",
+	}
+	_, err := normalizeRunForkSelectedContractRouteRecovery(RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         uuid.NewString(),
+		SourceRunID:       uuid.NewString(),
+		ForkEventID:       uuid.NewString(),
+		ContractSelection: selection,
+		RouteTopology: RunForkSelectedContractRouteTopology{
+			Owner:                         "internal/runtime/bus.RouteTable.AddFlowInstanceRoute",
+			NonMutating:                   true,
+			ContractSelection:             selection,
+			FrontierEvidenceFingerprint:   "frontier",
+			RoutePersistenceSupported:     false,
+			ExecutableRecipientsSupported: false,
+		},
+		RecipientPlanning: RunForkSelectedContractRecipientPlanning{
+			Owner:                       RunForkSelectedContractRecipientPlanningOwner,
+			RouteTopologyOwner:          RunForkSelectedContractRouteTopologyOwner,
+			NonMutating:                 true,
+			RecipientPlanningSupported:  true,
+			DeliveryWritesSupported:     false,
+			ContractSelection:           selection,
+			FrontierEvidenceFingerprint: "frontier",
+		},
+	}, time.Now().UTC())
+	if err == nil || !strings.Contains(err.Error(), RunForkSelectedContractRouteTopologyOwner) {
+		t.Fatalf("normalize error = %v, want canonical route topology owner rejection", err)
+	}
+}
+
+func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, sourceRunID, forkRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, payload, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'item.received', '{}'::jsonb, 'platform')
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	selection := RunForkContractSelection{
+		Mode:            "selected_contracts",
+		ContractsRoot:   "/tmp/contracts",
+		WorkflowName:    "workflow",
+		WorkflowVersion: "v1",
+	}
+	topology := RunForkSelectedContractRouteTopology{
+		Owner:                         RunForkSelectedContractRouteTopologyOwner,
+		RouteAdmissionOwner:           RunForkSelectedContractRouteAdmissionOwner,
+		NonMutating:                   true,
+		RoutePersistenceSupported:     false,
+		ExecutableRecipientsSupported: false,
+		ContractSelection:             selection,
+		StaticTopologySupported:       true,
+		DynamicTopologySupported:      true,
+		FrontierAdmissionOwner:        RunForkContractFrontierAdmissionOwner,
+		FrontierEventCount:            1,
+		FrontierSourceEventIDs:        []string{eventID},
+		FrontierEvidenceFingerprint:   "frontier-fingerprint",
+		StaticRouteEvents: []RunForkSelectedContractRouteEvent{{
+			SourceEventID: eventID,
+			EventName:     "item.received",
+			DerivedRecipients: []RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "node-a",
+				Path:           "flow-a/node-a",
+				RouteSource:    "selected_contracts",
+			}},
+			Disposition: RunForkSelectedContractDispositionForkLocalTruth,
+		}},
+	}
+	planning := RunForkSelectedContractRecipientPlanning{
+		Owner:                       RunForkSelectedContractRecipientPlanningOwner,
+		RouteTopologyOwner:          RunForkSelectedContractRouteTopologyOwner,
+		RouteAdmissionOwner:         RunForkSelectedContractRouteAdmissionOwner,
+		FutureExecutionOwner:        RunForkSelectedContractExecutionOwner,
+		NonMutating:                 true,
+		RecipientPlanningSupported:  true,
+		DeliveryWritesSupported:     false,
+		ContractSelection:           selection,
+		FrontierEventCount:          1,
+		FrontierSourceEventIDs:      []string{eventID},
+		FrontierEvidenceFingerprint: "frontier-fingerprint",
+		RecipientPlanEvents: []RunForkSelectedContractRecipientPlanEvent{{
+			SourceEventID: eventID,
+			EventName:     "item.received",
+			Recipients: []RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "node-a",
+				Path:           "flow-a/node-a",
+				RouteSource:    "selected_contracts",
+			}},
+			Disposition: RunForkSelectedContractDispositionForkLocalTruth,
+		}},
+	}
+
+	record, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	})
+	if err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if record.Owner != RunForkSelectedContractRoutePersistenceOwner ||
+		record.RuntimeRecoveryOwner != RunForkSelectedContractRouteRecoveryOwner ||
+		record.StaticRouteEventCount != 1 ||
+		record.RecipientPlanEventCount != 1 ||
+		record.RouteTopologyFingerprint == "" ||
+		record.RecipientPlanningFingerprint == "" {
+		t.Fatalf("record = %#v", record)
+	}
+	loaded, ok, err := pg.LoadRunForkSelectedContractRouteRecovery(ctx, forkRunID)
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if !ok {
+		t.Fatal("route recovery row not found")
+	}
+	if loaded.RouteTopologyFingerprint != record.RouteTopologyFingerprint ||
+		loaded.RecipientPlanningFingerprint != record.RecipientPlanningFingerprint ||
+		!strings.Contains(string(loaded.RouteTopology), "item.received") ||
+		!strings.Contains(string(loaded.RecipientPlanning), "node-a") {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+}

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -7,6 +7,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/testutil"
 )
 
@@ -64,6 +69,148 @@ func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t
 		t.Fatalf("seed fork point event: %v", err)
 	}
 
+	selection, topology, planning := testSelectedRouteRecoveryEvidence(eventID)
+
+	record, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	})
+	if err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if record.Owner != RunForkSelectedContractRoutePersistenceOwner ||
+		record.RuntimeRecoveryOwner != RunForkSelectedContractRouteRecoveryOwner ||
+		record.StaticRouteEventCount != 1 ||
+		record.RecipientPlanEventCount != 1 ||
+		record.RouteTopologyFingerprint == "" ||
+		record.RecipientPlanningFingerprint == "" {
+		t.Fatalf("record = %#v", record)
+	}
+	loaded, ok, err := pg.LoadRunForkSelectedContractRouteRecovery(ctx, forkRunID)
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if !ok {
+		t.Fatal("route recovery row not found")
+	}
+	if loaded.RouteTopologyFingerprint != record.RouteTopologyFingerprint ||
+		loaded.RecipientPlanningFingerprint != record.RecipientPlanningFingerprint ||
+		!strings.Contains(string(loaded.RouteTopology), "item.received") ||
+		!strings.Contains(string(loaded.RecipientPlanning), "node-a") {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+}
+
+func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJSONB(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, sourceRunID, forkRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, payload, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'item.received', '{}'::jsonb, 'platform')
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+	selection, topology, planning := testSelectedRouteRecoveryEvidence(eventID)
+	if _, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	}); err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	bus := &selectedRouteRecoveryPostgresBus{store: selectedRouteRecoveryStoreWrapper{pg: pg}}
+	am := runtimemanager.NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return selectedRouteRecoveryAgent{id: cfg.ID}, nil
+	}, pg)
+
+	if err := am.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	guard, ok := am.SelectedContractRouteRecoveryRecipientGuard(forkRunID)
+	if !ok {
+		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
+	}
+	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000991", eventID)
+	evt := events.Event{
+		ID:          "00000000-0000-0000-0000-000000000991",
+		Type:        events.EventType("item.received"),
+		SourceAgent: RunForkSelectedContractExecutionOwner,
+	}
+	if err := guard.Authorize(ctx, evt, runtimebus.PublishRecipientPlan{
+		RoutedRecipients: []runtimebus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "node-a",
+			Path:        "flow-a/node-a",
+			RouteSource: "selected_contracts",
+		}},
+	}); err != nil {
+		t.Fatalf("Authorize recovered JSONB recipient plan: %v", err)
+	}
+}
+
+func TestRecordRunForkSelectedContractRouteRecoveryRejectsJSONBTamperDuringManagerRecovery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, sourceRunID, forkRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, payload, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'item.received', '{}'::jsonb, 'platform')
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+	selection, topology, planning := testSelectedRouteRecoveryEvidence(eventID)
+	if _, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	}); err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE run_fork_selected_contract_route_recoveries
+		SET recipient_planning = jsonb_set(recipient_planning, '{recipient_plan_events,0,recipients,0,subscriber_id}', '"node-tampered"'::jsonb)
+		WHERE fork_run_id = $1::uuid
+	`, forkRunID); err != nil {
+		t.Fatalf("tamper recipient planning: %v", err)
+	}
+	am := runtimemanager.NewAgentManager(&selectedRouteRecoveryPostgresBus{store: selectedRouteRecoveryStoreWrapper{pg: pg}}, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return selectedRouteRecoveryAgent{id: cfg.ID}, nil
+	}, pg)
+
+	err := am.Recover(ctx)
+	if err == nil || !strings.Contains(err.Error(), "recipient planning fingerprint mismatch") {
+		t.Fatalf("Recover error = %v, want recipient planning fingerprint mismatch", err)
+	}
+}
+
+func testSelectedRouteRecoveryEvidence(eventID string) (RunForkContractSelection, RunForkSelectedContractRouteTopology, RunForkSelectedContractRecipientPlanning) {
 	selection := RunForkContractSelection{
 		Mode:            "selected_contracts",
 		ContractsRoot:   "/tmp/contracts",
@@ -119,37 +266,57 @@ func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t
 			Disposition: RunForkSelectedContractDispositionForkLocalTruth,
 		}},
 	}
+	return selection, topology, planning
+}
 
-	record, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
-		ForkRunID:         forkRunID,
-		SourceRunID:       sourceRunID,
-		ForkEventID:       eventID,
-		ContractSelection: selection,
-		RouteTopology:     topology,
-		RecipientPlanning: planning,
-	})
-	if err != nil {
-		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
-	}
-	if record.Owner != RunForkSelectedContractRoutePersistenceOwner ||
-		record.RuntimeRecoveryOwner != RunForkSelectedContractRouteRecoveryOwner ||
-		record.StaticRouteEventCount != 1 ||
-		record.RecipientPlanEventCount != 1 ||
-		record.RouteTopologyFingerprint == "" ||
-		record.RecipientPlanningFingerprint == "" {
-		t.Fatalf("record = %#v", record)
-	}
-	loaded, ok, err := pg.LoadRunForkSelectedContractRouteRecovery(ctx, forkRunID)
-	if err != nil {
-		t.Fatalf("LoadRunForkSelectedContractRouteRecovery: %v", err)
-	}
-	if !ok {
-		t.Fatal("route recovery row not found")
-	}
-	if loaded.RouteTopologyFingerprint != record.RouteTopologyFingerprint ||
-		loaded.RecipientPlanningFingerprint != record.RecipientPlanningFingerprint ||
-		!strings.Contains(string(loaded.RouteTopology), "item.received") ||
-		!strings.Contains(string(loaded.RecipientPlanning), "node-a") {
-		t.Fatalf("loaded = %#v", loaded)
-	}
+type selectedRouteRecoveryPostgresBus struct {
+	store runtimebus.EventStore
+	logs  []runtimepipeline.RuntimeLogEntry
+}
+
+func (*selectedRouteRecoveryPostgresBus) Publish(context.Context, events.Event) error { return nil }
+func (*selectedRouteRecoveryPostgresBus) PublishDirect(context.Context, events.Event, []string) error {
+	return nil
+}
+func (*selectedRouteRecoveryPostgresBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
+func (*selectedRouteRecoveryPostgresBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+func (*selectedRouteRecoveryPostgresBus) Unsubscribe(string)        {}
+func (*selectedRouteRecoveryPostgresBus) ResetInMemoryState() error { return nil }
+func (b *selectedRouteRecoveryPostgresBus) Store() runtimebus.EventStore {
+	return b.store
+}
+func (b *selectedRouteRecoveryPostgresBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.logs = append(b.logs, entry)
+	return nil
+}
+
+type selectedRouteRecoveryAgent struct{ id string }
+
+func (a selectedRouteRecoveryAgent) ID() string                      { return a.id }
+func (selectedRouteRecoveryAgent) Type() string                      { return "generic" }
+func (selectedRouteRecoveryAgent) Subscriptions() []events.EventType { return nil }
+func (selectedRouteRecoveryAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	return nil, nil
+}
+
+type selectedRouteRecoveryStoreWrapper struct {
+	pg *PostgresStore
+}
+
+func (s selectedRouteRecoveryStoreWrapper) AppendEvent(context.Context, events.Event) error {
+	return nil
+}
+func (s selectedRouteRecoveryStoreWrapper) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (s selectedRouteRecoveryStoreWrapper) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (s selectedRouteRecoveryStoreWrapper) SupportsPersistedReplay() bool { return false }
+func (s selectedRouteRecoveryStoreWrapper) ListSelectedContractRouteRecoveryRecords(ctx context.Context) ([]runtimemanager.SelectedContractRouteRecoveryRecord, error) {
+	return s.pg.ListSelectedContractRouteRecoveryRecords(ctx)
 }

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -321,8 +321,10 @@ func platformTableOrder(name string) int {
 		return 18
 	case "run_fork_selected_contract_branch_divergences":
 		return 19
-	case "dead_letters":
+	case "run_fork_selected_contract_route_recoveries":
 		return 20
+	case "dead_letters":
+		return 22
 	case "agents":
 		return 30
 	case "flow_instances":


### PR DESCRIPTION
## Summary

Closes #618.

Adds the fork-local selected-contract route persistence/recovery owner for selected-contract forks. Selected execution now records fork-local route topology and recipient-planning evidence under the fork `run_id`, and runtime recovery reads that owner instead of treating current/source `routing_rules` or `ListFlowInstanceRoutes` as selected-fork route truth.

## Governing Context

Exact authoritative spec refs updated/read:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.run_fork_selected_contract_route_recoveries`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.selected_contract_route_persistence_recovery`
- Adjacent binding refs: `run_model.fork.selected_contract_route_topology`, `run_model.fork.selected_contract_dynamic_route_topology`, `run_model.fork.selected_contract_recipient_planning`, `run_model.fork.selected_contract_execution_model`

Binding issue/gate refs:

- #618 pre-audit and independent gate outcome approved as first slice
- #564/#549 remain open for broader historical replay/resume and architecture tail

## Semantic Migration

New canonical owner:

- Store owner: `store.run_fork.selected_contract_route_persistence`
- Runtime recovery owner: `runtime.run_fork.selected_contract_route_recovery`

Old paths now invalid/non-authoritative for selected-fork route truth:

- Source/current `routing_rules`
- Source/current materialized flow-instance route rows
- `ListFlowInstanceRoutes` / `restoreFlowInstanceRoutes` as selected-fork recovery source
- `EventBus.AddFlowInstanceRoute` as owner, rather than current route infrastructure

Production paths checked for surviving old behavior:

- Selected execution records route recovery from selected topology and recipient planning before publish.
- Runtime recovery loads selected route recovery records from the new owner and rejects current-route owners.
- Current route persistence remains current-route infrastructure only.

Migration complete for the approved #618 child. Broader replay/resume, timers, sessions/turns, contract-swap, UI/API, and full historical recovery remain outside this PR under #564/#549.

## Tests

- `go test ./cmd/swarm -run 'RunForkCommand_.*Selected|RunForkCommand_SelectedContracts|RunForkCommand_RequiresContracts|RunForkCommand_DryRunJSONReportsSelected' -count=1`
- `go test ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/store ./internal/runtime/manager -run 'SelectedContract|RouteRecovery|ExecuteSelectedContract|RecipientPlanning|Publish|Delivery|ReplayScope|EventDeliveries|RouteTopology|DynamicRoute|Branch|SourceAdvanced|Recover' -count=1`
- `go test ./internal/runtime/contracts -run 'Platform|Spec|Contract|YAML|Load' -count=1`
- `go test ./internal/store -run 'Schema|SelectedContract|RouteRecovery|EnsureSchema|GeneratePlatform' -count=1`
- `go test ./...`