### PR TITLE
[agent-a][issue #668] Admit diagnostic platform outcomes as fork lineage

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -595,8 +595,10 @@ func TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *tes
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
+	diagnosticEventID := uuid.NewString()
 	at := time.Unix(1700000312, 0).UTC()
 	seedRunForkCLISelectedExecutionSource(t, db, sourceRunID, entityID, sourceEventID, at)
+	seedRunForkCLISelectedExecutionDiagnosticPlatformDeadLetter(t, db, sourceRunID, diagnosticEventID, at.Add(-time.Second))
 
 	var buf bytes.Buffer
 	code := runForkCommand(context.Background(), repo, []string{
@@ -632,6 +634,34 @@ func TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *tes
 	}
 	if lineageRows != 1 {
 		t.Fatalf("selected execution lineage rows = %d, want 1", lineageRows)
+	}
+	var diagnosticCopies int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND (
+			event_id = $2::uuid
+			OR COALESCE(source_event_id::text, '') = $2::text
+			OR event_name = 'platform.runtime_log'
+		  )
+	`, result.Materialization.ForkRunID, diagnosticEventID).Scan(&diagnosticCopies); err != nil {
+		t.Fatalf("count copied diagnostic platform events: %v", err)
+	}
+	if diagnosticCopies != 0 {
+		t.Fatalf("diagnostic platform events copied into fork = %d, want 0", diagnosticCopies)
+	}
+	var diagnosticLineageRows int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+		  AND source_event_id = $2::uuid
+	`, result.Materialization.ForkRunID, diagnosticEventID).Scan(&diagnosticLineageRows); err != nil {
+		t.Fatalf("count diagnostic selected execution lineage: %v", err)
+	}
+	if diagnosticLineageRows != 0 {
+		t.Fatalf("diagnostic platform execution lineage rows = %d, want 0", diagnosticLineageRows)
 	}
 }
 
