### PR TITLE
[agent-a][issue #642] Run-scope fork timer reconstruction

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3076,28 +3076,36 @@ platform_tables:
         \ 'draining', 'terminated')),\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    terminated_at     TIMESTAMPTZ\n\
         );"
     timers:
-      description: 'Durable timer and scheduled task store. Persisted across restarts. Entity-scoped timers: entity_id and
-        flow_instance set, tied to a specific entity lifecycle. Global timers: entity_id and flow_instance NULL, used for
-        recurring platform-level work (periodic scans, health checks, digest compilation). fire_payload carries context when
-        the timer fires. owner_node OR owner_agent identifies who declared the timer (mutually exclusive). recurrence_cron
-        supports cron expressions for global recurring schedules. recurrence_interval supports duration strings (e.g., "24h")
-        for entity-scoped recurring timers. task_type: timer (one-shot entity), scheduled_task (recurring entity), deadline
-        (hard cutoff), global_recurring (platform-level periodic work).'
+      description: 'Durable timer and scheduled task store. Persisted across restarts. Run-scoped timers carry run_id and
+        are claimed, fired, cancelled, and recovered under that run identity. Entity-scoped timers: entity_id and
+        flow_instance set, tied to a specific entity lifecycle inside run_id. Global timers: entity_id, flow_instance,
+        and run_id NULL, used for recurring platform-level work (periodic scans, health checks, digest compilation).
+        fire_payload carries context when the timer fires. owner_node OR owner_agent identifies who declared the timer
+        (mutually exclusive). source_timer_id, forked_from_run_id, forked_from_event_id, and reconstruction_owner are
+        lineage-only fields for fork-local reconstructed timers and must not make the source timer executable fork truth.
+        recurrence_cron supports cron expressions for global recurring schedules. recurrence_interval supports duration
+        strings (e.g., "24h") for entity-scoped recurring timers. task_type: timer (one-shot entity), scheduled_task
+        (recurring entity), deadline (hard cutoff), global_recurring (platform-level periodic work).'
       ddl: "CREATE TABLE timers (\n    timer_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    timer_name     \
-        \   TEXT NOT NULL,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    fire_event        TEXT NOT NULL,\n\
+        \   TEXT NOT NULL,\n    run_id            UUID REFERENCES runs(run_id),\n    source_timer_id   UUID REFERENCES timers(timer_id),\n\
+        \    forked_from_run_id UUID REFERENCES runs(run_id),\n    forked_from_event_id UUID REFERENCES events(event_id),\n\
+        \    reconstruction_owner TEXT,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    fire_event        TEXT NOT NULL,\n\
         \    fire_payload      JSONB NOT NULL DEFAULT '{}',\n    fire_at           TIMESTAMPTZ NOT NULL,\n    recurring  \
         \       BOOLEAN NOT NULL DEFAULT FALSE,\n    recurrence_cron   TEXT,\n    recurrence_interval TEXT,\n    owner_node\
         \        TEXT,\n    owner_agent       TEXT,\n    task_type         TEXT NOT NULL DEFAULT 'timer' CHECK (task_type\
         \ IN ('timer', 'scheduled_task', 'deadline', 'global_recurring')),\n    status            TEXT NOT NULL DEFAULT 'active'\
         \ CHECK (status IN ('active', 'fired', 'cancelled', 'expired')),\n    fired_at          TIMESTAMPTZ,\n    created_at\
-        \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_timers_fire (status, fire_at),\n    INDEX idx_timers_entity\
+        \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_timers_run (run_id, status, fire_at) WHERE run_id IS NOT NULL,\n\
+        \    INDEX idx_timers_source_lineage (source_timer_id) WHERE source_timer_id IS NOT NULL,\n    INDEX idx_timers_fire (status, fire_at),\n    INDEX idx_timers_entity\
         \ (entity_id) WHERE entity_id IS NOT NULL,\n    INDEX idx_timers_flow (flow_instance) WHERE flow_instance IS NOT NULL,\n\
         \    INDEX idx_timers_global (task_type, status) WHERE entity_id IS NULL\n);"
       scope_rules:
-        entity_scoped: entity_id NOT NULL, flow_instance NOT NULL. Tied to entity lifecycle. Cancelled when entity reaches
-          terminal state.
-        global: entity_id NULL, flow_instance NULL. Platform-level. Not tied to any entity. Survives entity lifecycle.
-        flow_scoped: entity_id NULL, flow_instance NOT NULL. Tied to flow instance. Cancelled when flow instance terminates.
+        entity_scoped: entity_id NOT NULL, flow_instance NOT NULL, run_id set for runtime-owned entity timers. Tied to entity
+          lifecycle inside run_id. Cancelled when entity reaches terminal state.
+        global: entity_id NULL, flow_instance NULL, run_id NULL. Platform-level. Not tied to any entity. Survives entity
+          lifecycle.
+        flow_scoped: entity_id NULL, flow_instance NOT NULL, run_id set for runtime-owned flow timers. Tied to flow instance
+          inside run_id. Cancelled when flow instance terminates.
     dead_letters:
       description: Failed events after retry exhaustion or chain depth overflow.
       ddl: "CREATE TABLE dead_letters (\n    dead_letter_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    original_event_id\
@@ -3416,13 +3424,17 @@ run_model:
         source run, must record terminal source status at activation as divergence evidence, must not copy post-fork source
         events or event_deliveries, and must continue to regenerate fork-local events, deliveries, receipts, dead letters,
         idempotency effects, and emitted follow-ups under the fork run_id.'
-    selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source timer and
-      route facts as evidence-only fail-closed blockers until separately approved timer and route reconstruction owners
-      exist. The runtime.run_fork.selected_contract_execution owner consumes the canonical
-      store.run_fork.replay_resume_admission timer_history and flow_route_history blockers before selected-contract
-      materialization or activation can create fork-local executable work. It MUST NOT copy source timers or
-      routing_rules, fire or replay source timers, persist fork-local timer/route rows, derive selected-source recipients
-      for execution, or use source timer/route outcomes as selected-fork suppressors in this policy slice.'
+    selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source route facts
+      as evidence-only fail-closed blockers until a separately approved route reconstruction owner exists. Active source
+      timers may be reconstructed only by runtime.run_fork.historical_replay_execution.timer_reconstruction, which
+      consumes store.run_fork.replay_resume_admission timer_history as lineage, writes fresh fork-local timer rows under
+      the fork run_id with source_timer_id/forked_from_run_id/forked_from_event_id/reconstruction_owner lineage, and
+      requires scheduler claim/fire/recovery identity to include run_id. Source timer rows are never copied as executable
+      truth, fired as source work, or used as selected-fork suppressors. Unsupported source timer histories and post-T
+      source timer facts remain fail-closed. The runtime.run_fork.selected_contract_execution owner must continue to
+      consume flow_route_history blockers and MUST NOT copy routing_rules, persist fork-local route rows, derive
+      selected-source recipients for execution outside recipient planning, or use source route outcomes as selected-fork
+      suppressors.'
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
       runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
@@ -3521,11 +3533,16 @@ run_model:
       and the canonical store.run_fork.replay_resume_admission taxonomy, validates that every historical source fact
       family has exactly one executable, reconstructed, lineage-only, fail-closed, or split-sibling classification, and
       emits the executable work set that downstream store/runtime writers may mutate. The current supported closure
