### PR TITLE
[agent-d][issue #638] Add typed accumulator entity projection

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1976,6 +1976,91 @@ accumulator:
 	}
 }
 
+func TestRunVerifyCommand_AllowsAccumulatorEntityProjection(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-accumulator-entity-projection
+version: "1.0.0"
+platform_version: ">=1.1.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: verify-accumulator-entity-projection
+initial_state: collecting
+terminal_states: [complete]
+states: [collecting, complete]
+pins:
+  inputs:
+    events: [score.dimension_complete]
+  outputs:
+    events: [score.completed]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "types.yaml"), `
+types:
+  DimensionScore:
+    dimension: text
+    tier: integer
+    score: integer
+    evidence: text
+    confidence: text
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+vertical:
+  scores:
+    type: list<DimensionScore>
+    materialize_from: scorer.dimensions_received
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+score.dimension_complete:
+  swarm:
+    source: external (verify accumulator projection fixture)
+  entity_id: string
+  expected_dimensions: integer
+  vertical_id: string
+  dimension: text
+  tier: integer
+  score: integer
+  evidence: text
+  confidence: text
+score.completed:
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+scorer:
+  id: scorer
+  execution_type: system_node
+  subscribes_to: [score.dimension_complete]
+  produces: [score.completed]
+  event_handlers:
+    score.dimension_complete:
+      accumulate:
+        into: dimensions_received
+        expected_from: payload.expected_dimensions
+        completion: all
+      on_complete:
+        - condition: "true"
+          emit: score.completed
+      advances_to: complete
+  state_schema:
+    fields:
+      dimensions_received: list<DimensionScore>
+`)
+
+	var buf bytes.Buffer
+	code := runVerifyCommand(context.Background(), repoRoot(), []string{
+		"-contracts", root,
+	}, &buf)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
+	}
+	if out := buf.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify output missing success marker:\n%s", out)
+	}
+}
+
 func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {
 	bundle := &runtimecontracts.WorkflowContractBundle{}
 	bundle.Platform.Platform.Name = "swarm"

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -259,6 +259,8 @@ contract_formats:
           entity_writes.<entity_type>.save or entity_writes.<flow_id>.<entity_type>.save.'
         update_path: 'update_{entity_type}_{field}_{subpath}({value}) updates one generated top-level subpath for a writable
           named-object field. The value schema is the exact declared subpath type.'
+        materialized_field_exclusion: 'Fields declaring materialize_from, and every nested subpath below them, MUST NOT
+          appear in generated write tools or writable-path summaries. They are runtime-owned projection fields.'
         create_rule: 'create authorization in entity_writes is author evidence for prompt/boot coverage. Path alpha does not
           expose a generic agent-facing create_entity replacement for current-entity tools.'
       generated_schema_closure: 'Generated entity-tool input and output schemas are closed recursively: additionalProperties
@@ -423,11 +425,51 @@ entity_contracts:
           initial: <value>
           immutable: <bool>
           description: <text>
+          materialize_from: <node_id>.<accumulator_name>
+          project:
+            <target_item_field>: source.<source_item_field>
           _unused_reason: <reason>
     notes:
     - Entity-level metadata is underscore-prefixed.
     - State does not live in entity contracts.
     - Envelope names are reserved and must not be author-declared.
+    - '`materialize_from` is valid only for a list of a declared named type.'
+    - '`materialize_from` and `_unused_reason` are mutually exclusive.'
+    - 'A `materialize_from` field is runtime-owned and not agent-writable.'
+  accumulator_entity_projection:
+    description: |
+      `materialize_from` declares a downstream typed entity-field copy of a
+      same-flow node accumulator. The accumulator remains canonical for
+      receipt acceptance, deduplication, completion, and computation. The
+      entity field is a persisted visibility/audit projection written by the
+      runtime on successful accumulator completion.
+    source_reference: |
+      The value has shape `<node_id>.<accumulator_name>`. The referenced node
+      must belong to the same flow as the declaring entity. The referenced
+      handler accumulator must be declared with `accumulate.into:
+      <accumulator_name>`.
+    target_type: |
+      The target field must be `list<NamedType>` or `[NamedType]`. The source
+      accumulator state_schema field named by `accumulate.into` must also be a
+      named-type list. `jsonb`, `[text]`, and untyped structural targets are
+      invalid for projection.
+    project: |
+      If source and target item named types are identical, `project` is
+      forbidden and identity projection is used. If they differ, `project` is
+      required and must name every field of the target item type. `source.*`
+      references resolve only against declared fields of the source item type.
+      Runtime accumulator metadata (`event_id`, `event_type`, `source`,
+      `received_at`) and event-payload extras outside the source named type are
+      not addressable through `source.*`.
+    writer_ownership: |
+      `materialize_from` is the sole runtime writer for the field after
+      create-time `initial:` materialization. Other authored writes
+      (`data_accumulation`, compute/filter/reduce/count/group_by store_as,
+      query store_as, clear, or agent entity_writes/save tools) are hard
+      invalidity.
+    e1_coverage: |
+      `materialize_from` counts as entity writer coverage for E1. It replaces
+      `_unused_reason`; the two may not coexist.
   one_entity_type_per_flow: |
     Each flow declares and creates at most one entity type. Verify
     rejects multiple entity types per flow in Wave 1.
@@ -564,7 +606,8 @@ handler_specification:
       \           └→ emit-site selection (handler emit OR active branch/rule/timeout/fan_out emit)\n                    \
       \                      └→ advances_to ─┐\n                                             sets_gate ────┤ (independent\
       \ of each other)\n                                             data_accumulation ┘\n                         \
-      \                         └→ emit.fields\n                                                       └→ emit.event\n  \
+      \                         └→ projection (materialize_from, if accumulator on_complete matched)\n                  \
+      \                                └→ emit.fields\n                                                       └→ emit.event\n  \
       \                                                          └→ action\n                                            \
       \                     └→ clear (optional — reset accumulator/state buckets)\n    "
   atomicity:
@@ -646,6 +689,9 @@ handler_specification:
       type: object
       purpose: Track multiple event arrivals for same entity. Wait until completion.
       sub_fields:
+        into: 'string — optional explicit accumulator buffer name. Required when any entity field declares
+          materialize_from: <this_node>.<into>. Must resolve to a state_schema field on this node typed as
+          list<NamedType> or [NamedType]. Within one node, a given into value may be declared by at most one handler.'
         expected_from: string — entity field containing expected count or items list
         completion: all | threshold | timeout
         from: string — optional sender path filter
@@ -657,6 +703,13 @@ handler_specification:
           with the same dedup key are ignored.'
       concept: Track multiple events arriving for the same entity. Fire on_complete when completion condition is met. Expected
         count read from entity state (written by initiating handler).
+      projection_hook: |
+        When a handler accumulator completes and an on_complete branch matches
+        successfully, any same-flow entity field declaring `materialize_from`
+        for this handler's `accumulate.into` buffer is written as a full
+        replacement list after data_accumulation and before emit.fields. No
+        projection occurs for incomplete accumulation, timeout branches, or
+        completion with no matching on_complete rule.
     compute:
       field: compute
       type: object
@@ -708,7 +761,9 @@ handler_specification:
           presence_checks: has(entity.X) and == null / != null comparisons remain available, but they are not required for declared fields.
         does_NOT_include: 'Accumulated items. Dimension scores, fan-out results, and other per-item data
           collected by the accumulate handler step are NOT promoted to entity fields automatically. They exist
-          only in the accumulator. To reference them, use the accumulated namespace.'
+          only in the accumulator. To reference them in post-accumulation conditions, use the accumulated namespace.
+          To persist a strict typed downstream copy, declare an entity field materialize_from; the runtime projection
+          step owns that write.'
       accumulated:
         resolves_to: 'The items array from the current handler''s accumulate step. Each item is a JSONB object
           representing one accumulated event payload. Available only in on_complete conditions and filter
@@ -719,6 +774,11 @@ handler_specification:
         not_available_in: 'guard.check — guards run before accumulation. data_accumulation.expression — runs
           before accumulation. rules.condition — rules are an alternative to on_complete, not used after
           accumulation.'
+        projection_boundary: |
+          `materialize_from` consumes accumulated items through the source
+          named type's typed view. Runtime accumulator metadata and event
+          payload extras outside the source named type are stripped before
+          writing the entity field and are not addressable as `source.*`.
       fan_out:
         resolves_to: 'Handler context produced by the fan_out step. fan_out.count is the number of items
           that were dispatched. Populated after fan_out executes, before data_accumulation.'
@@ -959,6 +1019,8 @@ handler_specification:
   - 'compute → emit-site selection: computed values written before branch/rule/timeout selection evaluates'
   - 'emit-site selection → {advances_to, sets_gate, data_accumulation}: active branch/rule/timeout may override these fields'
   - 'advances_to, sets_gate, data_accumulation: INDEPENDENT — no causal dependency, any order valid'
+  - 'data_accumulation → projection: accumulator-to-entity materialize_from writes run after selected branch writes'
+  - 'projection → emit.fields: emit payload expressions observe projected entity fields'
   - 'emit.fields → emit.event: output payload constructed before event persisted'
   - 'emit.event → action: events persisted before platform actions execute'
   - 'action → clear: state cleanup runs last, after all side effects committed'
@@ -4273,11 +4335,40 @@ static_analyzer:
         rule: Explicit `initial:` on the field counts as authored creation-time coverage.
       unused_reason:
         rule: Explicit `_unused_reason:` documents intentional no-writer intent and suppresses this slice only.
+      materialize_from:
+        rule: Explicit `materialize_from:` counts as runtime-owned writer coverage when accumulator_entity_projection verify passes.
       handler_write_sites:
         rule: Handler write targets that name the field explicitly count as coverage. This includes data_accumulation, compute,
           filter/group_by/reduce/count store_as, query store_as, and clear targets.
     rule: Emit hard invalidity when a declared entity field has no authored writer coverage, no explicit `initial:`, and no
       `_unused_reason:`.
+  slice_6b_accumulator_entity_projection:
+    id: accumulator_entity_projection
+    domain: semantic_validity
+    authority: hard_invalidity
+    severity: error
+    canonical_owner: internal/runtime/accprojection resolver consumed by bootverify and runtime executor
+    supported_surface: cmd/swarm verify and runtime handler execution
+    spec_basis:
+    - entity_contracts.accumulator_entity_projection
+    - handler_specification.handler_fields.accumulate
+    - canonical_invariants.no_structural_primitive_elides_type_discipline
+    rule: |
+      Verify every `materialize_from` field through the shared projection
+      resolver. Hard invalidity if the reference is malformed, the source node
+      is missing or cross-flow, the source handler lacks matching
+      `accumulate.into`, multiple handlers on one node declare the same
+      projectable buffer, the source/target types are not named-type lists, the
+      source event payload lacks the complete typed view, project coverage is
+      partial or reaches undeclared source fields/metadata/extras, the field
+      also declares `_unused_reason`, or any other authored writer targets the
+      same field.
+    runtime_rule: |
+      On a successful matching accumulator on_complete branch, runtime writes
+      the projection as a full replacement before emit.fields and validates the
+      result through entity named-type normalization. Failure rolls back the
+      whole handler transaction. Projection does not run for timeout,
+      incomplete accumulation, or no-match completion.
   slice_7_entity_reader_compliance:
     id: expression_field_reference_validation
     domain: semantic_validity

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -428,6 +428,8 @@ entity_contracts:
           materialize_from: <node_id>.<accumulator_name>
           project:
             <target_item_field>: source.<source_item_field>
+            <target_policy_field>: policy.<policy_path>
+            <target_literal_field>: <literal>
           _unused_reason: <reason>
     notes:
     - Entity-level metadata is underscore-prefixed.
@@ -456,11 +458,18 @@ entity_contracts:
     project: |
       If source and target item named types are identical, `project` is
       forbidden and identity projection is used. If they differ, `project` is
-      required and must name every field of the target item type. `source.*`
-      references resolve only against declared fields of the source item type.
-      Runtime accumulator metadata (`event_id`, `event_type`, `source`,
-      `received_at`) and event-payload extras outside the source named type are
-      not addressable through `source.*`.
+      required and must name every field of the target item type. Project
+      expressions support exactly `source.*`, `policy.*`, and literal YAML
+      scalar/sequence/mapping values. `source.*` references resolve only
+      against declared fields of the source item type. Runtime accumulator
+      metadata (`event_id`, `event_type`, `source`, `received_at`) and
+      event-payload extras outside the source named type are not addressable
+      through `source.*`. `policy.*` references resolve against the declaring
+      flow's resolved policy document and must be declared; unknown policy
+      paths are hard invalidity. Literal values are copied as authored and
+      validated through the target entity field's named-type normalizer at
+      runtime. Bindings to `entity.*`, `payload.*`, `event.*`, `fan_out.*`, or
+      `accumulated.*` are unsupported in `project`.
     writer_ownership: |
       `materialize_from` is the sole runtime writer for the field after
       create-time `initial:` materialization. Other authored writes
@@ -4360,7 +4369,8 @@ static_analyzer:
       `accumulate.into`, multiple handlers on one node declare the same
       projectable buffer, the source/target types are not named-type lists, the
       source event payload lacks the complete typed view, project coverage is
-      partial or reaches undeclared source fields/metadata/extras, the field
+      partial, reaches undeclared source fields/metadata/extras, references an
+      undeclared policy path, uses an unsupported binding namespace, the field
       also declares `_unused_reason`, or any other authored writer targets the
       same field.
     runtime_rule: |

--- a/internal/runtime/accprojection/resolver.go
+++ b/internal/runtime/accprojection/resolver.go
@@ -33,9 +33,13 @@ type Binding struct {
 }
 
 type Issue struct {
-	Code     string
-	Message  string
-	Location string
+	Code            string
+	Message         string
+	Location        string
+	FlowID          string
+	SourceNodeID    string
+	SourceEventType string
+	AccumulatorName string
 }
 
 type Result struct {
@@ -74,6 +78,7 @@ func ForHandler(source semanticview.Source, flowID, nodeID, eventType string) ([
 	flowID = strings.TrimSpace(flowID)
 	nodeID = strings.TrimSpace(nodeID)
 	eventType = strings.TrimSpace(eventType)
+	activeAccumulatorName := activeHandlerAccumulatorName(source, nodeID, eventType)
 	for _, binding := range resolved.Bindings {
 		if strings.TrimSpace(binding.FlowID) == flowID &&
 			strings.TrimSpace(binding.SourceNodeID) == nodeID &&
@@ -81,7 +86,56 @@ func ForHandler(source semanticview.Source, flowID, nodeID, eventType string) ([
 			out = append(out, binding)
 		}
 	}
-	return out, resolved.Issues
+	issues := make([]Issue, 0)
+	for _, issue := range resolved.Issues {
+		if issueRelevantToHandler(issue, flowID, nodeID, eventType, activeAccumulatorName) {
+			issues = append(issues, issue)
+		}
+	}
+	return out, issues
+}
+
+func activeHandlerAccumulatorName(source semanticview.Source, nodeID, eventType string) string {
+	if source == nil {
+		return ""
+	}
+	node, ok := source.NodeEntries()[strings.TrimSpace(nodeID)]
+	if !ok {
+		return ""
+	}
+	handler, ok := node.EventHandlers[strings.TrimSpace(eventType)]
+	if !ok || handler.Accumulate == nil {
+		return ""
+	}
+	return strings.TrimSpace(handler.Accumulate.Into)
+}
+
+func issueRelevantToHandler(issue Issue, flowID, nodeID, eventType, accumulatorName string) bool {
+	if strings.TrimSpace(issue.SourceNodeID) != strings.TrimSpace(nodeID) {
+		return false
+	}
+	if issueFlowID := strings.TrimSpace(issue.FlowID); issueFlowID != "" && issueFlowID != strings.TrimSpace(flowID) {
+		return false
+	}
+	if issueEventType := strings.TrimSpace(issue.SourceEventType); issueEventType != "" {
+		return issueEventType == strings.TrimSpace(eventType)
+	}
+	if issueAccumulatorName := strings.TrimSpace(issue.AccumulatorName); issueAccumulatorName != "" {
+		return issueAccumulatorName == strings.TrimSpace(accumulatorName)
+	}
+	return false
+}
+
+func scopedIssue(binding Binding, code, location, message string) Issue {
+	return Issue{
+		Code:            code,
+		Message:         message,
+		Location:        location,
+		FlowID:          strings.TrimSpace(binding.FlowID),
+		SourceNodeID:    strings.TrimSpace(binding.SourceNodeID),
+		SourceEventType: strings.TrimSpace(binding.SourceEventType),
+		AccumulatorName: strings.TrimSpace(binding.AccumulatorName),
+	}
 }
 
 type materializedFieldTarget struct {
@@ -143,9 +197,6 @@ func resolveTarget(source semanticview.Source, bundle *runtimecontracts.Workflow
 	}
 	loc := locationFor(target.FlowID, target.EntityType, target.FieldName)
 	issues := make([]Issue, 0)
-	if strings.TrimSpace(target.FieldDecl.UnusedReason) != "" {
-		issues = append(issues, Issue{Code: "unused_reason_with_materialize_from", Location: loc, Message: fmt.Sprintf("field %q declares both materialize_from and _unused_reason; remove _unused_reason", target.FieldName)})
-	}
 	sourceNodeID, accName, ok := parseMaterializeFrom(target.FieldDecl.MaterializeFrom)
 	if !ok {
 		issues = append(issues, Issue{Code: "invalid_reference", Location: loc, Message: fmt.Sprintf("materialize_from %q must have shape <node_id>.<accumulator_name>", strings.TrimSpace(target.FieldDecl.MaterializeFrom))})
@@ -156,7 +207,7 @@ func resolveTarget(source semanticview.Source, bundle *runtimecontracts.Workflow
 
 	node, ok := source.NodeEntries()[sourceNodeID]
 	if !ok {
-		issues = append(issues, Issue{Code: "unknown_source_node", Location: loc, Message: fmt.Sprintf("materialize_from %q references unknown node %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)})
+		issues = append(issues, scopedIssue(binding, "unknown_source_node", loc, fmt.Sprintf("materialize_from %q references unknown node %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)))
 		return binding, issues
 	}
 	sourceFlowID := ""
@@ -164,39 +215,13 @@ func resolveTarget(source semanticview.Source, bundle *runtimecontracts.Workflow
 		sourceFlowID = strings.TrimSpace(sourceRef.FlowID)
 	}
 	if sourceFlowID != strings.TrimSpace(target.FlowID) {
-		issues = append(issues, Issue{Code: "cross_flow_reference", Location: loc, Message: fmt.Sprintf("materialize_from %q references node in flow %s, but target entity %s belongs to flow %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), flowLabel(sourceFlowID), target.EntityType, flowLabel(target.FlowID))})
-	}
-
-	field, ok := nodeStateField(node, accName)
-	if !ok {
-		issues = append(issues, Issue{Code: "unknown_accumulator_state", Location: loc, Message: fmt.Sprintf("materialize_from %q references state_schema field %q missing on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), accName, sourceNodeID)})
-	} else {
-		binding.SourceField = field
-		sourceItem, ok := namedListItemType(field.Type)
-		if !ok {
-			issues = append(issues, Issue{Code: "unsupported_source_type", Location: loc, Message: fmt.Sprintf("materialize_from source %q is not a list of a named type; found %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), strings.TrimSpace(field.Type))})
-		} else if named, declared := target.TypeCatalog.Types[sourceItem]; !declared {
-			issues = append(issues, Issue{Code: "undeclared_source_named_type", Location: loc, Message: fmt.Sprintf("materialize_from source %q references undeclared named type %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceItem)})
-		} else {
-			binding.SourceItemType = sourceItem
-			binding.SourceNamedType = named
-		}
-	}
-
-	targetItem, ok := namedListItemType(target.FieldDecl.Type)
-	if !ok {
-		issues = append(issues, Issue{Code: "unsupported_target_type", Location: loc, Message: fmt.Sprintf("materialize_from target %q must be declared list<NamedType>; found %q", target.FieldName, strings.TrimSpace(target.FieldDecl.Type))})
-	} else if named, declared := target.TypeCatalog.Types[targetItem]; !declared {
-		issues = append(issues, Issue{Code: "undeclared_target_named_type", Location: loc, Message: fmt.Sprintf("materialize_from target %q references undeclared named type %s", target.FieldName, targetItem)})
-	} else {
-		binding.TargetItemType = targetItem
-		binding.TargetNamedType = named
+		issues = append(issues, scopedIssue(binding, "cross_flow_reference", loc, fmt.Sprintf("materialize_from %q references node in flow %s, but target entity %s belongs to flow %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), flowLabel(sourceFlowID), target.EntityType, flowLabel(target.FlowID))))
 	}
 
 	handlers := handlersForAccumulator(node, accName)
 	switch len(handlers) {
 	case 0:
-		issues = append(issues, Issue{Code: "missing_accumulate_into", Location: loc, Message: fmt.Sprintf("materialize_from %q does not resolve to an explicitly declared accumulator (accumulate.into:) on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)})
+		issues = append(issues, scopedIssue(binding, "missing_accumulate_into", loc, fmt.Sprintf("materialize_from %q does not resolve to an explicitly declared accumulator (accumulate.into:) on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)))
 	case 1:
 		binding.SourceEventType = handlers[0].EventType
 	default:
@@ -205,15 +230,44 @@ func resolveTarget(source semanticview.Source, bundle *runtimecontracts.Workflow
 			names = append(names, handler.EventType)
 		}
 		sort.Strings(names)
-		issues = append(issues, Issue{Code: "duplicate_accumulate_into", Location: loc, Message: fmt.Sprintf("accumulate.into %q declared by multiple handlers on node %s: %v; v1 supports a single producing handler per projectable buffer", accName, sourceNodeID, names)})
+		issues = append(issues, scopedIssue(binding, "duplicate_accumulate_into", loc, fmt.Sprintf("accumulate.into %q declared by multiple handlers on node %s: %v; v1 supports a single producing handler per projectable buffer", accName, sourceNodeID, names)))
+	}
+	if strings.TrimSpace(target.FieldDecl.UnusedReason) != "" {
+		issues = append(issues, scopedIssue(binding, "unused_reason_with_materialize_from", loc, fmt.Sprintf("field %q declares both materialize_from and _unused_reason; remove _unused_reason", target.FieldName)))
+	}
+
+	field, ok := nodeStateField(node, accName)
+	if !ok {
+		issues = append(issues, scopedIssue(binding, "unknown_accumulator_state", loc, fmt.Sprintf("materialize_from %q references state_schema field %q missing on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), accName, sourceNodeID)))
+	} else {
+		binding.SourceField = field
+		sourceItem, ok := namedListItemType(field.Type)
+		if !ok {
+			issues = append(issues, scopedIssue(binding, "unsupported_source_type", loc, fmt.Sprintf("materialize_from source %q is not a list of a named type; found %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), strings.TrimSpace(field.Type))))
+		} else if named, declared := target.TypeCatalog.Types[sourceItem]; !declared {
+			issues = append(issues, scopedIssue(binding, "undeclared_source_named_type", loc, fmt.Sprintf("materialize_from source %q references undeclared named type %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceItem)))
+		} else {
+			binding.SourceItemType = sourceItem
+			binding.SourceNamedType = named
+		}
+	}
+
+	targetItem, ok := namedListItemType(target.FieldDecl.Type)
+	if !ok {
+		issues = append(issues, scopedIssue(binding, "unsupported_target_type", loc, fmt.Sprintf("materialize_from target %q must be declared list<NamedType>; found %q", target.FieldName, strings.TrimSpace(target.FieldDecl.Type))))
+	} else if named, declared := target.TypeCatalog.Types[targetItem]; !declared {
+		issues = append(issues, scopedIssue(binding, "undeclared_target_named_type", loc, fmt.Sprintf("materialize_from target %q references undeclared named type %s", target.FieldName, targetItem)))
+	} else {
+		binding.TargetItemType = targetItem
+		binding.TargetNamedType = named
 	}
 
 	if binding.SourceItemType != "" && binding.TargetItemType != "" {
 		if binding.SourceItemType == binding.TargetItemType && len(binding.Project) > 0 {
-			issues = append(issues, Issue{Code: "project_forbidden", Location: loc, Message: fmt.Sprintf("materialize_from element types match (%s); project must be absent", binding.SourceItemType)})
+			issues = append(issues, scopedIssue(binding, "project_forbidden", loc, fmt.Sprintf("materialize_from element types match (%s); project must be absent", binding.SourceItemType)))
 		}
 		if binding.SourceItemType != binding.TargetItemType && len(binding.Project) == 0 {
-			issues = append(issues, Issue{Code: "project_required", Location: loc, Message: "materialize_from element types differ; project must be present and name all target fields"})
+			issues = append(issues, scopedIssue(binding, "project_required", loc, "materialize_from element types differ; project must be present and name all target fields"))
 		}
 		if len(binding.Project) > 0 {
 			issues = append(issues, validateProject(source, target, binding)...)
@@ -248,13 +302,13 @@ func validateProject(source semanticview.Source, target materializedFieldTarget,
 	targetFields := sortedTypeFields(binding.TargetNamedType)
 	for _, fieldName := range targetFields {
 		if _, ok := binding.Project[fieldName]; !ok {
-			issues = append(issues, Issue{Code: "project_missing_target_field", Location: loc, Message: fmt.Sprintf("project must name every field of target item type %s; missing %s", binding.TargetItemType, fieldName)})
+			issues = append(issues, scopedIssue(binding, "project_missing_target_field", loc, fmt.Sprintf("project must name every field of target item type %s; missing %s", binding.TargetItemType, fieldName)))
 		}
 	}
 	for fieldName, rawExpr := range binding.Project {
 		fieldName = strings.TrimSpace(fieldName)
 		if _, ok := binding.TargetNamedType.Fields[fieldName]; !ok {
-			issues = append(issues, Issue{Code: "project_unknown_target_field", Location: loc, Message: fmt.Sprintf("project names undeclared target field %q on item type %s", fieldName, binding.TargetItemType)})
+			issues = append(issues, scopedIssue(binding, "project_unknown_target_field", loc, fmt.Sprintf("project names undeclared target field %q on item type %s", fieldName, binding.TargetItemType)))
 		}
 		expr, isString := rawExpr.(string)
 		if !isString {
@@ -264,29 +318,29 @@ func validateProject(source semanticview.Source, target materializedFieldTarget,
 		if sourceField, ok := strings.CutPrefix(expr, "source."); ok {
 			sourceField = strings.TrimSpace(sourceField)
 			if _, reserved := ReservedAccumulatorMetadata[sourceField]; reserved {
-				issues = append(issues, Issue{Code: "project_metadata_reference", Location: loc, Message: fmt.Sprintf("project.%s references %q; reserved accumulator metadata is not addressable through source.*", fieldName, expr)})
+				issues = append(issues, scopedIssue(binding, "project_metadata_reference", loc, fmt.Sprintf("project.%s references %q; reserved accumulator metadata is not addressable through source.*", fieldName, expr)))
 				continue
 			}
 			sourceSpec, ok := binding.SourceNamedType.Fields[sourceField]
 			if !ok {
-				issues = append(issues, Issue{Code: "project_unknown_source_field", Location: loc, Message: fmt.Sprintf("project.%s references %q; %s is not a field of item type %s", fieldName, expr, sourceField, binding.SourceItemType)})
+				issues = append(issues, scopedIssue(binding, "project_unknown_source_field", loc, fmt.Sprintf("project.%s references %q; %s is not a field of item type %s", fieldName, expr, sourceField, binding.SourceItemType)))
 				continue
 			}
 			if targetSpec, ok := binding.TargetNamedType.Fields[fieldName]; ok && !typesAssignable(target.TypeCatalog, sourceSpec.Type, targetSpec.Type) {
-				issues = append(issues, Issue{Code: "project_type_mismatch", Location: loc, Message: fmt.Sprintf("project.%s references %q type %s, not assignable to target field type %s", fieldName, expr, strings.TrimSpace(sourceSpec.Type), strings.TrimSpace(targetSpec.Type))})
+				issues = append(issues, scopedIssue(binding, "project_type_mismatch", loc, fmt.Sprintf("project.%s references %q type %s, not assignable to target field type %s", fieldName, expr, strings.TrimSpace(sourceSpec.Type), strings.TrimSpace(targetSpec.Type))))
 			}
 			continue
 		}
 		if policyPath, ok := strings.CutPrefix(expr, "policy."); ok {
 			policyPath = strings.TrimSpace(policyPath)
 			if _, ok := semanticview.PolicyValueForFlow(source, target.FlowID, policyPath); !ok {
-				issues = append(issues, Issue{Code: "project_unknown_policy_field", Location: loc, Message: fmt.Sprintf("project.%s references %q; policy field %s is not declared for flow %s", fieldName, expr, policyPath, flowLabel(target.FlowID))})
+				issues = append(issues, scopedIssue(binding, "project_unknown_policy_field", loc, fmt.Sprintf("project.%s references %q; policy field %s is not declared for flow %s", fieldName, expr, policyPath, flowLabel(target.FlowID))))
 			}
 			continue
 		}
 		for _, forbidden := range []string{"entity.", "payload.", "event.", "fan_out.", "accumulated."} {
 			if strings.HasPrefix(expr, forbidden) {
-				issues = append(issues, Issue{Code: "project_forbidden_binding", Location: loc, Message: fmt.Sprintf("project.%s uses forbidden binding %q; project supports source.*, policy.*, or literals", fieldName, expr)})
+				issues = append(issues, scopedIssue(binding, "project_forbidden_binding", loc, fmt.Sprintf("project.%s uses forbidden binding %q; project supports source.*, policy.*, or literals", fieldName, expr)))
 				break
 			}
 		}
@@ -303,7 +357,7 @@ func validateEventTypedView(source semanticview.Source, types runtimecontracts.T
 		}
 	}
 	if !ok {
-		return []Issue{{Code: "unknown_source_event", Location: binding.SourceNodeID, Message: fmt.Sprintf("accumulate.into %q references event %q, but no event catalog entry exists", binding.AccumulatorName, binding.SourceEventType)}}
+		return []Issue{scopedIssue(binding, "unknown_source_event", binding.SourceNodeID, fmt.Sprintf("accumulate.into %q references event %q, but no event catalog entry exists", binding.AccumulatorName, binding.SourceEventType))}
 	}
 	issues := make([]Issue, 0)
 	loc := fmt.Sprintf("node %s handler %s", binding.SourceNodeID, binding.SourceEventType)
@@ -311,11 +365,11 @@ func validateEventTypedView(source semanticview.Source, types runtimecontracts.T
 		expected := strings.TrimSpace(binding.SourceNamedType.Fields[fieldName].Type)
 		payloadField, ok := entry.Payload.Properties[fieldName]
 		if !ok {
-			issues = append(issues, Issue{Code: "typed_view_missing_field", Location: loc, Message: fmt.Sprintf("event %q payload missing field %q required by accumulator element type %s", binding.SourceEventType, fieldName, binding.SourceItemType)})
+			issues = append(issues, scopedIssue(binding, "typed_view_missing_field", loc, fmt.Sprintf("event %q payload missing field %q required by accumulator element type %s", binding.SourceEventType, fieldName, binding.SourceItemType)))
 			continue
 		}
 		if !typesAssignable(types, payloadField.Type, expected) {
-			issues = append(issues, Issue{Code: "typed_view_type_mismatch", Location: loc, Message: fmt.Sprintf("event %q payload field %q has type %s not assignable to accumulator element type field %q type %s", binding.SourceEventType, fieldName, strings.TrimSpace(payloadField.Type), fieldName, expected)})
+			issues = append(issues, scopedIssue(binding, "typed_view_type_mismatch", loc, fmt.Sprintf("event %q payload field %q has type %s not assignable to accumulator element type field %q type %s", binding.SourceEventType, fieldName, strings.TrimSpace(payloadField.Type), fieldName, expected)))
 		}
 	}
 	return issues

--- a/internal/runtime/accprojection/resolver.go
+++ b/internal/runtime/accprojection/resolver.go
@@ -1,0 +1,447 @@
+package accprojection
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+var ReservedAccumulatorMetadata = map[string]struct{}{
+	"event_id":    {},
+	"event_type":  {},
+	"source":      {},
+	"received_at": {},
+}
+
+type Binding struct {
+	FlowID          string
+	EntityType      string
+	TargetField     string
+	TargetDecl      runtimecontracts.EntityFieldDecl
+	SourceNodeID    string
+	SourceEventType string
+	AccumulatorName string
+	SourceField     runtimecontracts.NodeStateField
+	SourceItemType  string
+	SourceNamedType runtimecontracts.NamedTypeDecl
+	TargetItemType  string
+	TargetNamedType runtimecontracts.NamedTypeDecl
+	Project         map[string]any
+}
+
+type Issue struct {
+	Code     string
+	Message  string
+	Location string
+}
+
+type Result struct {
+	Bindings []Binding
+	Issues   []Issue
+}
+
+func Resolve(source semanticview.Source) Result {
+	if source == nil {
+		return Result{}
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return Result{Issues: []Issue{{Code: "bundle_unavailable", Message: "materialize_from resolver requires a workflow contract bundle"}}}
+	}
+	var result Result
+	for _, target := range declaredMaterializedFields(source, bundle) {
+		binding, issues := resolveTarget(source, bundle, target)
+		result.Issues = append(result.Issues, issues...)
+		if len(issues) == 0 {
+			result.Bindings = append(result.Bindings, binding)
+		}
+	}
+	sort.Slice(result.Bindings, func(i, j int) bool {
+		if result.Bindings[i].FlowID == result.Bindings[j].FlowID {
+			return result.Bindings[i].TargetField < result.Bindings[j].TargetField
+		}
+		return result.Bindings[i].FlowID < result.Bindings[j].FlowID
+	})
+	return result
+}
+
+func ForHandler(source semanticview.Source, flowID, nodeID, eventType string) ([]Binding, []Issue) {
+	resolved := Resolve(source)
+	out := make([]Binding, 0)
+	flowID = strings.TrimSpace(flowID)
+	nodeID = strings.TrimSpace(nodeID)
+	eventType = strings.TrimSpace(eventType)
+	for _, binding := range resolved.Bindings {
+		if strings.TrimSpace(binding.FlowID) == flowID &&
+			strings.TrimSpace(binding.SourceNodeID) == nodeID &&
+			strings.TrimSpace(binding.SourceEventType) == eventType {
+			out = append(out, binding)
+		}
+	}
+	return out, resolved.Issues
+}
+
+type materializedFieldTarget struct {
+	FlowID      string
+	EntityType  string
+	FieldName   string
+	FieldDecl   runtimecontracts.EntityFieldDecl
+	TypeCatalog runtimecontracts.TypeCatalogDocument
+}
+
+func declaredMaterializedFields(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) []materializedFieldTarget {
+	out := make([]materializedFieldTarget, 0)
+	add := func(flowID, entityType string, contract runtimecontracts.EntityContract, types runtimecontracts.TypeCatalogDocument) {
+		fieldNames := make([]string, 0, len(contract.Fields))
+		for fieldName := range contract.Fields {
+			fieldNames = append(fieldNames, strings.TrimSpace(fieldName))
+		}
+		sort.Strings(fieldNames)
+		for _, fieldName := range fieldNames {
+			decl := contract.Fields[fieldName]
+			if strings.TrimSpace(decl.MaterializeFrom) == "" {
+				continue
+			}
+			out = append(out, materializedFieldTarget{
+				FlowID:      strings.TrimSpace(flowID),
+				EntityType:  strings.TrimSpace(entityType),
+				FieldName:   fieldName,
+				FieldDecl:   decl,
+				TypeCatalog: types,
+			})
+		}
+	}
+	if root := bundle.RootEntityContracts(); len(root) > 0 {
+		for entityType, contract := range root {
+			add("", entityType, contract, bundle.RootTypeCatalog())
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" {
+			continue
+		}
+		entityType, contract, ok := bundle.FlowOwnedEntityContract(flowID)
+		if !ok {
+			continue
+		}
+		add(flowID, entityType, contract, bundle.ResolvedTypeCatalogForFlow(flowID))
+	}
+	return out
+}
+
+func resolveTarget(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle, target materializedFieldTarget) (Binding, []Issue) {
+	binding := Binding{
+		FlowID:      target.FlowID,
+		EntityType:  target.EntityType,
+		TargetField: target.FieldName,
+		TargetDecl:  target.FieldDecl,
+		Project:     cloneProject(target.FieldDecl.Project),
+	}
+	loc := locationFor(target.FlowID, target.EntityType, target.FieldName)
+	issues := make([]Issue, 0)
+	if strings.TrimSpace(target.FieldDecl.UnusedReason) != "" {
+		issues = append(issues, Issue{Code: "unused_reason_with_materialize_from", Location: loc, Message: fmt.Sprintf("field %q declares both materialize_from and _unused_reason; remove _unused_reason", target.FieldName)})
+	}
+	sourceNodeID, accName, ok := parseMaterializeFrom(target.FieldDecl.MaterializeFrom)
+	if !ok {
+		issues = append(issues, Issue{Code: "invalid_reference", Location: loc, Message: fmt.Sprintf("materialize_from %q must have shape <node_id>.<accumulator_name>", strings.TrimSpace(target.FieldDecl.MaterializeFrom))})
+		return binding, issues
+	}
+	binding.SourceNodeID = sourceNodeID
+	binding.AccumulatorName = accName
+
+	node, ok := source.NodeEntries()[sourceNodeID]
+	if !ok {
+		issues = append(issues, Issue{Code: "unknown_source_node", Location: loc, Message: fmt.Sprintf("materialize_from %q references unknown node %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)})
+		return binding, issues
+	}
+	sourceFlowID := ""
+	if sourceRef, ok := source.NodeContractSource(sourceNodeID); ok {
+		sourceFlowID = strings.TrimSpace(sourceRef.FlowID)
+	}
+	if sourceFlowID != strings.TrimSpace(target.FlowID) {
+		issues = append(issues, Issue{Code: "cross_flow_reference", Location: loc, Message: fmt.Sprintf("materialize_from %q references node in flow %s, but target entity %s belongs to flow %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), flowLabel(sourceFlowID), target.EntityType, flowLabel(target.FlowID))})
+	}
+
+	field, ok := nodeStateField(node, accName)
+	if !ok {
+		issues = append(issues, Issue{Code: "unknown_accumulator_state", Location: loc, Message: fmt.Sprintf("materialize_from %q references state_schema field %q missing on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), accName, sourceNodeID)})
+	} else {
+		binding.SourceField = field
+		sourceItem, ok := namedListItemType(field.Type)
+		if !ok {
+			issues = append(issues, Issue{Code: "unsupported_source_type", Location: loc, Message: fmt.Sprintf("materialize_from source %q is not a list of a named type; found %q", strings.TrimSpace(target.FieldDecl.MaterializeFrom), strings.TrimSpace(field.Type))})
+		} else if named, declared := target.TypeCatalog.Types[sourceItem]; !declared {
+			issues = append(issues, Issue{Code: "undeclared_source_named_type", Location: loc, Message: fmt.Sprintf("materialize_from source %q references undeclared named type %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceItem)})
+		} else {
+			binding.SourceItemType = sourceItem
+			binding.SourceNamedType = named
+		}
+	}
+
+	targetItem, ok := namedListItemType(target.FieldDecl.Type)
+	if !ok {
+		issues = append(issues, Issue{Code: "unsupported_target_type", Location: loc, Message: fmt.Sprintf("materialize_from target %q must be declared list<NamedType>; found %q", target.FieldName, strings.TrimSpace(target.FieldDecl.Type))})
+	} else if named, declared := target.TypeCatalog.Types[targetItem]; !declared {
+		issues = append(issues, Issue{Code: "undeclared_target_named_type", Location: loc, Message: fmt.Sprintf("materialize_from target %q references undeclared named type %s", target.FieldName, targetItem)})
+	} else {
+		binding.TargetItemType = targetItem
+		binding.TargetNamedType = named
+	}
+
+	handlers := handlersForAccumulator(node, accName)
+	switch len(handlers) {
+	case 0:
+		issues = append(issues, Issue{Code: "missing_accumulate_into", Location: loc, Message: fmt.Sprintf("materialize_from %q does not resolve to an explicitly declared accumulator (accumulate.into:) on node %s", strings.TrimSpace(target.FieldDecl.MaterializeFrom), sourceNodeID)})
+	case 1:
+		binding.SourceEventType = handlers[0].EventType
+	default:
+		names := make([]string, 0, len(handlers))
+		for _, handler := range handlers {
+			names = append(names, handler.EventType)
+		}
+		sort.Strings(names)
+		issues = append(issues, Issue{Code: "duplicate_accumulate_into", Location: loc, Message: fmt.Sprintf("accumulate.into %q declared by multiple handlers on node %s: %v; v1 supports a single producing handler per projectable buffer", accName, sourceNodeID, names)})
+	}
+
+	if binding.SourceItemType != "" && binding.TargetItemType != "" {
+		if binding.SourceItemType == binding.TargetItemType && len(binding.Project) > 0 {
+			issues = append(issues, Issue{Code: "project_forbidden", Location: loc, Message: fmt.Sprintf("materialize_from element types match (%s); project must be absent", binding.SourceItemType)})
+		}
+		if binding.SourceItemType != binding.TargetItemType && len(binding.Project) == 0 {
+			issues = append(issues, Issue{Code: "project_required", Location: loc, Message: "materialize_from element types differ; project must be present and name all target fields"})
+		}
+		if len(binding.Project) > 0 {
+			issues = append(issues, validateProject(source, target, binding)...)
+		}
+		if binding.SourceEventType != "" && binding.SourceItemType != "" {
+			issues = append(issues, validateEventTypedView(source, target.TypeCatalog, binding)...)
+		}
+	}
+	return binding, issues
+}
+
+type handlerRef struct {
+	EventType string
+}
+
+func handlersForAccumulator(node runtimecontracts.SystemNodeContract, accName string) []handlerRef {
+	out := make([]handlerRef, 0)
+	for eventType, handler := range node.EventHandlers {
+		if handler.Accumulate == nil {
+			continue
+		}
+		if strings.TrimSpace(handler.Accumulate.Into) == strings.TrimSpace(accName) {
+			out = append(out, handlerRef{EventType: strings.TrimSpace(eventType)})
+		}
+	}
+	return out
+}
+
+func validateProject(source semanticview.Source, target materializedFieldTarget, binding Binding) []Issue {
+	loc := locationFor(target.FlowID, target.EntityType, target.FieldName)
+	issues := make([]Issue, 0)
+	targetFields := sortedTypeFields(binding.TargetNamedType)
+	for _, fieldName := range targetFields {
+		if _, ok := binding.Project[fieldName]; !ok {
+			issues = append(issues, Issue{Code: "project_missing_target_field", Location: loc, Message: fmt.Sprintf("project must name every field of target item type %s; missing %s", binding.TargetItemType, fieldName)})
+		}
+	}
+	for fieldName, rawExpr := range binding.Project {
+		fieldName = strings.TrimSpace(fieldName)
+		if _, ok := binding.TargetNamedType.Fields[fieldName]; !ok {
+			issues = append(issues, Issue{Code: "project_unknown_target_field", Location: loc, Message: fmt.Sprintf("project names undeclared target field %q on item type %s", fieldName, binding.TargetItemType)})
+		}
+		expr, isString := rawExpr.(string)
+		if !isString {
+			continue
+		}
+		expr = strings.TrimSpace(expr)
+		if sourceField, ok := strings.CutPrefix(expr, "source."); ok {
+			sourceField = strings.TrimSpace(sourceField)
+			if _, reserved := ReservedAccumulatorMetadata[sourceField]; reserved {
+				issues = append(issues, Issue{Code: "project_metadata_reference", Location: loc, Message: fmt.Sprintf("project.%s references %q; reserved accumulator metadata is not addressable through source.*", fieldName, expr)})
+				continue
+			}
+			sourceSpec, ok := binding.SourceNamedType.Fields[sourceField]
+			if !ok {
+				issues = append(issues, Issue{Code: "project_unknown_source_field", Location: loc, Message: fmt.Sprintf("project.%s references %q; %s is not a field of item type %s", fieldName, expr, sourceField, binding.SourceItemType)})
+				continue
+			}
+			if targetSpec, ok := binding.TargetNamedType.Fields[fieldName]; ok && !typesAssignable(target.TypeCatalog, sourceSpec.Type, targetSpec.Type) {
+				issues = append(issues, Issue{Code: "project_type_mismatch", Location: loc, Message: fmt.Sprintf("project.%s references %q type %s, not assignable to target field type %s", fieldName, expr, strings.TrimSpace(sourceSpec.Type), strings.TrimSpace(targetSpec.Type))})
+			}
+			continue
+		}
+		if policyPath, ok := strings.CutPrefix(expr, "policy."); ok {
+			policyPath = strings.TrimSpace(policyPath)
+			if _, ok := semanticview.PolicyValueForFlow(source, target.FlowID, policyPath); !ok {
+				issues = append(issues, Issue{Code: "project_unknown_policy_field", Location: loc, Message: fmt.Sprintf("project.%s references %q; policy field %s is not declared for flow %s", fieldName, expr, policyPath, flowLabel(target.FlowID))})
+			}
+			continue
+		}
+		for _, forbidden := range []string{"entity.", "payload.", "event.", "fan_out.", "accumulated."} {
+			if strings.HasPrefix(expr, forbidden) {
+				issues = append(issues, Issue{Code: "project_forbidden_binding", Location: loc, Message: fmt.Sprintf("project.%s uses forbidden binding %q; project supports source.*, policy.*, or literals", fieldName, expr)})
+				break
+			}
+		}
+	}
+	return issues
+}
+
+func validateEventTypedView(source semanticview.Source, types runtimecontracts.TypeCatalogDocument, binding Binding) []Issue {
+	entry, ok := source.EventEntry(binding.SourceEventType)
+	if !ok {
+		canonical := source.ResolveNodeEventReference(binding.SourceNodeID, binding.SourceEventType)
+		if canonical != "" {
+			entry, ok = source.EventEntry(canonical)
+		}
+	}
+	if !ok {
+		return []Issue{{Code: "unknown_source_event", Location: binding.SourceNodeID, Message: fmt.Sprintf("accumulate.into %q references event %q, but no event catalog entry exists", binding.AccumulatorName, binding.SourceEventType)}}
+	}
+	issues := make([]Issue, 0)
+	loc := fmt.Sprintf("node %s handler %s", binding.SourceNodeID, binding.SourceEventType)
+	for _, fieldName := range sortedTypeFields(binding.SourceNamedType) {
+		expected := strings.TrimSpace(binding.SourceNamedType.Fields[fieldName].Type)
+		payloadField, ok := entry.Payload.Properties[fieldName]
+		if !ok {
+			issues = append(issues, Issue{Code: "typed_view_missing_field", Location: loc, Message: fmt.Sprintf("event %q payload missing field %q required by accumulator element type %s", binding.SourceEventType, fieldName, binding.SourceItemType)})
+			continue
+		}
+		if !typesAssignable(types, payloadField.Type, expected) {
+			issues = append(issues, Issue{Code: "typed_view_type_mismatch", Location: loc, Message: fmt.Sprintf("event %q payload field %q has type %s not assignable to accumulator element type field %q type %s", binding.SourceEventType, fieldName, strings.TrimSpace(payloadField.Type), fieldName, expected)})
+		}
+	}
+	return issues
+}
+
+func nodeStateField(node runtimecontracts.SystemNodeContract, name string) (runtimecontracts.NodeStateField, bool) {
+	name = strings.TrimSpace(name)
+	for _, field := range node.StateSchema.Fields {
+		if strings.TrimSpace(field.Name) == name {
+			return field, true
+		}
+	}
+	return runtimecontracts.NodeStateField{}, false
+}
+
+func parseMaterializeFrom(raw string) (string, string, bool) {
+	raw = strings.TrimSpace(raw)
+	idx := strings.LastIndex(raw, ".")
+	if idx <= 0 || idx >= len(raw)-1 {
+		return "", "", false
+	}
+	nodeID := strings.TrimSpace(raw[:idx])
+	accName := strings.TrimSpace(raw[idx+1:])
+	return nodeID, accName, nodeID != "" && accName != ""
+}
+
+func namedListItemType(typeRef string) (string, bool) {
+	typeRef = strings.TrimSpace(typeRef)
+	switch {
+	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
+		item := strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
+		return item, item != "" && isNamedTypeName(item)
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		item := strings.TrimSpace(typeRef[1 : len(typeRef)-1])
+		return item, item != "" && isNamedTypeName(item)
+	case strings.HasSuffix(typeRef, "[]"):
+		item := strings.TrimSpace(typeRef[:len(typeRef)-2])
+		return item, item != "" && isNamedTypeName(item)
+	case strings.HasPrefix(typeRef, "[]"):
+		item := strings.TrimSpace(typeRef[2:])
+		return item, item != "" && isNamedTypeName(item)
+	default:
+		return "", false
+	}
+}
+
+func isNamedTypeName(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	first := raw[0]
+	if first < 'A' || first > 'Z' {
+		return false
+	}
+	for _, ch := range raw {
+		if ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func sortedTypeFields(named runtimecontracts.NamedTypeDecl) []string {
+	out := make([]string, 0, len(named.Fields))
+	for fieldName := range named.Fields {
+		fieldName = strings.TrimSpace(fieldName)
+		if fieldName != "" {
+			out = append(out, fieldName)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func typesAssignable(types runtimecontracts.TypeCatalogDocument, actual, expected string) bool {
+	actual = normalizeType(types, actual)
+	expected = normalizeType(types, expected)
+	if actual == expected {
+		return true
+	}
+	if actual == "integer" && expected == "numeric" {
+		return true
+	}
+	return false
+}
+
+func normalizeType(types runtimecontracts.TypeCatalogDocument, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if scalar, ok := types.Scalars[raw]; ok {
+		return normalizeType(types, scalar.Base)
+	}
+	switch strings.ToLower(raw) {
+	case "string":
+		return "text"
+	case "int", "bigint":
+		return "integer"
+	case "number", "float", "double", "real":
+		return "numeric"
+	case "bool":
+		return "boolean"
+	default:
+		return raw
+	}
+}
+
+func cloneProject(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[strings.TrimSpace(key)] = value
+	}
+	return out
+}
+
+func locationFor(flowID, entityType, fieldName string) string {
+	return fmt.Sprintf("flow %s entity_type %s field %s", flowLabel(flowID), strings.TrimSpace(entityType), strings.TrimSpace(fieldName))
+}
+
+func flowLabel(flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return "<root>"
+	}
+	return flowID
+}

--- a/internal/runtime/accprojection/resolver_test.go
+++ b/internal/runtime/accprojection/resolver_test.go
@@ -1,0 +1,101 @@
+package accprojection
+
+import (
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func projectionResolverBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension": {Type: "text"},
+						"score":     {Type: "integer"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"vertical": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"scores": {
+						Type:            "[DimensionScore]",
+						MaterializeFrom: "valid-node.dimensions_received",
+					},
+					"bad_scores": {
+						Type:            "[DimensionScore]",
+						MaterializeFrom: "bad-node.missing_buffer",
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"valid-node": {
+				StateSchema: runtimecontracts.NodeStateSchema{
+					Fields: []runtimecontracts.NodeStateField{{Name: "dimensions_received", Type: "[DimensionScore]"}},
+				},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"score.dimension_complete": {
+						Accumulate: &runtimecontracts.AccumulateSpec{Into: "dimensions_received"},
+					},
+				},
+			},
+			"bad-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"score.bad_dimension_complete": {
+						Accumulate: &runtimecontracts.AccumulateSpec{Into: "missing_buffer"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"score.dimension_complete": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"dimension": {Type: "text"},
+					"score":     {Type: "integer"},
+				}},
+			},
+			"score.bad_dimension_complete": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"dimension": {Type: "text"},
+					"score":     {Type: "integer"},
+				}},
+			},
+		},
+	}
+}
+
+func TestForHandler_FiltersProjectionIssuesToActiveHandler(t *testing.T) {
+	source := semanticview.Wrap(projectionResolverBundle())
+	resolved := Resolve(source)
+	if len(resolved.Issues) == 0 {
+		t.Fatal("Resolve issues = 0, want global invalid bad-node declaration")
+	}
+
+	bindings, issues := ForHandler(source, "", "valid-node", "score.dimension_complete")
+	if len(issues) != 0 {
+		t.Fatalf("ForHandler valid issues = %#v, want none", issues)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("ForHandler valid bindings = %d, want 1", len(bindings))
+	}
+
+	_, issues = ForHandler(source, "", "bad-node", "score.bad_dimension_complete")
+	if !issuesContain(issues, "missing_buffer") {
+		t.Fatalf("ForHandler bad issues = %#v, want missing_buffer issue", issues)
+	}
+}
+
+func issuesContain(issues []Issue, want string) bool {
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -120,6 +120,9 @@ type checkerContext struct {
 	nodeStateSchemaLoaded   bool
 	nodeStateSchemaFindings []Finding
 
+	accumulatorProjectionLoaded   bool
+	accumulatorProjectionFindings []Finding
+
 	producesDriftLoaded   bool
 	producesDriftFindings []Finding
 
@@ -200,6 +203,7 @@ var bootCheckRegistry = []Check{
 	{ID: "state_machine_coherence", Severity: "error", Run: checkStateMachineCoherence},
 	{ID: "semantic_drift_unreachable_state", Severity: "warning", Run: checkSemanticDriftUnreachableState},
 	{ID: "node_state_schema_typed_counterpart", Severity: SeverityHardInvalidity, Run: checkNodeStateSchemaTypedCounterpart},
+	{ID: "accumulator_entity_projection", Severity: SeverityHardInvalidity, Run: checkAccumulatorEntityProjection},
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3288,8 +3288,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 47 {
-		t.Fatalf("bootCheckRegistry count = %d, want 47", got)
+	if got := len(bootCheckRegistry); got != 48 {
+		t.Fatalf("bootCheckRegistry count = %d, want 48", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_accumulator_projection_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_projection_checks.go
@@ -1,0 +1,71 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/runtime/accprojection"
+)
+
+func checkAccumulatorEntityProjection(c *checkerContext) []Finding {
+	return c.accumulatorEntityProjection()
+}
+
+func (c *checkerContext) accumulatorEntityProjection() []Finding {
+	if c.accumulatorProjectionLoaded {
+		return c.accumulatorProjectionFindings
+	}
+	c.accumulatorProjectionLoaded = true
+
+	resolved := accprojection.Resolve(c.source)
+	for _, issue := range resolved.Issues {
+		c.accumulatorProjectionFindings = append(c.accumulatorProjectionFindings, Finding{
+			CheckID:  "accumulator_entity_projection",
+			Severity: SeverityHardInvalidity,
+			Message:  issue.Message,
+			Location: issue.Location,
+		})
+	}
+	for _, binding := range resolved.Bindings {
+		c.accumulatorProjectionFindings = append(c.accumulatorProjectionFindings, accumulatorProjectionWriterConflictFindings(c, binding)...)
+	}
+	return c.accumulatorProjectionFindings
+}
+
+func accumulatorProjectionWriterConflictFindings(c *checkerContext, binding accprojection.Binding) []Finding {
+	out := make([]Finding, 0)
+	for _, target := range wave1AllEntityWriteTargets(c.source) {
+		if !target.Entity || wave1EntityEnvelopeField(target.Field) || wave1SpecialClearTarget(target.Field) {
+			continue
+		}
+		_, ownerFlowID, rootField, err := wave1ResolveWriteTargetPath(c.source, target)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(ownerFlowID) != strings.TrimSpace(binding.FlowID) ||
+			strings.TrimSpace(rootField) != strings.TrimSpace(binding.TargetField) {
+			continue
+		}
+		out = append(out, Finding{
+			CheckID:  "accumulator_entity_projection",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("field %q declares materialize_from but also has authored writer at %s on node %s handler %s; remove the authored writer", binding.TargetField, target.Kind, target.NodeID, target.EventType),
+			Location: target.NodeID,
+		})
+	}
+	for flowID, fields := range wave1AgentExplicitEntityWriteCoverageByFlow(c.source) {
+		if strings.TrimSpace(flowID) != strings.TrimSpace(binding.FlowID) {
+			continue
+		}
+		if _, ok := fields[strings.TrimSpace(binding.TargetField)]; !ok {
+			continue
+		}
+		out = append(out, Finding{
+			CheckID:  "accumulator_entity_projection",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("field %q declares materialize_from but also appears in an agent entity_writes declaration; generated/agent write ownership is forbidden", binding.TargetField),
+			Location: defaultFlowLabel(binding.FlowID),
+		})
+	}
+	return out
+}

--- a/internal/runtime/bootverify/workflow_accumulator_projection_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_projection_checks_test.go
@@ -1,0 +1,241 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+func accumulatorProjectionBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension":  {Type: "text"},
+						"tier":       {Type: "integer"},
+						"score":      {Type: "integer"},
+						"evidence":   {Type: "text"},
+						"confidence": {Type: "text"},
+					},
+				},
+				"DimensionVerdict": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension": {Type: "text"},
+						"score":     {Type: "integer"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"vertical": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"scores": {
+						Type:            "[DimensionScore]",
+						MaterializeFrom: "scoring-node.dimensions_received",
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scoring-node": {
+				StateSchema: runtimecontracts.NodeStateSchema{
+					Fields: []runtimecontracts.NodeStateField{{Name: "dimensions_received", Type: "[DimensionScore]"}},
+				},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"score.dimension_complete": {
+						Accumulate: &runtimecontracts.AccumulateSpec{Into: "dimensions_received"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"score.dimension_complete": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"vertical_id": {Type: "uuid"},
+					"dimension":   {Type: "text"},
+					"tier":        {Type: "integer"},
+					"score":       {Type: "integer"},
+					"evidence":    {Type: "text"},
+					"confidence":  {Type: "text"},
+				}},
+			},
+		},
+	}
+}
+
+func TestRun_AcceptsAccumulatorEntityProjectionWithPayloadExtras(t *testing.T) {
+	report := Run(context.Background(), semanticview.Wrap(accumulatorProjectionBundle()), Options{})
+
+	if reportContains(report.HardInvalidities(), "accumulator_entity_projection", "scores") {
+		t.Fatalf("unexpected projection invalidity: %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionWithoutAccumulateInto(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	handler := bundle.Nodes["scoring-node"].EventHandlers["score.dimension_complete"]
+	handler.Accumulate.Into = ""
+	bundle.Nodes["scoring-node"].EventHandlers["score.dimension_complete"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "does not resolve to an explicitly declared accumulator") {
+		t.Fatalf("expected missing accumulate.into invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionMissingTypedViewField(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	payload := bundle.Events["score.dimension_complete"].Payload
+	delete(payload.Properties, "evidence")
+	event := bundle.Events["score.dimension_complete"]
+	event.Payload = payload
+	bundle.Events["score.dimension_complete"] = event
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "payload missing field \"evidence\"") {
+		t.Fatalf("expected missing typed-view field invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionSourceExtraReference(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	entity.Fields["summary"] = runtimecontracts.EntityFieldDecl{
+		Type:            "[DimensionVerdict]",
+		MaterializeFrom: "scoring-node.dimensions_received",
+		Project: map[string]any{
+			"dimension": "source.vertical_id",
+			"score":     "source.score",
+		},
+	}
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "vertical_id is not a field of item type DimensionScore") {
+		t.Fatalf("expected source extra projection invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionUnknownPolicyReference(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	entity.Fields["summary"] = runtimecontracts.EntityFieldDecl{
+		Type:            "[DimensionVerdict]",
+		MaterializeFrom: "scoring-node.dimensions_received",
+		Project: map[string]any{
+			"dimension": "source.dimension",
+			"score":     "policy.scoring.default_score",
+		},
+	}
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "policy field scoring.default_score is not declared") {
+		t.Fatalf("expected unknown policy projection invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionSourceTypeMismatch(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	entity.Fields["summary"] = runtimecontracts.EntityFieldDecl{
+		Type:            "[DimensionVerdict]",
+		MaterializeFrom: "scoring-node.dimensions_received",
+		Project: map[string]any{
+			"dimension": "source.dimension",
+			"score":     "source.evidence",
+		},
+	}
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "not assignable to target field type integer") {
+		t.Fatalf("expected source type mismatch invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsAccumulatorProjectionWithOtherWriter(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	handler := bundle.Nodes["scoring-node"].EventHandlers["score.dimension_complete"]
+	handler.DataAccumulation = runtimecontracts.WorkflowDataAccumulation{
+		Writes: []runtimecontracts.WorkflowDataWrite{{
+			TargetField: "scores",
+			Value:       runtimecontracts.LiteralExpression([]any{}),
+		}},
+	}
+	bundle.Nodes["scoring-node"].EventHandlers["score.dimension_complete"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "also has authored writer") {
+		t.Fatalf("expected writer conflict invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsDuplicateAccumulateInto(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	node := bundle.Nodes["scoring-node"]
+	node.EventHandlers["score.dimension_retry"] = runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{Into: "dimensions_received"},
+	}
+	bundle.Nodes["scoring-node"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "declared by multiple handlers") {
+		t.Fatalf("expected duplicate accumulate.into invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsMaterializeFromWithUnusedReason(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	field := entity.Fields["scores"]
+	field.UnusedReason = "scores are now materialized and this stale reason must be removed"
+	entity.Fields["scores"] = field
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "declares both materialize_from and _unused_reason") {
+		t.Fatalf("expected _unused_reason invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsProjectWhenTypesMatch(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	field := entity.Fields["scores"]
+	field.Project = map[string]any{"dimension": "source.dimension"}
+	entity.Fields["scores"] = field
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "element types match") {
+		t.Fatalf("expected project-forbidden invalidity, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_RejectsMissingProjectWhenTypesDiffer(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	field := entity.Fields["scores"]
+	field.Type = "[DimensionVerdict]"
+	entity.Fields["scores"] = field
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "accumulator_entity_projection", "project must be present") {
+		t.Fatalf("expected project-required invalidity, got %#v", report.HardInvalidities())
+	}
+}

--- a/internal/runtime/bootverify/workflow_accumulator_projection_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_projection_checks_test.go
@@ -27,8 +27,19 @@ func accumulatorProjectionBundle() *runtimecontracts.WorkflowContractBundle {
 						"score":     {Type: "integer"},
 					},
 				},
+				"DimensionSummary": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension":  {Type: "text"},
+						"score":      {Type: "integer"},
+						"confidence": {Type: "text"},
+						"source":     {Type: "text"},
+					},
+				},
 			},
 		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"projection": {Value: map[string]any{"default_confidence": "medium"}},
+		}},
 		RootEntities: runtimecontracts.EntityContractsDocument{
 			"vertical": {
 				Fields: map[string]runtimecontracts.EntityFieldDecl{
@@ -71,6 +82,28 @@ func TestRun_AcceptsAccumulatorEntityProjectionWithPayloadExtras(t *testing.T) {
 
 	if reportContains(report.HardInvalidities(), "accumulator_entity_projection", "scores") {
 		t.Fatalf("unexpected projection invalidity: %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_AcceptsAccumulatorProjectionWithPolicyAndLiteralProject(t *testing.T) {
+	bundle := accumulatorProjectionBundle()
+	entity := bundle.RootEntities["vertical"]
+	entity.Fields["summary"] = runtimecontracts.EntityFieldDecl{
+		Type:            "[DimensionSummary]",
+		MaterializeFrom: "scoring-node.dimensions_received",
+		Project: map[string]any{
+			"dimension":  "source.dimension",
+			"score":      "source.score",
+			"confidence": "policy.projection.default_confidence",
+			"source":     "scoring-node",
+		},
+	}
+	bundle.RootEntities["vertical"] = entity
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.HardInvalidities(), "accumulator_entity_projection", "summary") {
+		t.Fatalf("unexpected policy/literal projection invalidity: %#v", report.HardInvalidities())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -80,6 +80,9 @@ func (c *checkerContext) entityWriterCoverage() []Finding {
 			if fieldDecl.Initial != nil {
 				continue
 			}
+			if strings.TrimSpace(fieldDecl.MaterializeFrom) != "" {
+				continue
+			}
 			if strings.TrimSpace(fieldDecl.UnusedReason) != "" {
 				continue
 			}

--- a/internal/runtime/contracts/node_state_types.go
+++ b/internal/runtime/contracts/node_state_types.go
@@ -28,6 +28,16 @@ func NormalizeNodeStateFieldType(raw string) (string, error) {
 		}
 		return "[" + base + "]", nil
 	}
+	if strings.HasPrefix(raw, "list<") && strings.HasSuffix(raw, ">") {
+		base := strings.TrimSpace(raw[len("list<") : len(raw)-1])
+		if base == "" {
+			return "", fmt.Errorf("state_schema list type requires an element type")
+		}
+		if !nodeStateNamedTypePattern.MatchString(base) {
+			return "", fmt.Errorf("unsupported state_schema named list type %q; use list<NamedType> for declared types.yaml references", raw)
+		}
+		return "list<" + base + ">", nil
+	}
 	if strings.HasSuffix(raw, "[]") {
 		base := strings.TrimSpace(strings.TrimSuffix(raw, "[]"))
 		if base == "" {
@@ -73,6 +83,9 @@ func NodeStateNamedTypeName(raw string) (string, bool) {
 	}
 	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
 		raw = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]"))
+	}
+	if strings.HasPrefix(raw, "list<") && strings.HasSuffix(raw, ">") {
+		raw = strings.TrimSpace(raw[len("list<") : len(raw)-1])
 	}
 	if !nodeStateNamedTypePattern.MatchString(raw) {
 		return "", false

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -150,7 +150,9 @@ type GuardCheck struct {
 	Check string `yaml:"check"`
 }
 type AccumulateSpec struct {
+	Into         string               `yaml:"into"`
 	ExpectedFrom string               `yaml:"expected_from"`
+	From         string               `yaml:"from"`
 	ExpectedPath paths.Path           `yaml:"-"`
 	DedupBy      string               `yaml:"dedup_by"`
 	DedupPath    paths.Path           `yaml:"-"`
@@ -525,11 +527,13 @@ type EntityContract struct {
 }
 
 type EntityFieldDecl struct {
-	Type         string `yaml:"type"`
-	Initial      any    `yaml:"initial"`
-	Immutable    bool   `yaml:"immutable"`
-	Description  string `yaml:"description"`
-	UnusedReason string `yaml:"_unused_reason"`
+	Type            string         `yaml:"type"`
+	Initial         any            `yaml:"initial"`
+	Immutable       bool           `yaml:"immutable"`
+	Description     string         `yaml:"description"`
+	MaterializeFrom string         `yaml:"materialize_from"`
+	Project         map[string]any `yaml:"project"`
+	UnusedReason    string         `yaml:"_unused_reason"`
 }
 type ProjectPackageRef struct {
 	ID      string `yaml:"id"`

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -237,6 +237,13 @@ func cloneEntityContract(in EntityContract) EntityContract {
 	if len(in.Fields) > 0 {
 		out.Fields = make(map[string]EntityFieldDecl, len(in.Fields))
 		for key, value := range in.Fields {
+			if len(value.Project) > 0 {
+				project := make(map[string]any, len(value.Project))
+				for projectKey, projectValue := range value.Project {
+					project[projectKey] = projectValue
+				}
+				value.Project = project
+			}
 			out.Fields[key] = value
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -37,8 +37,13 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 	if a == nil {
 		return nil
 	}
+	if err := validateAccumulateFieldNodes(node); err != nil {
+		return err
+	}
 	var aux struct {
+		Into         string    `yaml:"into"`
 		ExpectedFrom string    `yaml:"expected_from"`
+		From         string    `yaml:"from"`
 		DedupBy      string    `yaml:"dedup_by"`
 		Threshold    int       `yaml:"threshold"`
 		TimeoutMS    int       `yaml:"timeout_ms"`
@@ -50,7 +55,9 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*a = AccumulateSpec{
+		Into:         strings.TrimSpace(aux.Into),
 		ExpectedFrom: strings.TrimSpace(aux.ExpectedFrom),
+		From:         strings.TrimSpace(aux.From),
 		ExpectedPath: paths.Parse(aux.ExpectedFrom),
 		DedupBy:      strings.TrimSpace(aux.DedupBy),
 		DedupPath:    paths.Parse(aux.DedupBy),
@@ -64,6 +71,33 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	if a.OnTimeout, err = decodeHandlerRuleEntryNode(&aux.OnTimeout); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAccumulateFieldNodes(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"into":          {},
+		"expected_from": {},
+		"from":          {},
+		"dedup_by":      {},
+		"threshold":     {},
+		"timeout_ms":    {},
+		"completion":    {},
+		"on_complete":   {},
+		"on_timeout":    {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: accumulate field %q not in platform spec", key)
+		}
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -702,3 +702,42 @@ action: increment_revision_count
 		t.Fatalf("yaml.Unmarshal error = %v, want unsupported handler action", err)
 	}
 }
+
+func TestEntityFieldDeclDecode_PreservesMaterializeFromProjection(t *testing.T) {
+	var field EntityFieldDecl
+	if err := yaml.Unmarshal([]byte(`
+type: list<DimensionVerdict>
+materialize_from: scoring-node.dimensions_received
+project:
+  dimension: source.dimension
+  score: source.score
+`), &field); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := field.MaterializeFrom; got != "scoring-node.dimensions_received" {
+		t.Fatalf("MaterializeFrom = %q", got)
+	}
+	if got := field.Project["dimension"]; got != "source.dimension" {
+		t.Fatalf("Project[dimension] = %#v", got)
+	}
+}
+
+func TestAccumulateSpecDecode_PreservesIntoAndRejectsUnknownField(t *testing.T) {
+	var spec AccumulateSpec
+	if err := yaml.Unmarshal([]byte(`
+into: dimensions_received
+dedup_by: payload.dimension
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := spec.Into; got != "dimensions_received" {
+		t.Fatalf("Into = %q", got)
+	}
+
+	err := yaml.Unmarshal([]byte(`
+legacy_buffer: dimensions_received
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -273,10 +273,12 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	}
 	parsed, err := decodeWave1FieldNode(node, wave1FieldNodeOptions{
-		Context:           "entity field",
-		AllowInitial:      true,
-		AllowImmutable:    true,
-		AllowUnusedReason: true,
+		Context:              "entity field",
+		AllowInitial:         true,
+		AllowImmutable:       true,
+		AllowUnusedReason:    true,
+		AllowMaterializeFrom: true,
+		AllowProject:         true,
 	})
 	if err != nil {
 		return err
@@ -285,6 +287,8 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 	f.Initial = parsed.Initial
 	f.Immutable = parsed.Immutable
 	f.Description = parsed.Description
+	f.MaterializeFrom = parsed.MaterializeFrom
+	f.Project = parsed.Project
 	f.UnusedReason = parsed.UnusedReason
 	return nil
 }
@@ -334,6 +338,12 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 	if opts.AllowUnusedReason {
 		allowed["_unused_reason"] = struct{}{}
 	}
+	if opts.AllowMaterializeFrom {
+		allowed["materialize_from"] = struct{}{}
+	}
+	if opts.AllowProject {
+		allowed["project"] = struct{}{}
+	}
 
 	var field wave1ParsedFieldNode
 	var listOf string
@@ -354,7 +364,7 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				}
 				listOf = listValue
 				continue
-			case "initial", "immutable", "_unused_reason":
+			case "initial", "immutable", "_unused_reason", "materialize_from", "project":
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
 			default:
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
@@ -391,6 +401,18 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				return wave1ParsedFieldNode{}, err
 			}
 			field.UnusedReason = text
+		case "materialize_from":
+			text, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.MaterializeFrom = strings.TrimSpace(text)
+		case "project":
+			project, err := decodeProjectionMapNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Project = project
 		}
 	}
 	if strings.EqualFold(strings.TrimSpace(field.Type), "list") {
@@ -409,6 +431,44 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reason must be at least 10 characters", opts.Context)
 	}
 	return field, nil
+}
+
+func decodeProjectionMapNode(node *yaml.Node) (map[string]any, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("entity field project must be a mapping")
+	}
+	out := make(map[string]any, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		var value any
+		switch node.Content[i+1].Kind {
+		case yaml.ScalarNode:
+			switch strings.TrimSpace(node.Content[i+1].Tag) {
+			case "!!int", "!!float", "!!bool":
+				if err := node.Content[i+1].Decode(&value); err != nil {
+					return nil, err
+				}
+			default:
+				text, err := decodeScalarStringNode(node.Content[i+1])
+				if err != nil {
+					return nil, err
+				}
+				value = text
+			}
+		default:
+			if err := node.Content[i+1].Decode(&value); err != nil {
+				return nil, err
+			}
+		}
+		out[key] = value
+	}
+	return out, nil
 }
 
 func validateWave1TypeRef(raw, context string) error {
@@ -465,16 +525,20 @@ func buildFlatEventPayloadSpec(node *yaml.Node) (EventPayloadSpec, error) {
 }
 
 type wave1FieldNodeOptions struct {
-	Context           string
-	AllowInitial      bool
-	AllowImmutable    bool
-	AllowUnusedReason bool
+	Context              string
+	AllowInitial         bool
+	AllowImmutable       bool
+	AllowUnusedReason    bool
+	AllowMaterializeFrom bool
+	AllowProject         bool
 }
 
 type wave1ParsedFieldNode struct {
-	Type         string
-	Initial      any
-	Immutable    bool
-	Description  string
-	UnusedReason string
+	Type            string
+	Initial         any
+	Immutable       bool
+	Description     string
+	MaterializeFrom string
+	Project         map[string]any
+	UnusedReason    string
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	"swarm/internal/runtime/accprojection"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
@@ -38,6 +39,7 @@ const (
 	StepAdvancesTo Step = "advances_to"
 	StepSetsGate   Step = "sets_gate"
 	StepDataWrites Step = "data_writes"
+	StepProjection Step = "projection"
 	StepTransform  Step = "transform"
 	StepEmits      Step = "emits"
 	StepAction     Step = "action"
@@ -60,6 +62,7 @@ var OrderedSteps = []Step{
 	StepAdvancesTo,
 	StepSetsGate,
 	StepDataWrites,
+	StepProjection,
 	StepTransform,
 	StepEmits,
 	StepAction,
@@ -72,15 +75,16 @@ type Executor struct {
 }
 
 type executionFrame struct {
-	tx                        Tx
-	req                       ExecutionRequest
-	base                      BaseContext
-	state                     ExecutionState
-	result                    ExecutionResult
-	rule                      *runtimecontracts.HandlerRuleEntry
-	payload                   map[string]any
-	topLevelDataAccumulation  runtimecontracts.WorkflowDataAccumulation
-	topLevelDataWritesApplied bool
+	tx                            Tx
+	req                           ExecutionRequest
+	base                          BaseContext
+	state                         ExecutionState
+	result                        ExecutionResult
+	rule                          *runtimecontracts.HandlerRuleEntry
+	payload                       map[string]any
+	topLevelDataAccumulation      runtimecontracts.WorkflowDataAccumulation
+	topLevelDataWritesApplied     bool
+	accumulatorProjectionEligible bool
 }
 
 func NewExecutor(deps RuntimeDependencies, evaluator Evaluator) (*Executor, error) {
@@ -537,6 +541,8 @@ func (e *Executor) runStep(frame *executionFrame, step Step) (bool, error) {
 		return false, e.stepSetsGate(frame)
 	case StepDataWrites:
 		return false, e.stepDataWrites(frame)
+	case StepProjection:
+		return false, e.stepProjection(frame)
 	case StepTransform:
 		return false, e.stepTransform(frame)
 	case StepEmits:
@@ -990,6 +996,11 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 	}
 	if rule != nil {
 		frame.rule = rule
+		if frame.result.AccumulatorCompletionDiagnostics.Relevant &&
+			frame.result.AccumulatorCompletionDiagnostics.CompletionReached &&
+			frame.req.Handler.Accumulate != nil {
+			frame.accumulatorProjectionEligible = true
+		}
 		e.applyRule(frame, rule)
 		if rule.FanOut != nil {
 			if _, err := e.stepFanOut(frame); err != nil {
@@ -1093,6 +1104,151 @@ func (e *Executor) stepDataWrites(frame *executionFrame) error {
 		frame.topLevelDataWritesApplied = true
 	}
 	return nil
+}
+
+func (e *Executor) stepProjection(frame *executionFrame) error {
+	if !frame.accumulatorProjectionEligible {
+		return nil
+	}
+	bindings, issues := accprojection.ForHandler(e.deps.Source, frame.req.FlowID.String(), frame.req.NodeID.String(), string(frame.req.Event.Type))
+	if len(issues) > 0 {
+		return fmt.Errorf("accumulator projection declarations are invalid: %s", issues[0].Message)
+	}
+	if len(bindings) == 0 {
+		return nil
+	}
+	acc, ok := loadAccumulator(frame.state.State, frame.req.NodeID, frame.req.Event.Type)
+	if !ok {
+		return fmt.Errorf("accumulator projection source missing for node %s event %s", frame.req.NodeID.String(), string(frame.req.Event.Type))
+	}
+	for _, binding := range bindings {
+		projected, err := e.projectAccumulatorItems(frame, binding, acc.Items)
+		if err != nil {
+			return err
+		}
+		if err := e.writeStepValue(frame, "entity."+binding.TargetField, projected); err != nil {
+			return fmt.Errorf("materialize_from %s.%s: %w", binding.SourceNodeID, binding.AccumulatorName, err)
+		}
+	}
+	return nil
+}
+
+func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {
+	out := make([]any, 0, len(items))
+	for idx, item := range items {
+		typedView, err := accumulatorTypedView(binding, item)
+		if err != nil {
+			return nil, fmt.Errorf("materialize_from %s.%s item %d: %w", binding.SourceNodeID, binding.AccumulatorName, idx, err)
+		}
+		if len(binding.Project) == 0 {
+			out = append(out, typedView)
+			continue
+		}
+		projected, err := e.projectAccumulatorItem(frame, binding, typedView)
+		if err != nil {
+			return nil, fmt.Errorf("materialize_from %s.%s item %d: %w", binding.SourceNodeID, binding.AccumulatorName, idx, err)
+		}
+		out = append(out, projected)
+	}
+	return out, nil
+}
+
+func accumulatorTypedView(binding accprojection.Binding, item map[string]any) (map[string]any, error) {
+	out := make(map[string]any, len(binding.SourceNamedType.Fields))
+	for fieldName := range binding.SourceNamedType.Fields {
+		fieldName = strings.TrimSpace(fieldName)
+		if fieldName == "" {
+			continue
+		}
+		value, ok := item[fieldName]
+		if !ok {
+			return nil, fmt.Errorf("source item missing required typed-view field %q", fieldName)
+		}
+		out[fieldName] = cloneProjectionValue(value)
+	}
+	return out, nil
+}
+
+func (e *Executor) projectAccumulatorItem(frame *executionFrame, binding accprojection.Binding, source map[string]any) (map[string]any, error) {
+	out := make(map[string]any, len(binding.TargetNamedType.Fields))
+	for fieldName := range binding.TargetNamedType.Fields {
+		rawExpr, ok := binding.Project[fieldName]
+		if !ok {
+			return nil, fmt.Errorf("project missing target field %q", fieldName)
+		}
+		value, err := e.evaluateProjectionExpression(frame, rawExpr, source)
+		if err != nil {
+			return nil, fmt.Errorf("project.%s: %w", fieldName, err)
+		}
+		out[fieldName] = value
+	}
+	return out, nil
+}
+
+func (e *Executor) evaluateProjectionExpression(frame *executionFrame, raw any, source map[string]any) (any, error) {
+	expr, ok := raw.(string)
+	if !ok {
+		return cloneProjectionValue(raw), nil
+	}
+	expr = strings.TrimSpace(expr)
+	if fieldName, ok := strings.CutPrefix(expr, "source."); ok {
+		fieldName = strings.TrimSpace(fieldName)
+		if _, reserved := accprojection.ReservedAccumulatorMetadata[fieldName]; reserved {
+			return nil, fmt.Errorf("reserved accumulator metadata %q is not addressable through source.*", fieldName)
+		}
+		value, ok := source[fieldName]
+		if !ok {
+			return nil, fmt.Errorf("unknown source field %q", fieldName)
+		}
+		return cloneProjectionValue(value), nil
+	}
+	if policyPath, ok := strings.CutPrefix(expr, "policy."); ok {
+		value, ok := lookupProjectionPath(e.currentContext(frame).Policy.Raw(), policyPath)
+		if !ok {
+			return nil, fmt.Errorf("unknown policy field %q", policyPath)
+		}
+		return cloneProjectionValue(value), nil
+	}
+	for _, forbidden := range []string{"entity.", "payload.", "event.", "fan_out.", "accumulated."} {
+		if strings.HasPrefix(expr, forbidden) {
+			return nil, fmt.Errorf("forbidden projection binding %q", expr)
+		}
+	}
+	return expr, nil
+}
+
+func cloneProjectionValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneStringAnyMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = cloneProjectionValue(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func lookupProjectionPath(raw map[string]any, path string) (any, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, false
+	}
+	current := any(raw)
+	for _, segment := range strings.Split(path, ".") {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[strings.TrimSpace(segment)]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
 }
 
 func (e *Executor) stepTransform(frame *executionFrame) error {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -519,6 +519,11 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 						Initial:         []any{},
 						MaterializeFrom: "scoring-node.dimensions_received",
 					},
+					"unrelated_invalid_scores": {
+						Type:            "[DimensionScore]",
+						Initial:         []any{},
+						MaterializeFrom: "other-node.missing_buffer",
+					},
 				},
 			},
 		},
@@ -530,6 +535,13 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
 					"score.dimension_complete": {
 						Accumulate: &runtimecontracts.AccumulateSpec{Into: "dimensions_received"},
+					},
+				},
+			},
+			"other-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"score.unrelated": {
+						Accumulate: &runtimecontracts.AccumulateSpec{Into: "missing_buffer"},
 					},
 				},
 			},

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -415,14 +415,17 @@ func TestExecutor_StepOrderIsStable(t *testing.T) {
 		t.Fatalf("NewExecutor error: %v", err)
 	}
 	steps := exec.Steps()
-	if len(steps) != 19 {
-		t.Fatalf("step count = %d, want 19", len(steps))
+	if len(steps) != 20 {
+		t.Fatalf("step count = %d, want 20", len(steps))
 	}
 	if steps[0] != StepQuery || steps[len(steps)-1] != StepClear {
 		t.Fatalf("unexpected step order: %v", steps)
 	}
 	if steps[5] != StepGroupBy {
 		t.Fatalf("expected group_by at index 5, got order %v", steps)
+	}
+	if steps[15] != StepProjection {
+		t.Fatalf("expected projection after data_writes at index 15, got order %v", steps)
 	}
 }
 
@@ -490,6 +493,128 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 	}
 	if got := shaper.lastReq.State.StateCarrier.Metadata["composite_score"]; got != 80.0 && got != 80 {
 		t.Fatalf("payload shaper saw composite_score = %#v, want 80", got)
+	}
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension":  {Type: "text"},
+						"tier":       {Type: "integer"},
+						"score":      {Type: "integer"},
+						"evidence":   {Type: "text"},
+						"confidence": {Type: "text"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"vertical": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"scores": {
+						Type:            "[DimensionScore]",
+						Initial:         []any{},
+						MaterializeFrom: "scoring-node.dimensions_received",
+					},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scoring-node": {
+				StateSchema: runtimecontracts.NodeStateSchema{
+					Fields: []runtimecontracts.NodeStateField{{Name: "dimensions_received", Type: "[DimensionScore]"}},
+				},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"score.dimension_complete": {
+						Accumulate: &runtimecontracts.AccumulateSpec{Into: "dimensions_received"},
+					},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"score.dimension_complete": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"vertical_id": {Type: "uuid"},
+					"dimension":   {Type: "text"},
+					"tier":        {Type: "integer"},
+					"score":       {Type: "integer"},
+					"evidence":    {Type: "text"},
+					"confidence":  {Type: "text"},
+				}},
+			},
+		},
+	})
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+			OnComplete: []runtimecontracts.HandlerRuleEntry{{
+				ID: "complete",
+				Emit: runtimecontracts.EmitSpec{
+					Event: "vertical.scored",
+					Fields: map[string]runtimecontracts.ExpressionValue{
+						"scores": runtimecontracts.RefExpression("entity.scores"),
+					},
+				},
+			}},
+		},
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		Event: events.Event{
+			ID:      "evt-1",
+			Type:    "score.dimension_complete",
+			Payload: json.RawMessage(`{"vertical_id":"11111111-1111-1111-1111-111111111111","dimension":"market","tier":2,"score":87,"evidence":"strong","confidence":"high"}`),
+		},
+		Handler: handler,
+		State:   testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	scores, ok := result.StateMutation.Metadata["scores"].([]any)
+	if !ok || len(scores) != 1 {
+		t.Fatalf("projected scores = %#v", result.StateMutation.Metadata["scores"])
+	}
+	score, ok := scores[0].(map[string]any)
+	if !ok {
+		t.Fatalf("projected score item = %#v", scores[0])
+	}
+	if _, exists := score["event_id"]; exists {
+		t.Fatalf("projected score leaked accumulator metadata: %#v", score)
+	}
+	if _, exists := score["vertical_id"]; exists {
+		t.Fatalf("projected score leaked payload extra field: %#v", score)
+	}
+	if got := score["dimension"]; got != "market" {
+		t.Fatalf("projected dimension = %#v", got)
+	}
+	if len(result.EmitIntents) != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))
+	}
+	var emitted map[string]any
+	if err := json.Unmarshal(result.EmitIntents[0].Event.Payload, &emitted); err != nil {
+		t.Fatalf("emit payload json: %v", err)
+	}
+	emittedScores, ok := emitted["scores"].([]any)
+	if !ok || len(emittedScores) != 1 {
+		t.Fatalf("emit payload scores = %#v", emitted["scores"])
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -509,8 +509,19 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 						"confidence": {Type: "text"},
 					},
 				},
+				"DimensionSummary": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension":  {Type: "text"},
+						"score":      {Type: "integer"},
+						"confidence": {Type: "text"},
+						"source":     {Type: "text"},
+					},
+				},
 			},
 		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"projection": {Value: map[string]any{"default_confidence": "medium"}},
+		}},
 		RootEntities: runtimecontracts.EntityContractsDocument{
 			"vertical": {
 				Fields: map[string]runtimecontracts.EntityFieldDecl{
@@ -518,6 +529,17 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 						Type:            "[DimensionScore]",
 						Initial:         []any{},
 						MaterializeFrom: "scoring-node.dimensions_received",
+					},
+					"summary": {
+						Type:            "[DimensionSummary]",
+						Initial:         []any{},
+						MaterializeFrom: "scoring-node.dimensions_received",
+						Project: map[string]any{
+							"dimension":  "source.dimension",
+							"score":      "source.score",
+							"confidence": "policy.projection.default_confidence",
+							"source":     "scoring-node",
+						},
 					},
 					"unrelated_invalid_scores": {
 						Type:            "[DimensionScore]",
@@ -616,6 +638,20 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 	}
 	if got := score["dimension"]; got != "market" {
 		t.Fatalf("projected dimension = %#v", got)
+	}
+	summaries, ok := result.StateMutation.Metadata["summary"].([]any)
+	if !ok || len(summaries) != 1 {
+		t.Fatalf("projected summary = %#v", result.StateMutation.Metadata["summary"])
+	}
+	summary, ok := summaries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("projected summary item = %#v", summaries[0])
+	}
+	if got := summary["confidence"]; got != "medium" {
+		t.Fatalf("projected summary confidence = %#v", got)
+	}
+	if got := summary["source"]; got != "scoring-node" {
+		t.Fatalf("projected summary literal source = %#v", got)
 	}
 	if len(result.EmitIntents) != 1 {
 		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -59,6 +59,9 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, err, "validate field")
 	}
+	if strings.TrimSpace(field.FieldDecl.MaterializeFrom) != "" {
+		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, "field %s is materialized by runtime accumulator projection and is not agent-writable", fieldName)
+	}
 	currentFields := entityRowFieldMap(row)
 	value, err := normalizeEntityFieldValue(schema, field, payload["value"])
 	if err != nil {

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -388,6 +388,9 @@ func entityToolWritablePathNames(contract entityruntime.Contract) []string {
 		if err != nil {
 			continue
 		}
+		if strings.TrimSpace(decl.MaterializeFrom) != "" {
+			continue
+		}
 		collectEntityToolWritablePaths(contract, strings.TrimSpace(name), strings.TrimSpace(decl.Type), seen, map[string]struct{}{}, &out)
 	}
 	sort.Strings(out)

--- a/internal/runtime/tools/platform_builtin_catalog_test.go
+++ b/internal/runtime/tools/platform_builtin_catalog_test.go
@@ -35,3 +35,32 @@ func TestEntityToolLeafSelectorNames_GuardsRecursiveNamedTypes(t *testing.T) {
 		t.Fatalf("entityToolLeafSelectorNames() = %#v, want [node.label status]", got)
 	}
 }
+
+func TestEntityToolWritablePathNames_ExcludesMaterializedFields(t *testing.T) {
+	contract := entityruntime.Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"status": {Type: "text"},
+				"scores": {
+					Type:            "[DimensionScore]",
+					MaterializeFrom: "scoring-node.dimensions_received",
+				},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension": {Type: "text"},
+						"score":     {Type: "integer"},
+					},
+				},
+			},
+		},
+	}
+
+	got := entityToolWritablePathNames(contract)
+	if len(got) != 1 || got[0] != "status" {
+		t.Fatalf("entityToolWritablePathNames() = %#v, want [status]", got)
+	}
+}


### PR DESCRIPTION
Closes #638

## Governing refs / context
- Approved Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/638#issuecomment-4393010430
- Independent gate outcome: https://github.com/yazzaoui/Swarm/issues/638#issuecomment-4393052559
- Approved review draft: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.accumulator-entity-projection.yaml`
- Authoritative merge artifact updated here: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Downstream blocker: Empire #19 remains the product-side application after this Swarm primitive lands.

## Semantic migration
- New canonical owner: `internal/runtime/accprojection` shared resolver, consumed by bootverify and runtime executor.
- Runtime owner: executor `projection` step runs after data writes and before `emit.fields` only for successful matching accumulator `on_complete` branches.
- Contract owner: entity fields may declare `materialize_from: <node_id>.<accumulator_name>` and optional `project`; accumulators declare `accumulate.into`.
- Old invalid/non-authoritative paths: product materializer nodes for this primitive, `data_accumulation.expression: accumulated...` shims, loose `jsonb`/list shims, `_unused_reason` on projected fields, and agent writes to runtime-materialized fields.
- Production paths checked for surviving old behavior: contract YAML parsing, bootverify, runtime execution, entity named-type normalization, role-scoped generated write catalogs, and legacy `save_entity_field` runtime writes.
- Migration completeness: complete for the Swarm primitive. Empire #19 still needs its contract-side materialization once this PR is merged.

## Verification
- `go test ./cmd/swarm ./internal/runtime/accprojection ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/tools`
- `go test ./...`
- `go test ./cmd/swarm -run TestRunVerifyCommand_AllowsAccumulatorEntityProjection -count=1`
- `go run ./cmd/swarm verify -contracts tests/tier8-boot-verification/test-boot-success`
- `git diff --check`
