### PR TITLE
[agent-a][issue #663] Selected replay-scope marker policy

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3402,8 +3402,10 @@ run_model:
       RunForkPlan or store.run_fork.replay_resume_admission. The store delivery-event replay primitive uses fresh fork
       event IDs, a direct committed replay-scope marker, and run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
       after the fork point, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
-      failed, dead-letter, committed replay-scope, timer, route, session, active-turn, replay, or contract-swap facts
-      would require unsupported historical replay. Activation does not copy source event IDs, replay delivered/completed
+      failed, dead-letter, timer, route, session, active-turn, replay, or contract-swap facts
+      would require unsupported historical replay. Source committed replay-scope marker facts remain fail-closed unless
+      an approved selected-contract marker policy classifies at/before-T markers as lineage/no-action evidence only.
+      Activation does not copy source event IDs, replay delivered/completed
       or receipt-only facts, reconstruct timer, route, session, turn, or contract rows, or recompute recipients from
       current subscriptions.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
@@ -3480,6 +3482,15 @@ run_model:
       creates them remain fail-closed. Post-T source session, turn, and conversation-audit facts remain fail-closed unless
       a separate approved source-advanced/reconstruction owner changes that policy. Committed replay-scope marker policy
       is a split sibling.'
+    selected_contract_committed_replay_scope_marker_policy: 'Mutating selected-contract timestamp-fork execution may
+      consume runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy to
+      classify at/before-fork-T source committed replay-scope marker rows as lineage/no-action evidence only. This policy
+      is selected-contract execution only and is not same-run replay recovery, fork-local delivery-event replay recovery,
+      or generic historical replay. Source marker rows MUST NOT be copied into the fork, reused as fork-local recovery
+      proof, treated as executable fork work, or used as selected-fork suppressors. Fork-local committed replay-scope
+      truth must be freshly written under the fork run_id by selected-contract execution or approved fork-local
+      delivery-event replay owners. Post-T/source-advanced source committed replay-scope marker facts remain fail-closed
+      unless a separate approved source-advanced/reconstruction owner changes that policy.'
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
       runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
@@ -3538,7 +3549,9 @@ run_model:
       run_fork_selected_contract_executions, runs selected handlers through the normal runtime pipeline, writes fork-local
       outcomes, and regenerates emitted follow-ups under the fork run_id. Source events are payload/lineage inputs only;
       source event_deliveries, recipients, receipts, dead letters, retry/idempotency state, and post-fork outcomes MUST
-      NOT become executable fork work or fork suppressors. Route persistence, timer reconstruction, session/turn/audit
+      NOT become executable fork work or fork suppressors. At/before-T source committed replay-scope marker rows may be
+      consumed only as lineage/no-action evidence by the selected-contract marker policy; fork-local recovery must use
+      fresh fork-run marker rows. Route persistence, timer reconstruction, session/turn/audit
       reconstruction, non-agent delivery replay, runtime restart recovery, contract-swap boot/resume beyond selected
       frontier execution, and UI/API ownership remain separately gated siblings.'
     contract_swap_boot_resume_admission: 'Contract-swap boot/resume readiness for timestamp forks is owned by
@@ -3547,8 +3560,9 @@ run_model:
       store.run_fork.replay_resume_admission, selected route topology, selected recipient planning, and fork-local
       selected route recovery evidence before answering whether full boot/resume under selected or swapped contracts is
       allowed. It MUST fail closed with named blockers for source deliveries, receipts, dead letters, retry/idempotency
-      state, post-fork source outcomes, timers, current/source routes, sessions, turns, audits, committed replay-scope
-      rows, non-agent replay, missing selected route recovery, or any missing/stale selected binding/source evidence. It
+      state, post-fork source outcomes, timers, current/source routes, sessions, turns, audits, source committed
+      replay-scope rows not admitted by the selected-contract marker policy, non-agent replay, missing selected route
+      recovery, or any missing/stale selected binding/source evidence. It
       MUST NOT run handlers, create fork-local events or event_deliveries, copy source rows, write receipts, dead
       letters, idempotency state, emitted follow-up events, timers, sessions, turns, route rows, API/UI state, or
       otherwise implement mutating historical replay/resume. CLI, API, dashboard, Builder, route helpers, delivery
@@ -3720,7 +3734,9 @@ run_model:
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
         parents or siblings. At/before-T source session/turn/audit facts may be admitted only as lineage/no-action
-        evidence by the separate selected-contract session/turn/audit lineage policy.'
+        evidence by the separate selected-contract session/turn/audit lineage policy. At/before-T source committed
+        replay-scope marker rows may be admitted only as lineage/no-action evidence by the separate selected-contract
+        committed replay-scope marker policy.'
       3h1_selected_contract_session_turn_audit_lineage_policy: 'For selected-contract timestamp-fork execution,
         runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy consumes the
         canonical replay_resume_admission session_history, active_turn_history, and conversation_audit_history facts and
@@ -3732,6 +3748,16 @@ run_model:
         execution under the fork run_id. This owner does not close full session reconstruction, committed replay-scope
         marker policy, timers, routes, non-agent replay, restart recovery, contract-swap boot/resume, or operator
         surfaces.'
+      3h2_selected_contract_committed_replay_scope_marker_policy: 'For selected-contract timestamp-fork execution,
+        runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy consumes the
+        canonical replay_resume_admission committed_replay_scope fact and may demote at/before-T source committed
+        replay-scope marker rows from fail-closed blockers to lineage/no-action evidence only. Source marker rows are
+        same-run proof only: they are not executable fork work, not fork-local recovery truth, not copied into the fork,
+        and not selected-fork suppressors. Fork-local replay/recovery proof must be newly written under the fork run_id
+        by selected-contract execution or approved fork-local delivery-event replay owners. Post-T/source-advanced source
+        committed replay-scope marker facts remain fail-closed unless a separate approved owner changes that policy. This
+        owner does not close same-run recovery, fork-local delivery-event replay recovery, sessions, turns, audits,
+        timers, routes, non-agent replay, restart recovery, contract-swap boot/resume, or operator surfaces.'
       3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
         readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
         replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -360,6 +360,7 @@ nodes:
       - contract-swap historical replay execution needs runtime.run_fork.historical_replay_execution.contract_swap_boot_resume as the selected-contract child owner for already-admitted delivery_event_replay_ready work; selected recipient planning owns fork recipients, source delivery subscribers are lineage only, and timers/routes/sessions/turns/audits/non-agent/restart/API siblings stay fail-closed or split
       - selected-contract timer reconstruction needs runtime.run_fork.historical_replay_execution.timer_reconstruction plus run-scoped scheduler identity; active source timers are lineage inputs only, reconstructed fork timers must be fresh fork-local rows under fork run_id, and unsupported source timer histories or post-T source timer facts remain fail-closed
       - selected-contract session/turn/audit lineage policy needs runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy to classify at/before-T source agent_sessions, agent_turns, and agent_conversation_audits as lineage/no-action only for selected-contract execution while keeping active delivery/session coupling, post-T source conversation facts, fork-local pre-existing rows, committed replay-scope, and full reconstruction split or fail-closed
+      - selected-contract committed replay-scope marker policy needs runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy to classify at/before-T source committed replay-scope marker rows as lineage/no-action only while keeping source marker copying, fork-local recovery proof reuse, post-T/source-advanced marker facts, same-run recovery, and full replay/resume split or fail-closed
     representative_issues:
       - 564
       - 565
@@ -390,6 +391,7 @@ nodes:
       - 639
       - 642
       - 661
+      - 663
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -71,7 +71,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	if err != nil {
 		return SelectedContractActivationGateResult{}, fmt.Errorf("plan selected-contract activation gate: %w", err)
 	}
-	replayAdmission := store.RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	replayAdmission := store.RunForkSelectedContractReplayResumeAdmission(plan)
 	if len(plan.ReplayResumeAdmission.Dispositions) > 0 || len(plan.ReplayResumeAdmission.UnsupportedBlockers) > 0 {
 		plan.UnsupportedBlockers = replayAdmission.UnsupportedBlockers
 		plan.UnsupportedBlockerCount = len(replayAdmission.UnsupportedBlockers)

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -220,6 +220,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 			RecipientPlanning: *model.RecipientPlanning,
 			SourceRunID:       binding.SourceRunID,
 			ForkRunID:         forkRunID,
+			ForkTime:          plan.ForkPoint.Timestamp,
 			SourceEvents:      sourceEventIDs,
 			ExecutionOwner:    store.RunForkHistoricalReplayContractSwapBootResumeOwner,
 		})

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -145,6 +145,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		RecipientPlanning: *model.RecipientPlanning,
 		SourceRunID:       plan.SourceRunID,
 		ForkRunID:         materialization.ForkRunID,
