### PR TITLE
[agent-a][issue #655] Prove post-T source routes fail closed

### DIFF
--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -493,6 +493,105 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	assertNoForkTimerCopiesForSource(t, db, sourceRunID)
 }
 
+func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003610, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow,
+			is_materialized, status, created_at
+		)
+		VALUES ('item.received', 'node', 'post-t-source-route-node', 'flow-a/1', 'flow-a', true, 'active', $1)
+	`, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed post-T route: %v", err)
+	}
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{eventID},
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_routes_advanced_after_fork_point") {
+		t.Fatalf("activation error = %v, want post-T route blocker", err)
+	}
+	if activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want blocked before selected branch divergence", activation)
+	}
+	if !runForkTestHasActivationBlocker(activation, "source_routes_advanced_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, want source_routes_advanced_after_fork_point", activation.UnsupportedBlockers)
+	}
+	if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_routes_advanced_after_fork_point") {
+		t.Fatalf("activation replay admission = %#v, want source advanced route blocker", activation.ReplayResumeAdmission)
+	}
+
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
+		t.Fatalf("run statuses source=%q fork=%q, want source running and fork materialized", sourceStatus, forkStatus)
+	}
+
+	var branchRows, forkDeliveryRows, sourceRouteRows, routeRecoveryRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_branch_divergences
+		WHERE fork_run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&branchRows); err != nil {
+		t.Fatalf("count branch divergences: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&forkDeliveryRows); err != nil {
+		t.Fatalf("count fork deliveries: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM routing_rules
+		WHERE subscriber_id = 'post-t-source-route-node'
+	`).Scan(&sourceRouteRows); err != nil {
+		t.Fatalf("count source route rows: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_route_recoveries
+		WHERE fork_run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&routeRecoveryRows); err != nil {
+		t.Fatalf("count route recovery rows: %v", err)
+	}
+	if branchRows != 0 || forkDeliveryRows != 0 || sourceRouteRows != 1 || routeRecoveryRows != 0 {
+		t.Fatalf("branch rows=%d fork delivery rows=%d source route rows=%d route recovery rows=%d, want no divergence, no fork deliveries, one source route, no fork route recovery", branchRows, forkDeliveryRows, sourceRouteRows, routeRecoveryRows)
+	}
+}
+
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #655

Part of #564
Related to #549, #602, #603, #604, #606, #609, #610, #611, #614, #615, #616, #618, #623, #648, #650, #652, #654

## Summary
- Adds a committed regression proving selected-contract timestamp-fork activation fails closed when a relevant source `routing_rules` row is created after the fork point.
- Proves the blocker is `source_routes_advanced_after_fork_point`, the replay admission records `source_advanced`, the source run stays `running`, and the fork stays `materialized`.
- Proves the post-T source route does not become branch-divergence, fork delivery/recipient, or route-recovery truth.

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_source_advanced_branch`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_timer_route_policy`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_route_admission`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_route_topology`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_dynamic_route_topology`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_route_persistence_recovery`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_recipient_planning`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.selected_contract_supported_execution`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.historical_replay_execution_admission`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `runtime.run_fork.historical_replay_execution`.
- Issue #655 pre-audit and independent gate outcome: approved as first slice for policy/proof-only fail-closed route facts.

## Semantic Migration
- No semantic migration and no runtime behavior change.
- Canonical owner remains `ensureRunForkNoRelevantPostForkRoutes`, consumed by selected-contract activation and generic source-advanced activation checks.
- Old invalid paths remain invalid: copying source `routing_rules` or `flow_instance_routes`, using source route rows as branch-divergence facts, executable fork route truth, recipient truth, route reconstruction input, route persistence/recovery truth, or CLI/API/dashboard-owned semantics.
- Migration complete: not applicable.

## Validation
- `go test -run 'TestPostTSourceRoute|TestPostTSourceTimerFailsClosedForSelectedContractActivation|TestSelectedContractExecutionMaterializationPreservesRouteBlocker|TestRecordRunForkSelectedContractRouteRecovery|TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan|TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint' -v ./internal/store ./internal/runtime/runforkexecution`
- `go test ./internal/store ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/runtime/manager ./cmd/swarm`
- `go test ./...`
