### PR TITLE
[agent-d][issue #643] Allow accumulate descriptions

### DIFF
--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -153,6 +153,7 @@ type AccumulateSpec struct {
 	Into         string               `yaml:"into"`
 	ExpectedFrom string               `yaml:"expected_from"`
 	From         string               `yaml:"from"`
+	Description  string               `yaml:"description"`
 	ExpectedPath paths.Path           `yaml:"-"`
 	DedupBy      string               `yaml:"dedup_by"`
 	DedupPath    paths.Path           `yaml:"-"`

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -44,6 +44,7 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		Into         string    `yaml:"into"`
 		ExpectedFrom string    `yaml:"expected_from"`
 		From         string    `yaml:"from"`
+		Description  string    `yaml:"description"`
 		DedupBy      string    `yaml:"dedup_by"`
 		Threshold    int       `yaml:"threshold"`
 		TimeoutMS    int       `yaml:"timeout_ms"`
@@ -58,6 +59,7 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		Into:         strings.TrimSpace(aux.Into),
 		ExpectedFrom: strings.TrimSpace(aux.ExpectedFrom),
 		From:         strings.TrimSpace(aux.From),
+		Description:  strings.TrimSpace(aux.Description),
 		ExpectedPath: paths.Parse(aux.ExpectedFrom),
 		DedupBy:      strings.TrimSpace(aux.DedupBy),
 		DedupPath:    paths.Parse(aux.DedupBy),
@@ -83,6 +85,7 @@ func validateAccumulateFieldNodes(node *yaml.Node) error {
 		"into":          {},
 		"expected_from": {},
 		"from":          {},
+		"description":   {},
 		"dedup_by":      {},
 		"threshold":     {},
 		"timeout_ms":    {},

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -722,16 +722,20 @@ project:
 	}
 }
 
-func TestAccumulateSpecDecode_PreservesIntoAndRejectsUnknownField(t *testing.T) {
+func TestAccumulateSpecDecode_PreservesDescriptionAndRejectsUnknownField(t *testing.T) {
 	var spec AccumulateSpec
 	if err := yaml.Unmarshal([]byte(`
 into: dimensions_received
+description: all dimension receipts have arrived
 dedup_by: payload.dimension
 `), &spec); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
 	if got := spec.Into; got != "dimensions_received" {
 		t.Fatalf("Into = %q", got)
+	}
+	if got := spec.Description; got != "all dimension receipts have arrived" {
+		t.Fatalf("Description = %q", got)
 	}
 
 	err := yaml.Unmarshal([]byte(`


### PR DESCRIPTION
Closes #643

## Summary

Aligns the strict `AccumulateSpec` YAML decoder/model with the authoritative platform spec for the metadata-only `accumulate.description` field.

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `handler_specification.handler_fields.accumulate.sub_fields.description`
- Swarm #643 pre-audit and approved gate outcome
- Empire #19 blocker comment showing current Empire verify was stopped by `UNDEFINED-FIELD: accumulate field "description" not in platform spec`

## Semantic migration

New canonical owner remains the authoritative platform spec plus strict contract loader:

- Spec owner: `platform-spec.yaml` accumulate subfields include `description` as a human-readable note.
- Runtime/loader owner: `AccumulateSpec` and `validateAccumulateFieldNodes` now consume that field.
- Old invalid path: strict decoder rejected `accumulate.description` even though the spec allowed it.
- Production paths checked: `AccumulateSpec.UnmarshalYAML`, `validateAccumulateFieldNodes`, focused contract tests, and Empire verify against `/Users/youmew/dev/empire/contracts`.
- Migration complete for this class: `accumulate.description` is accepted/preserved and unknown accumulate fields remain fail-closed.

## Tests

- `go test ./internal/runtime/contracts`
- `go run ./cmd/swarm verify -contracts /Users/youmew/dev/empire/contracts -platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
