### PR TITLE
[agent-a][issue #635] Prove historical replay recovery

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3456,6 +3456,20 @@ run_model:
       work, runtime restart state, API/UI/dashboard state, or use source/post-T outcomes as fork suppressors. Timers,
       routes, sessions, turns, audits, non-agent replay, contract-swap/full resume, restart recovery, and operator
       surfaces remain separately gated siblings under #564/#549/#618.'
+    historical_replay_delivery_event_replay_recovery: 'Restart and sweeper recovery for the admitted
+      delivery_event_replay_ready primitive is owned by
+      runtime.run_fork.historical_replay_execution.delivery_event_replay_ready_recovery. It consumes the fresh
+      fork-local event rows, fork-local event_deliveries rows, direct committed replay-scope marker rows, and
+      run_fork_delivery_event_replays lineage produced by runtime.run_fork.historical_replay_execution for the fork
+      run_id. Startup RecoveryManager and EventBus.SweepUndispatched MUST consume the existing persisted replay owner:
+      ListEventsMissingPipelineReceipt, ClaimPipelineReplay, ListEventDeliveryRecipients, LoadCommittedReplayScope,
+      and PublishPersistedRecipients. Fork-local event_deliveries are the recipient truth; source event IDs, source
+      delivery IDs, source recipients, current subscriptions, source receipts, source dead letters, retry/idempotency
+      state, emitted follow-ups, and post-fork source outcomes are lineage/proof only and MUST NOT become executable
+      fork work or recovery suppressors. ClaimPipelineReplay remains the duplicate/race owner for fork replay event IDs.
+      This owner MUST NOT reconstruct timers, routes, sessions, turns, audits, non-agent/node/system work,
+      contract-swap boot/resume, runtime-wide restart recovery, API/UI/dashboard state, or close the broader #564/#549
+      historical replay/resume parents.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -3556,6 +3570,14 @@ run_model:
         lineage through store.run_fork.delivery_event_replay, before source/fork lifecycle mutation, and only when
         event_deliveries are admitted as executable fork work. All other historical source fact families remain lineage,
         fail-closed blockers, or split siblings.'
+      3k1_historical_replay_delivery_event_replay_recovery: 'For the delivery_event_replay_ready primitive, startup
+        recovery and sweeper recovery consume the fork-local rows created by
+        runtime.run_fork.historical_replay_execution through the existing persisted replay owner. The recovery queue is
+        the fork event missing its platform pipeline receipt, serialized by ClaimPipelineReplay; recipients come from
+        fork-local event_deliveries; direct replay scope comes from the fork-local committed replay-scope marker. Source
+        rows and source outcomes are lineage/proof only and never suppress fork-local recovery. This is a restart
+        durability child only; timers, routes, sessions, turns, audits, non-agent replay, contract-swap boot/resume,
+        runtime-wide restart recovery, and API/UI/dashboard surfaces remain split under #564/#549/#618.'
       4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
         Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
       5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -195,6 +195,11 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 635
+    title: Gate historical replay delivery-event restart recovery
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -289,6 +294,7 @@ nodes:
       - selected-contract delivery writes from recipient planning are execution-proven through runtime.run_fork.selected_contract_execution and EventBus.Publish recipient-plan guards; a delivery-row-only writer would be a non-authoritative duplicate
       - historical replay execution admission must classify event deliveries, receipts, dead letters, retry/idempotency state, emitted follow-ups, and non-agent work before any future replay mutation; source delivery/outcome rows must remain lineage, blockers, or split siblings
       - historical replay delivery/event replay mutation must be owned by runtime.run_fork.historical_replay_execution consuming event_deliveries executable-fork-work admission before the store delivery replay primitive writes fork-local rows
+      - historical replay delivery/event replay restart and sweeper recovery must consume #633 fork-local event, delivery, and committed replay-scope rows through the persisted replay owner; source deliveries, current subscriptions, source receipts, and source dead letters are not recovery truth or suppressors
     representative_issues:
       - 112
       - 144
@@ -304,6 +310,7 @@ nodes:
       - 621
       - 631
       - 633
+      - 635
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -346,6 +353,7 @@ nodes:
       - contract-swap boot/resume readiness needs a non-mutating runtime owner that consumes selected binding, selected source admission, replay/resume taxonomy, selected route/recipient/recovery evidence, and classifies source deliveries/outcomes/timers/routes/sessions/non-agent facts as lineage, blockers, or split siblings before any full historical replay mutation
       - historical replay execution admission needs one non-mutating runtime owner that consumes replay_resume_admission, selected execution admission, selected binding/topology/recipient planning, route recovery evidence, and contract-swap admission before any full historical replay/resume mutation; it must classify every source fact family exactly once and keep mutation under a separate future owner
       - historical replay delivery/event replay mutation must consume runtime.run_fork.historical_replay_execution_admission and runtime.run_fork.historical_replay_execution before store.run_fork.delivery_event_replay writes fresh fork-local rows; activation/store must not directly authorize delivery_event_replay_ready mutation
+      - historical replay delivery/event replay recovery must prove startup RecoveryManager and EventBus.SweepUndispatched recover the fork-local rows produced by runtime.run_fork.historical_replay_execution, with source rows/outcomes as lineage only and broader replay/resume siblings still split
     representative_issues:
       - 564
       - 565
@@ -371,6 +379,7 @@ nodes:
       - 625
       - 631
       - 633
+      - 635
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -2,6 +2,7 @@ package pipeline_test
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+	"swarm/internal/runtime/runforkexecution"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
@@ -121,6 +123,49 @@ func persistCommittedReplayScope(t *testing.T, ctx context.Context, pg *store.Po
 	t.Helper()
 	if err := pg.UpsertCommittedReplayScope(ctx, eventID, scope); err != nil {
 		t.Fatalf("UpsertCommittedReplayScope(%s): %v", eventID, err)
+	}
+}
+
+func seedHistoricalReplayRecoverySourceRun(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed source event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"ready"'::jsonb, $3::uuid, 'platform', 'recovery-test', 'seed', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Recovery Entity"'::jsonb, $3::uuid, 'platform', 'recovery-test', 'seed', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed source mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'Recovery Entity',
+			'ready', '{}'::jsonb, '{"name":"Recovery Entity"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
 	}
 }
 