+		ForkTime:          plan.ForkPoint.Timestamp,
 		SourceEvents:      sourceEventIDs,
 		ExecutionOwner:    store.RunForkSelectedContractExecutionOwner,
 	})
@@ -217,11 +218,15 @@ type publishSelectedContractForkEventsRequest struct {
 	RecipientPlanning store.RunForkSelectedContractRecipientPlanning
 	SourceRunID       string
 	ForkRunID         string
+	ForkTime          time.Time
 	SourceEvents      []string
 	ExecutionOwner    string
 }
 
 func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedContractForkEventsRequest) ([]SelectedContractExecutionForkEvent, error) {
+	if err := req.Store.EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, req.SourceRunID, req.ForkTime); err != nil {
+		return nil, err
+	}
 	sourceEvents, err := req.Store.LoadRunForkSelectedContractSourceEvents(ctx, req.SourceRunID, req.SourceEvents)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -308,6 +308,69 @@ func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSe
 	}
 }
 
+func TestActivateSelectedContractRunForkFailsBeforePublishForPostTReplayScopeMarker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+	selection := runforkadmission.SelectedContractSelection(loaded.Source, contractsRoot)
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002605, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET subscriber_type = 'agent',
+		    subscriber_id = 'source-agent-that-must-not-route',
+		    status = 'pending',
+		    retry_count = 0,
+		    reason_code = 'source_pending_agent_delivery',
+		    active_session_id = NULL,
+		    started_at = NULL,
+		    delivered_at = NULL
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, sourceRunID, sourceEventID); err != nil {
+		t.Fatalf("seed replayable source agent delivery: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                sourceEventID,
+		ContractSelection: &selection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	seedSelectedExecutionSourceReplayScopeMarker(t, db, sourceRunID, sourceEventID, "replay_scope_direct", at.Add(time.Minute))
+
+	result, err := ActivateSelectedContractRunFork(ctx, SelectedContractActivationGateRequest{
+		ForkRunID:    materialized.ForkRunID,
+		Store:        pg,
+		SourceLoader: loader,
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("ActivateSelectedContractRunFork error = %v, want post-T marker blocker", err)
+	}
+	if result.ExecutedEventCount != 0 || len(result.ForkEvents) != 0 || result.Activated {
+		t.Fatalf("result = %#v, want no fork publish before marker block", result)
+	}
+	assertNoForkExecutionRowsForRun(t, db, materialized.ForkRunID)
+}
+
 func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -489,6 +552,72 @@ func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t 
 	if forkLocalMarkers == 0 {
 		t.Fatalf("fork-local replay-scope marker missing for selected execution result")
 	}
+}
+
+func TestExecuteSelectedContractRunForkFailsBeforePublishForPostTReplayScopeMarker(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002320, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	if _, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION seed_post_t_replay_scope_marker_after_route_recovery()
+		RETURNS trigger AS $$
+		BEGIN
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status,
+				retry_count, reason_code, delivered_at, created_at
+			)
+			VALUES (
+				NEW.source_run_id, NEW.fork_event_id, 'node', '__runtime_replay_scope__', 'delivered',
+				0, 'replay_scope_direct', NEW.created_at + interval '1 second', NEW.created_at + interval '1 second'
+			);
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+
+		CREATE TRIGGER seed_post_t_replay_scope_marker_after_route_recovery
+		AFTER INSERT ON run_fork_selected_contract_route_recoveries
+		FOR EACH ROW EXECUTE FUNCTION seed_post_t_replay_scope_marker_after_route_recovery();
+	`); err != nil {
+		t.Fatalf("install post-T marker trigger: %v", err)
+	}
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want post-T marker blocker", err)
+	}
+	if result.ExecutedEventCount != 0 || len(result.ForkEvents) != 0 || result.Activation.Activated {
+		t.Fatalf("result = %#v, want marker block before selected publish", result)
+	}
+	if result.Materialization.ForkRunID == "" {
+		t.Fatalf("expected materialization before post-route marker trigger, got %#v", result.Materialization)
+	}
+	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
 }
 
 func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterialization(t *testing.T) {
@@ -1042,6 +1171,27 @@ func seedSelectedExecutionSourceReplayScopeMarker(t *testing.T, db *sql.DB, sour
 		)
 	`, sourceRunID, sourceEventID, reasonCode, at); err != nil {
 		t.Fatalf("seed source replay-scope marker: %v", err)
+	}
+}
+
+func assertNoForkExecutionRowsForRun(t *testing.T, db *sql.DB, forkRunID string) {
+	t.Helper()
+	ctx := context.Background()
+	for name, query := range map[string]string{
+		"events":                                  `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`,
+		"event_deliveries":                        `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid`,
+		"run_fork_selected_contract_executions":   `SELECT COUNT(*) FROM run_fork_selected_contract_executions WHERE fork_run_id = $1::uuid`,
+		"run_fork_selected_contract_divergences":  `SELECT COUNT(*) FROM run_fork_selected_contract_branch_divergences WHERE fork_run_id = $1::uuid`,
+		"run_fork_selected_contract_route_rows":   `SELECT COUNT(*) FROM run_fork_selected_contract_route_recoveries WHERE fork_run_id = $1::uuid`,
+		"run_fork_delivery_event_replay_lineages": `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`,
+	} {
+		var count int
+		if err := db.QueryRowContext(ctx, query, forkRunID).Scan(&count); err != nil {
+			t.Fatalf("count %s rows: %v", name, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows for blocked selected fork = %d, want 0", name, count)
+		}
 	}
 }
 

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -416,6 +416,81 @@ func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(
 	}
 }
 
