### PR TITLE
[agent-a][issue #639] Execute contract-swap replay through selected recipients

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -934,7 +934,7 @@ func TestRunForkCommand_ActivateSelectedBindingConsumesRuntimeAdmission(t *testi
 	}
 }
 
-func TestRunForkCommand_ActivateSelectedBindingBlocksSourceReplayBeforeMutation(t *testing.T) {
+func TestRunForkCommand_ActivateSelectedBindingBlocksReplayWithoutSelectedRecipientPlan(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
@@ -979,8 +979,8 @@ func TestRunForkCommand_ActivateSelectedBindingBlocksSourceReplayBeforeMutation(
 	if activateCode != 1 {
 		t.Fatalf("activate code=%d, want 1; output=%s", activateCode, activateOut.String())
 	}
-	if !strings.Contains(activateOut.String(), store.RunForkBlockerSelectedContractSourceReplayUnsupported) {
-		t.Fatalf("activate output = %q, want selected source replay blocker", activateOut.String())
+	if !strings.Contains(activateOut.String(), "no selected recipients") {
+		t.Fatalf("activate output = %q, want selected recipient-plan blocker", activateOut.String())
 	}
 	var sourceStatus, forkStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, runID).Scan(&sourceStatus); err != nil {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3450,14 +3450,34 @@ run_model:
       and the canonical store.run_fork.replay_resume_admission taxonomy, validates that every historical source fact
       family has exactly one executable, reconstructed, lineage-only, fail-closed, or split-sibling classification, and
       emits the executable work set that downstream store/runtime writers may mutate. The current supported closure
-      level is canonical owner promotion with delivery_event_replay_ready only: full product-complete historical
-      replay/resume for timers, routes, sessions, turns, audits, non-agent/node/system work, contract-swap boot/resume,
-      generic source-advanced policy, broader restart recovery, and API/UI/dashboard surfaces remains unsupported unless
-      separately approved. Activation, store delivery-event replay, recovery, selected/contract-swap consumers, route
+      level is canonical owner promotion with delivery_event_replay_ready only; the selected-contract contract-swap
+      child runtime.run_fork.historical_replay_execution.contract_swap_boot_resume may execute only that already-admitted
+      primitive under selected/swapped contracts. Full product-complete historical replay/resume for timers, routes,
+      sessions, turns, audits, non-agent/node/system work, broader contract-swap boot/resume, generic source-advanced
+      policy, broader restart recovery, and API/UI/dashboard surfaces remains unsupported unless separately approved.
+      Activation, store delivery-event replay, recovery, selected/contract-swap consumers, route
       helpers, timer helpers, session helpers, and operator surfaces MUST consume this owner or remain explicit
       fail-closed/split outputs. They MUST NOT authorize mutation directly from replay_resume_admission, selected
       frontier execution, source rows, same-run outbox replay, source outcomes, CLI/API/dashboard state, or local
       helper predicates.'
+    historical_replay_contract_swap_boot_resume_execution: 'The selected-contract contract-swap boot/resume historical
+      replay child is owned by runtime.run_fork.historical_replay_execution.contract_swap_boot_resume. It consumes
+      runtime.run_fork.historical_replay_execution, runtime.run_fork.historical_replay_execution_admission,
+      runtime.run_fork.contract_swap_boot_resume_admission, store.run_fork.selected_contract_binding,
+      runtime.run_fork.selected_contract_execution_admission, selected route topology, selected recipient planning, and
+      fork-local selected route recovery before any fork-local event, delivery, handler, receipt, dead-letter,
+      retry/idempotency, or follow-up mutation. Its first-slice closure level is selected-contract execution of
+      owner-authorized delivery_event_replay_ready work only. It MUST map historical source delivery identities to
+      selected recipient-plan work by source event, mint fresh fork-local event IDs under the fork run_id, publish
+      through EventBus with selected recipient-plan guards, run selected handlers through the normal runtime pipeline,
+      and record fork-local lineage without copying source event IDs or source delivery rows. Source delivery
+      subscriber identity, source receipts, source dead letters, source retry/idempotency, emitted source follow-ups,
+      timers, source/current routes, sessions, turns, audits, non-agent/node/system work, source-advanced/post-T facts,
+      runtime restart state, and CLI/API/dashboard/Builder state are lineage-only, fail-closed blockers, split siblings,
+      or consumers; they MUST NOT become selected-fork recipient truth, executable fork work, or fork suppressors. This
+      child MUST NOT use store.run_fork.delivery_event_replay as-is when that writer preserves source subscriber
+      recipients, MUST NOT treat runtime.run_fork.selected_contract_execution as full replay/resume proof, and MUST NOT
+      make CLI/API/dashboard/Builder semantic owners. Product-complete #564 historical replay/resume remains open.'
     historical_replay_delivery_event_replay_execution: 'The first mutating historical replay execution child is owned by
       runtime.run_fork.historical_replay_execution and is limited to the already-admitted
       delivery_event_replay_ready primitive. It consumes runtime.run_fork.historical_replay_execution_admission before
@@ -3589,6 +3609,14 @@ run_model:
         fact families explicit as fail-closed blockers or split siblings. Its current supported mutation scope is only
         delivery_event_replay_ready; this closes canonical owner promotion, not product-complete historical replay/resume
         for every future fact family.'
+      3j2_historical_replay_contract_swap_boot_resume_execution: 'For selected or swapped contracts, the bounded
+        mutating contract-swap boot/resume child is
+        runtime.run_fork.historical_replay_execution.contract_swap_boot_resume. It consumes the promoted historical
+        replay owner plus contract-swap admission, selected binding/admission, selected route topology, selected
+        recipient planning, and selected route recovery. It may execute only owner-authorized delivery_event_replay_ready
+        work, and recipients must come from selected recipient planning rather than source delivery subscribers. Timers,
+        routes beyond selected recovery, sessions, turns, audits, non-agent work, source outcomes, restart recovery, and
+        operator surfaces remain lineage-only, fail-closed, or split siblings under #564/#549/#618.'
       3k_historical_replay_delivery_event_replay_execution: 'For the first mutating historical replay child,
         runtime.run_fork.historical_replay_execution consumes a concrete historical replay execution admission and may
         execute only the delivery_event_replay_ready primitive. It creates fresh fork-local event/delivery rows and

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -295,6 +295,7 @@ nodes:
       - historical replay execution admission must classify event deliveries, receipts, dead letters, retry/idempotency state, emitted follow-ups, and non-agent work before any future replay mutation; source delivery/outcome rows must remain lineage, blockers, or split siblings
       - historical replay delivery/event replay mutation must be owned by runtime.run_fork.historical_replay_execution consuming event_deliveries executable-fork-work admission before the store delivery replay primitive writes fork-local rows
       - historical replay delivery/event replay restart and sweeper recovery must consume #633 fork-local event, delivery, and committed replay-scope rows through the persisted replay owner; source deliveries, current subscriptions, source receipts, and source dead letters are not recovery truth or suppressors
+      - contract-swap historical replay execution must consume runtime.run_fork.historical_replay_execution plus selected recipient planning before EventBus.Publish writes selected fork deliveries; source delivery subscribers remain lineage only and store.run_fork.delivery_event_replay is not sufficient for selected recipient truth
     representative_issues:
       - 112
       - 144
@@ -311,6 +312,7 @@ nodes:
       - 631
       - 633
       - 635
+      - 639
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -355,6 +357,7 @@ nodes:
       - historical replay delivery/event replay mutation must consume runtime.run_fork.historical_replay_execution_admission and runtime.run_fork.historical_replay_execution before store.run_fork.delivery_event_replay writes fresh fork-local rows; activation/store must not directly authorize delivery_event_replay_ready mutation
       - historical replay delivery/event replay recovery must prove startup RecoveryManager and EventBus.SweepUndispatched recover the fork-local rows produced by runtime.run_fork.historical_replay_execution, with source rows/outcomes as lineage only and broader replay/resume siblings still split
       - broad historical replay execution owner promotion must make runtime.run_fork.historical_replay_execution the canonical mutating authority that emits executable work identities after validating the full fact matrix; store activation and delivery-event replay writers must consume that owner rather than selecting source deliveries from replay_resume_admission or RunForkPlan directly
+      - contract-swap historical replay execution needs runtime.run_fork.historical_replay_execution.contract_swap_boot_resume as the selected-contract child owner for already-admitted delivery_event_replay_ready work; selected recipient planning owns fork recipients, source delivery subscribers are lineage only, and timers/routes/sessions/turns/audits/non-agent/restart/API siblings stay fail-closed or split
     representative_issues:
       - 564
       - 565
@@ -382,6 +385,7 @@ nodes:
       - 631
       - 633
       - 635
+      - 639
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -74,43 +74,19 @@ set -eu
 capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
 captured="$capture_dir/$$.stdin"
 cat > "$captured"
-state_file="$capture_dir/state"
-state=0
-if [ -f "$state_file" ]; then
-  state="$(cat "$state_file")"
-fi
-case "$state" in
-0)
-  printf '%s' 1 > "$state_file"
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+if grep -q '"name":"emit_category_assessed"' "$captured" && grep -q '"ok":true' "$captured"; then
+  printf '%s\n' '{"type":"result","result":"done"}'
   exit 0
-  ;;
-1)
-  if ! grep -q '"name":"read_file"' "$captured" || ! grep -q '"ok":true' "$captured"; then
-    printf '%s\n' '{"type":"result","result":"missing read_file result"}'
-    exit 0
-  fi
-  printf '%s' 2 > "$state_file"
+fi
+if grep -q '"name":"read_file"' "$captured" && grep -q '"ok":true' "$captured"; then
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
   exit 0
-  ;;
-2)
-  if ! grep -q '"name":"emit_category_assessed"' "$captured" || ! grep -q '"ok":true' "$captured"; then
-    printf '%s\n' '{"type":"result","result":"missing emit_category_assessed result"}'
-    exit 0
-  fi
-  printf '%s' 3 > "$state_file"
-  printf '%s\n' '{"type":"result","result":"done"}'
-  exit 0
-  ;;
-*)
-  printf '%s\n' '{"type":"result","result":"done"}'
-  exit 0
-  ;;
-esac
+fi
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -27,10 +27,13 @@ type SelectedContractActivationGateRequest struct {
 
 type SelectedContractActivationGateResult struct {
 	store.RunForkActivation
-	Owner                              string                                           `json:"selected_contract_activation_gate_owner,omitempty"`
-	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
-	ContractSwapBootResumeAdmission    *store.RunForkContractSwapBootResumeAdmission    `json:"contract_swap_boot_resume_admission,omitempty"`
-	HistoricalReplayExecutionAdmission *store.RunForkHistoricalReplayExecutionAdmission `json:"historical_replay_execution_admission,omitempty"`
+	Owner                              string                                               `json:"selected_contract_activation_gate_owner,omitempty"`
+	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission     `json:"selected_contract_execution_admission,omitempty"`
+	ContractSwapBootResumeAdmission    *store.RunForkContractSwapBootResumeAdmission        `json:"contract_swap_boot_resume_admission,omitempty"`
+	HistoricalReplayExecutionAdmission *store.RunForkHistoricalReplayExecutionAdmission     `json:"historical_replay_execution_admission,omitempty"`
+	ContractSwapBootResumeExecution    *store.RunForkHistoricalReplayContractSwapBootResume `json:"contract_swap_boot_resume_execution,omitempty"`
+	ExecutedEventCount                 int                                                  `json:"executed_event_count,omitempty"`
+	ForkEvents                         []SelectedContractExecutionForkEvent                 `json:"fork_events,omitempty"`
 }
 
 func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractActivationGateRequest) (SelectedContractActivationGateResult, error) {
@@ -120,6 +123,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if ok {
 		routeRecovery = &recoveredRoute
 	}
+	pgStore, _ := req.Store.(*store.PostgresStore)
 	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
 		SelectedExecutionAdmission: admission,
 		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
@@ -147,7 +151,85 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		return result, fmt.Errorf("selected-contract activation gate requires execution-ready plan before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))
 	}
 	if plan.ReplayResumeAdmission.DeliveryEventReplayReady {
-		return result, fmt.Errorf("%s: selected-bound activation cannot consume source delivery/event replay as selected-contract executable work", store.RunForkBlockerSelectedContractSourceReplayUnsupported)
+		if pgStore == nil {
+			return result, fmt.Errorf("%s requires postgres store", store.RunForkHistoricalReplayContractSwapBootResumeOwner)
+		}
+		if routeRecovery == nil {
+			record, err := pgStore.RecordRunForkSelectedContractRouteRecovery(ctx, store.RunForkSelectedContractRouteRecoveryRequest{
+				ForkRunID:         forkRunID,
+				SourceRunID:       binding.SourceRunID,
+				ForkEventID:       binding.ForkEventID,
+				ContractSelection: binding.ContractSelection,
+				RouteTopology:     routeTopology,
+				RecipientPlanning: *model.RecipientPlanning,
+			})
+			if err != nil {
+				return result, fmt.Errorf("record selected-contract route recovery for contract-swap execution: %w", err)
+			}
+			routeRecovery = &record
+			contractSwapAdmission, err = BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+				SelectedExecutionAdmission: admission,
+				ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+				RouteRecovery:              routeRecovery,
+			})
+			if err != nil {
+				return result, err
+			}
+			historicalReplayAdmission, err = BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+				ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+				SelectedExecutionAdmission: admission,
+				ContractSwapAdmission:      contractSwapAdmission,
+				RouteRecovery:              routeRecovery,
+			})
+			if err != nil {
+				return result, err
+			}
+			result.ContractSwapBootResumeAdmission = &contractSwapAdmission
+			result.HistoricalReplayExecutionAdmission = &historicalReplayAdmission
+		}
+		historicalReplayExecution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+			Admission:             historicalReplayAdmission,
+			ReplayResumeAdmission: plan.ReplayResumeAdmission,
+			PendingWork:           plan.PendingWork,
+		})
+		if err != nil {
+			return result, err
+		}
+		contractSwapExecution, err := BuildHistoricalReplayContractSwapBootResumeExecution(HistoricalReplayContractSwapBootResumeRequest{
+			SelectedExecutionAdmission: admission,
+			ContractSwapAdmission:      contractSwapAdmission,
+			HistoricalReplayAdmission:  historicalReplayAdmission,
+			HistoricalReplayExecution:  historicalReplayExecution,
+			RouteRecovery:              routeRecovery,
+		})
+		if err != nil {
+			return result, err
+		}
+		result.ContractSwapBootResumeExecution = &contractSwapExecution
+		sourceEventIDs := contractSwapBootResumeSourceEvents(contractSwapExecution)
+		published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
+			Store:             pgStore,
+			LoadedSource:      loadedSource,
+			RecipientPlanning: *model.RecipientPlanning,
+			SourceRunID:       binding.SourceRunID,
+			ForkRunID:         forkRunID,
+			SourceEvents:      sourceEventIDs,
+			ExecutionOwner:    store.RunForkHistoricalReplayContractSwapBootResumeOwner,
+		})
+		result.ExecutedEventCount = len(published)
+		result.ForkEvents = published
+		if err != nil {
+			return result, cleanupSelectedContractExecutionFailure(ctx, pgStore, forkRunID, err)
+		}
+		activation, err := pgStore.ActivateRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionActivateRequest{
+			ForkRunID:             forkRunID,
+			AllowedSourceEventIDs: sourceEventIDs,
+		})
+		result.RunForkActivation = activation
+		if err != nil {
+			return result, cleanupSelectedContractExecutionFailure(ctx, pgStore, forkRunID, err)
+		}
+		return result, nil
 	}
 	if plan.ReplayResumeAdmission.HistoricalReplayRequired {
 		return result, fmt.Errorf("selected-contract activation gate blocks historical replay before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -94,7 +94,7 @@ func TestActivateSelectedContractRunForkConsumesAdmissionBeforeStateOnlyActivati
 	}
 }
 
