### PR TITLE
[agent-a][issue #564] Promote historical replay owner

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3287,8 +3287,10 @@ run_model:
       rows only after runtime.run_fork.historical_replay_execution consumes a concrete
       runtime.run_fork.historical_replay_execution_admission that marks event_deliveries as executable fork work for
       source pending unstarted agent deliveries that the canonical replay_resume_admission taxonomy marks
-      delivery_event_replay_ready, using fresh fork event IDs, a direct committed replay-scope marker, and
-      run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
+      delivery_event_replay_ready. Activation/store MUST consume owner-authorized executable work from
+      runtime.run_fork.historical_replay_execution and MUST NOT reselect replayable source deliveries directly from
+      RunForkPlan or store.run_fork.replay_resume_admission. The store delivery-event replay primitive uses fresh fork
+      event IDs, a direct committed replay-scope marker, and run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
       after the fork point, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
       failed, dead-letter, committed replay-scope, timer, route, session, active-turn, replay, or contract-swap facts
       would require unsupported historical replay. Activation does not copy source event IDs, replay delivered/completed
@@ -3443,15 +3445,31 @@ run_model:
       frontier execution as full historical replay/resume proof. CLI, API, dashboard, Builder, route helpers, delivery
       writers, runtime recovery, and pipeline boot paths may consume this owner but MUST NOT compute historical replay
       execution admission independently.'
+    historical_replay_execution: 'Mutating historical replay/resume execution authority is owned by
+      runtime.run_fork.historical_replay_execution. The owner consumes runtime.run_fork.historical_replay_execution_admission
+      and the canonical store.run_fork.replay_resume_admission taxonomy, validates that every historical source fact
+      family has exactly one executable, reconstructed, lineage-only, fail-closed, or split-sibling classification, and
+      emits the executable work set that downstream store/runtime writers may mutate. The current supported closure
+      level is canonical owner promotion with delivery_event_replay_ready only: full product-complete historical
+      replay/resume for timers, routes, sessions, turns, audits, non-agent/node/system work, contract-swap boot/resume,
+      generic source-advanced policy, broader restart recovery, and API/UI/dashboard surfaces remains unsupported unless
+      separately approved. Activation, store delivery-event replay, recovery, selected/contract-swap consumers, route
+      helpers, timer helpers, session helpers, and operator surfaces MUST consume this owner or remain explicit
+      fail-closed/split outputs. They MUST NOT authorize mutation directly from replay_resume_admission, selected
+      frontier execution, source rows, same-run outbox replay, source outcomes, CLI/API/dashboard state, or local
+      helper predicates.'
     historical_replay_delivery_event_replay_execution: 'The first mutating historical replay execution child is owned by
       runtime.run_fork.historical_replay_execution and is limited to the already-admitted
       delivery_event_replay_ready primitive. It consumes runtime.run_fork.historical_replay_execution_admission before
       any source freeze, fork activation, event row creation, delivery row creation, committed replay-scope marker, or
-      lineage write. It may delegate physical fork-local row writes to store.run_fork.delivery_event_replay, but that
-      store primitive is not the semantic execution owner. The owner may mint fresh fork-local event IDs and delivery
-      IDs under the fork run_id for pending unstarted source-agent deliveries admitted as event_deliveries executable
-      fork work, record run_fork_delivery_event_replays lineage, and let the normal runtime delivery pipeline process
-      the fork-local pending delivery. It MUST NOT copy source event IDs, source delivery IDs, receipts, dead letters,
+      lineage write. It validates the complete historical fact matrix, keeps unsupported families as explicit blockers
+      or split siblings, and emits owner-authorized delivery_event_replay_ready work identities. It may delegate physical
+      fork-local row writes to store.run_fork.delivery_event_replay, but that store primitive is not the semantic
+      execution owner and MUST NOT choose replayable source deliveries from the plan on its own. The owner may mint fresh
+      fork-local event IDs and delivery IDs under the fork run_id for pending unstarted source-agent deliveries admitted
+      as event_deliveries executable fork work, record run_fork_delivery_event_replays lineage, and let the normal
+      runtime delivery pipeline process the fork-local pending delivery. It MUST NOT copy source event IDs, source
+      delivery IDs, receipts, dead letters,
       retry/idempotency state, emitted follow-ups, timers, route rows, sessions, turns, audits, non-agent/node/system
       work, runtime restart state, API/UI/dashboard state, or use source/post-T outcomes as fork suppressors. Timers,
       routes, sessions, turns, audits, non-agent replay, contract-swap/full resume, restart recovery, and operator
@@ -3494,8 +3512,9 @@ run_model:
         Revalidate the original fork point against current source-run facts, require no source advancement and
         no unsupported replay/timer/route/session/turn/contract-swap facts, optionally create fork-local event/delivery
         rows and direct committed replay-scope markers for the delivery_event_replay_ready subset only through
-        runtime.run_fork.historical_replay_execution consuming historical replay execution admission, then atomically
-        mark the source run forked and the fork run running. Future runtime work uses the fork
+        runtime.run_fork.historical_replay_execution consuming historical replay execution admission and owner-authorized
+        executable delivery work, then atomically mark the source run forked and the fork run running. Activation/store
+        does not authorize replay directly from replay_resume_admission or RunForkPlan pending rows. Future runtime work uses the fork
         run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
         unsupported outside the gated delivery/event primitive.'
       3c_selected_contract_source_advanced_branch: 'For selected-contract mutating fork execution, source advancement
@@ -3564,12 +3583,20 @@ run_model:
         admission/model only: it does not run handlers, create fork-local rows, copy source rows, write outcomes, replay
         timers, reconstruct sessions/turns/audits, mutate routes, or own API/dashboard state. Full mutation remains
         with the separately gated runtime.run_fork.historical_replay_execution owner.'
+      3j1_historical_replay_execution_owner: 'The mutating authority for historical replay/resume is
+        runtime.run_fork.historical_replay_execution. It consumes the admission fact matrix, validates exactly one
+        classification for every source fact family, exposes the currently executable fork work set, and keeps unsupported
+        fact families explicit as fail-closed blockers or split siblings. Its current supported mutation scope is only
+        delivery_event_replay_ready; this closes canonical owner promotion, not product-complete historical replay/resume
+        for every future fact family.'
       3k_historical_replay_delivery_event_replay_execution: 'For the first mutating historical replay child,
         runtime.run_fork.historical_replay_execution consumes a concrete historical replay execution admission and may
         execute only the delivery_event_replay_ready primitive. It creates fresh fork-local event/delivery rows and
         lineage through store.run_fork.delivery_event_replay, before source/fork lifecycle mutation, and only when
-        event_deliveries are admitted as executable fork work. All other historical source fact families remain lineage,
-        fail-closed blockers, or split siblings.'
+        event_deliveries are admitted as executable fork work and the owner emits concrete executable work identities.
+        store.run_fork.delivery_event_replay is a physical writer only; it does not select replayable source deliveries
+        from plan/admission data by itself. All other historical source fact families remain lineage, fail-closed
+        blockers, or split siblings.'
       3k1_historical_replay_delivery_event_replay_recovery: 'For the delivery_event_replay_ready primitive, startup
         recovery and sweeper recovery consume the fork-local rows created by
         runtime.run_fork.historical_replay_execution through the existing persisted replay owner. The recovery queue is

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -354,6 +354,7 @@ nodes:
       - historical replay execution admission needs one non-mutating runtime owner that consumes replay_resume_admission, selected execution admission, selected binding/topology/recipient planning, route recovery evidence, and contract-swap admission before any full historical replay/resume mutation; it must classify every source fact family exactly once and keep mutation under a separate future owner
       - historical replay delivery/event replay mutation must consume runtime.run_fork.historical_replay_execution_admission and runtime.run_fork.historical_replay_execution before store.run_fork.delivery_event_replay writes fresh fork-local rows; activation/store must not directly authorize delivery_event_replay_ready mutation
       - historical replay delivery/event replay recovery must prove startup RecoveryManager and EventBus.SweepUndispatched recover the fork-local rows produced by runtime.run_fork.historical_replay_execution, with source rows/outcomes as lineage only and broader replay/resume siblings still split
+      - broad historical replay execution owner promotion must make runtime.run_fork.historical_replay_execution the canonical mutating authority that emits executable work identities after validating the full fact matrix; store activation and delivery-event replay writers must consume that owner rather than selecting source deliveries from replay_resume_admission or RunForkPlan directly
     representative_issues:
       - 564
       - 565
@@ -377,6 +378,7 @@ nodes:
       - 619
       - 621
       - 625
+      - 629
       - 631
       - 633
       - 635

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -74,19 +74,43 @@ set -eu
 capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
 captured="$capture_dir/$$.stdin"
 cat > "$captured"
-if grep -q '"name":"emit_category_assessed"' "$captured" && grep -q '"ok":true' "$captured"; then
-  printf '%s\n' '{"type":"result","result":"done"}'
-  exit 0
+state_file="$capture_dir/state"
+state=0
+if [ -f "$state_file" ]; then
+  state="$(cat "$state_file")"
 fi
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-if grep -q '"name":"read_file"' "$captured" && grep -q '"ok":true' "$captured"; then
+case "$state" in
+0)
+  printf '%s' 1 > "$state_file"
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+  exit 0
+  ;;
+1)
+  if ! grep -q '"name":"read_file"' "$captured" || ! grep -q '"ok":true' "$captured"; then
+    printf '%s\n' '{"type":"result","result":"missing read_file result"}'
+    exit 0
+  fi
+  printf '%s' 2 > "$state_file"
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
   exit 0
