### PR TITLE
[agent-a][issue #631] Gate historical replay admission owner

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3422,6 +3422,23 @@ run_model:
       otherwise implement mutating historical replay/resume. CLI, API, dashboard, Builder, route helpers, delivery
       writers, and pipeline boot paths may consume this owner but MUST NOT compute contract-swap boot/resume readiness
       independently.'
+    historical_replay_execution_admission: 'Full historical replay/resume execution admission is owned by
+      runtime.run_fork.historical_replay_execution_admission. This owner is non-mutating and establishes the authority
+      boundary for the future runtime.run_fork.historical_replay_execution owner. It consumes the canonical
+      store.run_fork.replay_resume_admission taxonomy plus selected-contract execution admission, selected binding,
+      selected route topology, selected recipient planning, selected route recovery when present, and
+      runtime.run_fork.contract_swap_boot_resume_admission. It classifies source events, event deliveries, receipts,
+      dead letters, retry/idempotency state, emitted follow-ups, timers, routes/current route rows, sessions, turns,
+      audits, non-agent/node/system work, source-advanced/post-T source outcomes, runtime restart recovery, and
+      CLI/API/dashboard/operator consumers exactly once as executable fork work, reconstructed fork-local state,
+      lineage-only evidence, fail-closed blockers, or split siblings. Source events and outcomes are lineage/proof only;
+      the only admitted executable delivery family is the separately proven delivery_event_replay_ready primitive from
+      store.run_fork.replay_resume_admission. This owner MUST NOT run handlers, create or copy events or
+      event_deliveries, write receipts, dead letters, retry/idempotency state, emitted follow-up events, timers,
+      sessions, turns, route rows, API/UI/dashboard state, suppress fork work from source outcomes, or treat selected
+      frontier execution as full historical replay/resume proof. CLI, API, dashboard, Builder, route helpers, delivery
+      writers, runtime recovery, and pipeline boot paths may consume this owner but MUST NOT compute historical replay
+      execution admission independently.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3507,6 +3524,13 @@ run_model:
         fork-local work. This owner is non-mutating and does not authorize handler execution, delivery writes, receipts,
         dead letters, idempotency, emitted follow-ups, timers, sessions, turns, non-agent replay, route row mutation, or
         API/UI state.'
+      3j_historical_replay_execution_admission: 'Before any future full historical replay/resume mutation,
+        runtime.run_fork.historical_replay_execution_admission classifies every historical source fact family under one
+        runtime authority. It consumes replay_resume_admission, selected-contract execution admission, route topology,
+        recipient planning, route recovery evidence when present, and contract-swap boot/resume admission. It is
+        admission/model only: it does not run handlers, create fork-local rows, copy source rows, write outcomes, replay
+        timers, reconstruct sessions/turns/audits, mutate routes, or own API/dashboard state. Full mutation remains
+        with the separately gated runtime.run_fork.historical_replay_execution owner.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -282,6 +282,7 @@ nodes:
       - selected-contract fork execution must classify delivery-write boundaries before future mutation; source deliveries remain lineage/blocker evidence, not executable fork work
       - selected-contract fork execution must write fresh fork-local event/delivery/outcome rows through the runtime selected-contract execution owner, with source rows used only as lineage evidence
       - selected-contract delivery writes from recipient planning are execution-proven through runtime.run_fork.selected_contract_execution and EventBus.Publish recipient-plan guards; a delivery-row-only writer would be a non-authoritative duplicate
+      - historical replay execution admission must classify event deliveries, receipts, dead letters, retry/idempotency state, emitted follow-ups, and non-agent work before any future replay mutation; source delivery/outcome rows must remain lineage, blockers, or split siblings
     representative_issues:
       - 112
       - 144
@@ -295,6 +296,7 @@ nodes:
       - 598
       - 619
       - 621
+      - 631
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -335,6 +337,7 @@ nodes:
       - selected-contract parent-tail rebaseline must close or narrow stale #588/#608 tracker state while keeping #564/#549 open for full replay/resume and fork architecture siblings
       - selected-contract route persistence/runtime recovery needs a fork-local owner keyed by fork run_id and selected binding/topology/recipient evidence; current routing_rules, flow_instance_routes, and startup ListFlowInstanceRoutes recovery remain current-route infrastructure and must not become selected-fork route truth
       - contract-swap boot/resume readiness needs a non-mutating runtime owner that consumes selected binding, selected source admission, replay/resume taxonomy, selected route/recipient/recovery evidence, and classifies source deliveries/outcomes/timers/routes/sessions/non-agent facts as lineage, blockers, or split siblings before any full historical replay mutation
+      - historical replay execution admission needs one non-mutating runtime owner that consumes replay_resume_admission, selected execution admission, selected binding/topology/recipient planning, route recovery evidence, and contract-swap admission before any full historical replay/resume mutation; it must classify every source fact family exactly once and keep mutation under a separate future owner
     representative_issues:
       - 564
       - 565
@@ -358,6 +361,7 @@ nodes:
       - 619
       - 621
       - 625
+      - 631
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -30,6 +30,7 @@ type SelectedContractActivationGateResult struct {
 	Owner                              string                                           `json:"selected_contract_activation_gate_owner,omitempty"`
 	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
 	ContractSwapBootResumeAdmission    *store.RunForkContractSwapBootResumeAdmission    `json:"contract_swap_boot_resume_admission,omitempty"`
+	HistoricalReplayExecutionAdmission *store.RunForkHistoricalReplayExecutionAdmission `json:"historical_replay_execution_admission,omitempty"`
 }
 
 func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractActivationGateRequest) (SelectedContractActivationGateResult, error) {
@@ -124,10 +125,20 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
+	historicalReplayAdmission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+		SelectedExecutionAdmission: admission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              routeRecovery,
+	})
+	if err != nil {
+		return SelectedContractActivationGateResult{}, err
+	}
 	result := SelectedContractActivationGateResult{
 		Owner:                              store.RunForkSelectedContractExecutionActivationGateOwner,
 		SelectedContractExecutionAdmission: &admission,
 		ContractSwapBootResumeAdmission:    &contractSwapAdmission,
+		HistoricalReplayExecutionAdmission: &historicalReplayAdmission,
 	}
 	if !plan.ExecutionReady {
 		return result, fmt.Errorf("selected-contract activation gate requires execution-ready plan before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -76,6 +76,13 @@ func TestActivateSelectedContractRunForkConsumesAdmissionBeforeStateOnlyActivati
 		!unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) {
 		t.Fatalf("contract-swap admission = %#v", result.ContractSwapBootResumeAdmission)
 	}
+	if result.HistoricalReplayExecutionAdmission == nil ||
+		result.HistoricalReplayExecutionAdmission.Owner != store.RunForkHistoricalReplayExecutionAdmissionOwner ||
+		!result.HistoricalReplayExecutionAdmission.NonMutating ||
+		result.HistoricalReplayExecutionAdmission.ExecutionSupported ||
+		result.HistoricalReplayExecutionAdmission.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner {
+		t.Fatalf("historical replay admission = %#v", result.HistoricalReplayExecutionAdmission)
+	}
 	if result.RunForkActivation.ForkRunID != forkRunID || !result.Activated {
 		t.Fatalf("activation = %#v", result.RunForkActivation)
 	}
@@ -121,6 +128,11 @@ func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMuta
 	if result.ContractSwapBootResumeAdmission == nil ||
 		!unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) {
 		t.Fatalf("contract-swap admission = %#v, want non-mutating blocker before source replay block", result.ContractSwapBootResumeAdmission)
+	}
+	if result.HistoricalReplayExecutionAdmission == nil ||
+		!unsupportedBlockerHas(result.HistoricalReplayExecutionAdmission.UnsupportedBlockers, store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating) ||
+		!historicalReplayFactHas(result.HistoricalReplayExecutionAdmission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkHistoricalReplayAdmissionExecutableForkWork) {
+		t.Fatalf("historical replay admission = %#v, want non-mutating replayable-source classification before source replay block", result.HistoricalReplayExecutionAdmission)
 	}
 }
 
