### PR TITLE
[agent-d][issue #649] Resolve named event payload types

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -184,6 +184,11 @@ contract_formats:
       producer-owned payload fields.
       The platform validates emit calls against the declared payload
       contract and populates envelope fields separately.
+      Runtime emit-payload validators MUST validate against the
+      canonical type-aware event schema lowered through the active
+      Wave 1 type catalog. Runtime validators MUST NOT pass unresolved
+      contract type names such as named types, scalar aliases, or enums
+      to the primitive JSON schema validator as literal schema types.
     format:
       event_name: |
         swarm:
@@ -3997,8 +4002,8 @@ observation_model:
           site. Consumers read envelope fields through event.*.
         runtime_validation:
           description: Runtime validates the emitted payload fail-closed on this surface.
-          validation_view: Validate the producer-authored payload carrier against the target event schema. Runtime-owned envelope
-            fields are not synthesized into payload for validation.
+          validation_view: Validate the producer-authored payload carrier against the target event schema after canonical
+            Wave 1 type-aware schema lowering. Runtime-owned envelope fields are not synthesized into payload for validation.
           rejection_rule: If any producer-authored field is absent from the target event schema, if any declared field violates
             the schema, or if emit.fields authors an envelope-owned key, handler execution fails. Runtime does not silently trim
             producer-authored business payload keys.
@@ -4013,8 +4018,8 @@ observation_model:
           read envelope fields through event.* rather than payload.*.
         runtime_validation:
           description: Runtime validates the emitted payload fail-closed on this surface before publish.
-          validation_view: Validate the emitted payload carrier that will actually be published. Runtime-owned envelope fields are
-            not synthesized into payload for validation.
+          validation_view: Validate the emitted payload carrier that will actually be published after canonical Wave 1 type-aware
+            schema lowering. Runtime-owned envelope fields are not synthesized into payload for validation.
           rejection_rule: If any inherited or producer-authored business field is undeclared or violates the schema, handler execution
             fails. Runtime does not silently trim inherited trigger-payload keys and does not clear the failure by projecting
             envelope-owned fields back into payload.
@@ -4031,8 +4036,8 @@ observation_model:
         runtime_validation:
           description: Runtime validates the constructed auto-emit payload fail-closed before either immediate publish or queued
             post-commit publish.
-          validation_view: Validate the constructed payload carrier against the target event schema. Runtime-owned envelope fields are
-            not synthesized into payload for validation.
+          validation_view: Validate the constructed payload carrier against the target event schema after canonical Wave 1 type-aware
+            schema lowering. Runtime-owned envelope fields are not synthesized into payload for validation.
           rejection_rule: If any lifecycle/config-authored field is undeclared or violates the schema, flow activation fails. Runtime
             does not downgrade auto_emit_on_create schema violations into warning-only success on the queued post-commit branch.
   entity_state:

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -295,11 +295,38 @@ func eventSchemaDeclarationEntry(bundle *WorkflowContractBundle, declaration eve
 }
 
 func eventSchemaLookupKeys(bundle *WorkflowContractBundle, flowID, eventType string) []string {
-	keys := []string{resolvedEventSchemaKey(bundle, flowID, eventType)}
+	keys := []string{
+		eventType,
+		resolvedEventSchemaKey(bundle, flowID, eventType),
+	}
+	if strings.TrimSpace(flowID) != "" {
+		keys = append(keys, eventSchemaScopedLeafKey(bundle, flowID, eventType))
+	}
 	if key := instanceScopedEventSchemaKey(bundle, eventType); key != "" {
 		keys = append(keys, key)
 	}
 	return uniqueNormalizedEventSchemaKeys(keys...)
+}
+
+func eventSchemaScopedLeafKey(bundle *WorkflowContractBundle, flowID, eventType string) string {
+	eventType = normalizedEventSchemaKey(eventType)
+	if eventType == "" || !strings.Contains(eventType, "/") {
+		return ""
+	}
+	flowPath := ""
+	if bundle != nil {
+		flowPath = normalizedEventSchemaKey(bundle.FlowPath(flowID))
+	}
+	if flowPath == "" {
+		flowPath = normalizedEventSchemaKey(flowID)
+	}
+	if flowPath == "" || !strings.HasPrefix(eventType, flowPath+"/") {
+		return ""
+	}
+	if idx := strings.LastIndex(eventType, "/"); idx >= 0 && idx+1 < len(eventType) {
+		return strings.TrimSpace(eventType[idx+1:])
+	}
+	return ""
 }
 
 func resolvedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventType string) string {

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -295,3 +295,80 @@ func TestEventSchemaForFlowEvent_UsesDeclaringFlowTypeCatalogForOverride(t *test
 		t.Fatalf("instance priority enum = %#v, want [urgent]", got)
 	}
 }
