### PR TITLE
[agent-b][issue #665] Add v1 RPC transport skeleton

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	apiv1 "swarm/internal/apiv1"
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/config"
 	dashboardserver "swarm/internal/dashboard/server"
@@ -174,7 +175,14 @@ func main() {
 			log.Printf("runtime shutdown failed: %v", err)
 		}
 	}()
-	healthServer := newHealthServer(*healthAddr, &ready, rt.ToolGateway, dashboardServerOptions(supervisor, stores, &ready, cfg.LLM.Session.RotateAfterTurns, credentialStore))
+	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
+		PlatformSpecPath: resolvedPlatformSpecPath,
+		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
+	})
+	if err != nil {
+		log.Fatalf("init v1 api: %v", err)
+	}
+	healthServer := newHealthServer(*healthAddr, &ready, rt.ToolGateway, apiV1Handler, dashboardServerOptions(supervisor, stores, &ready, cfg.LLM.Session.RotateAfterTurns, credentialStore))
 	go serveHealth(healthServer)
 	defer shutdownHealthServer(healthServer)
 
@@ -1447,7 +1455,7 @@ func templateFlowCount(source semanticview.Source) int {
 	return count
 }
 
-func newHealthServer(addr string, ready *atomic.Bool, toolGateway *runtimemcp.Gateway, dashboardOpts dashboardserver.Options) *http.Server {
+func newHealthServer(addr string, ready *atomic.Bool, toolGateway *runtimemcp.Gateway, apiV1Handler http.Handler, dashboardOpts dashboardserver.Options) *http.Server {
 	mux := http.NewServeMux()
 	dashboardHandler := dashboardserver.NewHandler(dashboardOpts)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -1466,6 +1474,10 @@ func newHealthServer(addr string, ready *atomic.Bool, toolGateway *runtimemcp.Ga
 		gatewayHandler := toolGateway.Handler()
 		mux.Handle("/mcp", gatewayHandler)
 		mux.Handle("/tools/", gatewayHandler)
+	}
+	if apiV1Handler != nil {
+		mux.Handle("/v1/rpc", apiV1Handler)
+		mux.Handle("/v1/ws", apiV1Handler)
 	}
 	mux.Handle("/api/", dashboardHandler)
 	mux.Handle("/api", dashboardHandler)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -13,11 +13,13 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	builderpkg "swarm/internal/builder"
+	dashboardserver "swarm/internal/dashboard/server"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebootverify "swarm/internal/runtime/bootverify"
@@ -65,6 +67,48 @@ func (a delayedRunStatusAgent) OnEvent(ctx context.Context, evt events.Event) ([
 		CreatedAt:   time.Now().UTC(),
 	}).WithEntityID(evt.EntityID())
 	return []events.Event{out}, nil
+}
+
+func TestNewHealthServerPreservesProcessProbesAndMountsV1API(t *testing.T) {
+	var ready atomic.Bool
+	var apiHit atomic.Bool
+	apiHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHit.Store(true)
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("api path = %q, want /v1/rpc", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"test","result":{"ok":true}}`))
+	})
+	server := newHealthServer(":0", &ready, nil, apiHandler, dashboardserver.Options{})
+	handler := server.Handler
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "ok" {
+		t.Fatalf("/healthz status/body = %d/%q, want 200 ok", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz before ready status = %d, want 503", rec.Code)
+	}
+	ready.Store(true)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "ready" {
+		t.Fatalf("/readyz ready status/body = %d/%q, want 200 ready", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"test","method":"rpc.unsubscribe","params":{"subscription_id":"sub"}}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/rpc status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !apiHit.Load() {
+		t.Fatal("/v1/rpc did not route to v1 API handler")
+	}
 }
 
 func TestPrintRunStatusReport(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -665,7 +665,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1935,7 +1935,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1973,7 +1973,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2096,7 +2096,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2165,7 +2165,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2298,7 +2298,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2336,7 +2336,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2378,7 +2378,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2582,7 +2582,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2661,7 +2661,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2807,7 +2807,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2845,7 +2845,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2976,7 +2976,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3053,7 +3053,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3288,7 +3288,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3400,7 +3400,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5185,8 +5185,46 @@
           "type": "object"
         }
       },
-      "PAYLOAD_VALIDATION_FAILED": {
+      "METHOD_UNAVAILABLE": {
         "code": -32010,
+        "message": "Application error: METHOD_UNAVAILABLE",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "METHOD_UNAVAILABLE",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "method": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "PAYLOAD_VALIDATION_FAILED": {
+        "code": -32011,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -5244,7 +5282,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5275,7 +5313,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5306,7 +5344,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5344,7 +5382,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -5386,7 +5424,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5424,7 +5462,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5466,7 +5504,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5504,7 +5542,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5960,6 +5960,14 @@ api_specification:
                   type: string
                 message:
                   type: string
+      METHOD_UNAVAILABLE:
+        type: object
+        additionalProperties: false
+        required:
+        - method
+        properties:
+          method:
+            type: string
       RUN_NOT_FOUND:
         type: object
         additionalProperties: false

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -457,6 +457,10 @@ func openRPCApplicationErrorCodes(errors map[string]any) map[string]int {
 	return out
 }
 
+func ApplicationErrorCodes(errors map[string]any) map[string]int {
+	return openRPCApplicationErrorCodes(errors)
+}
+
 func openRPCApplicationErrorCodeCapacity() int {
 	return OpenRPCApplicationErrorCodeStart - OpenRPCApplicationErrorCodeMinimum + 1
 }

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -22,8 +22,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 49 {
 		t.Fatalf("schema count = %d, want 49", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 19 {
-		t.Fatalf("error code count = %d, want 19", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 20 {
+		t.Fatalf("error code count = %d, want 20", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 12 {
 		t.Fatalf("mutating method count = %d, want 12", report.MutatingMethodCount)
@@ -67,8 +67,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 49 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 49", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 19 {
-		t.Fatalf("generated OpenRPC errors = %d, want 19", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 20 {
+		t.Fatalf("generated OpenRPC errors = %d, want 20", len(doc.Components.Errors))
 	}
 }
 

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -252,6 +252,10 @@ func (h *Handler) parseRequest(raw []byte, fallbackCorrelationID string) (Reques
 	if len(bytes.TrimSpace(idRaw)) == 0 {
 		return Request{}, nil, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "id is invalid"})
 	}
+	if !validJSONRPCID(req.ID) {
+		correlationID = requestCorrelationID(nil, req.ID, correlationID)
+		return Request{}, req.ID, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "id must be a string, number, or null"})
+	}
 	correlationID = requestCorrelationID(nil, req.ID, correlationID)
 	method := strings.TrimSpace(req.Method)
 	if method == "" {
@@ -285,6 +289,15 @@ func decodeParams(raw json.RawMessage, correlationID string) (map[string]any, *r
 		params = map[string]any{}
 	}
 	return params, nil
+}
+
+func validJSONRPCID(id any) bool {
+	switch id.(type) {
+	case nil, string, float64, json.Number:
+		return true
+	default:
+		return false
+	}
 }
 
 var opaqueIDPattern = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
@@ -362,14 +375,41 @@ func validateParamValue(descriptor apispec.ContentDescriptor, value any) string 
 				return "must be a boolean"
 			}
 		case "number", "integer":
-			switch value.(type) {
-			case float64, int, int64, json.Number:
-			default:
+			if !isJSONNumber(value) {
 				return "must be a number"
+			}
+			if typ == "integer" && !isJSONInteger(value) {
+				return "must be an integer"
 			}
 		}
 	}
 	return ""
+}
+
+func isJSONNumber(value any) bool {
+	switch typed := value.(type) {
+	case float64:
+		return true
+	case json.Number:
+		_, err := typed.Float64()
+		return err == nil
+	default:
+		return false
+	}
+}
+
+func isJSONInteger(value any) bool {
+	switch typed := value.(type) {
+	case float64:
+		return typed == float64(int64(typed))
+	case json.Number:
+		if _, err := typed.Int64(); err == nil {
+			return true
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 func invalidParams(correlationID string, details any) *rpcError {

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -1,0 +1,514 @@
+package apiv1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"swarm/internal/apispec"
+)
+
+const (
+	jsonRPCVersion = "2.0"
+
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+type Handler struct {
+	registry *Registry
+	tokens   map[string]struct{}
+	handlers map[string]MethodHandler
+	upgrader websocket.Upgrader
+}
+
+type MethodHandler func(context.Context, Request) (any, error)
+
+type Options struct {
+	PlatformSpecPath string
+	Registry         *Registry
+	AuthTokens       []string
+	Handlers         map[string]MethodHandler
+}
+
+type Request struct {
+	ID            any
+	Method        string
+	Params        map[string]any
+	CorrelationID string
+	Transport     string
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string    `json:"jsonrpc"`
+	ID      any       `json:"id"`
+	Result  any       `json:"result,omitempty"`
+	Error   *rpcError `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type standardErrorData struct {
+	CorrelationID string `json:"correlation_id"`
+	Details       any    `json:"details,omitempty"`
+}
+
+type applicationErrorData struct {
+	Code          string `json:"code"`
+	Details       any    `json:"details"`
+	Retryable     bool   `json:"retryable"`
+	CorrelationID string `json:"correlation_id"`
+}
+
+func NewHandler(opts Options) (*Handler, error) {
+	registry := opts.Registry
+	if registry == nil {
+		var err error
+		registry, err = LoadRegistry(opts.PlatformSpecPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	handlers := map[string]MethodHandler{
+		"rpc.unsubscribe": func(context.Context, Request) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	for name, handler := range opts.Handlers {
+		clean := strings.TrimSpace(name)
+		if clean == "" {
+			return nil, errors.New("api handler method name is empty")
+		}
+		if _, ok := registry.Method(clean); !ok {
+			return nil, fmt.Errorf("api handler %s is not in the canonical method catalog", clean)
+		}
+		if handler == nil {
+			return nil, fmt.Errorf("api handler %s is nil", clean)
+		}
+		handlers[clean] = handler
+	}
+	return &Handler{
+		registry: registry,
+		tokens:   tokenSet(opts.AuthTokens),
+		handlers: handlers,
+		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+	}, nil
+}
+
+func AuthTokensFromEnvironment() []string {
+	keys := []string{"SWARM_API_TOKEN", "SWARM_BUILDER_AUTH_TOKEN", "SWARM_OPERATOR_AUTH_TOKEN"}
+	out := make([]string, 0, len(keys))
+	seen := map[string]struct{}{}
+	for _, key := range keys {
+		value := strings.TrimSpace(os.Getenv(key))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h == nil {
+		http.NotFound(w, r)
+		return
+	}
+	switch {
+	case r.Method == http.MethodPost && r.URL != nil && r.URL.Path == "/v1/rpc":
+		h.handleRPC(w, r)
+	case r.Method == http.MethodGet && r.URL != nil && r.URL.Path == "/v1/ws":
+		h.handleWS(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *Handler) handleRPC(w http.ResponseWriter, r *http.Request) {
+	correlationID := requestCorrelationID(r, nil)
+	w.Header().Set("X-Correlation-ID", correlationID)
+	if failure := h.authorize(r); failure != nil {
+		writeAuthFailure(w, failure)
+		return
+	}
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeRPC(w, rpcResponse{JSONRPC: jsonRPCVersion, ID: nil, Error: h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "read body failed"})})
+		return
+	}
+	resp := h.dispatch(r.Context(), raw, "http", correlationID)
+	writeRPC(w, resp)
+}
+
+func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
+	if failure := h.authorize(r); failure != nil {
+		writeAuthFailure(w, failure)
+		return
+	}
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		resp := h.dispatch(r.Context(), raw, "websocket", requestCorrelationID(r, nil))
+		if err := conn.WriteJSON(resp); err != nil {
+			return
+		}
+	}
+}
+
+func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackCorrelationID string) rpcResponse {
+	req, id, correlationID, rpcErr := h.parseRequest(raw, fallbackCorrelationID)
+	if rpcErr != nil {
+		return rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Error: rpcErr}
+	}
+	req.Transport = transport
+	if method, ok := h.registry.Method(req.Method); ok {
+		if rpcErr := validateParams(method, req.Params, req.CorrelationID); rpcErr != nil {
+			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
+		}
+	} else {
+		return rpcResponse{
+			JSONRPC: jsonRPCVersion,
+			ID:      req.ID,
+			Error:   h.standardError(codeMethodNotFound, "method not found", correlationID, map[string]any{"method": req.Method}),
+		}
+	}
+	handler := h.handlers[req.Method]
+	if handler == nil {
+		return rpcResponse{
+			JSONRPC: jsonRPCVersion,
+			ID:      req.ID,
+			Error: h.applicationError(MethodUnavailableCode, req.CorrelationID, false, map[string]any{
+				"method": req.Method,
+			}),
+		}
+	}
+	result, err := handler(ctx, req)
+	if err != nil {
+		return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: h.standardError(codeInternalError, "internal error", req.CorrelationID, map[string]any{"error": err.Error()})}
+	}
+	return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: result}
+}
+
+func (h *Handler) parseRequest(raw []byte, fallbackCorrelationID string) (Request, any, string, *rpcError) {
+	correlationID := strings.TrimSpace(fallbackCorrelationID)
+	if correlationID == "" {
+		correlationID = uuid.NewString()
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return Request{}, nil, correlationID, h.standardError(codeParseError, "parse error", correlationID, map[string]any{"reason": "empty request body"})
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return Request{}, nil, correlationID, h.standardError(codeParseError, "parse error", correlationID, map[string]any{"error": err.Error()})
+	}
+	if object == nil {
+		return Request{}, nil, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "request must be an object"})
+	}
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return Request{}, nil, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"error": err.Error()})
+	}
+	idRaw, hasID := object["id"]
+	if !hasID {
+		return Request{}, nil, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "id is required"})
+	}
+	if strings.TrimSpace(req.JSONRPC) != jsonRPCVersion {
+		return Request{}, req.ID, requestCorrelationID(nil, req.ID, correlationID), h.standardError(codeInvalidRequest, "invalid request", requestCorrelationID(nil, req.ID, correlationID), map[string]any{"reason": "jsonrpc must be 2.0"})
+	}
+	if len(bytes.TrimSpace(idRaw)) == 0 {
+		return Request{}, nil, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "id is invalid"})
+	}
+	correlationID = requestCorrelationID(nil, req.ID, correlationID)
+	method := strings.TrimSpace(req.Method)
+	if method == "" {
+		return Request{}, req.ID, correlationID, h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "method is required"})
+	}
+	params, rpcErr := decodeParams(req.Params, correlationID)
+	if rpcErr != nil {
+		return Request{}, req.ID, correlationID, rpcErr
+	}
+	return Request{
+		ID:            req.ID,
+		Method:        method,
+		Params:        params,
+		CorrelationID: correlationID,
+	}, req.ID, correlationID, nil
+}
+
+func decodeParams(raw json.RawMessage, correlationID string) (map[string]any, *rpcError) {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return map[string]any{}, nil
+	}
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &rpcError{
+			Code:    codeInvalidParams,
+			Message: "invalid params",
+			Data:    standardErrorData{CorrelationID: correlationID, Details: map[string]any{"reason": "params must be an object"}},
+		}
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	return params, nil
+}
+
+var opaqueIDPattern = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
+
+func validateParams(method apispec.Method, params map[string]any, correlationID string) *rpcError {
+	if params == nil {
+		params = map[string]any{}
+	}
+	declared := make(map[string]apispec.ContentDescriptor, len(method.Params))
+	for _, descriptor := range method.Params {
+		declared[descriptor.Name] = descriptor
+		value, exists := params[descriptor.Name]
+		if descriptor.Required && (!exists || isEmptyParam(value)) {
+			return invalidParams(correlationID, map[string]any{
+				"field":  descriptor.Name,
+				"reason": "required parameter is missing",
+			})
+		}
+		if exists && !isEmptyParam(value) {
+			if reason := validateParamValue(descriptor, value); reason != "" {
+				return invalidParams(correlationID, map[string]any{
+					"field":  descriptor.Name,
+					"reason": reason,
+				})
+			}
+		}
+	}
+	for name := range params {
+		if _, ok := declared[name]; !ok {
+			return invalidParams(correlationID, map[string]any{
+				"field":  name,
+				"reason": "unknown parameter",
+			})
+		}
+	}
+	return nil
+}
+
+func validateParamValue(descriptor apispec.ContentDescriptor, value any) string {
+	schema := asStringMap(descriptor.Schema)
+	ref, _ := schema["$ref"].(string)
+	switch ref {
+	case "#/components/schemas/OpaqueId":
+		text, ok := value.(string)
+		if !ok {
+			return "must be a string"
+		}
+		if strings.TrimSpace(text) == "" {
+			return "must not be empty"
+		}
+		if len(text) > 256 {
+			return "must be at most 256 characters"
+		}
+		if !opaqueIDPattern.MatchString(text) {
+			return "must match OpaqueId pattern"
+		}
+		return ""
+	}
+	if typ, _ := schema["type"].(string); typ != "" {
+		switch typ {
+		case "string":
+			if _, ok := value.(string); !ok {
+				return "must be a string"
+			}
+		case "object":
+			if _, ok := value.(map[string]any); !ok {
+				return "must be an object"
+			}
+		case "array":
+			if _, ok := value.([]any); !ok {
+				return "must be an array"
+			}
+		case "boolean":
+			if _, ok := value.(bool); !ok {
+				return "must be a boolean"
+			}
+		case "number", "integer":
+			switch value.(type) {
+			case float64, int, int64, json.Number:
+			default:
+				return "must be a number"
+			}
+		}
+	}
+	return ""
+}
+
+func invalidParams(correlationID string, details any) *rpcError {
+	return &rpcError{
+		Code:    codeInvalidParams,
+		Message: "invalid params",
+		Data:    standardErrorData{CorrelationID: correlationID, Details: details},
+	}
+}
+
+func isEmptyParam(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(typed) == ""
+	default:
+		return false
+	}
+}
+
+func asStringMap(value any) map[string]any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed
+	case map[interface{}]interface{}:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[fmt.Sprint(key)] = value
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func (h *Handler) standardError(code int, message, correlationID string, details any) *rpcError {
+	return &rpcError{
+		Code:    code,
+		Message: message,
+		Data: standardErrorData{
+			CorrelationID: strings.TrimSpace(correlationID),
+			Details:       details,
+		},
+	}
+}
+
+func (h *Handler) applicationError(code, correlationID string, retryable bool, details any) *rpcError {
+	numeric, ok := h.registry.ApplicationErrorCode(code)
+	if !ok {
+		return h.standardError(codeInternalError, "internal error", correlationID, map[string]any{"missing_application_error": code})
+	}
+	return &rpcError{
+		Code:    numeric,
+		Message: "Application error: " + code,
+		Data: applicationErrorData{
+			Code:          code,
+			Details:       details,
+			Retryable:     retryable,
+			CorrelationID: correlationID,
+		},
+	}
+}
+
+type authFailure struct {
+	status  int
+	message string
+}
+
+func (h *Handler) authorize(r *http.Request) *authFailure {
+	if len(h.tokens) == 0 {
+		return &authFailure{status: http.StatusServiceUnavailable, message: "v1 API auth is not configured"}
+	}
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authz == "" {
+		return &authFailure{status: http.StatusUnauthorized, message: "missing authorization bearer token"}
+	}
+	const prefix = "bearer "
+	if !strings.HasPrefix(strings.ToLower(authz), prefix) {
+		return &authFailure{status: http.StatusUnauthorized, message: "invalid authorization header"}
+	}
+	if _, ok := h.tokens[strings.TrimSpace(authz[len(prefix):])]; !ok {
+		return &authFailure{status: http.StatusUnauthorized, message: "invalid bearer token"}
+	}
+	return nil
+}
+
+func writeAuthFailure(w http.ResponseWriter, failure *authFailure) {
+	if failure == nil {
+		return
+	}
+	if failure.status == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="swarm-api"`)
+	}
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(failure.status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": failure.message})
+}
+
+func writeRPC(w http.ResponseWriter, resp rpcResponse) {
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func requestCorrelationID(r *http.Request, id any, fallback ...string) string {
+	if r != nil {
+		for _, header := range []string{"X-Correlation-ID", "X-Request-ID"} {
+			if value := strings.TrimSpace(r.Header.Get(header)); value != "" {
+				return value
+			}
+		}
+	}
+	switch typed := id.(type) {
+	case string:
+		if strings.TrimSpace(typed) != "" {
+			return strings.TrimSpace(typed)
+		}
+	case json.Number:
+		if strings.TrimSpace(typed.String()) != "" {
+			return strings.TrimSpace(typed.String())
+		}
+	case float64:
+		return fmt.Sprintf("%v", typed)
+	}
+	for _, value := range fallback {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return uuid.NewString()
+}
+
+func tokenSet(tokens []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, token := range tokens {
+		if token = strings.TrimSpace(token); token != "" {
+			out[token] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -1,0 +1,283 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+const testToken = "test-v1-token"
+
+func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
+	registry := testRegistry(t)
+	openRPCNames, err := OpenRPCMethodNames(filepath.Join(repoRoot(t), "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json"))
+	if err != nil {
+		t.Fatalf("OpenRPCMethodNames() error = %v", err)
+	}
+	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
+		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
+	}
+	if len(openRPCNames) != 36 {
+		t.Fatalf("method count = %d, want 36", len(openRPCNames))
+	}
+	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
+		t.Fatal("rpc.unsubscribe missing from generated registry")
+	}
+}
+
+func TestNewHandlerRejectsHandlersOutsideCanonicalCatalog(t *testing.T) {
+	_, err := NewHandler(Options{
+		Registry:   testRegistry(t),
+		AuthTokens: []string{testToken},
+		Handlers: map[string]MethodHandler{
+			"not.in.catalog": func(context.Context, Request) (any, error) {
+				return nil, nil
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not in the canonical method catalog") {
+		t.Fatalf("NewHandler() error = %v, want canonical catalog rejection", err)
+	}
+}
+
+func TestAuthTokensFromEnvironmentPrefersUnifiedTokenAndDeduplicatesLegacyFallbacks(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "api")
+	t.Setenv("SWARM_BUILDER_AUTH_TOKEN", "legacy")
+	t.Setenv("SWARM_OPERATOR_AUTH_TOKEN", "legacy")
+
+	got := AuthTokensFromEnvironment()
+	want := []string{"api", "legacy"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AuthTokensFromEnvironment() = %v, want %v", got, want)
+	}
+}
+
+func TestHandlerHTTPAuthBoundary(t *testing.T) {
+	cases := []struct {
+		name       string
+		tokens     []string
+		authHeader string
+		wantStatus int
+		wantWWW    bool
+	}{
+		{name: "auth not configured", tokens: nil, authHeader: "Bearer " + testToken, wantStatus: http.StatusServiceUnavailable},
+		{name: "missing auth", tokens: []string{testToken}, wantStatus: http.StatusUnauthorized, wantWWW: true},
+		{name: "malformed auth", tokens: []string{testToken}, authHeader: "Basic nope", wantStatus: http.StatusUnauthorized, wantWWW: true},
+		{name: "invalid bearer", tokens: []string{testToken}, authHeader: "Bearer wrong", wantStatus: http.StatusUnauthorized, wantWWW: true},
+		{name: "valid bearer", tokens: []string{testToken}, authHeader: "Bearer " + testToken, wantStatus: http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := testHandler(t, Options{AuthTokens: tc.tokens})
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"auth","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`))
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantWWW && !strings.Contains(rec.Header().Get("WWW-Authenticate"), "Bearer") {
+				t.Fatalf("WWW-Authenticate = %q, want bearer challenge", rec.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+func TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: map[string]MethodHandler{
+			"health.ping": func(context.Context, Request) (any, error) {
+				return nil, errors.New("boom")
+			},
+		},
+	})
+
+	tests := []struct {
+		name      string
+		body      string
+		headerCID string
+		wantCode  int
+		wantApp   string
+		wantOK    bool
+	}{
+		{name: "parse error", body: `{`, wantCode: codeParseError},
+		{name: "invalid request", body: `{"jsonrpc":"2.0","method":"rpc.unsubscribe"}`, wantCode: codeInvalidRequest},
+		{name: "method not found", body: `{"jsonrpc":"2.0","id":"missing","method":"missing.method","params":{}}`, wantCode: codeMethodNotFound},
+		{name: "invalid params object", body: `{"jsonrpc":"2.0","id":"bad-params-object","method":"rpc.unsubscribe","params":["sub-1"]}`, wantCode: codeInvalidParams},
+		{name: "invalid params required", body: `{"jsonrpc":"2.0","id":"bad-params-required","method":"rpc.unsubscribe","params":{}}`, wantCode: codeInvalidParams},
+		{name: "known business method unavailable", body: `{"jsonrpc":"2.0","id":"known","method":"run.list","params":{}}`, wantApp: MethodUnavailableCode},
+		{name: "internal error", body: `{"jsonrpc":"2.0","id":"internal","method":"health.ping","params":{}}`, wantCode: codeInternalError},
+		{name: "unsubscribe success", body: `{"jsonrpc":"2.0","id":"ok","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, headerCID: "trace-123", wantOK: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			if tc.headerCID != "" {
+				req.Header.Set("X-Correlation-ID", tc.headerCID)
+			}
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+			}
+			var resp rpcResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode rpc response: %v body=%s", err, rec.Body.String())
+			}
+			if tc.wantOK {
+				if resp.Error != nil {
+					t.Fatalf("error = %#v, want success", resp.Error)
+				}
+				result, ok := resp.Result.(map[string]any)
+				if !ok || result["ok"] != true {
+					t.Fatalf("result = %#v, want ok true", resp.Result)
+				}
+				if got := rec.Header().Get("X-Correlation-ID"); got != tc.headerCID {
+					t.Fatalf("X-Correlation-ID = %q, want %q", got, tc.headerCID)
+				}
+				return
+			}
+			if resp.Error == nil {
+				t.Fatalf("error = nil, want code/app error")
+			}
+			if tc.wantApp != "" {
+				data := asMap(t, resp.Error.Data)
+				if got := data["code"]; got != tc.wantApp {
+					t.Fatalf("application data.code = %v, want %s", got, tc.wantApp)
+				}
+				if _, ok := data["correlation_id"].(string); !ok {
+					t.Fatalf("application data missing correlation_id: %#v", data)
+				}
+				return
+			}
+			if resp.Error.Code != tc.wantCode {
+				t.Fatalf("error code = %d, want %d body=%s", resp.Error.Code, tc.wantCode, rec.Body.String())
+			}
+			data := asMap(t, resp.Error.Data)
+			if _, ok := data["correlation_id"].(string); !ok {
+				t.Fatalf("standard error data missing correlation_id: %#v", data)
+			}
+		})
+	}
+}
+
+func TestHandlerWebSocketAuthAndFrameValidation(t *testing.T) {
+	server := httptest.NewServer(testHandler(t, Options{AuthTokens: []string{testToken}}))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/ws"
+
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		t.Fatal("missing auth websocket dial unexpectedly succeeded")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing auth upgrade response = %#v, want 401", resp)
+	}
+
+	_, resp, err = websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer wrong"}})
+	if err == nil {
+		t.Fatal("invalid auth websocket dial unexpectedly succeeded")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("invalid auth upgrade response = %#v, want 401", resp)
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer " + testToken}})
+	if err != nil {
+		t.Fatalf("valid websocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{`)); err != nil {
+		t.Fatalf("write invalid frame: %v", err)
+	}
+	var invalid rpcResponse
+	if err := conn.ReadJSON(&invalid); err != nil {
+		t.Fatalf("read invalid-frame response: %v", err)
+	}
+	if invalid.Error == nil || invalid.Error.Code != codeParseError {
+		t.Fatalf("invalid-frame error = %#v, want parse error", invalid.Error)
+	}
+
+	if err := conn.WriteJSON(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "ws-ok",
+		"method":  "rpc.unsubscribe",
+		"params": map[string]any{
+			"subscription_id": "sub-1",
+		},
+	}); err != nil {
+		t.Fatalf("write unsubscribe: %v", err)
+	}
+	var ok rpcResponse
+	if err := conn.ReadJSON(&ok); err != nil {
+		t.Fatalf("read unsubscribe response: %v", err)
+	}
+	if ok.Error != nil {
+		t.Fatalf("unsubscribe error = %#v, want success", ok.Error)
+	}
+	if result := asMap(t, ok.Result); result["ok"] != true {
+		t.Fatalf("unsubscribe result = %#v, want ok true", ok.Result)
+	}
+}
+
+func testHandler(t *testing.T, opts Options) *Handler {
+	t.Helper()
+	opts.Registry = testRegistry(t)
+	handler, err := NewHandler(opts)
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	return handler
+}
+
+func testRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registry, err := LoadRegistry(filepath.Join(repoRoot(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+	if err != nil {
+		t.Fatalf("LoadRegistry() error = %v", err)
+	}
+	return registry
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root with go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func asMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	out, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("value = %#v, want map[string]any", value)
+	}
+	return out
+}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -115,9 +115,13 @@ func TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics(t *testing.T) {
 	}{
 		{name: "parse error", body: `{`, wantCode: codeParseError},
 		{name: "invalid request", body: `{"jsonrpc":"2.0","method":"rpc.unsubscribe"}`, wantCode: codeInvalidRequest},
+		{name: "invalid request object id", body: `{"jsonrpc":"2.0","id":{},"method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, wantCode: codeInvalidRequest},
+		{name: "invalid request array id", body: `{"jsonrpc":"2.0","id":[],"method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, wantCode: codeInvalidRequest},
+		{name: "invalid request boolean id", body: `{"jsonrpc":"2.0","id":true,"method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, wantCode: codeInvalidRequest},
 		{name: "method not found", body: `{"jsonrpc":"2.0","id":"missing","method":"missing.method","params":{}}`, wantCode: codeMethodNotFound},
 		{name: "invalid params object", body: `{"jsonrpc":"2.0","id":"bad-params-object","method":"rpc.unsubscribe","params":["sub-1"]}`, wantCode: codeInvalidParams},
 		{name: "invalid params required", body: `{"jsonrpc":"2.0","id":"bad-params-required","method":"rpc.unsubscribe","params":{}}`, wantCode: codeInvalidParams},
+		{name: "invalid integer param", body: `{"jsonrpc":"2.0","id":"bad-integer","method":"run.list","params":{"limit":1.5}}`, wantCode: codeInvalidParams},
 		{name: "known business method unavailable", body: `{"jsonrpc":"2.0","id":"known","method":"run.list","params":{}}`, wantApp: MethodUnavailableCode},
 		{name: "internal error", body: `{"jsonrpc":"2.0","id":"internal","method":"health.ping","params":{}}`, wantCode: codeInternalError},
 		{name: "unsubscribe success", body: `{"jsonrpc":"2.0","id":"ok","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, headerCID: "trace-123", wantOK: true},

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -1,0 +1,94 @@
+package apiv1
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"swarm/internal/apispec"
+)
+
+const MethodUnavailableCode = "METHOD_UNAVAILABLE"
+
+type Registry struct {
+	api        *apispec.APISpecification
+	methods    map[string]apispec.Method
+	errorCodes map[string]int
+}
+
+func LoadRegistry(platformSpecPath string) (*Registry, error) {
+	api, err := apispec.LoadPlatformSpec(strings.TrimSpace(platformSpecPath))
+	if err != nil {
+		return nil, err
+	}
+	if _, err := apispec.Validate(api); err != nil {
+		return nil, err
+	}
+	return NewRegistry(api)
+}
+
+func NewRegistry(api *apispec.APISpecification) (*Registry, error) {
+	if _, err := apispec.Validate(api); err != nil {
+		return nil, err
+	}
+	methods := make(map[string]apispec.Method, len(api.MethodCatalog))
+	for name, method := range api.MethodCatalog {
+		methods[strings.TrimSpace(name)] = method
+	}
+	errorCodes := apispec.ApplicationErrorCodes(api.Components.Errors)
+	if _, ok := errorCodes[MethodUnavailableCode]; !ok {
+		return nil, fmt.Errorf("api specification missing components.errors.%s", MethodUnavailableCode)
+	}
+	return &Registry{
+		api:        api,
+		methods:    methods,
+		errorCodes: errorCodes,
+	}, nil
+}
+
+func (r *Registry) Method(name string) (apispec.Method, bool) {
+	if r == nil {
+		return apispec.Method{}, false
+	}
+	method, ok := r.methods[strings.TrimSpace(name)]
+	return method, ok
+}
+
+func (r *Registry) MethodNames() []string {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.methods))
+	for name := range r.methods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (r *Registry) ApplicationErrorCode(code string) (int, bool) {
+	if r == nil {
+		return 0, false
+	}
+	numeric, ok := r.errorCodes[strings.TrimSpace(code)]
+	return numeric, ok
+}
+
+func OpenRPCMethodNames(path string) ([]string, error) {
+	raw, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return nil, err
+	}
+	var doc apispec.OpenRPCDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse openrpc: %w", err)
+	}
+	names := make([]string, 0, len(doc.Methods))
+	for _, method := range doc.Methods {
+		names = append(names, strings.TrimSpace(method.Name))
+	}
+	sort.Strings(names)
+	return names, nil
+}


### PR DESCRIPTION
## Summary

Part of #665.

Implements Slice 2's bounded v1 protocol skeleton:

- adds `/v1/rpc` JSON-RPC and `/v1/ws` WebSocket admission through a shared `internal/apiv1` handler
- loads method metadata from canonical `platform-spec.yaml.api_specification` via `internal/apispec`, with parity against generated `openrpc.json`
- wires bearer auth from `SWARM_API_TOKEN` with documented legacy token fallback, JSON-RPC standard errors, application error data shape, correlation IDs, and descriptor-backed params validation
- preserves unauthenticated `/healthz` and `/readyz` probes and mounts v1 next to existing legacy `/api/*` adapter surfaces

## Governing Context

Exact governing refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` → `api_specification` foundations, auth, error format, method catalog, and `rpc.unsubscribe`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` → generated artifact from the authoritative spec
- #665 Slice 2 pre-audit and independent gate comment
- `docs/IMPLEMENTER_GUIDELINES.md`
- `docs/SEMANTIC_DRIFT.md`

## Migration/Ownership

New canonical owner: `platform-spec.yaml.api_specification` consumed by `internal/apispec` and `internal/apiv1.Registry`.

Old producer/reader/writer paths now invalid as v1 owners: legacy builder/dashboard RPC switches and route handlers remain live only as legacy adapter surfaces; they are not used as the v1 registry or method catalog.

Production paths checked for surviving old behavior: `/v1/rpc`, `/v1/ws`, `/healthz`, `/readyz`, existing `/api/*` mounting order, generated OpenRPC parity, and known-catalog unimplemented method handling.

Migration completeness: complete for Slice 2 transport/registry skeleton only. Business method handlers, idempotency store, real subscriptions, CLI/dashboard migration, and legacy adapter migration remain later #665 slices.

## Tests

- `go test ./internal/apiv1 -count=1`
- `go test ./internal/apispec ./cmd/swarm-openrpc-gen -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./cmd/swarm -run TestNewHealthServerPreservesProcessProbesAndMountsV1API -count=1`
- `go test ./internal/apiv1 ./internal/apispec ./cmd/swarm ./cmd/swarm-openrpc-gen -count=1`
- `go test ./... -count=1`