-      level is canonical owner promotion with delivery_event_replay_ready only; the selected-contract contract-swap
-      child runtime.run_fork.historical_replay_execution.contract_swap_boot_resume may execute only that already-admitted
-      primitive under selected/swapped contracts. Full product-complete historical replay/resume for timers, routes,
-      sessions, turns, audits, non-agent/node/system work, broader contract-swap boot/resume, generic source-advanced
-      policy, broader restart recovery, and API/UI/dashboard surfaces remains unsupported unless separately approved.
+      level is canonical owner promotion with delivery_event_replay_ready plus the selected-contract active-timer
+      reconstruction child runtime.run_fork.historical_replay_execution.timer_reconstruction. The timer reconstruction
+      child may reconstruct only active source timers at T into fresh fork-local timer rows under fork run_id with
+      lineage fields; it does not copy source rows, fire source timers, clear route/session/turn/audit/non-agent
+      blockers, or authorize full scheduler/recovery replay beyond run-scoped timer claim/fire/reload identity. The
+      selected-contract contract-swap child runtime.run_fork.historical_replay_execution.contract_swap_boot_resume may
+      execute only already-admitted delivery_event_replay_ready work under selected/swapped contracts. Full
+      product-complete historical replay/resume for routes, sessions, turns, audits, non-agent/node/system work,
+      broader contract-swap boot/resume, generic source-advanced policy, broader restart recovery, and API/UI/dashboard
+      surfaces remains unsupported unless separately approved.
       Activation, store delivery-event replay, recovery, selected/contract-swap consumers, route
       helpers, timer helpers, session helpers, and operator surfaces MUST consume this owner or remain explicit
       fail-closed/split outputs. They MUST NOT authorize mutation directly from replay_resume_admission, selected

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -358,6 +358,7 @@ nodes:
       - historical replay delivery/event replay recovery must prove startup RecoveryManager and EventBus.SweepUndispatched recover the fork-local rows produced by runtime.run_fork.historical_replay_execution, with source rows/outcomes as lineage only and broader replay/resume siblings still split
       - broad historical replay execution owner promotion must make runtime.run_fork.historical_replay_execution the canonical mutating authority that emits executable work identities after validating the full fact matrix; store activation and delivery-event replay writers must consume that owner rather than selecting source deliveries from replay_resume_admission or RunForkPlan directly
       - contract-swap historical replay execution needs runtime.run_fork.historical_replay_execution.contract_swap_boot_resume as the selected-contract child owner for already-admitted delivery_event_replay_ready work; selected recipient planning owns fork recipients, source delivery subscribers are lineage only, and timers/routes/sessions/turns/audits/non-agent/restart/API siblings stay fail-closed or split
+      - selected-contract timer reconstruction needs runtime.run_fork.historical_replay_execution.timer_reconstruction plus run-scoped scheduler identity; active source timers are lineage inputs only, reconstructed fork timers must be fresh fork-local rows under fork run_id, and unsupported source timer histories or post-T source timer facts remain fail-closed
     representative_issues:
       - 564
       - 565
@@ -386,6 +387,7 @@ nodes:
       - 633
       - 635
       - 639
+      - 642
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -72,21 +72,31 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 	script := `#!/bin/sh
 set -eu
 capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
-captured="$capture_dir/$$.stdin"
-cat > "$captured"
-if grep -q '"name":"emit_category_assessed"' "$captured" && grep -q '"ok":true' "$captured"; then
-  printf '%s\n' '{"type":"result","result":"done"}'
-  exit 0
+count_file="$capture_dir/invocations"
+if [ -f "$count_file" ]; then
+  count="$(cat "$count_file")"
+else
+  count=0
 fi
-if grep -q '"name":"read_file"' "$captured" && grep -q '"ok":true' "$captured"; then
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+captured="$capture_dir/$count.stdin"
+cat > "$captured"
+case "$count" in
+1)
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+  ;;
+2)
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-  exit 0
-fi
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
-printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+  ;;
+*)
+  printf '%s\n' '{"type":"result","result":"done"}'
+  ;;
+esac
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)

--- a/internal/runtime/pipeline/scheduler.go
+++ b/internal/runtime/pipeline/scheduler.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Schedule struct {
+	RunID        string
 	AgentID      string
 	EventType    string
 	Mode         string // once | cron
@@ -20,6 +21,17 @@ type Schedule struct {
 	FlowInstance string
 	TaskID       string
 	Payload      []byte
+}
+
+func (s Schedule) EffectiveRunID() string {
+	return strings.TrimSpace(s.RunID)
+}
+
+func (s *Schedule) NormalizeRunID() {
+	if s == nil {
+		return
+	}
+	s.RunID = s.EffectiveRunID()
 }
 
 func (s Schedule) EffectiveEntityID() string {
@@ -76,6 +88,7 @@ func (s *Scheduler) Register(sc Schedule) error {
 	if sc.AgentID == "" || sc.EventType == "" {
 		return errors.New("agent_id and event_type are required")
 	}
+	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	if sc.Mode == "" {
@@ -121,9 +134,8 @@ func (s *Scheduler) Cancel(agentID string, eventType string) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	prefix := schedulePrefix(agentID, eventType)
 	for key, task := range s.tasks {
-		if !strings.HasPrefix(key, prefix) {
+		if !scheduleKeyMatchesAgentEvent(key, agentID, eventType) {
 			continue
 		}
 		close(task.stop)
@@ -226,6 +238,7 @@ func (s *Scheduler) unregisterTask(key string, task *scheduledTask) {
 
 func scheduleKey(sc Schedule) string {
 	return strings.Join([]string{
+		strings.TrimSpace(sc.EffectiveRunID()),
 		strings.TrimSpace(sc.AgentID),
 		strings.TrimSpace(sc.EventType),
 		strings.TrimSpace(sc.EffectiveEntityID()),
@@ -234,8 +247,11 @@ func scheduleKey(sc Schedule) string {
 	}, "|")
 }
 
-func schedulePrefix(agentID, eventType string) string {
-	return strings.TrimSpace(agentID) + "|" + strings.TrimSpace(eventType) + "|"
+func scheduleKeyMatchesAgentEvent(key, agentID, eventType string) bool {
+	parts := strings.Split(key, "|")
+	return len(parts) >= 3 &&
+		strings.TrimSpace(parts[1]) == strings.TrimSpace(agentID) &&
+		strings.TrimSpace(parts[2]) == strings.TrimSpace(eventType)
 }
 
 func parseCronSpec(expr string) (cronSpec, error) {

--- a/internal/runtime/pipeline/scheduler_run_identity_test.go
+++ b/internal/runtime/pipeline/scheduler_run_identity_test.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSchedulerKeysSchedulesByRunID(t *testing.T) {
+	runA := "11111111-1111-1111-1111-111111111111"
+	runB := "22222222-2222-2222-2222-222222222222"
+	base := Schedule{
+		AgentID:      "agent-a",
+		EventType:    "timer.fire",
+		Mode:         "once",
+		At:           time.Now().Add(time.Hour),
+		EntityID:     "33333333-3333-3333-3333-333333333333",
+		FlowInstance: "flow-a/1",
+		TaskID:       "task-a",
+	}
+	scA := base
+	scA.RunID = runA
+	scB := base
+	scB.RunID = runB
+
+	if scheduleKey(scA) == scheduleKey(scB) {
+		t.Fatalf("schedule keys matched across run_id: %q", scheduleKey(scA))
+	}
+
+	s := NewScheduler()
+	if err := s.Register(scA); err != nil {
+		t.Fatalf("Register(run A): %v", err)
+	}
+	if err := s.Register(scB); err != nil {
+		t.Fatalf("Register(run B): %v", err)
+	}
+	if len(s.tasks) != 2 {
+		t.Fatalf("registered tasks = %d, want 2", len(s.tasks))
+	}
+	if err := s.CancelExact(scA); err != nil {
+		t.Fatalf("CancelExact(run A): %v", err)
+	}
+	if len(s.tasks) != 1 {
+		t.Fatalf("registered tasks after exact cancel = %d, want 1", len(s.tasks))
+	}
+	if _, ok := s.tasks[scheduleKey(scB)]; !ok {
+		t.Fatalf("run B schedule was cancelled by run A exact cancel")
+	}
+	s.Stop()
+}

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -94,6 +94,8 @@ type WorkflowInstanceStore struct {
 
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
+const workflowInstanceTimerOwnerNode = "workflow_instance_store"
+
 type workflowCreateEntityInitialValuesContextKey struct{}
 
 type workflowCreateEntityInitialValues struct {
@@ -389,7 +391,7 @@ func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, for
 	}
 	item.StorageRef = persistedIdentity.StorageRef
 	item.InstanceID = persistedIdentity.InstanceID
-	timers, err := s.loadWorkflowTimersSpec(ctx, keys[0])
+	timers, err := s.loadWorkflowTimersSpec(ctx, runID, keys[0])
 	if err != nil {
 		return WorkflowInstance{}, false, err
 	}
@@ -501,7 +503,7 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 		item.StorageRef = persistedIdentity.StorageRef
 		item.InstanceID = persistedIdentity.InstanceID
 		item.TransitionHistory = append([]WorkflowTransitionRecord{}, projection.Control.TransitionHistory...)
-		timers, err := s.loadWorkflowTimersSpec(ctx, persistedIdentity.RowID())
+		timers, err := s.loadWorkflowTimersSpec(ctx, runID, persistedIdentity.RowID())
 		if err != nil {
 			return nil, err
 		}
@@ -633,10 +635,12 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	}
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM timers
-		WHERE entity_id = $1::uuid
-		  AND flow_instance = $2
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND flow_instance = $3
+		  AND owner_node = $4
 		  AND owner_agent IS NULL
-	`, rowID, storageRef); err != nil {
+	`, runID, rowID, storageRef, workflowInstanceTimerOwnerNode); err != nil {
 		return err
 	}
 	for _, timer := range instance.TimerState {
@@ -653,16 +657,16 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 		}
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO timers (
-				timer_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
 				fire_at, recurring, owner_node, task_type, status, created_at
 			)
 			VALUES (
-				$1::uuid, $2, $3::uuid, $4, $5, $6::jsonb,
-				$7, $8, NULL, $9, $10, $11
+				$1::uuid, $2::uuid, $3, $4::uuid, $5, $6, $7::jsonb,
+				$8, $9, $10, $11, $12, $13
 			)
-		`, workflowInstanceTimerRowID(strings.TrimSpace(timer.TimerID), rowID), strings.TrimSpace(timer.TimerID), rowID, storageRef,
+		`, workflowInstanceTimerRowID(runID, strings.TrimSpace(timer.TimerID), rowID), runID, strings.TrimSpace(timer.TimerID), rowID, storageRef,
 			strings.TrimSpace(timer.EventType), jsonOrDefault(payloadJSON, "{}"), timer.FiresAt, timer.Recurring,
-			workflowInstanceTimerTaskType(timer), status, workflowTimeOrNow(timer.CreatedAt),
+			workflowInstanceTimerOwnerNode, workflowInstanceTimerTaskType(timer), status, workflowTimeOrNow(timer.CreatedAt),
 		); err != nil {
 			return err
 		}
@@ -804,7 +808,7 @@ func loadTrackedEntityStateProjection(ctx context.Context, tx *sql.Tx, runID, en
 	}, nil
 }
 
-func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, entityID string) ([]WorkflowTimerState, error) {
+func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, runID, entityID string) ([]WorkflowTimerState, error) {
 	rows, err := dbQueryContext(ctx, s.db, `
 		SELECT
 			timer_name,
@@ -815,10 +819,12 @@ func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, enti
 			recurring,
 			status = 'cancelled'
 		FROM timers
-		WHERE entity_id = $1::uuid
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND owner_node = $3
 		  AND owner_agent IS NULL
 		ORDER BY created_at ASC, timer_name ASC
-	`, entityID)
+	`, runID, entityID, workflowInstanceTimerOwnerNode)
 	if err != nil {
 		return nil, err
 	}
