### PR TITLE
[agent-a][issue #648] Prove unsupported fork timer histories fail closed

### DIFF
--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -235,6 +235,178 @@ func TestSelectedContractExecutionMaterializationReconstructsActiveTimer(t *test
 	}
 }
 
+func TestSelectedContractExecutionMaterializationFailsClosedForUnsupportedTimerHistory(t *testing.T) {
+	cases := []struct {
+		name           string
+		insertTimer    func(t *testing.T, db *sql.DB, sourceRunID, entityID string, at time.Time)
+		expectedReason string
+	}{
+		{
+			name: "fired timer",
+			insertTimer: func(t *testing.T, db *sql.DB, sourceRunID, entityID string, at time.Time) {
+				t.Helper()
+				if _, err := db.ExecContext(context.Background(), `
+					INSERT INTO timers (
+						run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+						fire_at, owner_agent, task_type, status, fired_at, created_at
+					)
+					VALUES (
+						$1::uuid, 'selected-fired-timer', $2::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb,
+						$3, 'agent-a', 'timer', 'fired', $4, $5
+					)
+				`, sourceRunID, entityID, at.Add(time.Hour), at.Add(30*time.Minute), at.Add(-time.Minute)); err != nil {
+					t.Fatalf("seed fired timer: %v", err)
+				}
+			},
+			expectedReason: "source timer history is not active-at-fork only",
+		},
+		{
+			name: "non-active timer",
+			insertTimer: func(t *testing.T, db *sql.DB, sourceRunID, entityID string, at time.Time) {
+				t.Helper()
+				if _, err := db.ExecContext(context.Background(), `
+					INSERT INTO timers (
+						run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+						fire_at, owner_agent, task_type, status, created_at
+					)
+					VALUES (
+						$1::uuid, 'selected-cancelled-timer', $2::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb,
+						$3, 'agent-a', 'timer', 'cancelled', $4
+					)
+				`, sourceRunID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+					t.Fatalf("seed cancelled timer: %v", err)
+				}
+			},
+			expectedReason: "source timer history is not active-at-fork only",
+		},
+		{
+			name: "missing executable owner",
+			insertTimer: func(t *testing.T, db *sql.DB, sourceRunID, entityID string, at time.Time) {
+				t.Helper()
+				if _, err := db.ExecContext(context.Background(), `
+					INSERT INTO timers (
+						run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+						fire_at, owner_node, task_type, status, created_at
+					)
+					VALUES (
+						$1::uuid, 'selected-ownerless-timer', $2::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb,
+						$3, 'timer-node', 'timer', 'active', $4
+					)
+				`, sourceRunID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+					t.Fatalf("seed ownerless timer: %v", err)
+				}
+			},
+			expectedReason: "source timer lacks executable owner/event identity",
+		},
+		{
+			name: "missing fire event",
+			insertTimer: func(t *testing.T, db *sql.DB, sourceRunID, entityID string, at time.Time) {
+				t.Helper()
+				if _, err := db.ExecContext(context.Background(), `
+					INSERT INTO timers (
+						run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+						fire_at, owner_agent, task_type, status, created_at
+					)
+					VALUES (
+						$1::uuid, 'selected-eventless-timer', $2::uuid, 'flow-a/1', '', '{"source":true}'::jsonb,
+						$3, 'agent-a', 'timer', 'active', $4
+					)
+				`, sourceRunID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+					t.Fatalf("seed eventless timer: %v", err)
+				}
+			},
+			expectedReason: "source timer lacks executable owner/event identity",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+			sourceRunID := uuid.NewString()
+			entityID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700003525, 0).UTC()
+			seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+			tc.insertTimer(t, db, sourceRunID, entityID, at)
+
+			materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+				SourceRunID: sourceRunID,
+				At:          eventID,
+				ContractSelection: RunForkContractSelection{
+					Mode:            "selected_contracts",
+					ContractsRoot:   "/tmp/selected-contracts",
+					WorkflowName:    "selected-workflow",
+					WorkflowVersion: "v1",
+				},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.expectedReason) {
+				t.Fatalf("materialization error = %v, want %q", err, tc.expectedReason)
+			}
+			if materialized.ForkRunID != "" {
+				t.Fatalf("materialized fork despite unsupported timer history: %#v", materialized)
+			}
+			assertNoSelectedContractForkRows(t, db, sourceRunID)
+			assertNoForkTimerCopiesForSource(t, db, sourceRunID)
+		})
+	}
+}
+
+func TestSelectedContractTimerReconstructionFailsClosedForInvalidPayload(t *testing.T) {
+	_, err := validateRunForkReconstructableSourceTimer(runForkTimerReconstructionRow{
+		Status:      "active",
+		OwnerAgent:  "agent-a",
+		FireEvent:   "timer.selected",
+		FirePayload: []byte(`{"broken"`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "source timer payload is invalid JSON") {
+		t.Fatalf("validate invalid timer payload error = %v", err)
+	}
+}
+
+func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappearsAfterPlanning(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003550, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	timerID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, owner_agent, task_type, status, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'selected-vanishing-timer', $3::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb,
+			$4, 'agent-a', 'timer', 'active', $5
+		)
+	`, timerID, sourceRunID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed timer: %v", err)
+	}
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if !runForkPlanHasTimerBlocker(plan) {
+		t.Fatalf("plan missing timer blocker: %#v", plan.ReplayResumeAdmission)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM timers WHERE timer_id = $1::uuid`, timerID); err != nil {
+		t.Fatalf("delete timer after planning: %v", err)
+	}
+	catalog, err := pg.requireRunForkSelectedContractExecutionCapabilities(ctx)
+	if err != nil {
+		t.Fatalf("require selected contract capabilities: %v", err)
+	}
+	_, err = pg.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
+	if err == nil || !strings.Contains(err.Error(), "no reconstructable active source timers") {
+		t.Fatalf("timer reconstruction error = %v, want no reconstructable timer blocker", err)
+	}
+}
+
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -320,6 +492,26 @@ func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, so
 		)
 	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