-fi
-printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
-printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-exit 0
+  ;;
+2)
+  if ! grep -q '"name":"emit_category_assessed"' "$captured" || ! grep -q '"ok":true' "$captured"; then
+    printf '%s\n' '{"type":"result","result":"missing emit_category_assessed result"}'
+    exit 0
+  fi
+  printf '%s' 3 > "$state_file"
+  printf '%s\n' '{"type":"result","result":"done"}'
+  exit 0
+  ;;
+*)
+  printf '%s\n' '{"type":"result","result":"done"}'
+  exit 0
+  ;;
+esac
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -25,6 +25,7 @@ type HistoricalReplayDeliveryEventReplayAdmissionRequest struct {
 type HistoricalReplayExecutionRequest struct {
 	Admission             store.RunForkHistoricalReplayExecutionAdmission
 	ReplayResumeAdmission store.RunForkReplayResumeAdmission
+	PendingWork           []store.RunForkPendingWork
 }
 
 type HistoricalReplayExecutionAdmitter struct{}
@@ -42,6 +43,7 @@ func (HistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalReplayExecution(_
 	return BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
 		Admission:             admission,
 		ReplayResumeAdmission: req.ReplayResumeAdmission,
+		PendingWork:           req.PendingWork,
 	})
 }
 
@@ -115,6 +117,13 @@ func BuildHistoricalReplayExecution(req HistoricalReplayExecutionRequest) (store
 		!replayDispositionHas(replayAdmission, store.RunForkReplayResumeFactDeliveryPendingHistory, store.RunForkReplayResumeDispositionForkReplay) {
 		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires delivery_event_replay_ready replay taxonomy")
 	}
+	if err := validateHistoricalReplayFactMatrix(admission.FactAdmissions); err != nil {
+		return store.RunForkHistoricalReplayExecution{}, err
+	}
+	deliveryEventReplayWork := historicalReplayDeliveryEventReplayWork(req.PendingWork)
+	if len(deliveryEventReplayWork) == 0 {
+		return store.RunForkHistoricalReplayExecution{}, fmt.Errorf("historical replay execution requires owner-authorized delivery_event_replay_ready work")
+	}
 	return store.RunForkHistoricalReplayExecution{
 		Owner:                      store.RunForkHistoricalReplayExecutionOwner,
 		AdmissionOwner:             admission.Owner,
@@ -122,8 +131,13 @@ func BuildHistoricalReplayExecution(req HistoricalReplayExecutionRequest) (store
 		ForkRunID:                  strings.TrimSpace(admission.ForkRunID),
 		SourceRunID:                strings.TrimSpace(admission.SourceRunID),
 		ForkEventID:                strings.TrimSpace(admission.ForkEventID),
+		ClosureLevel:               "canonical_owner_promotion_with_delivery_event_replay_ready_only",
+		FullReplayResumeSupported:  false,
 		DeliveryEventReplayReady:   true,
 		EventDeliveriesAdmission:   eventDeliveries,
+		FactAdmissions:             append([]store.RunForkHistoricalReplayFactAdmission(nil), admission.FactAdmissions...),
+		DeliveryEventReplayWork:    deliveryEventReplayWork,
+		RequiredConsumers:          append([]store.RunForkSelectedContractExecutionBoundary(nil), admission.RequiredConsumers...),
 		BlockedSiblings:            historicalReplayExecutionBlockedSiblings(admission.BlockedSiblings),
 		InvalidPaths:               admission.InvalidPaths,
 	}, nil
@@ -388,6 +402,76 @@ func historicalReplayFactAdmission(admissions []store.RunForkHistoricalReplayFac
 		}
 	}
 	return store.RunForkHistoricalReplayFactAdmission{}, false
+}
+
+func validateHistoricalReplayFactMatrix(admissions []store.RunForkHistoricalReplayFactAdmission) error {
+	required := map[string]struct{}{
+		store.RunForkHistoricalReplayFactSourceEvents:             {},
+		store.RunForkHistoricalReplayFactEventDeliveries:          {},
+		store.RunForkHistoricalReplayFactReceipts:                 {},
+		store.RunForkHistoricalReplayFactDeadLetters:              {},
+		store.RunForkHistoricalReplayFactRetryIdempotency:         {},
+		store.RunForkHistoricalReplayFactEmittedFollowUps:         {},
+		store.RunForkHistoricalReplayFactTimers:                   {},
+		store.RunForkHistoricalReplayFactRoutes:                   {},
+		store.RunForkHistoricalReplayFactSessions:                 {},
+		store.RunForkHistoricalReplayFactTurns:                    {},
+		store.RunForkHistoricalReplayFactAudits:                   {},
+		store.RunForkHistoricalReplayFactNonAgentNodeSystemWork:   {},
+		store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts: {},
+		store.RunForkHistoricalReplayFactRuntimeRestartRecovery:   {},
+		store.RunForkHistoricalReplayFactCLIApiDashboardOperator:  {},
+	}
+	allowed := map[string]struct{}{
+		store.RunForkHistoricalReplayAdmissionExecutableForkWork:     {},
+		store.RunForkHistoricalReplayAdmissionReconstructedForkState: {},
+		store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence:    {},
+		store.RunForkHistoricalReplayAdmissionFailClosedBlocker:      {},
+		store.RunForkHistoricalReplayAdmissionSplitSibling:           {},
+	}
+	seen := map[string]struct{}{}
+	for _, admission := range admissions {
+		fact := strings.TrimSpace(admission.Fact)
+		if _, ok := required[fact]; !ok {
+			return fmt.Errorf("historical replay execution encountered unowned fact family %q", admission.Fact)
+		}
+		if _, ok := seen[fact]; ok {
+			return fmt.Errorf("historical replay execution fact family %q admitted more than once", fact)
+		}
+		seen[fact] = struct{}{}
+		disposition := strings.TrimSpace(admission.Admission)
+		if _, ok := allowed[disposition]; !ok {
+			return fmt.Errorf("historical replay execution fact %s has unsupported admission %q", fact, admission.Admission)
+		}
+		if disposition == store.RunForkHistoricalReplayAdmissionExecutableForkWork && fact != store.RunForkHistoricalReplayFactEventDeliveries {
+			return fmt.Errorf("historical replay execution cannot execute unsupported fact family %s", fact)
+		}
+	}
+	for fact := range required {
+		if _, ok := seen[fact]; !ok {
+			return fmt.Errorf("historical replay execution missing fact family %s", fact)
+		}
+	}
+	return nil
+}
+
+func historicalReplayDeliveryEventReplayWork(pending []store.RunForkPendingWork) []store.RunForkHistoricalReplayExecutableWork {
+	work := make([]store.RunForkHistoricalReplayExecutableWork, 0, len(pending))
+	for _, item := range pending {
+		if !store.RunForkPendingWorkReplayableForHistoricalReplay(item) {
+			continue
+		}
+		work = append(work, store.RunForkHistoricalReplayExecutableWork{
+			Fact:             store.RunForkHistoricalReplayFactEventDeliveries,
+			SourceEventID:    strings.TrimSpace(item.EventID),
+			SourceDeliveryID: strings.TrimSpace(item.DeliveryID),
+			SubscriberType:   strings.TrimSpace(item.SubscriberType),
+			SubscriberID:     strings.TrimSpace(item.SubscriberID),
+			ReasonCode:       strings.TrimSpace(item.ReasonCode),
+			Classification:   strings.TrimSpace(item.Classification),
+		})
+	}
+	return work
 }
 
 func historicalReplayExecutionBlockedSiblings(items []store.RunForkSelectedContractExecutionBoundary) []store.RunForkSelectedContractExecutionBoundary {

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -200,6 +200,14 @@ func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMu
 	execution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
 		Admission:             admission,
 		ReplayResumeAdmission: replayAdmission,
+		PendingWork: []store.RunForkPendingWork{{
+			EventID:        "source-event",
+			DeliveryID:     "source-delivery",
+			SubscriberType: "agent",
+			SubscriberID:   "agent-a",
+			Classification: store.RunForkPendingClassificationPending,
+			Status:         "pending",
+		}},
 	})
 	if err != nil {
 		t.Fatalf("BuildHistoricalReplayExecution: %v", err)
@@ -214,10 +222,59 @@ func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMu
 		execution.EventDeliveriesAdmission.Admission != store.RunForkHistoricalReplayAdmissionExecutableForkWork {
 		t.Fatalf("event deliveries admission = %#v", execution.EventDeliveriesAdmission)
 	}
+	if execution.ClosureLevel != "canonical_owner_promotion_with_delivery_event_replay_ready_only" ||
+		execution.FullReplayResumeSupported ||
+		len(execution.FactAdmissions) != 15 ||
+		len(execution.RequiredConsumers) == 0 {
+		t.Fatalf("execution broad owner accounting = %#v", execution)
+	}
+	if len(execution.DeliveryEventReplayWork) != 1 ||
+		execution.DeliveryEventReplayWork[0].SourceEventID != "source-event" ||
+		execution.DeliveryEventReplayWork[0].SourceDeliveryID != "source-delivery" {
+		t.Fatalf("owner-authorized delivery replay work = %#v", execution.DeliveryEventReplayWork)
+	}
 	if !executionBoundaryHas(execution.InvalidPaths, "source_delivery_copy", store.RunForkSelectedContractDispositionInvalid) ||
 		!executionBoundaryHas(execution.InvalidPaths, "source_outcome_suppression", store.RunForkSelectedContractDispositionInvalid) ||
 		!executionBoundaryHas(execution.BlockedSiblings, "timer_reconstruction", store.RunForkSelectedContractDispositionBlockedSibling) {
 		t.Fatalf("execution boundaries invalid=%#v blocked=%#v", execution.InvalidPaths, execution.BlockedSiblings)
+	}
+}
+
+func TestBuildHistoricalReplayExecutionRejectsTaxonomyReadyWithoutOwnerWork(t *testing.T) {
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition: store.RunForkReplayResumeDispositionForkReplay,
+			Message:     "pending unstarted source delivery can be replayed",
+		}},
+	}
+	admission, err := BuildHistoricalReplayDeliveryEventReplayAdmission(HistoricalReplayDeliveryEventReplayAdmissionRequest{
+		ForkRunID:             "fork-run",
+		SourceRunID:           "source-run",
+		ForkEventID:           "fork-event",
+		ReplayResumeAdmission: replayAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayDeliveryEventReplayAdmission: %v", err)
+	}
+
+	_, err = BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission:             admission,
+		ReplayResumeAdmission: replayAdmission,
+		PendingWork: []store.RunForkPendingWork{{
+			EventID:        "source-event",
+			DeliveryID:     "source-delivery",
+			SubscriberType: "agent",
+			SubscriberID:   "agent-a",
+			Classification: store.RunForkPendingClassificationPending,
+			Status:         "pending",
+			RetryCount:     1,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "owner-authorized delivery_event_replay_ready work") {
+		t.Fatalf("error = %v, want owner-authorized work failure", err)
 	}
 }
 

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -173,6 +173,11 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	if err != nil {
 		return result, err
 	}
+	if historicalReplayExecution.DeliveryEventReplayReady {
+		if err := validateRunForkDeliveryEventReplayWorkAgainstPlan(plan.PendingWork, historicalReplayExecution.DeliveryEventReplayWork); err != nil {
+			return result, err
+		}
+	}
 
 	now := time.Now().UTC()
 	sourceResult, err := tx.ExecContext(ctx, `

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -189,9 +189,16 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	} else if affected != 1 {
 		return result, fmt.Errorf("fork activation blocked: source_run_freeze_not_applied")
 	}
-	replayResult, err := applyRunForkDeliveryEventReplay(ctx, tx, lineage, plan, now)
-	if err != nil {
-		return result, err
+	replayResult := RunForkDeliveryEventReplayResult{
+		Owner:       RunForkDeliveryEventReplayOwner,
+		SourceRunID: lineage.SourceRunID,
+		ForkRunID:   lineage.ForkRunID,
+	}
+	if historicalReplayExecution.DeliveryEventReplayReady {
+		replayResult, err = applyRunForkDeliveryEventReplay(ctx, tx, lineage, historicalReplayExecution, now)
+		if err != nil {
+			return result, err
+		}
 	}
 	forkResult, err := tx.ExecContext(ctx, `
 		UPDATE runs
@@ -229,7 +236,7 @@ func requireRunForkHistoricalReplayExecution(
 	lineage runForkActivationLineage,
 	plan RunForkPlan,
 ) (RunForkHistoricalReplayExecution, error) {
-	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady && len(runForkReplayablePendingWork(plan.PendingWork)) == 0 {
+	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady {
 		return RunForkHistoricalReplayExecution{}, nil
 	}
 	if admitter == nil {
@@ -240,6 +247,7 @@ func requireRunForkHistoricalReplayExecution(
 		SourceRunID:           lineage.SourceRunID,
 		ForkEventID:           lineage.ForkEventID,
 		ReplayResumeAdmission: plan.ReplayResumeAdmission,
+		PendingWork:           plan.PendingWork,
 	})
 	if err != nil {
 		return RunForkHistoricalReplayExecution{}, err
@@ -259,6 +267,9 @@ func requireRunForkHistoricalReplayExecution(
 		execution.EventDeliveriesAdmission.Fact != RunForkHistoricalReplayFactEventDeliveries ||
 		execution.EventDeliveriesAdmission.Admission != RunForkHistoricalReplayAdmissionExecutableForkWork {
 		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation requires event_deliveries executable fork work admission")
+	}
+	if len(execution.DeliveryEventReplayWork) == 0 {
+		return RunForkHistoricalReplayExecution{}, fmt.Errorf("delivery/event replay mutation requires owner-authorized delivery_event_replay_ready work")
 	}
 	return execution, nil
 }

--- a/internal/store/run_fork_delivery_event_replay.go
+++ b/internal/store/run_fork_delivery_event_replay.go
@@ -102,6 +102,51 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 	return result, nil
 }
 
+func validateRunForkDeliveryEventReplayWorkAgainstPlan(pending []RunForkPendingWork, work []RunForkHistoricalReplayExecutableWork) error {
+	evidenceByDeliveryID := make(map[string]RunForkPendingWork, len(pending))
+	for _, item := range pending {
+		deliveryID := strings.TrimSpace(item.DeliveryID)
+		if deliveryID == "" {
+			continue
+		}
+		if _, exists := evidenceByDeliveryID[deliveryID]; exists {
+			return fmt.Errorf("store.run_fork.delivery_event_replay current pending evidence has duplicate source delivery %s", deliveryID)
+		}
+		evidenceByDeliveryID[deliveryID] = item
+	}
+
+	seenWork := make(map[string]struct{}, len(work))
+	for _, item := range work {
+		sourceDeliveryID := strings.TrimSpace(item.SourceDeliveryID)
+		if sourceDeliveryID == "" {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work missing source delivery identity")
+		}
+		if _, exists := seenWork[sourceDeliveryID]; exists {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work has duplicate source delivery %s", sourceDeliveryID)
+		}
+		seenWork[sourceDeliveryID] = struct{}{}
+
+		evidence, ok := evidenceByDeliveryID[sourceDeliveryID]
+		if !ok {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work source delivery %s is not in current pending evidence", sourceDeliveryID)
+		}
+		if item.Fact != RunForkHistoricalReplayFactEventDeliveries {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work for source delivery %s has fact %q; want %q", sourceDeliveryID, item.Fact, RunForkHistoricalReplayFactEventDeliveries)
+		}
+		if !RunForkPendingWorkReplayableForHistoricalReplay(evidence) {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work source delivery %s is not replayable pending agent work", sourceDeliveryID)
+		}
+		if strings.TrimSpace(item.SourceEventID) != strings.TrimSpace(evidence.EventID) ||
+			strings.TrimSpace(item.SubscriberType) != strings.TrimSpace(evidence.SubscriberType) ||
+			strings.TrimSpace(item.SubscriberID) != strings.TrimSpace(evidence.SubscriberID) ||
+			strings.TrimSpace(item.Classification) != strings.TrimSpace(evidence.Classification) ||
+			strings.TrimSpace(item.ReasonCode) != strings.TrimSpace(evidence.ReasonCode) {
+			return fmt.Errorf("store.run_fork.delivery_event_replay owner work source delivery %s does not exactly match current pending evidence", sourceDeliveryID)
+		}
+	}
+	return nil
+}
+
 func loadRunForkReplaySourceEvent(ctx context.Context, tx *sql.Tx, sourceRunID, sourceEventID string) (runForkReplaySourceEvent, error) {
 	var event runForkReplaySourceEvent
 	err := tx.QueryRowContext(ctx, `

--- a/internal/store/run_fork_delivery_event_replay.go
+++ b/internal/store/run_fork_delivery_event_replay.go
@@ -37,13 +37,20 @@ type runForkReplaySourceEvent struct {
 	HandlerNode    sql.NullString
 }
 
-func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, plan RunForkPlan, now time.Time) (RunForkDeliveryEventReplayResult, error) {
+func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, execution RunForkHistoricalReplayExecution, now time.Time) (RunForkDeliveryEventReplayResult, error) {
 	result := RunForkDeliveryEventReplayResult{
 		Owner:       RunForkDeliveryEventReplayOwner,
 		SourceRunID: lineage.SourceRunID,
 		ForkRunID:   lineage.ForkRunID,
 	}
-	replayable := runForkReplayablePendingWork(plan.PendingWork)
+	if strings.TrimSpace(execution.Owner) != RunForkHistoricalReplayExecutionOwner ||
+		strings.TrimSpace(execution.AdmissionOwner) != RunForkHistoricalReplayExecutionAdmissionOwner ||
+		!execution.DeliveryEventReplayReady ||
+		execution.EventDeliveriesAdmission.Fact != RunForkHistoricalReplayFactEventDeliveries ||
+		execution.EventDeliveriesAdmission.Admission != RunForkHistoricalReplayAdmissionExecutableForkWork {
+		return result, fmt.Errorf("store.run_fork.delivery_event_replay requires %s owner-authorized executable event_deliveries", RunForkHistoricalReplayExecutionOwner)
+	}
+	replayable := execution.DeliveryEventReplayWork
 	if len(replayable) == 0 {
 		return result, nil
 	}
@@ -51,7 +58,11 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 	sourceEvents := map[string]runForkReplaySourceEvent{}
 	insertedEvents := map[string]string{}
 	for _, item := range replayable {
-		sourceEventID := strings.TrimSpace(item.EventID)
+		sourceEventID := strings.TrimSpace(item.SourceEventID)
+		sourceDeliveryID := strings.TrimSpace(item.SourceDeliveryID)
+		if item.Fact != RunForkHistoricalReplayFactEventDeliveries || sourceEventID == "" || sourceDeliveryID == "" {
+			return result, fmt.Errorf("store.run_fork.delivery_event_replay requires owner-authorized source event and delivery identity")
+		}
 		sourceEvent, ok := sourceEvents[sourceEventID]
 		if !ok {
 			loaded, err := loadRunForkReplaySourceEvent(ctx, tx, lineage.SourceRunID, sourceEventID)
@@ -76,7 +87,7 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 			}
 			insertedEvents[sourceEventID] = forkEventID
 		}
-		forkDeliveryID := deterministicRunForkReplayDeliveryID(lineage.ForkRunID, item.DeliveryID)
+		forkDeliveryID := deterministicRunForkReplayDeliveryID(lineage.ForkRunID, sourceDeliveryID)
 		inserted, err := insertRunForkReplayDelivery(ctx, tx, lineage, item, sourceEventID, forkEventID, forkDeliveryID, now)
 		if err != nil {
 			return result, err
@@ -89,16 +100,6 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 		return result, err
 	}
 	return result, nil
-}
-
-func runForkReplayablePendingWork(pending []RunForkPendingWork) []RunForkPendingWork {
-	out := make([]RunForkPendingWork, 0, len(pending))
-	for _, item := range pending {
-		if runForkPendingWorkReplayable(item) {
-			out = append(out, item)
-		}
-	}
-	return out
 }
 
 func loadRunForkReplaySourceEvent(ctx context.Context, tx *sql.Tx, sourceRunID, sourceEventID string) (runForkReplaySourceEvent, error) {
@@ -178,7 +179,7 @@ func insertRunForkReplayScopeMarker(ctx context.Context, tx *sql.Tx, forkRunID, 
 	return nil
 }
 
-func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, item RunForkPendingWork, sourceEventID, forkEventID, forkDeliveryID string, now time.Time) (bool, error) {
+func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, item RunForkHistoricalReplayExecutableWork, sourceEventID, forkEventID, forkDeliveryID string, now time.Time) (bool, error) {
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
@@ -193,7 +194,7 @@ func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runFor
 		ON CONFLICT (delivery_id) DO NOTHING
 	`, forkDeliveryID, lineage.ForkRunID, forkEventID, item.SubscriberType, item.SubscriberID, runForkReplayReasonCode(item), now)
 	if err != nil {
-		return false, fmt.Errorf("insert fork replay delivery %s from source delivery %s: %w", forkDeliveryID, item.DeliveryID, err)
+		return false, fmt.Errorf("insert fork replay delivery %s from source delivery %s: %w", forkDeliveryID, item.SourceDeliveryID, err)
 	}
 	inserted, err := rowsAffected(res)
 	if err != nil {
@@ -209,13 +210,13 @@ func insertRunForkReplayDelivery(ctx context.Context, tx *sql.Tx, lineage runFor
 			$5::uuid, $6::uuid, $7, $8, $9
 		)
 		ON CONFLICT (fork_run_id, source_delivery_id) DO NOTHING
-	`, lineage.ForkRunID, lineage.SourceRunID, sourceEventID, item.DeliveryID, forkEventID, forkDeliveryID, item.SubscriberType, item.SubscriberID, now); err != nil {
-		return false, fmt.Errorf("insert fork delivery/event replay lineage for source delivery %s: %w", item.DeliveryID, err)
+	`, lineage.ForkRunID, lineage.SourceRunID, sourceEventID, item.SourceDeliveryID, forkEventID, forkDeliveryID, item.SubscriberType, item.SubscriberID, now); err != nil {
+		return false, fmt.Errorf("insert fork delivery/event replay lineage for source delivery %s: %w", item.SourceDeliveryID, err)
 	}
 	return inserted, nil
 }
 
-func runForkReplayReasonCode(item RunForkPendingWork) string {
+func runForkReplayReasonCode(item RunForkHistoricalReplayExecutableWork) string {
 	if reason := strings.TrimSpace(item.ReasonCode); reason != "" {
 		return "fork_replay:" + reason
 	}

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -578,12 +578,15 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	if admitter.request.ForkRunID != materialized.ForkRunID ||
 		admitter.request.SourceRunID != sourceRunID ||
 		admitter.request.ForkEventID != eventID ||
-		!admitter.request.ReplayResumeAdmission.DeliveryEventReplayReady {
+		!admitter.request.ReplayResumeAdmission.DeliveryEventReplayReady ||
+		len(admitter.request.PendingWork) != 1 ||
+		admitter.request.PendingWork[0].DeliveryID != sourceDeliveryID {
 		t.Fatalf("historical replay execution request = %#v", admitter.request)
 	}
 	if activated.HistoricalReplayExecution == nil ||
 		activated.HistoricalReplayExecution.Owner != RunForkHistoricalReplayExecutionOwner ||
 		activated.HistoricalReplayExecution.AdmissionOwner != RunForkHistoricalReplayExecutionAdmissionOwner ||
+		len(activated.HistoricalReplayExecution.DeliveryEventReplayWork) != 1 ||
 		activated.HistoricalReplayExecution.DeliveryEventReplay == nil {
 		t.Fatalf("HistoricalReplayExecution = %#v", activated.HistoricalReplayExecution)
 	}
@@ -1022,12 +1025,24 @@ func (a *fakeRunForkHistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalRep
 		ForkRunID:                  req.ForkRunID,
 		SourceRunID:                req.SourceRunID,
 		ForkEventID:                req.ForkEventID,
+		ClosureLevel:               "canonical_owner_promotion_with_delivery_event_replay_ready_only",
 		DeliveryEventReplayReady:   true,
 		EventDeliveriesAdmission: RunForkHistoricalReplayFactAdmission{
 			Fact:        RunForkHistoricalReplayFactEventDeliveries,
 			Admission:   RunForkHistoricalReplayAdmissionExecutableForkWork,
 			SourceOwner: RunForkReplayResumeAdmissionOwner,
 			Message:     "test admission",
+		},
+		DeliveryEventReplayWork: []RunForkHistoricalReplayExecutableWork{
+			{
+				Fact:             RunForkHistoricalReplayFactEventDeliveries,
+				SourceEventID:    req.PendingWork[0].EventID,
+				SourceDeliveryID: req.PendingWork[0].DeliveryID,
+				SubscriberType:   req.PendingWork[0].SubscriberType,
+				SubscriberID:     req.PendingWork[0].SubscriberID,
+				ReasonCode:       req.PendingWork[0].ReasonCode,
+				Classification:   req.PendingWork[0].Classification,
+			},
 		},
 	}, nil
 }

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -731,6 +731,210 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	}
 }
 
+func TestRunForkActivation_RejectsOwnerWorkOutsideCurrentSafePendingEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		seed     func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string
+		work     func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork
+		wantText string
+	}{
+		{
+			name: "stale missing delivery",
+			seed: func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string {
+				t.Helper()
+				return uuid.NewString()
+			},
+			work: func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork {
+				item := req.PendingWork[0]
+				item.DeliveryID = targetDeliveryID
+				return []RunForkHistoricalReplayExecutableWork{runForkHistoricalReplayWorkFromPending(item)}
+			},
+			wantText: "is not in current pending evidence",
+		},
+		{
+			name: "foreign delivery",
+			seed: func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string {
+				t.Helper()
+				foreignRunID := uuid.NewString()
+				foreignEventID := uuid.NewString()
+				if _, err := db.ExecContext(ctx, `
+					INSERT INTO runs (run_id, status, started_at)
+					VALUES ($1::uuid, 'running', $2)
+				`, foreignRunID, at.Add(-time.Minute)); err != nil {
+					t.Fatalf("seed foreign run: %v", err)
+				}
+				if _, err := db.ExecContext(ctx, `
+					INSERT INTO events (
+						run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'foreign.ready', 'global', '{}'::jsonb, 'test', 'platform', $3)
+				`, foreignRunID, foreignEventID, at); err != nil {
+					t.Fatalf("seed foreign event: %v", err)
+				}
+				var deliveryID string
+				if err := db.QueryRowContext(ctx, `
+					INSERT INTO event_deliveries (
+						run_id, event_id, subscriber_type, subscriber_id, status, retry_count, created_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent', 'foreign-agent', 'pending', 0, $3)
+					RETURNING delivery_id::text
+				`, foreignRunID, foreignEventID, at).Scan(&deliveryID); err != nil {
+					t.Fatalf("seed foreign delivery: %v", err)
+				}
+				return deliveryID
+			},
+			work: func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork {
+				item := req.PendingWork[0]
+				item.DeliveryID = targetDeliveryID
+				return []RunForkHistoricalReplayExecutableWork{runForkHistoricalReplayWorkFromPending(item)}
+			},
+			wantText: "is not in current pending evidence",
+		},
+		{
+			name: "delivered delivery",
+			seed: func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string {
+				t.Helper()
+				var deliveryID string
+				if err := db.QueryRowContext(ctx, `
+					INSERT INTO event_deliveries (
+						run_id, event_id, subscriber_type, subscriber_id, status, retry_count, delivered_at, created_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent', 'done-agent', 'delivered', 0, $3, $3)
+					RETURNING delivery_id::text
+				`, sourceRunID, eventID, at).Scan(&deliveryID); err != nil {
+					t.Fatalf("seed delivered delivery: %v", err)
+				}
+				return deliveryID
+			},
+			work: func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork {
+				return []RunForkHistoricalReplayExecutableWork{runForkHistoricalReplayWorkForDelivery(req, targetDeliveryID)}
+			},
+			wantText: "is not replayable pending agent work",
+		},
+		{
+			name: "duplicate owner work",
+			seed: func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string {
+				t.Helper()
+				return ""
+			},
+			work: func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork {
+				item := runForkHistoricalReplayWorkFromPending(req.PendingWork[0])
+				return []RunForkHistoricalReplayExecutableWork{item, item}
+			},
+			wantText: "duplicate source delivery",
+		},
+		{
+			name: "subscriber mismatch",
+			seed: func(t *testing.T, ctx context.Context, db *sql.DB, sourceRunID, eventID string, at time.Time) string {
+				t.Helper()
+				return ""
+			},
+			work: func(req RunForkHistoricalReplayExecutionRequest, targetDeliveryID string) []RunForkHistoricalReplayExecutableWork {
+				item := runForkHistoricalReplayWorkFromPending(req.PendingWork[0])
+				item.SubscriberID = "wrong-agent"
+				return []RunForkHistoricalReplayExecutableWork{item}
+			},
+			wantText: "does not exactly match current pending evidence",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+
+			sourceRunID := uuid.NewString()
+			entityID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700000875, 0).UTC()
+			seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO event_deliveries (
+					run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+				)
+				VALUES ($1::uuid, $2::uuid, 'agent', 'safe-agent', 'pending', 0, 'matched_agent_subscription', $3)
+			`, sourceRunID, eventID, at); err != nil {
+				t.Fatalf("seed safe pending delivery: %v", err)
+			}
+			targetDeliveryID := tc.seed(t, ctx, db, sourceRunID, eventID, at)
+			materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+			if err != nil {
+				t.Fatalf("MaterializeRunFork: %v", err)
+			}
+
+			admitter := &fakeRunForkHistoricalReplayExecutionAdmitter{
+				work: func(req RunForkHistoricalReplayExecutionRequest) []RunForkHistoricalReplayExecutableWork {
+					return tc.work(req, targetDeliveryID)
+				},
+			}
+			blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{
+				ForkRunID:                         materialized.ForkRunID,
+				HistoricalReplayExecutionAdmitter: admitter,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("ActivateRunFork error = %v, want %q", err, tc.wantText)
+			}
+			if blocked.Activated || blocked.SourceFrozen {
+				t.Fatalf("blocked activation mutated lifecycle: %#v", blocked)
+			}
+			assertRunForkActivationReplayMutationAbsent(t, db, sourceRunID, materialized.ForkRunID)
+		})
+	}
+}
+
+func TestRunForkDeliveryEventReplayValidationRejectsUnsafeCurrentEvidence(t *testing.T) {
+	base := RunForkPendingWork{
+		EventID:        uuid.NewString(),
+		DeliveryID:     uuid.NewString(),
+		SubscriberType: "agent",
+		SubscriberID:   "safe-agent",
+		Classification: RunForkPendingClassificationPending,
+		Status:         "pending",
+		RetryCount:     0,
+		CreatedAt:      time.Unix(1700000880, 0).UTC(),
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*RunForkPendingWork)
+	}{
+		{
+			name: "in-progress",
+			mutate: func(item *RunForkPendingWork) {
+				started := item.CreatedAt
+				item.Status = "in_progress"
+				item.ActiveSessionID = uuid.NewString()
+				item.StartedAt = &started
+				item.Classification = RunForkPendingClassificationInProgress
+			},
+		},
+		{
+			name: "non-agent",
+			mutate: func(item *RunForkPendingWork) {
+				item.SubscriberType = "node"
+				item.SubscriberID = "node-worker"
+			},
+		},
+		{
+			name: "retry",
+			mutate: func(item *RunForkPendingWork) {
+				item.RetryCount = 1
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := base
+			tc.mutate(&item)
+			err := validateRunForkDeliveryEventReplayWorkAgainstPlan(
+				[]RunForkPendingWork{item},
+				[]RunForkHistoricalReplayExecutableWork{runForkHistoricalReplayWorkFromPending(item)},
+			)
+			if err == nil || !strings.Contains(err.Error(), "is not replayable pending agent work") {
+				t.Fatalf("validateRunForkDeliveryEventReplayWorkAgainstPlan error = %v, want unsafe pending-agent rejection", err)
+			}
+		})
+	}
+}
+
 func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1010,6 +1214,7 @@ type fakeRunForkHistoricalReplayExecutionAdmitter struct {
 	called  bool
 	request RunForkHistoricalReplayExecutionRequest
 	err     error
+	work    func(RunForkHistoricalReplayExecutionRequest) []RunForkHistoricalReplayExecutableWork
 }
 
 func (a *fakeRunForkHistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalReplayExecution(_ context.Context, req RunForkHistoricalReplayExecutionRequest) (RunForkHistoricalReplayExecution, error) {
@@ -1017,6 +1222,12 @@ func (a *fakeRunForkHistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalRep
 	a.request = req
 	if a.err != nil {
 		return RunForkHistoricalReplayExecution{}, a.err
+	}
+	deliveryEventReplayWork := []RunForkHistoricalReplayExecutableWork{
+		runForkHistoricalReplayWorkFromPending(req.PendingWork[0]),
+	}
+	if a.work != nil {
+		deliveryEventReplayWork = a.work(req)
 	}
 	return RunForkHistoricalReplayExecution{
 		Owner:                      RunForkHistoricalReplayExecutionOwner,
@@ -1033,18 +1244,65 @@ func (a *fakeRunForkHistoricalReplayExecutionAdmitter) AdmitRunForkHistoricalRep
 			SourceOwner: RunForkReplayResumeAdmissionOwner,
 			Message:     "test admission",
 		},
-		DeliveryEventReplayWork: []RunForkHistoricalReplayExecutableWork{
-			{
-				Fact:             RunForkHistoricalReplayFactEventDeliveries,
-				SourceEventID:    req.PendingWork[0].EventID,
-				SourceDeliveryID: req.PendingWork[0].DeliveryID,
-				SubscriberType:   req.PendingWork[0].SubscriberType,
-				SubscriberID:     req.PendingWork[0].SubscriberID,
-				ReasonCode:       req.PendingWork[0].ReasonCode,
-				Classification:   req.PendingWork[0].Classification,
-			},
-		},
+		DeliveryEventReplayWork: deliveryEventReplayWork,
 	}, nil
+}
+
+func runForkHistoricalReplayWorkFromPending(item RunForkPendingWork) RunForkHistoricalReplayExecutableWork {
+	return RunForkHistoricalReplayExecutableWork{
+		Fact:             RunForkHistoricalReplayFactEventDeliveries,
+		SourceEventID:    item.EventID,
+		SourceDeliveryID: item.DeliveryID,
+		SubscriberType:   item.SubscriberType,
+		SubscriberID:     item.SubscriberID,
+		ReasonCode:       item.ReasonCode,
+		Classification:   item.Classification,
+	}
+}
+
+func runForkHistoricalReplayWorkForDelivery(req RunForkHistoricalReplayExecutionRequest, deliveryID string) RunForkHistoricalReplayExecutableWork {
+	for _, item := range req.PendingWork {
+		if item.DeliveryID == deliveryID {
+			return runForkHistoricalReplayWorkFromPending(item)
+		}
+	}
+	return RunForkHistoricalReplayExecutableWork{
+		Fact:             RunForkHistoricalReplayFactEventDeliveries,
+		SourceEventID:    req.PendingWork[0].EventID,
+		SourceDeliveryID: deliveryID,
+		SubscriberType:   req.PendingWork[0].SubscriberType,
+		SubscriberID:     req.PendingWork[0].SubscriberID,
+		ReasonCode:       req.PendingWork[0].ReasonCode,
+		Classification:   req.PendingWork[0].Classification,
+	}
+}
+
+func assertRunForkActivationReplayMutationAbsent(t *testing.T, db *sql.DB, sourceRunID, forkRunID string) {
+	t.Helper()
+	ctx := context.Background()
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status after blocked activation: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, forkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status after blocked activation: %v", err)
+	}
+	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
+		t.Fatalf("blocked activation lifecycle = source:%s fork:%s, want running/%s", sourceStatus, forkStatus, RunForkMaterializedStatus)
+	}
+	for name, query := range map[string]string{
+		"fork events":     `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`,
+		"fork deliveries": `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`,
+		"lineage rows":    `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`,
+	} {
+		var count int
+		if err := db.QueryRowContext(ctx, query, forkRunID).Scan(&count); err != nil {
+			t.Fatalf("count %s after blocked activation: %v", name, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s after blocked activation = %d, want 0", name, count)
+		}
+	}
 }
 
 type execContextDB interface {

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -223,7 +223,9 @@ func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunFo
 	}
 }
 
-func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
+// RunForkPendingWorkReplayableForHistoricalReplay is the shared taxonomy predicate
+// consumed by the runtime historical replay owner before any fork-local mutation.
+func RunForkPendingWorkReplayableForHistoricalReplay(item RunForkPendingWork) bool {
 	if item.Classification != RunForkPendingClassificationPending {
 		return false
 	}
@@ -240,6 +242,10 @@ func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
 		item.StartedAt == nil &&
 		item.DeliveredAt == nil &&
 		item.ReceiptAt == nil
+}
+
+func runForkPendingWorkReplayable(item RunForkPendingWork) bool {
+	return RunForkPendingWorkReplayableForHistoricalReplay(item)
 }
 
 func runForkPendingWorkIsNonAgent(item RunForkPendingWork) bool {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -279,9 +279,14 @@ type RunForkHistoricalReplayExecution struct {
 	ForkRunID                  string                                     `json:"fork_run_id"`
 	SourceRunID                string                                     `json:"source_run_id"`
 	ForkEventID                string                                     `json:"fork_event_id"`
+	ClosureLevel               string                                     `json:"closure_level"`
+	FullReplayResumeSupported  bool                                       `json:"full_replay_resume_supported"`
 	DeliveryEventReplayReady   bool                                       `json:"delivery_event_replay_ready"`
 	EventDeliveriesAdmission   RunForkHistoricalReplayFactAdmission       `json:"event_deliveries_admission"`
+	FactAdmissions             []RunForkHistoricalReplayFactAdmission     `json:"fact_admissions,omitempty"`
+	DeliveryEventReplayWork    []RunForkHistoricalReplayExecutableWork    `json:"delivery_event_replay_work,omitempty"`
 	DeliveryEventReplay        *RunForkDeliveryEventReplayResult          `json:"delivery_event_replay,omitempty"`
+	RequiredConsumers          []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings            []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths               []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
 }
@@ -291,6 +296,7 @@ type RunForkHistoricalReplayExecutionRequest struct {
 	SourceRunID           string
 	ForkEventID           string
 	ReplayResumeAdmission RunForkReplayResumeAdmission
+	PendingWork           []RunForkPendingWork
 }
 
 type RunForkHistoricalReplayExecutionAdmitter interface {
@@ -304,6 +310,16 @@ type RunForkHistoricalReplayFactAdmission struct {
 	BlockerCode string `json:"blocker_code,omitempty"`
 	Tracker     string `json:"tracker,omitempty"`
 	Message     string `json:"message"`
+}
+
+type RunForkHistoricalReplayExecutableWork struct {
+	Fact             string `json:"fact"`
+	SourceEventID    string `json:"source_event_id"`
+	SourceDeliveryID string `json:"source_delivery_id"`
+	SubscriberType   string `json:"subscriber_type"`
+	SubscriberID     string `json:"subscriber_id"`
+	ReasonCode       string `json:"reason_code,omitempty"`
+	Classification   string `json:"classification"`
 }
 
 func RunForkContractFrontierEvidenceBinding(frontier RunForkContractFrontierAdmission) (int, []string, string) {


### PR DESCRIPTION
## Summary

Part of #564. Related to #549 and blocked sibling #629.

Promotes `runtime.run_fork.historical_replay_execution` from a narrow delivery-event replay wrapper into the canonical mutating authority boundary for timestamp-fork historical replay execution decisions after admission.

This PR does not claim product-complete replay/resume for every future fact family. Its closure claim is canonical owner promotion: downstream store/runtime mutation now consumes owner-authorized executable work from the runtime historical replay owner, and unsupported families remain explicit blockers/splits.

## Governing refs/context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: fork sections `activation_admission`, `historical_replay_execution_admission`, new/updated `historical_replay_execution`, `historical_replay_delivery_event_replay_execution`, semantics `3b`, `3j`, `3j1`, `3k`, and `3k1`.
- #564 Broad Refactor Pre-Implementation Coverage Audit and independent gate outcome: approved for broad refactor / canonical owner promotion only.
- #631/#632: prerequisite non-mutating historical replay execution admission.
- #633/#634: prerequisite limited delivery-event replay mutation.
- #635/#636: prerequisite limited delivery-event replay recovery.
- #629: blocked contract-swap sibling proving narrow mutation cannot proceed without the broad owner.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`.

## Semantic migration

- New canonical mutating authority boundary: `runtime.run_fork.historical_replay_execution`.
- Old producer/reader/writer path now invalid: store activation and `store.run_fork.delivery_event_replay` selecting executable delivery-event replay work directly from `RunForkPlan`, `ReplayResumeAdmission`, or source delivery rows.
- Production paths checked for surviving old behavior: activation, historical replay execution builder, store delivery-event replay writer, delivery-event lineage writer, committed replay-scope marker writer, startup/sweeper recovery consumers, platform spec, and runtime watchlist.
- Migration completeness: complete for #564's approved canonical owner promotion class. Full product replay/resume remains open for timers, routes, sessions, turns, audits, non-agent replay, contract-swap full boot/resume, broader source-advanced policy, restart recovery beyond the safe primitive, and API/dashboard/Builder consumers.

## Tests

- `go test ./internal/runtime/runforkexecution ./internal/store -run 'HistoricalReplayExecution|DeliveryEventReplay|ActivateRunFork' -count=1`
- `go test ./...`
- `python3` YAML parse for `platform-spec.yaml` and `runtime-operations.yaml`
- `git diff --check`
