### PR TITLE
[agent-a][issue #661] Selected conversation lineage policy

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3454,7 +3454,9 @@ run_model:
       advancement and may freeze the source run. A selected-contract branch must not freeze or rewind an already-advanced
         source run, must record terminal source status at activation as divergence evidence, must not copy post-fork source
         events or event_deliveries, and must continue to regenerate fork-local events, deliveries, receipts, dead letters,
-        idempotency effects, and emitted follow-ups under the fork run_id.'
+        idempotency effects, and emitted follow-ups under the fork run_id. Post-fork source session, turn, and
+        conversation-audit facts are not covered by this branch-divergence policy and remain fail-closed unless a separate
+        approved owner classifies them.'
     selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source route facts
       as evidence-only fail-closed blockers until a separately approved route reconstruction owner exists. Active source
       timers may be reconstructed only by runtime.run_fork.historical_replay_execution.timer_reconstruction, which
@@ -3466,6 +3468,18 @@ run_model:
       consume flow_route_history blockers and MUST NOT copy routing_rules, persist fork-local route rows, derive
       selected-source recipients for execution outside recipient planning, or use source route outcomes as selected-fork
       suppressors.'
+    selected_contract_session_turn_audit_lineage_policy: 'Mutating selected-contract timestamp-fork execution may consume
+      runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy to classify
+      at/before-fork-T source agent_sessions, agent_turns, and agent_conversation_audits as lineage/no-action evidence
+      only. This policy is selected-contract execution only and is not session, turn, or audit reconstruction. It applies
+      only when selected-contract execution regenerates fresh fork-local work through canonical owners and no pending or
+      in-progress source delivery at T requires live session continuity through active_session_id, started_at, partial
+      receipt/outcome state, or equivalent active execution evidence. Source session, turn, audit, provider-session,
+      transcript, receipt, outcome, or task-audit rows MUST NOT be copied into the fork, reused as fork-local runtime
+      truth, or used as selected-fork suppressors. Fork-local conversation rows before the selected execution owner
+      creates them remain fail-closed. Post-T source session, turn, and conversation-audit facts remain fail-closed unless
+      a separate approved source-advanced/reconstruction owner changes that policy. Committed replay-scope marker policy
+      is a split sibling.'
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
       runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
@@ -3705,7 +3719,19 @@ run_model:
         outcomes, and regenerates follow-up events under the fork run_id. This is not full historical resume: route
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
-        parents or siblings.'
+        parents or siblings. At/before-T source session/turn/audit facts may be admitted only as lineage/no-action
+        evidence by the separate selected-contract session/turn/audit lineage policy.'
+      3h1_selected_contract_session_turn_audit_lineage_policy: 'For selected-contract timestamp-fork execution,
+        runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy consumes the
+        canonical replay_resume_admission session_history, active_turn_history, and conversation_audit_history facts and
+        may demote those at/before-T source facts from fail-closed blockers to lineage/no-action evidence only. The owner
+        must keep pending/in-progress delivery session coupling, post-T source conversation facts, and fork-local
+        pre-existing conversation rows fail-closed. It must not copy or reuse source session IDs, provider session IDs,
+        transcripts, task audits, turns, receipts, outcomes, or source audit rows as fork-local runtime truth or
+        suppressors. Fresh fork-local sessions, turns, and audits may appear only through normal selected fork runtime
+        execution under the fork run_id. This owner does not close full session reconstruction, committed replay-scope
+        marker policy, timers, routes, non-agent replay, restart recovery, contract-swap boot/resume, or operator
+        surfaces.'
       3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
         readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
         replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -359,6 +359,7 @@ nodes:
       - broad historical replay execution owner promotion must make runtime.run_fork.historical_replay_execution the canonical mutating authority that emits executable work identities after validating the full fact matrix; store activation and delivery-event replay writers must consume that owner rather than selecting source deliveries from replay_resume_admission or RunForkPlan directly
       - contract-swap historical replay execution needs runtime.run_fork.historical_replay_execution.contract_swap_boot_resume as the selected-contract child owner for already-admitted delivery_event_replay_ready work; selected recipient planning owns fork recipients, source delivery subscribers are lineage only, and timers/routes/sessions/turns/audits/non-agent/restart/API siblings stay fail-closed or split
       - selected-contract timer reconstruction needs runtime.run_fork.historical_replay_execution.timer_reconstruction plus run-scoped scheduler identity; active source timers are lineage inputs only, reconstructed fork timers must be fresh fork-local rows under fork run_id, and unsupported source timer histories or post-T source timer facts remain fail-closed
+      - selected-contract session/turn/audit lineage policy needs runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy to classify at/before-T source agent_sessions, agent_turns, and agent_conversation_audits as lineage/no-action only for selected-contract execution while keeping active delivery/session coupling, post-T source conversation facts, fork-local pre-existing rows, committed replay-scope, and full reconstruction split or fail-closed
     representative_issues:
       - 564
       - 565
@@ -388,6 +389,7 @@ nodes:
       - 635
       - 639
       - 642
+      - 661
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -71,6 +71,13 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, fmt.Errorf("plan selected-contract activation gate: %w", err)
 	}
