### PR TITLE
[agent-a][issue #633] Gate historical replay delivery mutation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      SWARM_TEST_POSTGRES_DSN: host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3284,7 +3284,9 @@ run_model:
       requires a fork run with status=paused, fork lineage, fork-local entity_state rows, and a revalidated
       execution_ready=true planner result at the original fork point. Activation atomically transitions the
       fork run to status=running and the source run to status=forked. It may create fork-local event and delivery
-      rows only for source pending unstarted agent deliveries that the canonical replay_resume_admission taxonomy marks
+      rows only after runtime.run_fork.historical_replay_execution consumes a concrete
+      runtime.run_fork.historical_replay_execution_admission that marks event_deliveries as executable fork work for
+      source pending unstarted agent deliveries that the canonical replay_resume_admission taxonomy marks
       delivery_event_replay_ready, using fresh fork event IDs, a direct committed replay-scope marker, and
       run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
       after the fork point, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
@@ -3427,7 +3429,9 @@ run_model:
       boundary for the future runtime.run_fork.historical_replay_execution owner. It consumes the canonical
       store.run_fork.replay_resume_admission taxonomy plus selected-contract execution admission, selected binding,
       selected route topology, selected recipient planning, selected route recovery when present, and
-      runtime.run_fork.contract_swap_boot_resume_admission. It classifies source events, event deliveries, receipts,
+      runtime.run_fork.contract_swap_boot_resume_admission when selected/swap evidence exists. For non-selected
+      activation delivery/event replay, it may consume the canonical replay_resume_admission taxonomy directly and must
+      still classify every historical fact family before mutation. It classifies source events, event deliveries, receipts,
       dead letters, retry/idempotency state, emitted follow-ups, timers, routes/current route rows, sessions, turns,
       audits, non-agent/node/system work, source-advanced/post-T source outcomes, runtime restart recovery, and
       CLI/API/dashboard/operator consumers exactly once as executable fork work, reconstructed fork-local state,
@@ -3439,6 +3443,19 @@ run_model:
       frontier execution as full historical replay/resume proof. CLI, API, dashboard, Builder, route helpers, delivery
       writers, runtime recovery, and pipeline boot paths may consume this owner but MUST NOT compute historical replay
       execution admission independently.'
+    historical_replay_delivery_event_replay_execution: 'The first mutating historical replay execution child is owned by
+      runtime.run_fork.historical_replay_execution and is limited to the already-admitted
+      delivery_event_replay_ready primitive. It consumes runtime.run_fork.historical_replay_execution_admission before
+      any source freeze, fork activation, event row creation, delivery row creation, committed replay-scope marker, or
+      lineage write. It may delegate physical fork-local row writes to store.run_fork.delivery_event_replay, but that
+      store primitive is not the semantic execution owner. The owner may mint fresh fork-local event IDs and delivery
+      IDs under the fork run_id for pending unstarted source-agent deliveries admitted as event_deliveries executable
+      fork work, record run_fork_delivery_event_replays lineage, and let the normal runtime delivery pipeline process
+      the fork-local pending delivery. It MUST NOT copy source event IDs, source delivery IDs, receipts, dead letters,
+      retry/idempotency state, emitted follow-ups, timers, route rows, sessions, turns, audits, non-agent/node/system
+      work, runtime restart state, API/UI/dashboard state, or use source/post-T outcomes as fork suppressors. Timers,
+      routes, sessions, turns, audits, non-agent replay, contract-swap/full resume, restart recovery, and operator
+      surfaces remain separately gated siblings under #564/#549/#618.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3462,8 +3479,9 @@ run_model:
       3b_activate_materialized_fork: 'For an activation fork, consume a previously materialized fork run.
         Revalidate the original fork point against current source-run facts, require no source advancement and
         no unsupported replay/timer/route/session/turn/contract-swap facts, optionally create fork-local event/delivery
-        rows and direct committed replay-scope markers for the delivery_event_replay_ready subset with explicit source
-        lineage, then atomically mark the source run forked and the fork run running. Future runtime work uses the fork
+        rows and direct committed replay-scope markers for the delivery_event_replay_ready subset only through
+        runtime.run_fork.historical_replay_execution consuming historical replay execution admission, then atomically
+        mark the source run forked and the fork run running. Future runtime work uses the fork
         run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
         unsupported outside the gated delivery/event primitive.'
       3c_selected_contract_source_advanced_branch: 'For selected-contract mutating fork execution, source advancement
@@ -3527,10 +3545,17 @@ run_model:
       3j_historical_replay_execution_admission: 'Before any future full historical replay/resume mutation,
         runtime.run_fork.historical_replay_execution_admission classifies every historical source fact family under one
         runtime authority. It consumes replay_resume_admission, selected-contract execution admission, route topology,
-        recipient planning, route recovery evidence when present, and contract-swap boot/resume admission. It is
+        recipient planning, route recovery evidence when present, and contract-swap boot/resume admission when those
+        prerequisites exist. It is
         admission/model only: it does not run handlers, create fork-local rows, copy source rows, write outcomes, replay
         timers, reconstruct sessions/turns/audits, mutate routes, or own API/dashboard state. Full mutation remains
         with the separately gated runtime.run_fork.historical_replay_execution owner.'
+      3k_historical_replay_delivery_event_replay_execution: 'For the first mutating historical replay child,
+        runtime.run_fork.historical_replay_execution consumes a concrete historical replay execution admission and may
+        execute only the delivery_event_replay_ready primitive. It creates fresh fork-local event/delivery rows and
+        lineage through store.run_fork.delivery_event_replay, before source/fork lifecycle mutation, and only when
+        event_deliveries are admitted as executable fork work. All other historical source fact families remain lineage,
+        fail-closed blockers, or split siblings.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -188,6 +188,8 @@ active_issues:
     title: Gate contract-swap boot/resume semantics for timestamp forks
     maps_to:
       - timestamp_fork_replay_resume_ownership
+      - run_isolated_current_state_ownership
+      - delivery_and_replay_ownership
   - id: 633
     title: Gate historical replay delivery-event replay mutation from admission
     maps_to:

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -188,7 +188,10 @@ active_issues:
     title: Gate contract-swap boot/resume semantics for timestamp forks
     maps_to:
       - timestamp_fork_replay_resume_ownership
-      - run_isolated_current_state_ownership
+  - id: 633
+    title: Gate historical replay delivery-event replay mutation from admission
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
@@ -283,6 +286,7 @@ nodes:
       - selected-contract fork execution must write fresh fork-local event/delivery/outcome rows through the runtime selected-contract execution owner, with source rows used only as lineage evidence
       - selected-contract delivery writes from recipient planning are execution-proven through runtime.run_fork.selected_contract_execution and EventBus.Publish recipient-plan guards; a delivery-row-only writer would be a non-authoritative duplicate
       - historical replay execution admission must classify event deliveries, receipts, dead letters, retry/idempotency state, emitted follow-ups, and non-agent work before any future replay mutation; source delivery/outcome rows must remain lineage, blockers, or split siblings
+      - historical replay delivery/event replay mutation must be owned by runtime.run_fork.historical_replay_execution consuming event_deliveries executable-fork-work admission before the store delivery replay primitive writes fork-local rows
     representative_issues:
       - 112
       - 144
@@ -297,6 +301,7 @@ nodes:
       - 619
       - 621
       - 631
+      - 633
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -338,6 +343,7 @@ nodes:
       - selected-contract route persistence/runtime recovery needs a fork-local owner keyed by fork run_id and selected binding/topology/recipient evidence; current routing_rules, flow_instance_routes, and startup ListFlowInstanceRoutes recovery remain current-route infrastructure and must not become selected-fork route truth
       - contract-swap boot/resume readiness needs a non-mutating runtime owner that consumes selected binding, selected source admission, replay/resume taxonomy, selected route/recipient/recovery evidence, and classifies source deliveries/outcomes/timers/routes/sessions/non-agent facts as lineage, blockers, or split siblings before any full historical replay mutation
       - historical replay execution admission needs one non-mutating runtime owner that consumes replay_resume_admission, selected execution admission, selected binding/topology/recipient planning, route recovery evidence, and contract-swap admission before any full historical replay/resume mutation; it must classify every source fact family exactly once and keep mutation under a separate future owner
+      - historical replay delivery/event replay mutation must consume runtime.run_fork.historical_replay_execution_admission and runtime.run_fork.historical_replay_execution before store.run_fork.delivery_event_replay writes fresh fork-local rows; activation/store must not directly authorize delivery_event_replay_ready mutation
     representative_issues:
       - 564
       - 565
@@ -362,6 +368,7 @@ nodes:
       - 621
       - 625
       - 631
+      - 633
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -64,7 +64,6 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	tempDir := t.TempDir()
-	stateFile := filepath.Join(tempDir, "docker-state")
 	captureDir := filepath.Join(tempDir, "captures")
 	if err := os.MkdirAll(captureDir, 0o755); err != nil {
 		t.Fatalf("mkdir capture dir: %v", err)
@@ -72,31 +71,27 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
 	script := `#!/bin/sh
 set -eu
-state_file="${FAKE_DOCKER_STATE_FILE}"
 capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
-count=0
-if [ -f "$state_file" ]; then
-  count=$(cat "$state_file")
-fi
-count=$((count + 1))
-printf '%s' "$count" > "$state_file"
-cat > "$capture_dir/$count.stdin"
-if [ "$count" -gt 1 ] && grep -q '"name":"read_file"' "$capture_dir/$count.stdin" && grep -q '"ok":true' "$capture_dir/$count.stdin"; then
+captured="$capture_dir/$$.stdin"
+cat > "$captured"
+if grep -q '"name":"emit_category_assessed"' "$captured" && grep -q '"ok":true' "$captured"; then
   printf '%s\n' '{"type":"result","result":"done"}'
   exit 0
 fi
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+if grep -q '"name":"read_file"' "$captured" && grep -q '"ok":true' "$captured"; then
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"provider-sess-1"}'
   exit 0
+fi
+printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+exit 0
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
 	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
-	t.Setenv("FAKE_DOCKER_STATE_FILE", stateFile)
 	t.Setenv("FAKE_DOCKER_CAPTURE_DIR", captureDir)
 
 	cfg := &config.Config{}
@@ -206,8 +201,8 @@ fi
 	if err := json.Unmarshal(secondInput, &payload); err != nil {
 		t.Fatalf("unmarshal second stdin: %v", err)
 	}
-	if len(payload) != 2 {
-		t.Fatalf("tool payload entries = %d, want 2 (%#v)", len(payload), payload)
+	if len(payload) != 1 {
+		t.Fatalf("tool payload entries = %d, want 1 (%#v)", len(payload), payload)
 	}
 	readEntry := payload[0]
 	if readEntry["name"] != "read_file" || readEntry["ok"] != true {

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -50,7 +50,10 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		return SelectedContractActivationGateResult{}, fmt.Errorf("load selected-contract binding for activation gate: %w", err)
 	}
 	if !ok {
-		activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{ForkRunID: forkRunID})
+		activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{
+			ForkRunID:                         forkRunID,
+			HistoricalReplayExecutionAdmitter: HistoricalReplayExecutionAdmitter{},
+		})
 		return SelectedContractActivationGateResult{RunForkActivation: activation}, err
 	}
 	if req.SourceLoader == nil {
@@ -153,7 +156,10 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		return result, fmt.Errorf("%s: selected-contract frontier execution remains non-mutating", store.RunForkBlockerContractFrontierExecutionUnsupported)
 	}
 
-	activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{ForkRunID: forkRunID})
+	activation, err := req.Store.ActivateRunFork(ctx, store.RunForkActivateRequest{
+		ForkRunID:                         forkRunID,
+		HistoricalReplayExecutionAdmitter: HistoricalReplayExecutionAdmitter{},
+	})
 	result.RunForkActivation = activation
 	return result, err
 }

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -34,6 +34,9 @@ func TestActivateSelectedContractRunForkDelegatesNonSelectedActivation(t *testin
 	if !fakeStore.activateCalled || fakeStore.planCalled {
 		t.Fatalf("store calls = activate:%v plan:%v, want delegate activate without selected plan", fakeStore.activateCalled, fakeStore.planCalled)
 	}
+	if fakeStore.activateRequest.HistoricalReplayExecutionAdmitter == nil {
+		t.Fatal("non-selected activation did not receive historical replay execution admitter")
+	}
 	if result.SelectedContractExecutionAdmission != nil || result.ForkRunID != forkRunID || !result.Activated {
 		t.Fatalf("result = %#v", result)
 	}
@@ -61,6 +64,9 @@ func TestActivateSelectedContractRunForkConsumesAdmissionBeforeStateOnlyActivati
 	}
 	if !fakeStore.planCalled || !fakeStore.requireCalled || !fakeStore.activateCalled {
 		t.Fatalf("store calls = plan:%v require:%v activate:%v, want admission before activation", fakeStore.planCalled, fakeStore.requireCalled, fakeStore.activateCalled)
+	}
+	if fakeStore.activateRequest.HistoricalReplayExecutionAdmitter == nil {
+		t.Fatal("selected state-only activation did not receive historical replay execution admitter")
 	}
 	if result.Owner != store.RunForkSelectedContractExecutionActivationGateOwner {
 		t.Fatalf("owner = %q, want %q", result.Owner, store.RunForkSelectedContractExecutionActivationGateOwner)
@@ -272,17 +278,18 @@ func historicalReplayFactHas(items []store.RunForkHistoricalReplayFactAdmission,
 }
 
 type fakeSelectedContractActivationStore struct {
-	binding       store.RunForkSelectedContractBinding
-	bindingOK     bool
-	bindingErr    error
-	requireErr    error
-	plan          store.RunForkPlan
-	planErr       error
-	routeRecovery store.RunForkSelectedContractRouteRecovery
-	routeOK       bool
-	routeErr      error
-	activation    store.RunForkActivation
-	activationErr error
+	binding         store.RunForkSelectedContractBinding
+	bindingOK       bool
+	bindingErr      error
+	requireErr      error
+	plan            store.RunForkPlan
+	planErr         error
+	routeRecovery   store.RunForkSelectedContractRouteRecovery
+	routeOK         bool
+	routeErr        error
+	activation      store.RunForkActivation
+	activationErr   error
+	activateRequest store.RunForkActivateRequest
 
 	loadCalled      bool
 	requireCalled   bool
@@ -326,8 +333,9 @@ func (s *fakeSelectedContractActivationStore) PlanRunFork(_ context.Context, _ s
 	return s.plan, nil
 }
 
-func (s *fakeSelectedContractActivationStore) ActivateRunFork(_ context.Context, _ store.RunForkActivateRequest) (store.RunForkActivation, error) {
+func (s *fakeSelectedContractActivationStore) ActivateRunFork(_ context.Context, req store.RunForkActivateRequest) (store.RunForkActivation, error) {
 	s.activateCalled = true
+	s.activateRequest = req
 	if s.activationErr != nil {
 		return store.RunForkActivation{}, s.activationErr
 	}

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -1,6 +1,7 @@
 package runforkexecution
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,120 @@ type HistoricalReplayExecutionAdmissionRequest struct {
 	SelectedExecutionAdmission store.RunForkSelectedContractExecutionAdmission
 	ContractSwapAdmission      store.RunForkContractSwapBootResumeAdmission
 	RouteRecovery              *store.RunForkSelectedContractRouteRecovery
+}
+
+type HistoricalReplayDeliveryEventReplayAdmissionRequest struct {
+	ForkRunID             string
+	SourceRunID           string
+	ForkEventID           string
+	ReplayResumeAdmission store.RunForkReplayResumeAdmission
+}
+
+type HistoricalReplayExecutionRequest struct {
+	Admission             store.RunForkHistoricalReplayExecutionAdmission
+	ReplayResumeAdmission store.RunForkReplayResumeAdmission
+}
+
+type HistoricalReplayExecutionAdmitter struct{}
+
+func (HistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalReplayExecution(_ context.Context, req store.RunForkHistoricalReplayExecutionRequest) (store.RunForkHistoricalReplayExecution, error) {
+	admission, err := BuildHistoricalReplayDeliveryEventReplayAdmission(HistoricalReplayDeliveryEventReplayAdmissionRequest{
+		ForkRunID:             req.ForkRunID,
+		SourceRunID:           req.SourceRunID,
+		ForkEventID:           req.ForkEventID,
+		ReplayResumeAdmission: req.ReplayResumeAdmission,
+	})
+	if err != nil {
+		return store.RunForkHistoricalReplayExecution{}, err
+	}
+	return BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission:             admission,
+		ReplayResumeAdmission: req.ReplayResumeAdmission,
+	})
+}
+
+func BuildHistoricalReplayDeliveryEventReplayAdmission(req HistoricalReplayDeliveryEventReplayAdmissionRequest) (store.RunForkHistoricalReplayExecutionAdmission, error) {
+	replayAdmission := req.ReplayResumeAdmission
+	if strings.TrimSpace(replayAdmission.Owner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkHistoricalReplayExecutionAdmission{}, fmt.Errorf("historical replay delivery/event replay admission requires %s; got %q", store.RunForkReplayResumeAdmissionOwner, replayAdmission.Owner)
+	}
+	forkRunID := strings.TrimSpace(req.ForkRunID)
+	sourceRunID := strings.TrimSpace(req.SourceRunID)
+	forkEventID := strings.TrimSpace(req.ForkEventID)
+	if forkRunID == "" || sourceRunID == "" || forkEventID == "" {
+		return store.RunForkHistoricalReplayExecutionAdmission{}, fmt.Errorf("historical replay delivery/event replay admission requires fork/source/event identity")
+	}
+	blockers := []store.RunForkUnsupportedBlocker{}
+	for _, blocker := range replayAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
+		Code:    store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating,
+		Message: "historical replay execution admission is non-mutating; delivery/event replay mutation requires runtime.run_fork.historical_replay_execution",
+	})
+	return store.RunForkHistoricalReplayExecutionAdmission{
+		Owner:                      store.RunForkHistoricalReplayExecutionAdmissionOwner,
+		NonMutating:                true,
+		ExecutionSupported:         false,
+		FutureExecutionOwner:       store.RunForkHistoricalReplayExecutionOwner,
+		ForkRunID:                  forkRunID,
+		SourceRunID:                sourceRunID,
+		ForkEventID:                forkEventID,
+		ReplayResumeAdmissionOwner: replayAdmission.Owner,
+		FactAdmissions:             historicalReplayFactAdmissions(replayAdmission),
+		Prerequisites: []store.RunForkSelectedContractExecutionBoundary{
+			{
+				Concept:     "replay_resume_admission",
+				Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+				Owner:       store.RunForkReplayResumeAdmissionOwner,
+				Reason:      "delivery/event replay mutation consumes the canonical replay taxonomy and does not recompute source fact classifications",
+			},
+		},
+		RequiredConsumers:   historicalReplayRequiredConsumers(),
+		BlockedSiblings:     historicalReplayBlockedSiblings(),
+		InvalidPaths:        historicalReplayInvalidPaths(),
+		UnsupportedBlockers: blockers,
+	}, nil
+}
+
+func BuildHistoricalReplayExecution(req HistoricalReplayExecutionRequest) (store.RunForkHistoricalReplayExecution, error) {
+	admission := req.Admission
+	if strings.TrimSpace(admission.Owner) != store.RunForkHistoricalReplayExecutionAdmissionOwner {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires %s; got %q", store.RunForkHistoricalReplayExecutionAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires non-mutating admission proof")
+	}
+	if strings.TrimSpace(admission.FutureExecutionOwner) != store.RunForkHistoricalReplayExecutionOwner {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires future owner %s; got %q", store.RunForkHistoricalReplayExecutionOwner, admission.FutureExecutionOwner)
+	}
+	if strings.TrimSpace(admission.ReplayResumeAdmissionOwner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires replay taxonomy owner %s; got %q", store.RunForkReplayResumeAdmissionOwner, admission.ReplayResumeAdmissionOwner)
+	}
+	replayAdmission := req.ReplayResumeAdmission
+	if strings.TrimSpace(replayAdmission.Owner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires %s; got %q", store.RunForkReplayResumeAdmissionOwner, replayAdmission.Owner)
+	}
+	eventDeliveries, ok := historicalReplayFactAdmission(admission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries)
+	if !ok || eventDeliveries.Admission != store.RunForkHistoricalReplayAdmissionExecutableForkWork {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires event_deliveries executable fork work admission")
+	}
+	if !replayAdmission.DeliveryEventReplayReady &&
+		!replayDispositionHas(replayAdmission, store.RunForkReplayResumeFactDeliveryPendingHistory, store.RunForkReplayResumeDispositionForkReplay) {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires delivery_event_replay_ready replay taxonomy")
+	}
+	return store.RunForkHistoricalReplayExecution{
+		Owner:                      store.RunForkHistoricalReplayExecutionOwner,
+		AdmissionOwner:             admission.Owner,
+		ReplayResumeAdmissionOwner: replayAdmission.Owner,
+		ForkRunID:                  strings.TrimSpace(admission.ForkRunID),
+		SourceRunID:                strings.TrimSpace(admission.SourceRunID),
+		ForkEventID:                strings.TrimSpace(admission.ForkEventID),
+		DeliveryEventReplayReady:   true,
+		EventDeliveriesAdmission:   eventDeliveries,
+		BlockedSiblings:            historicalReplayExecutionBlockedSiblings(admission.BlockedSiblings),
+		InvalidPaths:               admission.InvalidPaths,
+	}, nil
 }
 
 func BuildHistoricalReplayExecutionAdmission(req HistoricalReplayExecutionAdmissionRequest) (store.RunForkHistoricalReplayExecutionAdmission, error) {
@@ -264,6 +379,32 @@ func replayDispositionHas(replay store.RunForkReplayResumeAdmission, fact, dispo
 		}
 	}
 	return false
+}
+
+func historicalReplayFactAdmission(admissions []store.RunForkHistoricalReplayFactAdmission, fact string) (store.RunForkHistoricalReplayFactAdmission, bool) {
+	for _, item := range admissions {
+		if strings.TrimSpace(item.Fact) == fact {
+			return item, true
+		}
+	}
+	return store.RunForkHistoricalReplayFactAdmission{}, false
+}
+
+func historicalReplayExecutionBlockedSiblings(items []store.RunForkSelectedContractExecutionBoundary) []store.RunForkSelectedContractExecutionBoundary {
+	out := make([]store.RunForkSelectedContractExecutionBoundary, 0, len(items)+1)
+	for _, item := range items {
+		if strings.TrimSpace(item.Concept) == "mutating_historical_replay_execution" {
+			continue
+		}
+		out = append(out, item)
+	}
+	out = append(out, store.RunForkSelectedContractExecutionBoundary{
+		Concept:     "full_historical_replay_execution",
+		Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+		Owner:       store.RunForkHistoricalReplayExecutionOwner,
+		Reason:      "this child mutates only delivery_event_replay_ready; full replay/resume remains under #564",
+	})
+	return out
 }
 
 func stringInSet(value string, items []string) bool {

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -177,6 +177,74 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsReplayablePrimitiveWithou
 	}
 }
 
+func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation(t *testing.T) {
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition: store.RunForkReplayResumeDispositionForkReplay,
+			Message:     "pending unstarted source delivery can be replayed",
+		}},
+	}
+	admission, err := BuildHistoricalReplayDeliveryEventReplayAdmission(HistoricalReplayDeliveryEventReplayAdmissionRequest{
+		ForkRunID:             "fork-run",
+		SourceRunID:           "source-run",
+		ForkEventID:           "fork-event",
+		ReplayResumeAdmission: replayAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayDeliveryEventReplayAdmission: %v", err)
+	}
+
+	execution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission:             admission,
+		ReplayResumeAdmission: replayAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecution: %v", err)
+	}
+	if execution.Owner != store.RunForkHistoricalReplayExecutionOwner ||
+		execution.AdmissionOwner != store.RunForkHistoricalReplayExecutionAdmissionOwner ||
+		execution.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner ||
+		!execution.DeliveryEventReplayReady {
+		t.Fatalf("execution = %#v", execution)
+	}
+	if execution.EventDeliveriesAdmission.Fact != store.RunForkHistoricalReplayFactEventDeliveries ||
+		execution.EventDeliveriesAdmission.Admission != store.RunForkHistoricalReplayAdmissionExecutableForkWork {
+		t.Fatalf("event deliveries admission = %#v", execution.EventDeliveriesAdmission)
+	}
+	if !executionBoundaryHas(execution.InvalidPaths, "source_delivery_copy", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(execution.InvalidPaths, "source_outcome_suppression", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(execution.BlockedSiblings, "timer_reconstruction", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("execution boundaries invalid=%#v blocked=%#v", execution.InvalidPaths, execution.BlockedSiblings)
+	}
+}
+
+func TestBuildHistoricalReplayExecutionRejectsNonExecutableAdmission(t *testing.T) {
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+	}
+	_, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission: store.RunForkHistoricalReplayExecutionAdmission{
+			Owner:                      store.RunForkHistoricalReplayExecutionAdmissionOwner,
+			NonMutating:                true,
+			FutureExecutionOwner:       store.RunForkHistoricalReplayExecutionOwner,
+			ReplayResumeAdmissionOwner: store.RunForkReplayResumeAdmissionOwner,
+			FactAdmissions: []store.RunForkHistoricalReplayFactAdmission{{
+				Fact:      store.RunForkHistoricalReplayFactEventDeliveries,
+				Admission: store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+				Message:   "not executable",
+			}},
+		},
+		ReplayResumeAdmission: replayAdmission,
+	})
+	if err == nil || !strings.Contains(err.Error(), "event_deliveries executable fork work") {
+		t.Fatalf("error = %v, want executable event_deliveries admission failure", err)
+	}
+}
+
 func TestBuildHistoricalReplayExecutionAdmissionRejectsNonCanonicalReplayTaxonomy(t *testing.T) {
 	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
 	contractSwapAdmission := store.RunForkContractSwapBootResumeAdmission{

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -18,26 +18,28 @@ const (
 )
 
 type RunForkActivateRequest struct {
-	ForkRunID string
+	ForkRunID                         string
+	HistoricalReplayExecutionAdmitter RunForkHistoricalReplayExecutionAdmitter
 }
 
 type RunForkActivation struct {
-	SourceRunID              string                                   `json:"source_run_id"`
-	ForkRunID                string                                   `json:"fork_run_id"`
-	ForkRunStatus            string                                   `json:"fork_run_status"`
-	SourceRunStatus          string                                   `json:"source_run_status"`
-	ForkPoint                RunForkPoint                             `json:"fork_point"`
-	Activated                bool                                     `json:"activated"`
-	SourceFrozen             bool                                     `json:"source_frozen"`
-	HistoricalReplayBlocked  bool                                     `json:"historical_replay_blocked"`
-	ReplayResumeAdmission    RunForkReplayResumeAdmission             `json:"replay_resume_admission"`
-	UnsupportedBlockers      []RunForkUnsupportedBlocker              `json:"unsupported_blockers,omitempty"`
-	MaterializedEntityCount  int                                      `json:"materialized_entity_count"`
-	DeliveryEventReplay      *RunForkDeliveryEventReplayResult        `json:"delivery_event_replay,omitempty"`
-	SelectedContractBinding  *RunForkSelectedContractBinding          `json:"selected_contract_binding,omitempty"`
-	BranchDivergence         *RunForkSelectedContractBranchDivergence `json:"selected_contract_branch_divergence,omitempty"`
-	SourceAdvancedAfterFork  bool                                     `json:"source_advanced_after_fork_point,omitempty"`
-	RepeatedActivationFailed bool                                     `json:"repeated_activation_failed,omitempty"`
+	SourceRunID               string                                   `json:"source_run_id"`
+	ForkRunID                 string                                   `json:"fork_run_id"`
+	ForkRunStatus             string                                   `json:"fork_run_status"`
+	SourceRunStatus           string                                   `json:"source_run_status"`
+	ForkPoint                 RunForkPoint                             `json:"fork_point"`
+	Activated                 bool                                     `json:"activated"`
+	SourceFrozen              bool                                     `json:"source_frozen"`
+	HistoricalReplayBlocked   bool                                     `json:"historical_replay_blocked"`
+	ReplayResumeAdmission     RunForkReplayResumeAdmission             `json:"replay_resume_admission"`
+	UnsupportedBlockers       []RunForkUnsupportedBlocker              `json:"unsupported_blockers,omitempty"`
+	MaterializedEntityCount   int                                      `json:"materialized_entity_count"`
+	HistoricalReplayExecution *RunForkHistoricalReplayExecution        `json:"historical_replay_execution,omitempty"`
+	DeliveryEventReplay       *RunForkDeliveryEventReplayResult        `json:"delivery_event_replay,omitempty"`
+	SelectedContractBinding   *RunForkSelectedContractBinding          `json:"selected_contract_binding,omitempty"`
+	BranchDivergence          *RunForkSelectedContractBranchDivergence `json:"selected_contract_branch_divergence,omitempty"`
+	SourceAdvancedAfterFork   bool                                     `json:"source_advanced_after_fork_point,omitempty"`
+	RepeatedActivationFailed  bool                                     `json:"repeated_activation_failed,omitempty"`
 }
 
 type runForkActivationLineage struct {
@@ -167,6 +169,11 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		return result, err
 	}
 
+	historicalReplayExecution, err := requireRunForkHistoricalReplayExecution(ctx, req.HistoricalReplayExecutionAdmitter, lineage, plan)
+	if err != nil {
+		return result, err
+	}
+
 	now := time.Now().UTC()
 	sourceResult, err := tx.ExecContext(ctx, `
 		UPDATE runs
@@ -209,9 +216,51 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	result.Activated = true
 	result.SourceFrozen = true
 	if replayResult.ReplayedEventCount > 0 || replayResult.ReplayedDeliveryCount > 0 {
+		historicalReplayExecution.DeliveryEventReplay = &replayResult
+		result.HistoricalReplayExecution = &historicalReplayExecution
 		result.DeliveryEventReplay = &replayResult
 	}
 	return result, nil
+}
+
+func requireRunForkHistoricalReplayExecution(
+	ctx context.Context,
+	admitter RunForkHistoricalReplayExecutionAdmitter,
+	lineage runForkActivationLineage,
+	plan RunForkPlan,
+) (RunForkHistoricalReplayExecution, error) {
+	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady && len(runForkReplayablePendingWork(plan.PendingWork)) == 0 {
+		return RunForkHistoricalReplayExecution{}, nil
+	}
+	if admitter == nil {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("%s admission required before delivery_event_replay_ready mutation", RunForkHistoricalReplayExecutionOwner)
+	}
+	execution, err := admitter.AdmitRunForkHistoricalReplayExecution(ctx, RunForkHistoricalReplayExecutionRequest{
+		ForkRunID:             lineage.ForkRunID,
+		SourceRunID:           lineage.SourceRunID,
+		ForkEventID:           lineage.ForkEventID,
+		ReplayResumeAdmission: plan.ReplayResumeAdmission,
+	})
+	if err != nil {
+		return RunForkHistoricalReplayExecution{}, err
+	}
+	if strings.TrimSpace(execution.Owner) != RunForkHistoricalReplayExecutionOwner {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation requires %s; got %q", RunForkHistoricalReplayExecutionOwner, execution.Owner)
+	}
+	if strings.TrimSpace(execution.AdmissionOwner) != RunForkHistoricalReplayExecutionAdmissionOwner {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation requires %s; got %q", RunForkHistoricalReplayExecutionAdmissionOwner, execution.AdmissionOwner)
+	}
+	if strings.TrimSpace(execution.ForkRunID) != lineage.ForkRunID ||
+		strings.TrimSpace(execution.SourceRunID) != lineage.SourceRunID ||
+		strings.TrimSpace(execution.ForkEventID) != lineage.ForkEventID {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation historical replay execution identity mismatch")
+	}
+	if !execution.DeliveryEventReplayReady ||
+		execution.EventDeliveriesAdmission.Fact != RunForkHistoricalReplayFactEventDeliveries ||
+		execution.EventDeliveriesAdmission.Admission != RunForkHistoricalReplayAdmissionExecutableForkWork {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation requires event_deliveries executable fork work admission")
+	}
+	return execution, nil
 }
 
 func loadRunForkActivationLineage(ctx context.Context, tx *sql.Tx, forkRunID string) (runForkActivationLineage, error) {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -549,9 +549,43 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
 	}
-	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err == nil || !strings.Contains(err.Error(), RunForkHistoricalReplayExecutionOwner) {
+		t.Fatalf("ActivateRunFork without historical replay owner error = %v, want %s", err, RunForkHistoricalReplayExecutionOwner)
+	}
+	if blocked.Activated || blocked.SourceFrozen {
+		t.Fatalf("blocked activation mutated lifecycle: %#v", blocked)
+	}
+	var sourceStatusAfterBlocked string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatusAfterBlocked); err != nil {
+		t.Fatalf("load source status after blocked activation: %v", err)
+	}
+	if sourceStatusAfterBlocked != "running" {
+		t.Fatalf("source status after blocked activation = %q, want running", sourceStatusAfterBlocked)
+	}
+
+	admitter := &fakeRunForkHistoricalReplayExecutionAdmitter{}
+	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{
+		ForkRunID:                         materialized.ForkRunID,
+		HistoricalReplayExecutionAdmitter: admitter,
+	})
 	if err != nil {
 		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if !admitter.called {
+		t.Fatal("historical replay execution admitter was not called")
+	}
+	if admitter.request.ForkRunID != materialized.ForkRunID ||
+		admitter.request.SourceRunID != sourceRunID ||
+		admitter.request.ForkEventID != eventID ||
+		!admitter.request.ReplayResumeAdmission.DeliveryEventReplayReady {
+		t.Fatalf("historical replay execution request = %#v", admitter.request)
+	}
+	if activated.HistoricalReplayExecution == nil ||
+		activated.HistoricalReplayExecution.Owner != RunForkHistoricalReplayExecutionOwner ||
+		activated.HistoricalReplayExecution.AdmissionOwner != RunForkHistoricalReplayExecutionAdmissionOwner ||
+		activated.HistoricalReplayExecution.DeliveryEventReplay == nil {
+		t.Fatalf("HistoricalReplayExecution = %#v", activated.HistoricalReplayExecution)
 	}
 	if activated.DeliveryEventReplay == nil {
 		t.Fatalf("DeliveryEventReplay = nil, want fork-local replay result: %#v", activated)
@@ -961,6 +995,35 @@ func TestRunForkActivation_ToleratesOptionalLegacyReplaySchemas(t *testing.T) {
 type sqlNullTime struct {
 	Time  time.Time
 	Valid bool
+}
+
+type fakeRunForkHistoricalReplayExecutionAdmitter struct {
+	called  bool
+	request RunForkHistoricalReplayExecutionRequest
+	err     error
+}
+
+func (a *fakeRunForkHistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalReplayExecution(_ context.Context, req RunForkHistoricalReplayExecutionRequest) (RunForkHistoricalReplayExecution, error) {
+	a.called = true
+	a.request = req
+	if a.err != nil {
+		return RunForkHistoricalReplayExecution{}, a.err
+	}
+	return RunForkHistoricalReplayExecution{
+		Owner:                      RunForkHistoricalReplayExecutionOwner,
+		AdmissionOwner:             RunForkHistoricalReplayExecutionAdmissionOwner,
+		ReplayResumeAdmissionOwner: req.ReplayResumeAdmission.Owner,
+		ForkRunID:                  req.ForkRunID,
+		SourceRunID:                req.SourceRunID,
+		ForkEventID:                req.ForkEventID,
+		DeliveryEventReplayReady:   true,
+		EventDeliveriesAdmission: RunForkHistoricalReplayFactAdmission{
+			Fact:        RunForkHistoricalReplayFactEventDeliveries,
+			Admission:   RunForkHistoricalReplayAdmissionExecutableForkWork,
+			SourceOwner: RunForkReplayResumeAdmissionOwner,
+			Message:     "test admission",
+		},
+	}, nil
 }
 
 type execContextDB interface {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -269,6 +270,31 @@ type RunForkHistoricalReplayExecutionAdmission struct {
 	BlockedSiblings                 []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths                    []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
 	UnsupportedBlockers             []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkHistoricalReplayExecution struct {
+	Owner                      string                                     `json:"owner"`
+	AdmissionOwner             string                                     `json:"admission_owner"`
+	ReplayResumeAdmissionOwner string                                     `json:"replay_resume_admission_owner"`
+	ForkRunID                  string                                     `json:"fork_run_id"`
+	SourceRunID                string                                     `json:"source_run_id"`
+	ForkEventID                string                                     `json:"fork_event_id"`
+	DeliveryEventReplayReady   bool                                       `json:"delivery_event_replay_ready"`
+	EventDeliveriesAdmission   RunForkHistoricalReplayFactAdmission       `json:"event_deliveries_admission"`
+	DeliveryEventReplay        *RunForkDeliveryEventReplayResult          `json:"delivery_event_replay,omitempty"`
+	BlockedSiblings            []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths               []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+}
+
+type RunForkHistoricalReplayExecutionRequest struct {
+	ForkRunID             string
+	SourceRunID           string
+	ForkEventID           string
+	ReplayResumeAdmission RunForkReplayResumeAdmission
+}
+
+type RunForkHistoricalReplayExecutionAdmitter interface {
+	AdmitRunForkHistoricalReplayExecution(context.Context, RunForkHistoricalReplayExecutionRequest) (RunForkHistoricalReplayExecution, error)
 }
 
 type RunForkHistoricalReplayFactAdmission struct {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -144,6 +144,20 @@ func waitForTestDatabase(ctx context.Context, db *sql.DB, timeout time.Duration)
 }
 
 func (s *sharedPostgresState) startLocked() error {
+	if adminDSN := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_DSN")); adminDSN != "" {
+		db, err := sql.Open("postgres", adminDSN)
+		if err != nil {
+			return fmt.Errorf("open external postgres: %w", err)
+		}
+		defer db.Close()
+		if err := waitForTestDatabase(context.Background(), db, 180*time.Second); err != nil {
+			return fmt.Errorf("external postgres not ready: %w", err)
+		}
+		s.started = true
+		s.adminDSN = adminDSN
+		return nil
+	}
+
 	dockerBin, err := exec.LookPath("docker")
 	if err != nil {
 		return fmt.Errorf("docker not found in PATH: %w", err)


### PR DESCRIPTION
## Summary

Closes #633.

Moves the approved `delivery_event_replay_ready` mutation behind `runtime.run_fork.historical_replay_execution` by requiring a concrete historical replay execution admission before activation can create fork-local replay event/delivery rows.

The store path remains the physical row writer for fresh fork-local events, deliveries, committed replay-scope markers, and `run_fork_delivery_event_replays` lineage, but it no longer directly authorizes the replay mutation from `ReplayResumeAdmission.DeliveryEventReplayReady` alone.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` fork sections: `activation_admission`, `replay_resume_admission_taxonomy`, `historical_replay_execution_admission`, new `historical_replay_delivery_event_replay_execution`, `3b_activate_materialized_fork`, `3j_historical_replay_execution_admission`, and new `3k_historical_replay_delivery_event_replay_execution`.
- #633 pre-audit and independent gate outcome: approved as first slice only for `runtime.run_fork.historical_replay_execution.delivery_event_replay_ready_mutation`.
- #631 / PR #632: prerequisite non-mutating historical replay execution admission owner; admission only, not execution proof.
- #569 / PR #570: existing safe pending-agent delivery/event replay primitive.
- #572/#573, #574/#575, #618, #564, #549: sibling blockers/parents that remain open.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`.

## Semantic Migration

- New canonical mutation owner for this child: `runtime.run_fork.historical_replay_execution`.
- Admission prerequisite: `runtime.run_fork.historical_replay_execution_admission` must classify `event_deliveries` as `executable_fork_work`.
- Old producer/reader/writer path now invalid: activation/store direct authorization from `ReplayResumeAdmission.DeliveryEventReplayReady` without the runtime historical replay execution owner.
- Store primitive retained: `store.run_fork.delivery_event_replay` remains only the physical fork-local event/delivery/lineage writer.
- Production paths checked: CLI activation wrapper, selected activation gate delegation, store `ActivateRunFork`, historical replay admission/execution builders, planner replay taxonomy, bus/sweeper delivery proof, platform spec, and runtime watchlist.
- Migration completeness: complete for #633's chosen child. Full #564 historical replay/resume remains open for timers, routes, sessions, turns, audits, non-agent replay, restart recovery, contract-swap/full resume, and API/dashboard/Builder surfaces.

## Tests

- `go test ./internal/runtime/runforkexecution ./internal/store -run 'HistoricalReplayExecution|DeliveryEventReplay|ActivateRunFork|RunForkPlanner|ActivateSelectedContract' -count=1`
- `go test ./...`
- `git diff --check`