@@ -1116,6 +1146,36 @@ func seedRunForkCLISelectedExecutionSource(t *testing.T, db interface {
 		)
 	`, runID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
+	}
+}
+
+func seedRunForkCLISelectedExecutionDiagnosticPlatformDeadLetter(t *testing.T, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, runID, eventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'platform.runtime_log', NULL, NULL, 'global',
+			'{"level":"info","message":"diagnostic platform row must remain lineage-only"}'::jsonb,
+			'pipeline', 'platform', $3
+		)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed diagnostic platform event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES (
+			$1::uuid, 'platform', 'pipeline', NULL, NULL,
+			'dead_letter', 'runtime_log_pipeline_dead_letter', '{}'::jsonb, $2
+		)
+	`, eventID, at); err != nil {
+		t.Fatalf("seed diagnostic platform receipt: %v", err)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3491,6 +3491,16 @@ run_model:
       truth must be freshly written under the fork run_id by selected-contract execution or approved fork-local
       delivery-event replay owners. Post-T/source-advanced source committed replay-scope marker facts remain fail-closed
       unless a separate approved source-advanced/reconstruction owner changes that policy.'
+    selected_contract_diagnostic_platform_outcome_policy: 'Mutating selected-contract timestamp-fork execution may consume
+      runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy to classify
+      at/before-fork-T source outcome facts for spec-declared diagnostic/non-routed platform events as lineage/no-action
+      evidence only. The diagnostic event set is defined by platform_events.routing_rules.diagnostic_events, currently
+      platform.runtime_log and platform.inbound_recorded. This policy is selected-contract frontier admission only. It
+      MUST NOT route diagnostic platform events through selected contracts, synthesize selected recipients, copy source
+      events, event_deliveries, event_receipts, or dead_letters into the fork, use diagnostic source outcomes as
+      selected-fork suppressors, change generic non-agent/dead-letter replay policy, or make CLI, API, dashboard, or
+      Builder surfaces semantic owners. Non-diagnostic platform/node/system event outcomes remain fail-closed or split
+      unless a separate approved owner changes that policy.'
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
       runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
@@ -3551,7 +3561,9 @@ run_model:
       source event_deliveries, recipients, receipts, dead letters, retry/idempotency state, and post-fork outcomes MUST
       NOT become executable fork work or fork suppressors. At/before-T source committed replay-scope marker rows may be
       consumed only as lineage/no-action evidence by the selected-contract marker policy; fork-local recovery must use
-      fresh fork-run marker rows. Route persistence, timer reconstruction, session/turn/audit
+      fresh fork-run marker rows. At/before-T source outcome facts for spec-declared diagnostic/non-routed platform
+      events may be consumed only as lineage/no-action evidence by the selected-contract diagnostic platform outcome
+      policy. Route persistence, timer reconstruction, session/turn/audit
       reconstruction, non-agent delivery replay, runtime restart recovery, contract-swap boot/resume beyond selected
       frontier execution, and UI/API ownership remain separately gated siblings.'
     contract_swap_boot_resume_admission: 'Contract-swap boot/resume readiness for timestamp forks is owned by
@@ -3758,6 +3770,16 @@ run_model:
         committed replay-scope marker facts remain fail-closed unless a separate approved owner changes that policy. This
         owner does not close same-run recovery, fork-local delivery-event replay recovery, sessions, turns, audits,
         timers, routes, non-agent replay, restart recovery, contract-swap boot/resume, or operator surfaces.'
+      3h3_selected_contract_diagnostic_platform_outcome_policy: 'For selected-contract timestamp-fork execution,
+        runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy consumes
+        at/before-T source outcome facts for platform_events.routing_rules.diagnostic_events and may demote those
+        diagnostic/non-routed platform facts from selected frontier work to lineage/no-action evidence only. The owner is
+        part of selected-contract frontier admission before route topology, recipient planning, and selected execution.
+        Diagnostic platform source facts are not executable fork work, route truth, selected recipients, copied source
+        rows, source outcome suppressors, or operator-surface truth. Non-diagnostic platform/node/system outcome facts,
+        generic non-agent replay, delivery-event replay, committed replay-scope marker policy, sessions, turns, audits,
+        timers, routes, retry/idempotency, follow-up policy, restart recovery, contract-swap boot/resume, and operator
+        surfaces remain separate fail-closed or split siblings unless independently approved.'
       3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
         readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
         replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -200,6 +200,11 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 668
+    title: Gate selected-contract diagnostic platform dead-letter lineage/no-action policy
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -296,6 +301,7 @@ nodes:
       - historical replay delivery/event replay mutation must be owned by runtime.run_fork.historical_replay_execution consuming event_deliveries executable-fork-work admission before the store delivery replay primitive writes fork-local rows
       - historical replay delivery/event replay restart and sweeper recovery must consume #633 fork-local event, delivery, and committed replay-scope rows through the persisted replay owner; source deliveries, current subscriptions, source receipts, and source dead letters are not recovery truth or suppressors
       - contract-swap historical replay execution must consume runtime.run_fork.historical_replay_execution plus selected recipient planning before EventBus.Publish writes selected fork deliveries; source delivery subscribers remain lineage only and store.run_fork.delivery_event_replay is not sufficient for selected recipient truth
+      - selected-contract diagnostic/non-routed platform event outcome facts such as platform.runtime_log and platform.inbound_recorded are lineage/no-action evidence under frontier admission; they are not routed, copied, replayed, or used as selected-fork suppressors, while non-diagnostic platform/node/system outcomes remain split or fail-closed
     representative_issues:
       - 112
       - 144
@@ -313,6 +319,7 @@ nodes:
       - 633
       - 635
       - 639
+      - 668
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -361,6 +368,7 @@ nodes:
       - selected-contract timer reconstruction needs runtime.run_fork.historical_replay_execution.timer_reconstruction plus run-scoped scheduler identity; active source timers are lineage inputs only, reconstructed fork timers must be fresh fork-local rows under fork run_id, and unsupported source timer histories or post-T source timer facts remain fail-closed
       - selected-contract session/turn/audit lineage policy needs runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy to classify at/before-T source agent_sessions, agent_turns, and agent_conversation_audits as lineage/no-action only for selected-contract execution while keeping active delivery/session coupling, post-T source conversation facts, fork-local pre-existing rows, committed replay-scope, and full reconstruction split or fail-closed
       - selected-contract committed replay-scope marker policy needs runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy to classify at/before-T source committed replay-scope marker rows as lineage/no-action only while keeping source marker copying, fork-local recovery proof reuse, post-T/source-advanced marker facts, same-run recovery, and full replay/resume split or fail-closed
+      - selected-contract diagnostic platform outcome policy needs runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy to classify at/before-T source platform.runtime_log/platform.inbound_recorded outcome facts as lineage/no-action before route topology, recipient planning, and selected execution, while preserving real frontier unresolved-route blockers and generic non-agent/dead-letter replay blockers
     representative_issues:
       - 564
       - 565
@@ -392,6 +400,7 @@ nodes:
       - 642
       - 661
       - 663
+      - 668
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -58,7 +58,7 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract workflow nodes: %w", err)
 	}
 