+	replayAdmission := store.RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	if len(plan.ReplayResumeAdmission.Dispositions) > 0 || len(plan.ReplayResumeAdmission.UnsupportedBlockers) > 0 {
+		plan.UnsupportedBlockers = replayAdmission.UnsupportedBlockers
+		plan.UnsupportedBlockerCount = len(replayAdmission.UnsupportedBlockers)
+	}
+	plan.ReplayResumeAdmission = replayAdmission
+	plan.ExecutionReady = replayAdmission.StateOnlyExecutionReady || replayAdmission.DeliveryEventReplayReady
 	frontier, err := runforkadmission.AdmitContractFrontier(runforkadmission.ContractFrontierRequest{
 		Plan:              plan,
 		Source:            loadedSource.Source,

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -308,7 +308,7 @@ func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSe
 	}
 }
 
-func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
+func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
@@ -328,6 +328,8 @@ func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
 	at := time.Unix(1700002300, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
 	if _, err := db.ExecContext(ctx, `
@@ -347,8 +349,28 @@ func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 	`, sessionID, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed source session: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'task', '{}'::jsonb, 'active', $4, $4)
+	`, auditID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source conversation audit: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'session_per_entity', $4::text, $4::uuid,
+			$5::uuid, 'item.received', 'task-a', $6)
+	`, turnID, sourceRunID, sessionID, entityID, sourceEventID, at); err != nil {
+		t.Fatalf("seed source turn: %v", err)
+	}
 
-	_, err = ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
 		At:           sourceEventID,
 		Store:        pg,
@@ -358,8 +380,39 @@ func TestExecuteSelectedContractRunForkPreservesSessionBlocker(t *testing.T) {
 			contractsRoot,
 		),
 	})