@@ -1149,8 +1155,8 @@ func workflowInstanceMode(storageRef string) string {
 	return "static"
 }
 
-func workflowInstanceTimerRowID(timerID, entityID string) string {
-	return uuid.NewSHA1(workflowInstancePathNamespace, []byte(strings.TrimSpace(entityID)+":"+strings.TrimSpace(timerID))).String()
+func workflowInstanceTimerRowID(runID, timerID, entityID string) string {
+	return uuid.NewSHA1(workflowInstancePathNamespace, []byte(strings.TrimSpace(runID)+":"+strings.TrimSpace(entityID)+":"+strings.TrimSpace(timerID))).String()
 }
 
 func workflowInstanceTimerTaskType(timer WorkflowTimerState) string {

--- a/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	runtimecorrelation "swarm/internal/runtime/correlation"
@@ -66,5 +67,83 @@ func TestWorkflowInstanceStore_RunScopedCurrentStateRowsDoNotBleed(t *testing.T)
 	}
 	if gotA.CurrentState != "source_state" || gotB.CurrentState != "fork_state" {
 		t.Fatalf("states = source:%q fork:%q", gotA.CurrentState, gotB.CurrentState)
+	}
+}
+
+func TestWorkflowInstanceStore_RunScopedTimerRowsDoNotBleed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := NewWorkflowInstanceStore(db)
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	now := time.Now().UTC().Round(time.Microsecond)
+	for _, runID := range []string{runA, runB} {
+		if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	ctxA := runtimecorrelation.WithRunID(context.Background(), runA)
+	ctxB := runtimecorrelation.WithRunID(context.Background(), runB)
+
+	if err := store.Upsert(ctxA, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "run-scope",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "source_state",
+		TimerState: []WorkflowTimerState{{
+			TimerID:   "shared_timer",
+			EventType: "timer.source",
+			CreatedAt: now,
+			FiresAt:   now.Add(time.Hour),
+		}},
+	}); err != nil {
+		t.Fatalf("upsert source timer: %v", err)
+	}
+	if err := store.Upsert(ctxB, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "run-scope",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "fork_state",
+		TimerState: []WorkflowTimerState{{
+			TimerID:   "shared_timer",
+			EventType: "timer.fork",
+			CreatedAt: now.Add(time.Minute),
+			FiresAt:   now.Add(2 * time.Hour),
+			Cancelled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("upsert fork timer: %v", err)
+	}
+
+	gotA, ok, err := store.Load(ctxA, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load source ok=%v err=%v", ok, err)
+	}
+	gotB, ok, err := store.Load(ctxB, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load fork ok=%v err=%v", ok, err)
+	}
+	if len(gotA.TimerState) != 1 || gotA.TimerState[0].EventType != "timer.source" || gotA.TimerState[0].Cancelled {
+		t.Fatalf("source timers = %#v, want active source timer only", gotA.TimerState)
+	}
+	if len(gotB.TimerState) != 1 || gotB.TimerState[0].EventType != "timer.fork" || !gotB.TimerState[0].Cancelled {
+		t.Fatalf("fork timers = %#v, want cancelled fork timer only", gotB.TimerState)
+	}
+
+	var timerRows int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE entity_id = $1::uuid
+		  AND timer_name = 'shared_timer'
+		  AND owner_node = $2
+		  AND owner_agent IS NULL
+	`, entityID, workflowInstanceTimerOwnerNode).Scan(&timerRows); err != nil {
+		t.Fatalf("count workflow timer rows: %v", err)
+	}
+	if timerRows != 2 {
+		t.Fatalf("workflow timer rows = %d, want one per run", timerRows)
 	}
 }

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -8,6 +8,7 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -72,10 +73,10 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 		return err
 	}
 	for _, sc := range toCancel {
-		pc.persistWorkflowTimerCancellation(ctx, sc)
+		pc.persistWorkflowTimerCancellation(ctx, scheduleWithRunIDFromContext(ctx, sc))
 	}
 	for _, sc := range toSchedule {
-		pc.persistWorkflowTimerSchedule(ctx, sc)
+		pc.persistWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, sc))
 	}
 	return nil
 }
@@ -160,10 +161,10 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 		return
 	}
 	for _, sc := range toCancel {
-		pc.cancelWorkflowTimerSchedule(ctx, sc)
+		pc.cancelWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, sc))
 	}
 	for _, sc := range toSchedule {
-		pc.registerWorkflowTimerSchedule(ctx, sc)
+		pc.registerWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, sc))
 	}
 }
 
@@ -192,6 +193,9 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 		return nil
 	}
 	sc := accumulationTimeoutSchedule(entityID, evt.FlowInstance(), bucketRef, time.Time{}, spec.TimeoutMS)
+	if runID := strings.TrimSpace(evt.RunID); runID != "" {
+		sc.RunID = runID
+	}
 	if isAccumulationTimeoutEvent(evt.Type) || !waiting {
 		pc.persistWorkflowTimerCancellation(ctx, sc)
 		return nil
@@ -265,6 +269,19 @@ func accumulationTimeoutPayload(handle timeridentity.TimerHandle, timeoutMS int)
 	}
 	payload["timeout_ms"] = timeoutMS
 	return payload
+}
+
+func scheduleWithRunIDFromContext(ctx context.Context, sc Schedule) Schedule {
+	if strings.TrimSpace(sc.RunID) == "" {
+		sc.RunID = runtimecorrelation.RunIDFromContext(ctx)
+	}
+	if strings.TrimSpace(sc.RunID) == "" {
+		if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+			sc.RunID = strings.TrimSpace(inbound.RunID)
+		}
+	}
+	sc.NormalizeRunID()
+	return sc
 }
 
 func workflowTimerStateActive(items []WorkflowTimerState, timerID string) bool {

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -256,7 +256,7 @@ func historicalReplayFactAdmissions(replay store.RunForkReplayResumeAdmission) [
 		historicalReplayDeadLettersAdmission(replay),
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactRetryIdempotency, "runtime idempotency and retry state must be owned by a later mutating replay child; source state cannot suppress fork work", "#564"),
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactEmittedFollowUps, "emitted follow-up regeneration belongs to the future mutating replay owner; source follow-up rows are not copied", "#564"),
-		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactTimers, []string{store.RunForkReplayResumeFactTimerHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "timer reconstruction remains a split sibling unless timer_history is present and fail-closed", "#564"),
+		historicalReplayTimersAdmission(replay),
 		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactRoutes, []string{store.RunForkReplayResumeFactRouteHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "route and route-recovery truth remains split under fork-local route persistence/runtime recovery", "#618"),
 		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactSessions, []string{store.RunForkReplayResumeFactSessionHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "session reconstruction remains a split sibling unless active session facts are present and fail-closed", "#564"),
 		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactTurns, []string{store.RunForkReplayResumeFactActiveTurnHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "turn reconstruction remains a split sibling unless active turn facts are present and fail-closed", "#564"),
@@ -266,6 +266,28 @@ func historicalReplayFactAdmissions(replay store.RunForkReplayResumeAdmission) [
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactRuntimeRestartRecovery, "runtime restart recovery remains a consumer/sibling and cannot reconstruct historical replay state from current rows", "#564"),
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactCLIApiDashboardOperator, "CLI, API, dashboard, and Builder surfaces are consumers only and must not compute historical replay admission independently", "#549"),
 	}
+}
+
+func historicalReplayTimersAdmission(replay store.RunForkReplayResumeAdmission) store.RunForkHistoricalReplayFactAdmission {
+	if blocker, ok := replayBlockerForFacts(replay, store.RunForkReplayResumeFactTimerHistory); ok {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactTimers,
+			Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		}
+	}
+	if replayDispositionHas(replay, store.RunForkReplayResumeFactTimerHistory, store.RunForkReplayResumeDispositionReconstruct) {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactTimers,
+			Admission:   store.RunForkHistoricalReplayAdmissionReconstructedForkState,
+			SourceOwner: store.RunForkHistoricalReplayTimerReconstructionOwner,
+			Tracker:     "#642",
+			Message:     "active source timers are lineage inputs only; fork-local timer rows are reconstructed under the fork run_id by the timer reconstruction owner",
+		}
+	}
+	return historicalReplaySplitFact(store.RunForkHistoricalReplayFactTimers, "timer reconstruction remains split unless the canonical replay taxonomy admits active timer reconstruction", "#564")
 }
 
 func historicalReplayEventDeliveriesAdmission(replay store.RunForkReplayResumeAdmission) store.RunForkHistoricalReplayFactAdmission {

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -177,6 +177,48 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsReplayablePrimitiveWithou
 	}
 }
 
+func TestBuildHistoricalReplayExecutionAdmissionReportsTimerReconstructionOwner(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		HistoricalReplayRequired: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:           store.RunForkReplayResumeFactTimerHistory,
+			Disposition:    store.RunForkReplayResumeDispositionReconstruct,
+			Classification: store.RunForkHistoricalReplayAdmissionReconstructedForkState,
+			Message:        "timer reconstruction owner admits active source timers",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	timerAdmission, ok := historicalReplayFactAdmission(admission.FactAdmissions, store.RunForkHistoricalReplayFactTimers)
+	if !ok {
+		t.Fatalf("timer fact admission missing: %#v", admission.FactAdmissions)
+	}
+	if timerAdmission.Admission != store.RunForkHistoricalReplayAdmissionReconstructedForkState ||
+		timerAdmission.SourceOwner != store.RunForkHistoricalReplayTimerReconstructionOwner ||
+		timerAdmission.Tracker != "#642" {
+		t.Fatalf("timer admission = %#v", timerAdmission)
+	}
+}
+
 func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation(t *testing.T) {
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	llm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -278,6 +279,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 				handleRuntimeLogPersistenceError("scheduler", "publish_failed", rt.Logger.Error(callbackCtx, "scheduler", "publish_failed", map[string]any{
 					"agent_id":   sc.AgentID,
 					"event_type": sc.EventType,
+					"run_id":     sc.EffectiveRunID(),
 					"entity_id":  sc.EffectiveEntityID(),
 				}, err))
 			}
@@ -288,6 +290,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 					handleRuntimeLogPersistenceError("scheduler", "mark_fired_failed", rt.Logger.Error(callbackCtx, "scheduler", "mark_fired_failed", map[string]any{
 						"agent_id":   sc.AgentID,
 						"event_type": sc.EventType,
+						"run_id":     sc.EffectiveRunID(),
 						"entity_id":  sc.EffectiveEntityID(),
 					}, err))
 				}
@@ -506,6 +509,7 @@ func scheduledEvent(sc runtimepipeline.Schedule) events.Event {
 		SourceAgent: sc.AgentID,
 		TaskID:      sc.TaskID,
 		Payload:     scheduleEventPayload(sc),
+		RunID:       sc.EffectiveRunID(),
 		CreatedAt:   time.Now(),
 	}).WithEnvelope(events.EventEnvelope{
 		EntityID:     sc.EffectiveEntityID(),
@@ -865,6 +869,7 @@ func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline
 			continue
 		}
 		sc := runtimepipeline.Schedule{
+			RunID:     runtimecorrelation.RunIDFromContext(ctx),
 			AgentID:   owner,
 			EventType: eventType,
 			Mode:      "cron",
@@ -921,6 +926,7 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 				continue
 			}
 			sc := runtimepipeline.Schedule{
+				RunID:        runtimecorrelation.RunIDFromContext(ctx),
 				AgentID:      owner,
 				EventType:    eventType,
 				Mode:         "once",

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -72,6 +72,7 @@ func TestScheduleEventPayloadPreservesAccumulationTimeoutHandle(t *testing.T) {
 
 func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
 	evt := scheduledEvent(runtimepipeline.Schedule{
+		RunID:        "11111111-1111-1111-1111-111111111111",
 		AgentID:      "runtime",
 		EventType:    "timer.check",
 		EntityID:     "ent-001",
@@ -84,6 +85,9 @@ func TestScheduledEventUsesTypedScheduleEnvelope(t *testing.T) {
 	}
 	if got := evt.FlowInstance(); got != "review/inst-1" {
 		t.Fatalf("event flow_instance = %q, want review/inst-1", got)
+	}
+	if evt.RunID != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("event run_id = %q, want schedule run_id", evt.RunID)
 	}
 	if got := evt.Scope(); got != events.EventScopeEntity {
 		t.Fatalf("event scope = %q, want %q", got, events.EventScopeEntity)

--- a/internal/runtime/tools/executor_agents.go
+++ b/internal/runtime/tools/executor_agents.go
@@ -12,6 +12,7 @@ import (
 	"swarm/internal/events"
 	runtimeauthority "swarm/internal/runtime/authority"
 	models "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 )
 
 func (e *Executor) execAgentMessage(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
@@ -194,6 +195,7 @@ func (e *Executor) execSchedule(ctx context.Context, actor models.AgentConfig, i
 	}
 
 	schedule := Schedule{
+		RunID:        runtimecorrelation.RunIDFromContext(ctx),
 		AgentID:      in.AgentID,
 		EventType:    in.EventType,
 		Mode:         in.Mode,

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2622,6 +2622,92 @@ func TestSchedules_ExactIdentityUsesFlowInstance(t *testing.T) {
 	}
 }
 
+func TestSchedules_ExactIdentityUsesRunID(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, runA, runB); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	base := runtimepipeline.Schedule{
+		AgentID:      "validation-orchestrator",
+		EventType:    "timer.validation_timeout",
+		Mode:         "once",
+		At:           time.Now().Add(30 * time.Minute).UTC(),
+		EntityID:     entityID,
+		FlowInstance: "review/inst-1",
+		TaskID:       "timer-a",
+		Payload:      []byte(`{"timer_id":"timer-a"}`),
+	}
+	first := base
+	first.RunID = runA
+	second := base
+	second.RunID = runB
+	second.At = time.Now().Add(60 * time.Minute).UTC()
+
+	if err := pg.UpsertSchedule(ctx, first); err != nil {
+		t.Fatalf("UpsertSchedule(first): %v", err)
+	}
+	if err := pg.UpsertSchedule(ctx, second); err != nil {
+		t.Fatalf("UpsertSchedule(second): %v", err)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	var exact []runtimepipeline.Schedule
+	for _, sc := range active {
+		if sc.AgentID == base.AgentID &&
+			sc.EventType == base.EventType &&
+			sc.EntityID == base.EntityID &&
+			sc.FlowInstance == base.FlowInstance &&
+			sc.TaskID == base.TaskID {
+			exact = append(exact, sc)
+		}
+	}
+	if len(exact) != 2 {
+		t.Fatalf("expected two exact schedules to coexist across run_id, got %+v", exact)
+	}
+
+	if err := pg.MarkScheduleFiredExact(ctx, first); err != nil {
+		t.Fatalf("MarkScheduleFiredExact(first): %v", err)
+	}
+	statuses := map[string]string{}
+	rows, err := db.QueryContext(ctx, `
+		SELECT run_id::text, status
+		FROM timers
+		WHERE owner_agent = $1
+		  AND fire_event = $2
+		  AND entity_id = $3::uuid
+		  AND flow_instance = $4
+		  AND `+exactScheduleTaskIDSQL()+` = $5
+	`, base.AgentID, base.EventType, base.EntityID, base.FlowInstance, base.TaskID)
+	if err != nil {
+		t.Fatalf("query timer statuses: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var runID, status string
+		if err := rows.Scan(&runID, &status); err != nil {
+			t.Fatalf("scan timer status: %v", err)
+		}
+		statuses[runID] = status
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate timer statuses: %v", err)
+	}
+	if statuses[runA] != "fired" || statuses[runB] != "active" {
+		t.Fatalf("timer statuses = %#v, want runA fired and runB active", statuses)
+	}
+}
+
 func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2740,6 +2740,42 @@ func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 	}
 }
 
+func TestSchedules_LoadActiveSchedulesIgnoresWorkflowSidecarRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, recurring, recurrence_cron, recurrence_interval,
+			owner_node, owner_agent, task_type, status
+		)
+		VALUES (
+			$1::uuid, 'workflow-sidecar', $2::uuid, 'review/inst-1', 'timer.workflow', '{}'::jsonb,
+			$3, false, NULL, NULL,
+			'workflow_instance_store', NULL, 'timer', 'active'
+		)
+	`, runID, entityID, time.Now().Add(30*time.Minute).UTC()); err != nil {
+		t.Fatalf("seed workflow sidecar timer: %v", err)
+	}
+
+	active, err := pg.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("active executable schedules = %+v, want workflow sidecar ignored", active)
+	}
+}
+
 func TestSchedules_LoadActiveSchedulesDoesNotReconstructTaskIDFromTimerName(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -432,7 +432,7 @@ func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, catalog sch
 }
 
 func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