-	frontier := runForkFrontierEvents(req.Plan.PendingWork)
+	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
 	for i := range frontier {
 		eventName := frontier[i].EventName
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
@@ -96,11 +96,12 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 		HistoricalExecutionSupported: false,
 		FrontierEventCount:           len(frontier),
 		FrontierEvents:               frontier,
+		LineageOnlyEvents:            lineageOnly,
 		UnsupportedBlockers:          blockers,
 	}, nil
 }
 
-func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkContractFrontierEvent {
+func runForkFrontierEvents(pending []store.RunForkPendingWork) ([]store.RunForkContractFrontierEvent, []store.RunForkContractFrontierLineageEvent) {
 	type aggregate struct {
 		event           store.RunForkContractFrontierEvent
 		classifications map[string]struct{}
@@ -108,7 +109,15 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkCo
 		subscriberTypes map[string]struct{}
 		subscriberIDs   map[string]struct{}
 	}
+	type lineageAggregate struct {
+		event           store.RunForkContractFrontierLineageEvent
+		classifications map[string]struct{}
+		flowInstances   map[string]struct{}
+		subscriberTypes map[string]struct{}
+		subscriberIDs   map[string]struct{}
+	}
 	byEvent := map[string]*aggregate{}
+	lineageByEvent := map[string]*lineageAggregate{}
 	for _, item := range pending {
 		switch strings.TrimSpace(item.Classification) {
 		case store.RunForkPendingClassificationDeliveredCompleted, store.RunForkPendingClassificationCommittedReplay:
@@ -116,6 +125,30 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkCo
 		}
 		eventID := strings.TrimSpace(item.EventID)
 		if eventID == "" {
+			continue
+		}
+		if store.RunForkSelectedContractDiagnosticPlatformOutcomePolicyApplies(item) {
+			agg := lineageByEvent[eventID]
+			if agg == nil {
+				agg = &lineageAggregate{
+					event: store.RunForkContractFrontierLineageEvent{
+						SourceEventID: eventID,
+						EventName:     strings.TrimSpace(item.EventName),
+						Owner:         store.RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner,
+						Disposition:   store.RunForkContractFrontierDispositionLineageNoAction,
+						Reason:        "spec-declared diagnostic platform outcome facts are persisted for lineage and are not selected-contract frontier work",
+					},
+					classifications: map[string]struct{}{},
+					flowInstances:   map[string]struct{}{},
+					subscriberTypes: map[string]struct{}{},
+					subscriberIDs:   map[string]struct{}{},
+				}
+				lineageByEvent[eventID] = agg
+			}
+			addString(agg.classifications, item.Classification)
+			addString(agg.flowInstances, item.FlowInstance)
+			addString(agg.subscriberTypes, item.SubscriberType)
+			addString(agg.subscriberIDs, item.SubscriberID)
 			continue
 		}
 		agg := byEvent[eventID]
@@ -145,7 +178,21 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) []store.RunForkCo
 		agg.event.SourceSubscriberIDs = sortedSet(agg.subscriberIDs)
 		out = append(out, agg.event)
 	}
-	return out
+	lineage := make([]store.RunForkContractFrontierLineageEvent, 0, len(lineageByEvent))
+	for _, agg := range lineageByEvent {
+		agg.event.SourceClassifications = sortedSet(agg.classifications)
+		agg.event.SourceFlowInstances = sortedSet(agg.flowInstances)
+		agg.event.SourceSubscriberTypes = sortedSet(agg.subscriberTypes)
+		agg.event.SourceSubscriberIDs = sortedSet(agg.subscriberIDs)
+		lineage = append(lineage, agg.event)
+	}
+	sort.Slice(lineage, func(i, j int) bool {
+		if lineage[i].EventName != lineage[j].EventName {
+			return lineage[i].EventName < lineage[j].EventName
+		}
+		return lineage[i].SourceEventID < lineage[j].SourceEventID
+	})
+	return out, lineage
 }
 
 func installContractFrontierFlowInstanceRoutes(routeTable *runtimebus.RouteTable, source semanticview.Source, pending []store.RunForkPendingWork) error {

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -121,6 +121,95 @@ func TestAdmitContractFrontier_CommittedReplayScopeMarkersAreNotFrontierWork(t *
 	}
 }
 