+
+func TestEventSchemaForFlowEvent_UsesDeclaringRootTypeCatalogForChildOutput(t *testing.T) {
+	childFlow := FlowContractView{
+		Paths: FlowContractPaths{ID: "child", Flow: "child"},
+		Path:  "child",
+		Schema: FlowSchemaDocument{
+			Pins: FlowPins{
+				Outputs: FlowOutputPins{Events: []string{"handoff.completed"}},
+			},
+		},
+	}
+	root := &FlowContractView{
+		Events: map[string]EventCatalogEntry{
+			"handoff.completed": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"evidence": {Type: "Evidence"},
+					},
+					Required: []string{"evidence"},
+				},
+			},
+		},
+		Children: []FlowContractView{childFlow},
+	}
+	bundle := &WorkflowContractBundle{
+		RootTypes: TypeCatalogDocument{
+			Types: map[string]NamedTypeDecl{
+				"Evidence": {
+					Fields: map[string]TypeFieldSpec{
+						"root_field": {Type: "text"},
+					},
+				},
+			},
+		},
+		FlowTree: FlowTree{
+			Root: root,
+			ByID: map[string]*FlowContractView{
+				"child": &root.Children[0],
+			},
+		},
+		flowTypes: map[string]TypeCatalogDocument{
+			"child": {
+				Types: map[string]NamedTypeDecl{
+					"Evidence": {
+						Fields: map[string]TypeFieldSpec{
+							"child_field": {Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, eventType := range []string{"handoff.completed", "child/handoff.completed"} {
+		t.Run(eventType, func(t *testing.T) {
+			schema, key, ok := EventSchemaForFlowEvent(bundle, "child", eventType)
+			if !ok {
+				t.Fatal("missing child output event schema")
+			}
+			if key != "handoff.completed" {
+				t.Fatalf("schema key = %q, want root declaration handoff.completed", key)
+			}
+			props, _ := schema.Schema["properties"].(map[string]any)
+			evidence, _ := props["evidence"].(map[string]any)
+			evidenceProps, _ := evidence["properties"].(map[string]any)
+			if _, ok := evidenceProps["root_field"]; !ok {
+				t.Fatalf("evidence properties = %#v, want root_field", evidenceProps)
+			}
+			if _, ok := evidenceProps["child_field"]; ok {
+				t.Fatalf("evidence properties = %#v, must not use child Evidence override for root-declared event", evidenceProps)
+			}
+		})
+	}
+	if _, _, ok := EventSchemaForFlowEvent(bundle, "child", "sibling/handoff.completed"); ok {
+		t.Fatal("sibling-qualified event must not match root declaration by leaf name")
+	}
+}

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -202,19 +202,14 @@ func validateAutoEmitPayload(source semanticview.Source, flowID, eventType strin
 	if !proof.HasSchema {
 		return nil
 	}
-	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
-		proof.CatalogKey: proof.Entry,
-	})
-	schema, ok := registry[proof.CatalogKey]
-	if bundle, okBundle := semanticview.Bundle(source); okBundle && bundle != nil {
-		if resolved, _, okResolved := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); okResolved {
-			schema = resolved
-			ok = true
-		}
-	}
-	if !ok {
+	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+	if !resolution.HasSchema {
 		return nil
 	}
+	if err := resolution.UnresolvedTypeError(); err != nil {
+		return fmt.Errorf("%w for %s: %v", runtimebus.ErrPayloadValidation, proof.EventKey(), err)
+	}
+	schema := resolution.Schema
 	validationPayload := runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(payload, autoEmitSchemaPropertyNames(schema.Schema))
 	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, validationPayload); err != nil {
 		return fmt.Errorf("%w for %s: %v", runtimebus.ErrPayloadValidation, proof.EventKey(), err)

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -528,6 +528,55 @@ func TestValidateAutoEmitPayload_RejectsListTypeViolation(t *testing.T) {
 	}
 }
 
+func TestValidateAutoEmitPayload_AllowsNamedTypeThroughCanonicalSchema(t *testing.T) {
+	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"instance_id":      {Type: "string"},
+				"template_id":      {Type: "string"},
+				"flow_path":        {Type: "string"},
+				"parent_entity_id": {Type: "string"},
+				"details":          {Type: "ReviewDetails"},
+			},
+		},
+		Required: []string{"instance_id", "template_id", "flow_path", "parent_entity_id", "details"},
+	})
+	bundle.RootTypes = runtimecontracts.TypeCatalogDocument{
+		Types: map[string]runtimecontracts.NamedTypeDecl{
+			"ReviewDetails": {
+				Fields: map[string]runtimecontracts.TypeFieldSpec{
+					"summary": {Type: "text"},
+				},
+			},
+		},
+	}
+
+	err := validateAutoEmitPayload(semanticview.Wrap(bundle), "review", "task.started", map[string]any{
+		"instance_id":      "inst-1",
+		"template_id":      "review",
+		"flow_path":        "review/inst-1",
+		"parent_entity_id": "ent-parent",
+		"details":          map[string]any{"summary": "ready"},
+	})
+	if err != nil {
+		t.Fatalf("validateAutoEmitPayload valid named type: %v", err)
+	}
+
+	err = validateAutoEmitPayload(semanticview.Wrap(bundle), "review", "task.started", map[string]any{
+		"instance_id":      "inst-1",
+		"template_id":      "review",
+		"flow_path":        "review/inst-1",
+		"parent_entity_id": "ent-parent",
+		"details":          "not-object",
+	})
+	if err == nil {
+		t.Fatal("expected named-type auto-emit violation")
+	}
+	if !strings.Contains(err.Error(), "$.details must be object") {
+		t.Fatalf("validateAutoEmitPayload error = %v, want named-type detail", err)
+	}
+}
+
 func TestNormalizedStaticFlowEmitEvents_ExternalizesLocalEvents(t *testing.T) {
 	got := normalizedStaticFlowEmitEvents(
 		[]string{"analysis.done", "shared.event"},

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -805,19 +805,14 @@ func validatePipelineEmitPayload(source semanticview.Source, flowID, eventType s
 	if !proof.HasSchema {
 		return nil
 	}
-	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
-		proof.CatalogKey: proof.Entry,
-	})
-	schema, ok := registry[proof.CatalogKey]
-	if bundle, okBundle := semanticview.Bundle(source); okBundle && bundle != nil {
-		if resolved, _, okResolved := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); okResolved {
-			schema = resolved
-			ok = true
-		}
-	}
-	if !ok {
+	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+	if !resolution.HasSchema {
 		return nil
 	}
+	if err := resolution.UnresolvedTypeError(); err != nil {
+		return fmt.Errorf("%w: event %s payload schema is unresolved: %v", runtimeengine.ErrEmitPayloadContractViolation, proof.EventKey(), err)
+	}
+	schema := resolution.Schema
 	allowed := eventPayloadProperties(proof.Entry)
 	validationPayload := cloneStringAnyMap(payload)
 	if surface != runtimeengine.EmitSurfaceDeclarative {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -853,6 +853,68 @@ func TestValidatePipelineEmitPayload_RejectsEnumViolationOnActionSurface(t *test
 	}
 }
 
+func TestPipelineEnginePayloadShaper_UsesRootNamedTypeSchemaForChildOutput(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml":             "name: child-output-named-type\nversion: 1.0.0\ndescription: child output named type proof\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
+		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  outputs:\n    events: [handoff.completed]\n",
+		"types.yaml":               "types:\n  Evidence:\n    root_field: text\n",
+		"events.yaml":              "handoff.completed:\n  evidence: Evidence\n  required: [evidence]\n",
+		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
+		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  outputs:\n    events: [handoff.completed]\n",
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected workflow fixture bundle")
+	}
+	shaper := pipelineEnginePayloadShaper{
+		coordinator: &PipelineCoordinator{
+			module: &previewWorkflowModule{
+				bundle: bundle,
+			},
+		},
+	}
+	req := runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("ent-child"),
+		FlowID:   identity.NormalizeFlowID("child"),
+		Event: events.Event{
+			Type:    events.EventType("child/child.internal"),
+			Payload: json.RawMessage(`{"entity_id":"ent-child"}`),
+		}.WithEntityID("ent-child"),
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1"}, nil, nil),
+		},
+	}
+
+	for _, eventType := range []string{"handoff.completed", "child/handoff.completed"} {
+		t.Run(eventType, func(t *testing.T) {
+			payload, err := shaper.ShapeEmitPayload(context.Background(), req, eventType, map[string]any{
+				"evidence": map[string]any{"root_field": "ok"},
+			})
+			if err != nil {
+				t.Fatalf("ShapeEmitPayload valid root named type: %v", err)
+			}
+			evidence, _ := payload["evidence"].(map[string]any)
+			if _, ok := evidence["root_field"]; !ok {
+				t.Fatalf("payload = %#v, want root_field evidence", payload)
+			}
+
+			_, err = shaper.ShapeEmitPayload(context.Background(), req, eventType, map[string]any{
+				"evidence": map[string]any{"child_field": "wrong catalog"},
+			})
+			if err == nil {
+				t.Fatal("expected child Evidence override to fail for root-declared output event")
+			}
+			if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+				t.Fatalf("ShapeEmitPayload invalid catalog error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
+			}
+			if !strings.Contains(err.Error(), "$.evidence.root_field is required") {
+				t.Fatalf("ShapeEmitPayload error = %v, want root_field required proof", err)
+			}
+		})
+	}
+}
+
 func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-child-flow-local-events")
 	bundle, ok := semanticview.Bundle(source)

