### PR TITLE
[agent-a][issue #625] Gate contract-swap boot resume admission

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3405,6 +3405,19 @@ run_model:
       NOT become executable fork work or fork suppressors. Route persistence, timer reconstruction, session/turn/audit
       reconstruction, non-agent delivery replay, runtime restart recovery, contract-swap boot/resume beyond selected
       frontier execution, and UI/API ownership remain separately gated siblings.'
+    contract_swap_boot_resume_admission: 'Contract-swap boot/resume readiness for timestamp forks is owned by
+      runtime.run_fork.contract_swap_boot_resume_admission. This owner is non-mutating and consumes the durable
+      store.run_fork.selected_contract_binding, runtime.run_fork.selected_contract_execution_admission,
+      store.run_fork.replay_resume_admission, selected route topology, selected recipient planning, and fork-local
+      selected route recovery evidence before answering whether full boot/resume under selected or swapped contracts is
+      allowed. It MUST fail closed with named blockers for source deliveries, receipts, dead letters, retry/idempotency
+      state, post-fork source outcomes, timers, current/source routes, sessions, turns, audits, committed replay-scope
+      rows, non-agent replay, missing selected route recovery, or any missing/stale selected binding/source evidence. It
+      MUST NOT run handlers, create fork-local events or event_deliveries, copy source rows, write receipts, dead
+      letters, idempotency state, emitted follow-up events, timers, sessions, turns, route rows, API/UI state, or
+      otherwise implement mutating historical replay/resume. CLI, API, dashboard, Builder, route helpers, delivery
+      writers, and pipeline boot paths may consume this owner but MUST NOT compute contract-swap boot/resume readiness
+      independently.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3482,6 +3495,14 @@ run_model:
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
         parents or siblings.'
+      3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
+        readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
+        replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route
+        topology, selected recipient planning, and selected route recovery evidence. Source rows and post-T outcomes
+        remain lineage/evidence or fail-closed blockers; they are not executable fork work and do not suppress future
+        fork-local work. This owner is non-mutating and does not authorize handler execution, delivery writes, receipts,
+        dead letters, idempotency, emitted follow-ups, timers, sessions, turns, non-agent replay, route row mutation, or
+        API/UI state.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.
@@ -3489,10 +3510,11 @@ run_model:
     parallel_safety: 'Timestamp-based fork handles parallel agent execution naturally. At timestamp T, all
       concurrent branches either committed their mutations or did not. No DAG traversal, no branch
       classification, no sibling carry-over logic. The reconstructed state is simply "what was the world at T."'
-    contract_swap: 'When --contracts specifies a new contract path, the forked run uses the new handler logic
-      for all re-delivered events. This is the primary use case: fix a bug in a handler or prompt, fork to
-      before the failure, resume with the fix. All re-delivered events use the new contracts uniformly —
-      no mixed-version state.'
+    contract_swap: 'When --contracts specifies a new contract path, the intended full historical replay/resume behavior
+      is that admitted re-delivered events use the new handler logic uniformly with no mixed-version state. This product
+      intent is not itself an execution owner. Runtime/store readiness for full boot/resume is governed by
+      runtime.run_fork.contract_swap_boot_resume_admission, and mutating replay/resume requires separately approved
+      owners for any admitted historical work.'
     timestamp_precision: 'Events committed in the same millisecond are disambiguated by (created_at, event_id)
       composite ordering. The fork point is inclusive: mutations from the target moment are included in
       reconstructed state. Only mutations strictly after T are undone.'

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -184,6 +184,12 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 625
+    title: Gate contract-swap boot/resume semantics for timestamp forks
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - run_isolated_current_state_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -328,6 +334,7 @@ nodes:
       - selected-contract delivery writes are now closed for the supported swarm fork --contracts path through runtime.run_fork.selected_contract_execution consuming runtime.run_fork.selected_contract_recipient_planning; source deliveries remain lineage/blocker evidence and route persistence remains split
       - selected-contract parent-tail rebaseline must close or narrow stale #588/#608 tracker state while keeping #564/#549 open for full replay/resume and fork architecture siblings
       - selected-contract route persistence/runtime recovery needs a fork-local owner keyed by fork run_id and selected binding/topology/recipient evidence; current routing_rules, flow_instance_routes, and startup ListFlowInstanceRoutes recovery remain current-route infrastructure and must not become selected-fork route truth
+      - contract-swap boot/resume readiness needs a non-mutating runtime owner that consumes selected binding, selected source admission, replay/resume taxonomy, selected route/recipient/recovery evidence, and classifies source deliveries/outcomes/timers/routes/sessions/non-agent facts as lineage, blockers, or split siblings before any full historical replay mutation
     representative_issues:
       - 564
       - 565
@@ -350,6 +357,7 @@ nodes:
       - 618
       - 619
       - 621
+      - 625
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -14,6 +14,7 @@ import (
 type SelectedContractActivationStore interface {
 	LoadRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, bool, error)
 	RequireRunForkSelectedContractBinding(context.Context, string) (store.RunForkSelectedContractBinding, error)
+	LoadRunForkSelectedContractRouteRecovery(context.Context, string) (store.RunForkSelectedContractRouteRecovery, bool, error)
 	PlanRunFork(context.Context, store.RunForkPlanRequest) (store.RunForkPlan, error)
 	ActivateRunFork(context.Context, store.RunForkActivateRequest) (store.RunForkActivation, error)
 }
@@ -107,9 +108,18 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
+	var routeRecovery *store.RunForkSelectedContractRouteRecovery
+	recoveredRoute, ok, err := req.Store.LoadRunForkSelectedContractRouteRecovery(ctx, forkRunID)
+	if err != nil {
+		return SelectedContractActivationGateResult{}, fmt.Errorf("load selected-contract route recovery for contract-swap admission: %w", err)
+	}
+	if ok {
+		routeRecovery = &recoveredRoute
+	}
 	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
 		SelectedExecutionAdmission: admission,
 		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+		RouteRecovery:              routeRecovery,
 	})
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -28,6 +28,7 @@ type SelectedContractActivationGateResult struct {
 	store.RunForkActivation
 	Owner                              string                                           `json:"selected_contract_activation_gate_owner,omitempty"`
 	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
+	ContractSwapBootResumeAdmission    *store.RunForkContractSwapBootResumeAdmission    `json:"contract_swap_boot_resume_admission,omitempty"`
 }
 
 func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractActivationGateRequest) (SelectedContractActivationGateResult, error) {
@@ -106,9 +107,17 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: admission,
+		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
 	result := SelectedContractActivationGateResult{
 		Owner:                              store.RunForkSelectedContractExecutionActivationGateOwner,
 		SelectedContractExecutionAdmission: &admission,
+		ContractSwapBootResumeAdmission:    &contractSwapAdmission,
 	}
 	if !plan.ExecutionReady {
 		return result, fmt.Errorf("selected-contract activation gate requires execution-ready plan before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -70,6 +70,12 @@ func TestActivateSelectedContractRunForkConsumesAdmissionBeforeStateOnlyActivati
 		result.SelectedContractExecutionAdmission.FrontierEventCount != 0 {
 		t.Fatalf("selected admission = %#v", result.SelectedContractExecutionAdmission)
 	}
+	if result.ContractSwapBootResumeAdmission == nil ||
+		result.ContractSwapBootResumeAdmission.Owner != store.RunForkContractSwapBootResumeAdmissionOwner ||
+		result.ContractSwapBootResumeAdmission.BootResumeSupported ||
+		!unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) {
+		t.Fatalf("contract-swap admission = %#v", result.ContractSwapBootResumeAdmission)
+	}
 	if result.RunForkActivation.ForkRunID != forkRunID || !result.Activated {
 		t.Fatalf("activation = %#v", result.RunForkActivation)
 	}
@@ -111,6 +117,10 @@ func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMuta
 	}
 	if !fakeStore.requireCalled || result.SelectedContractExecutionAdmission == nil {
 		t.Fatalf("admission not consumed before block; require:%v result:%#v", fakeStore.requireCalled, result)
+	}
+	if result.ContractSwapBootResumeAdmission == nil ||
+		!unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) {
+		t.Fatalf("contract-swap admission = %#v, want non-mutating blocker before source replay block", result.ContractSwapBootResumeAdmission)
 	}
 }
 

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -124,6 +124,53 @@ func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMuta
 	}
 }
 
