### PR TITLE
[agent-d][issue #645] Align accumulator projection event binding

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -476,6 +476,12 @@ entity_contracts:
       (`data_accumulation`, compute/filter/reduce/count/group_by store_as,
       query store_as, clear, or agent entity_writes/save tools) are hard
       invalidity.
+    runtime_binding_identity: |
+      Runtime projection binding uses the same node event identity semantics as
+      handler dispatch. A flow-local authored handler key and the
+      namespace-qualified runtime event that dispatched that handler are the
+      same projection source when the node event resolver canonicalizes them to
+      the same event identity.
     e1_coverage: |
       `materialize_from` counts as entity writer coverage for E1. It replaces
       `_unused_reason`; the two may not coexist.
@@ -4405,7 +4411,10 @@ static_analyzer:
       On a successful matching accumulator on_complete branch, runtime writes
       the projection as a full replacement before emit.fields and validates the
       result through entity named-type normalization. Failure rolls back the
-      whole handler transaction. Projection does not run for timeout,
+      whole handler transaction. If a verify-clean declaration exists for the
+      active handler accumulator but runtime resolves zero projection bindings,
+      execution fails closed as a runtime invariant violation rather than
+      silently skipping the projection. Projection does not run for timeout,
       incomplete accumulation, or no-match completion.
   slice_7_entity_reader_compliance:
     id: expression_field_reference_validation

--- a/internal/runtime/accprojection/resolver.go
+++ b/internal/runtime/accprojection/resolver.go
@@ -47,6 +47,15 @@ type Result struct {
 	Issues   []Issue
 }
 
+type HandlerResult struct {
+	Bindings                 []Binding
+	Issues                   []Issue
+	ExpectedBindingCount     int
+	ActiveAccumulatorName    string
+	ActiveAuthoredEventType  string
+	ActiveCanonicalEventType string
+}
+
 func Resolve(source semanticview.Source) Result {
 	if source == nil {
 		return Result{}
@@ -73,44 +82,86 @@ func Resolve(source semanticview.Source) Result {
 }
 
 func ForHandler(source semanticview.Source, flowID, nodeID, eventType string) ([]Binding, []Issue) {
+	result := ForHandlerWithAccumulator(source, flowID, nodeID, eventType, "")
+	return result.Bindings, result.Issues
+}
+
+func ForHandlerWithAccumulator(source semanticview.Source, flowID, nodeID, eventType, activeAccumulatorName string) HandlerResult {
 	resolved := Resolve(source)
+	result := HandlerResult{}
 	out := make([]Binding, 0)
 	flowID = strings.TrimSpace(flowID)
 	nodeID = strings.TrimSpace(nodeID)
-	eventType = strings.TrimSpace(eventType)
-	activeAccumulatorName := activeHandlerAccumulatorName(source, nodeID, eventType)
+	eventType = normalizeEventType(eventType)
+	activeAccumulatorName = strings.TrimSpace(activeAccumulatorName)
+	active := activeHandlerResolution(source, nodeID, eventType)
+	if activeAccumulatorName == "" {
+		activeAccumulatorName = active.AccumulatorName
+	}
+	result.ActiveAccumulatorName = activeAccumulatorName
+	result.ActiveAuthoredEventType = active.AuthoredEventType
+	result.ActiveCanonicalEventType = active.CanonicalEventType
 	for _, binding := range resolved.Bindings {
+		if bindingMatchesActiveAccumulator(binding, flowID, nodeID, activeAccumulatorName) {
+			result.ExpectedBindingCount++
+		}
 		if strings.TrimSpace(binding.FlowID) == flowID &&
 			strings.TrimSpace(binding.SourceNodeID) == nodeID &&
-			strings.TrimSpace(binding.SourceEventType) == eventType {
+			handlerEventMatches(source, nodeID, binding.SourceEventType, eventType, active) {
 			out = append(out, binding)
 		}
 	}
 	issues := make([]Issue, 0)
 	for _, issue := range resolved.Issues {
-		if issueRelevantToHandler(issue, flowID, nodeID, eventType, activeAccumulatorName) {
+		if issueMatchesActiveAccumulator(issue, flowID, nodeID, activeAccumulatorName) {
+			result.ExpectedBindingCount++
+		}
+		if issueRelevantToHandler(source, issue, flowID, nodeID, eventType, activeAccumulatorName, active) {
 			issues = append(issues, issue)
 		}
 	}
-	return out, issues
+	result.Bindings = out
+	result.Issues = issues
+	return result
 }
 
-func activeHandlerAccumulatorName(source semanticview.Source, nodeID, eventType string) string {
+type activeHandler struct {
+	AccumulatorName    string
+	AuthoredEventType  string
+	CanonicalEventType string
+}
+
+func activeHandlerResolution(source semanticview.Source, nodeID, eventType string) activeHandler {
+	var active activeHandler
 	if source == nil {
-		return ""
+		return active
+	}
+	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil {
+		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
+		if resolved.Matched {
+			active.AuthoredEventType = strings.TrimSpace(resolved.AuthoredEventType)
+			active.CanonicalEventType = normalizeEventType(resolved.CanonicalEventType)
+			if resolved.Handler.Accumulate != nil {
+				active.AccumulatorName = strings.TrimSpace(resolved.Handler.Accumulate.Into)
+			}
+			return active
+		}
 	}
 	node, ok := source.NodeEntries()[strings.TrimSpace(nodeID)]
 	if !ok {
-		return ""
+		return active
 	}
-	handler, ok := node.EventHandlers[strings.TrimSpace(eventType)]
+	handler, ok := node.EventHandlers[normalizeEventType(eventType)]
 	if !ok || handler.Accumulate == nil {
-		return ""
+		return active
 	}
-	return strings.TrimSpace(handler.Accumulate.Into)
+	active.AuthoredEventType = normalizeEventType(eventType)
+	active.CanonicalEventType = canonicalNodeEvent(source, nodeID, eventType)
+	active.AccumulatorName = strings.TrimSpace(handler.Accumulate.Into)
+	return active
 }
 
-func issueRelevantToHandler(issue Issue, flowID, nodeID, eventType, accumulatorName string) bool {
+func issueRelevantToHandler(source semanticview.Source, issue Issue, flowID, nodeID, eventType, accumulatorName string, active activeHandler) bool {
 	if strings.TrimSpace(issue.SourceNodeID) != strings.TrimSpace(nodeID) {
 		return false
 	}
@@ -118,12 +169,71 @@ func issueRelevantToHandler(issue Issue, flowID, nodeID, eventType, accumulatorN
 		return false
 	}
 	if issueEventType := strings.TrimSpace(issue.SourceEventType); issueEventType != "" {
-		return issueEventType == strings.TrimSpace(eventType)
+		return handlerEventMatches(source, nodeID, issueEventType, eventType, active)
 	}
 	if issueAccumulatorName := strings.TrimSpace(issue.AccumulatorName); issueAccumulatorName != "" {
 		return issueAccumulatorName == strings.TrimSpace(accumulatorName)
 	}
 	return false
+}
+
+func bindingMatchesActiveAccumulator(binding Binding, flowID, nodeID, accumulatorName string) bool {
+	if strings.TrimSpace(accumulatorName) == "" {
+		return false
+	}
+	return strings.TrimSpace(binding.FlowID) == strings.TrimSpace(flowID) &&
+		strings.TrimSpace(binding.SourceNodeID) == strings.TrimSpace(nodeID) &&
+		strings.TrimSpace(binding.AccumulatorName) == strings.TrimSpace(accumulatorName)
+}
+
+func issueMatchesActiveAccumulator(issue Issue, flowID, nodeID, accumulatorName string) bool {
+	if strings.TrimSpace(accumulatorName) == "" {
+		return false
+	}
+	if strings.TrimSpace(issue.FlowID) != "" && strings.TrimSpace(issue.FlowID) != strings.TrimSpace(flowID) {
+		return false
+	}
+	return strings.TrimSpace(issue.SourceNodeID) == strings.TrimSpace(nodeID) &&
+		strings.TrimSpace(issue.AccumulatorName) == strings.TrimSpace(accumulatorName)
+}
+
+func handlerEventMatches(source semanticview.Source, nodeID, authoredEventType, runtimeEventType string, active activeHandler) bool {
+	authoredEventType = normalizeEventType(authoredEventType)
+	runtimeEventType = normalizeEventType(runtimeEventType)
+	if authoredEventType == "" || runtimeEventType == "" {
+		return false
+	}
+	if authoredEventType == runtimeEventType {
+		return true
+	}
+	if active.AuthoredEventType != "" && authoredEventType == active.AuthoredEventType {
+		return true
+	}
+	authoredCanonical := canonicalNodeEvent(source, nodeID, authoredEventType)
+	runtimeCanonical := canonicalNodeEvent(source, nodeID, runtimeEventType)
+	if authoredCanonical != "" && runtimeCanonical != "" && authoredCanonical == runtimeCanonical {
+		return true
+	}
+	return active.CanonicalEventType != "" && authoredCanonical == active.CanonicalEventType
+}
+
+func canonicalNodeEvent(source semanticview.Source, nodeID, eventType string) string {
+	eventType = normalizeEventType(eventType)
+	if eventType == "" {
+		return ""
+	}
+	if source == nil {
+		return eventType
+	}
+	canonical := normalizeEventType(source.ResolveNodeEventReference(strings.TrimSpace(nodeID), eventType))
+	if canonical == "" {
+		return eventType
+	}
+	return canonical
+}
+
+func normalizeEventType(eventType string) string {
+	return strings.Trim(strings.TrimSpace(eventType), "/")
 }
 
 func scopedIssue(binding Binding, code, location, message string) Issue {

--- a/internal/runtime/accprojection/resolver_test.go
+++ b/internal/runtime/accprojection/resolver_test.go
@@ -1,6 +1,8 @@
 package accprojection
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -91,6 +93,24 @@ func TestForHandler_FiltersProjectionIssuesToActiveHandler(t *testing.T) {
 	}
 }
 
+func TestForHandler_ResolvesQualifiedRuntimeEventToLocalProjectionBinding(t *testing.T) {
+	source := semanticview.Wrap(loadProjectionFlowBundle(t))
+
+	result := ForHandlerWithAccumulator(source, "scoring", "scoring-node", "scoring/score.dimension_complete", "dimensions_received")
+	if len(result.Issues) != 0 {
+		t.Fatalf("ForHandler issues = %#v, want none", result.Issues)
+	}
+	if len(result.Bindings) != 1 {
+		t.Fatalf("ForHandler bindings = %d, want 1", len(result.Bindings))
+	}
+	if got := result.Bindings[0].SourceEventType; got != "score.dimension_complete" {
+		t.Fatalf("binding source event = %q, want authored local event", got)
+	}
+	if got := result.ExpectedBindingCount; got != 1 {
+		t.Fatalf("ExpectedBindingCount = %d, want 1", got)
+	}
+}
+
 func issuesContain(issues []Issue, want string) bool {
 	for _, issue := range issues {
 		if strings.Contains(issue.Message, want) {
@@ -98,4 +118,92 @@ func issuesContain(issues []Issue, want string) bool {
 		}
 	}
 	return false
+}
+
+func loadProjectionFlowBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writeProjectionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: projection-flow
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: projection-flow\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "schema.yaml"), `
+name: scoring
+initial_state: discovered
+states: [discovered, scored]
+terminal_states: [scored]
+pins:
+  inputs:
+    events: []
+  outputs:
+    events:
+      - score.dimension_complete
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "types.yaml"), `
+types:
+  DimensionScore:
+    dimension: text
+    score: integer
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "entities.yaml"), `
+vertical:
+  scores:
+    type: "[DimensionScore]"
+    initial: []
+    materialize_from: scoring-node.dimensions_received
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "events.yaml"), `
+score.dimension_complete:
+  dimension: text
+  score: integer
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "nodes.yaml"), `
+scoring-node:
+  id: scoring-node
+  execution_type: system_node
+  event_handlers:
+    score.dimension_complete:
+      accumulate:
+        into: dimensions_received
+  state_schema:
+    fields:
+      dimensions_received: "[DimensionScore]"
+`)
+
+	repoRoot := repoRootForProjectionTest(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func writeProjectionFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(content, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func repoRootForProjectionTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
 }

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -642,6 +642,16 @@ func (b *WorkflowContractBundle) NodeHandlerSubscriptions(nodeID string) []strin
 	return out
 }
 
+type NodeEventHandlerResolution struct {
+	NodeID             string
+	RawEventType       string
+	LocalizedEventType string
+	AuthoredEventType  string
+	CanonicalEventType string
+	Handler            SystemNodeEventHandler
+	Matched            bool
+}
+
 func (b *WorkflowContractBundle) nodeContract(nodeID string) (SystemNodeContract, bool) {
 	nodeID = strings.TrimSpace(nodeID)
 	if b == nil || nodeID == "" {
@@ -678,37 +688,59 @@ func (b *WorkflowContractBundle) nodeContract(nodeID string) (SystemNodeContract
 	return SystemNodeContract{}, false
 }
 func (b *WorkflowContractBundle) NodeEventHandler(nodeID, eventType string) (SystemNodeEventHandler, bool) {
-	if b == nil {
+	resolved := b.ResolveNodeEventHandler(nodeID, eventType)
+	if !resolved.Matched {
 		return SystemNodeEventHandler{}, false
 	}
-	nodeID = strings.TrimSpace(nodeID)
-	rawEventType := strings.TrimSpace(eventType)
-	eventType = b.localizeNodeEventType(nodeID, rawEventType)
+	return b.externalizeNodeHandler(nodeID, resolved.Handler), true
+}
+
+func (b *WorkflowContractBundle) ResolveNodeEventHandler(nodeID, eventType string) NodeEventHandlerResolution {
+	resolved := NodeEventHandlerResolution{
+		NodeID:       strings.TrimSpace(nodeID),
+		RawEventType: eventidentity.Normalize(eventType),
+	}
+	if b == nil {
+		return resolved
+	}
+	nodeID = resolved.NodeID
+	rawEventType := resolved.RawEventType
+	localizedEventType := b.localizeNodeEventType(nodeID, rawEventType)
+	resolved.LocalizedEventType = localizedEventType
 	handlers, ok := b.Semantics.NodeHandlers[nodeID]
 	if !ok {
-		return SystemNodeEventHandler{}, false
+		return resolved
 	}
-	if handler, ok := handlers[eventType]; ok {
-		return b.externalizeNodeHandler(nodeID, handler), true
+	if handler, ok := handlers[localizedEventType]; ok {
+		return b.nodeEventHandlerResolution(resolved, localizedEventType, handler)
 	}
-	if rawEventType != "" && rawEventType != eventType {
+	if rawEventType != "" && rawEventType != localizedEventType {
 		if handler, ok := handlers[rawEventType]; ok {
-			return b.externalizeNodeHandler(nodeID, handler), true
+			return b.nodeEventHandlerResolution(resolved, rawEventType, handler)
 		}
 	}
 	for pattern, handler := range handlers {
-		if handlerPatternMatches(pattern, eventType) {
-			return b.externalizeNodeHandler(nodeID, handler), true
+		if handlerPatternMatches(pattern, localizedEventType) {
+			return b.nodeEventHandlerResolution(resolved, pattern, handler)
 		}
 	}
-	if rawEventType != "" && rawEventType != eventType {
+	if rawEventType != "" && rawEventType != localizedEventType {
 		for pattern, handler := range handlers {
 			if handlerPatternMatches(pattern, rawEventType) {
-				return b.externalizeNodeHandler(nodeID, handler), true
+				return b.nodeEventHandlerResolution(resolved, pattern, handler)
 			}
 		}
 	}
-	return SystemNodeEventHandler{}, false
+	return resolved
+}
+
+func (b *WorkflowContractBundle) nodeEventHandlerResolution(resolved NodeEventHandlerResolution, authoredEventType string, handler SystemNodeEventHandler) NodeEventHandlerResolution {
+	authoredEventType = strings.TrimSpace(authoredEventType)
+	resolved.AuthoredEventType = authoredEventType
+	resolved.CanonicalEventType = b.ResolveNodeEventReference(resolved.NodeID, authoredEventType)
+	resolved.Handler = handler
+	resolved.Matched = true
+	return resolved
 }
 func (b *WorkflowContractBundle) RuntimeEventOwners(eventType string) []string {
 	if b == nil {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1110,18 +1110,21 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 	if !frame.accumulatorProjectionEligible {
 		return nil
 	}
-	bindings, issues := accprojection.ForHandler(e.deps.Source, frame.req.FlowID.String(), frame.req.NodeID.String(), string(frame.req.Event.Type))
-	if len(issues) > 0 {
-		return fmt.Errorf("accumulator projection declarations are invalid: %s", issues[0].Message)
+	result := accprojection.ForHandlerWithAccumulator(e.deps.Source, frame.req.FlowID.String(), frame.req.NodeID.String(), string(frame.req.Event.Type), activeAccumulatorName(frame.req.Handler))
+	if len(result.Issues) > 0 {
+		return fmt.Errorf("accumulator projection declarations are invalid: %s", result.Issues[0].Message)
 	}
-	if len(bindings) == 0 {
+	if len(result.Bindings) == 0 {
+		if result.ExpectedBindingCount > 0 {
+			return fmt.Errorf("runtime_invariant_violation: materialize_from binding declared for node %s accumulator %s but no accumulator buffer resolved at runtime for event %s; likely event identity drift between verify-time declaration and execution-time lookup", frame.req.NodeID.String(), result.ActiveAccumulatorName, string(frame.req.Event.Type))
+		}
 		return nil
 	}
 	acc, ok := loadAccumulator(frame.state.State, frame.req.NodeID, frame.req.Event.Type)
 	if !ok {
 		return fmt.Errorf("accumulator projection source missing for node %s event %s", frame.req.NodeID.String(), string(frame.req.Event.Type))
 	}
-	for _, binding := range bindings {
+	for _, binding := range result.Bindings {
 		projected, err := e.projectAccumulatorItems(frame, binding, acc.Items)
 		if err != nil {
 			return err
@@ -1131,6 +1134,13 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 		}
 	}
 	return nil
+}
+
+func activeAccumulatorName(handler runtimecontracts.SystemNodeEventHandler) string {
+	if handler.Accumulate == nil {
+		return ""
+	}
+	return strings.TrimSpace(handler.Accumulate.Into)
 }
 
 func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -663,6 +665,88 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 	emittedScores, ok := emitted["scores"].([]any)
 	if !ok || len(emittedScores) != 1 {
 		t.Fatalf("emit payload scores = %#v", emitted["scores"])
+	}
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesForQualifiedRuntimeEvent(t *testing.T) {
+	source := semanticview.Wrap(loadEngineProjectionFlowBundle(t))
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	handler, ok := source.NodeEventHandler("scoring-node", "scoring/score.dimension_complete")
+	if !ok {
+		t.Fatal("expected qualified runtime event to resolve to authored local handler")
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		FlowID:   "scoring",
+		Event: events.Event{
+			ID:      "evt-1",
+			Type:    "scoring/score.dimension_complete",
+			Payload: json.RawMessage(`{"dimension":"market","score":87}`),
+		},
+		Handler: handler,
+		State:   testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	scores, ok := result.StateMutation.Metadata["scores"].([]any)
+	if !ok || len(scores) != 1 {
+		t.Fatalf("projected scores = %#v", result.StateMutation.Metadata["scores"])
+	}
+	score, ok := scores[0].(map[string]any)
+	if !ok {
+		t.Fatalf("projected score item = %#v", scores[0])
+	}
+	if got := score["dimension"]; got != "market" {
+		t.Fatalf("projected dimension = %#v", got)
+	}
+	if _, exists := score["event_type"]; exists {
+		t.Fatalf("projected score leaked accumulator metadata: %#v", score)
+	}
+}
+
+func TestExecutor_AccumulatorProjectionFailsClosedWhenDeclaredBindingDoesNotResolveAtRuntime(t *testing.T) {
+	source := semanticview.Wrap(loadEngineProjectionFlowBundle(t))
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	handler, ok := source.NodeEventHandler("scoring-node", "scoring/score.dimension_complete")
+	if !ok {
+		t.Fatal("expected qualified runtime event to resolve to authored local handler")
+	}
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		FlowID:   "scoring",
+		Event: events.Event{
+			ID:      "evt-1",
+			Type:    "scoring/score.unregistered_dimension_complete",
+			Payload: json.RawMessage(`{"dimension":"market","score":87}`),
+		},
+		Handler: handler,
+		State:   testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime_invariant_violation") {
+		t.Fatalf("Execute error = %v, want runtime_invariant_violation", err)
 	}
 }
 
@@ -2273,4 +2357,103 @@ func TestExecutor_GuardOnFailEscalateCreatesEmitIntent(t *testing.T) {
 	if len(shaper.lastPayload) != 0 {
 		t.Fatalf("guard escalation payload = %#v, want empty explicit business payload", shaper.lastPayload)
 	}
+}
+
+func loadEngineProjectionFlowBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: projection-flow
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: projection-flow\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "schema.yaml"), `
+name: scoring
+initial_state: pending
+states: [pending, scored]
+terminal_states: [scored]
+pins:
+  inputs:
+    events:
+      - score.dimension_complete
+  outputs:
+    events:
+      - vertical.scored
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "types.yaml"), `
+types:
+  DimensionScore:
+    dimension: text
+    score: integer
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "entities.yaml"), `
+vertical:
+  scores:
+    type: "[DimensionScore]"
+    initial: []
+    materialize_from: scoring-node.dimensions_received
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "events.yaml"), `
+score.dimension_complete:
+  dimension: text
+  score: integer
+vertical.scored:
+  scores: "[DimensionScore]"
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "scoring", "nodes.yaml"), `
+scoring-node:
+  id: scoring-node
+  execution_type: system_node
+  event_handlers:
+    score.dimension_complete:
+      accumulate:
+        into: dimensions_received
+        completion: all
+        dedup_by: payload.dimension
+        on_complete:
+          - id: complete
+            emit:
+              event: vertical.scored
+              fields:
+                scores: entity.scores
+  state_schema:
+    fields:
+      dimensions_received: "[DimensionScore]"
+`)
+
+	repoRoot := repoRootForEngineProjectionTest(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func writeEngineProjectionFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(content, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func repoRootForEngineProjectionTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
 }


### PR DESCRIPTION
Closes #645

## Summary
- Adds a shared handler-event resolution result from `WorkflowContractBundle.ResolveNodeEventHandler`, used by existing dispatch-facing `NodeEventHandler` and accumulator projection binding.
- Makes accumulator projection match authored local handler keys against namespace-qualified runtime event types through canonical node event identity, while preserving runtime accumulator storage keyed by the actual runtime event type.
- Fails closed with `runtime_invariant_violation` when a verify-clean `materialize_from` declaration exists for the active accumulator but runtime resolves zero projection bindings.
- Updates authoritative `platform-spec.yaml` for projection runtime event identity and fail-closed behavior.

## Governing refs/context
- Swarm #645 issue body and approved Pre-Implementation Coverage Audit.
- Independent gate review on #645 approved the class: accumulator `materialize_from` runtime binding used different local-vs-qualified event identity semantics than node handler dispatch, causing silent no-op projection.
- Exact spec refs: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` sections `entity_contracts.accumulator_entity_projection`, `handler_specification.handler_fields.accumulate`, `handler_specification.dependency_graph`, and `static_analyzer.slice_6b_accumulator_entity_projection`.
- Review draft context: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.accumulator-entity-projection.yaml` required verify/runtime resolver parity and runtime contract-drift guards.

## Semantic ownership
- Canonical owner after this PR: node handler event identity resolution is exposed through `WorkflowContractBundle.ResolveNodeEventHandler`; accumulator projection consumes the same local/qualified identity semantics for binding and issue relevance.
- Old invalid path: exact `binding.SourceEventType == eventType` matching in `accprojection.ForHandler` and raw exact active accumulator lookup for runtime-qualified events.
- Runtime accumulator storage remains keyed by the actual runtime event type; this PR does not re-key persisted accumulator buckets.
- Migration complete for the chosen #645 projection-binding child class. Broader all-runtime event identity consolidation remains watchlist/parent risk, not claimed closed here.

## Proof
- `go test ./internal/runtime/contracts -run TestNodeEventHandler_LocalizesCrossFlowQualifiedInputEventToLocalHandler -count=1`
- `go test ./internal/runtime/accprojection -count=1`
- `go test ./internal/runtime/engine -run 'TestExecutor_AccumulatorProjection(Materializes|Fails)' -count=1`
- `go test ./internal/runtime/accprojection ./internal/runtime/engine ./internal/runtime/bootverify`
- `go test ./...`

## Downstream note
Empire #19/#55 still requires supported downstream proof after this Swarm PR merges: completed scoring entities must have `scores` receipt count equal to accumulator item count, with no runtime metadata or extras projected.