+func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002315, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	seedSelectedExecutionSourceReplayScopeMarker(t, db, sourceRunID, sourceEventID, "replay_scope_subscribed", at)
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.Materialization.ForkRunID == "" || !result.Activation.Activated {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	if selectedExecutionResultHasBlocker(result, store.RunForkBlockerCommittedReplayScopeReplayUnsupported) {
+		t.Fatalf("selected execution retained committed replay-scope blocker: materialization=%#v activation=%#v", result.Materialization.UnsupportedBlockers, result.Activation.UnsupportedBlockers)
+	}
+
+	var copiedSourceMarkers int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = '__runtime_replay_scope__'
+		  AND reason_code = 'replay_scope_subscribed'
+		  AND event_id = $2::uuid
+	`, result.Materialization.ForkRunID, sourceEventID).Scan(&copiedSourceMarkers); err != nil {
+		t.Fatalf("count copied source replay-scope markers: %v", err)
+	}
+	if copiedSourceMarkers != 0 {
+		t.Fatalf("copied source replay-scope markers into fork = %d, want 0", copiedSourceMarkers)
+	}
+	var forkLocalMarkers int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = '__runtime_replay_scope__'
+		  AND reason_code IN ('replay_scope_direct', 'replay_scope_subscribed')
+		  AND event_id <> $2::uuid
+	`, result.Materialization.ForkRunID, sourceEventID).Scan(&forkLocalMarkers); err != nil {
+		t.Fatalf("count fork-local replay-scope markers: %v", err)
+	}
+	if forkLocalMarkers == 0 {
+		t.Fatalf("fork-local replay-scope marker missing for selected execution result")
+	}
+}
+
 func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterialization(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -951,6 +1026,22 @@ func seedSourceOutcomeThatMustNotSuppressFork(t *testing.T, db *sql.DB, sourceEv
 		VALUES ($1::uuid, 'item.received', $2::uuid, 'flow-a/1', 'handler_error', 'source dead letter must not suppress fork', 'old-source-node', $3)
 	`, sourceEventID, entityID, at); err != nil {
 		t.Fatalf("seed source dead letter: %v", err)
+	}
+}
+
+func seedSelectedExecutionSourceReplayScopeMarker(t *testing.T, db *sql.DB, sourceRunID, sourceEventID, reasonCode string, at time.Time) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status,
+			retry_count, reason_code, delivered_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'node', '__runtime_replay_scope__', 'delivered',
+			0, $3, $4, $4
+		)
+	`, sourceRunID, sourceEventID, reasonCode, at); err != nil {
+		t.Fatalf("seed source replay-scope marker: %v", err)
 	}
 }
 

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -315,6 +315,16 @@ func historicalReplayEventDeliveriesAdmission(replay store.RunForkReplayResumeAd
 			Message:     "only the existing delivery_event_replay_ready primitive is admitted as future executable fork work; this admission does not create event or delivery rows",
 		}
 	}