+func TestAdmitContractFrontier_DiagnosticPlatformOutcomesAreLineageOnly(t *testing.T) {
+	for _, eventName := range []string{"platform.runtime_log", "platform.inbound_recorded"} {
+		t.Run(eventName, func(t *testing.T) {
+			plan := testRunForkPlan(eventName, store.RunForkPendingClassificationDeadLetter, "platform", "pipeline")
+			source := testContractFrontierSource("consumer-node")
+
+			admission, err := AdmitContractFrontier(ContractFrontierRequest{
+				Plan:              plan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+			})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier: %v", err)
+			}
+			if admission.FrontierEventCount != 0 || len(admission.FrontierEvents) != 0 {
+				t.Fatalf("frontier events = %#v, want none for diagnostic platform outcome", admission.FrontierEvents)
+			}
+			if len(admission.UnsupportedBlockers) != 0 {
+				t.Fatalf("blockers = %#v, want none for diagnostic platform outcome", admission.UnsupportedBlockers)
+			}
+			if len(admission.LineageOnlyEvents) != 1 {
+				t.Fatalf("lineage-only events = %#v, want one diagnostic lineage event", admission.LineageOnlyEvents)
+			}
+			lineage := admission.LineageOnlyEvents[0]
+			if lineage.EventName != eventName {
+				t.Fatalf("lineage event name = %q, want %q", lineage.EventName, eventName)
+			}
+			if lineage.Owner != store.RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner {
+				t.Fatalf("lineage owner = %q, want %q", lineage.Owner, store.RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner)
+			}
+			if lineage.Disposition != store.RunForkContractFrontierDispositionLineageNoAction {
+				t.Fatalf("lineage disposition = %q, want %q", lineage.Disposition, store.RunForkContractFrontierDispositionLineageNoAction)
+			}
+			if !hasString(lineage.SourceClassifications, store.RunForkPendingClassificationDeadLetter) || !hasString(lineage.SourceSubscriberTypes, "platform") {
+				t.Fatalf("lineage evidence = classifications:%v subscriber_types:%v", lineage.SourceClassifications, lineage.SourceSubscriberTypes)
+			}
+		})
+	}
+}
+
+func TestAdmitContractFrontier_NonDiagnosticPlatformDeadLetterRemainsFailClosed(t *testing.T) {
+	plan := testRunForkPlan("platform.dead_letter", store.RunForkPendingClassificationDeadLetter, "platform", "pipeline")
+	source := testContractFrontierSource("consumer-node")
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v, want non-diagnostic platform outcome to remain frontier", admission.FrontierEvents)
+	}
+	if len(admission.LineageOnlyEvents) != 0 {
+		t.Fatalf("lineage-only events = %#v, want none for non-diagnostic platform outcome", admission.LineageOnlyEvents)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want unresolved-route blocker", admission.UnsupportedBlockers)
+	}
+}
+
+func TestAdmitContractFrontier_SelectedDeadLetterRemainsExecutableFrontier(t *testing.T) {
+	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationDeadLetter, "node", "source-node")
+	source := testContractFrontierSource("consumer-node")
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if admission.FrontierEventCount != 1 || len(admission.FrontierEvents) != 1 {
+		t.Fatalf("frontier events = %#v, want selected dead-letter source fact to remain frontier", admission.FrontierEvents)
+	}
+	if len(admission.LineageOnlyEvents) != 0 {
+		t.Fatalf("lineage-only events = %#v, want none for selected dead-letter source fact", admission.LineageOnlyEvents)
+	}
+	if hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want no unresolved-route blocker for selected source fact", admission.UnsupportedBlockers)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierExecutionUnsupported) {
+		t.Fatalf("blockers = %#v, want execution unsupported", admission.UnsupportedBlockers)
+	}
+}
+
 func TestAdmitContractFrontier_MaterializesSourceFlowInstanceRoutes(t *testing.T) {
 	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
 	plan.PendingWork[0].FlowInstance = "review/inst-1"

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -189,6 +189,97 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 	}
 }
 