-	if err == nil || !strings.Contains(err.Error(), store.RunForkBlockerSessionHistoryUnproven) {
-		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want session blocker", err)
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.Materialization.ForkRunID == "" || !result.Activation.Activated {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	for _, code := range []string{
+		store.RunForkBlockerSessionHistoryUnproven,
+		store.RunForkBlockerConversationAuditUnproven,
+		store.RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if selectedExecutionResultHasBlocker(result, code) {
+			t.Fatalf("selected execution retained %s: materialization=%#v activation=%#v", code, result.Materialization.UnsupportedBlockers, result.Activation.UnsupportedBlockers)
+		}
+	}
+	var copiedSessions, copiedAudits, copiedTurns int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_sessions WHERE run_id = $1::uuid OR session_id = $2::uuid
+	`, result.Materialization.ForkRunID, sessionID).Scan(&copiedSessions); err != nil {
+		t.Fatalf("count session copies: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_conversation_audits WHERE run_id = $1::uuid OR session_id = $2::uuid
+	`, result.Materialization.ForkRunID, auditID).Scan(&copiedAudits); err != nil {
+		t.Fatalf("count audit copies: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_turns WHERE run_id = $1::uuid OR turn_id = $2::uuid
+	`, result.Materialization.ForkRunID, turnID).Scan(&copiedTurns); err != nil {
+		t.Fatalf("count turn copies: %v", err)
+	}
+	if copiedSessions != 1 || copiedAudits != 1 || copiedTurns != 1 {
+		t.Fatalf("copied conversation rows sessions=%d audits=%d turns=%d, want source-only 1/1/1", copiedSessions, copiedAudits, copiedTurns)
 	}
 }
 
@@ -904,6 +957,20 @@ func seedSourceOutcomeThatMustNotSuppressFork(t *testing.T, db *sql.DB, sourceEv
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func selectedExecutionResultHasBlocker(result SelectedContractExecutionResult, code string) bool {
+	for _, blocker := range result.Materialization.UnsupportedBlockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	for _, blocker := range result.Activation.UnsupportedBlockers {
+		if blocker.Code == code {
 			return true
 		}
 	}

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -258,9 +258,9 @@ func historicalReplayFactAdmissions(replay store.RunForkReplayResumeAdmission) [
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactEmittedFollowUps, "emitted follow-up regeneration belongs to the future mutating replay owner; source follow-up rows are not copied", "#564"),
 		historicalReplayTimersAdmission(replay),
 		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactRoutes, []string{store.RunForkReplayResumeFactRouteHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "route and route-recovery truth remains split under fork-local route persistence/runtime recovery", "#618"),
-		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactSessions, []string{store.RunForkReplayResumeFactSessionHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "session reconstruction remains a split sibling unless active session facts are present and fail-closed", "#564"),
-		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactTurns, []string{store.RunForkReplayResumeFactActiveTurnHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "turn reconstruction remains a split sibling unless active turn facts are present and fail-closed", "#564"),
-		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactAudits, []string{store.RunForkReplayResumeFactConversationAuditHistory}, store.RunForkHistoricalReplayAdmissionSplitSibling, "task conversation audit reconstruction remains a split sibling unless audit facts are present and fail-closed", "#564"),
+		historicalReplayConversationFactAdmission(replay, store.RunForkHistoricalReplayFactSessions, store.RunForkReplayResumeFactSessionHistory, "source session rows admitted by the selected-contract lineage policy are lineage/no-action evidence only; fresh fork-local sessions must be created by normal runtime execution"),
+		historicalReplayConversationFactAdmission(replay, store.RunForkHistoricalReplayFactTurns, store.RunForkReplayResumeFactActiveTurnHistory, "source turn rows admitted by the selected-contract lineage policy are lineage/no-action evidence only; fresh fork-local turns must be created by normal runtime execution"),
+		historicalReplayConversationFactAdmission(replay, store.RunForkHistoricalReplayFactAudits, store.RunForkReplayResumeFactConversationAuditHistory, "source task conversation audit rows admitted by the selected-contract lineage policy are lineage/no-action evidence only; fresh fork-local audits must be created by normal runtime execution"),
 		historicalReplayNonAgentAdmission(replay),
 		historicalReplayFactFromReplay(replay, store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts, []string{store.RunForkReplayResumeFactSourceAdvanced}, store.RunForkHistoricalReplayAdmissionSplitSibling, "source-advanced and post-T source outcomes remain source-run evidence and cannot suppress fork-local replay", "#564"),
 		historicalReplaySplitFact(store.RunForkHistoricalReplayFactRuntimeRestartRecovery, "runtime restart recovery remains a consumer/sibling and cannot reconstruct historical replay state from current rows", "#564"),
@@ -346,6 +346,32 @@ func historicalReplayNonAgentAdmission(replay store.RunForkReplayResumeAdmission
 	return historicalReplaySplitFact(store.RunForkHistoricalReplayFactNonAgentNodeSystemWork, "node, system, platform, and non-agent delivery replay requires a separate handler/idempotency/receipt owner", "#564")
 }
 
+func historicalReplayConversationFactAdmission(replay store.RunForkReplayResumeAdmission, fact, replayFact, lineageMessage string) store.RunForkHistoricalReplayFactAdmission {
+	if blocker, ok := replayBlockerForFacts(replay, replayFact); ok {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        fact,
+			Admission:   store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		}
+	}
+	if disposition, ok := replayDispositionForFact(replay, replayFact, store.RunForkReplayResumeDispositionLineageOnly); ok {
+		sourceOwner := strings.TrimSpace(disposition.Owner)
+		if sourceOwner == "" {
+			sourceOwner = store.RunForkReplayResumeAdmissionOwner
+		}
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        fact,
+			Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+			SourceOwner: sourceOwner,
+			Tracker:     "#661",
+			Message:     lineageMessage,
+		}
+	}
+	return historicalReplaySplitFact(fact, "session/turn/audit reconstruction remains a split sibling unless the selected-contract lineage policy admits source conversation history as lineage/no-action evidence", "#564")
+}
+
 func historicalReplayFactFromReplay(replay store.RunForkReplayResumeAdmission, fact string, replayFacts []string, fallbackAdmission, fallbackMessage, tracker string) store.RunForkHistoricalReplayFactAdmission {
 	if blocker, ok := replayBlockerForFacts(replay, replayFacts...); ok {
 		return store.RunForkHistoricalReplayFactAdmission{
@@ -409,12 +435,17 @@ func replayBlockerForFacts(replay store.RunForkReplayResumeAdmission, facts ...s
 }
 
 func replayDispositionHas(replay store.RunForkReplayResumeAdmission, fact, disposition string) bool {
+	_, ok := replayDispositionForFact(replay, fact, disposition)
+	return ok
+}
+
+func replayDispositionForFact(replay store.RunForkReplayResumeAdmission, fact, disposition string) (store.RunForkReplayResumeDisposition, bool) {
 	for _, item := range replay.Dispositions {
 		if strings.TrimSpace(item.Fact) == fact && strings.TrimSpace(item.Disposition) == disposition {
-			return true
+			return item, true
 		}
 	}
-	return false
+	return store.RunForkReplayResumeDisposition{}, false
 }
 
 func historicalReplayFactAdmission(admissions []store.RunForkHistoricalReplayFactAdmission, fact string) (store.RunForkHistoricalReplayFactAdmission, bool) {

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -219,6 +219,68 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsTimerReconstructionOwner(
 	}
 }
 
+func TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversationLineageOwner(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                   store.RunForkReplayResumeAdmissionOwner,
+		StateOnlyExecutionReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{
+			{
+				Fact:        store.RunForkReplayResumeFactSessionHistory,
+				Disposition: store.RunForkReplayResumeDispositionLineageOnly,
+				Owner:       store.RunForkSelectedContractSessionTurnAuditLineagePolicyOwner,
+				Message:     "selected-contract session lineage/no-action evidence",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactActiveTurnHistory,
+				Disposition: store.RunForkReplayResumeDispositionLineageOnly,
+				Owner:       store.RunForkSelectedContractSessionTurnAuditLineagePolicyOwner,
+				Message:     "selected-contract turn lineage/no-action evidence",
+			},
+			{
+				Fact:        store.RunForkReplayResumeFactConversationAuditHistory,
+				Disposition: store.RunForkReplayResumeDispositionLineageOnly,
+				Owner:       store.RunForkSelectedContractSessionTurnAuditLineagePolicyOwner,
+				Message:     "selected-contract audit lineage/no-action evidence",
+			},
+		},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	for _, fact := range []string{
+		store.RunForkHistoricalReplayFactSessions,
+		store.RunForkHistoricalReplayFactTurns,
+		store.RunForkHistoricalReplayFactAudits,
+	} {
+		item, ok := historicalReplayFactAdmission(admission.FactAdmissions, fact)
+		if !ok {
+			t.Fatalf("missing fact admission for %s", fact)
+		}
+		if item.Admission != store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence ||
+			item.SourceOwner != store.RunForkSelectedContractSessionTurnAuditLineagePolicyOwner ||
+			item.Tracker != "#661" {
+			t.Fatalf("%s admission = %#v, want #661 lineage owner", fact, item)
+		}
+	}
+}
+
 func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation(t *testing.T) {
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -60,6 +60,7 @@ type RunForkReplayResumeAdmission struct {
 type RunForkReplayResumeDisposition struct {
 	Fact           string `json:"fact"`
 	Disposition    string `json:"disposition"`
+	Owner          string `json:"owner,omitempty"`
 	BlockerCode    string `json:"blocker_code,omitempty"`
 	Classification string `json:"classification,omitempty"`
 	Message        string `json:"message"`

--- a/internal/store/run_fork_selected_contract_conversation_lineage.go
+++ b/internal/store/run_fork_selected_contract_conversation_lineage.go
@@ -71,7 +71,12 @@ func runForkSelectedContractConversationLineageBlocker(code string) bool {
 
 func runForkSelectedContractHasActiveDeliverySessionCoupling(pending []RunForkPendingWork) bool {
 	for _, item := range pending {
-		if strings.TrimSpace(item.Classification) == RunForkPendingClassificationDeliveredCompleted {
+		classification := strings.TrimSpace(item.Classification)
+		switch classification {
+		case RunForkPendingClassificationInProgress:
+			return true
+		case RunForkPendingClassificationPending:
+		default:
 			continue
 		}
 		if strings.TrimSpace(item.ActiveSessionID) != "" ||
@@ -79,9 +84,6 @@ func runForkSelectedContractHasActiveDeliverySessionCoupling(pending []RunForkPe
 			item.DeliveredAt != nil ||
 			item.ReceiptAt != nil ||
 			strings.TrimSpace(item.ReceiptOutcome) != "" {
-			return true
-		}
-		if strings.TrimSpace(item.Classification) == RunForkPendingClassificationInProgress {
 			return true
 		}
 	}

--- a/internal/store/run_fork_selected_contract_conversation_lineage.go
+++ b/internal/store/run_fork_selected_contract_conversation_lineage.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+const RunForkSelectedContractSessionTurnAuditLineagePolicyOwner = "runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy"
+
+var runForkSelectedContractConversationLineageFacts = map[string]string{
+	RunForkReplayResumeFactSessionHistory:           RunForkBlockerSessionHistoryUnproven,
+	RunForkReplayResumeFactConversationAuditHistory: RunForkBlockerConversationAuditUnproven,
+	RunForkReplayResumeFactActiveTurnHistory:        RunForkBlockerActiveTurnHistoryUnproven,
+}
+
+// RunForkSelectedContractSessionTurnAuditLineageAdmission applies the selected-contract
+// conversation-history policy after the store replay taxonomy has identified source facts.
+func RunForkSelectedContractSessionTurnAuditLineageAdmission(plan RunForkPlan) RunForkReplayResumeAdmission {
+	admission := plan.ReplayResumeAdmission
+	if strings.TrimSpace(admission.Owner) == "" {
+		admission.Owner = RunForkReplayResumeAdmissionOwner
+	}
+	if runForkSelectedContractHasActiveDeliverySessionCoupling(plan.PendingWork) {
+		return admission
+	}
+
+	changed := false
+	for i := range admission.Dispositions {
+		disposition := &admission.Dispositions[i]
+		fact := strings.TrimSpace(disposition.Fact)
+		blockerCode, ok := runForkSelectedContractConversationLineageFacts[fact]
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		if code := strings.TrimSpace(disposition.BlockerCode); code != "" && code != blockerCode {
+			continue
+		}
+		disposition.Disposition = RunForkReplayResumeDispositionLineageOnly
+		disposition.Owner = RunForkSelectedContractSessionTurnAuditLineagePolicyOwner
+		disposition.BlockerCode = ""
+		disposition.Classification = ""
+		disposition.Message = fmt.Sprintf("%s classifies at/before-T source %s as selected-contract lineage/no-action evidence only; fresh fork-local conversation rows must be created by normal runtime execution under the fork run_id", RunForkSelectedContractSessionTurnAuditLineagePolicyOwner, fact)
+		changed = true
+	}
+	if !changed {
+		return admission
+	}
+
+	filtered := make([]RunForkUnsupportedBlocker, 0, len(admission.UnsupportedBlockers))
+	for _, blocker := range admission.UnsupportedBlockers {
+		if runForkSelectedContractConversationLineageBlocker(strings.TrimSpace(blocker.Code)) {
+			continue
+		}
+		filtered = append(filtered, blocker)
+	}
+	admission.UnsupportedBlockers = filtered
+	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
+}
+
+func runForkSelectedContractConversationLineageBlocker(code string) bool {
+	for _, blockerCode := range runForkSelectedContractConversationLineageFacts {
+		if code == blockerCode {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkSelectedContractHasActiveDeliverySessionCoupling(pending []RunForkPendingWork) bool {
+	for _, item := range pending {
+		if strings.TrimSpace(item.Classification) == RunForkPendingClassificationDeliveredCompleted {
+			continue
+		}
+		if strings.TrimSpace(item.ActiveSessionID) != "" ||
+			item.StartedAt != nil ||
+			item.DeliveredAt != nil ||
+			item.ReceiptAt != nil ||
+			strings.TrimSpace(item.ReceiptOutcome) != "" {
+			return true
+		}
+		if strings.TrimSpace(item.Classification) == RunForkPendingClassificationInProgress {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkReplayResumeAdmissionRecalculateReadiness(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
+	hasHistoricalReplayRequirement := false
+	hasReplayableDeliveryEvent := false
+	for _, disposition := range admission.Dispositions {
+		switch strings.TrimSpace(disposition.Fact) {
+		case RunForkReplayResumeFactEntityStateSnapshot,
+			RunForkReplayResumeFactHistoricalReplayExecution,
+			RunForkReplayResumeFactContractSwap:
+			continue
+		}
+		switch strings.TrimSpace(disposition.Disposition) {
+		case RunForkReplayResumeDispositionForkReplay:
+			hasHistoricalReplayRequirement = true
+			hasReplayableDeliveryEvent = true
+		case RunForkReplayResumeDispositionFailClosedBlocker,
+			RunForkReplayResumeDispositionReconstruct:
+			hasHistoricalReplayRequirement = true
+		}
+	}
+	admission.DeliveryEventReplayReady = hasReplayableDeliveryEvent && len(admission.UnsupportedBlockers) == 0
+	admission.StateOnlyExecutionReady = len(admission.UnsupportedBlockers) == 0 && !hasHistoricalReplayRequirement
+	admission.HistoricalReplayRequired = hasHistoricalReplayRequirement
+	admission.HistoricalReplaySupported = admission.DeliveryEventReplayReady
+	return admission
+}

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -126,10 +126,11 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
+	replayAdmission := RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
 	timerReconstruction, err := s.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
 	if err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			admission := runForkReplayResumeAdmissionWithBlocker(plan.ReplayResumeAdmission, fact, blocker)
+			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
 			return RunForkMaterialization{
 				SourceRunID:           plan.SourceRunID,
 				ForkPoint:             plan.ForkPoint,
@@ -141,12 +142,27 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		}
 		return RunForkMaterialization{}, err
 	}
-	if blockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, nil, timerReconstruction.Required); len(blockers) > 0 {
+	replayAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(replayAdmission, timerReconstruction)
+	if err := ensureRunForkNoPostForkConversationHistory(ctx, s.DB, catalog, plan.SourceRunID, plan.ForkPoint.Timestamp); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
+			return RunForkMaterialization{
+				SourceRunID:           plan.SourceRunID,
+				ForkPoint:             plan.ForkPoint,
+				ExecutionReady:        false,
+				ReplayResumeAdmission: admission,
+				UnsupportedBlockers:   admission.UnsupportedBlockers,
+				DeliveryResumeBlocked: true,
+			}, err
+		}
+		return RunForkMaterialization{}, err
+	}
+	if blockers := runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, replayAdmission, nil); len(blockers) > 0 {
 		return RunForkMaterialization{
 			SourceRunID:           plan.SourceRunID,
 			ForkPoint:             plan.ForkPoint,
 			ExecutionReady:        false,
-			ReplayResumeAdmission: runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, timerReconstruction),
+			ReplayResumeAdmission: replayAdmission,
 			UnsupportedBlockers:   blockers,
 			DeliveryResumeBlocked: true,
 		}, fmt.Errorf("selected-contract fork execution materialization blocked: %s", runForkBlockerCodes(blockers))
@@ -207,8 +223,7 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		return RunForkMaterialization{}, fmt.Errorf("commit selected-contract fork materialization: %w", err)
 	}
 	committed = true
-	replayAdmission := runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, timerReconstruction)
-	unsupportedBlockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, nil, timerReconstruction.Required)
+	unsupportedBlockers := runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, replayAdmission, nil)
 	return RunForkMaterialization{
 		SourceRunID:              plan.SourceRunID,
 		ForkRunID:                forkRunID,
@@ -287,15 +302,22 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	if err != nil {
 		return result, err
 	}
-	result.ReplayResumeAdmission = plan.ReplayResumeAdmission
+	result.ReplayResumeAdmission = RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
 	timerResolved, err := runForkSelectedContractTimerReconstructionComplete(ctx, tx, lineage, plan)
 	if err != nil {
 		return result, err
 	}
-	result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(plan.ReplayResumeAdmission, runForkTimerReconstructionPlan{Required: timerResolved})
-	if blockers := runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan, req.AllowedSourceEventIDs, timerResolved); len(blockers) > 0 {
+	result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(result.ReplayResumeAdmission, runForkTimerReconstructionPlan{Required: timerResolved})
+	if blockers := runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, result.ReplayResumeAdmission, req.AllowedSourceEventIDs); len(blockers) > 0 {
 		result.UnsupportedBlockers = blockers
 		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
+	}
+	if err := ensureRunForkNoPostForkConversationHistory(ctx, tx, catalog, lineage.SourceRunID, lineage.ForkEventTime); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
+		return result, err
 	}
 	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, catalog, lineage)
 	if err != nil {
@@ -770,6 +792,10 @@ func insertRunForkSelectedContractBranchDivergence(ctx context.Context, tx *sql.
 }
 
 func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourceEventIDs []string) []RunForkUnsupportedBlocker {
+	return runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, RunForkSelectedContractSessionTurnAuditLineageAdmission(plan), allowedSourceEventIDs)
+}
+
+func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan, admission RunForkReplayResumeAdmission, allowedSourceEventIDs []string) []RunForkUnsupportedBlocker {
 	allowedEvents := map[string]struct{}{}
 	for _, eventID := range allowedSourceEventIDs {
 		if eventID = strings.TrimSpace(eventID); eventID != "" {
@@ -777,7 +803,7 @@ func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourc
 		}
 	}
 	blockers := []RunForkUnsupportedBlocker{}
-	for _, blocker := range plan.UnsupportedBlockers {
+	for _, blocker := range admission.UnsupportedBlockers {
 		switch strings.TrimSpace(blocker.Code) {
 		case RunForkBlockerDeliveryHistoryUnproven, RunForkBlockerNonAgentDeliveryReplayUnsupported:
 			continue
@@ -805,6 +831,61 @@ func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourc
 		}
 	}
 	return blockers
+}
+
+func ensureRunForkNoPostForkConversationHistory(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) error {
+	checks := []struct {
+		code       string
+		table      string
+		predicates []string
+	}{
+		{
+			code:       "source_sessions_advanced_after_fork_point",
+			table:      "agent_sessions",
+			predicates: runForkPostForkConversationPredicates(catalog, "agent_sessions", "created_at", "updated_at", "terminated_at"),
+		},
+		{
+			code:       "source_conversation_audits_advanced_after_fork_point",
+			table:      "agent_conversation_audits",
+			predicates: runForkPostForkConversationPredicates(catalog, "agent_conversation_audits", "created_at", "updated_at"),
+		},
+		{
+			code:       "source_turns_advanced_after_fork_point",
+			table:      "agent_turns",
+			predicates: runForkPostForkConversationPredicates(catalog, "agent_turns", "created_at"),
+		},
+	}
+	for _, check := range checks {
+		if len(check.predicates) == 0 || !catalog.hasColumns(check.table, "run_id") {
+			continue
+		}
+		var exists bool
+		query := fmt.Sprintf(`
+			SELECT EXISTS (
+				SELECT 1
+				FROM %s
+				WHERE run_id = $1::uuid
+				  AND (%s)
+			)
+		`, check.table, strings.Join(check.predicates, " OR "))
+		if err := q.QueryRowContext(ctx, query, sourceRunID, forkTime).Scan(&exists); err != nil {
+			return fmt.Errorf("check selected-contract %s: %w", check.code, err)
+		}
+		if exists {
+			return runForkReplayResumeError(check.code, RunForkReplayResumeFactSourceAdvanced, fmt.Sprintf("selected-contract conversation lineage policy blocked: %s", check.code))
+		}
+	}
+	return nil
+}
+
+func runForkPostForkConversationPredicates(catalog schemaColumnCatalog, table string, columns ...string) []string {
+	predicates := []string{}
+	for _, column := range columns {
+		if catalog.hasColumns(table, column) {
+			predicates = append(predicates, fmt.Sprintf("%s > $2::timestamptz", column))
+		}
+	}
+	return predicates
 }
 
 func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID string, allowedSourceEventIDs []string) error {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -51,6 +51,112 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	}
 }
 
+func TestSelectedContractExecutionMaterializationTreatsSourceConversationHistoryAsLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700002410, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, eventID, sessionID, auditID, turnID, at)
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	for _, code := range []string{
+		RunForkBlockerSessionHistoryUnproven,
+		RunForkBlockerConversationAuditUnproven,
+		RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if !runForkTestHasPlanBlocker(plan, code) {
+			t.Fatalf("plan blockers = %#v, want %s", plan.UnsupportedBlockers, code)
+		}
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+	for _, code := range []string{
+		RunForkBlockerSessionHistoryUnproven,
+		RunForkBlockerConversationAuditUnproven,
+		RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if runForkTestHasMaterializationBlocker(materialized, code) {
+			t.Fatalf("selected-contract materialization kept %s: %#v", code, materialized.UnsupportedBlockers)
+		}
+	}
+	for _, fact := range []string{
+		RunForkReplayResumeFactSessionHistory,
+		RunForkReplayResumeFactConversationAuditHistory,
+		RunForkReplayResumeFactActiveTurnHistory,
+	} {
+		if !runForkTestHasLineageDispositionOwner(materialized.ReplayResumeAdmission, fact, RunForkSelectedContractSessionTurnAuditLineagePolicyOwner) {
+			t.Fatalf("admission missing %s lineage owner: %#v", fact, materialized.ReplayResumeAdmission)
+		}
+	}
+	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
+}
+
+func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCouplingFailClosed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002420, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'active-agent', 'in_progress', $4::uuid, $3, $3)
+	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
+		t.Fatalf("seed active delivery coupling: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || (!strings.Contains(err.Error(), RunForkBlockerSessionHistoryUnproven) && !strings.Contains(err.Error(), RunForkBlockerActiveTurnHistoryUnproven)) {
+		t.Fatalf("materialization error = %v, want active session/turn blocker", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite active coupling: %#v", materialized)
+	}
+	if !runForkTestHasMaterializationBlocker(materialized, RunForkBlockerSessionHistoryUnproven) ||
+		!runForkTestHasMaterializationBlocker(materialized, RunForkBlockerActiveTurnHistoryUnproven) {
+		t.Fatalf("materialization blockers = %#v, want active session and turn blockers", materialized.UnsupportedBlockers)
+	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
+}
+
 func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -493,6 +599,52 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	assertNoForkTimerCopiesForSource(t, db, sourceRunID)
 }
 
+func TestPostTSourceSessionFailsClosedBeforeSelectedContractMaterialization(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003605, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, llm_backend, conversation_mode, status, created_at)
+		VALUES ('agent-a', 'worker', 'standard', 'mock', 'session_per_entity', 'active', $1)
+		ON CONFLICT (agent_id) DO NOTHING
+	`, at); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'session_per_entity', 'active', $4, $4)
+	`, uuid.NewString(), sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+		t.Fatalf("seed post-T source session: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_sessions_advanced_after_fork_point") {
+		t.Fatalf("materialization error = %v, want post-T source session blocker", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite post-T source session: %#v", materialized)
+	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
+}
+
 func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -592,6 +744,112 @@ func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) 
 	}
 }
 
+func TestPostTSourceConversationHistoryFailsClosedForSelectedContractActivation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code string
+		seed func(context.Context, *sql.DB, string, string, string, time.Time) error
+	}{
+		{
+			name: "session",
+			code: "source_sessions_advanced_after_fork_point",
+			seed: func(ctx context.Context, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_sessions (
+						session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+						runtime_mode, status, created_at, updated_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+						'session_per_entity', 'active', $4, $4)
+				`, uuid.NewString(), sourceRunID, entityID, at.Add(time.Minute))
+				return err
+			},
+		},
+		{
+			name: "conversation audit",
+			code: "source_conversation_audits_advanced_after_fork_point",
+			seed: func(ctx context.Context, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_conversation_audits (
+						session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+						runtime_mode, runtime_state, status, created_at, updated_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+						'task', '{}'::jsonb, 'active', $4, $4)
+				`, uuid.NewString(), sourceRunID, entityID, at.Add(time.Minute))
+				return err
+			},
+		},
+		{
+			name: "turn",
+			code: "source_turns_advanced_after_fork_point",
+			seed: func(ctx context.Context, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) error {
+				_, err := db.ExecContext(ctx, `
+					INSERT INTO agent_turns (
+						turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+						trigger_event_id, trigger_event_type, task_id, created_at
+					)
+					VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'task', $4::text, $4::uuid,
+						$5::uuid, 'item.received', 'task-a', $6)
+				`, uuid.NewString(), sourceRunID, uuid.NewString(), entityID, eventID, at.Add(time.Minute))
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+			sourceRunID := uuid.NewString()
+			entityID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700003620, 0).UTC()
+			seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO agents (agent_id, role, model_tier, llm_backend, conversation_mode, status, created_at)
+				VALUES ('agent-a', 'worker', 'standard', 'mock', 'session_per_entity', 'active', $1)
+				ON CONFLICT (agent_id) DO NOTHING
+			`, at); err != nil {
+				t.Fatalf("seed agent: %v", err)
+			}
+
+			materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+				SourceRunID: sourceRunID,
+				At:          eventID,
+				ContractSelection: RunForkContractSelection{
+					Mode:            "selected_contracts",
+					ContractsRoot:   "/tmp/selected-contracts",
+					WorkflowName:    "selected-workflow",
+					WorkflowVersion: "v1",
+				},
+			})
+			if err != nil {
+				t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+			}
+			if err := tc.seed(ctx, db, sourceRunID, entityID, eventID, at); err != nil {
+				t.Fatalf("seed post-T %s: %v", tc.name, err)
+			}
+
+			activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+				ForkRunID:             materialized.ForkRunID,
+				AllowedSourceEventIDs: []string{eventID},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.code) {
+				t.Fatalf("activation error = %v, want %s", err, tc.code)
+			}
+			if activation.Activated || activation.BranchDivergence != nil || activation.SourceAdvancedAfterFork {
+				t.Fatalf("activation = %#v, want conversation post-T blocked before branch divergence", activation)
+			}
+			if !runForkTestHasActivationBlocker(activation, tc.code) {
+				t.Fatalf("activation blockers = %#v, want %s", activation.UnsupportedBlockers, tc.code)
+			}
+			if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, tc.code) {
+				t.Fatalf("activation replay admission = %#v, want source advanced blocker %s", activation.ReplayResumeAdmission, tc.code)
+			}
+		})
+	}
+}
+
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -678,6 +936,108 @@ func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, so
 	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