+	if disposition, ok := replayDispositionForFact(replay, store.RunForkReplayResumeFactCommittedReplayScope, store.RunForkReplayResumeDispositionLineageOnly); ok &&
+		strings.TrimSpace(disposition.Owner) == store.RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactEventDeliveries,
+			Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+			SourceOwner: store.RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner,
+			Tracker:     "#663",
+			Message:     "at/before-T source committed replay-scope marker rows are lineage/no-action evidence only for selected-contract timestamp forks; fork-local recovery proof must be written under the fork run_id",
+		}
+	}
 	return historicalReplayLineageFact(store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkReplayResumeAdmissionOwner, "source delivery history is lineage/no-op evidence unless the canonical replay taxonomy admits the pending unstarted agent-delivery primitive")
 }
 

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -281,6 +281,48 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversat
 	}
 }
 
+func TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractReplayScopeMarkerOwner(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                   store.RunForkReplayResumeAdmissionOwner,
+		StateOnlyExecutionReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactCommittedReplayScope,
+			Disposition: store.RunForkReplayResumeDispositionLineageOnly,
+			Owner:       store.RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner,
+			Message:     "selected-contract replay-scope marker lineage/no-action evidence",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	item, ok := historicalReplayFactAdmission(admission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries)
+	if !ok {
+		t.Fatalf("missing event_deliveries admission: %#v", admission.FactAdmissions)
+	}
+	if item.Admission != store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence ||
+		item.SourceOwner != store.RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner ||
+		item.Tracker != "#663" {
+		t.Fatalf("event_deliveries admission = %#v, want #663 marker lineage owner", item)
+	}
+}
+
 func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation(t *testing.T) {
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -857,6 +857,17 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 	return blockers
 }
 