+func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	diagnosticEventID := uuid.NewString()
+	at := time.Unix(1700002215, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	seedSelectedExecutionDiagnosticPlatformDeadLetter(t, db, sourceRunID, diagnosticEventID, at.Add(-time.Second))
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.Materialization.ForkRunID == "" || !result.Activation.Activated || result.ExecutedEventCount != 1 {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	if result.SelectedContractExecutionAdmission == nil || result.SelectedContractExecutionAdmission.FrontierEventCount != 1 {
+		t.Fatalf("selected execution admission = %#v, want only selected source frontier", result.SelectedContractExecutionAdmission)
+	}
+	if selectedExecutionResultHasBlocker(result, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("selected execution retained unresolved route blocker: materialization=%#v activation=%#v", result.Materialization.UnsupportedBlockers, result.Activation.UnsupportedBlockers)
+	}
+
+	var diagnosticCopies int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND (
+			event_id = $2::uuid
+			OR COALESCE(source_event_id::text, '') = $2::text
+			OR event_name = 'platform.runtime_log'
+		  )
+	`, result.Materialization.ForkRunID, diagnosticEventID).Scan(&diagnosticCopies); err != nil {
+		t.Fatalf("count copied diagnostic events: %v", err)
+	}
+	if diagnosticCopies != 0 {
+		t.Fatalf("diagnostic platform events copied into fork = %d, want 0", diagnosticCopies)
+	}
+
+	var diagnosticExecutionLineage int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+		  AND source_event_id = $2::uuid
+	`, result.Materialization.ForkRunID, diagnosticEventID).Scan(&diagnosticExecutionLineage); err != nil {
+		t.Fatalf("count diagnostic execution lineage: %v", err)
+	}
+	if diagnosticExecutionLineage != 0 {
+		t.Fatalf("diagnostic platform execution lineage rows = %d, want 0", diagnosticExecutionLineage)
+	}
+
+	var selectedExecutionLineage int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid
+		  AND source_event_id = $2::uuid
+	`, result.Materialization.ForkRunID, sourceEventID).Scan(&selectedExecutionLineage); err != nil {
+		t.Fatalf("count selected execution lineage: %v", err)
+	}
+	if selectedExecutionLineage != 1 {
+		t.Fatalf("selected source execution lineage rows = %d, want 1", selectedExecutionLineage)
+	}
+}
+
 func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSelectedRecipients(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -1155,6 +1246,37 @@ func seedSourceOutcomeThatMustNotSuppressFork(t *testing.T, db *sql.DB, sourceEv
 		VALUES ($1::uuid, 'item.received', $2::uuid, 'flow-a/1', 'handler_error', 'source dead letter must not suppress fork', 'old-source-node', $3)
 	`, sourceEventID, entityID, at); err != nil {
 		t.Fatalf("seed source dead letter: %v", err)
+	}
+}
+
+func seedSelectedExecutionDiagnosticPlatformDeadLetter(t *testing.T, db *sql.DB, sourceRunID, diagnosticEventID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	payload, _ := json.Marshal(map[string]any{
+		"level":   "info",
+		"message": "diagnostic platform row must remain lineage-only",
+	})
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'platform.runtime_log', NULL, NULL, 'global',
+			$3::jsonb, 'pipeline', 'platform', $4
+		)
+	`, sourceRunID, diagnosticEventID, string(payload), at); err != nil {
+		t.Fatalf("seed diagnostic platform event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES (
+			$1::uuid, 'platform', 'pipeline', NULL, NULL,
+			'dead_letter', 'runtime_log_pipeline_dead_letter', '{}'::jsonb, $2
+		)
+	`, diagnosticEventID, at); err != nil {
+		t.Fatalf("seed diagnostic platform receipt: %v", err)
 	}
 }
 