+}
+
+func seedSelectedContractSourceConversationHistory(t *testing.T, db execContextDB, sourceRunID, entityID, eventID, sessionID, auditID, turnID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, llm_backend, conversation_mode, status, created_at)
+		VALUES ('agent-a', 'worker', 'standard', 'mock', 'session_per_entity', 'active', $1)
+		ON CONFLICT (agent_id) DO NOTHING
+	`, at); err != nil {
+		t.Fatalf("seed conversation agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'session_per_entity', 'active', $4, $4)
+	`, sessionID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'task', '{}'::jsonb, 'active', $4, $4)
+	`, auditID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source conversation audit: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $3::uuid, 'session_per_entity', $4::text, $4::uuid,
+			$5::uuid, 'item.received', 'task-a', $6)
+	`, turnID, sourceRunID, sessionID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed source turn: %v", err)
+	}
+}
+
+func assertNoCopiedConversationRows(t *testing.T, db *sql.DB, forkRunID, sourceSessionID, sourceAuditID, sourceTurnID string) {
+	t.Helper()
+	ctx := context.Background()
+	checks := map[string]struct {
+		query string
+		id    string
+	}{
+		"agent_sessions": {
+			query: `SELECT COUNT(*) FROM agent_sessions WHERE run_id = $1::uuid OR session_id = $2::uuid`,
+			id:    sourceSessionID,
+		},
+		"agent_conversation_audits": {
+			query: `SELECT COUNT(*) FROM agent_conversation_audits WHERE run_id = $1::uuid OR session_id = $2::uuid`,
+			id:    sourceAuditID,
+		},
+		"agent_turns": {
+			query: `SELECT COUNT(*) FROM agent_turns WHERE run_id = $1::uuid OR turn_id = $2::uuid`,
+			id:    sourceTurnID,
+		},
+	}
+	for name, check := range checks {
+		var count int
+		if err := db.QueryRowContext(ctx, check.query, forkRunID, check.id).Scan(&count); err != nil {
+			t.Fatalf("count copied %s: %v", name, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s fork/copy count = %d, want exactly the original source row only", name, count)
+		}
+	}
+}
+
+func runForkTestHasPlanBlocker(plan RunForkPlan, code string) bool {
+	for _, blocker := range plan.UnsupportedBlockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkTestHasMaterializationBlocker(materialized RunForkMaterialization, code string) bool {
+	for _, blocker := range materialized.UnsupportedBlockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkTestHasLineageDispositionOwner(admission RunForkReplayResumeAdmission, fact, owner string) bool {
+	for _, disposition := range admission.Dispositions {
+		if disposition.Fact == fact &&
+			disposition.Disposition == RunForkReplayResumeDispositionLineageOnly &&
+			disposition.Owner == owner {
+			return true
+		}
+	}
+	return false
 }
 
 func assertNoForkTimerCopiesForSource(t *testing.T, db *sql.DB, sourceRunID string) {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -157,6 +157,67 @@ func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCoupl
 	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
+func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsActiveSessionCoupling(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700002430, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, eventID, sessionID, auditID, turnID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count,
+			started_at, delivered_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'terminal-agent', 'failed', 2, $3, $3, $3)
+	`, sourceRunID, eventID, at); err != nil {
+		t.Fatalf("seed terminal delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		VALUES ($1::uuid, 'agent', 'terminal-agent', $2::uuid, 'flow-a/1',
+			'reject', 'terminal_source_delivery', '{}'::jsonb, $3)
+	`, eventID, entityID, at); err != nil {
+		t.Fatalf("seed terminal delivery receipt: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+	for _, code := range []string{
+		RunForkBlockerSessionHistoryUnproven,
+		RunForkBlockerConversationAuditUnproven,
+		RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if runForkTestHasMaterializationBlocker(materialized, code) {
+			t.Fatalf("terminal delivery preserved conversation blocker %s: %#v", code, materialized.UnsupportedBlockers)
+		}
+	}
+	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
+}
+
 func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -50,18 +50,11 @@ func runForkPlanHasTimerBlocker(plan RunForkPlan) bool {
 }
 
 func runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan RunForkPlan, allowedSourceEventIDs []string, timerResolved bool) []RunForkUnsupportedBlocker {
-	blockers := runForkSelectedContractExecutionPlanBlockers(plan, allowedSourceEventIDs)
-	if !timerResolved {
-		return blockers
+	admission := RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	if timerResolved {
+		admission = runForkReplayResumeAdmissionWithTimerReconstruction(admission, runForkTimerReconstructionPlan{Required: true})
 	}
-	out := blockers[:0]
-	for _, blocker := range blockers {
-		if strings.TrimSpace(blocker.Code) == RunForkBlockerTimerHistoryUnproven {
-			continue
-		}
-		out = append(out, blocker)
-	}
-	return out
+	return runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, admission, allowedSourceEventIDs)
 }
 
 func runForkReplayResumeAdmissionWithTimerReconstruction(admission RunForkReplayResumeAdmission, reconstruction runForkTimerReconstructionPlan) RunForkReplayResumeAdmission {


### PR DESCRIPTION
## Summary
Closes #661.

Implements the approved selected-contract timestamp-fork conversation-history lineage/no-action policy for source `agent_sessions`, `agent_turns`, and `agent_conversation_audits` at or before fork T.

## Governing Refs
- Issue gate: #661 `approved as first slice`.
- Parent trackers: #564 and #549 remain open.
- Exact spec sections updated in this PR: `run_model.fork.selected_contract_session_turn_audit_lineage_policy` and `run_model.fork.semantics.3h1_selected_contract_session_turn_audit_lineage_policy` in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Adjacent spec sections consumed: `selected_contract_source_advanced_branch`, `selected_contract_supported_execution`, `historical_replay_execution_admission`, and `historical_replay_execution_owner`.

## Semantic Migration
- New canonical owner: `runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy`.
- Old invalid path: selected-contract materialization/activation preserving `session_history_unproven`, `conversation_audit_history_unproven`, and `active_turn_history_unproven` for at/before-T source conversation history even when no active delivery/session coupling exists.
- Still invalid: copying source sessions, turns, conversation audits, provider session IDs, transcripts, receipts/outcomes, or source audits into a fork; treating source conversation rows as fork-local runtime truth; using source outcomes as selected-fork suppressors.
- Production paths checked: selected-contract materialization, selected-contract activation, runtime activation gate, historical replay fact matrix, fork-local replay-state guards, and normal runtime selected execution fixture.
- Migration complete for the approved first-slice class. Full session/turn/audit reconstruction, committed replay-scope marker policy, timers/routes/non-agent replay/restart/API remain split under #564/#549.

## Proof
- `go test -run 'TestSelectedContractExecution(MaterializationTreatsSourceConversationHistoryAsLineage|MaterializationKeepsActiveDeliverySessionCouplingFailClosed)|TestPostTSource(SessionFailsClosedBeforeSelectedContractMaterialization|ConversationHistoryFailsClosedForSelectedContractActivation)|TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage|TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversationLineageOwner' ./internal/store ./internal/runtime/runforkexecution -count=1`
- `go test ./internal/store ./internal/runtime/runforkexecution -count=1`
- `go test ./... -count=1`