@@ -237,6 +282,156 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	recipients, _ := detail["persisted_recipients"].([]string)
 	if len(recipients) != 1 || recipients[0] != recipientID {
 		t.Fatalf("persisted_recipients = %#v, want [%q]", detail["persisted_recipients"], recipientID)
+	}
+}
+
+func TestRecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700001200, 0).UTC()
+	seedHistoricalReplayRecoverySourceRun(t, db, sourceRunID, entityID, sourceEventID, at)
+
+	var sourceDeliveryID string
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id,
+			status, retry_count, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'safe-agent', 'pending', 0, 'source_pending', $3)
+		RETURNING delivery_id::text
+	`, sourceRunID, sourceEventID, at).Scan(&sourceDeliveryID); err != nil {
+		t.Fatalf("seed source pending delivery: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          sourceEventID,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	activated, err := pg.ActivateRunFork(ctx, store.RunForkActivateRequest{
+		ForkRunID:                         materialized.ForkRunID,
+		HistoricalReplayExecutionAdmitter: runforkexecution.HistoricalReplayExecutionAdmitter{},
+	})
+	if err != nil {
+		t.Fatalf("ActivateRunFork: %v", err)
+	}
+	if activated.DeliveryEventReplay == nil || activated.DeliveryEventReplay.ReplayedEventCount != 1 || activated.DeliveryEventReplay.ReplayedDeliveryCount != 1 {
+		t.Fatalf("DeliveryEventReplay = %#v, want one fork-local event and delivery", activated.DeliveryEventReplay)
+	}
+
+	var forkEventID, forkDeliveryID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT fork_event_id::text, fork_delivery_id::text
+		FROM run_fork_delivery_event_replays
+		WHERE fork_run_id = $1::uuid
+		  AND source_delivery_id = $2::uuid
+	`, materialized.ForkRunID, sourceDeliveryID).Scan(&forkEventID, &forkDeliveryID); err != nil {
+		t.Fatalf("load fork replay lineage: %v", err)
+	}
+	if forkEventID == sourceEventID || forkDeliveryID == sourceDeliveryID {
+		t.Fatalf("fork replay reused source ids: fork_event=%s fork_delivery=%s", forkEventID, forkDeliveryID)
+	}
+
+	scope, err := pg.LoadCommittedReplayScope(ctx, forkEventID)
+	if err != nil {
+		t.Fatalf("LoadCommittedReplayScope(fork event): %v", err)
+	}
+	if scope != runtimereplayclaim.CommittedReplayScopeDirect {
+		t.Fatalf("fork replay scope = %q, want direct", scope)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, sourceEventID, "processed", "source_outcome_after_fork"); err != nil {
+		t.Fatalf("mark source pipeline receipt: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'agent', 'safe-agent', e.entity_id, e.flow_instance,
+			'dead_letter', 'source_outcome_after_fork', '{}'::jsonb, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+	`, sourceEventID); err != nil {
+		t.Fatalf("seed source agent dead-letter receipt: %v", err)
+	}
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	capture := &recoveryCapturePublisher{inner: bus}
+	safeAgent := bus.Subscribe("safe-agent", events.EventType("fork.ready"))
+	currentOnly := bus.Subscribe("current-only-agent", events.EventType("fork.ready"))
+
+	rm := runtimepipeline.NewRecoveryManagerWith(pg, capture)
+	if err := rm.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(capture.direct) != 1 {
+		t.Fatalf("direct replayed events = %#v, want one fork-local replay", capture.direct)
+	}
+	replayed := capture.direct[0]
+	if replayed.ID != forkEventID || replayed.RunID != materialized.ForkRunID {
+		t.Fatalf("replayed event = id:%s run:%s, want fork event %s run %s", replayed.ID, replayed.RunID, forkEventID, materialized.ForkRunID)
+	}
+	select {
+	case evt := <-safeAgent:
+		if evt.ID != forkEventID || evt.RunID != materialized.ForkRunID {
+			t.Fatalf("safe-agent received = id:%s run:%s, want fork event %s run %s", evt.ID, evt.RunID, forkEventID, materialized.ForkRunID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected safe-agent to receive recovered fork replay event")
+	}
+	select {
+	case evt := <-currentOnly:
+		t.Fatalf("current-only subscription should not receive direct fork replay: %#v", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	var forkPipelineOutcome, forkPipelineReason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, forkEventID).Scan(&forkPipelineOutcome, &forkPipelineReason); err != nil {
+		t.Fatalf("load fork pipeline receipt: %v", err)
+	}
+	if forkPipelineOutcome != "success" || forkPipelineReason != "pipeline_persisted" {
+		t.Fatalf("fork pipeline receipt = outcome:%s reason:%s, want success/pipeline_persisted", forkPipelineOutcome, forkPipelineReason)
+	}
+
+	var sourceDeliveryRun, sourceDeliveryStatus, sourceAgentOutcome string
+	if err := db.QueryRowContext(ctx, `
+		SELECT d.run_id::text, d.status, r.outcome
+		FROM event_deliveries d
+		JOIN event_receipts r
+		  ON r.event_id = d.event_id
+		 AND r.subscriber_type = 'agent'
+		 AND r.subscriber_id = d.subscriber_id
+		WHERE d.delivery_id = $1::uuid
+	`, sourceDeliveryID).Scan(&sourceDeliveryRun, &sourceDeliveryStatus, &sourceAgentOutcome); err != nil {
+		t.Fatalf("load source delivery/receipt after recovery: %v", err)
+	}
+	if sourceDeliveryRun != sourceRunID || sourceDeliveryStatus != "pending" || sourceAgentOutcome != "dead_letter" {
+		t.Fatalf("source state changed or suppressed recovery = run:%s status:%s outcome:%s", sourceDeliveryRun, sourceDeliveryStatus, sourceAgentOutcome)
+	}
+
+	logEntry := findRecoveryAftermathLog(t, capture.logs, forkEventID, "replayed", "persisted_recipients_replayed")
+	detail, _ := logEntry.Detail.(map[string]any)
+	if got := recoveryDetailString(detail["persisted_run_id"]); got != materialized.ForkRunID {
+		t.Fatalf("recovery persisted_run_id = %q, want fork run %q", got, materialized.ForkRunID)
 	}
 }
 

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -692,6 +692,7 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	ch := eb.Subscribe("safe-agent", events.EventType("fork.ready"))
+	currentOnly := eb.Subscribe("current-only-agent", events.EventType("fork.ready"))
 	replayed, err := eb.SweepUndispatched(ctx, time.Hour, 10)
 	if err != nil {
 		t.Fatalf("SweepUndispatched: %v", err)
@@ -706,6 +707,11 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for fork replay event delivery")
+	}
+	select {
+	case evt := <-currentOnly:
+		t.Fatalf("current-only subscription should not receive direct fork replay: %#v", evt)
+	case <-time.After(50 * time.Millisecond):
 	}
 	var pipelineOutcome, pipelineReason string
 	if err := db.QueryRowContext(ctx, `


### PR DESCRIPTION
Closes #635

## Summary
- Adds startup RecoveryManager proof that #634-created fork-local delivery_event_replay_ready rows recover after restart through the persisted replay owner.
- Strengthens the existing sweeper proof so EventBus.SweepUndispatched uses fork-local event_deliveries rather than current subscription drift.
- Updates the authoritative platform spec and runtime watchlist to map #635 recovery ownership.

## Governing refs/context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `run_model.fork.historical_replay_execution_admission`, `run_model.fork.historical_replay_delivery_event_replay_execution`, new `historical_replay_delivery_event_replay_recovery`, semantics `3k` and new `3k1`.
- Issue #635 Pre-Implementation Coverage Audit and independent gate outcome.
- Parent context remains #564 and #549; #631/#632 are admission prerequisites, #633/#634 are mutation prerequisites.

## Semantic migration / owner state
- New canonical recovery child: `runtime.run_fork.historical_replay_execution.delivery_event_replay_ready_recovery`.
- Canonical recovery consumers: startup `RecoveryManager` and `EventBus.SweepUndispatched`, both through `ListEventsMissingPipelineReceipt`, `ClaimPipelineReplay`, `ListEventDeliveryRecipients`, `LoadCommittedReplayScope`, and `PublishPersistedRecipients`.
- Old invalid paths: source event IDs, source delivery IDs, source recipients, current subscriptions, source receipts/dead letters/retry/idempotency/follow-ups/post-T outcomes as executable fork work or suppressors.
- Production paths checked for surviving old behavior: startup recovery, outbox sweeper, fork activation row writer, committed replay scope lookup, persisted recipient publish path.
- Migration complete for #635 only; #564/#549 remain open for timers/routes/sessions/turns/audits/non-agent/contract-swap/API/full replay siblings.

## Proof
- `go test ./internal/runtime/pipeline -run 'RecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows|RecoveryManager_ClaimsReplayOwnershipUnderOverlap|RecoveryManager_ReplaysPersistedCorrelationEnvelope|RecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions' -count=1`
- `go test ./internal/store -run 'TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage' -count=1`
- `go test ./internal/runtime/bus -run 'SweepUndispatched|CommittedReplayScope' -count=1`
- `python3` YAML parse for `platform-spec.yaml` and `runtime-operations.yaml`
- `git diff --check`
- `go test ./...`