--- a/internal/store/run_fork_contract_frontier_admission.go
+++ b/internal/store/run_fork_contract_frontier_admission.go
@@ -1,7 +1,13 @@
 package store
 
+import "strings"
+
 const (
 	RunForkContractFrontierAdmissionOwner = "runtime.run_fork.contract_frontier_admission"
+
+	RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner = "runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy"
+
+	RunForkContractFrontierDispositionLineageNoAction = "lineage_no_action"
 
 	RunForkBlockerContractFrontierExecutionUnsupported = "contract_frontier_execution_unsupported"
 	RunForkBlockerContractFrontierRouteUnresolved      = "contract_frontier_route_unresolved"
@@ -15,13 +21,26 @@ type RunForkContractSelection struct {
 }
 
 type RunForkContractFrontierAdmission struct {
-	Owner                        string                         `json:"owner"`
-	ContractSelection            RunForkContractSelection       `json:"contract_selection"`
-	NonMutating                  bool                           `json:"non_mutating"`
-	HistoricalExecutionSupported bool                           `json:"historical_execution_supported"`
-	FrontierEventCount           int                            `json:"frontier_event_count"`
-	FrontierEvents               []RunForkContractFrontierEvent `json:"frontier_events,omitempty"`
-	UnsupportedBlockers          []RunForkUnsupportedBlocker    `json:"unsupported_blockers,omitempty"`
+	Owner                        string                                `json:"owner"`
+	ContractSelection            RunForkContractSelection              `json:"contract_selection"`
+	NonMutating                  bool                                  `json:"non_mutating"`
+	HistoricalExecutionSupported bool                                  `json:"historical_execution_supported"`
+	FrontierEventCount           int                                   `json:"frontier_event_count"`
+	FrontierEvents               []RunForkContractFrontierEvent        `json:"frontier_events,omitempty"`
+	LineageOnlyEvents            []RunForkContractFrontierLineageEvent `json:"lineage_only_events,omitempty"`
+	UnsupportedBlockers          []RunForkUnsupportedBlocker           `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkContractFrontierLineageEvent struct {
+	SourceEventID         string   `json:"source_event_id"`
+	EventName             string   `json:"event_name"`
+	SourceClassifications []string `json:"source_classifications,omitempty"`
+	SourceFlowInstances   []string `json:"source_flow_instances,omitempty"`
+	SourceSubscriberTypes []string `json:"source_subscriber_types,omitempty"`
+	SourceSubscriberIDs   []string `json:"source_subscriber_ids,omitempty"`
+	Owner                 string   `json:"owner"`
+	Disposition           string   `json:"disposition"`
+	Reason                string   `json:"reason"`
 }
 
 type RunForkContractFrontierEvent struct {
@@ -41,4 +60,23 @@ type RunForkContractFrontierRecipient struct {
 	SubscriberID   string `json:"subscriber_id"`
 	Path           string `json:"path,omitempty"`
 	RouteSource    string `json:"route_source,omitempty"`
+}
+
+func RunForkSelectedContractDiagnosticPlatformOutcomePolicyApplies(item RunForkPendingWork) bool {
+	if strings.TrimSpace(item.Classification) != RunForkPendingClassificationDeadLetter {
+		return false
+	}
+	if strings.TrimSpace(item.SubscriberType) != "platform" {
+		return false
+	}
+	return RunForkSpecDiagnosticPlatformEvent(item.EventName)
+}
+
+func RunForkSpecDiagnosticPlatformEvent(eventName string) bool {
+	switch strings.TrimSpace(eventName) {
+	case "platform.runtime_log", "platform.inbound_recorded":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -837,6 +837,9 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 		if classification == RunForkPendingClassificationDeliveredCompleted {
 			continue
 		}
+		if RunForkSelectedContractDiagnosticPlatformOutcomePolicyApplies(item) {
+			continue
+		}
 		if classification == RunForkPendingClassificationCommittedReplay {
 			if runForkSelectedContractCommittedReplayScopeMarkerAdmitted(admission) {
 				continue


### PR DESCRIPTION
## Summary
- Adds the canonical `runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy` owner for selected-contract timestamp forks.
- Classifies spec-declared diagnostic/non-routed platform outcome facts (`platform.runtime_log`, `platform.inbound_recorded`) as frontier-admission lineage/no-action evidence instead of selected-contract frontier work.
- Keeps real selected frontier events, non-diagnostic platform/node/system dead-letter facts, generic non-agent replay, and source outcome/copy/suppressor paths fail-closed or split.

Closes #668

## Governing refs / context
- `platform-spec.yaml`: `run_model.fork.selected_contract_diagnostic_platform_outcome_policy`
- `platform-spec.yaml`: `run_model.fork.semantics.3h3_selected_contract_diagnostic_platform_outcome_policy`
- `platform-spec.yaml`: `platform_events.routing_rules.diagnostic_events`
- `platform-spec.yaml`: `run_model.fork.selected_contract_supported_execution`
- Binding issue/gate context: #668 Pre-Implementation Coverage Audit and independent gate outcome `approved as first slice`.

## Semantic migration
- New canonical owner: `runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy`.
- Old invalid path: `AdmitContractFrontier` treating `platform.runtime_log`/`platform.inbound_recorded` diagnostic platform dead-letter/source-outcome rows as unresolved selected frontier events and surfacing `contract_frontier_route_unresolved`.
- Production paths checked: contract frontier admission, selected-contract activation allowed-source validation, selected execution, and CLI `swarm fork --contracts` JSON path.
- Migration completeness: complete for the approved first slice. Generic non-agent/dead-letter replay, non-diagnostic platform rows, routes, sessions/turns/audits, timers, restart recovery, and API/dashboard/Builder ownership remain outside this PR.

## Proof
- `go test ./cmd/swarm ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/store`
- CLI supported-surface fixture: `TestRunForkCommand_SelectedContractsExecuteThroughCanonicalOwnerJSON` now includes a source `platform.runtime_log` diagnostic dead-letter row and proves selected-contract execution succeeds without copying or executing that diagnostic row.
- Focused admission tests cover both diagnostic events, non-diagnostic platform dead-letter fail-closed behavior, and selected dead-letter frontier behavior.
