### PR TITLE
[agent-a][issue #652] Prove post-T source timers fail closed

### DIFF
--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -82,21 +82,17 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-case "$count" in
-1)
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-  ;;
-2)
+if grep -Fq '"name":"emit_category_assessed"' "$captured" && grep -Fq '"ok":true' "$captured"; then
+  printf '%s\n' '{"type":"result","result":"done"}'
+elif grep -Fq '"name":"read_file"' "$captured" && grep -Fq '"ok":true' "$captured"; then
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-  ;;
-*)
-  printf '%s\n' '{"type":"result","result":"done"}'
-  ;;
-esac
+else
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+fi
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -407,6 +407,92 @@ func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappea
 	}
 }
 
+func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003600, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+
+	timerID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, owner_agent, task_type, status, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'post-t-source-timer', $3::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb,
+			$4, 'agent-a', 'timer', 'active', $5
+		)
+	`, timerID, sourceRunID, entityID, at.Add(time.Hour), at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed post-T timer: %v", err)
+	}
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{eventID},
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_timers_advanced_after_fork_point") {
+		t.Fatalf("activation error = %v, want post-T timer blocker", err)
+	}
+	if activation.Activated || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want blocked before selected branch divergence", activation)
+	}
+	if !runForkTestHasActivationBlocker(activation, "source_timers_advanced_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, want source_timers_advanced_after_fork_point", activation.UnsupportedBlockers)
+	}
+	if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_timers_advanced_after_fork_point") {
+		t.Fatalf("activation replay admission = %#v, want source advanced timer blocker", activation.ReplayResumeAdmission)
+	}
+
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
+		t.Fatalf("run statuses source=%q fork=%q, want source running and fork materialized", sourceStatus, forkStatus)
+	}
+
+	var branchRows, forkTimerRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_branch_divergences
+		WHERE fork_run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&branchRows); err != nil {
+		t.Fatalf("count branch divergences: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM timers WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkTimerRows); err != nil {
+		t.Fatalf("count fork timers: %v", err)
+	}
+	if branchRows != 0 || forkTimerRows != 0 {
+		t.Fatalf("branch rows=%d fork timer rows=%d, want no branch divergence and no fork timer copies", branchRows, forkTimerRows)
+	}
+	assertNoForkTimerCopiesForSource(t, db, sourceRunID)
+}
+
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #652
Part of #564
Related to #549, #642, #646, #648, #650

## Summary

Adds the approved proof-only regression for post-T source timer facts during selected-contract timestamp-fork activation.

The PR keeps the approved #652 boundary: post-T source timer rows remain fail-closed with `source_timers_advanced_after_fork_point`. It does not make post-T timers branch-divergence evidence, executable fork truth, source timer suppressors, or fork-local timer copies.

## Governing refs / context

Authoritative spec refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.selected_contract_source_advanced_branch`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.selected_contract_timer_route_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.historical_replay_execution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3c_selected_contract_source_advanced_branch`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3d_selected_contract_timer_route_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3h_selected_contract_supported_execution`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3j_historical_replay_execution_admission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `run_model.fork.semantics.3j1_historical_replay_execution_owner`

Binding gate context:

- #652 pre-audit and independent gate outcome: `approved as first slice` for policy/proof only.
- Parent trackers: #564 historical replay/resume and #549 fork architecture/current-state ownership.
- #642/#646 closed active-at-T selected-contract timer reconstruction and run-scoped scheduler identity.
- #648/#650 closed unsupported at/before-T timer histories as fail-closed proof.

## Semantic migration

No semantic migration and no runtime semantic widening.

Canonical owner after this PR remains:

- `ensureRunForkNoRelevantPostForkTimers` as the post-T source timer fail-closed gate consumed by selected-contract activation and generic activation.

Invalid paths remain invalid:

- copying post-T source timer rows into the fork;
- firing source timers as fork work;
- using source timer status/outcome as fork suppressors;
- adding timers to selected-contract branch divergence facts without a widened gate and spec change;
- making CLI/API/dashboard/Builder the semantic owner.

Production paths checked for surviving old behavior:

- selected-contract activation source-advanced gate;
- generic source-advanced activation gate;
- active-at-T timer reconstruction;
- unsupported at/before-T timer-history fail-closed policy;
- selected source-advanced branch divergence for non-timer post-T facts.

Migration completeness: not applicable; this PR closes #652 as proof that the approved fail-closed policy is explicit and regression-protected.

## Validation

- `go test -run 'TestPostTSourceTimer|TestSelectedContractExecutionMaterialization(ReconstructsActiveTimer|FailsClosedForUnsupportedTimerHistory)|TestSelectedContractTimerReconstructionFailsClosed|TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat' -v ./internal/store`
- `go test -run 'TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint' -v ./internal/runtime/runforkexecution`
- `go test ./internal/store ./internal/runtime/runforkexecution ./internal/runtime/pipeline ./cmd/swarm`
- `go test ./...`