-func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMutation(t *testing.T) {
+func TestActivateSelectedContractRunForkRequiresConcreteStoreForReplayMutation(t *testing.T) {
 	forkRunID := uuid.NewString()
 	binding := testSelectedContractBinding(forkRunID)
 	plan := testSelectedContractStateOnlyPlan(binding)
@@ -102,9 +102,11 @@ func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMuta
 	plan.PendingWorkCount = 1
 	plan.PendingWork = []store.RunForkPendingWork{{
 		EventID:        uuid.NewString(),
+		DeliveryID:     uuid.NewString(),
 		EventName:      "work.begin",
 		SubscriberType: "agent",
 		SubscriberID:   "safe-agent",
+		Status:         "pending",
 		Classification: store.RunForkPendingClassificationPending,
 		CreatedAt:      time.Unix(1700001000, 0).UTC(),
 	}}
@@ -122,8 +124,8 @@ func TestActivateSelectedContractRunForkBlocksReplayableSourceDeliveryBeforeMuta
 		Store:        fakeStore,
 		SourceLoader: loader,
 	})
-	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerSelectedContractSourceReplayUnsupported) {
-		t.Fatalf("err = %v, want selected source replay blocker", err)
+	if err == nil || !strings.Contains(err.Error(), store.RunForkHistoricalReplayContractSwapBootResumeOwner) {
+		t.Fatalf("err = %v, want concrete store requirement for contract-swap historical replay execution", err)
 	}
 	if fakeStore.activateCalled {
 		t.Fatal("ActivateRunFork called, want fail closed before mutation")

--- a/internal/runtime/runforkexecution/contract_swap_admission.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission.go
@@ -68,7 +68,7 @@ func BuildContractSwapBootResumeAdmission(req ContractSwapBootResumeAdmissionReq
 		Owner:                           store.RunForkContractSwapBootResumeAdmissionOwner,
 		NonMutating:                     true,
 		BootResumeSupported:             false,
-		FutureExecutionOwner:            store.RunForkSelectedContractExecutionOwner + ".contract_swap_boot_resume",
+		FutureExecutionOwner:            store.RunForkHistoricalReplayContractSwapBootResumeOwner,
 		ForkRunID:                       selectedAdmission.ForkRunID,
 		SourceRunID:                     selectedAdmission.SourceRunID,
 		ForkEventID:                     selectedAdmission.ForkEventID,
@@ -183,7 +183,7 @@ func contractSwapBootResumeBlockedSiblings() []store.RunForkSelectedContractExec
 		{
 			Concept:     "mutating_contract_swap_boot_resume",
 			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
-			Owner:       store.RunForkSelectedContractExecutionOwner + ".contract_swap_boot_resume",
+			Owner:       store.RunForkHistoricalReplayContractSwapBootResumeOwner,
 			Reason:      "this admission owner classifies readiness only; handler execution and fork-local writes remain separately gated",
 		},
 		{

--- a/internal/runtime/runforkexecution/contract_swap_admission_test.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission_test.go
@@ -38,7 +38,8 @@ func TestBuildContractSwapBootResumeAdmissionConsumesCanonicalPrerequisites(t *t
 	}
 	if admission.Owner != store.RunForkContractSwapBootResumeAdmissionOwner ||
 		!admission.NonMutating ||
-		admission.BootResumeSupported {
+		admission.BootResumeSupported ||
+		admission.FutureExecutionOwner != store.RunForkHistoricalReplayContractSwapBootResumeOwner {
 		t.Fatalf("admission ownership = %#v", admission)
 	}
 	if admission.SelectedBindingOwner != store.RunForkSelectedContractBindingOwner ||

--- a/internal/runtime/runforkexecution/contract_swap_execution.go
+++ b/internal/runtime/runforkexecution/contract_swap_execution.go
@@ -1,0 +1,303 @@
+package runforkexecution
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type HistoricalReplayContractSwapBootResumeRequest struct {
+	SelectedExecutionAdmission store.RunForkSelectedContractExecutionAdmission
+	ContractSwapAdmission      store.RunForkContractSwapBootResumeAdmission
+	HistoricalReplayAdmission  store.RunForkHistoricalReplayExecutionAdmission
+	HistoricalReplayExecution  store.RunForkHistoricalReplayExecution
+	RouteRecovery              *store.RunForkSelectedContractRouteRecovery
+}
+
+func BuildHistoricalReplayContractSwapBootResumeExecution(req HistoricalReplayContractSwapBootResumeRequest) (store.RunForkHistoricalReplayContractSwapBootResume, error) {
+	selectedAdmission := req.SelectedExecutionAdmission
+	if err := validateContractSwapSelectedExecutionAdmission(selectedAdmission); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, fmt.Errorf("contract-swap historical replay execution selected prerequisite: %w", err)
+	}
+	contractSwapAdmission := req.ContractSwapAdmission
+	if err := validateContractSwapExecutionAdmission(selectedAdmission, contractSwapAdmission); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, err
+	}
+	historicalAdmission := req.HistoricalReplayAdmission
+	if err := validateContractSwapHistoricalReplayAdmission(selectedAdmission, contractSwapAdmission, historicalAdmission); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, err
+	}
+	if req.RouteRecovery == nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, fmt.Errorf("contract-swap historical replay execution requires %s route recovery", store.RunForkSelectedContractRouteRecoveryOwner)
+	}
+	if err := validateContractSwapRouteRecovery(selectedAdmission, *req.RouteRecovery); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, fmt.Errorf("contract-swap historical replay execution route recovery prerequisite: %w", err)
+	}
+	historicalExecution := req.HistoricalReplayExecution
+	if err := validateContractSwapHistoricalReplayExecution(historicalAdmission, historicalExecution); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, err
+	}
+	if err := validateContractSwapFactMatrix(historicalExecution.FactAdmissions); err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, err
+	}
+	work, err := contractSwapExecutableWork(historicalExecution.DeliveryEventReplayWork, selectedAdmission.RecipientPlanning)
+	if err != nil {
+		return store.RunForkHistoricalReplayContractSwapBootResume{}, err
+	}
+
+	return store.RunForkHistoricalReplayContractSwapBootResume{
+		Owner:                                   store.RunForkHistoricalReplayContractSwapBootResumeOwner,
+		ParentHistoricalReplayExecutionOwner:    historicalExecution.Owner,
+		HistoricalReplayExecutionAdmissionOwner: historicalAdmission.Owner,
+		ContractSwapAdmissionOwner:              contractSwapAdmission.Owner,
+		SelectedExecutionAdmissionOwner:         selectedAdmission.Owner,
+		SelectedBindingOwner:                    selectedAdmission.ContractBindingOwner,
+		RouteTopologyOwner:                      selectedAdmission.RouteTopology.Owner,
+		RouteRecoveryOwner:                      req.RouteRecovery.Owner,
+		RuntimeRouteRecoveryOwner:               req.RouteRecovery.RuntimeRecoveryOwner,
+		RecipientPlanningOwner:                  selectedAdmission.RecipientPlanning.Owner,
+		ForkRunID:                               selectedAdmission.ForkRunID,
+		SourceRunID:                             selectedAdmission.SourceRunID,
+		ForkEventID:                             selectedAdmission.ForkEventID,
+		ContractSelection:                       selectedAdmission.ContractSelection,
+		ClosureLevel:                            "contract_swap_boot_resume_delivery_event_replay_ready_first_slice",
+		DeliveryEventReplayReady:                true,
+		ExecutableWork:                          work,
+		FactAdmissions:                          append([]store.RunForkHistoricalReplayFactAdmission(nil), historicalExecution.FactAdmissions...),
+		RequiredConsumers:                       contractSwapExecutionRequiredConsumers(),
+		BlockedSiblings:                         contractSwapExecutionBlockedSiblings(historicalExecution.BlockedSiblings),
+		InvalidPaths:                            contractSwapExecutionInvalidPaths(historicalExecution.InvalidPaths),
+	}, nil
+}
+
+func validateContractSwapExecutionAdmission(selectedAdmission store.RunForkSelectedContractExecutionAdmission, admission store.RunForkContractSwapBootResumeAdmission) error {
+	if strings.TrimSpace(admission.Owner) != store.RunForkContractSwapBootResumeAdmissionOwner {
+		return fmt.Errorf("contract-swap historical replay execution requires %s; got %q", store.RunForkContractSwapBootResumeAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating || admission.BootResumeSupported {
+		return fmt.Errorf("contract-swap historical replay execution consumes non-mutating contract-swap admission only")
+	}
+	if strings.TrimSpace(admission.FutureExecutionOwner) != store.RunForkHistoricalReplayContractSwapBootResumeOwner {
+		return fmt.Errorf("contract-swap historical replay execution requires future owner %s; got %q", store.RunForkHistoricalReplayContractSwapBootResumeOwner, admission.FutureExecutionOwner)
+	}
+	if strings.TrimSpace(admission.SelectedExecutionAdmissionOwner) != selectedAdmission.Owner ||
+		strings.TrimSpace(admission.SelectedBindingOwner) != selectedAdmission.ContractBindingOwner ||
+		strings.TrimSpace(admission.ForkRunID) != strings.TrimSpace(selectedAdmission.ForkRunID) ||
+		strings.TrimSpace(admission.SourceRunID) != strings.TrimSpace(selectedAdmission.SourceRunID) ||
+		strings.TrimSpace(admission.ForkEventID) != strings.TrimSpace(selectedAdmission.ForkEventID) {
+		return fmt.Errorf("contract-swap historical replay execution admission identity does not match selected execution admission")
+	}
+	return nil
+}
+
+func validateContractSwapHistoricalReplayAdmission(
+	selectedAdmission store.RunForkSelectedContractExecutionAdmission,
+	contractSwapAdmission store.RunForkContractSwapBootResumeAdmission,
+	admission store.RunForkHistoricalReplayExecutionAdmission,
+) error {
+	if strings.TrimSpace(admission.Owner) != store.RunForkHistoricalReplayExecutionAdmissionOwner {
+		return fmt.Errorf("contract-swap historical replay execution requires %s; got %q", store.RunForkHistoricalReplayExecutionAdmissionOwner, admission.Owner)
+	}
+	if !admission.NonMutating || admission.ExecutionSupported {
+		return fmt.Errorf("contract-swap historical replay execution consumes non-mutating historical replay admission only")
+	}
+	if strings.TrimSpace(admission.FutureExecutionOwner) != store.RunForkHistoricalReplayExecutionOwner {
+		return fmt.Errorf("contract-swap historical replay execution requires parent future owner %s; got %q", store.RunForkHistoricalReplayExecutionOwner, admission.FutureExecutionOwner)
+	}
+	if strings.TrimSpace(admission.ContractSwapAdmissionOwner) != contractSwapAdmission.Owner ||
+		strings.TrimSpace(admission.SelectedExecutionAdmissionOwner) != selectedAdmission.Owner ||
+		strings.TrimSpace(admission.SelectedBindingOwner) != selectedAdmission.ContractBindingOwner ||
+		strings.TrimSpace(admission.RouteTopologyOwner) != store.RunForkSelectedContractRouteTopologyOwner ||
+		strings.TrimSpace(admission.RecipientPlanningOwner) != store.RunForkSelectedContractRecipientPlanningOwner ||
+		strings.TrimSpace(admission.RouteRecoveryOwner) != store.RunForkSelectedContractRoutePersistenceOwner ||
+		strings.TrimSpace(admission.RuntimeRouteRecoveryOwner) != store.RunForkSelectedContractRouteRecoveryOwner {
+		return fmt.Errorf("contract-swap historical replay execution historical admission owner consumption is incomplete")
+	}
+	if strings.TrimSpace(admission.ForkRunID) != strings.TrimSpace(selectedAdmission.ForkRunID) ||
+		strings.TrimSpace(admission.SourceRunID) != strings.TrimSpace(selectedAdmission.SourceRunID) ||
+		strings.TrimSpace(admission.ForkEventID) != strings.TrimSpace(selectedAdmission.ForkEventID) {
+		return fmt.Errorf("contract-swap historical replay execution historical admission identity mismatch")
+	}
+	return nil
+}
+
+func validateContractSwapHistoricalReplayExecution(admission store.RunForkHistoricalReplayExecutionAdmission, execution store.RunForkHistoricalReplayExecution) error {
+	if strings.TrimSpace(execution.Owner) != store.RunForkHistoricalReplayExecutionOwner {
+		return fmt.Errorf("contract-swap historical replay execution requires parent owner %s; got %q", store.RunForkHistoricalReplayExecutionOwner, execution.Owner)
+	}
+	if strings.TrimSpace(execution.AdmissionOwner) != admission.Owner ||
+		strings.TrimSpace(execution.ReplayResumeAdmissionOwner) != admission.ReplayResumeAdmissionOwner ||
+		strings.TrimSpace(execution.ForkRunID) != strings.TrimSpace(admission.ForkRunID) ||
+		strings.TrimSpace(execution.SourceRunID) != strings.TrimSpace(admission.SourceRunID) ||
+		strings.TrimSpace(execution.ForkEventID) != strings.TrimSpace(admission.ForkEventID) {
+		return fmt.Errorf("contract-swap historical replay execution parent execution identity mismatch")
+	}
+	if execution.FullReplayResumeSupported {
+		return fmt.Errorf("contract-swap historical replay execution first slice cannot consume full replay/resume execution")
+	}
+	if !execution.DeliveryEventReplayReady ||
+		execution.EventDeliveriesAdmission.Fact != store.RunForkHistoricalReplayFactEventDeliveries ||
+		execution.EventDeliveriesAdmission.Admission != store.RunForkHistoricalReplayAdmissionExecutableForkWork ||
+		len(execution.DeliveryEventReplayWork) == 0 {
+		return fmt.Errorf("contract-swap historical replay execution requires owner-authorized delivery_event_replay_ready work")
+	}
+	return nil
+}
+
+func validateContractSwapFactMatrix(admissions []store.RunForkHistoricalReplayFactAdmission) error {
+	for _, admission := range admissions {
+		if strings.TrimSpace(admission.Fact) == store.RunForkHistoricalReplayFactEventDeliveries {
+			if strings.TrimSpace(admission.Admission) != store.RunForkHistoricalReplayAdmissionExecutableForkWork {
+				return fmt.Errorf("contract-swap historical replay execution requires event_deliveries executable fork work")
+			}
+			continue
+		}
+		if strings.TrimSpace(admission.Admission) == store.RunForkHistoricalReplayAdmissionExecutableForkWork {
+			return fmt.Errorf("contract-swap historical replay execution cannot execute unsupported fact family %s", admission.Fact)
+		}
+		if strings.TrimSpace(admission.Admission) == store.RunForkHistoricalReplayAdmissionFailClosedBlocker {
+			return fmt.Errorf("contract-swap historical replay execution blocked by fact family %s: %s", admission.Fact, admission.BlockerCode)
+		}
+	}
+	return nil
+}
+
+func contractSwapExecutableWork(
+	historicalWork []store.RunForkHistoricalReplayExecutableWork,
+	planning *store.RunForkSelectedContractRecipientPlanning,
+) ([]store.RunForkHistoricalReplayContractSwapWork, error) {
+	if planning == nil || strings.TrimSpace(planning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return nil, fmt.Errorf("contract-swap historical replay execution requires %s", store.RunForkSelectedContractRecipientPlanningOwner)
+	}
+	planBySourceEvent := map[string]store.RunForkSelectedContractRecipientPlanEvent{}
+	for _, event := range planning.RecipientPlanEvents {
+		sourceEventID := strings.TrimSpace(event.SourceEventID)
+		if sourceEventID == "" {
+			continue
+		}
+		if len(event.Recipients) == 0 {
+			return nil, fmt.Errorf("contract-swap historical replay execution source event %s has no selected recipients", sourceEventID)
+		}
+		planBySourceEvent[sourceEventID] = event
+	}
+
+	byEvent := map[string]*store.RunForkHistoricalReplayContractSwapWork{}
+	seenDeliveries := map[string]struct{}{}
+	for _, item := range historicalWork {
+		if item.Fact != store.RunForkHistoricalReplayFactEventDeliveries {
+			return nil, fmt.Errorf("contract-swap historical replay execution cannot consume historical work fact %q", item.Fact)
+		}
+		sourceEventID := strings.TrimSpace(item.SourceEventID)
+		sourceDeliveryID := strings.TrimSpace(item.SourceDeliveryID)
+		if sourceEventID == "" || sourceDeliveryID == "" {
+			return nil, fmt.Errorf("contract-swap historical replay execution requires source event and delivery lineage identity")
+		}
+		if _, exists := seenDeliveries[sourceDeliveryID]; exists {
+			return nil, fmt.Errorf("contract-swap historical replay execution duplicate source delivery %s", sourceDeliveryID)
+		}
+		seenDeliveries[sourceDeliveryID] = struct{}{}
+		plan, ok := planBySourceEvent[sourceEventID]
+		if !ok {
+			return nil, fmt.Errorf("contract-swap historical replay execution has no selected recipient plan for source event %s", sourceEventID)
+		}
+		work, ok := byEvent[sourceEventID]
+		if !ok {
+			work = &store.RunForkHistoricalReplayContractSwapWork{
+				Fact:               store.RunForkHistoricalReplayFactEventDeliveries,
+				SourceEventID:      sourceEventID,
+				EventName:          strings.TrimSpace(plan.EventName),
+				SelectedRecipients: append([]store.RunForkContractFrontierRecipient(nil), plan.Recipients...),
+				Classification:     strings.TrimSpace(item.Classification),
+				ReasonCode:         strings.TrimSpace(item.ReasonCode),
+				SourceDeliveryIDs:  []string{},
+			}
+			byEvent[sourceEventID] = work
+		}
+		if strings.TrimSpace(work.EventName) != strings.TrimSpace(plan.EventName) {
+			return nil, fmt.Errorf("contract-swap historical replay execution event name mismatch for source event %s", sourceEventID)
+		}
+		work.SourceDeliveryIDs = append(work.SourceDeliveryIDs, sourceDeliveryID)
+	}
+	out := make([]store.RunForkHistoricalReplayContractSwapWork, 0, len(byEvent))
+	for _, work := range byEvent {
+		sort.Strings(work.SourceDeliveryIDs)
+		out = append(out, *work)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].SourceEventID < out[j].SourceEventID
+	})
+	if len(out) == 0 {
+		return nil, fmt.Errorf("contract-swap historical replay execution requires executable selected work")
+	}
+	return out, nil
+}
+
+func contractSwapExecutionRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "historical_replay_execution",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkHistoricalReplayExecutionOwner,
+			Reason:      "contract-swap boot/resume consumes owner-authorized historical replay work before mutation",
+		},
+		{
+			Concept:     "selected_recipient_planning",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+			Reason:      "selected recipient planning, not source delivery subscribers, owns selected-fork recipient truth",
+		},
+		{
+			Concept:     "eventbus_publish",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       "internal/runtime/bus.EventBus.Publish",
+			Reason:      "fork-local event, delivery, receipt, and follow-up writes must pass through normal selected-contract publish and pipeline execution",
+		},
+	}
+}
+
+func contractSwapExecutionBlockedSiblings(items []store.RunForkSelectedContractExecutionBoundary) []store.RunForkSelectedContractExecutionBoundary {
+	out := append([]store.RunForkSelectedContractExecutionBoundary(nil), items...)
+	out = append(out,
+		store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "full_historical_replay_resume",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkHistoricalReplayExecutionOwner,
+			Reason:      "this child closes only selected-contract execution of delivery_event_replay_ready work; full #564 replay/resume remains open",
+		},
+		store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "timers_sessions_turns_audits_non_agent_restart_api",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Reason:      "unsupported source fact families remain fail-closed or split siblings and are not silently replayed",
+		},
+	)
+	return out
+}
+
+func contractSwapExecutionInvalidPaths(items []store.RunForkSelectedContractExecutionBoundary) []store.RunForkSelectedContractExecutionBoundary {
+	out := append([]store.RunForkSelectedContractExecutionBoundary(nil), items...)
+	out = append(out,
+		store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "source_subscriber_as_selected_recipient",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source delivery subscriber identity is lineage only; selected recipient planning owns fork delivery recipients",
+		},
+		store.RunForkSelectedContractExecutionBoundary{
+			Concept:     "store_delivery_event_replay_as_contract_swap_owner",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "the generic delivery replay writer preserves source subscribers and cannot own selected-contract boot/resume",
+		},
+	)
+	return out
+}
+
+func contractSwapBootResumeSourceEvents(execution store.RunForkHistoricalReplayContractSwapBootResume) []string {
+	out := make([]string, 0, len(execution.ExecutableWork))
+	for _, item := range execution.ExecutableWork {
+		if eventID := strings.TrimSpace(item.SourceEventID); eventID != "" {
+			out = append(out, eventID)
+		}
+	}
+	return out
+}