-	if !catalog.hasColumns("timers", "entity_id", "flow_instance", "created_at") {
+	if !catalog.hasColumns("timers", "run_id", "entity_id", "flow_instance", "created_at") {
 		return nil
 	}
 	if len(lineage.EntityIDs) == 0 && len(lineage.FlowInstances) == 0 {
@@ -443,14 +443,15 @@ func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, cata
 		SELECT EXISTS (
 			SELECT 1
 			FROM timers
-			WHERE created_at > $1::timestamptz
+			WHERE run_id = $1::uuid
+			  AND created_at > $2::timestamptz
 			  AND (
-					(entity_id IS NOT NULL AND entity_id::text = ANY($2::text[]))
+					(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
 					OR
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($3::text[]))
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
 			  )
 		)
-	`, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&exists); err != nil {
+	`, lineage.SourceRunID, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&exists); err != nil {
 		return fmt.Errorf("check source timer advancement: %w", err)
 	}
 	if exists {

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -559,7 +559,7 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 	if err != nil {
 		return runForkAdmissionEvidence{}, err
 	}
-	relevantTimer, err := s.hasRunForkRelevantTimer(ctx, catalog, facts, cursor)
+	relevantTimer, err := s.hasRunForkRelevantTimer(ctx, catalog, runID, facts, cursor)
 	if err != nil {
 		return runForkAdmissionEvidence{}, err
 	}
@@ -639,8 +639,8 @@ func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string
 	}, nil
 }
 
