### PR TITLE
[agent-d][issue #544] Split startup inventory from turn surface

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -244,6 +244,10 @@ contract_formats:
         root/run-owned, missing, or belongs to another flow/entity contract, generated current-entity read/save/update tools
         MUST be removed from provider-visible catalogs and marked not callable for that turn. Executor validation remains
         fail-closed defense-in-depth.'
+      startup_validation_surface: 'Runtime startup validation distinguishes actor-static generated schema inventory from
+        concrete turn-eligible MCP tools/list. Actor-static inventory may prove generated read/save/update schemas exist for
+        an actor, but a no-current startup MCP tools/list probe MUST be compared against the concrete startup turn context
+        and MUST NOT require generated current-entity tools to appear without a valid current entity.'
       generated_reads:
         read_entity: 'read_{entity_type}() returns the complete current entity envelope and fields for the actor''s flow-owned
           entity contract.'

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -66,6 +66,11 @@ type claudeStartupToolSource interface {
 	ToolCapabilitiesForActor(runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
 }
 
+type claudeStartupContextAwareToolSource interface {
+	ToolDefinitionsForActorInContext(context.Context, runtimeactors.AgentConfig) []llm.ToolDefinition
+	ToolCapabilitiesForActorInContext(context.Context, runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
+}
+
 func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, startupProbe llm.StartupVisibleToolSurfaceProber, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
 	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
 		return nil
@@ -115,14 +120,11 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 		if len(surface.RuntimeToolNames) == 0 {
 			continue
 		}
-		expectedNames, capabilities, err := expectedStartupMCPTools(agentCfg, tools, sessionTools)
+		agentCtx := runtimeactors.WithActor(ctx, agentCfg)
+		expectedNames, capabilities, err := expectedStartupMCPTools(agentCtx, agentCfg, tools, sessionTools)
 		if err != nil {
 			return fmt.Errorf("mcp startup probe expected tools for agent %s: %w", agentID, err)
 		}
-		if len(expectedNames) == 0 {
-			return fmt.Errorf("mcp startup probe found no visible tools for agent %s", agentID)
-		}
-		agentCtx := runtimeactors.WithActor(ctx, agentCfg)
 		binding, enabled, err := llm.BuildMCPHTTPBinding(agentCtx, cfg, turnStore, &llm.Session{
 			AgentID: agentID,
 			Tools:   sessionTools,
@@ -179,31 +181,55 @@ func runtimeConfiguredMCPGatewayToken() string {
 	return strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
 }
 
-func expectedStartupMCPTools(agentCfg runtimeactors.AgentConfig, tools claudeStartupToolSource, sessionTools []llm.ToolDefinition) ([]string, toolcapabilities.Set, error) {
-	names := llm.AgentVisibleToolSurfaceForActor(agentCfg, sessionTools).RuntimeToolNames
-	if len(names) == 0 {
+func expectedStartupMCPTools(ctx context.Context, agentCfg runtimeactors.AgentConfig, tools claudeStartupToolSource, sessionTools []llm.ToolDefinition) ([]string, toolcapabilities.Set, error) {
+	staticNames := llm.AgentVisibleToolSurfaceForActor(agentCfg, sessionTools).RuntimeToolNames
+	if len(staticNames) == 0 {
 		return nil, toolcapabilities.Set{}, nil
 	}
-	allowed := make(map[string]struct{}, len(names))
-	for _, name := range names {
+	allowed := make(map[string]struct{}, len(staticNames))
+	for _, name := range staticNames {
 		allowed[name] = struct{}{}
 	}
-	caps := tools.ToolCapabilitiesForActor(agentCfg, names, allowed)
-	if len(caps.ByName) == 0 {
-		return nil, toolcapabilities.Set{}, fmt.Errorf("tool capability set is required")
+	staticCaps := tools.ToolCapabilitiesForActor(agentCfg, staticNames, allowed)
+	staticVisible, err := visibleStartupCapabilityNames(staticNames, staticCaps)
+	if err != nil {
+		return nil, toolcapabilities.Set{}, err
 	}
+	if len(staticVisible) == 0 {
+		return nil, toolcapabilities.Set{}, fmt.Errorf("found no visible tools")
+	}
+
+	concreteTools := sessionTools
+	if contextAware, ok := tools.(claudeStartupContextAwareToolSource); ok {
+		concreteTools = contextAware.ToolDefinitionsForActorInContext(ctx, agentCfg)
+	}
+	concreteNames := llm.AgentVisibleToolSurfaceForActor(agentCfg, concreteTools).RuntimeToolNames
+	var concreteCaps toolcapabilities.Set
+	if contextAware, ok := tools.(claudeStartupContextAwareToolSource); ok {
+		concreteCaps = contextAware.ToolCapabilitiesForActorInContext(ctx, agentCfg, concreteNames, allowed)
+	} else {
+		concreteCaps = tools.ToolCapabilitiesForActor(agentCfg, concreteNames, allowed)
+	}
+	visible, err := visibleStartupCapabilityNames(concreteNames, concreteCaps)
+	if err != nil {
+		return nil, toolcapabilities.Set{}, err
+	}
+	sort.Strings(visible)
+	return visible, concreteCaps, nil
+}
+
+func visibleStartupCapabilityNames(names []string, caps toolcapabilities.Set) ([]string, error) {
 	visible := make([]string, 0, len(names))
 	for _, name := range names {
 		capability, ok := caps.Capability(name)
 		if !ok {
-			return nil, toolcapabilities.Set{}, fmt.Errorf("missing tool capability for %s", name)
+			return nil, fmt.Errorf("missing tool capability for %s", name)
 		}
 		if capability.Visible {
 			visible = append(visible, name)
 		}
 	}
-	sort.Strings(visible)
-	return visible, caps, nil
+	return visible, nil
 }
 
 func startupSessionToolNames(tools []llm.ToolDefinition) []string {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -99,10 +99,14 @@ func TestValidateClaudeManagedAgentWorkspaces_AcceptsContainerTargets(t *testing
 }
 
 type startupProbeToolExecutor struct {
-	defs     []llm.ToolDefinition
-	caps     map[string]toolcapabilities.Capability
-	executed []string
-	execErrs map[string]error
+	defs             []llm.ToolDefinition
+	contextDefs      []llm.ToolDefinition
+	caps             map[string]toolcapabilities.Capability
+	contextCaps      map[string]toolcapabilities.Capability
+	contextDefCalls  int
+	contextCapsCalls int
+	executed         []string
+	execErrs         map[string]error
 }
 
 func (s *startupProbeToolExecutor) Execute(_ context.Context, name string, _ any) (any, error) {
@@ -123,9 +127,29 @@ func (s *startupProbeToolExecutor) ToolDefinitionsForActor(runtimeactors.AgentCo
 }
 
 func (s *startupProbeToolExecutor) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	return startupProbeCapabilitySet(names, s.caps)
+}
+
+func (s *startupProbeToolExecutor) ToolDefinitionsForActorInContext(context.Context, runtimeactors.AgentConfig) []llm.ToolDefinition {
+	s.contextDefCalls++
+	if s.contextDefs != nil {
+		return append([]llm.ToolDefinition(nil), s.contextDefs...)
+	}
+	return append([]llm.ToolDefinition(nil), s.defs...)
+}
+
+func (s *startupProbeToolExecutor) ToolCapabilitiesForActorInContext(_ context.Context, _ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	s.contextCapsCalls++
+	if s.contextCaps != nil {
+		return startupProbeCapabilitySet(names, s.contextCaps)
+	}
+	return startupProbeCapabilitySet(names, s.caps)
+}
+
+func startupProbeCapabilitySet(names []string, source map[string]toolcapabilities.Capability) toolcapabilities.Set {
 	caps := make([]toolcapabilities.Capability, 0, len(names))
 	for _, name := range names {
-		capability, ok := s.caps[strings.TrimSpace(name)]
+		capability, ok := source[strings.TrimSpace(name)]
 		if !ok {
 			capability = toolcapabilities.Capability{
 				Name:               strings.TrimSpace(name),
@@ -245,6 +269,84 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 	}
 	if !slices.Equal(exec.executed, []string{"health_check"}) {
 		t.Fatalf("executed = %#v, want health_check tools/call smoke", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_SeparatesStaticInventoryFromNoCurrentTurnSurface(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "analysis-agent",
+		Role:   "analysis",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{
+			{Name: "emit_vertical_derived", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+			{Name: "read_vertical", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+			{Name: "save_vertical_scores", Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "object"}}}},
+			{Name: "update_vertical_scores_signal_strength", Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "number"}}}},
+		},
+		contextDefs: []llm.ToolDefinition{
+			{Name: "emit_vertical_derived", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+		},
+		caps: map[string]toolcapabilities.Capability{
+			"emit_vertical_derived":                  {Name: "emit_vertical_derived", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
+			"read_vertical":                          {Name: "read_vertical", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+			"save_vertical_scores":                   {Name: "save_vertical_scores", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+			"update_vertical_scores_signal_strength": {Name: "update_vertical_scores_signal_strength", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+		},
+		contextCaps: map[string]toolcapabilities.Capability{
+			"emit_vertical_derived": {Name: "emit_vertical_derived", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
+		},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if exec.contextDefCalls == 0 || exec.contextCapsCalls == 0 {
+		t.Fatalf("expected startup MCP proof to consume context-aware surface, defCalls=%d capCalls=%d", exec.contextDefCalls, exec.contextCapsCalls)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want visibility-only proof for no-current generated entity tools", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_AllowsEmptyConcreteSurfaceWhenStaticInventoryIsGeneratedCurrentEntityOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:   "validation-agent",
+		Role: "validation",
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: []llm.ToolDefinition{
+			{Name: "read_validation_case", Schema: map[string]any{"type": "object", "properties": map[string]any{}}},
+			{Name: "save_validation_case_mvp_spec", Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "object"}}}},
+			{Name: "update_validation_case_mvp_spec_summary", Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}}},
+		},
+		contextDefs: []llm.ToolDefinition{},
+		caps: map[string]toolcapabilities.Capability{
+			"read_validation_case":                    {Name: "read_validation_case", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+			"save_validation_case_mvp_spec":           {Name: "save_validation_case_mvp_spec", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+			"update_validation_case_mvp_spec_summary": {Name: "update_validation_case_mvp_spec_summary", Visible: true, Callable: true, ContextRequirement: toolcapabilities.ContextRequirementTurnContext},
+		},
+		contextCaps: map[string]toolcapabilities.Capability{},
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no callable startup probe for empty concrete surface", exec.executed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #544.

This PR repairs the post-#624 startup validation regression by separating two startup proof surfaces:

- actor-static generated schema inventory, used to prove an actor has generated read/save/update schemas available by contract
- concrete turn-eligible MCP `tools/list`, used to prove only the tools actually provider-visible for the registered startup turn

Generated current-entity tools remain hidden/not callable when the startup turn has no current entity. The fix does not fake current entity context and does not weaken runtime executor validation.

## Governing refs

Exact spec refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `contract_formats.persistence_model.role_scoped_entity_tools.turn_eligibility`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `contract_formats.persistence_model.role_scoped_entity_tools.startup_validation_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `tool_model.agent_tool_filtering.role_scoped_entity_tools`

Binding issue/gate context:

- Swarm #544 reopened post-#624 startup failure: `analysis-agent` actor-static expected generated `read_vertical*` tools while startup MCP `tools/list` correctly returned only concrete no-current emit tools.
- Gate outcome: approved as first slice under `transport_policy_and_surface_parity`.

## Semantic migration

New canonical startup validation owner:

- `validateClaudeMCPToolsForManagedAgents` / `expectedStartupMCPTools` now consume actor-static inventory and context-aware concrete MCP tool definitions separately.

Old invalid interpreter:

- Startup MCP validation used one actor-static expected runtime-tool list as both schema inventory and concrete `tools/list` expectation.

Production paths checked:

- managed-agent startup validation
- MCP gateway concrete turn filtering
- generated role-scoped read/save/update turn eligibility
- provider-native startup strictness
- startup safe-call probing

Migration completeness:

- Complete for the approved #544 startup validation child class. The broader `transport_policy_and_surface_parity` parent remains open.

## Proof

- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents' -count=1`
- `go test ./internal/runtime/mcp ./internal/runtime/agents ./internal/runtime/tools -run 'RoleScoped|CurrentEntity|ToolDefinitionsForActor|GatewayMCPToolsForRequest|LLMAgentOnEvent_FiltersRoleScopedToolsByTurnEntityEligibility' -count=1`
- `go run ./cmd/swarm verify --contracts /tmp/empire-rebaseline-post624/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `go test ./...`
- Supported startup/run proof: `make run-clear CONTRACTS_ROOT=/tmp/empire-rebaseline-post624/contracts LOG_FILE=/tmp/swarm-empire-rebaseline-post544fix.log PID_FILE=/tmp/swarm-empire-rebaseline-post544fix.pid`

Supported proof result:

- Swarm commit under test: `8aaf94c5`
- Empire contracts head: `25c9d7231dfb7e5d2a66316255e4b9bd983fb37f`
- Run id: `f3e8c217-fdd0-40c3-a339-578e478a0916`
- Startup reached ready and produced a run id
- `platform.runtime_log` rows with `details.action = mcp.tools.call.exec_error`: `0`
- Dead letters: `0`
- Failed deliveries: `0`

Note: the supported run remained in normal `market-research-agent` processing when sampled. This PR uses it only as #544 startup/rebaseline-unblock proof, not as Empire #25 closure proof.