### PR TITLE
[agent-d][issue #556] Gate typed entity tools by current entity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -239,6 +239,11 @@ contract_formats:
       no_contract_surface: Normal agents that do not resolve to a flow-owned entity contract receive no entity tools.
       current_entity_binding: 'Generated role-scoped entity tools operate on the current entity resolved from the triggering
         event/session context. Agent-supplied entity_id, entity_type, or flow_instance arguments are not accepted.'
+      turn_eligibility: 'A generated current-entity tool is provider-visible and callable for a concrete turn only when
+        the turn current entity resolves to the same flow-owned entity contract as the actor. If the current entity is absent,
+        root/run-owned, missing, or belongs to another flow/entity contract, generated current-entity read/save/update tools
+        MUST be removed from provider-visible catalogs and marked not callable for that turn. Executor validation remains
+        fail-closed defense-in-depth.'
       generated_reads:
         read_entity: 'read_{entity_type}() returns the complete current entity envelope and fields for the actor''s flow-owned
           entity contract.'
@@ -2351,10 +2356,10 @@ tool_model:
       tools nor emit tools require explicit tools entry.'
     role_scoped_entity_tools: 'When a normal actor resolves to a flow-owned entity contract, the platform generates
       current-entity read/save/update tools from that contract and the actor''s entity_writes declaration. The generated
-      tools are included in the agent-visible/provider-visible surface without explicit tools entries. The legacy entity
-      names create_entity, get_entity, get_subject_status, query_entities, search_entities, query_metrics, and
-      save_entity_field are removed before provider delivery and remain denied by runtime authorization as defense-in-depth.
-      Normal actors without an entity contract receive no entity tools.'
+      tools are eligible for the agent-visible/provider-visible surface without explicit tools entries, then filtered per
+      turn by current-entity contract eligibility. The legacy entity names create_entity, get_entity, get_subject_status,
+      query_entities, search_entities, query_metrics, and save_entity_field are removed before provider delivery and remain
+      denied by runtime authorization as defense-in-depth. Normal actors without an entity contract receive no entity tools.'
     context_cost: An agent with 4 tools in tools pays for 4 tool schemas in LLM context, regardless of how many tools
       exist in the registry or how many tools an MCP server exposes. The filter is the contract, not the source.
     default_deny: If an agent calls a tool that is not in its tools list, not a universal communication tool, not an emit

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -200,6 +200,10 @@ active_issues:
     title: Per-role entity tool contracts / provider-visible schemas
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 556
+    title: Root/run current-entity context can make generated role-scoped tools impossible
+    maps_to:
+      - transport_policy_and_surface_parity
   - id: 579
     title: Retire universal agent-surface entity tools for fully opted-in role-scoped flows
     maps_to:
@@ -227,6 +231,7 @@ nodes:
       - fallback relay on a supported turn can degrade file-backed work by clamping large relayed tool results to preview-only text
       - supported no-read_file turns can emit runtime_read_file follow-up artifacts for oversized tool results even though the same turn surface cannot call read_file
       - legacy universal entity tools can remain normal-agent provider-visible/callable beside generated role-scoped typed tools
+      - generated role-scoped current-entity tools can remain provider-visible/callable on turns whose current entity cannot resolve to the actor's flow-owned entity contract
       - oversized file-backed tool results on supported Claude helper turns can leak provider scratch paths back into later runtime read_file calls
       - CLI native tools can still use mixed provider-plus-platform fallback semantics, so visible turn surface does not equal callable provider-native truth for bash, web_search, and file_io
       - startup validation can compare provider-native init output against the full runtime MCP/local fallback surface and can select ordinary semantic tools as startup probes because their schemas accept empty objects
@@ -242,6 +247,7 @@ nodes:
       - 381
       - 444
       - 544
+      - 556
       - 568
       - 571
       - 579

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -28,6 +28,7 @@ type LLMAgent struct {
 	scopeKey       string
 	promptCache    map[string]string
 	promptResolver runtimecontracts.PromptResolver
+	toolExecutor   actorScopedToolExecutor
 	authority      runtimeauthority.Provider
 	emitRegistry   *runtimetools.EmitRegistry
 	mu             sync.Mutex
@@ -42,6 +43,10 @@ type LLMAgentOptions struct {
 type actorScopedToolExecutor interface {
 	llm.CapabilityAwareToolExecutor
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
+}
+
+type contextAwareActorScopedToolExecutor interface {
+	ToolDefinitionsForActorInContext(context.Context, models.AgentConfig) []llm.ToolDefinition
 }
 
 type roleScopedEntityToolCatalog interface {
@@ -115,6 +120,7 @@ func newLLMAgent(cfg models.AgentConfig, modelRuntime llm.Runtime, toolExecutor 
 		conversation:   c,
 		promptCache:    promptCache,
 		promptResolver: opts.PromptResolver,
+		toolExecutor:   toolExecutor,
 		authority:      authority,
 		emitRegistry:   emitRegistry,
 	}, nil
@@ -183,6 +189,7 @@ func (a *LLMAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Even
 	ctx = sessions.WithScope(ctx, llm.ConversationModeString(a.conversation.Mode), a.cfg.SessionScope, conversationScopeKeyForEvent(a.conversation.Mode, evt))
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx = runtimebus.WithEmittedEventsRecorder(ctx, recorder)
+	a.applyTurnToolDefinitions(ctx)
 
 	// Human task events must feed back into the requesting agent's reasoning context
 	// as an async tool-result style message correlated by task_id.
@@ -217,6 +224,21 @@ func (a *LLMAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Even
 	}
 	_ = resp
 	return nil, nil
+}
+
+func (a *LLMAgent) applyTurnToolDefinitions(ctx context.Context) {
+	if a == nil || a.conversation == nil || a.toolExecutor == nil {
+		return
+	}
+	contextAware, ok := a.toolExecutor.(contextAwareActorScopedToolExecutor)
+	if !ok {
+		return
+	}
+	tools := contextAware.ToolDefinitionsForActorInContext(ctx, a.cfg)
+	a.conversation.Tools = tools
+	if a.conversation.Session != nil {
+		a.conversation.Session.Tools = tools
+	}
 }
 
 func (a *LLMAgent) applyPromptForEvent(evt events.Event) {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -399,12 +399,16 @@ func TestNewLLMAgent_UsesConfiguredEmitEventsAndAllowedTools(t *testing.T) {
 }
 
 type boardTestRuntime struct {
-	steps []*llm.Response
-	errs  []error
-	call  int
+	steps         []*llm.Response
+	errs          []error
+	call          int
+	startTools    []string
+	continueTools []string
+	inputs        []string
 }
 
 func (r *boardTestRuntime) StartSession(_ context.Context, agentID, systemPrompt string, tools []llm.ToolDefinition) (*llm.Session, error) {
+	r.startTools = toolNamesForAgentTest(tools)
 	return &llm.Session{
 		ID:                "sess-1",
 		AgentID:           agentID,
@@ -419,6 +423,10 @@ func (r *boardTestRuntime) StartSession(_ context.Context, agentID, systemPrompt
 }
 
 func (r *boardTestRuntime) ContinueSession(_ context.Context, s *llm.Session, message llm.Message) (*llm.Response, error) {
+	if s != nil {
+		r.continueTools = toolNamesForAgentTest(s.Tools)
+	}
+	r.inputs = append(r.inputs, strings.TrimSpace(message.Content))
 	if r.call < len(r.errs) && r.errs[r.call] != nil {
 		err := r.errs[r.call]
 		r.call++
@@ -430,6 +438,14 @@ func (r *boardTestRuntime) ContinueSession(_ context.Context, s *llm.Session, me
 	resp := r.steps[r.call]
 	r.call++
 	return resp, nil
+}
+
+func toolNamesForAgentTest(tools []llm.ToolDefinition) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, strings.TrimSpace(tool.Name))
+	}
+	return names
 }
 
 func TestLLMAgent_OnEvent_UsesSinglePostStepExecutionPath(t *testing.T) {
@@ -509,6 +525,53 @@ func (actorScopedFactoryToolExec) ToolDefinitionsForActor(cfg models.AgentConfig
 		{Name: "emit_scan_requested"},
 		{Name: "scoped_" + strings.TrimSpace(cfg.ID)},
 	}
+}
+
+type contextAwareFactoryToolExec struct{}
+
+func (contextAwareFactoryToolExec) Execute(context.Context, string, any) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+func (contextAwareFactoryToolExec) ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition {
+	return []llm.ToolDefinition{
+		{Name: "read_scan_campaign"},
+		{Name: "save_scan_campaign_mode"},
+		{Name: "emit_market_research_scan_complete"},
+	}
+}
+
+func (contextAwareFactoryToolExec) ToolDefinitionsForActorInContext(ctx context.Context, cfg models.AgentConfig) []llm.ToolDefinition {
+	inbound, ok := runtimebus.InboundEventFromContext(ctx)
+	if ok && strings.HasPrefix(inbound.EntityID(), "valid-") {
+		return contextAwareFactoryToolExec{}.ToolDefinitionsForActor(cfg)
+	}
+	return []llm.ToolDefinition{{Name: "emit_market_research_scan_complete"}}
+}
+
+func (contextAwareFactoryToolExec) ToolCapabilitiesForActor(_ models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	return roleScopedCapabilitiesForAgentTest(names, true)
+}
+
+func (contextAwareFactoryToolExec) ToolCapabilitiesForActorInContext(ctx context.Context, _ models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	inbound, ok := runtimebus.InboundEventFromContext(ctx)
+	return roleScopedCapabilitiesForAgentTest(names, ok && strings.HasPrefix(inbound.EntityID(), "valid-"))
+}
+
+func roleScopedCapabilitiesForAgentTest(names []string, currentEntityEligible bool) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, name := range names {
+		visible := true
+		callable := true
+		if strings.HasPrefix(strings.TrimSpace(name), "read_scan_campaign") || strings.HasPrefix(strings.TrimSpace(name), "save_scan_campaign") {
+			if !currentEntityEligible {
+				visible = false
+				callable = false
+			}
+		}
+		caps = append(caps, toolcapabilities.Capability{Name: name, Visible: visible, Callable: callable})
+	}
+	return toolcapabilities.NewSet(caps)
 }
 
 func TestBoardStep_ReturnsErrorWhenDirectiveDoesNotAct(t *testing.T) {
@@ -607,6 +670,45 @@ func TestNewLLMAgentFactory_PrefersActorScopedToolDefinitions(t *testing.T) {
 	}
 	if !containsString(names, "scoped_analysis-agent") {
 		t.Fatalf("expected precomposed actor-scoped tool to survive local filtering, got %v", names)
+	}
+}
+
+func TestLLMAgentOnEvent_FiltersRoleScopedToolsByTurnEntityEligibility(t *testing.T) {
+	rt := &boardTestRuntime{
+		steps: []*llm.Response{
+			{Message: llm.Message{Role: "assistant", Content: "handled"}},
+		},
+	}
+	factory := NewLLMAgentFactory(rt, contextAwareFactoryToolExec{}, nil, LLMAgentOptions{})
+	agent, err := factory(models.AgentConfig{
+		ID:               "market-research-agent",
+		Role:             "market_research",
+		ConversationMode: "task",
+		Config: mustAgentConfigJSON(t, map[string]any{
+			"system_prompt": "You are here.",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	llmAgent := agent.(*LLMAgent)
+	evt := events.Event{
+		ID:      "evt-root",
+		Type:    events.EventType("discovery/market_research.corpus_file_assigned"),
+		RunID:   "run-1",
+		Payload: []byte(`{"assignment":{"scan_id":"root-run-id","geography":"US"}}`),
+	}.WithEntityID("root-run-id")
+	if _, err := llmAgent.OnEvent(context.Background(), evt); err != nil {
+		t.Fatalf("OnEvent: %v", err)
+	}
+	if containsString(rt.continueTools, "read_scan_campaign") || containsString(rt.continueTools, "save_scan_campaign_mode") {
+		t.Fatalf("invalid current entity left role-scoped tools in provider turn: %#v", rt.continueTools)
+	}
+	if !containsString(rt.continueTools, "emit_market_research_scan_complete") {
+		t.Fatalf("invalid current entity removed non-entity emit tool: %#v", rt.continueTools)
+	}
+	if len(rt.inputs) == 0 || strings.Contains(rt.inputs[0], "read_scan_campaign") || strings.Contains(rt.inputs[0], "save_scan_campaign_mode") {
+		t.Fatalf("event prompt advertised ineligible role-scoped tools: %#v", rt.inputs)
 	}
 }
 

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -54,6 +54,10 @@ type CapabilityAwareToolExecutor interface {
 	ToolCapabilitiesForActor(models.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
 }
 
+type ContextAwareCapabilityToolExecutor interface {
+	ToolCapabilitiesForActorInContext(context.Context, models.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
+}
+
 type executedToolCall struct {
 	Name     string
 	OK       bool
@@ -402,8 +406,9 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 	if c.toolExecutor == nil {
 		return ctx
 	}
-	names := make([]string, 0, len(c.Tools))
-	for _, def := range c.Tools {
+	defs := c.turnToolDefinitions()
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
 		name := strings.TrimSpace(def.Name)
 		if name == "" {
 			continue
@@ -412,6 +417,9 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 	}
 	if len(names) == 0 {
 		return ctx
+	}
+	if contextAware, ok := c.toolExecutor.(ContextAwareCapabilityToolExecutor); ok {
+		return toolcapabilities.WithContext(ctx, contextAware.ToolCapabilitiesForActorInContext(ctx, actor, names, nil))
 	}
 	return toolcapabilities.WithContext(ctx, c.toolExecutor.ToolCapabilitiesForActor(actor, names, nil))
 }

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -415,9 +415,6 @@ func (c *Conversation) withToolCapabilities(ctx context.Context) context.Context
 		}
 		names = append(names, name)
 	}
-	if len(names) == 0 {
-		return ctx
-	}
 	if contextAware, ok := c.toolExecutor.(ContextAwareCapabilityToolExecutor); ok {
 		return toolcapabilities.WithContext(ctx, contextAware.ToolCapabilitiesForActorInContext(ctx, actor, names, nil))
 	}

--- a/internal/runtime/llm/conversation_test.go
+++ b/internal/runtime/llm/conversation_test.go
@@ -249,6 +249,30 @@ func (c *capabilityAwareToolExec) ToolCapabilitiesForActor(_ models.AgentConfig,
 	return toolcapabilities.NewSet(caps)
 }
 
+type emptyTurnCapabilityToolExec struct {
+	contextNames []string
+}
+
+func (e *emptyTurnCapabilityToolExec) Execute(ctx context.Context, name string, _ any) (any, error) {
+	set, ok := toolcapabilities.FromContext(ctx)
+	if !ok {
+		return map[string]any{"accepted_without_capabilities": name}, nil
+	}
+	if _, ok := set.Capability(name); !ok {
+		return nil, errors.New("tool not offered for this turn")
+	}
+	return map[string]any{"name": name}, nil
+}
+
+func (e *emptyTurnCapabilityToolExec) ToolCapabilitiesForActor(_ models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	return toolcapabilities.NewSet(nil)
+}
+
+func (e *emptyTurnCapabilityToolExec) ToolCapabilitiesForActorInContext(_ context.Context, _ models.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	e.contextNames = append([]string(nil), names...)
+	return toolcapabilities.NewSet(nil)
+}
+
 func testAsString(v any) string {
 	s, _ := v.(string)
 	return s
@@ -309,6 +333,34 @@ func TestConversationStep_AttachesCanonicalToolCapabilitySetToExecutionContext(t
 	}
 	if _, ok := te.captured.Capability("emit_scan_requested"); !ok {
 		t.Fatalf("expected capability set to include emit_scan_requested, got %#v", te.captured.ByName)
+	}
+}
+
+func TestConversationExecuteToolCalls_PreservesEmptyTurnDenialContext(t *testing.T) {
+	te := &emptyTurnCapabilityToolExec{}
+	c := NewConversation("market-research-agent", "t1", "sys", nil, SessionScoped, 10, &scriptedRuntime{})
+	c.SetToolExecutor(te)
+
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:   "market-research-agent",
+		Role: "market_research",
+	})
+	raw, executed := c.executeToolCalls(ctx, []ToolCall{{
+		Name:      "read_scan_campaign",
+		Arguments: map[string]any{},
+	}})
+
+	if len(te.contextNames) != 0 {
+		t.Fatalf("expected empty turn capability request, got %#v", te.contextNames)
+	}
+	if len(executed) != 1 || executed[0].OK {
+		t.Fatalf("expected hallucinated tool call to fail closed, got executed=%#v raw=%s", executed, raw)
+	}
+	if !strings.Contains(raw, "tool not offered for this turn") {
+		t.Fatalf("expected explicit turn-denial error, got %s", raw)
+	}
+	if strings.Contains(raw, "accepted_without_capabilities") {
+		t.Fatalf("tool call executed without turn capability context: %s", raw)
 	}
 }
 

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -53,6 +53,11 @@ type runtimeGatewayExecutor interface {
 	ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition
 }
 
+type runtimeGatewayContextAwareExecutor interface {
+	ToolDefinitionsForActorInContext(context.Context, models.AgentConfig) []llm.ToolDefinition
+	ToolCapabilitiesForActorInContext(context.Context, models.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
+}
+
 func NewGateway(executor runtimeGatewayExecutor, authToken string, hooks GatewayHooks) *Gateway {
 	return &Gateway{
 		executor:  executor,
@@ -497,6 +502,9 @@ func (g *Gateway) withToolCapabilities(ctx context.Context, actor models.AgentCo
 	if g.executor == nil {
 		return ctx
 	}
+	if contextAware, ok := g.executor.(runtimeGatewayContextAwareExecutor); ok {
+		return toolcapabilities.WithContext(ctx, contextAware.ToolCapabilitiesForActorInContext(ctx, actor, names, requestAllowed))
+	}
 	set := g.executor.ToolCapabilitiesForActor(actor, names, requestAllowed)
 	return toolcapabilities.WithContext(ctx, set)
 }
@@ -555,7 +563,8 @@ func (g *Gateway) mcpToolsForRequest(r *http.Request) ([]ToolDef, error) {
 	if err != nil {
 		return nil, err
 	}
-	return g.mcpToolsForActor(turn.Actor, turn.Allowed, true), nil
+	ctx := g.baseContextForResolvedTurn(r.Context(), turn)
+	return g.mcpToolsForActorInContext(ctx, turn.Actor, turn.Allowed, true), nil
 }
 
 func (g *Gateway) MCPToolsForActor(actor models.AgentConfig) []ToolDef {
@@ -567,8 +576,12 @@ func (g *Gateway) MCPToolsForActor(actor models.AgentConfig) []ToolDef {
 }
 
 func (g *Gateway) mcpToolsForActor(actor models.AgentConfig, allowed map[string]struct{}, actorOK bool) []ToolDef {
-	catalog := g.toolCatalog(actor, actorOK)
-	set, hasSet := g.requestToolCapabilities(actor, actorOK, catalog, allowed)
+	return g.mcpToolsForActorInContext(context.Background(), actor, allowed, actorOK)
+}
+
+func (g *Gateway) mcpToolsForActorInContext(ctx context.Context, actor models.AgentConfig, allowed map[string]struct{}, actorOK bool) []ToolDef {
+	catalog := g.toolCatalogInContext(ctx, actor, actorOK)
+	set, hasSet := g.requestToolCapabilitiesInContext(ctx, actor, actorOK, catalog, allowed)
 
 	names := make([]string, 0, len(catalog))
 	if hasSet {
@@ -626,12 +639,20 @@ func (g *Gateway) mcpToolsForActor(actor models.AgentConfig, allowed map[string]
 }
 
 func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string]llm.ToolDefinition {
+	return g.toolCatalogInContext(context.Background(), actor, actorOK)
+}
+
+func (g *Gateway) toolCatalogInContext(ctx context.Context, actor models.AgentConfig, actorOK bool) map[string]llm.ToolDefinition {
 	catalog := map[string]llm.ToolDefinition{}
 	if !actorOK {
 		return catalog
 	}
 	if g.executor != nil {
-		for _, def := range g.executor.ToolDefinitionsForActor(actor) {
+		defs := g.executor.ToolDefinitionsForActor(actor)
+		if contextAware, ok := g.executor.(runtimeGatewayContextAwareExecutor); ok {
+			defs = contextAware.ToolDefinitionsForActorInContext(ctx, actor)
+		}
+		for _, def := range defs {
 			name := normalizeGatewayToolName(def.Name)
 			if name != "" {
 				def.Name = name
@@ -664,8 +685,15 @@ func (g *Gateway) toolCatalog(actor models.AgentConfig, actorOK bool) map[string
 }
 
 func (g *Gateway) requestToolCapabilities(actor models.AgentConfig, actorOK bool, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {
+	return g.requestToolCapabilitiesInContext(context.Background(), actor, actorOK, catalog, requestAllowed)
+}
+
+func (g *Gateway) requestToolCapabilitiesInContext(ctx context.Context, actor models.AgentConfig, actorOK bool, catalog map[string]llm.ToolDefinition, requestAllowed map[string]struct{}) (toolcapabilities.Set, bool) {
 	if g.executor == nil || !actorOK {
 		return toolcapabilities.Set{}, false
+	}
+	if contextAware, ok := g.executor.(runtimeGatewayContextAwareExecutor); ok {
+		return contextAware.ToolCapabilitiesForActorInContext(ctx, actor, g.catalogNames(catalog), requestAllowed), true
 	}
 	return g.executor.ToolCapabilitiesForActor(actor, g.catalogNames(catalog), requestAllowed), true
 }
@@ -723,7 +751,7 @@ func (g *Gateway) runtimeTurnContextForRequest(r *http.Request, operation string
 	return turn, nil
 }
 
-func (g *Gateway) contextForResolvedTurn(ctx context.Context, turn TurnContext) context.Context {
+func (g *Gateway) baseContextForResolvedTurn(ctx context.Context, turn TurnContext) context.Context {
 	if g.hooks.WithActor != nil {
 		ctx = g.hooks.WithActor(ctx, turn.Actor)
 	}
@@ -737,7 +765,12 @@ func (g *Gateway) contextForResolvedTurn(ctx context.Context, turn TurnContext) 
 	if turn.Recorder != nil && g.hooks.WithEmittedEventsRecorder != nil {
 		ctx = g.hooks.WithEmittedEventsRecorder(ctx, turn.Recorder)
 	}
-	return g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalog(turn.Actor, true)), turn.Allowed)
+	return ctx
+}
+
+func (g *Gateway) contextForResolvedTurn(ctx context.Context, turn TurnContext) context.Context {
+	ctx = g.baseContextForResolvedTurn(ctx, turn)
+	return g.withToolCapabilities(ctx, turn.Actor, g.catalogNames(g.toolCatalogInContext(ctx, turn.Actor, true)), turn.Allowed)
 }
 
 func (g *Gateway) AuthorizeForTest(r *http.Request) error {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -239,6 +239,71 @@ func (s actorScopedToolExecutorStub) ToolCapabilitiesForActor(_ models.AgentConf
 	return toolcapabilities.NewSet(caps)
 }
 
+type contextAwareRoleScopedExecutorStub struct {
+	callCount int
+}
+
+func (s *contextAwareRoleScopedExecutorStub) Execute(context.Context, string, any) (any, error) {
+	s.callCount++
+	return map[string]any{"ok": true}, nil
+}
+
+func (s *contextAwareRoleScopedExecutorStub) ToolDefinitions() []llm.ToolDefinition {
+	return []llm.ToolDefinition{{Name: "read_scan_campaign"}, {Name: "save_scan_campaign_mode"}, {Name: "emit_market_research_scan_complete"}}
+}
+
+func (s *contextAwareRoleScopedExecutorStub) ToolDefinitionsForActor(models.AgentConfig) []llm.ToolDefinition {
+	return s.ToolDefinitions()
+}
+
+func (s *contextAwareRoleScopedExecutorStub) ToolDefinitionsForActorInContext(ctx context.Context, actor models.AgentConfig) []llm.ToolDefinition {
+	if roleScopedCurrentEntityEligibleInGatewayTest(ctx) {
+		return s.ToolDefinitionsForActor(actor)
+	}
+	return []llm.ToolDefinition{{Name: "emit_market_research_scan_complete"}}
+}
+
+func (s *contextAwareRoleScopedExecutorStub) ToolCapabilitiesForActor(actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
+	return roleScopedGatewayCapabilities(names, requestAllowed, true)
+}
+
+func (s *contextAwareRoleScopedExecutorStub) ToolCapabilitiesForActorInContext(ctx context.Context, actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
+	return roleScopedGatewayCapabilities(names, requestAllowed, roleScopedCurrentEntityEligibleInGatewayTest(ctx))
+}
+
+func roleScopedCurrentEntityEligibleInGatewayTest(ctx context.Context) bool {
+	inbound, ok := runtimebus.InboundEventFromContext(ctx)
+	return ok && strings.HasPrefix(inbound.EntityID(), "valid-")
+}
+
+func roleScopedGatewayCapabilities(names []string, requestAllowed map[string]struct{}, currentEntityEligible bool) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, raw := range names {
+		name := toolidentity.CanonicalName(raw)
+		if name == "" {
+			continue
+		}
+		visible := true
+		callable := true
+		if len(requestAllowed) > 0 {
+			_, visible = requestAllowed[name]
+			callable = visible
+		}
+		if strings.HasPrefix(name, "read_scan_campaign") || strings.HasPrefix(name, "save_scan_campaign") {
+			if !currentEntityEligible {
+				visible = false
+				callable = false
+			}
+		}
+		caps = append(caps, toolcapabilities.Capability{
+			Name:     name,
+			Visible:  visible,
+			Callable: callable,
+		})
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
 type capabilityAwareExecutorStub struct {
 	callCount int
 }
@@ -751,6 +816,85 @@ func TestGatewayMCPToolsForRoleScopedActor_RetiresLegacyEntitySurface(t *testing
 	}
 	if executeCount != 0 {
 		t.Fatalf("direct denied legacy tool calls reached executor %d times, want 0", executeCount)
+	}
+}
+
+func TestGatewayMCPToolsForRequest_FiltersRoleScopedToolsByTurnEntityEligibility(t *testing.T) {
+	registry := newTestTurnContextRegistry()
+	exec := &contextAwareRoleScopedExecutorStub{}
+	g := NewGateway(exec, testGatewayToken, GatewayHooks{
+		ResolveTurnContext: registry.ResolveTurnContext,
+		WithActor:          models.WithActor,
+		WithInboundEvent:   runtimebus.WithInboundEvent,
+	})
+	actor := models.AgentConfig{ID: "market-research-agent", Role: "market_research"}
+	putTestTurnContext(t, registry, "ctx-invalid-current-entity", TurnContext{
+		Actor: actor,
+		Inbound: events.Event{
+			ID:   "evt-root",
+			Type: events.EventType("discovery/market_research.corpus_file_assigned"),
+		}.WithEntityID("root-run-id"),
+		HasInbound: true,
+		CreatedAt:  time.Now().UTC(),
+		ExpiresAt:  time.Now().UTC().Add(time.Hour),
+	})
+	putTestTurnContext(t, registry, "ctx-valid-current-entity", TurnContext{
+		Actor: actor,
+		Inbound: events.Event{
+			ID:   "evt-scan",
+			Type: events.EventType("discovery/market_research.corpus_file_assigned"),
+		}.WithEntityID("valid-scan-campaign-id"),
+		HasInbound: true,
+		CreatedAt:  time.Now().UTC(),
+		ExpiresAt:  time.Now().UTC().Add(time.Hour),
+	})
+
+	invalidReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-invalid-current-entity")
+	invalidTools := mustMCPToolsForRequest(t, g, invalidReq)
+	invalidNames := make([]string, 0, len(invalidTools))
+	for _, tool := range invalidTools {
+		invalidNames = append(invalidNames, tool.Name)
+	}
+	if slices.Contains(invalidNames, "read_scan_campaign") || slices.Contains(invalidNames, "save_scan_campaign_mode") {
+		t.Fatalf("invalid current entity exposed role-scoped tools: %#v", invalidNames)
+	}
+	if !slices.Contains(invalidNames, "emit_market_research_scan_complete") {
+		t.Fatalf("invalid current entity filtered non-entity tool: %#v", invalidNames)
+	}
+
+	validReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", nil), "ctx-valid-current-entity")
+	validTools := mustMCPToolsForRequest(t, g, validReq)
+	validNames := make([]string, 0, len(validTools))
+	for _, tool := range validTools {
+		validNames = append(validNames, tool.Name)
+	}
+	if !slices.Contains(validNames, "read_scan_campaign") || !slices.Contains(validNames, "save_scan_campaign_mode") {
+		t.Fatalf("valid current entity did not expose role-scoped tools: %#v", validNames)
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"id":     "req-read",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "read_scan_campaign",
+			"arguments": map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	callReq := withContextToken(httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body))), "ctx-invalid-current-entity")
+	authorizeGatewayRequest(callReq)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, callReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if exec.callCount != 0 {
+		t.Fatalf("ineligible role-scoped MCP call reached executor %d times", exec.callCount)
+	}
+	if !strings.Contains(rec.Body.String(), "tool is not allowed for this agent") {
+		t.Fatalf("response = %s, want tool-not-allowed", rec.Body.String())
 	}
 }
 

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -216,6 +216,22 @@ func (e *Executor) ToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 	return filtered
 }
 
+func (e *Executor) ToolDefinitionsForActorInContext(ctx context.Context, actor models.AgentConfig) []llm.ToolDefinition {
+	defs := e.ToolDefinitionsForActor(actor)
+	roleScopedNames := e.RoleScopedEntityToolNamesForActor(actor)
+	if len(roleScopedNames) == 0 || e.roleScopedEntityToolsEligibleForCurrentTurn(ctx, actor) {
+		return defs
+	}
+	filtered := make([]llm.ToolDefinition, 0, len(defs))
+	for _, def := range defs {
+		if _, ok := roleScopedNames[strings.TrimSpace(def.Name)]; ok {
+			continue
+		}
+		filtered = append(filtered, def)
+	}
+	return filtered
+}
+
 func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
 	caps := make([]toolcapabilities.Capability, 0, len(names))
 	seen := map[string]struct{}{}
@@ -248,6 +264,24 @@ func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []st
 		}
 		if !decision.allowed {
 			cap.DenialReason = "tool_not_allowed"
+		}
+		caps = append(caps, cap)
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func (e *Executor) ToolCapabilitiesForActorInContext(ctx context.Context, actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
+	set := e.ToolCapabilitiesForActor(actor, names, requestAllowed)
+	roleScopedNames := e.RoleScopedEntityToolNamesForActor(actor)
+	if len(roleScopedNames) == 0 || e.roleScopedEntityToolsEligibleForCurrentTurn(ctx, actor) {
+		return set
+	}
+	caps := make([]toolcapabilities.Capability, 0, len(set.ByName))
+	for name, cap := range set.ByName {
+		if _, ok := roleScopedNames[name]; ok {
+			cap.Visible = false
+			cap.Callable = false
+			cap.DenialReason = "current_entity_contract_unavailable"
 		}
 		caps = append(caps, cap)
 	}

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -17,6 +17,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	llm "swarm/internal/runtime/llm"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -327,6 +328,62 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 		if _, err := exec.Execute(ctx, name, map[string]any{}); err == nil || !strings.Contains(err.Error(), "not allowed") {
 			t.Fatalf("direct %s execution error = %v, want tool-not-allowed", name, err)
 		}
+	}
+}
+
+func TestRoleScopedEntityTools_CurrentEntityEligibilityFiltersTurnSurface(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{
+		"get_entity",
+		"save_entity_field",
+		"query_entities",
+	}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	currentID := uuid.NewString()
+	foreignID := uuid.NewString()
+	seedEntityStateRow(t, db, currentID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
+		"status":         "open",
+		"business_brief": map[string]any{"summary": "valid", "confidence": 1},
+	}, time.Now().UTC())
+	seedEntityStateRow(t, db, foreignID, "", "run-root", "default", "queued", map[string]any{
+		"status": "root",
+	}, time.Now().UTC())
+
+	validCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-current",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(currentID).WithFlowInstance("validation/inst-1"))
+	invalidCtx := runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-root",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(foreignID).WithFlowInstance("run-root"))
+
+	validNames := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(validCtx, actor))
+	for _, name := range []string{"read_validation_case", "read_validation_case_status", "save_validation_case_business_brief", "update_validation_case_business_brief_summary"} {
+		if _, ok := validNames[name]; !ok {
+			t.Fatalf("valid current entity filtered %s from %#v", name, sortedRoleScopedToolNames(validNames))
+		}
+	}
+
+	invalidNames := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(invalidCtx, actor))
+	for _, name := range []string{"read_validation_case", "read_validation_case_status", "save_validation_case_business_brief", "update_validation_case_business_brief_summary"} {
+		if _, ok := invalidNames[name]; ok {
+			t.Fatalf("invalid current entity left %s visible in %#v", name, sortedRoleScopedToolNames(invalidNames))
+		}
+	}
+
+	caps := exec.ToolCapabilitiesForActorInContext(invalidCtx, actor, []string{"read_validation_case", "save_validation_case_business_brief"}, nil)
+	for _, name := range []string{"read_validation_case", "save_validation_case_business_brief"} {
+		cap, ok := caps.Capability(name)
+		if !ok || cap.Visible || cap.Callable || cap.DenialReason != "current_entity_contract_unavailable" {
+			t.Fatalf("%s invalid-current capability = %#v ok=%v", name, cap, ok)
+		}
+	}
+	deniedCtx := toolcapabilities.WithContext(invalidCtx, caps)
+	if _, err := exec.Execute(deniedCtx, "read_validation_case", map[string]any{}); err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("context-denied read_validation_case error = %v, want not allowed before execution", err)
 	}
 }
 

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
@@ -331,6 +332,36 @@ func (e *Executor) RoleScopedEntityToolNamesForActor(actor models.AgentConfig) m
 		}
 	}
 	return out
+}
+
+func (e *Executor) roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, actor models.AgentConfig) bool {
+	if e == nil {
+		return false
+	}
+	e.mu.RLock()
+	db := e.sqlDB
+	source := e.workflowSource
+	e.mu.RUnlock()
+	return roleScopedEntityToolsEligibleForCurrentTurn(ctx, db, source, actor)
+}
+
+func roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, db *sql.DB, source semanticview.Source, actor models.AgentConfig) bool {
+	if db == nil || source == nil {
+		return false
+	}
+	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	if !ok {
+		return false
+	}
+	entityID := roleScopedCurrentEntityID(ctx)
+	if entityID == "" {
+		return false
+	}
+	row, found, err := loadEntityState(ctx, db, entityID)
+	if err != nil || !found {
+		return false
+	}
+	return roleScopedEntityMatchesContract(source, row, contract) == nil
 }
 
 func (e *Executor) dispatchRoleScopedEntityTool(ctx context.Context, actor models.AgentConfig, name string, input any) (any, bool, error) {


### PR DESCRIPTION
## Summary

Closes #556.

This PR makes generated role-scoped current-entity tools turn-eligible instead of actor-static only. If a turn's inbound current entity is absent, root/run-owned, missing, or does not resolve to the actor's flow-owned entity contract, generated `read_*`, `save_*`, and `update_*` entity tools are removed from provider/MCP catalogs and marked not callable for that turn. Executor validation remains fail-closed defense-in-depth.

## Governing Context

- Pre-Implementation Coverage Audit: #556 issue thread.
- Gate outcome: approved under the repaired/widened #556 boundary.
- Authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Binding spec concepts: `contract_formats.persistence_model.role_scoped_entity_tools.current_entity_binding`, generated read/write rules, and `tool_model.tool_access.role_scoped_entity_tools`.

## Semantic Migration

- New canonical owner: runtime turn-current-entity eligibility for generated role-scoped entity tool provider visibility/callability.
- Old producer/reader path now invalid: actor-contract-only generated tool delivery for concrete turns.
- Production paths checked: LLM agent turn tool definitions, MCP `tools/list`, MCP/direct call capability checks, executor dispatch/authorization, conversation capability context, spec, and watchlist mapping.
- Migration completeness: complete for generated role-scoped current-entity read/save/update eligibility. Root/run entities are not made readable and caller-supplied identity remains invalid.

## Verification

- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/agents ./internal/runtime/llm -run 'TestRoleScopedEntityTools_|TestToolDefinitionsForActor_|TestGatewayMCPToolsForRequest_|TestGatewayMCPToolsForRoleScopedActor_|TestLLMAgentOnEvent_FiltersRoleScopedToolsByTurnEntityEligibility|TestNewLLMAgentFactory_PrefersActorScopedToolDefinitions' -count=1`
- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/agents ./internal/runtime/llm -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/dev/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` (`verify ok`; existing `lint_evidence` only)
- `git diff --check`
- `go test ./...`