-func (s *PostgresStore) hasRunForkRelevantTimer(ctx context.Context, catalog schemaColumnCatalog, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("timers", "entity_id", "flow_instance", "created_at") {
+func (s *PostgresStore) hasRunForkRelevantTimer(ctx context.Context, catalog schemaColumnCatalog, runID string, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
+	if !catalog.hasColumns("timers", "run_id", "entity_id", "flow_instance", "created_at") {
 		return false, nil
 	}
 	if len(facts.EntityIDs) == 0 && len(facts.FlowInstances) == 0 {
@@ -651,14 +651,15 @@ func (s *PostgresStore) hasRunForkRelevantTimer(ctx context.Context, catalog sch
 		SELECT EXISTS (
 			SELECT 1
 			FROM timers
-			WHERE created_at <= $1::timestamptz
+			WHERE run_id = $1::uuid
+			  AND created_at <= $2::timestamptz
 			  AND (
-					(entity_id IS NOT NULL AND entity_id::text = ANY($2::text[]))
+					(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
 					OR
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($3::text[]))
+					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
 			  )
 		)
-	`, cursor.CreatedAt, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
+	`, runID, cursor.CreatedAt, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
 		return false, fmt.Errorf("check fork timer blockers: %w", err)
 	}
 	return exists, nil

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -566,10 +566,10 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO timers (
-			timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
+			run_id, timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
 		)
-		VALUES ('unrelated', $1::uuid, 'flow-other/1', 'timer.fire', $2, 'other-node', 'timer', 'active', $3)
-	`, uuid.NewString(), at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+		VALUES ($1::uuid, 'unrelated', $2::uuid, 'flow-other/1', 'timer.fire', $3, 'other-node', 'timer', 'active', $4)
+	`, runID, uuid.NewString(), at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed unrelated timer: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -645,10 +645,10 @@ func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO timers (
-			timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
+			run_id, timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
 		)
-		VALUES ('relevant', $1::uuid, 'flow-a/1', 'timer.fire', $2, 'node-a', 'timer', 'active', $3)
-	`, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+		VALUES ($1::uuid, 'relevant', $2::uuid, 'flow-a/1', 'timer.fire', $3, 'node-a', 'timer', 'active', $4)
+	`, runID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed relevant timer: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -22,6 +22,7 @@ const (
 	RunForkHistoricalReplayExecutionAdmissionOwner      = "runtime.run_fork.historical_replay_execution_admission"
 	RunForkHistoricalReplayExecutionOwner               = "runtime.run_fork.historical_replay_execution"
 	RunForkHistoricalReplayContractSwapBootResumeOwner  = RunForkHistoricalReplayExecutionOwner + ".contract_swap_boot_resume"
+	RunForkHistoricalReplayTimerReconstructionOwner     = RunForkHistoricalReplayExecutionOwner + ".timer_reconstruction"
 	RunForkSelectedContractBranchDivergenceOwner        = "store.run_fork.selected_contract_branch_divergence"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -122,12 +122,31 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
-	if blockers := runForkSelectedContractExecutionPlanBlockers(plan, nil); len(blockers) > 0 {
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	timerReconstruction, err := s.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
+	if err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			admission := runForkReplayResumeAdmissionWithBlocker(plan.ReplayResumeAdmission, fact, blocker)
+			return RunForkMaterialization{
+				SourceRunID:           plan.SourceRunID,
+				ForkPoint:             plan.ForkPoint,
+				ExecutionReady:        false,
+				ReplayResumeAdmission: admission,
+				UnsupportedBlockers:   admission.UnsupportedBlockers,
+				DeliveryResumeBlocked: true,
+			}, err
+		}
+		return RunForkMaterialization{}, err
+	}
+	if blockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, nil, timerReconstruction.Required); len(blockers) > 0 {
 		return RunForkMaterialization{
 			SourceRunID:           plan.SourceRunID,
 			ForkPoint:             plan.ForkPoint,
 			ExecutionReady:        false,
-			ReplayResumeAdmission: plan.ReplayResumeAdmission,
+			ReplayResumeAdmission: runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, timerReconstruction),
 			UnsupportedBlockers:   blockers,
 			DeliveryResumeBlocked: true,
 		}, fmt.Errorf("selected-contract fork execution materialization blocked: %s", runForkBlockerCodes(blockers))
@@ -181,10 +200,15 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
+	if err := insertRunForkSelectedContractTimerReconstructions(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID, timerReconstruction, now); err != nil {
+		return RunForkMaterialization{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit selected-contract fork materialization: %w", err)
 	}
 	committed = true
+	replayAdmission := runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, timerReconstruction)
+	unsupportedBlockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, nil, timerReconstruction.Required)
 	return RunForkMaterialization{
 		SourceRunID:              plan.SourceRunID,
 		ForkRunID:                forkRunID,
@@ -192,9 +216,9 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		ForkPoint:                plan.ForkPoint,
 		MaterializedEntityCount:  len(plan.Entities),
 		ExecutionReady:           false,
-		ReplayResumeAdmission:    plan.ReplayResumeAdmission,
+		ReplayResumeAdmission:    replayAdmission,
 		SelectedContractBinding:  &binding,
-		UnsupportedBlockers:      plan.UnsupportedBlockers,
+		UnsupportedBlockers:      unsupportedBlockers,
 		DeliveryResumeBlocked:    true,
 		SourceRunStatusUnchanged: true,
 	}, nil
@@ -264,7 +288,12 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		return result, err
 	}
 	result.ReplayResumeAdmission = plan.ReplayResumeAdmission
-	if blockers := runForkSelectedContractExecutionPlanBlockers(plan, req.AllowedSourceEventIDs); len(blockers) > 0 {
+	timerResolved, err := runForkSelectedContractTimerReconstructionComplete(ctx, tx, lineage, plan)
+	if err != nil {
+		return result, err
+	}
+	result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, runForkTimerReconstructionPlan{Required: timerResolved})
+	if blockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, req.AllowedSourceEventIDs, timerResolved); len(blockers) > 0 {
 		result.UnsupportedBlockers = blockers
 		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
 	}