+	}
+}
+
+func assertNoForkTimerCopiesForSource(t *testing.T, db *sql.DB, sourceRunID string) {
+	t.Helper()
+	var copied int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE forked_from_run_id = $1::uuid
+		   OR source_timer_id IN (
+				SELECT timer_id
+				FROM timers
+				WHERE run_id = $1::uuid
+		   )
+	`, sourceRunID).Scan(&copied); err != nil {
+		t.Fatalf("count fork timer copies: %v", err)
+	}
+	if copied != 0 {
+		t.Fatalf("fork timer copies for source run = %d, want 0", copied)
 	}
 }
 

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -174,24 +174,32 @@ func loadRunForkReconstructableSourceTimers(ctx context.Context, q timerReconstr
 		); err != nil {
 			return nil, fmt.Errorf("scan source timer for reconstruction: %w", err)
 		}
-		if strings.TrimSpace(row.Status) != "active" || row.FiredAt.Valid {
-			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer history is not active-at-fork only")
+		normalized, err := validateRunForkReconstructableSourceTimer(row)
+		if err != nil {
+			return nil, err
 		}
-		if strings.TrimSpace(row.OwnerAgent) == "" || strings.TrimSpace(row.FireEvent) == "" {
-			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer lacks executable owner/event identity")
-		}
-		if len(row.FirePayload) == 0 || string(row.FirePayload) == "null" {
-			row.FirePayload = []byte("{}")
-		}
-		if !json.Valid(row.FirePayload) {
-			return nil, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer payload is invalid JSON")
-		}
-		out = append(out, row)
+		out = append(out, normalized)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate source timers for reconstruction: %w", err)
 	}
 	return out, nil
+}
+
+func validateRunForkReconstructableSourceTimer(row runForkTimerReconstructionRow) (runForkTimerReconstructionRow, error) {
+	if strings.TrimSpace(row.Status) != "active" || row.FiredAt.Valid {
+		return runForkTimerReconstructionRow{}, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer history is not active-at-fork only")
+	}
+	if strings.TrimSpace(row.OwnerAgent) == "" || strings.TrimSpace(row.FireEvent) == "" {
+		return runForkTimerReconstructionRow{}, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer lacks executable owner/event identity")
+	}
+	if len(row.FirePayload) == 0 || string(row.FirePayload) == "null" {
+		row.FirePayload = []byte("{}")
+	}
+	if !json.Valid(row.FirePayload) {
+		return runForkTimerReconstructionRow{}, runForkReplayResumeError(RunForkBlockerTimerHistoryUnproven, RunForkReplayResumeFactTimerHistory, "selected-contract timer reconstruction blocked: source timer payload is invalid JSON")
+	}
+	return row, nil
 }
 
 func insertRunForkSelectedContractTimerReconstructions(ctx context.Context, tx *sql.Tx, forkRunID, sourceRunID, forkEventID string, reconstruction runForkTimerReconstructionPlan, now time.Time) error {


### PR DESCRIPTION
## Summary

Closes #648.

This PR closes the approved first-slice boundary for unsupported at/before-T selected-contract timer histories as a policy/proof slice. Runtime behavior remains fail-closed: unsupported source timer histories are not reconstructed, copied, fired, or used as fork suppressors.

## Governing refs / context

Authoritative spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.selected_contract_timer_route_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.historical_replay_execution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3d_selected_contract_timer_route_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3j1_historical_replay_execution_owner`

Approved gate: #648 repaired boundary, approved as first slice. Post-T source timer facts are explicitly split to source-advanced-after-fork policy under #564/#549 and are not changed here.

No platform runtime semantics are changed in this PR; the authoritative spec already says unsupported source timer histories remain fail-closed. The code change extracts the existing validation into a named helper so the policy can be regression-tested directly.

## What changed

- Added focused store proofs for fired/non-active at-or-before-T source timers and source timers missing executable owner/event identity.
- Added direct validation proof for invalid source timer payload policy.
- Added proof for the no-reconstructable-active-source-timer case after planning evidence exists.
- Kept active-at-T timer reconstruction regression coverage intact.

## Validation

- `go test -run 'TestSelectedContract(ExecutionMaterialization(ReconstructsActiveTimer|FailsClosedForUnsupportedTimerHistory)|TimerReconstructionFailsClosed)' -v ./internal/store`
- `go test ./internal/store ./internal/runtime/runforkexecution ./internal/runtime/pipeline ./cmd/swarm`
- `go test ./...`