--- a/internal/runtime/runforkexecution/contract_swap_execution_test.go
+++ b/internal/runtime/runforkexecution/contract_swap_execution_test.go
@@ -1,0 +1,164 @@
+package runforkexecution
+
+import (
+	"strings"
+	"testing"
+
+	"swarm/internal/store"
+)
+
+func TestBuildHistoricalReplayContractSwapBootResumeConsumesOwnersAndSelectedRecipients(t *testing.T) {
+	selectedAdmission, contractSwapAdmission, historicalAdmission, historicalExecution, routeRecovery := testContractSwapExecutionInputs(t)
+
+	execution, err := BuildHistoricalReplayContractSwapBootResumeExecution(HistoricalReplayContractSwapBootResumeRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		HistoricalReplayAdmission:  historicalAdmission,
+		HistoricalReplayExecution:  historicalExecution,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayContractSwapBootResumeExecution: %v", err)
+	}
+	if execution.Owner != store.RunForkHistoricalReplayContractSwapBootResumeOwner ||
+		execution.ParentHistoricalReplayExecutionOwner != store.RunForkHistoricalReplayExecutionOwner ||
+		execution.HistoricalReplayExecutionAdmissionOwner != store.RunForkHistoricalReplayExecutionAdmissionOwner ||
+		execution.ContractSwapAdmissionOwner != store.RunForkContractSwapBootResumeAdmissionOwner ||
+		execution.SelectedExecutionAdmissionOwner != store.RunForkSelectedContractExecutionAdmissionOwner ||
+		execution.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		execution.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		!execution.DeliveryEventReplayReady {
+		t.Fatalf("owner consumption = %#v", execution)
+	}
+	if len(execution.ExecutableWork) != 1 ||
+		execution.ExecutableWork[0].SourceEventID != "source-event" ||
+		len(execution.ExecutableWork[0].SourceDeliveryIDs) != 2 ||
+		len(execution.ExecutableWork[0].SelectedRecipients) != 1 ||
+		execution.ExecutableWork[0].SelectedRecipients[0].SubscriberID != "selected-node" {
+		t.Fatalf("executable work = %#v, want selected recipient-plan work grouped by source event", execution.ExecutableWork)
+	}
+	if execution.ExecutableWork[0].SelectedRecipients[0].SubscriberID == "source-agent" {
+		t.Fatalf("source subscriber leaked into selected recipient truth: %#v", execution.ExecutableWork[0])
+	}
+	if !executionBoundaryHas(execution.InvalidPaths, "source_subscriber_as_selected_recipient", store.RunForkSelectedContractDispositionInvalid) ||
+		!executionBoundaryHas(execution.BlockedSiblings, "full_historical_replay_resume", store.RunForkSelectedContractDispositionBlockedSibling) {
+		t.Fatalf("boundaries invalid=%#v blocked=%#v", execution.InvalidPaths, execution.BlockedSiblings)
+	}
+}
+
+func TestBuildHistoricalReplayContractSwapBootResumeRejectsSourceSubscriberFallback(t *testing.T) {
+	selectedAdmission, contractSwapAdmission, historicalAdmission, historicalExecution, routeRecovery := testContractSwapExecutionInputs(t)
+	selectedAdmission.RecipientPlanning.RecipientPlanEvents = nil
+
+	_, err := BuildHistoricalReplayContractSwapBootResumeExecution(HistoricalReplayContractSwapBootResumeRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		HistoricalReplayAdmission:  historicalAdmission,
+		HistoricalReplayExecution:  historicalExecution,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected recipient plan") {
+		t.Fatalf("error = %v, want selected recipient planning failure instead of source subscriber fallback", err)
+	}
+}
+
+func TestBuildHistoricalReplayContractSwapBootResumeRejectsFailClosedSiblingFact(t *testing.T) {
+	selectedAdmission, contractSwapAdmission, historicalAdmission, historicalExecution, routeRecovery := testContractSwapExecutionInputs(t)
+	historicalExecution.FactAdmissions = append([]store.RunForkHistoricalReplayFactAdmission(nil), historicalExecution.FactAdmissions...)
+	for i := range historicalExecution.FactAdmissions {
+		if historicalExecution.FactAdmissions[i].Fact == store.RunForkHistoricalReplayFactTimers {
+			historicalExecution.FactAdmissions[i].Admission = store.RunForkHistoricalReplayAdmissionFailClosedBlocker
+			historicalExecution.FactAdmissions[i].BlockerCode = store.RunForkBlockerTimerHistoryUnproven
+			break
+		}
+	}
+
+	_, err := BuildHistoricalReplayContractSwapBootResumeExecution(HistoricalReplayContractSwapBootResumeRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		HistoricalReplayAdmission:  historicalAdmission,
+		HistoricalReplayExecution:  historicalExecution,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkHistoricalReplayFactTimers) {
+		t.Fatalf("error = %v, want fail-closed timer sibling blocker", err)
+	}
+}
+
+func testContractSwapExecutionInputs(t *testing.T) (
+	store.RunForkSelectedContractExecutionAdmission,
+	store.RunForkContractSwapBootResumeAdmission,
+	store.RunForkHistoricalReplayExecutionAdmission,
+	store.RunForkHistoricalReplayExecution,
+	store.RunForkSelectedContractRouteRecovery,
+) {
+	t.Helper()
+	selection := testContractSwapSelection()
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(selection)
+	selectedAdmission.RecipientPlanning.RecipientPlanEvents = []store.RunForkSelectedContractRecipientPlanEvent{{
+		SourceEventID: "source-event",
+		EventName:     "work.begin",
+		Recipients: []store.RunForkContractFrontierRecipient{{
+			SubscriberType: "node",
+			SubscriberID:   "selected-node",
+			Path:           "flow-a/selected-node",
+			RouteSource:    "selected_contracts",
+		}},
+		Disposition: store.RunForkSelectedContractDispositionForkLocalTruth,
+	}}
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition: store.RunForkReplayResumeDispositionForkReplay,
+			Message:     "pending unstarted source delivery can be replayed",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+	historicalAdmission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	historicalExecution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission:             historicalAdmission,
+		ReplayResumeAdmission: replayAdmission,
+		PendingWork: []store.RunForkPendingWork{
+			{
+				EventID:        "source-event",
+				EventName:      "work.begin",
+				DeliveryID:     "source-delivery-1",
+				SubscriberType: "agent",
+				SubscriberID:   "source-agent",
+				Status:         "pending",
+				Classification: store.RunForkPendingClassificationPending,
+			},
+			{
+				EventID:        "source-event",
+				EventName:      "work.begin",
+				DeliveryID:     "source-delivery-2",
+				SubscriberType: "agent",
+				SubscriberID:   "other-source-agent",
+				Status:         "pending",
+				Classification: store.RunForkPendingClassificationPending,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecution: %v", err)
+	}
+	return selectedAdmission, contractSwapAdmission, historicalAdmission, historicalExecution, routeRecovery
+}

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -146,6 +146,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		SourceRunID:       plan.SourceRunID,
 		ForkRunID:         materialization.ForkRunID,
 		SourceEvents:      sourceEventIDs,
+		ExecutionOwner:    store.RunForkSelectedContractExecutionOwner,
 	})
 	if err != nil {
 		return SelectedContractExecutionResult{
@@ -217,6 +218,7 @@ type publishSelectedContractForkEventsRequest struct {
 	SourceRunID       string
 	ForkRunID         string
 	SourceEvents      []string
+	ExecutionOwner    string
 }
 
 func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedContractForkEventsRequest) ([]SelectedContractExecutionForkEvent, error) {
@@ -224,7 +226,11 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	if err != nil {
 		return nil, err
 	}
-	guard, err := newSelectedContractRecipientPlanPublishGuard(req.RecipientPlanning)
+	executionOwner := strings.TrimSpace(req.ExecutionOwner)
+	if executionOwner == "" {
+		executionOwner = store.RunForkSelectedContractExecutionOwner
+	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(req.RecipientPlanning, executionOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -243,13 +249,13 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	out := make([]SelectedContractExecutionForkEvent, 0, len(sourceEvents))
 	for _, sourceEvent := range sourceEvents {
 		forkEventID := uuid.NewString()
-		evt := selectedContractForkEvent(req.ForkRunID, forkEventID, sourceEvent)
+		evt := selectedContractForkEvent(req.ForkRunID, forkEventID, sourceEvent, executionOwner)
 		guard.ExpectForkEvent(forkEventID, sourceEvent.SourceEventID)
 		if err := bus.Publish(runCtx, evt); err != nil {
 			return out, fmt.Errorf("execute selected-contract fork event %s as %s: %w", sourceEvent.SourceEventID, forkEventID, err)
 		}
 		lineage := store.RunForkSelectedContractExecutionLineage{
-			Owner:         store.RunForkSelectedContractExecutionLineageOwner,
+			Owner:         executionOwner,
 			ForkRunID:     req.ForkRunID,
 			SourceRunID:   req.SourceRunID,
 			SourceEventID: sourceEvent.SourceEventID,
@@ -269,7 +275,7 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	return out, nil
 }
 
-func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.RunForkSelectedContractSourceEvent) events.Event {
+func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.RunForkSelectedContractSourceEvent, sourceAgent string) events.Event {
 	payload := json.RawMessage("{}")
 	if len(sourceEvent.Payload) > 0 && json.Valid(sourceEvent.Payload) {
 		payload = append(json.RawMessage(nil), sourceEvent.Payload...)
@@ -277,7 +283,7 @@ func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.
 	evt := events.Event{
 		ID:          strings.TrimSpace(forkEventID),
 		Type:        events.EventType(strings.TrimSpace(sourceEvent.EventName)),
-		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+		SourceAgent: strings.TrimSpace(sourceAgent),
 		Payload:     payload,
 		RunID:       strings.TrimSpace(forkRunID),
 		CreatedAt:   time.Now().UTC(),

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -189,6 +189,125 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 	}
 }
 
+func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSelectedRecipients(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+	selection := runforkadmission.SelectedContractSelection(loaded.Source, contractsRoot)
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002600, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET subscriber_type = 'agent',
+		    subscriber_id = 'source-agent-that-must-not-route',
+		    status = 'pending',
+		    retry_count = 0,
+		    reason_code = 'source_pending_agent_delivery',
+		    active_session_id = NULL,
+		    started_at = NULL,
+		    delivered_at = NULL
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, sourceRunID, sourceEventID); err != nil {
+		t.Fatalf("seed replayable source agent delivery: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                sourceEventID,
+		ContractSelection: &selection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+
+	result, err := ActivateSelectedContractRunFork(ctx, SelectedContractActivationGateRequest{
+		ForkRunID:    materialized.ForkRunID,
+		Store:        pg,
+		SourceLoader: loader,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSelectedContractRunFork: %v", err)
+	}
+	if result.ContractSwapBootResumeExecution == nil ||
+		result.ContractSwapBootResumeExecution.Owner != store.RunForkHistoricalReplayContractSwapBootResumeOwner ||
+		result.ContractSwapBootResumeExecution.ParentHistoricalReplayExecutionOwner != store.RunForkHistoricalReplayExecutionOwner ||
+		len(result.ContractSwapBootResumeExecution.ExecutableWork) != 1 {
+		t.Fatalf("contract-swap execution = %#v", result.ContractSwapBootResumeExecution)
+	}
+	if result.ExecutedEventCount != 1 || len(result.ForkEvents) != 1 || !result.Activated {
+		t.Fatalf("activation result = %#v", result)
+	}
+	forkEventID := result.ForkEvents[0].ForkEventID
+
+	var sourceSubscriberDeliveries, forkEventDeliveries int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+		  AND subscriber_id = 'source-agent-that-must-not-route'
+	`, materialized.ForkRunID, forkEventID).Scan(&sourceSubscriberDeliveries); err != nil {
+		t.Fatalf("count source subscriber deliveries: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, materialized.ForkRunID, forkEventID).Scan(&forkEventDeliveries); err != nil {
+		t.Fatalf("count fork event deliveries: %v", err)
+	}
+	if sourceSubscriberDeliveries != 0 || forkEventDeliveries == 0 {
+		t.Fatalf("fork delivery recipients source=%d total=%d, want selected recipient planning without source subscriber", sourceSubscriberDeliveries, forkEventDeliveries)
+	}
+
+	var genericReplayRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_delivery_event_replays
+		WHERE fork_run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&genericReplayRows); err != nil {
+		t.Fatalf("count generic delivery replay rows: %v", err)
+	}
+	if genericReplayRows != 0 {
+		t.Fatalf("generic delivery replay rows = %d, want contract-swap execution to avoid source-subscriber writer", genericReplayRows)
+	}
+
+	var forkReceipts, emittedFollowUps int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, forkEventID).Scan(&forkReceipts); err != nil {
+		t.Fatalf("count fork receipts: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'item.processed'
+		  AND source_event_id = $2::uuid
+	`, materialized.ForkRunID, forkEventID).Scan(&emittedFollowUps); err != nil {
+		t.Fatalf("count emitted follow-ups: %v", err)
+	}
+	if forkReceipts == 0 || emittedFollowUps != 1 {
+		t.Fatalf("fork outcomes receipts=%d followUps=%d, want selected handler execution", forkReceipts, emittedFollowUps)
+	}
+}
+
 func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -545,6 +664,42 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan(t *tes
 	})
 	if err != nil {
 		t.Fatalf("Authorize canonical recipient plan: %v", err)
+	}
+}
+
+func TestSelectedContractRecipientPlanPublishGuardAuthorizesContractSwapOwner(t *testing.T) {
+	frontier := testContractFrontierAdmission(testContractSelection())
+	sourceEventID := frontier.FrontierEvents[0].SourceEventID
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	planning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(planning, store.RunForkHistoricalReplayContractSwapBootResumeOwner)
+	if err != nil {
+		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
+	}
+	guard.ExpectForkEvent("fork-event", sourceEventID)
+
+	err = guard.Authorize(context.Background(), events.Event{
+		ID:          "fork-event",
+		Type:        "work.begin",
+		SourceAgent: store.RunForkHistoricalReplayContractSwapBootResumeOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "alpha-intake",
+			Path:        "flow-a/alpha-intake",
+			RouteSource: "selected_contracts",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Authorize contract-swap owner recipient plan: %v", err)
 	}
 }
 

--- a/internal/runtime/runforkexecution/recipient_planning.go
+++ b/internal/runtime/runforkexecution/recipient_planning.go
@@ -304,11 +304,25 @@ func validateSelectedContractRecipientPlanningForPublish(planning store.RunForkS
 type selectedContractRecipientPlanPublishGuard struct {
 	plansBySourceEvent map[string]store.RunForkSelectedContractRecipientPlanEvent
 	sourceByForkEvent  map[string]string
+	sourceAgents       map[string]struct{}
 }
 
-func newSelectedContractRecipientPlanPublishGuard(planning store.RunForkSelectedContractRecipientPlanning) (*selectedContractRecipientPlanPublishGuard, error) {
+func newSelectedContractRecipientPlanPublishGuard(planning store.RunForkSelectedContractRecipientPlanning, sourceAgents ...string) (*selectedContractRecipientPlanPublishGuard, error) {
 	if err := validateSelectedContractRecipientPlanningForPublish(planning); err != nil {
 		return nil, err
+	}
+	if len(sourceAgents) == 0 {
+		sourceAgents = []string{store.RunForkSelectedContractExecutionOwner}
+	}
+	allowedAgents := map[string]struct{}{}
+	for _, agent := range sourceAgents {
+		agent = strings.TrimSpace(agent)
+		if agent != "" {
+			allowedAgents[agent] = struct{}{}
+		}
+	}
+	if len(allowedAgents) == 0 {
+		return nil, fmt.Errorf("selected-contract recipient planning publish guard requires source-agent owner")
 	}
 	plans := map[string]store.RunForkSelectedContractRecipientPlanEvent{}
 	for _, event := range planning.RecipientPlanEvents {
@@ -321,6 +335,7 @@ func newSelectedContractRecipientPlanPublishGuard(planning store.RunForkSelected
 	return &selectedContractRecipientPlanPublishGuard{
 		plansBySourceEvent: plans,
 		sourceByForkEvent:  map[string]string{},
+		sourceAgents:       allowedAgents,
 	}, nil
 }
 
@@ -340,7 +355,7 @@ func (g *selectedContractRecipientPlanPublishGuard) AuthorizeEvent(ctx context.C
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if strings.TrimSpace(evt.SourceAgent) != store.RunForkSelectedContractExecutionOwner {
+	if !g.authorizesSourceAgent(evt.SourceAgent) {
 		return nil
 	}
 	_, _, err := g.expectedRecipientPlanEvent(evt)
@@ -351,7 +366,7 @@ func (g *selectedContractRecipientPlanPublishGuard) Authorize(ctx context.Contex
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if strings.TrimSpace(evt.SourceAgent) != store.RunForkSelectedContractExecutionOwner {
+	if !g.authorizesSourceAgent(evt.SourceAgent) {
 		return nil
 	}
 	sourceEventID, expected, err := g.expectedRecipientPlanEvent(evt)
@@ -365,6 +380,14 @@ func (g *selectedContractRecipientPlanPublishGuard) Authorize(ctx context.Contex
 		return fmt.Errorf("selected-contract publish routed recipients do not match %s for source event %s", store.RunForkSelectedContractRecipientPlanningOwner, sourceEventID)
 	}
 	return nil
+}
+
+func (g *selectedContractRecipientPlanPublishGuard) authorizesSourceAgent(sourceAgent string) bool {
+	if g == nil {
+		return false
+	}
+	_, ok := g.sourceAgents[strings.TrimSpace(sourceAgent)]
+	return ok
 }
 
 func (g *selectedContractRecipientPlanPublishGuard) expectedRecipientPlanEvent(evt events.Event) (string, store.RunForkSelectedContractRecipientPlanEvent, error) {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -21,6 +21,7 @@ const (
 	RunForkContractSwapBootResumeAdmissionOwner         = "runtime.run_fork.contract_swap_boot_resume_admission"
 	RunForkHistoricalReplayExecutionAdmissionOwner      = "runtime.run_fork.historical_replay_execution_admission"
 	RunForkHistoricalReplayExecutionOwner               = "runtime.run_fork.historical_replay_execution"
+	RunForkHistoricalReplayContractSwapBootResumeOwner  = RunForkHistoricalReplayExecutionOwner + ".contract_swap_boot_resume"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
@@ -289,6 +290,40 @@ type RunForkHistoricalReplayExecution struct {
 	RequiredConsumers          []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
 	BlockedSiblings            []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
 	InvalidPaths               []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+}
+
+type RunForkHistoricalReplayContractSwapBootResume struct {
+	Owner                                   string                                     `json:"owner"`
+	ParentHistoricalReplayExecutionOwner    string                                     `json:"parent_historical_replay_execution_owner"`
+	HistoricalReplayExecutionAdmissionOwner string                                     `json:"historical_replay_execution_admission_owner"`
+	ContractSwapAdmissionOwner              string                                     `json:"contract_swap_admission_owner"`
+	SelectedExecutionAdmissionOwner         string                                     `json:"selected_execution_admission_owner"`
+	SelectedBindingOwner                    string                                     `json:"selected_binding_owner"`
+	RouteTopologyOwner                      string                                     `json:"route_topology_owner"`
+	RouteRecoveryOwner                      string                                     `json:"route_recovery_owner"`
+	RuntimeRouteRecoveryOwner               string                                     `json:"runtime_route_recovery_owner"`
+	RecipientPlanningOwner                  string                                     `json:"recipient_planning_owner"`
+	ForkRunID                               string                                     `json:"fork_run_id"`
+	SourceRunID                             string                                     `json:"source_run_id"`
+	ForkEventID                             string                                     `json:"fork_event_id"`
+	ContractSelection                       RunForkContractSelection                   `json:"contract_selection"`
+	ClosureLevel                            string                                     `json:"closure_level"`
+	DeliveryEventReplayReady                bool                                       `json:"delivery_event_replay_ready"`
+	ExecutableWork                          []RunForkHistoricalReplayContractSwapWork  `json:"executable_work,omitempty"`
+	FactAdmissions                          []RunForkHistoricalReplayFactAdmission     `json:"fact_admissions,omitempty"`
+	RequiredConsumers                       []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings                         []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                            []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+}
+
+type RunForkHistoricalReplayContractSwapWork struct {
+	Fact               string                             `json:"fact"`
+	SourceEventID      string                             `json:"source_event_id"`
+	SourceDeliveryIDs  []string                           `json:"source_delivery_ids"`
+	EventName          string                             `json:"event_name"`
+	SelectedRecipients []RunForkContractFrontierRecipient `json:"selected_recipients,omitempty"`
+	Classification     string                             `json:"classification,omitempty"`
+	ReasonCode         string                             `json:"reason_code,omitempty"`
 }
 
 type RunForkHistoricalReplayExecutionRequest struct {


### PR DESCRIPTION
## Summary

Closes #639.

This PR defines and consumes `runtime.run_fork.historical_replay_execution.contract_swap_boot_resume` as the bounded selected-contract contract-swap historical replay execution child. It executes only owner-authorized `delivery_event_replay_ready` work emitted by `runtime.run_fork.historical_replay_execution`, maps source delivery evidence through selected recipient planning, and publishes through EventBus under the selected contract bundle.

## Governing Refs / Context

Exact spec refs updated and consumed:

- `run_model.fork.contract_swap_boot_resume_admission`
- `run_model.fork.historical_replay_execution_admission`
- `run_model.fork.historical_replay_execution`
- `run_model.fork.historical_replay_contract_swap_boot_resume_execution`
- boot sequence `3j2_historical_replay_contract_swap_boot_resume_execution`

Issue/gate refs:

- #639 pre-audit and independent gate outcome: `approved as first slice`
- #564 remains open for full historical replay/resume
- #549 remains open for broad fork architecture/current-state ownership
- #629 remains the blocked prior narrow gate

## Semantic Migration

New canonical owner:

- `runtime.run_fork.historical_replay_execution.contract_swap_boot_resume`

Old invalid/non-authoritative paths:

- `runtime.run_fork.selected_contract_execution.contract_swap_boot_resume` future-owner string is superseded.
- `runtime.run_fork.contract_swap_boot_resume_admission` remains non-mutating readiness only.
- `store.run_fork.delivery_event_replay` is not used for selected contract-swap execution because it preserves source subscriber identity.

Production paths checked:

- selected-contract activation gate
- contract-swap admission
- historical replay execution admission/execution
- selected recipient planning publish guard
- EventBus publish/pipeline execution
- CLI selected binding activation failure surface

Migration completeness:

- Complete for the #639 first slice: selected-contract execution of already-admitted `delivery_event_replay_ready` work.
- Not product-complete #564 replay/resume; timers, broader routes, sessions, turns, audits, non-agent work, restart recovery, source-outcome policy, and API/dashboard/Builder surfaces remain tracked siblings.

## Validation

- `go test ./internal/runtime/runforkexecution ./internal/store`
- `go test ./cmd/swarm`
- `go test ./...`