@@ -474,6 +503,11 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 		   OR event_id IN (SELECT event_id FROM events WHERE run_id = $1::uuid)
 	`, forkRunID); err != nil {
 		return fmt.Errorf("delete selected-contract fork deliveries: %w", err)
+	}
+	if catalog.hasColumns("timers", "run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM timers WHERE run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork timers: %w", err)
+		}
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM entity_mutations WHERE run_id = $1::uuid`, forkRunID); err != nil {
 		return fmt.Errorf("delete selected-contract fork mutations: %w", err)

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -168,7 +168,7 @@ func TestSelectedContractExecutionMaterializationPreflightsRouteRecoveryCapabili
 	}
 }
 
-func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) {
+func TestSelectedContractExecutionMaterializationReconstructsActiveTimer(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -178,9 +178,9 @@ func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) 
 	at := time.Unix(1700002500, 0).UTC()
 	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO timers (timer_name, entity_id, flow_instance, fire_event, fire_at, status, created_at)
-		VALUES ('selected-timer', $1::uuid, 'flow-a/1', 'timer.selected', $2, 'active', $3)
-	`, entityID, at.Add(time.Hour), at); err != nil {
+		INSERT INTO timers (run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload, fire_at, owner_agent, task_type, status, created_at)
+		VALUES ($1::uuid, 'selected-timer', $2::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb, $3, 'agent-a', 'timer', 'active', $4)
+	`, sourceRunID, entityID, at.Add(time.Hour), at); err != nil {
 		t.Fatalf("seed timer: %v", err)
 	}
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
@@ -193,13 +193,46 @@ func TestSelectedContractExecutionActivationPreservesTimerBlocker(t *testing.T) 
 			WorkflowVersion: "v1",
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), RunForkBlockerTimerHistoryUnproven) {
-		t.Fatalf("materialization error = %v, want timer blocker", err)
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
 	}
-	if materialized.ForkRunID != "" {
-		t.Fatalf("materialized fork despite timer blocker: %#v", materialized)
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
 	}