@@ -168,6 +180,11 @@ func TestActivateSelectedContractRunForkPassesRecoveredRouteEvidenceToContractSw
 	}
 	if unsupportedBlockerHas(result.ContractSwapBootResumeAdmission.UnsupportedBlockers, store.RunForkBlockerContractSwapRouteRecoveryMissing) {
 		t.Fatalf("unexpected missing-route blocker with route recovery evidence: %#v", result.ContractSwapBootResumeAdmission.UnsupportedBlockers)
+	}
+	if result.HistoricalReplayExecutionAdmission == nil ||
+		result.HistoricalReplayExecutionAdmission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		result.HistoricalReplayExecutionAdmission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner {
+		t.Fatalf("historical replay route recovery owners = %#v", result.HistoricalReplayExecutionAdmission)
 	}
 }
 
@@ -243,6 +260,15 @@ func TestActivateSelectedContractRunForkPreservesPlannerBlockersBeforeMutation(t
 	if fakeStore.activateCalled {
 		t.Fatal("ActivateRunFork called, want fail closed before mutation")
 	}
+}
+
+func historicalReplayFactHas(items []store.RunForkHistoricalReplayFactAdmission, fact, admission string) bool {
+	for _, item := range items {
+		if item.Fact == fact && item.Admission == admission {
+			return true
+		}
+	}
+	return false
 }
 
 type fakeSelectedContractActivationStore struct {

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -1,0 +1,423 @@
+package runforkexecution
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type HistoricalReplayExecutionAdmissionRequest struct {
+	ReplayResumeAdmission      store.RunForkReplayResumeAdmission
+	SelectedExecutionAdmission store.RunForkSelectedContractExecutionAdmission
+	ContractSwapAdmission      store.RunForkContractSwapBootResumeAdmission
+	RouteRecovery              *store.RunForkSelectedContractRouteRecovery
+}
+
+func BuildHistoricalReplayExecutionAdmission(req HistoricalReplayExecutionAdmissionRequest) (store.RunForkHistoricalReplayExecutionAdmission, error) {
+	replayAdmission := req.ReplayResumeAdmission
+	if strings.TrimSpace(replayAdmission.Owner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkHistoricalReplayExecutionAdmission{}, fmt.Errorf("historical replay execution admission requires %s; got %q", store.RunForkReplayResumeAdmissionOwner, replayAdmission.Owner)
+	}
+	selectedAdmission := req.SelectedExecutionAdmission
+	if err := validateContractSwapSelectedExecutionAdmission(selectedAdmission); err != nil {
+		return store.RunForkHistoricalReplayExecutionAdmission{}, fmt.Errorf("historical replay execution admission selected prerequisite: %w", err)
+	}
+	contractSwapAdmission := req.ContractSwapAdmission
+	if err := validateHistoricalReplayContractSwapAdmission(selectedAdmission, replayAdmission, contractSwapAdmission); err != nil {
+		return store.RunForkHistoricalReplayExecutionAdmission{}, err
+	}
+	if req.RouteRecovery != nil {
+		if err := validateContractSwapRouteRecovery(selectedAdmission, *req.RouteRecovery); err != nil {
+			return store.RunForkHistoricalReplayExecutionAdmission{}, fmt.Errorf("historical replay execution admission route recovery prerequisite: %w", err)
+		}
+	}
+
+	blockers := []store.RunForkUnsupportedBlocker{}
+	for _, blocker := range replayAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	for _, blocker := range selectedAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	for _, blocker := range contractSwapAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
+		Code:    store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating,
+		Message: "historical replay execution admission is non-mutating; full replay/resume mutation remains separately gated",
+	})
+
+	var routeTopologyOwner, recipientPlanningOwner string
+	if selectedAdmission.RouteTopology != nil {
+		routeTopologyOwner = selectedAdmission.RouteTopology.Owner
+	}
+	if selectedAdmission.RecipientPlanning != nil {
+		recipientPlanningOwner = selectedAdmission.RecipientPlanning.Owner
+	}
+	var routeRecoveryOwner, runtimeRouteRecoveryOwner string
+	if req.RouteRecovery != nil {
+		routeRecoveryOwner = req.RouteRecovery.Owner
+		runtimeRouteRecoveryOwner = req.RouteRecovery.RuntimeRecoveryOwner
+	}
+	selection := selectedAdmission.ContractSelection
+
+	return store.RunForkHistoricalReplayExecutionAdmission{
+		Owner:                           store.RunForkHistoricalReplayExecutionAdmissionOwner,
+		NonMutating:                     true,
+		ExecutionSupported:              false,
+		FutureExecutionOwner:            store.RunForkHistoricalReplayExecutionOwner,
+		ForkRunID:                       selectedAdmission.ForkRunID,
+		SourceRunID:                     selectedAdmission.SourceRunID,
+		ForkEventID:                     selectedAdmission.ForkEventID,
+		ContractSelection:               &selection,
+		ReplayResumeAdmissionOwner:      replayAdmission.Owner,
+		SelectedExecutionAdmissionOwner: selectedAdmission.Owner,
+		SelectedBindingOwner:            selectedAdmission.ContractBindingOwner,
+		RouteTopologyOwner:              routeTopologyOwner,
+		RouteRecoveryOwner:              routeRecoveryOwner,
+		RuntimeRouteRecoveryOwner:       runtimeRouteRecoveryOwner,
+		RecipientPlanningOwner:          recipientPlanningOwner,
+		ContractSwapAdmissionOwner:      contractSwapAdmission.Owner,
+		FactAdmissions:                  historicalReplayFactAdmissions(replayAdmission),
+		Prerequisites:                   historicalReplayPrerequisites(req.RouteRecovery != nil),
+		RequiredConsumers:               historicalReplayRequiredConsumers(),
+		BlockedSiblings:                 historicalReplayBlockedSiblings(),
+		InvalidPaths:                    historicalReplayInvalidPaths(),
+		UnsupportedBlockers:             blockers,
+	}, nil
+}
+
+func validateHistoricalReplayContractSwapAdmission(
+	selectedAdmission store.RunForkSelectedContractExecutionAdmission,
+	replayAdmission store.RunForkReplayResumeAdmission,
+	admission store.RunForkContractSwapBootResumeAdmission,
+) error {
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractSwapBootResumeAdmissionOwner {
+		return fmt.Errorf("historical replay execution admission requires %s; got %q", store.RunForkContractSwapBootResumeAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return fmt.Errorf("historical replay execution admission requires non-mutating contract-swap admission")
+	}
+	if admission.BootResumeSupported {
+		return fmt.Errorf("historical replay execution admission cannot consume mutating contract-swap admission")
+	}
+	if strings.TrimSpace(admission.SelectedExecutionAdmissionOwner) != selectedAdmission.Owner ||
+		strings.TrimSpace(admission.ReplayResumeAdmissionOwner) != replayAdmission.Owner {
+		return fmt.Errorf("historical replay execution admission contract-swap prerequisite owner mismatch")
+	}
+	if strings.TrimSpace(admission.ForkRunID) != strings.TrimSpace(selectedAdmission.ForkRunID) ||
+		strings.TrimSpace(admission.SourceRunID) != strings.TrimSpace(selectedAdmission.SourceRunID) ||
+		strings.TrimSpace(admission.ForkEventID) != strings.TrimSpace(selectedAdmission.ForkEventID) {
+		return fmt.Errorf("historical replay execution admission contract-swap identity does not match selected execution admission")
+	}
+	return nil
+}
+
+func historicalReplayFactAdmissions(replay store.RunForkReplayResumeAdmission) []store.RunForkHistoricalReplayFactAdmission {
+	return []store.RunForkHistoricalReplayFactAdmission{
+		{
+			Fact:        store.RunForkHistoricalReplayFactSourceEvents,
+			Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+			SourceOwner: "events",
+			Message:     "source events are payload and lineage evidence only; future replay must mint fresh fork-local events under the fork run_id",
+		},
+		historicalReplayEventDeliveriesAdmission(replay),
+		historicalReplayLineageFact(store.RunForkHistoricalReplayFactReceipts, "event_receipts", "source receipts are outcome lineage only and cannot suppress future fork-local work"),
+		historicalReplayDeadLettersAdmission(replay),
+		historicalReplaySplitFact(store.RunForkHistoricalReplayFactRetryIdempotency, "runtime idempotency and retry state must be owned by a later mutating replay child; source state cannot suppress fork work", "#564"),
+		historicalReplaySplitFact(store.RunForkHistoricalReplayFactEmittedFollowUps, "emitted follow-up regeneration belongs to the future mutating replay owner; source follow-up rows are not copied", "#564"),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactTimers, []string{store.RunForkReplayResumeFactTimerHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "timer reconstruction remains a split sibling unless timer_history is present and fail-closed", "#564"),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactRoutes, []string{store.RunForkReplayResumeFactRouteHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "route and route-recovery truth remains split under fork-local route persistence/runtime recovery", "#618"),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactSessions, []string{store.RunForkReplayResumeFactSessionHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "session reconstruction remains a split sibling unless active session facts are present and fail-closed", "#564"),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactTurns, []string{store.RunForkReplayResumeFactActiveTurnHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "turn reconstruction remains a split sibling unless active turn facts are present and fail-closed", "#564"),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactAudits, []string{store.RunForkReplayResumeFactConversationAuditHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "task conversation audit reconstruction remains a split sibling unless audit facts are present and fail-closed", "#564"),
+		historicalReplayNonAgentAdmission(replay),
+		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts, []string{store.RunForkReplayResumeFactSourceAdvanced}, store.RunForkHistoricalReplayAdmissionSplitSibling, "source-advanced and post-T source outcomes remain source-run evidence and cannot suppress fork-local replay", "#564"),
+		historicalReplaySplitFact(store.RunForkHistoricalReplayFactRuntimeRestartRecovery, "runtime restart recovery remains a consumer/sibling and cannot reconstruct historical replay state from current rows", "#564"),
+		historicalReplaySplitFact(store.RunForkHistoricalReplayFactCLIApiDashboardOperator, "CLI, API, dashboard, and Builder surfaces are consumers only and must not compute historical replay admission independently", "#549"),
+	}
+}
+
+func historicalReplayEventDeliveriesAdmission(replay store.RunForkReplayResumeAdmission) store.RunForkHistoricalReplayFactAdmission {
+	facts := []string{
+		store.RunForkReplayResumeFactDeliveryPendingHistory,
+		store.RunForkReplayResumeFactDeliveryInProgressHistory,
+		store.RunForkReplayResumeFactDeliveryFailedHistory,
+		store.RunForkReplayResumeFactDeliveryDeadLetterHistory,
+		store.RunForkReplayResumeFactCommittedReplayScope,
+	}
+	if blocker, ok := replayBlockerForFacts(replay, facts...); ok {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactEventDeliveries,
+			Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		}
+	}
+	if replay.DeliveryEventReplayReady || replayDispositionHas(replay, store.RunForkReplayResumeFactDeliveryPendingHistory, store.RunForkReplayResumeDispositionForkReplay) {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactEventDeliveries,
+			Admission:   store.RunForkHistoricalReplayAdmissionExecutableForkWork,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			Message:     "only the existing delivery_event_replay_ready primitive is admitted as future executable fork work; this admission does not create event or delivery rows",
+		}
+	}
+	return historicalReplayLineageFact(store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkReplayResumeAdmissionOwner, "source delivery history is lineage/no-op evidence unless the canonical replay taxonomy admits the pending unstarted agent-delivery primitive")
+}
+
+func historicalReplayDeadLettersAdmission(replay store.RunForkReplayResumeAdmission) store.RunForkHistoricalReplayFactAdmission {
+	if blocker, ok := replayBlockerForFacts(replay, store.RunForkReplayResumeFactDeliveryDeadLetterHistory); ok {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactDeadLetters,
+			Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		}
+	}
+	return historicalReplayLineageFact(store.RunForkHistoricalReplayFactDeadLetters, "event_deliveries", "source dead letters are terminal source-run outcome evidence only and cannot suppress future fork-local work")
+}
+
+func historicalReplayNonAgentAdmission(replay store.RunForkReplayResumeAdmission) store.RunForkHistoricalReplayFactAdmission {
+	for _, blocker := range replay.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == store.RunForkBlockerNonAgentDeliveryReplayUnsupported {
+			return store.RunForkHistoricalReplayFactAdmission{
+				Fact:        store.RunForkHistoricalReplayFactNonAgentNodeSystemWork,
+				Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+				SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+				BlockerCode: blocker.Code,
+				Message:     blocker.Message,
+			}
+		}
+	}
+	return historicalReplaySplitFact(store.RunForkHistoricalReplayFactNonAgentNodeSystemWork, "node, system, platform, and non-agent delivery replay requires a separate handler/idempotency/receipt owner", "#564")
+}
+
+func historicalReplayFactFromReplay(replay store.RunForkReplayResumeAdmission, fact string, replayFacts []string, fallbackAdmission, fallbackMessage, tracker string) store.RunForkHistoricalReplayFactAdmission {
+	if blocker, ok := replayBlockerForFacts(replay, replayFacts...); ok {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        fact,
+			Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		}
+	}
+	return store.RunForkHistoricalReplayFactAdmission{
+		Fact:        fact,
+		Admission:   fallbackAdmission,
+		SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+		Tracker:     tracker,
+		Message:     fallbackMessage,
+	}
+}
+
+func historicalReplayLineageFact(fact, sourceOwner, message string) store.RunForkHistoricalReplayFactAdmission {
+	return store.RunForkHistoricalReplayFactAdmission{
+		Fact:        fact,
+		Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+		SourceOwner: sourceOwner,
+		Message:     message,
+	}
+}
+
+func historicalReplaySplitFact(fact, message, tracker string) store.RunForkHistoricalReplayFactAdmission {
+	return store.RunForkHistoricalReplayFactAdmission{
+		Fact:      fact,
+		Admission: store.RunForkHistoricalReplayAdmissionSplitSibling,
+		Tracker:   tracker,
+		Message:   message,
+	}
+}
+
+func replayBlockerForFacts(replay store.RunForkReplayResumeAdmission, facts ...string) (store.RunForkUnsupportedBlocker, bool) {
+	for _, disposition := range replay.Dispositions {
+		if !stringInSet(disposition.Fact, facts) {
+			continue
+		}
+		if strings.TrimSpace(disposition.Disposition) != store.RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		code := strings.TrimSpace(disposition.BlockerCode)
+		if code == "" {
+			code = "historical_replay_fact_unproven"
+		}
+		for _, blocker := range replay.UnsupportedBlockers {
+			if strings.TrimSpace(blocker.Code) == code {
+				return blocker, true
+			}
+		}
+		return store.RunForkUnsupportedBlocker{
+			Code:    code,
+			Message: strings.TrimSpace(disposition.Message),
+		}, true
+	}
+	return store.RunForkUnsupportedBlocker{}, false
+}
+
+func replayDispositionHas(replay store.RunForkReplayResumeAdmission, fact, disposition string) bool {
+	for _, item := range replay.Dispositions {
+		if strings.TrimSpace(item.Fact) == fact && strings.TrimSpace(item.Disposition) == disposition {
+			return true
+		}
+	}
+	return false
+}
+
+func stringInSet(value string, items []string) bool {
+	value = strings.TrimSpace(value)
+	for _, item := range items {
+		if value == strings.TrimSpace(item) {
+			return true
+		}
+	}
+	return false
+}
+
+func historicalReplayPrerequisites(routeRecoveryPresent bool) []store.RunForkSelectedContractExecutionBoundary {
+	disposition := store.RunForkSelectedContractDispositionPrerequisite
+	routeRecoveryReason := "selected route recovery is consumed when present; missing recovery remains a named blocker from contract-swap admission"
+	if !routeRecoveryPresent {
+		disposition = store.RunForkSelectedContractDispositionFailClosed
+	}
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "replay_resume_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkReplayResumeAdmissionOwner,
+			Reason:      "historical replay execution admission consumes the canonical store taxonomy and does not recompute source fact classifications",
+		},
+		{
+			Concept:     "selected_contract_execution_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractExecutionAdmissionOwner,
+			Reason:      "selected binding/source/frontier evidence must come from the selected execution admission owner",
+		},
+		{
+			Concept:     "selected_contract_route_topology",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRouteTopologyOwner,
+			Reason:      "route topology is prerequisite evidence; source routing rows remain invalid as fork truth",
+		},
+		{
+			Concept:     "selected_contract_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "future delivery work must consume recipient planning rather than deriving recipients from source deliveries or current routes",
+		},
+		{
+			Concept:     "selected_contract_route_recovery",
+			Disposition: disposition,
+			Owner:       store.RunForkSelectedContractRouteRecoveryOwner,
+			Reason:      routeRecoveryReason,
+		},
+		{
+			Concept:     "contract_swap_boot_resume_admission",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkContractSwapBootResumeAdmissionOwner,
+			Reason:      "contract-swap readiness is an adjacent non-mutating prerequisite and must not be recomputed by historical replay admission",
+		},
+	}
+}
+
+func historicalReplayRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "future_historical_replay_execution",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       store.RunForkHistoricalReplayExecutionOwner,
+			Reason:      "mutating replay/resume must consume this admission before any handler execution or fork-local write",
+		},
+		{
+			Concept:     "selected_contract_execution",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			Reason:      "supported selected-contract execution remains a prerequisite proof, not a replacement for full replay/resume",
+		},
+		{
+			Concept:     "event_bus_publish",
+			Disposition: store.RunForkSelectedContractDispositionFutureOwnerRequired,
+			Owner:       "internal/runtime/bus.EventBus.Publish",
+			Reason:      "future fork-local event delivery must route through publish guards rather than direct source row copying",
+		},
+		{
+			Concept:     "operator_surfaces",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Reason:      "CLI, API, dashboard, and Builder may display this admission but must not own replay/resume semantics",
+		},
+	}
+}
+
+func historicalReplayBlockedSiblings() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "mutating_historical_replay_execution",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkHistoricalReplayExecutionOwner,
+			Reason:      "this slice establishes admission only and does not authorize mutation",
+		},
+		{
+			Concept:     "timer_reconstruction",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "timer reconstruction remains under #564 until a timer owner is approved",
+		},
+		{
+			Concept:     "route_persistence_runtime_recovery",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractRouteRecoveryOwner,
+			Reason:      "route persistence/runtime recovery remains tracked separately under #618",
+		},
+		{
+			Concept:     "sessions_turns_audits",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "session, turn, and audit reconstruction remains under #564",
+		},
+		{
+			Concept:     "node_system_non_agent_replay",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "non-agent replay requires its own handler/idempotency/receipt owner",
+		},
+		{
+			Concept:     "api_dashboard_builder_mutation",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "operator surfaces remain consumers only",
+		},
+	}
+}
+
+func historicalReplayInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "source_event_copy",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source event IDs are lineage inputs; future replay must mint fork-local events under the fork run_id",
+		},
+		{
+			Concept:     "source_delivery_copy",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source event_deliveries are lineage or blockers, not executable fork delivery rows",
+		},
+		{
+			Concept:     "source_outcome_suppression",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source receipts, dead letters, retry/idempotency state, and post-T outcomes cannot suppress fork-local work",
+		},
+		{
+			Concept:     "current_route_rows_as_fork_truth",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "current routing_rules, flow-instance routes, and runtime recovery rows are not historical replay admission owners",
+		},
+		{
+			Concept:     "selected_frontier_execution_as_full_replay",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "supported selected frontier execution does not prove full historical replay/resume",
+		},
+		{
+			Concept:     "cli_api_dashboard_owned_replay",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "operator surfaces may request or display replay admission but cannot own it",
+		},
+	}
+}

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -1,0 +1,247 @@
+package runforkexecution
+
+import (
+	"strings"
+	"testing"
+
+	"swarm/internal/store"
+)
+
+func TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners(t *testing.T) {
+	selection := testContractSwapSelection()
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(selection)
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		HistoricalReplayRequired: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{
+			{
+				Fact:        store.RunForkReplayResumeFactDeliveryDeadLetterHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerDeliveryHistoryUnproven,
+				Message:     "dead-letter delivery history is not replayable",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerNonAgentDeliveryReplayUnsupported,
+				Message:     "non-agent work is not replayable",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactTimerHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerTimerHistoryUnproven,
+				Message:     "timer history is unproven",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactRouteHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerFlowRouteHistoryUnproven,
+				Message:     "route history is unproven",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactSessionHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerSessionHistoryUnproven,
+				Message:     "session history is unproven",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactActiveTurnHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerActiveTurnHistoryUnproven,
+				Message:     "turn history is unproven",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactConversationAuditHistory,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: store.RunForkBlockerConversationAuditUnproven,
+				Message:     "audit history is unproven",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactSourceAdvanced,
+				Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,
+				BlockerCode: "source_events_advanced_after_fork_point",
+				Message:     "source advanced after fork point",
+			},
+		},
+		UnsupportedBlockers: []store.RunForkUnsupportedBlocker{
+			{Code: store.RunForkBlockerDeliveryHistoryUnproven, Message: "delivery history is not replayable"},
+			{Code: store.RunForkBlockerNonAgentDeliveryReplayUnsupported, Message: "non-agent work is not replayable"},
+			{Code: store.RunForkBlockerTimerHistoryUnproven, Message: "timer history is unproven"},
+			{Code: store.RunForkBlockerFlowRouteHistoryUnproven, Message: "route history is unproven"},
+			{Code: store.RunForkBlockerSessionHistoryUnproven, Message: "session history is unproven"},
+			{Code: store.RunForkBlockerActiveTurnHistoryUnproven, Message: "turn history is unproven"},
+			{Code: store.RunForkBlockerConversationAuditUnproven, Message: "audit history is unproven"},
+			{Code: "source_events_advanced_after_fork_point", Message: "source advanced after fork point"},
+		},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	if admission.Owner != store.RunForkHistoricalReplayExecutionAdmissionOwner ||
+		!admission.NonMutating ||
+		admission.ExecutionSupported ||
+		admission.FutureExecutionOwner != store.RunForkHistoricalReplayExecutionOwner {
+		t.Fatalf("admission owner/support = %#v", admission)
+	}
+	if admission.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner ||
+		admission.SelectedExecutionAdmissionOwner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		admission.SelectedBindingOwner != store.RunForkSelectedContractBindingOwner ||
+		admission.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		admission.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		admission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		admission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner ||
+		admission.ContractSwapAdmissionOwner != store.RunForkContractSwapBootResumeAdmissionOwner {
+		t.Fatalf("owner consumption = %#v", admission)
+	}
+	assertHistoricalReplayFactSet(t, admission.FactAdmissions)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactSourceEvents, store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence, "")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactReceipts, store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence, "")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerDeliveryHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactDeadLetters, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerDeliveryHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactTimers, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerTimerHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactRoutes, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerFlowRouteHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactSessions, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerSessionHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactTurns, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerActiveTurnHistoryUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactAudits, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerConversationAuditUnproven)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactNonAgentNodeSystemWork, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, store.RunForkBlockerNonAgentDeliveryReplayUnsupported)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts, store.RunForkHistoricalReplayAdmissionFailClosedBlocker, "source_events_advanced_after_fork_point")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactRetryIdempotency, store.RunForkHistoricalReplayAdmissionSplitSibling, "")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactEmittedFollowUps, store.RunForkHistoricalReplayAdmissionSplitSibling, "")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactRuntimeRestartRecovery, store.RunForkHistoricalReplayAdmissionSplitSibling, "")
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactCLIApiDashboardOperator, store.RunForkHistoricalReplayAdmissionSplitSibling, "")
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating) ||
+		!unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating) ||
+		!unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerTimerHistoryUnproven) {
+		t.Fatalf("unsupported blockers = %#v", admission.UnsupportedBlockers)
+	}
+	if !executionBoundaryHas(admission.InvalidPaths, "source_event_copy", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(admission.InvalidPaths, "selected_frontier_execution_as_full_replay", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(admission.BlockedSiblings, "mutating_historical_replay_execution", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("boundaries invalid=%#v blocked=%#v", admission.InvalidPaths, admission.BlockedSiblings)
+	}
+}
+
+func TestBuildHistoricalReplayExecutionAdmissionReportsReplayablePrimitiveWithoutMutation(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition: store.RunForkReplayResumeDispositionForkReplay,
+			Message:     "pending unstarted source delivery can be replayed",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	assertHistoricalReplayFactSet(t, admission.FactAdmissions)
+	assertHistoricalReplayAdmission(t, admission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkHistoricalReplayAdmissionExecutableForkWork, "")
+	if !admission.NonMutating || admission.ExecutionSupported {
+		t.Fatalf("admission mutation flags = %#v", admission)
+	}
+	if !unsupportedBlockerHas(admission.UnsupportedBlockers, store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating) {
+		t.Fatalf("unsupported blockers = %#v, want non-mutating blocker", admission.UnsupportedBlockers)
+	}
+}
+
+func TestBuildHistoricalReplayExecutionAdmissionRejectsNonCanonicalReplayTaxonomy(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	contractSwapAdmission := store.RunForkContractSwapBootResumeAdmission{
+		Owner:                           store.RunForkContractSwapBootResumeAdmissionOwner,
+		NonMutating:                     true,
+		SelectedExecutionAdmissionOwner: selectedAdmission.Owner,
+		ReplayResumeAdmissionOwner:      "cmd.swarm.local_replay_helper",
+		ForkRunID:                       selectedAdmission.ForkRunID,
+		SourceRunID:                     selectedAdmission.SourceRunID,
+		ForkEventID:                     selectedAdmission.ForkEventID,
+	}
+
+	_, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      store.RunForkReplayResumeAdmission{Owner: "cmd.swarm.local_replay_helper"},
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkReplayResumeAdmissionOwner) {
+		t.Fatalf("error = %v, want canonical replay admission owner failure", err)
+	}
+}
+
+func assertHistoricalReplayFactSet(t *testing.T, admissions []store.RunForkHistoricalReplayFactAdmission) {
+	t.Helper()
+	required := []string{
+		store.RunForkHistoricalReplayFactSourceEvents,
+		store.RunForkHistoricalReplayFactEventDeliveries,
+		store.RunForkHistoricalReplayFactReceipts,
+		store.RunForkHistoricalReplayFactDeadLetters,
+		store.RunForkHistoricalReplayFactRetryIdempotency,
+		store.RunForkHistoricalReplayFactEmittedFollowUps,
+		store.RunForkHistoricalReplayFactTimers,
+		store.RunForkHistoricalReplayFactRoutes,
+		store.RunForkHistoricalReplayFactSessions,
+		store.RunForkHistoricalReplayFactTurns,
+		store.RunForkHistoricalReplayFactAudits,
+		store.RunForkHistoricalReplayFactNonAgentNodeSystemWork,
+		store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts,
+		store.RunForkHistoricalReplayFactRuntimeRestartRecovery,
+		store.RunForkHistoricalReplayFactCLIApiDashboardOperator,
+	}
+	if len(admissions) != len(required) {
+		t.Fatalf("fact admission count = %d, want %d: %#v", len(admissions), len(required), admissions)
+	}
+	seen := map[string]int{}
+	for _, admission := range admissions {
+		seen[admission.Fact]++
+	}
+	for _, fact := range required {
+		if seen[fact] != 1 {
+			t.Fatalf("fact %s count = %d, want exactly once in %#v", fact, seen[fact], admissions)
+		}
+	}
+}
+
+func assertHistoricalReplayAdmission(t *testing.T, admissions []store.RunForkHistoricalReplayFactAdmission, fact, admission, blockerCode string) {
+	t.Helper()
+	for _, item := range admissions {
+		if item.Fact != fact {
+			continue
+		}
+		if item.Admission != admission || strings.TrimSpace(item.BlockerCode) != strings.TrimSpace(blockerCode) {
+			t.Fatalf("fact %s admission = %#v, want admission=%s blocker=%s", fact, item, admission, blockerCode)
+		}
+		return
+	}
+	t.Fatalf("missing fact admission %s in %#v", fact, admissions)
+}

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -18,6 +18,8 @@ const (
 	RunForkSelectedContractDynamicRouteTopologyOwner    = "runtime.run_fork.selected_contract_dynamic_route_topology"
 	RunForkSelectedContractRecipientPlanningOwner       = "runtime.run_fork.selected_contract_recipient_planning"
 	RunForkContractSwapBootResumeAdmissionOwner         = "runtime.run_fork.contract_swap_boot_resume_admission"
+	RunForkHistoricalReplayExecutionAdmissionOwner      = "runtime.run_fork.historical_replay_execution_admission"
+	RunForkHistoricalReplayExecutionOwner               = "runtime.run_fork.historical_replay_execution"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -40,8 +42,33 @@ const (
 	RunForkBlockerSelectedContractRecipientPlanningNonMutating  = "selected_contract_recipient_planning_non_mutating"
 	RunForkBlockerContractSwapBootResumeAdmissionNonMutating    = "contract_swap_boot_resume_admission_non_mutating"
 	RunForkBlockerContractSwapRouteRecoveryMissing              = "contract_swap_route_recovery_missing"
+	RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating = "historical_replay_execution_admission_non_mutating"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
+)
+
+const (
+	RunForkHistoricalReplayFactSourceEvents             = "source_events"
+	RunForkHistoricalReplayFactEventDeliveries          = "event_deliveries"
+	RunForkHistoricalReplayFactReceipts                 = "receipts"
+	RunForkHistoricalReplayFactDeadLetters              = "dead_letters"
+	RunForkHistoricalReplayFactRetryIdempotency         = "retry_idempotency"
+	RunForkHistoricalReplayFactEmittedFollowUps         = "emitted_follow_ups"
+	RunForkHistoricalReplayFactTimers                   = "timers"
+	RunForkHistoricalReplayFactRoutes                   = "routes"
+	RunForkHistoricalReplayFactSessions                 = "sessions"
+	RunForkHistoricalReplayFactTurns                    = "turns"
+	RunForkHistoricalReplayFactAudits                   = "audits"
+	RunForkHistoricalReplayFactNonAgentNodeSystemWork   = "non_agent_node_system_work"
+	RunForkHistoricalReplayFactSourceAdvancedPostTFacts = "source_advanced_post_t_facts"
+	RunForkHistoricalReplayFactRuntimeRestartRecovery   = "runtime_restart_recovery"
+	RunForkHistoricalReplayFactCLIApiDashboardOperator  = "cli_api_dashboard_operator_consumers"
+
+	RunForkHistoricalReplayAdmissionExecutableForkWork     = "executable_fork_work"
+	RunForkHistoricalReplayAdmissionReconstructedForkState = "reconstructed_fork_local_state"
+	RunForkHistoricalReplayAdmissionLineageOnlyEvidence    = "lineage_only_evidence"
+	RunForkHistoricalReplayAdmissionFailClosedBlocker      = "fail_closed_blocker"
+	RunForkHistoricalReplayAdmissionSplitSibling           = "split_sibling"
 )
 
 type RunForkSelectedContractExecution struct {
@@ -217,6 +244,40 @@ type RunForkContractSwapBootResumeAdmission struct {
 	BlockedSiblings                 []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths                    []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
 	UnsupportedBlockers             []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkHistoricalReplayExecutionAdmission struct {
+	Owner                           string                                     `json:"owner"`
+	NonMutating                     bool                                       `json:"non_mutating"`
+	ExecutionSupported              bool                                       `json:"execution_supported"`
+	FutureExecutionOwner            string                                     `json:"future_execution_owner"`
+	ForkRunID                       string                                     `json:"fork_run_id,omitempty"`
+	SourceRunID                     string                                     `json:"source_run_id,omitempty"`
+	ForkEventID                     string                                     `json:"fork_event_id,omitempty"`
+	ContractSelection               *RunForkContractSelection                  `json:"contract_selection,omitempty"`
+	ReplayResumeAdmissionOwner      string                                     `json:"replay_resume_admission_owner"`
+	SelectedExecutionAdmissionOwner string                                     `json:"selected_execution_admission_owner,omitempty"`
+	SelectedBindingOwner            string                                     `json:"selected_binding_owner,omitempty"`
+	RouteTopologyOwner              string                                     `json:"route_topology_owner,omitempty"`
+	RouteRecoveryOwner              string                                     `json:"route_recovery_owner,omitempty"`
+	RuntimeRouteRecoveryOwner       string                                     `json:"runtime_route_recovery_owner,omitempty"`
+	RecipientPlanningOwner          string                                     `json:"recipient_planning_owner,omitempty"`
+	ContractSwapAdmissionOwner      string                                     `json:"contract_swap_admission_owner,omitempty"`
+	FactAdmissions                  []RunForkHistoricalReplayFactAdmission     `json:"fact_admissions,omitempty"`
+	Prerequisites                   []RunForkSelectedContractExecutionBoundary `json:"prerequisites,omitempty"`
+	RequiredConsumers               []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings                 []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                    []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers             []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkHistoricalReplayFactAdmission struct {
+	Fact        string `json:"fact"`
+	Admission   string `json:"admission"`
+	SourceOwner string `json:"source_owner,omitempty"`
+	BlockerCode string `json:"blocker_code,omitempty"`
+	Tracker     string `json:"tracker,omitempty"`
+	Message     string `json:"message"`
 }
 
 func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmission) (int, []string, string) {


### PR DESCRIPTION
## Summary

Closes #631.

Introduces `runtime.run_fork.historical_replay_execution_admission` as the non-mutating admission authority for the future `runtime.run_fork.historical_replay_execution` owner. The selected-contract activation gate now builds and exposes this admission from existing canonical prerequisites before any activation mutation.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` fork sections: `replay_resume_admission_taxonomy`, `selected_contract_execution_admission`, `selected_contract_route_persistence_recovery`, `selected_contract_supported_execution`, `contract_swap_boot_resume_admission`, new `historical_replay_execution_admission`, and new step `3j_historical_replay_execution_admission`.
- #631 issue body: non-mutating historical replay execution admission / owner model.
- #564 independent gate outcome: approved as first slice for #631 only; no #564/#549 closure.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`.

## Semantic Migration

- New canonical owner: `runtime.run_fork.historical_replay_execution_admission`.
- Future mutation owner named but not implemented: `runtime.run_fork.historical_replay_execution`.
- Old invalid/non-authoritative paths: CLI/API/dashboard-owned replay admission, source event/delivery copying, source outcome suppression, current route rows as fork truth, and selected frontier execution as full replay proof.
- Production paths checked: selected activation gate, selected execution admission, replay/resume admission taxonomy, contract-swap admission, selected route recovery/topology, recipient planning, `EventBus.Publish` consumer boundary, platform spec, and runtime watchlist.
- Migration completeness: complete for #631's non-mutating admission owner. Full historical replay/resume mutation remains open under #564/#549 and is not claimed here.

## Tests

- `go test ./internal/runtime/runforkexecution`
- `go test ./internal/store`
- `go test ./...`