### PR TITLE
[agent-d][issue #657] Add mailbox materialization action

### DIFF
--- a/docs/specs/swarm-platform/SWARM-PLATFORM-BRIEF.md
+++ b/docs/specs/swarm-platform/SWARM-PLATFORM-BRIEF.md
@@ -90,7 +90,7 @@ When an order gets approved, the platform creates a new fulfillment flow instanc
 ## Platform Capabilities
 
 ### Handler primitives
-guard, advances_to, sets_gate, clear_gates, data_accumulation, emit, rules, on_complete, accumulate, compute, fan_out, filter, reduce, count, group_by, query, clear, record_evidence, action (create_flow_instance)
+guard, advances_to, sets_gate, clear_gates, data_accumulation, emit, rules, on_complete, accumulate, compute, fan_out, filter, reduce, count, group_by, query, clear, record_evidence, action (create_flow_instance, mailbox_write)
 
 ### Expression language
 CEL (Common Expression Language) for all conditions, guards, and filters. Strongly typed, non-Turing-complete, safe for policy evaluation.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -12,8 +12,8 @@ vocabulary:
     - kill
     - escalate:{event}
   action:
-    description: 'A platform-provided operation executed as the final step of a handler. Only two valid actions exist: create_flow_instance
-      and record_evidence. Product-specific actions are not supported.'
+    description: 'A platform-provided operation executed as the final step of a handler. Valid actions are create_flow_instance,
+      record_evidence, and mailbox_write. Product-specific actions are not supported.'
   timer:
     description: 'A time-based trigger attached to a stage. When the delay elapses, the platform emits the timer''s event,
       which can trigger a transition.
@@ -970,8 +970,8 @@ handler_specification:
         clear_gates which runs before guard.
     action:
       field: action
-      type: string
-      purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence. The platform executes
+      type: string or object
+      purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write. The platform executes
         the named action. NOT for platform actions — all behavior must be declarative.'
       emit_interaction: If the resolved runtime action instruction emits a follow-up event, that event uses the action-originated
         emitted-event payload rules under observation_model.emitted_events.payload_rules. The action field itself does not
@@ -989,6 +989,23 @@ handler_specification:
           behavior: Reads the event payload and appends it as a new entry in the entity's evidence accumulator (from state_schema).
             Append-only — never replaces. Used for building an audit trail of signals, scores, or decisions.
           required_sibling_fields: {}
+        mailbox_write:
+          description: Deterministically materialize an authored mailbox request event into public.mailbox.
+          required_mapping:
+            action.id: mailbox_write
+            action.mailbox: object — typed mailbox row declaration.
+          mailbox_fields:
+            item_type: expression value resolving to the mailbox item/review kind. Required. Normalized by lowercasing and
+              replacing hyphen/dot with underscore.
+            severity: optional expression value resolving to normal, urgent, or critical. Defaults to normal.
+            summary: expression value resolving to human-readable row summary. Required.
+            entity_id: optional expression value. Defaults to the triggering event entity_id when present.
+            flow_instance: optional expression value. Defaults to the triggering event flow_instance when present.
+            payload: optional mapping of payload/context fields to expression values. Only explicitly declared fields are copied;
+              no implicit event payload pass-through occurs.
+          behavior: Inserts a pending public.mailbox row inside the system-node handler transaction. source_event_id is the
+            triggering event id. from_agent is the deterministic system node identity. item_id is deterministic for source_event_id
+            and materializer node so duplicate/replayed node delivery does not create duplicate mailbox rows.
     retired_fields:
       description: Legacy declarative emit carriers retired by the structured emit grammar.
       rule: These fields are retired compatibility syntax, not alternate current-contract forms.
@@ -2155,6 +2172,7 @@ compliance:
     - State state_changes only follow declared advances_to paths
     - Guards evaluated before state advancement — block if false
     - Events, including action-originated emits, validated against payload schema before publish
+    - mailbox_write handler actions preserve source_event_id and are row-idempotent for the same source event and materializer
     - Accumulation is idempotent — duplicate events do not double-count
     - Permission checks read from agent.permissions, not hardcoded policy functions
     - Product behavior read from policy configuration, not hardcoded
@@ -2168,6 +2186,7 @@ compliance:
     - Every declared handler has a matching Handle() implementation
     - Every state state_change follows declared advances_to paths
     - Every emitted event has a payload schema in events.yaml
+    - mailbox_write materializes exactly one mailbox row per source event/materializer and rejects unsupported declarations
     - Every agent subscription resolves to an event some node or agent produces
     - Permission enforcement blocks unauthorized tool calls
     - Accumulation is idempotent under duplicate event delivery
@@ -2339,6 +2358,7 @@ tool_model:
       actions:
         create_flow_instance: Create a new dynamic flow instance from a template.
         record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler.
+        mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler action only.
     planned_tools:
       description: Tools planned for future platform versions. Not yet implemented. The permission may exist (as an authorization
         gate) before the tool does.

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -22,7 +22,7 @@ This section defines the platform vocabulary for `state_change`, `guard`, `actio
 
 ## action
 
-- `description`: A platform-provided operation executed as the final step of a handler. Only two valid actions exist: create_flow_instance and record_evidence. Product-specific actions are not supported.
+- `description`: A platform-provided operation executed as the final step of a handler. Valid actions are create_flow_instance, record_evidence, and mailbox_write. Product-specific actions are not supported.
 ## timer
 
 - `description`: A time-based trigger attached to a stage. When the delay elapses, the platform emits the timer's event, which can trigger a transition.
@@ -330,7 +330,7 @@ query (optional — pre-fetch cross-entity data into handler context)
 ### description_field
 
 - `field`: description
-- `type`: string
+- `type`: string or object
 - `purpose`: Human-readable description of what this handler does. Not executed.
 ### guard
 
@@ -544,7 +544,7 @@ data_accumulation:
 
 - `field`: action
 - `type`: string
-- `purpose`: Names a platform-provided action. Valid values: create_flow_instance, record_evidence. The platform executes the named action. NOT for platform actions — all behavior must be declarative.
+- `purpose`: Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write. The platform executes the named action. NOT for platform actions — all behavior must be declarative.
 #### valid_values
 
 ##### create_flow_instance
@@ -560,6 +560,21 @@ data_accumulation:
 - `description`: Append event payload to entity accumulator state.
 - `behavior`: Reads the event payload and appends it as a new entry in the entity's evidence accumulator (from state_schema). Append-only — never replaces. Used for building an audit trail of signals, scores, or decisions.
 - `required_sibling_fields`:
+
+##### mailbox_write
+
+- `description`: Deterministically materialize an authored mailbox request event into public.mailbox.
+- `required_mapping`:
+  - `action.id`: mailbox_write
+  - `action.mailbox`: object — typed mailbox row declaration.
+- `mailbox_fields`:
+  - `item_type`: expression value resolving to the mailbox item/review kind. Required. Normalized by lowercasing and replacing hyphen/dot with underscore.
+  - `severity`: optional expression value resolving to normal, urgent, or critical. Defaults to normal.
+  - `summary`: expression value resolving to human-readable row summary. Required.
+  - `entity_id`: optional expression value. Defaults to the triggering event entity_id when present.
+  - `flow_instance`: optional expression value. Defaults to the triggering event flow_instance when present.
+  - `payload`: optional mapping of payload/context fields to expression values. Only explicitly declared fields are copied; no implicit event payload pass-through occurs.
+- `behavior`: Inserts a pending public.mailbox row inside the system-node handler transaction. source_event_id is the triggering event id. from_agent is the deterministic system node identity. item_id is deterministic for source_event_id and materializer node so duplicate/replayed node delivery does not create duplicate mailbox rows.
 
 ### clear_gates
 
@@ -1140,6 +1155,7 @@ Boot-time and runtime compliance enforcement.
 - `State state_changes only follow declared advances_to paths`
 - `Guards evaluated before state advancement — block if false`
 - `Events validated against payload schema before publish`
+- `mailbox_write handler actions preserve source_event_id and are row-idempotent for the same source event and materializer`
 - `Accumulation is idempotent — duplicate events do not double-count`
 - `Permission checks read from agent.permissions, not hardcoded policy functions`
 - `Scan mode behavior read from policy.scan_modes, not hardcoded`
@@ -1155,6 +1171,7 @@ Boot-time and runtime compliance enforcement.
 - `Every declared handler has a matching Handle() implementation`
 - `Every state state_change follows declared advances_to paths`
 - `Every emitted event has a payload schema in events.yaml`
+- `mailbox_write materializes exactly one mailbox row per source event/materializer and rejects unsupported declarations`
 - `Every agent subscription resolves to an event some node or agent produces`
 - `Permission enforcement blocks unauthorized tool calls`
 - `Accumulation is idempotent under duplicate event delivery`
@@ -1282,6 +1299,7 @@ The platform owns ALL tool schema serving. It reads tool definition YAML, genera
 - `tools`:
   - `create_flow_instance`: Create a new dynamic flow instance from a template. Handler action only.
   - `record_evidence`: Append payload to entity accumulator. Requires evidence_target field on the handler specifying which accumulator key to write to.
+  - `mailbox_write`: Deterministically materialize authored mailbox request events into public.mailbox. Handler action only.
   - `create_entity`: Create a new entity row in entity_state. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
   - `get_entity`: Read an entity by ID. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces in favor of generated `read_{entity_type}` tools.
   - `query_entities`: Query entities by state, fields, or aggregation. Legacy/operator/system compatibility surface; removed from fully opted-in role-scoped agent surfaces.
@@ -1291,7 +1309,7 @@ The platform owns ALL tool schema serving. It reads tool definition YAML, genera
   - `agent_message`: Send a message to another agent (auto-granted to all agents).
   - `mailbox_send`: Send an item to the human mailbox (auto-granted to all agents).
 
-- `note`: create_flow_instance is a handler ACTION field value, not a tool agents can call. It is listed here for completeness but invoked via action: create_flow_instance in node handlers.
+- `note`: create_flow_instance, record_evidence, and mailbox_write are handler ACTION field values, not tools agents can call.
 - `handler_registration`: At bootstrap, the workflow module registers handlers for its tools. The platform provides the MCP gateway and schema validation. One tools file per workflow contains all tool schemas for the actor's visible surface: universal communication tools, generated emit tools, generated role-scoped entity tools for opted-in actors, and explicitly configured workflow-specific tools.
 - `default_deny`: If an agent calls a tool that is not in its `tools` list, not a universal communication tool, not an emit tool, not a generated role-scoped entity tool for an opted-in actor, and not an authorized `native_tools` capability, the call is rejected.
 ## custom_tool_schema

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -330,7 +330,7 @@ query (optional — pre-fetch cross-entity data into handler context)
 ### description_field
 
 - `field`: description
-- `type`: string or object
+- `type`: string
 - `purpose`: Human-readable description of what this handler does. Not executed.
 ### guard
 

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -543,7 +543,7 @@ data_accumulation:
 ### action
 
 - `field`: action
-- `type`: string
+- `type`: string or object
 - `purpose`: Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write. The platform executes the named action. NOT for platform actions — all behavior must be declarative.
 #### valid_values
 

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1115,6 +1115,40 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 						Location: nodeID,
 					})
 				}
+				if normalizeWorkflowBuiltinActionID(actionID) == "mailbox_write" {
+					if handler.Action.Mailbox == nil {
+						c.handlerFindings = append(c.handlerFindings, Finding{
+							CheckID:  "handler_field_compliance",
+							Severity: "error",
+							Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox", nodeID, eventType),
+							Location: nodeID,
+						})
+					} else {
+						if handler.Action.Mailbox.ItemType.IsZero() {
+							c.handlerFindings = append(c.handlerFindings, Finding{
+								CheckID:  "handler_field_compliance",
+								Severity: "error",
+								Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox.item_type", nodeID, eventType),
+								Location: nodeID,
+							})
+						}
+						if handler.Action.Mailbox.Summary.IsZero() {
+							c.handlerFindings = append(c.handlerFindings, Finding{
+								CheckID:  "handler_field_compliance",
+								Severity: "error",
+								Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox.summary", nodeID, eventType),
+								Location: nodeID,
+							})
+						}
+					}
+				} else if handler.Action.Mailbox != nil {
+					c.handlerFindings = append(c.handlerFindings, Finding{
+						CheckID:  "handler_field_compliance",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s handler %s mailbox declaration requires action mailbox_write", nodeID, eventType),
+						Location: nodeID,
+					})
+				}
 				if !handlerActionExecutable(c.source, actionID) {
 					c.handlerFindings = append(c.handlerFindings, Finding{
 						CheckID:  "handler_field_compliance",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -690,6 +690,79 @@ func TestRun_ReportsRecordEvidenceMissingEvidenceTarget(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsMailboxWriteMissingMailboxSpec(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "mailbox_write is missing mailbox") {
+		t.Fatalf("expected handler_field_compliance missing mailbox error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsMailboxWriteMissingRequiredFields(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID:      "mailbox_write",
+							Mailbox: &runtimecontracts.MailboxWriteSpec{},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "mailbox_write is missing mailbox.item_type") {
+		t.Fatalf("expected handler_field_compliance missing mailbox.item_type error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "mailbox_write is missing mailbox.summary") {
+		t.Fatalf("expected handler_field_compliance missing mailbox.summary error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsMailboxDeclarationOnNonMailboxAction(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID: "record_evidence",
+							Mailbox: &runtimecontracts.MailboxWriteSpec{
+								ItemType: runtimecontracts.LiteralExpression("review_request"),
+								Summary:  runtimecontracts.LiteralExpression("review"),
+							},
+						},
+						EvidenceTarget: "evidence",
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "mailbox declaration requires action mailbox_write") {
+		t.Fatalf("expected handler_field_compliance mailbox/action mismatch error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsPromptStubToPromptExistsWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-prompt-stub")
 

--- a/internal/runtime/contracts/system_node_contract_vocab.go
+++ b/internal/runtime/contracts/system_node_contract_vocab.go
@@ -13,7 +13,7 @@ func NormalizeHandlerActionID(id string) string {
 
 func IsSupportedHandlerActionID(id string) bool {
 	switch NormalizeHandlerActionID(id) {
-	case "create_flow_instance", "record_evidence":
+	case "create_flow_instance", "record_evidence", "mailbox_write":
 		return true
 	default:
 		return false

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -297,11 +297,21 @@ func (s *QuerySpec) hydratePaths() {
 }
 
 type ActionSpec struct {
-	ID             string          `yaml:"id"`
-	Template       string          `yaml:"template"`
-	InstanceIDFrom string          `yaml:"instance_id_from"`
-	InstanceIDPath paths.Path      `yaml:"-"`
-	ConfigFrom     *ConfigFromSpec `yaml:"config_from"`
+	ID             string            `yaml:"id"`
+	Template       string            `yaml:"template"`
+	InstanceIDFrom string            `yaml:"instance_id_from"`
+	InstanceIDPath paths.Path        `yaml:"-"`
+	ConfigFrom     *ConfigFromSpec   `yaml:"config_from"`
+	Mailbox        *MailboxWriteSpec `yaml:"mailbox"`
+}
+
+type MailboxWriteSpec struct {
+	ItemType     ExpressionValue            `yaml:"item_type"`
+	Severity     ExpressionValue            `yaml:"severity"`
+	Summary      ExpressionValue            `yaml:"summary"`
+	EntityID     ExpressionValue            `yaml:"entity_id"`
+	FlowInstance ExpressionValue            `yaml:"flow_instance"`
+	Payload      map[string]ExpressionValue `yaml:"payload"`
 }
 type EntitySchema struct {
 	Groups []EntitySchemaGroup `yaml:"groups"`

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -134,6 +134,99 @@ func decodeEmitFieldsNode(node *yaml.Node) (map[string]ExpressionValue, error) {
 	return fields, nil
 }
 
+func (m *MailboxWriteSpec) UnmarshalYAML(node *yaml.Node) error {
+	if m == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*m = MailboxWriteSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-MAILBOX-WRITE: mailbox must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"item_type":     {},
+		"severity":      {},
+		"summary":       {},
+		"entity_id":     {},
+		"flow_instance": {},
+		"payload":       {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: mailbox field %q not in platform spec", key)
+		}
+	}
+	var out MailboxWriteSpec
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		var err error
+		switch key {
+		case "item_type":
+			out.ItemType, err = decodeMailboxExpressionValueNode(value)
+		case "severity":
+			out.Severity, err = decodeMailboxExpressionValueNode(value)
+		case "summary":
+			out.Summary, err = decodeMailboxExpressionValueNode(value)
+		case "entity_id":
+			out.EntityID, err = decodeMailboxExpressionValueNode(value)
+		case "flow_instance":
+			out.FlowInstance, err = decodeMailboxExpressionValueNode(value)
+		case "payload":
+			out.Payload, err = decodeMailboxPayloadNode(value)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	*m = out
+	return nil
+}
+
+func decodeMailboxPayloadNode(node *yaml.Node) (map[string]ExpressionValue, error) {
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("INVALID-MAILBOX-WRITE: mailbox.payload must be a mapping")
+	}
+	fields := make(map[string]ExpressionValue, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		target := strings.TrimSpace(node.Content[i].Value)
+		if target == "" {
+			continue
+		}
+		value, err := decodeMailboxExpressionValueNode(node.Content[i+1])
+		if err != nil {
+			return nil, fmt.Errorf("INVALID-MAILBOX-WRITE: mailbox.payload.%s: %w", target, err)
+		}
+		fields[target] = value
+	}
+	return fields, nil
+}
+
+func decodeMailboxExpressionValueNode(node *yaml.Node) (ExpressionValue, error) {
+	if node == nil || node.Kind == 0 {
+		return ExpressionValue{}, nil
+	}
+	if node.Kind == yaml.MappingNode {
+		if err := validateEmitFieldExpressionMappingNode(node); err != nil {
+			return ExpressionValue{}, fmt.Errorf("mailbox expression values must use explicit expression keys literal, ref, cel, or expression: %w", err)
+		}
+	}
+	var value ExpressionValue
+	if err := node.Decode(&value); err != nil {
+		return ExpressionValue{}, err
+	}
+	return value, nil
+}
+
 func decodeEmitFieldValueNode(node *yaml.Node) (ExpressionValue, error) {
 	if node == nil {
 		return ExpressionValue{}, nil
@@ -715,6 +808,7 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			"template":         {},
 			"instance_id_from": {},
 			"config_from":      {},
+			"mailbox":          {},
 		}
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
@@ -732,10 +826,11 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			}
 		}
 		var aux struct {
-			ID             string    `yaml:"id"`
-			Template       string    `yaml:"template"`
-			InstanceIDFrom string    `yaml:"instance_id_from"`
-			ConfigFrom     yaml.Node `yaml:"config_from"`
+			ID             string            `yaml:"id"`
+			Template       string            `yaml:"template"`
+			InstanceIDFrom string            `yaml:"instance_id_from"`
+			ConfigFrom     yaml.Node         `yaml:"config_from"`
+			Mailbox        *MailboxWriteSpec `yaml:"mailbox"`
 		}
 		if err := node.Decode(&aux); err != nil {
 			return ActionSpec{}, err
@@ -757,6 +852,7 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			InstanceIDFrom: strings.TrimSpace(aux.InstanceIDFrom),
 			InstanceIDPath: paths.Parse(aux.InstanceIDFrom),
 			ConfigFrom:     configFrom,
+			Mailbox:        aux.Mailbox,
 		}, nil
 	default:
 		return ActionSpec{}, fmt.Errorf("unsupported action yaml node kind %d", node.Kind)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -693,6 +693,80 @@ evidence_target: validation.results
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_PreservesMailboxWriteAction(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+action:
+  id: mailbox_write
+  mailbox:
+    item_type:
+      literal: review_request
+    severity:
+      literal: urgent
+    summary:
+      literal: Review validation package
+    entity_id:
+      ref: event.entity_id
+    flow_instance:
+      ref: event.flow_instance
+    payload:
+      review_kind:
+        ref: payload.review_kind
+      operator_hint:
+        literal: inspect_package
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := handler.Action.ID; got != "mailbox_write" {
+		t.Fatalf("Action.ID = %q", got)
+	}
+	if handler.Action.Mailbox == nil {
+		t.Fatal("expected Action.Mailbox")
+	}
+	if got := handler.Action.Mailbox.ItemType.Literal; got != "review_request" {
+		t.Fatalf("Mailbox.ItemType.Literal = %#v", got)
+	}
+	if got := handler.Action.Mailbox.EntityID.Ref; got != "event.entity_id" {
+		t.Fatalf("Mailbox.EntityID.Ref = %q", got)
+	}
+	if got := handler.Action.Mailbox.Payload["review_kind"].Ref; got != "payload.review_kind" {
+		t.Fatalf("Mailbox.Payload[review_kind].Ref = %q", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnknownMailboxWriteField(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action:
+  id: mailbox_write
+  mailbox:
+    item_type:
+      literal: review_request
+    summary:
+      literal: Review validation package
+    implicit_payload: true
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnsupportedMailboxExpressionShape(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action:
+  id: mailbox_write
+  mailbox:
+    item_type:
+      literal: review_request
+    summary:
+      from_payload: summary
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "explicit expression keys") {
+		t.Fatalf("yaml.Unmarshal error = %v, want explicit expression keys", err)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_RejectsUnsupportedActionID(t *testing.T) {
 	var handler SystemNodeEventHandler
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -755,6 +755,11 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 			return true, err
 		}
 		return true, nil
+	case "mailbox_write":
+		if err := pc.materializeMailboxItem(ctx, action, execCtx); err != nil {
+			return true, err
+		}
+		return true, nil
 	default:
 		return false, nil
 	}

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -569,6 +569,143 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 	}
 }
 
+func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pc := &PipelineCoordinator{db: db}
+	runner := pipelineEngineActionRunner{coordinator: pc}
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	txctx := WithPipelineSQLTxContext(ctx, tx)
+	eventID := "11111111-1111-1111-1111-111111111111"
+	entityID := "22222222-2222-2222-2222-222222222222"
+	action := runtimecontracts.ActionSpec{
+		ID: "mailbox_write",
+		Mailbox: &runtimecontracts.MailboxWriteSpec{
+			ItemType:     runtimecontracts.LiteralExpression("review_request"),
+			Severity:     runtimecontracts.LiteralExpression("urgent"),
+			Summary:      runtimecontracts.LiteralExpression("Review validation package"),
+			EntityID:     runtimecontracts.RefExpression("event.entity_id"),
+			FlowInstance: runtimecontracts.RefExpression("event.flow_instance"),
+			Payload: map[string]runtimecontracts.ExpressionValue{
+				"review_kind":   runtimecontracts.RefExpression("payload.review_kind"),
+				"operator_hint": runtimecontracts.LiteralExpression("inspect_package"),
+			},
+		},
+	}
+	evt := (events.Event{
+		ID:      eventID,
+		Type:    "mailbox.review_requested",
+		Payload: []byte(`{"review_kind":"validation"}`),
+	}).WithEnvelope(events.EventEnvelope{
+		EntityID:     entityID,
+		FlowInstance: "validation/case-1",
+		Scope:        events.EventScopeEntity,
+	})
+	base := values.NewContext()
+	base.Event = values.Wrap(evt.ContextMap(""))
+	base.Payload = values.Wrap(parsePayloadMap(evt.Payload))
+	execCtx := runtimeengine.ExecutionContext{
+		Base: base,
+		Request: runtimeengine.ExecutionRequest{
+			EntityID: identity.NormalizeEntityID(entityID),
+			NodeID:   identity.NormalizeNodeID("mailbox-node"),
+			Event:    evt,
+		},
+	}
+	for i := 0; i < 2; i++ {
+		ok, err := runner.ExecuteAction(txctx, action, runtimeregistry.ActionInstruction{Builtin: "mailbox_write"}, execCtx)
+		if err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("ExecuteAction iteration %d: %v", i, err)
+		}
+		if !ok {
+			_ = tx.Rollback()
+			t.Fatalf("ExecuteAction iteration %d was not claimed", i)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	var count int
+	var sourceEventID, gotEntityID, flowInstance, itemType, severity, summary, payloadKind, fromAgent, status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COALESCE(MAX(source_event_id::text), ''),
+		       COALESCE(MAX(entity_id::text), ''),
+		       COALESCE(MAX(flow_instance), ''),
+		       COALESCE(MAX(item_type), ''),
+		       COALESCE(MAX(severity), ''),
+		       COALESCE(MAX(summary), ''),
+		       COALESCE(MAX(payload->>'review_kind'), ''),
+		       COALESCE(MAX(from_agent), ''),
+		       COALESCE(MAX(status), '')
+		FROM mailbox
+		WHERE source_event_id = $1::uuid
+	`, eventID).Scan(&count, &sourceEventID, &gotEntityID, &flowInstance, &itemType, &severity, &summary, &payloadKind, &fromAgent, &status); err != nil {
+		t.Fatalf("query mailbox: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("mailbox row count = %d, want 1", count)
+	}
+	if sourceEventID != eventID || gotEntityID != entityID || flowInstance != "validation/case-1" {
+		t.Fatalf("mailbox identity = source %q entity %q flow %q", sourceEventID, gotEntityID, flowInstance)
+	}
+	if itemType != "review_request" || severity != "urgent" || summary != "Review validation package" || status != "pending" {
+		t.Fatalf("mailbox row fields type=%q severity=%q summary=%q status=%q", itemType, severity, summary, status)
+	}
+	if payloadKind != "validation" {
+		t.Fatalf("payload review_kind = %q", payloadKind)
+	}
+	if fromAgent != "system_node:mailbox-node" {
+		t.Fatalf("from_agent = %q", fromAgent)
+	}
+}
+
+func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpression(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	runner := pipelineEngineActionRunner{coordinator: &PipelineCoordinator{db: db}}
+	ctx := context.Background()
+	eventID := "33333333-3333-3333-3333-333333333333"
+	action := runtimecontracts.ActionSpec{
+		ID: "mailbox_write",
+		Mailbox: &runtimecontracts.MailboxWriteSpec{
+			ItemType: runtimecontracts.LiteralExpression("review_request"),
+			Summary:  runtimecontracts.RefExpression("payload.missing_summary"),
+		},
+	}
+	evt := events.Event{ID: eventID, Type: "mailbox.review_requested", Payload: []byte(`{}`)}
+	base := values.NewContext()
+	base.Event = values.Wrap(evt.ContextMap(""))
+	base.Payload = values.Wrap(parsePayloadMap(evt.Payload))
+
+	ok, err := runner.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "mailbox_write"}, runtimeengine.ExecutionContext{
+		Base: base,
+		Request: runtimeengine.ExecutionRequest{
+			NodeID: identity.NormalizeNodeID("mailbox-node"),
+			Event:  evt,
+		},
+	})
+	if !ok {
+		t.Fatal("expected mailbox_write action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "mailbox.summary resolved empty") {
+		t.Fatalf("ExecuteAction error = %v, want missing summary", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE source_event_id = $1::uuid`, eventID).Scan(&count); err != nil {
+		t.Fatalf("query mailbox count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("mailbox row count = %d, want 0", count)
+	}
+}
+
 func TestPipelineEngineEvaluator_ExposesAccumulatedScopeForCEL(t *testing.T) {
 	eval := pipelineEngineEvaluator{evaluator: newWorkflowExpressionEvaluator()}
 	ok, err := eval.EvalBool(
@@ -1062,20 +1199,21 @@ func TestPipelineEngineTimerApplierPersistsTimersAndDefersSchedulerToPostCommit(
 
 func TestPipelineEngineActionRegistry_SynthesizesSupportedBuiltinActions(t *testing.T) {
 	registry := pipelineEngineActionRegistry{}
-	id := identity.NormalizeActionKey("create_flow_instance")
-
-	if !registry.HasAction(id) {
-		t.Fatal("expected builtin action to be discoverable without explicit registry entry")
-	}
-	if !registry.IsExecutable(id) {
-		t.Fatal("expected builtin action to be executable without explicit registry entry")
-	}
-	instruction, ok := registry.Action(id)
-	if !ok {
-		t.Fatal("expected builtin action instruction")
-	}
-	if got := instruction.Builtin; got != "create_flow_instance" {
-		t.Fatalf("Builtin = %q", got)
+	for _, builtin := range []string{"create_flow_instance", "mailbox_write"} {
+		id := identity.NormalizeActionKey(builtin)
+		if !registry.HasAction(id) {
+			t.Fatalf("expected builtin action %s to be discoverable without explicit registry entry", builtin)
+		}
+		if !registry.IsExecutable(id) {
+			t.Fatalf("expected builtin action %s to be executable without explicit registry entry", builtin)
+		}
+		instruction, ok := registry.Action(id)
+		if !ok {
+			t.Fatalf("expected builtin action %s instruction", builtin)
+		}
+		if got := instruction.Builtin; got != builtin {
+			t.Fatalf("Builtin = %q, want %q", got, builtin)
+		}
 	}
 }
 

--- a/internal/runtime/pipeline/mailbox_materialization.go
+++ b/internal/runtime/pipeline/mailbox_materialization.go
@@ -1,0 +1,206 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/values"
+	runtimeengine "swarm/internal/runtime/engine"
+	"swarm/internal/runtime/workflowexpr"
+)
+
+func (pc *PipelineCoordinator) materializeMailboxItem(ctx context.Context, action runtimecontracts.ActionSpec, execCtx runtimeengine.ExecutionContext) error {
+	if pc == nil || pc.db == nil {
+		return fmt.Errorf("mailbox_write requires pipeline database")
+	}
+	spec := action.Mailbox
+	if spec == nil {
+		return fmt.Errorf("mailbox_write requires mailbox declaration")
+	}
+	sourceEventID := strings.TrimSpace(execCtx.Request.Event.ID)
+	if sourceEventID == "" {
+		return fmt.Errorf("mailbox_write requires triggering event id")
+	}
+	nodeID := strings.TrimSpace(execCtx.Request.NodeID.String())
+	if nodeID == "" {
+		return fmt.Errorf("mailbox_write requires node id")
+	}
+	itemType, err := requiredMailboxString(execCtx.Base, spec.ItemType, "mailbox.item_type")
+	if err != nil {
+		return err
+	}
+	normalizedType, err := normalizeMailboxWriteItemType(itemType)
+	if err != nil {
+		return fmt.Errorf("mailbox.item_type: %w", err)
+	}
+	summary, err := requiredMailboxString(execCtx.Base, spec.Summary, "mailbox.summary")
+	if err != nil {
+		return err
+	}
+	severity := "normal"
+	if !spec.Severity.IsZero() {
+		severity, err = requiredMailboxString(execCtx.Base, spec.Severity, "mailbox.severity")
+		if err != nil {
+			return err
+		}
+		severity, err = normalizeMailboxWriteSeverity(severity)
+		if err != nil {
+			return err
+		}
+	}
+	entityID := strings.TrimSpace(execCtx.Request.Event.EntityID())
+	if entityID == "" {
+		entityID = strings.TrimSpace(execCtx.Request.EntityID.String())
+	}
+	if !spec.EntityID.IsZero() {
+		entityID, err = requiredMailboxString(execCtx.Base, spec.EntityID, "mailbox.entity_id")
+		if err != nil {
+			return err
+		}
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(execCtx.Request.Event.FlowInstance()), "/")
+	if !spec.FlowInstance.IsZero() {
+		flowInstance, err = requiredMailboxString(execCtx.Base, spec.FlowInstance, "mailbox.flow_instance")
+		if err != nil {
+			return err
+		}
+		flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	}
+	payload, err := mailboxWritePayload(execCtx.Base, spec.Payload)
+	if err != nil {
+		return err
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("mailbox.payload: %w", err)
+	}
+	if len(payloadJSON) == 0 || string(payloadJSON) == "null" {
+		payloadJSON = []byte("{}")
+	}
+	scope := "global"
+	switch {
+	case strings.TrimSpace(entityID) != "":
+		scope = "entity"
+	case strings.TrimSpace(flowInstance) != "":
+		scope = "flow"
+	}
+	itemID := deterministicMailboxItemID(sourceEventID, nodeID)
+	_, err = dbExecContext(ctx, pc.db, `
+		INSERT INTO mailbox (
+			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+			from_agent, severity, summary, payload, status, notified, created_at
+		)
+		VALUES (
+			$1::uuid, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5, $6::uuid,
+			$7, $8, NULLIF($9,''), $10::jsonb, 'pending', false, now()
+		)
+		ON CONFLICT (item_id) DO NOTHING
+	`, itemID, strings.TrimSpace(entityID), flowInstance, scope, normalizedType, sourceEventID, "system_node:"+nodeID, severity, summary, string(payloadJSON))
+	if err != nil {
+		return fmt.Errorf("mailbox_write insert: %w", err)
+	}
+	return nil
+}
+
+func deterministicMailboxItemID(sourceEventID, nodeID string) string {
+	key := strings.Join([]string{
+		"swarm",
+		"mailbox_write",
+		strings.TrimSpace(sourceEventID),
+		strings.TrimSpace(nodeID),
+	}, ":")
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+}
+
+func requiredMailboxString(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
+	value, ok, err := evalMailboxExpressionValue(base, expr)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", field, err)
+	}
+	if !ok {
+		return "", fmt.Errorf("%s resolved empty", field)
+	}
+	out, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%s resolved non-string %T", field, value)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", fmt.Errorf("%s resolved empty", field)
+	}
+	return out, nil
+}
+
+func evalMailboxExpressionValue(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue) (any, bool, error) {
+	if expr.IsZero() {
+		return nil, false, nil
+	}
+	switch expr.Kind {
+	case runtimecontracts.ExpressionKindLiteral:
+		return expr.Literal, true, nil
+	case runtimecontracts.ExpressionKindRef:
+		value, ok := base.Lookup(expr.RefPath)
+		return value, ok, nil
+	case runtimecontracts.ExpressionKindCEL:
+		value, err := workflowexpr.EvalValueExpressionWithOptions(expr.CEL, workflowexpr.ValueContext{
+			Entity:  base.Entity.Raw(),
+			Event:   base.Event.Raw(),
+			Payload: base.Payload.Raw(),
+			Policy:  base.Policy.Raw(),
+			FanOut:  base.FanOut.Raw(),
+		}, workflowexpr.ValueExpressionOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		return value, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported expression kind %q", expr.Kind)
+	}
+}
+
+func mailboxWritePayload(base runtimeengine.BaseContext, fields map[string]runtimecontracts.ExpressionValue) (map[string]any, error) {
+	out := map[string]any{}
+	for target, expr := range fields {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+		value, ok, err := evalMailboxExpressionValue(base, expr)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", target, err)
+		}
+		if !ok {
+			continue
+		}
+		values.Wrap(out).SetPath(paths.Parse(target), value)
+	}
+	return out, nil
+}
+
+func normalizeMailboxWriteSeverity(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "normal":
+		return "normal", nil
+	case "urgent":
+		return "urgent", nil
+	case "critical":
+		return "critical", nil
+	default:
+		return "", fmt.Errorf("invalid mailbox severity %q", raw)
+	}
+}
+
+func normalizeMailboxWriteItemType(raw string) (string, error) {
+	itemType := strings.ToLower(strings.TrimSpace(raw))
+	itemType = strings.ReplaceAll(itemType, "-", "_")
+	itemType = strings.ReplaceAll(itemType, ".", "_")
+	if itemType == "" {
+		return "", fmt.Errorf("invalid mailbox item_type %q", raw)
+	}
+	return itemType, nil
+}


### PR DESCRIPTION
## Summary

Closes #657.

Adds the platform-owned `mailbox_write` system-node handler action for deterministic authored event-to-`public.mailbox` materialization.

## Governing Context

- Binding issue/gate: #657 pre-audit and independent gate review, approved as first slice.
- Authoritative spec updated in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Adjacent context: Empire #57 consumes this primitive later; Empire #60 and #59 remain split for decision routing and OpCo design.

## Semantic Migration / Ownership

- New canonical owner: Swarm handler action `mailbox_write` across platform spec, contract decoding, bootverify, and runtime pipeline action execution.
- Old non-authoritative path now invalid for this class: prompt/agent-owned `mailbox_send` as deterministic materializer for authored mailbox request events.
- Production paths checked: system-node action vocabulary, action YAML decoding, bootverify handler compliance, pipeline action registry/runner, DB mailbox row insertion, source event preservation, duplicate/replay idempotency.
- Migration completeness: complete for the Swarm primitive. Empire #57 still needs a separate product PR to declare the root mailbox node using this action.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline -run 'Test(SystemNodeEventHandlerDecode_.*Mailbox|Run_ReportsMailboxWrite|PipelineEngineActionRunner_MailboxWrite|PipelineEngineActionRegistry_SynthesizesSupportedBuiltinActions)'`
- `go test -run 'Test.*(Mailbox|SystemNode|Handler|Action|CreateFlowInstance|RecordEvidence)' ./internal/runtime/contracts ./internal/runtime/pipeline ./internal/store ./internal/runtime/tools ./internal/runtime/bootverify`
- `go test ./...`