-	assertNoSelectedContractForkRows(t, db, sourceRunID)
+	for _, blocker := range materialized.ReplayResumeAdmission.UnsupportedBlockers {
+		if blocker.Code == RunForkBlockerTimerHistoryUnproven {
+			t.Fatalf("timer blocker survived reconstruction: %#v", materialized.ReplayResumeAdmission.UnsupportedBlockers)
+		}
+	}
+	var forkTimerCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND source_timer_id IS NOT NULL
+		  AND forked_from_run_id = $2::uuid
+		  AND forked_from_event_id = $3::uuid
+		  AND reconstruction_owner = $4
+		  AND status = 'active'
+	`, materialized.ForkRunID, sourceRunID, eventID, RunForkHistoricalReplayTimerReconstructionOwner).Scan(&forkTimerCount); err != nil {
+		t.Fatalf("count reconstructed fork timers: %v", err)
+	}
+	if forkTimerCount != 1 {
+		t.Fatalf("reconstructed fork timers = %d, want 1", forkTimerCount)
+	}
+	var sourceTimerCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND source_timer_id IS NULL
+		  AND status = 'active'
+	`, sourceRunID).Scan(&sourceTimerCount); err != nil {
+		t.Fatalf("count source timers: %v", err)
+	}
+	if sourceTimerCount != 1 {
+		t.Fatalf("source timers = %d, want 1", sourceTimerCount)
+	}
 }
 
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -1,0 +1,263 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+type runForkTimerReconstructionPlan struct {
+	Required bool
+	Rows     []runForkTimerReconstructionRow
+}
+
+type runForkTimerReconstructionRow struct {
+	TimerID            string
+	TimerName          string
+	EntityID           string
+	FlowInstance       string
+	FireEvent          string
+	FirePayload        []byte
+	FireAt             time.Time
+	Recurring          bool
+	RecurrenceCron     string
+	RecurrenceInterval string
+	OwnerNode          string
+	OwnerAgent         string
+	TaskType           string
+	Status             string
+	FiredAt            sql.NullTime
+	CreatedAt          time.Time
+}
+
+type timerReconstructionQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func runForkPlanHasTimerBlocker(plan RunForkPlan) bool {
+	for _, blocker := range plan.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == RunForkBlockerTimerHistoryUnproven {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan RunForkPlan, allowedSourceEventIDs []string, timerResolved bool) []RunForkUnsupportedBlocker {
+	blockers := runForkSelectedContractExecutionPlanBlockers(plan, allowedSourceEventIDs)
+	if !timerResolved {
+		return blockers
+	}
+	out := blockers[:0]
+	for _, blocker := range blockers {
+		if strings.TrimSpace(blocker.Code) == RunForkBlockerTimerHistoryUnproven {
+			continue
+		}
+		out = append(out, blocker)
+	}
+	return out
+}
+
+func runForkReplayResumeAdmissionWithTimerReconstruction(admission RunForkReplayResumeAdmission, reconstruction runForkTimerReconstructionPlan) RunForkReplayResumeAdmission {
+	if !reconstruction.Required {
+		return admission
+	}
+	filteredBlockers := make([]RunForkUnsupportedBlocker, 0, len(admission.UnsupportedBlockers))
+	for _, blocker := range admission.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == RunForkBlockerTimerHistoryUnproven {
+			continue
+		}
+		filteredBlockers = append(filteredBlockers, blocker)
+	}
+	admission.UnsupportedBlockers = filteredBlockers
+	for i := range admission.Dispositions {
+		if strings.TrimSpace(admission.Dispositions[i].Fact) != RunForkReplayResumeFactTimerHistory {
+			continue
+		}
+		admission.Dispositions[i].Disposition = RunForkReplayResumeDispositionReconstruct
+		admission.Dispositions[i].BlockerCode = ""
+		admission.Dispositions[i].Classification = RunForkHistoricalReplayAdmissionReconstructedForkState
+		admission.Dispositions[i].Message = fmt.Sprintf("%s reconstructs %d active fork-local timer(s) under the fork run_id", RunForkHistoricalReplayTimerReconstructionOwner, len(reconstruction.Rows))
+	}
+	admission.HistoricalReplaySupported = len(admission.UnsupportedBlockers) == 0
+	return admission
+}
+
+func (s *PostgresStore) planRunForkSelectedContractTimerReconstruction(ctx context.Context, catalog schemaColumnCatalog, plan RunForkPlan) (runForkTimerReconstructionPlan, error) {
+	if !runForkPlanHasTimerBlocker(plan) {
+		return runForkTimerReconstructionPlan{}, nil
+	}
+	if !catalog.hasColumns("timers", "run_id", "source_timer_id", "forked_from_run_id", "forked_from_event_id", "reconstruction_owner") {
+		return runForkTimerReconstructionPlan{}, fmt.Errorf("selected-contract timer reconstruction requires run-scoped timer lineage columns")
+	}
+	facts, err := s.loadRunForkSourceFacts(ctx, plan.SourceRunID, runForkEventCursor{
+		EventID:   plan.ForkPoint.EventID,
+		EventName: plan.ForkPoint.EventName,
+		CreatedAt: plan.ForkPoint.Timestamp,
+	}, plan.Entities)
+	if err != nil {
+		return runForkTimerReconstructionPlan{}, err
+	}
+	rows, err := loadRunForkReconstructableSourceTimers(ctx, s.DB, plan.SourceRunID, plan.ForkPoint.Timestamp, facts)
+	if err != nil {
+		return runForkTimerReconstructionPlan{}, err
+	}
+	if len(rows) == 0 {
+		return runForkTimerReconstructionPlan{}, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: no reconstructable active source timers")
+	}
+	return runForkTimerReconstructionPlan{Required: true, Rows: rows}, nil
+}
+
+func loadRunForkReconstructableSourceTimers(ctx context.Context, q timerReconstructionQueryer, sourceRunID string, at time.Time, facts runForkSourceFacts) ([]runForkTimerReconstructionRow, error) {
+	if len(facts.EntityIDs) == 0 && len(facts.FlowInstances) == 0 {
+		return nil, nil
+	}
+	rows, err := q.QueryContext(ctx, `
+		SELECT
+			timer_id::text,
+			timer_name,
+			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
+			fire_event,
+			fire_payload,
+			fire_at,
+			recurring,
+			COALESCE(recurrence_cron, ''),
+			COALESCE(recurrence_interval, ''),
+			COALESCE(owner_node, ''),
+			COALESCE(owner_agent, ''),
+			task_type,
+			status,
+			fired_at,
+			created_at
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND created_at <= $2::timestamptz
+		  AND (
+				(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
+				OR
+				(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
+		  )
+		ORDER BY created_at ASC, timer_id ASC
+	`, sourceRunID, at, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances))
+	if err != nil {
+		return nil, fmt.Errorf("load source timers for reconstruction: %w", err)
+	}
+	defer rows.Close()
+
+	out := []runForkTimerReconstructionRow{}
+	for rows.Next() {
+		var row runForkTimerReconstructionRow
+		if err := rows.Scan(
+			&row.TimerID,
+			&row.TimerName,
+			&row.EntityID,
+			&row.FlowInstance,
+			&row.FireEvent,
+			&row.FirePayload,
+			&row.FireAt,
+			&row.Recurring,
+			&row.RecurrenceCron,
+			&row.RecurrenceInterval,
+			&row.OwnerNode,
+			&row.OwnerAgent,
+			&row.TaskType,
+			&row.Status,
+			&row.FiredAt,
+			&row.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan source timer for reconstruction: %w", err)
+		}
+		if strings.TrimSpace(row.Status) != "active" || row.FiredAt.Valid {
+			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer history is not active-at-fork only")
+		}
+		if strings.TrimSpace(row.OwnerAgent) == "" || strings.TrimSpace(row.FireEvent) == "" {
+			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer lacks executable owner/event identity")
+		}
+		if len(row.FirePayload) == 0 || string(row.FirePayload) == "null" {
+			row.FirePayload = []byte("{}")
+		}
+		if !json.Valid(row.FirePayload) {
+			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer payload is invalid JSON")
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate source timers for reconstruction: %w", err)
+	}
+	return out, nil
+}
+
+func insertRunForkSelectedContractTimerReconstructions(ctx context.Context, tx *sql.Tx, forkRunID, sourceRunID, forkEventID string, reconstruction runForkTimerReconstructionPlan, now time.Time) error {
+	if !reconstruction.Required {
+		return nil
+	}
+	for _, row := range reconstruction.Rows {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO timers (
+				run_id, source_timer_id, forked_from_run_id, forked_from_event_id, reconstruction_owner,
+				timer_name, entity_id, flow_instance, fire_event, fire_payload,
+				fire_at, recurring, recurrence_cron, recurrence_interval,
+				owner_node, owner_agent, task_type, status, created_at
+			)
+			VALUES (
+				$1::uuid, $2::uuid, $3::uuid, $4::uuid, $5,
+				$6, NULLIF($7,'')::uuid, NULLIF($8,''), $9, $10::jsonb,
+				$11, $12, NULLIF($13,''), NULLIF($14,''),
+				NULLIF($15,''), NULLIF($16,''), $17, 'active', $18
+			)
+			ON CONFLICT DO NOTHING
+		`,
+			forkRunID, row.TimerID, sourceRunID, forkEventID, RunForkHistoricalReplayTimerReconstructionOwner,
+			row.TimerName, row.EntityID, row.FlowInstance, row.FireEvent, string(row.FirePayload),
+			row.FireAt, row.Recurring, row.RecurrenceCron, row.RecurrenceInterval,
+			row.OwnerNode, row.OwnerAgent, row.TaskType, now,
+		); err != nil {
+			return fmt.Errorf("insert selected-contract reconstructed timer: %w", err)
+		}
+	}
+	return nil
+}
+
+func runForkSelectedContractTimerReconstructionComplete(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, plan RunForkPlan) (bool, error) {
+	if !runForkPlanHasTimerBlocker(plan) {
+		return false, nil
+	}
+	var sourceCount, forkCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND created_at <= $2::timestamptz
+		  AND status = 'active'
+		  AND fired_at IS NULL
+		  AND (
+				(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
+				OR
+				(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
+		  )
+	`, lineage.SourceRunID, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&sourceCount); err != nil {
+		return false, fmt.Errorf("count source timers for reconstruction proof: %w", err)
+	}
+	if sourceCount == 0 {
+		return false, nil
+	}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT source_timer_id)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND forked_from_run_id = $2::uuid
+		  AND forked_from_event_id = $3::uuid
+		  AND reconstruction_owner = $4
+		  AND status = 'active'
+	`, lineage.ForkRunID, lineage.SourceRunID, lineage.ForkEventID, RunForkHistoricalReplayTimerReconstructionOwner).Scan(&forkCount); err != nil {
+		return false, fmt.Errorf("count fork reconstructed timers: %w", err)
+	}
+	return forkCount == sourceCount, nil
+}

--- a/internal/store/schedule_claims.go
+++ b/internal/store/schedule_claims.go
@@ -20,6 +20,8 @@ func (s *PostgresStore) ClaimSchedule(ctx context.Context, sc runtimepipeline.Sc
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return false, fmt.Errorf("agent_id and event_type are required")
 	}
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	key := scheduleClaimLockKey(sc)
@@ -69,6 +71,8 @@ func (s *PostgresStore) ReleaseSchedule(ctx context.Context, sc runtimepipeline.
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	key := scheduleClaimLockKey(sc)
@@ -167,14 +171,15 @@ func scheduleActiveOnConn(ctx context.Context, conn *sql.Conn, sc runtimepipelin
 		SELECT EXISTS (
 			SELECT 1
 			FROM timers
-			WHERE owner_agent = $1
-			  AND fire_event = $2
-			  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-			  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-			  AND %s = $5
+			WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+			  AND owner_agent = $2
+			  AND fire_event = $3
+			  AND entity_id IS NOT DISTINCT FROM NULLIF($4,'')::uuid
+			  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
+			  AND %s = $6
 			  AND status = 'active'
 		)
-	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)).Scan(&active)
+	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)).Scan(&active)
 	if err != nil {
 		return false, fmt.Errorf("check active schedule ownership target: %w", err)
 	}

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 )
 
@@ -21,8 +22,10 @@ func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.S
 	if strings.TrimSpace(sc.Mode) == "" {
 		sc.Mode = "once"
 	}
+	sc = scheduleWithContextRunID(ctx, sc)
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	sc.NormalizeRunID()
 	flowInstance := sc.EffectiveFlowInstance()
 	sc.FlowInstance = flowInstance
 
@@ -44,7 +47,7 @@ func (s *PostgresStore) CancelSchedule(ctx context.Context, agentID, eventType s
 	}
 	switch caps.Schedules {
 	case SchemaFlavorCanonical:
-		return s.cancelScheduleSpec(ctx, agentID, eventType)
+		return s.cancelScheduleSpec(ctx, runtimecorrelation.RunIDFromContext(ctx), agentID, eventType)
 	default:
 		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
 	}
@@ -60,6 +63,8 @@ func (s *PostgresStore) CancelScheduleExact(ctx context.Context, sc runtimepipel
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
 	flowInstance := sc.EffectiveFlowInstance()
 	sc.FlowInstance = flowInstance
 	switch caps.Schedules {
@@ -91,6 +96,8 @@ func (s *PostgresStore) MarkScheduleFired(ctx context.Context, sc runtimepipelin
 	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
 		return nil
 	}
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
 	switch caps.Schedules {
 	case SchemaFlavorCanonical:
 		return s.markScheduleFiredSpec(ctx, sc)
@@ -109,6 +116,8 @@ func (s *PostgresStore) MarkScheduleFiredExact(ctx context.Context, sc runtimepi
 	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
 	flowInstance := sc.EffectiveFlowInstance()
 	sc.FlowInstance = flowInstance
 	switch caps.Schedules {
@@ -144,6 +153,13 @@ func exactScheduleTaskIDSQL() string {
 	return `COALESCE(fire_payload->>'__schedule_task_id', '')`
 }
 
+func scheduleWithContextRunID(ctx context.Context, sc runtimepipeline.Schedule) runtimepipeline.Schedule {
+	if strings.TrimSpace(sc.RunID) == "" {
+		sc.RunID = runtimecorrelation.RunIDFromContext(ctx)
+	}
+	return sc
+}
+
 func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -155,13 +171,14 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = 'cancelled'
-		WHERE owner_agent = $1
-		  AND fire_event = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND %s = $5
+		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		  AND owner_agent = $2
+		  AND fire_event = $3
+		  AND entity_id IS NOT DISTINCT FROM NULLIF($4,'')::uuid
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
+		  AND %s = $6
 		  AND status = 'active'
-	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)); err != nil {
+	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID)); err != nil {
 		return fmt.Errorf("deactivate previous timer: %w", err)
 	}
 
@@ -183,16 +200,16 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 	}
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO timers (
-			timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
 			fire_at, recurring, recurrence_cron, recurrence_interval,
 			owner_node, owner_agent, task_type, status
 		)
 		VALUES (
-			$1, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5::jsonb,
-			$6, $7, NULLIF($8,''), NULL,
-			NULL, $9, $10, 'active'
+			NULLIF($1,'')::uuid, $2, NULLIF($3,'')::uuid, NULLIF($4,''), $5, $6::jsonb,
+			$7, $8, NULLIF($9,''), NULL,
+			NULL, $10, $11, 'active'
 		)
-	`, timerName, sc.EntityID, sc.FlowInstance, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, taskType)
+	`, sc.RunID, timerName, sc.EntityID, sc.FlowInstance, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, taskType)
 	if err != nil {
 		return fmt.Errorf("insert timer: %w", err)
 	}
@@ -202,14 +219,15 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 	return nil
 }
 
-func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, agentID, eventType string) error {
+func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, runID, agentID, eventType string) error {
 	_, err := s.DB.ExecContext(ctx, `
 		UPDATE timers
 		SET status = 'cancelled'