+func (s *PostgresStore) EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, sourceRunID string, forkTime time.Time) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	return ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, s.DB, catalog, sourceRunID, forkTime)
+}
+
 func ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) error {
 	if !catalog.hasColumns("event_deliveries", "run_id", "subscriber_type", "subscriber_id", "reason_code") {
 		return nil

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -126,7 +126,7 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
-	replayAdmission := RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	replayAdmission := RunForkSelectedContractReplayResumeAdmission(plan)
 	timerReconstruction, err := s.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
 	if err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
@@ -144,6 +144,20 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	}
 	replayAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(replayAdmission, timerReconstruction)
 	if err := ensureRunForkNoPostForkConversationHistory(ctx, s.DB, catalog, plan.SourceRunID, plan.ForkPoint.Timestamp); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
+			return RunForkMaterialization{
+				SourceRunID:           plan.SourceRunID,
+				ForkPoint:             plan.ForkPoint,
+				ExecutionReady:        false,
+				ReplayResumeAdmission: admission,
+				UnsupportedBlockers:   admission.UnsupportedBlockers,
+				DeliveryResumeBlocked: true,
+			}, err
+		}
+		return RunForkMaterialization{}, err
+	}
+	if err := ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, s.DB, catalog, plan.SourceRunID, plan.ForkPoint.Timestamp); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
 			return RunForkMaterialization{
@@ -302,7 +316,7 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	if err != nil {
 		return result, err
 	}
-	result.ReplayResumeAdmission = RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	result.ReplayResumeAdmission = RunForkSelectedContractReplayResumeAdmission(plan)
 	timerResolved, err := runForkSelectedContractTimerReconstructionComplete(ctx, tx, lineage, plan)
 	if err != nil {
 		return result, err
@@ -313,6 +327,13 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
 	}
 	if err := ensureRunForkNoPostForkConversationHistory(ctx, tx, catalog, lineage.SourceRunID, lineage.ForkEventTime); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
+		return result, err
+	}
+	if err := ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, tx, catalog, lineage.SourceRunID, lineage.ForkEventTime); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
 			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
@@ -792,7 +813,7 @@ func insertRunForkSelectedContractBranchDivergence(ctx context.Context, tx *sql.
 }
 
 func runForkSelectedContractExecutionPlanBlockers(plan RunForkPlan, allowedSourceEventIDs []string) []RunForkUnsupportedBlocker {
-	return runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, RunForkSelectedContractSessionTurnAuditLineageAdmission(plan), allowedSourceEventIDs)
+	return runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, RunForkSelectedContractReplayResumeAdmission(plan), allowedSourceEventIDs)
 }
 
 func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan, admission RunForkReplayResumeAdmission, allowedSourceEventIDs []string) []RunForkUnsupportedBlocker {
@@ -817,6 +838,9 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 			continue
 		}
 		if classification == RunForkPendingClassificationCommittedReplay {
+			if runForkSelectedContractCommittedReplayScopeMarkerAdmitted(admission) {
+				continue
+			}
 			blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(RunForkBlockerCommittedReplayScopeReplayUnsupported))
 			continue
 		}