+func TestActivateSelectedContractRunForkPassesRecoveredRouteEvidenceToContractSwapAdmission(t *testing.T) {
+	forkRunID := uuid.NewString()
+	binding := testSelectedContractBinding(forkRunID)
+	plan := testSelectedContractStateOnlyPlan(binding)
+	routeRecovery := store.RunForkSelectedContractRouteRecovery{
+		Owner:                  store.RunForkSelectedContractRoutePersistenceOwner,
+		RuntimeRecoveryOwner:   store.RunForkSelectedContractRouteRecoveryOwner,
+		ForkRunID:              binding.ForkRunID,
+		SourceRunID:            binding.SourceRunID,
+		ForkEventID:            binding.ForkEventID,
+		ContractSelection:      binding.ContractSelection,
+		RouteTopologyOwner:     store.RunForkSelectedContractRouteTopologyOwner,
+		RecipientPlanningOwner: store.RunForkSelectedContractRecipientPlanningOwner,
+	}
+	fakeStore := &fakeSelectedContractActivationStore{
+		binding:       binding,
+		bindingOK:     true,
+		plan:          plan,
+		routeRecovery: routeRecovery,
+		routeOK:       true,
+		activation:    store.RunForkActivation{SourceRunID: binding.SourceRunID, ForkRunID: forkRunID, Activated: true, SourceFrozen: true},
+	}
+	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
+
+	result, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{
+		ForkRunID:    forkRunID,
+		Store:        fakeStore,
+		SourceLoader: loader,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSelectedContractRunFork: %v", err)
+	}
+	if !fakeStore.loadRouteCalled {
+		t.Fatal("LoadRunForkSelectedContractRouteRecovery was not called")
+	}
+	if result.ContractSwapBootResumeAdmission == nil {
+		t.Fatalf("missing contract-swap admission: %#v", result)
+	}
+	if result.ContractSwapBootResumeAdmission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		result.ContractSwapBootResumeAdmission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner {
+		t.Fatalf("contract-swap route recovery owners = %#v", result.ContractSwapBootResumeAdmission)
+	}
+	if unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapRouteRecoveryMissing) {
+		t.Fatalf("unexpected missing-route blocker with route recovery evidence: %#v", result.ContractSwapBootResumeAdmission.UnsupportedBlockers)
+	}
+}
+
 func TestActivateSelectedContractRunForkFailsBeforeMutationOnUnavailableSource(t *testing.T) {
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
@@ -205,13 +252,17 @@ type fakeSelectedContractActivationStore struct {
 	requireErr    error
 	plan          store.RunForkPlan
 	planErr       error
+	routeRecovery store.RunForkSelectedContractRouteRecovery
+	routeOK       bool
+	routeErr      error
 	activation    store.RunForkActivation
 	activationErr error
 
-	loadCalled     bool
-	requireCalled  bool
-	planCalled     bool
-	activateCalled bool
+	loadCalled      bool
+	requireCalled   bool
+	loadRouteCalled bool
+	planCalled      bool
+	activateCalled  bool
 }
 
 func (s *fakeSelectedContractActivationStore) LoadRunForkSelectedContractBinding(_ context.Context, _ string) (store.RunForkSelectedContractBinding, bool, error) {
@@ -231,6 +282,14 @@ func (s *fakeSelectedContractActivationStore) RequireRunForkSelectedContractBind
 		return store.RunForkSelectedContractBinding{}, errors.New("selected contract binding not found")
 	}
 	return s.binding, nil
+}
+
+func (s *fakeSelectedContractActivationStore) LoadRunForkSelectedContractRouteRecovery(_ context.Context, _ string) (store.RunForkSelectedContractRouteRecovery, bool, error) {
+	s.loadRouteCalled = true
+	if s.routeErr != nil {
+		return store.RunForkSelectedContractRouteRecovery{}, false, s.routeErr
+	}
+	return s.routeRecovery, s.routeOK, nil
 }
 
 func (s *fakeSelectedContractActivationStore) PlanRunFork(_ context.Context, _ store.RunForkPlanRequest) (store.RunForkPlan, error) {

--- a/internal/runtime/runforkexecution/contract_swap_admission.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission.go
@@ -1,0 +1,240 @@
+package runforkexecution
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type ContractSwapBootResumeAdmissionRequest struct {
+	SelectedExecutionAdmission store.RunForkSelectedContractExecutionAdmission
+	ReplayResumeAdmission      store.RunForkReplayResumeAdmission
+	RouteRecovery              *store.RunForkSelectedContractRouteRecovery
+}
+
+func BuildContractSwapBootResumeAdmission(req ContractSwapBootResumeAdmissionRequest) (store.RunForkContractSwapBootResumeAdmission, error) {
+	selectedAdmission := req.SelectedExecutionAdmission
+	if err := validateContractSwapSelectedExecutionAdmission(selectedAdmission); err != nil {
+		return store.RunForkContractSwapBootResumeAdmission{}, err
+	}
+	replayAdmission := req.ReplayResumeAdmission
+	if strings.TrimSpace(replayAdmission.Owner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkContractSwapBootResumeAdmission{}, fmt.Errorf("contract-swap boot/resume admission requires %s; got %q", store.RunForkReplayResumeAdmissionOwner, replayAdmission.Owner)
+	}
+
+	var routeRecoveryOwner, runtimeRouteRecoveryOwner string
+	if req.RouteRecovery != nil {
+		if err := validateContractSwapRouteRecovery(selectedAdmission, *req.RouteRecovery); err != nil {
+			return store.RunForkContractSwapBootResumeAdmission{}, err
+		}
+		routeRecoveryOwner = req.RouteRecovery.Owner
+		runtimeRouteRecoveryOwner = req.RouteRecovery.RuntimeRecoveryOwner
+	}
+
+	blockers := append([]store.RunForkUnsupportedBlocker(nil), selectedAdmission.UnsupportedBlockers...)
+	for _, blocker := range replayAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
+		Code:    store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating,
+		Message: "contract-swap boot/resume admission is non-mutating; full historical replay/resume remains separately gated",
+	})
+	if req.RouteRecovery == nil {
+		blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerContractSwapRouteRecoveryMissing,
+			Message: "contract-swap boot/resume readiness requires fork-local selected route recovery evidence before future mutation",
+		})
+	}
+
+	classifications := append([]store.RunForkReplayResumeDisposition(nil), replayAdmission.Dispositions...)
+	classifications = append(classifications, store.RunForkReplayResumeDisposition{
+		Fact:        store.RunForkReplayResumeFactContractSwap,
+		Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+		BlockerCode: store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating,
+		Message:     "contract-swap boot/resume readiness is classified by the canonical non-mutating admission owner; mutation is not authorized by this slice",
+	})
+
+	routeTopologyOwner := ""
+	if selectedAdmission.RouteTopology != nil {
+		routeTopologyOwner = selectedAdmission.RouteTopology.Owner
+	}
+	recipientPlanningOwner := ""
+	if selectedAdmission.RecipientPlanning != nil {
+		recipientPlanningOwner = selectedAdmission.RecipientPlanning.Owner
+	}
+
+	return store.RunForkContractSwapBootResumeAdmission{
+		Owner:                           store.RunForkContractSwapBootResumeAdmissionOwner,
+		NonMutating:                     true,
+		BootResumeSupported:             false,
+		FutureExecutionOwner:            store.RunForkSelectedContractExecutionOwner + ".contract_swap_boot_resume",
+		ForkRunID:                       selectedAdmission.ForkRunID,
+		SourceRunID:                     selectedAdmission.SourceRunID,
+		ForkEventID:                     selectedAdmission.ForkEventID,
+		ContractSelection:               selectedAdmission.ContractSelection,
+		SelectedBindingOwner:            selectedAdmission.ContractBindingOwner,
+		SelectedExecutionAdmissionOwner: selectedAdmission.Owner,
+		ReplayResumeAdmissionOwner:      replayAdmission.Owner,
+		RouteTopologyOwner:              routeTopologyOwner,
+		RouteRecoveryOwner:              routeRecoveryOwner,
+		RuntimeRouteRecoveryOwner:       runtimeRouteRecoveryOwner,
+		RecipientPlanningOwner:          recipientPlanningOwner,
+		SourceWorkflowName:              selectedAdmission.SourceWorkflowName,
+		SourceWorkflowVersion:           selectedAdmission.SourceWorkflowVersion,
+		FrontierEventCount:              selectedAdmission.FrontierEventCount,
+		Prerequisites:                   contractSwapBootResumePrerequisites(),
+		Classifications:                 classifications,
+		BlockedSiblings:                 contractSwapBootResumeBlockedSiblings(),
+		InvalidPaths:                    contractSwapBootResumeInvalidPaths(),
+		UnsupportedBlockers:             blockers,
+	}, nil
+}
+
+func validateContractSwapSelectedExecutionAdmission(admission store.RunForkSelectedContractExecutionAdmission) error {
+	if strings.TrimSpace(admission.Owner) != store.RunForkSelectedContractExecutionAdmissionOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s; got %q", store.RunForkSelectedContractExecutionAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return fmt.Errorf("contract-swap boot/resume admission requires non-mutating selected execution admission")
+	}
+	if admission.ExecutionSupported {
+		return fmt.Errorf("contract-swap boot/resume admission cannot consume mutating selected execution admission")
+	}
+	if strings.TrimSpace(admission.ContractBindingOwner) != store.RunForkSelectedContractBindingOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s; got %q", store.RunForkSelectedContractBindingOwner, admission.ContractBindingOwner)
+	}
+	if strings.TrimSpace(admission.ForkRunID) == "" || strings.TrimSpace(admission.SourceRunID) == "" || strings.TrimSpace(admission.ForkEventID) == "" {
+		return fmt.Errorf("contract-swap boot/resume admission requires fork/source/event identity from selected binding")
+	}
+	if err := validateSelectedContractSelection("contract-swap boot/resume admission", admission.ContractSelection); err != nil {
+		return err
+	}
+	if admission.RouteTopology == nil || strings.TrimSpace(admission.RouteTopology.Owner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s evidence", store.RunForkSelectedContractRouteTopologyOwner)
+	}
+	if admission.RecipientPlanning == nil || strings.TrimSpace(admission.RecipientPlanning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s evidence", store.RunForkSelectedContractRecipientPlanningOwner)
+	}
+	return nil
+}
+
+func validateContractSwapRouteRecovery(admission store.RunForkSelectedContractExecutionAdmission, recovery store.RunForkSelectedContractRouteRecovery) error {
+	if strings.TrimSpace(recovery.Owner) != store.RunForkSelectedContractRoutePersistenceOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s route recovery; got %q", store.RunForkSelectedContractRoutePersistenceOwner, recovery.Owner)
+	}
+	if strings.TrimSpace(recovery.RuntimeRecoveryOwner) != store.RunForkSelectedContractRouteRecoveryOwner {
+		return fmt.Errorf("contract-swap boot/resume admission requires %s runtime recovery; got %q", store.RunForkSelectedContractRouteRecoveryOwner, recovery.RuntimeRecoveryOwner)
+	}
+	if strings.TrimSpace(recovery.ForkRunID) != strings.TrimSpace(admission.ForkRunID) ||
+		strings.TrimSpace(recovery.SourceRunID) != strings.TrimSpace(admission.SourceRunID) ||
+		strings.TrimSpace(recovery.ForkEventID) != strings.TrimSpace(admission.ForkEventID) {
+		return fmt.Errorf("contract-swap boot/resume admission route recovery identity does not match selected execution admission")
+	}
+	if err := validateSelectionMatches("contract-swap route recovery", admission.ContractSelection, recovery.ContractSelection); err != nil {
+		return err
+	}
+	if strings.TrimSpace(recovery.RouteTopologyOwner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return fmt.Errorf("contract-swap boot/resume admission route recovery requires %s; got %q", store.RunForkSelectedContractRouteTopologyOwner, recovery.RouteTopologyOwner)
+	}
+	if strings.TrimSpace(recovery.RecipientPlanningOwner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return fmt.Errorf("contract-swap boot/resume admission route recovery requires %s; got %q", store.RunForkSelectedContractRecipientPlanningOwner, recovery.RecipientPlanningOwner)
+	}
+	return nil
+}
+
+func contractSwapBootResumePrerequisites() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "selected_contract_binding",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractBindingOwner,
+			Reason:      "contract-swap boot/resume readiness consumes the durable selected contract binding; CLI/API arguments are not owners",
+		},
+		{
+			Concept:     "selected_contract_execution_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractExecutionAdmissionOwner,
+			Reason:      "selected semantic source loading and validation must come from the canonical selected execution admission owner",
+		},
+		{
+			Concept:     "replay_resume_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkReplayResumeAdmissionOwner,
+			Reason:      "source historical facts must be classified by the canonical replay/resume taxonomy before contract-swap readiness is answered",
+		},
+		{
+			Concept:     "selected_contract_route_recovery",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRouteRecoveryOwner,
+			Reason:      "future mutating boot/resume must recover selected route truth from fork-local route recovery evidence, not current routing rows",
+		},
+		{
+			Concept:     "selected_contract_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "future mutation must continue to route recipients through selected recipient planning and publish guards",
+		},
+	}
+}
+
+func contractSwapBootResumeBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "mutating_contract_swap_boot_resume",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".contract_swap_boot_resume",
+			Reason:      "this admission owner classifies readiness only; handler execution and fork-local writes remain separately gated",
+		},
+		{
+			Concept:     "timer_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "source timer facts remain fail-closed until a timer reconstruction owner is approved",
+		},
+		{
+			Concept:     "sessions_turns_audits",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "source session, turn, and audit reconstruction remains under historical replay/resume siblings",
+		},
+		{
+			Concept:     "node_system_non_agent_execution",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "node/system/non-agent replay remains separately gated and is not admitted through contract-swap readiness",
+		},
+		{
+			Concept:     "builder_dashboard_api",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "operator surfaces may consume this admission but must not own contract-swap readiness semantics",
+		},
+	}
+}
+
+func contractSwapBootResumeInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "cli_owned_contract_swap_readiness",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "CLI/API flags are request surfaces and cannot decide contract-swap boot/resume readiness",
+		},
+		{
+			Concept:     "copy_source_event_deliveries",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source event_deliveries are lineage/blocker evidence, not executable selected-fork work",
+		},
+		{
+			Concept:     "source_outcome_suppression",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source receipts, dead letters, retry state, and post-T outcomes cannot suppress future fork-local work",
+		},
+		{
+			Concept:     "current_route_rows_as_fork_truth",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "current routing_rules and flow-instance route rows are not selected-fork route truth",
+		},
+		{
+			Concept:     "same_run_outbox_replay_as_timestamp_fork_resume",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "same-run replay proof does not define timestamp-fork contract-swap boot/resume semantics",
+		},
+	}
+}