-		WHERE owner_agent = $1
-		  AND fire_event = $2
+		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		  AND owner_agent = $2
+		  AND fire_event = $3
 		  AND status = 'active'
-	`, agentID, eventType)
+	`, runID, agentID, eventType)
 	if err != nil {
 		return fmt.Errorf("cancel timer: %w", err)
 	}
@@ -220,13 +238,14 @@ func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimep
 	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = 'cancelled'
-		WHERE owner_agent = $1
-		  AND fire_event = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND %s = $5
+		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		  AND owner_agent = $2
+		  AND fire_event = $3
+		  AND entity_id IS NOT DISTINCT FROM NULLIF($4,'')::uuid
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
+		  AND %s = $6
 		  AND status = 'active'
-	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
+	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
 	if err != nil {
 		return fmt.Errorf("cancel exact timer: %w", err)
 	}
@@ -236,6 +255,7 @@ func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimep
 func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimepipeline.Schedule, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
+			COALESCE(run_id::text, ''),
 			owner_agent,
 			fire_event,
 			CASE WHEN recurring THEN 'cron' ELSE 'once' END,
@@ -261,6 +281,7 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			payload []byte
 		)
 		if err := rows.Scan(
+			&sc.RunID,
 			&sc.AgentID,
 			&sc.EventType,
 			&sc.Mode,
@@ -289,12 +310,13 @@ func (s *PostgresStore) markScheduleFiredSpec(ctx context.Context, sc runtimepip
 	}
 	_, err := s.DB.ExecContext(ctx, `
 		UPDATE timers
-		SET status = $3,
+		SET status = $4,
 		    fired_at = now()
-		WHERE owner_agent = $1
-		  AND fire_event = $2
+		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		  AND owner_agent = $2
+		  AND fire_event = $3
 		  AND status = 'active'
-	`, sc.AgentID, sc.EventType, status)
+	`, sc.RunID, sc.AgentID, sc.EventType, status)
 	if err != nil {
 		return fmt.Errorf("mark timer fired: %w", err)
 	}
@@ -308,15 +330,16 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	}
 	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
-		SET status = $6,
+		SET status = $7,
 		    fired_at = now()
-		WHERE owner_agent = $1
-		  AND fire_event = $2
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($3,'')::uuid
-		  AND flow_instance IS NOT DISTINCT FROM NULLIF($4,'')
-		  AND %s = $5
+		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		  AND owner_agent = $2
+		  AND fire_event = $3
+		  AND entity_id IS NOT DISTINCT FROM NULLIF($4,'')::uuid
+		  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
+		  AND %s = $6
 		  AND status = 'active'
-	`, exactScheduleTaskIDSQL()), sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
+	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
 	if err != nil {
 		return fmt.Errorf("mark exact timer fired: %w", err)
 	}

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -266,6 +266,7 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			fire_payload
 		FROM timers
 		WHERE status = 'active'
+		  AND owner_agent IS NOT NULL
 		ORDER BY created_at ASC
 	`)
 	if err != nil {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -230,7 +230,8 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 
 	caps.Schedules = detectSchemaFlavor(catalog, "timers",
 		[]string{
-			"timer_id", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
+			"timer_id", "run_id", "source_timer_id", "forked_from_run_id", "forked_from_event_id",
+			"reconstruction_owner", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
 			"fire_at", "recurring", "recurrence_cron", "recurrence_interval", "owner_node",
 			"owner_agent", "task_type", "status", "fired_at", "created_at",
 		},

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -68,7 +68,8 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		"decided_by", "decided_at", "notified", "expires_at", "created_at",
 	)
 	addColumns("timers",
-		"timer_id", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
+		"timer_id", "run_id", "source_timer_id", "forked_from_run_id", "forked_from_event_id",
+		"reconstruction_owner", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload",
 		"fire_at", "recurring", "recurrence_cron", "recurrence_interval", "owner_node",
 		"owner_agent", "task_type", "status", "fired_at", "created_at",
 	)

--- a/internal/store/shared_store_claims.go
+++ b/internal/store/shared_store_claims.go
@@ -73,6 +73,7 @@ func replayClaimLockKey(eventID string) string {
 
 func scheduleClaimLockKey(sc runtimepipeline.Schedule) string {
 	return scheduleClaimNamespace + strings.Join([]string{
+		strings.TrimSpace(sc.EffectiveRunID()),
 		strings.TrimSpace(sc.AgentID),
 		strings.TrimSpace(sc.EventType),
 		strings.TrimSpace(sc.EffectiveEntityID()),


### PR DESCRIPTION
Closes #642
Part of #564
Related to #549

## Summary

Implements the approved #642 first-slice boundary: selected-contract fork-local timer reconstruction plus run-scoped/fork-local timer scheduler identity, persistence, claim, fire, and recovery semantics.

## Governing refs

Authoritative spec refs updated in this PR:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.timers`
- `run_model.fork.semantics.selected_contract_timer_route_policy`
- `run_model.fork.semantics.historical_replay_execution`
- Adjacent refs kept as blockers/siblings: `selected_contract_recipient_planning`, `selected_contract_supported_execution`, `historical_replay_execution_admission`, `historical_replay_delivery_event_replay_execution`, and `historical_replay_delivery_event_replay_recovery`

Binding gate context:

- #642 pre-audit and independent gate outcome: `approved as first slice`
- Parent trackers: #564 and #549

## Semantic migration

New canonical owner:

- `runtime.run_fork.historical_replay_execution.timer_reconstruction`

Old non-authoritative paths now invalid for this class:

- Unscoped schedule identity by only `agent_id/event_type/entity_id/flow_instance/task_id`
- Clearing `timer_history_unproven` from selected-contract materialization without a timer owner
- Copying source timer rows as executable fork truth
- Using source timer status/outcomes as fork suppressors

Production paths checked/migrated:

- `runtime/pipeline.Schedule` now carries `RunID`
- scheduler keying includes `run_id`
- store timer upsert/load/exact cancel/exact fire include `run_id`
- schedule claim keys and active checks include `run_id`
- runtime scheduled events inherit schedule `run_id`
- workflow/lifecycle/accumulation timer creation carries run identity from runtime correlation/event context
- selected-contract materialization/activation consumes timer reconstruction before clearing timer blockers
- historical replay admission reports timers as reconstructed fork-local state only through the timer owner

Migration completeness:

- Complete for the approved #642 selected-contract active-at-T timer reconstruction/run-scoped scheduler identity class.
- Unsupported timer histories, post-T source timer facts, routes, sessions, turns, audits, non-agent replay, retry/follow-up policy, broader recovery, contract-swap full resume, and API/dashboard/Builder surfaces remain fail-closed or split siblings under #564/#549/#618.

## Tests

- `go test ./internal/store ./internal/runtime/runforkexecution ./internal/runtime/pipeline ./cmd/swarm`
- `go test ./...`