@@ -831,6 +855,46 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 		}
 	}
 	return blockers
+}
+
+func ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) error {
+	if !catalog.hasColumns("event_deliveries", "run_id", "subscriber_type", "subscriber_id", "reason_code") {
+		return nil
+	}
+	predicates := runForkPostForkCommittedReplayScopeMarkerPredicates(catalog, "created_at", "started_at", "delivered_at")
+	if len(predicates) == 0 {
+		return nil
+	}
+	var exists bool
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE run_id = $1::uuid
+			  AND subscriber_type = $2
+			  AND subscriber_id = $3
+			  AND reason_code = ANY($4::text[])
+			  AND (%s)
+		)
+	`, strings.Join(predicates, " OR "))
+	if err := q.QueryRowContext(ctx, query, sourceRunID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, pq.Array([]string{replayScopeReasonDirect, replayScopeReasonSubscribed}), forkTime).Scan(&exists); err != nil {
+		return fmt.Errorf("check selected-contract source_committed_replay_scope_advanced_after_fork_point: %w", err)
+	}
+	if exists {
+		code := "source_committed_replay_scope_advanced_after_fork_point"
+		return runForkReplayResumeError(code, RunForkReplayResumeFactSourceAdvanced, fmt.Sprintf("selected-contract committed replay-scope marker policy blocked: %s", code))
+	}
+	return nil
+}
+
+func runForkPostForkCommittedReplayScopeMarkerPredicates(catalog schemaColumnCatalog, columns ...string) []string {
+	predicates := []string{}
+	for _, column := range columns {
+		if catalog.hasColumns("event_deliveries", column) {
+			predicates = append(predicates, fmt.Sprintf("%s > $5::timestamptz", column))
+		}
+	}
+	return predicates
 }
 
 func ensureRunForkNoPostForkConversationHistory(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) error {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -116,6 +116,60 @@ func TestSelectedContractExecutionMaterializationTreatsSourceConversationHistory
 	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
 }
 
+func TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		reasonCode string
+	}{
+		{name: "direct", reasonCode: replayScopeReasonDirect},
+		{name: "subscribed", reasonCode: replayScopeReasonSubscribed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &PostgresStore{DB: db}
+			ctx := context.Background()
+			sourceRunID := uuid.NewString()
+			entityID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Unix(1700002415, 0).UTC()
+			seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+			seedSelectedContractSourceReplayScopeMarker(t, db, sourceRunID, eventID, tc.reasonCode, at)
+
+			plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+			if err != nil {
+				t.Fatalf("PlanRunFork: %v", err)
+			}
+			if !runForkTestHasPlanBlocker(plan, RunForkBlockerCommittedReplayScopeReplayUnsupported) {
+				t.Fatalf("plan blockers = %#v, want committed replay-scope blocker", plan.UnsupportedBlockers)
+			}
+
+			materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+				SourceRunID: sourceRunID,
+				At:          eventID,
+				ContractSelection: RunForkContractSelection{
+					Mode:            "selected_contracts",
+					ContractsRoot:   "/tmp/selected-contracts",
+					WorkflowName:    "selected-workflow",
+					WorkflowVersion: "v1",
+				},
+			})
+			if err != nil {
+				t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+			}
+			if materialized.ForkRunID == "" {
+				t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+			}
+			if runForkTestHasMaterializationBlocker(materialized, RunForkBlockerCommittedReplayScopeReplayUnsupported) {
+				t.Fatalf("selected-contract materialization kept committed replay-scope blocker: %#v", materialized.UnsupportedBlockers)
+			}
+			if !runForkTestHasLineageDispositionOwner(materialized.ReplayResumeAdmission, RunForkReplayResumeFactCommittedReplayScope, RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner) {
+				t.Fatalf("admission missing committed replay-scope marker lineage owner: %#v", materialized.ReplayResumeAdmission)
+			}
+			assertNoCopiedReplayScopeMarkers(t, db, materialized.ForkRunID)
+		})
+	}
+}
+
 func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCouplingFailClosed(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -911,6 +965,64 @@ func TestPostTSourceConversationHistoryFailsClosedForSelectedContractActivation(
 	}
 }
 
+func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003625, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+	seedSelectedContractSourceReplayScopeMarker(t, db, sourceRunID, eventID, replayScopeReasonDirect, at.Add(time.Minute))
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{eventID},
+	})
+	if err == nil || !strings.Contains(err.Error(), "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("activation error = %v, want post-T committed replay-scope marker blocker", err)
+	}
+	if activation.Activated || activation.BranchDivergence != nil || activation.SourceAdvancedAfterFork {
+		t.Fatalf("activation = %#v, want marker post-T blocked before branch divergence", activation)
+	}
+	if !runForkTestHasActivationBlocker(activation, "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, want source_committed_replay_scope_advanced_after_fork_point", activation.UnsupportedBlockers)
+	}
+	if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("activation replay admission = %#v, want source advanced marker blocker", activation.ReplayResumeAdmission)
+	}
+
+	var sourceStatus, forkStatus string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {
+		t.Fatalf("load source status: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
+		t.Fatalf("load fork status: %v", err)
+	}
+	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
+		t.Fatalf("run statuses source=%q fork=%q, want source running and fork materialized", sourceStatus, forkStatus)
+	}
+	assertNoCopiedReplayScopeMarkers(t, db, materialized.ForkRunID)
+}
+
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1041,6 +1153,22 @@ func seedSelectedContractSourceConversationHistory(t *testing.T, db execContextD
 	}
 }
 
+func seedSelectedContractSourceReplayScopeMarker(t *testing.T, db execContextDB, sourceRunID, eventID, reasonCode string, at time.Time) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status,
+			retry_count, reason_code, delivered_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3, $4, 'delivered',
+			0, $5, $6, $6
+		)
+	`, sourceRunID, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, reasonCode, at); err != nil {
+		t.Fatalf("seed source replay-scope marker: %v", err)
+	}
+}
+
 func assertNoCopiedConversationRows(t *testing.T, db *sql.DB, forkRunID, sourceSessionID, sourceAuditID, sourceTurnID string) {
 	t.Helper()
 	ctx := context.Background()
@@ -1069,6 +1197,24 @@ func assertNoCopiedConversationRows(t *testing.T, db *sql.DB, forkRunID, sourceS
 		if count != 1 {
 			t.Fatalf("%s fork/copy count = %d, want exactly the original source row only", name, count)
 		}
+	}
+}
+
+func assertNoCopiedReplayScopeMarkers(t *testing.T, db *sql.DB, forkRunID string) {
+	t.Helper()
+	var copied int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+		  AND reason_code IN ($4, $5)
+	`, forkRunID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, replayScopeReasonDirect, replayScopeReasonSubscribed).Scan(&copied); err != nil {
+		t.Fatalf("count copied replay-scope markers: %v", err)
+	}
+	if copied != 0 {
+		t.Fatalf("fork replay-scope marker rows = %d, want 0 copied source markers", copied)
 	}
 }
 

--- a/internal/store/run_fork_selected_contract_replay_scope_marker.go
+++ b/internal/store/run_fork_selected_contract_replay_scope_marker.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+const RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner = "runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy"
+
+// RunForkSelectedContractReplayResumeAdmission applies the selected-contract
+// replay/resume policies that are allowed to reinterpret source-run facts before
+// any selected-contract fork mutation.
+func RunForkSelectedContractReplayResumeAdmission(plan RunForkPlan) RunForkReplayResumeAdmission {
+	return RunForkSelectedContractCommittedReplayScopeMarkerAdmission(
+		RunForkSelectedContractSessionTurnAuditLineageAdmission(plan),
+	)
+}
+
+// RunForkSelectedContractCommittedReplayScopeMarkerAdmission treats at/before-T
+// source committed replay-scope marker rows as lineage/no-action evidence for
+// selected-contract timestamp forks. It does not authorize copying source marker
+// rows or using them as fork-local recovery proof.
+func RunForkSelectedContractCommittedReplayScopeMarkerAdmission(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
+	if strings.TrimSpace(admission.Owner) == "" {
+		admission.Owner = RunForkReplayResumeAdmissionOwner
+	}
+
+	changed := false
+	for i := range admission.Dispositions {
+		disposition := &admission.Dispositions[i]
+		if strings.TrimSpace(disposition.Fact) != RunForkReplayResumeFactCommittedReplayScope {
+			continue
+		}
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		if code := strings.TrimSpace(disposition.BlockerCode); code != "" && code != RunForkBlockerCommittedReplayScopeReplayUnsupported {
+			continue
+		}
+		disposition.Disposition = RunForkReplayResumeDispositionLineageOnly
+		disposition.Owner = RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner
+		disposition.BlockerCode = ""
+		disposition.Classification = ""
+		disposition.Message = fmt.Sprintf("%s classifies at/before-T source committed replay-scope marker rows as selected-contract lineage/no-action evidence only; fork-local recovery proof must be written under the fork run_id by runtime execution or fork-local replay owners", RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner)
+		changed = true
+	}
+	if !changed {
+		return admission
+	}
+
+	filtered := make([]RunForkUnsupportedBlocker, 0, len(admission.UnsupportedBlockers))
+	for _, blocker := range admission.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == RunForkBlockerCommittedReplayScopeReplayUnsupported {
+			continue
+		}
+		filtered = append(filtered, blocker)
+	}
+	admission.UnsupportedBlockers = filtered
+	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
+}
+
+func runForkSelectedContractCommittedReplayScopeMarkerAdmitted(admission RunForkReplayResumeAdmission) bool {
+	for _, disposition := range admission.Dispositions {
+		if strings.TrimSpace(disposition.Fact) != RunForkReplayResumeFactCommittedReplayScope {
+			continue
+		}
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionLineageOnly {
+			continue
+		}
+		if strings.TrimSpace(disposition.Owner) == RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -50,7 +50,7 @@ func runForkPlanHasTimerBlocker(plan RunForkPlan) bool {
 }
 
 func runForkSelectedContractExecutionPlanBlockersWithTimerResolution(plan RunForkPlan, allowedSourceEventIDs []string, timerResolved bool) []RunForkUnsupportedBlocker {
-	admission := RunForkSelectedContractSessionTurnAuditLineageAdmission(plan)
+	admission := RunForkSelectedContractReplayResumeAdmission(plan)
 	if timerResolved {
 		admission = runForkReplayResumeAdmissionWithTimerReconstruction(admission, runForkTimerReconstructionPlan{Required: true})
 	}


### PR DESCRIPTION
Closes #663

## Summary
- Adds `runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy` as the selected-contract timestamp-fork owner for at/before-T source committed replay-scope marker rows.
- Demotes those source marker rows from local selected-contract blockers to lineage/no-action evidence while preserving generic planner fail-closed behavior.
- Fails closed on post-T/source-advanced committed replay-scope marker rows before selected-contract branch divergence, copying, or activation mutation.
- Updates authoritative `platform-spec.yaml` and `docs/watchlists/runtime-operations.yaml` for the #663 marker-policy boundary.

## Governing Refs / Context
- Issue gate: #663, approved as first slice.
- Spec sections updated/consumed: `fork_execution.activation_admission`, `fork_execution.selected_contract_supported_execution`, `fork_execution.selected_contract_committed_replay_scope_marker_policy`, semantics `3h`, `3h2`, `3j`, `3k`, `3k1` in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Parent context remains #564 and #549; sibling split context includes #658, #659, #661, and PR #662.

## Semantic Migration
- New canonical owner: `runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy`.
- Old invalid selected-contract path: `runForkSelectedContractExecutionPlanBlockersFromAdmission` reinterpreting `RunForkPendingClassificationCommittedReplay` as a selected-contract blocker after admission already had enough context to classify marker rows.
- Still-authoritative old paths: generic `store.run_fork.replay_resume_admission`, same-run EventBus/outbox recovery, and fork-local delivery-event replay marker writers remain unchanged.
- Production paths checked for surviving old behavior: generic `PlanRunFork`, selected-contract materialization, selected-contract activation, runtime selected-contract execution, timer-resolution blocker helper, historical replay admission, and activation gate.
- Migration completeness: complete for at/before-T source committed replay-scope marker rows on supported selected-contract timestamp forks. Post-T markers, same-run recovery, fork-local recovery, non-agent replay, timers, routes, sessions/turns/audits, contract swap, and full replay/resume remain split or fail-closed.

## Proof
- `go test -run 'TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage|TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation|TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage|TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractReplayScopeMarkerOwner' ./internal/store ./internal/runtime/runforkexecution -count=1`
- `go test ./internal/store ./internal/runtime/runforkexecution -count=1`
- `go test -run 'TestRunForkPlanner_(ReplayScopeMarkerRemainsCommittedReplayBlocker|ClassifiesPendingWorkAndNamedBlockers)|TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners|TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage|TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint' ./internal/store ./internal/runtime/runforkexecution -count=1`
- `go test ./internal/store ./internal/runtime/runforkexecution -run 'TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage|TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation|TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage' -count=3`
- `go test ./... -count=1`