--- a/internal/runtime/runforkexecution/contract_swap_admission_test.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission_test.go
@@ -1,0 +1,199 @@
+package runforkexecution
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"swarm/internal/store"
+)
+
+func TestBuildContractSwapBootResumeAdmissionConsumesCanonicalPrerequisites(t *testing.T) {
+	selection := testContractSwapSelection()
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(selection)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		HistoricalReplayRequired: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactTimerHistory,
+			Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: store.RunForkBlockerTimerHistoryUnproven,
+			Message:     "timer history remains unproven",
+		}},
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
+			Code:    store.RunForkBlockerTimerHistoryUnproven,
+			Message: "timer history remains unproven",
+		}},
+	}
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+
+	admission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+	if admission.Owner != store.RunForkContractSwapBootResumeAdmissionOwner ||
+		!admission.NonMutating ||
+		admission.BootResumeSupported {
+		t.Fatalf("admission ownership = %#v", admission)
+	}
+	if admission.SelectedBindingOwner != store.RunForkSelectedContractBindingOwner ||
+		admission.SelectedExecutionAdmissionOwner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		admission.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner {
+		t.Fatalf("owner consumption = %#v", admission)
+	}
+	if admission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		admission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner {
+		t.Fatalf("route recovery owners = store:%q runtime:%q", admission.RouteRecoveryOwner, admission.RuntimeRouteRecoveryOwner)
+	}
+	if !executionBoundaryHas(admission.Prerequisites, "selected_contract_binding", store.RunForkSelectedContractDispositionPrerequisite) ||
+		!executionBoundaryHas(admission.Prerequisites, "replay_resume_admission", store.RunForkSelectedContractDispositionPrerequisite) ||
+		!executionBoundaryHas(admission.Prerequisites, "selected_contract_route_recovery", store.RunForkSelectedContractDispositionPrerequisite) {
+		t.Fatalf("prerequisites = %#v, want canonical selected/replay/route owners", admission.Prerequisites)
+	}
+	if !contractSwapClassificationHas(admission.Classifications, store.RunForkReplayResumeFactTimerHistory, store.RunForkReplayResumeDispositionFailClosedBlocker) ||
+		!contractSwapClassificationHas(admission.Classifications, store.RunForkReplayResumeFactContractSwap, store.RunForkReplayResumeDispositionFailClosedBlocker) {
+		t.Fatalf("classifications = %#v, want timer and contract-swap fail-closed classifications", admission.Classifications)
+	}
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerTimerHistoryUnproven) ||
+		!unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want replay and non-mutating blockers", admission.UnsupportedBlockers)
+	}
+	if !executionBoundaryHas(admission.InvalidPaths, "copy_source_event_deliveries", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(admission.InvalidPaths, "source_outcome_suppression", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want source rows/outcomes invalid", admission.InvalidPaths)
+	}
+}
+
+func TestBuildContractSwapBootResumeAdmissionFailsClosedWithoutRouteRecovery(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	replayAdmission := store.RunForkReplayResumeAdmission{Owner: store.RunForkReplayResumeAdmissionOwner}
+
+	admission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+	if admission.RouteRecoveryOwner != "" || admission.RuntimeRouteRecoveryOwner != "" {
+		t.Fatalf("route recovery owners = %#v, want absent when route recovery evidence is missing", admission)
+	}
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerContractSwapRouteRecoveryMissing) {
+		t.Fatalf("unsupported blockers = %#v, want route recovery missing blocker", admission.UnsupportedBlockers)
+	}
+}
+
+func TestBuildContractSwapBootResumeAdmissionRejectsLocalSelectedAdmissionOwner(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	selectedAdmission.Owner = "cmd.swarm.contract_swap_helper"
+
+	_, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      store.RunForkReplayResumeAdmission{Owner: store.RunForkReplayResumeAdmissionOwner},
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractExecutionAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical selected execution admission owner failure", err)
+	}
+}
+
+func TestBuildContractSwapBootResumeAdmissionRejectsMismatchedRouteRecovery(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	routeRecovery.ForkRunID = uuid.NewString()
+
+	_, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      store.RunForkReplayResumeAdmission{Owner: store.RunForkReplayResumeAdmissionOwner},
+		RouteRecovery:              &routeRecovery,
+	})
+	if err == nil || !strings.Contains(err.Error(), "identity does not match") {
+		t.Fatalf("error = %v, want route recovery identity failure", err)
+	}
+}
+
+func contractSwapClassificationHas(items []store.RunForkReplayResumeDisposition, fact, disposition string) bool {
+	for _, item := range items {
+		if item.Fact == fact && item.Disposition == disposition {
+			return true
+		}
+	}
+	return false
+}
+
+func testContractSwapSelection() store.RunForkContractSelection {
+	return store.RunForkContractSelection{
+		Mode:            "selected_contracts",
+		ContractsRoot:   "/tmp/contracts",
+		WorkflowName:    "workflow",
+		WorkflowVersion: "v1",
+	}
+}
+
+func testContractSwapSelectedExecutionAdmission(selection store.RunForkContractSelection) store.RunForkSelectedContractExecutionAdmission {
+	return store.RunForkSelectedContractExecutionAdmission{
+		Owner:                 store.RunForkSelectedContractExecutionAdmissionOwner,
+		FutureExecutionOwner:  store.RunForkSelectedContractExecutionOwner,
+		NonMutating:           true,
+		ExecutionSupported:    false,
+		ForkRunID:             uuid.NewString(),
+		SourceRunID:           uuid.NewString(),
+		ForkEventID:           uuid.NewString(),
+		ContractSelection:     selection,
+		ContractBindingOwner:  store.RunForkSelectedContractBindingOwner,
+		AdmissionOwner:        store.RunForkContractFrontierAdmissionOwner,
+		AdmissionUse:          store.RunForkSelectedContractExecutionAdmissionUseDurableBinding,
+		ExecutionModelOwner:   store.RunForkSelectedContractExecutionModelOwner,
+		SourceWorkflowName:    selection.WorkflowName,
+		SourceWorkflowVersion: selection.WorkflowVersion,
+		FrontierEventCount:    1,
+		RouteTopology: &store.RunForkSelectedContractRouteTopology{
+			Owner:                         store.RunForkSelectedContractRouteTopologyOwner,
+			NonMutating:                   true,
+			ContractSelection:             selection,
+			FrontierEvidenceFingerprint:   "frontier-fingerprint",
+			FrontierEventCount:            1,
+			DynamicTopologySupported:      true,
+			DynamicTopologyDisposition:    store.RunForkSelectedContractDispositionForkLocalTruth,
+			StaticTopologySupported:       true,
+			RouteAdmissionOwner:           store.RunForkSelectedContractRouteAdmissionOwner,
+			ExecutableRecipientsSupported: false,
+		},
+		RecipientPlanning: &store.RunForkSelectedContractRecipientPlanning{
+			Owner:                       store.RunForkSelectedContractRecipientPlanningOwner,
+			RouteTopologyOwner:          store.RunForkSelectedContractRouteTopologyOwner,
+			RouteAdmissionOwner:         store.RunForkSelectedContractRouteAdmissionOwner,
+			FutureExecutionOwner:        store.RunForkSelectedContractExecutionOwner,
+			NonMutating:                 true,
+			RecipientPlanningSupported:  true,
+			DeliveryWritesSupported:     false,
+			ContractSelection:           selection,
+			FrontierEvidenceFingerprint: "frontier-fingerprint",
+			FrontierEventCount:          1,
+		},
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{{
+			Code:    store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating,
+			Message: "selected-contract admission is non-mutating",
+		}},
+	}
+}
+
+func testContractSwapRouteRecovery(admission store.RunForkSelectedContractExecutionAdmission) store.RunForkSelectedContractRouteRecovery {
+	return store.RunForkSelectedContractRouteRecovery{
+		Owner:                        store.RunForkSelectedContractRoutePersistenceOwner,
+		RuntimeRecoveryOwner:         store.RunForkSelectedContractRouteRecoveryOwner,
+		ForkRunID:                    admission.ForkRunID,
+		SourceRunID:                  admission.SourceRunID,
+		ForkEventID:                  admission.ForkEventID,
+		ContractSelection:            admission.ContractSelection,
+		RouteTopologyOwner:           store.RunForkSelectedContractRouteTopologyOwner,
+		RecipientPlanningOwner:       store.RunForkSelectedContractRecipientPlanningOwner,
+		FrontierEvidenceFingerprint:  "frontier-fingerprint",
+		RouteTopologyFingerprint:     "route-fingerprint",
+		RecipientPlanningFingerprint: "recipient-fingerprint",
+	}
+}

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -17,6 +17,7 @@ const (
 	RunForkSelectedContractRouteTopologyOwner           = "runtime.run_fork.selected_contract_route_topology"
 	RunForkSelectedContractDynamicRouteTopologyOwner    = "runtime.run_fork.selected_contract_dynamic_route_topology"
 	RunForkSelectedContractRecipientPlanningOwner       = "runtime.run_fork.selected_contract_recipient_planning"
+	RunForkContractSwapBootResumeAdmissionOwner         = "runtime.run_fork.contract_swap_boot_resume_admission"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -37,6 +38,8 @@ const (
 	RunForkBlockerSelectedContractRouteTopologyNonMutating      = "selected_contract_route_topology_non_mutating"
 	RunForkBlockerSelectedContractDynamicRouteTopologyUnproven  = "selected_contract_dynamic_route_topology_unproven"
 	RunForkBlockerSelectedContractRecipientPlanningNonMutating  = "selected_contract_recipient_planning_non_mutating"
+	RunForkBlockerContractSwapBootResumeAdmissionNonMutating    = "contract_swap_boot_resume_admission_non_mutating"
+	RunForkBlockerContractSwapRouteRecoveryMissing              = "contract_swap_route_recovery_missing"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
 )
@@ -188,6 +191,32 @@ type RunForkSelectedContractExecutionBoundary struct {
 	Disposition string `json:"disposition"`
 	Owner       string `json:"owner,omitempty"`
 	Reason      string `json:"reason"`
+}
+
+type RunForkContractSwapBootResumeAdmission struct {
+	Owner                           string                                     `json:"owner"`
+	NonMutating                     bool                                       `json:"non_mutating"`
+	BootResumeSupported             bool                                       `json:"boot_resume_supported"`
+	FutureExecutionOwner            string                                     `json:"future_execution_owner"`
+	ForkRunID                       string                                     `json:"fork_run_id"`
+	SourceRunID                     string                                     `json:"source_run_id"`
+	ForkEventID                     string                                     `json:"fork_event_id"`
+	ContractSelection               RunForkContractSelection                   `json:"contract_selection"`
+	SelectedBindingOwner            string                                     `json:"selected_binding_owner"`
+	SelectedExecutionAdmissionOwner string                                     `json:"selected_execution_admission_owner"`
+	ReplayResumeAdmissionOwner      string                                     `json:"replay_resume_admission_owner"`
+	RouteTopologyOwner              string                                     `json:"route_topology_owner,omitempty"`
+	RouteRecoveryOwner              string                                     `json:"route_recovery_owner,omitempty"`
+	RuntimeRouteRecoveryOwner       string                                     `json:"runtime_route_recovery_owner,omitempty"`
+	RecipientPlanningOwner          string                                     `json:"recipient_planning_owner,omitempty"`
+	SourceWorkflowName              string                                     `json:"source_workflow_name"`
+	SourceWorkflowVersion           string                                     `json:"source_workflow_version"`
+	FrontierEventCount              int                                        `json:"frontier_event_count"`
+	Prerequisites                   []RunForkSelectedContractExecutionBoundary `json:"prerequisites,omitempty"`
+	Classifications                 []RunForkReplayResumeDisposition           `json:"classifications,omitempty"`
+	BlockedSiblings                 []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                    []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers             []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
 }
 
 func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmission) (int, []string, string) {


### PR DESCRIPTION
## Summary

Closes #625.

Adds the non-mutating `runtime.run_fork.contract_swap_boot_resume_admission` owner for timestamp forks with selected/swapped contracts. The owner consumes selected execution admission and replay/resume taxonomy, classifies contract-swap boot/resume as fail-closed/non-mutating, and keeps source rows, outcomes, timers, sessions, non-agent replay, route recovery, and UI/API surfaces outside the mutating boundary.

## Governing Context

Exact authoritative spec refs updated/read:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.contract_swap_boot_resume_admission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3i_contract_swap_boot_resume_admission`
- Adjacent refs: `selected_contract_execution_admission`, `selected_contract_supported_execution`, `selected_contract_route_persistence_recovery`, `contract_swap`, `replay_resume_admission_taxonomy`

Binding issue/gate refs:

- #625 pre-audit
- #625 independent gate outcome: `approved as first slice`
- #564/#549 remain open for full historical replay/resume and broader fork architecture tail

## Semantic Migration

New canonical owner:

- `runtime.run_fork.contract_swap_boot_resume_admission`

Old paths now invalid/non-authoritative for contract-swap boot/resume readiness:

- CLI/API/dashboard/Builder-owned readiness decisions
- Selected frontier execution as proof of full historical boot/resume
- Source event/delivery/receipt/dead-letter/outcome row copy or suppression
- Current/source timer, route, session, turn, audit, and non-agent replay facts as implicit fork truth

Production paths checked for surviving old behavior:

- Selected-bound activation now builds and returns the canonical contract-swap admission result after selected execution admission.
- Existing selected execution remains the supported frontier mutation path and is not widened.
- Route recovery remains a prerequisite/sibling and is not reopened.
- Runtime mutation, delivery writes, handlers, receipts, dead letters, idempotency, emitted follow-ups, timers, sessions, turns, non-agent replay, and UI/API mutation are not introduced.

Migration complete for the approved non-mutating #625 child. Broader mutating contract-swap replay/resume remains open under #564/#549.

## Tests

- `go test ./internal/runtime/runforkexecution ./internal/store -run 'ContractSwap|SelectedContract|RunFork|ReplayResume' -count=1`
- `go test ./cmd/swarm -run 'RunForkCommand_.*Selected|RunForkCommand_SelectedContracts|RunForkCommand_RequiresContracts|RunForkCommand_DryRunJSONReportsSelected|ActivateSelected' -count=1`
- `go test ./internal/runtime/contracts -run 'Platform|Spec|Contract|YAML|Load' -count=1`
- `go test ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/runtime/manager ./internal/store -run 'ContractSwap|SelectedContract|RouteRecovery|RecipientPlanning|Publish|Delivery|ReplayScope|EventDeliveries|RouteTopology|DynamicRoute|Branch|SourceAdvanced|Recover' -count=1`
- `go test ./...`