--- a/internal/runtime/semanticview/event_schema.go
+++ b/internal/runtime/semanticview/event_schema.go
@@ -1,0 +1,115 @@
+package semanticview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+type EventSchemaResolution struct {
+	Schema          runtimecontracts.EventSchema
+	EventKey        string
+	HasSchema       bool
+	UnresolvedTypes []string
+}
+
+func ResolveEventSchema(source Source, flowID, eventType string) EventSchemaResolution {
+	flowID = strings.TrimSpace(flowID)
+	eventType = strings.TrimSpace(eventType)
+	if source == nil || eventType == "" {
+		return EventSchemaResolution{}
+	}
+	if bundle, ok := Bundle(source); ok && bundle != nil {
+		if schema, key, ok := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); ok {
+			return EventSchemaResolution{
+				Schema:          schema,
+				EventKey:        strings.TrimSpace(key),
+				HasSchema:       true,
+				UnresolvedTypes: UnsupportedJSONSchemaTypes(schema.Schema),
+			}
+		}
+	}
+	proof := ResolveFlowEventProof(source, flowID, eventType)
+	if !proof.HasSchema {
+		return EventSchemaResolution{}
+	}
+	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
+		proof.CatalogKey: proof.Entry,
+	})
+	schema, ok := registry[proof.CatalogKey]
+	if !ok {
+		return EventSchemaResolution{}
+	}
+	return EventSchemaResolution{
+		Schema:          schema,
+		EventKey:        proof.EventKey(),
+		HasSchema:       true,
+		UnresolvedTypes: UnsupportedJSONSchemaTypes(schema.Schema),
+	}
+}
+
+func (r EventSchemaResolution) UnresolvedTypeError() error {
+	if len(r.UnresolvedTypes) == 0 {
+		return nil
+	}
+	eventKey := strings.TrimSpace(r.EventKey)
+	if eventKey == "" {
+		eventKey = "event"
+	}
+	return fmt.Errorf("%s schema contains unresolved contract type(s): %s", eventKey, strings.Join(r.UnresolvedTypes, ", "))
+}
+
+func UnsupportedJSONSchemaTypes(schema map[string]any) []string {
+	if len(schema) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	collectUnsupportedJSONSchemaTypes(schema, seen)
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectUnsupportedJSONSchemaTypes(schema map[string]any, out map[string]struct{}) {
+	if len(schema) == 0 {
+		return
+	}
+	if raw, ok := schema["type"]; ok {
+		if typ := strings.TrimSpace(asSchemaString(raw)); typ != "" && !supportedJSONSchemaType(typ) {
+			out[typ] = struct{}{}
+		}
+	}
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for _, raw := range props {
+			if nested, ok := raw.(map[string]any); ok {
+				collectUnsupportedJSONSchemaTypes(nested, out)
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		collectUnsupportedJSONSchemaTypes(items, out)
+	}
+}
+
+func supportedJSONSchemaType(typ string) bool {
+	switch typ {
+	case "object", "array", "string", "number", "integer", "boolean", "null":
+		return true
+	default:
+		return false
+	}
+}
+
+func asSchemaString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/semanticview/event_schema_test.go
+++ b/internal/runtime/semanticview/event_schema_test.go
@@ -1,0 +1,40 @@
+package semanticview
+
+import (
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+)
+
+func TestResolveEventSchema_ReportsUnresolvedTypesAfterBundleResolution(t *testing.T) {
+	root := &runtimecontracts.FlowContractView{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"handoff.completed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"evidence": {Type: "NotDeclared"},
+					},
+					Required: []string{"evidence"},
+				},
+			},
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: root,
+		},
+	}
+
+	resolution := ResolveEventSchema(Wrap(bundle), "", "handoff.completed")
+	if !resolution.HasSchema {
+		t.Fatal("expected event schema resolution")
+	}
+	if len(resolution.UnresolvedTypes) != 1 || resolution.UnresolvedTypes[0] != "NotDeclared" {
+		t.Fatalf("UnresolvedTypes = %#v, want [NotDeclared]", resolution.UnresolvedTypes)
+	}
+	if err := resolution.UnresolvedTypeError(); err == nil || !strings.Contains(err.Error(), "NotDeclared") {
+		t.Fatalf("UnresolvedTypeError = %v, want NotDeclared", err)
+	}
+}

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -216,20 +216,11 @@ func (r *EmitRegistry) schemaForActorEvent(actor models.AgentConfig, eventType s
 	if flowID == "" {
 		return EmitSchema{}, false
 	}
-	proof := semanticview.ResolveFlowEventProof(r.source, flowID, eventType)
-	if !proof.HasSchema {
+	resolution := semanticview.ResolveEventSchema(r.source, flowID, eventType)
+	if !resolution.HasSchema || len(resolution.UnresolvedTypes) > 0 {
 		return EmitSchema{}, false
 	}
-	if bundle, ok := semanticview.Bundle(r.source); ok && bundle != nil {
-		if schema, _, ok := runtimecontracts.EventSchemaForFlowEvent(bundle, flowID, eventType); ok {
-			return closeGeneratedEmitSchema(schema), true
-		}
-	}
-	registry := runtimecontracts.EventSchemaRegistryFromCatalog(map[string]runtimecontracts.EventCatalogEntry{
-		proof.CatalogKey: proof.Entry,
-	})
-	schema, ok := closeGeneratedEmitSchemaRegistry(registry)[proof.CatalogKey]
-	return schema, ok
+	return closeGeneratedEmitSchema(resolution.Schema), true
 }
 
 func (r *EmitRegistry) GeneratedEmitSchemasForAgentRoles() []string {
@@ -271,8 +262,28 @@ func ValidateGeneratedEmitToolSchemasForSource(source semanticview.Source) []err
 	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
 	var errs []error
 	for _, actor := range providerSchemaValidationActors(source) {
+		validatedTools := map[string]struct{}{}
 		for _, tool := range registry.GenerateEmitToolsForActor(actor, nil) {
+			validatedTools[tool.Name] = struct{}{}
 			if err := llm.ValidateProviderToolSchema(tool.Name, tool.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("agent %s: %w", strings.TrimSpace(actor.ID), err))
+			}
+		}
+		for _, eventType := range UniqueNonEmpty(actor.EmitEvents) {
+			toolName := EmitToolName(eventType)
+			if _, ok := validatedTools[toolName]; ok {
+				continue
+			}
+			flowID := strings.TrimSpace(actor.Mode)
+			if flowID == "" {
+				continue
+			}
+			resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+			if !resolution.HasSchema {
+				continue
+			}
+			schema := closeGeneratedEmitSchema(resolution.Schema)
+			if err := llm.ValidateProviderToolSchema(toolName, schema.Schema); err != nil {
 				errs = append(errs, fmt.Errorf("agent %s: %w", strings.TrimSpace(actor.ID), err))
 			}
 		}


### PR DESCRIPTION
Closes #649
Related: yazzaoui/empire#56

## Summary
- Adds a shared runtime event-schema resolution path that returns canonical, Wave 1 type-aware event schemas and reports unresolved contract type names fail-closed.
- Moves pipeline/system-node emit validation, auto-emit validation, and agent emit fallback schema lookup onto the shared resolver.
- Repairs child-flow output lookup so qualified runtime events like `child/handoff.completed` can resolve root-declared output schemas without letting sibling-qualified events match by leaf.
- Updates authoritative `platform-spec.yaml` to require runtime emit-payload validation against canonical type-aware lowered schemas.

## Governing Context
- Swarm #649 issue and approved gate comment.
- Exact authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` event schema and observation-model emit validation sections.
- Related sibling context: #645/#647 resolver drift, but accumulator projection and entity writes are intentionally out of scope.

## Semantic Migration
- New canonical owner for runtime emit-payload schema lookup: `internal/runtime/semanticview.ResolveEventSchema` backed by `internal/runtime/contracts.EventSchemaForFlowEvent` / bundle type catalogs.
- Old invalid path: runtime emit validators rebuilding event schemas from a single catalog entry with an empty type catalog before primitive payload validation.
- Checked production paths: pipeline declarative/action emits, auto-emit-on-create, agent emit fallback, event bus snapshot via generated emit registry.
- Migration complete for the approved emit-payload validation class; entityruntime and accprojection remain separate canonical owners.

## Verification
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/pipeline ./internal/runtime/manager ./internal/runtime/tools ./internal/runtime/eventschema -count=1`
- `go run ./cmd/swarm verify -contracts /Users/youmew/dev/empire-worktrees/agent-d-19/contracts -platform-spec /tmp/swarm-master-643/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `go test ./...`
- Supported Empire control-plane proof in isolated DB `swarm_issue649_20260509021753`: run `d0f0b84b-4d4b-4427-b571-1d72b36ab561` published `vertical.resumed` with `raw_signals: DiscoveryEvidence`, created downstream validation entity `1508a1db-49b6-5f03-b768-486f8edc148e`, and had 0 MCP exec-error rows and 0 dead letters.

## Supported-Run Caveat
The same-corpus #56 rerun (`88fea6b8-480f-4835-a750-16b2c8e79845`) has no MCP exec errors or dead letters so far, but has not produced the marginal lifecycle event needed to prove lifecycle-specific closure. After this PR merges, Empire #56 still needs the explicit fresh marginal-producing supported run required by its closure criteria.
