### PR TITLE
[agent-b][issue #665] Add read-only operator RPC methods

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -119,6 +119,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("load Swarm contracts: %v", err)
 	}
+	bootBundleIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		log.Fatalf("compute boot bundle identity: %v", err)
+	}
 	source := semanticview.Wrap(bundle)
 	stateStoreSummary, err := initializeStateStores(ctx, stores, bundle)
 	if err != nil {
@@ -178,6 +182,14 @@ func main() {
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
 		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
+		Handlers: apiv1.OperatorReadHandlers(apiv1.OperatorReadOptions{
+			Ready: func() bool {
+				return ready.Load()
+			},
+			Database: stores.Postgres,
+			Runs:     stores.Postgres,
+			Bundle:   bootBundleIdentity,
+		}),
 	})
 	if err != nil {
 		log.Fatalf("init v1 api: %v", err)

--- a/internal/apiv1/errors.go
+++ b/internal/apiv1/errors.go
@@ -1,0 +1,39 @@
+package apiv1
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ApplicationError struct {
+	Code      string
+	Retryable bool
+	Details   any
+}
+
+func NewApplicationError(code string, retryable bool, details any) *ApplicationError {
+	return &ApplicationError{
+		Code:      strings.TrimSpace(code),
+		Retryable: retryable,
+		Details:   details,
+	}
+}
+
+func (e *ApplicationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("application error: %s", strings.TrimSpace(e.Code))
+}
+
+type InvalidParamsError struct {
+	Details any
+}
+
+func NewInvalidParamsError(details any) *InvalidParamsError {
+	return &InvalidParamsError{Details: details}
+}
+
+func (e *InvalidParamsError) Error() string {
+	return "invalid params"
+}

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -218,6 +218,14 @@ func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackC
 	}
 	result, err := handler(ctx, req)
 	if err != nil {
+		var appErr *ApplicationError
+		if errors.As(err, &appErr) && appErr != nil {
+			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: h.applicationError(appErr.Code, req.CorrelationID, appErr.Retryable, appErr.Details)}
+		}
+		var paramsErr *InvalidParamsError
+		if errors.As(err, &paramsErr) && paramsErr != nil {
+			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: invalidParams(req.CorrelationID, paramsErr.Details)}
+		}
 		return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: h.standardError(codeInternalError, "internal error", req.CorrelationID, map[string]any{"error": err.Error()})}
 	}
 	return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: result}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -11,8 +11,11 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
 )
 
 const testToken = "test-v1-token"
@@ -238,6 +241,204 @@ func TestHandlerWebSocketAuthAndFrameValidation(t *testing.T) {
 	if result := asMap(t, ok.Result); result["ok"] != true {
 		t.Fatalf("unsubscribe result = %#v, want ok true", ok.Result)
 	}
+}
+
+func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
+	now := time.Unix(1700000000, 123456789).UTC()
+	runID := "run-1"
+	eventID := "event-1"
+	fakeRuns := &fakeRunReadStore{
+		headers: map[string]store.RunHeader{
+			runID: {
+				RunID:            runID,
+				Status:           "running",
+				TriggerEventType: "scan.requested",
+				TriggerEventID:   eventID,
+				EntityCount:      2,
+				EventCount:       1,
+				StartedAt:        now.Add(-time.Hour),
+			},
+		},
+		reports: map[string]store.RunDebugReport{
+			runID: {
+				RunID:          runID,
+				RunTableStatus: "running",
+				RootEventID:    eventID,
+				RootEventType:  "scan.requested",
+				StartedAt:      now.Add(-time.Hour),
+				LastEventAt:    now.Add(-time.Minute),
+				EventCount:     1,
+				EntityCount:    2,
+				Deliveries:     []store.RunDebugDeliveryCount{{SubscriberID: "worker", Status: "pending", Count: 1}},
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:      func() time.Time { return now },
+			Ready:    func() bool { return true },
+			Database: fakePinger{err: nil},
+			Runs:     fakeRuns,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.2.3",
+				Fingerprint:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		}),
+	})
+
+	ping := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"ping","method":"health.ping","params":{}}`)
+	if ping.Error != nil {
+		t.Fatalf("health.ping error = %#v", ping.Error)
+	}
+	if got := asMap(t, ping.Result)["ts"]; got != now.Format(time.RFC3339Nano) {
+		t.Fatalf("health.ping ts = %v, want %s", got, now.Format(time.RFC3339Nano))
+	}
+
+	health := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"health","method":"health.check","params":{}}`)
+	if health.Error != nil {
+		t.Fatalf("health.check error = %#v", health.Error)
+	}
+	healthResult := asMap(t, health.Result)
+	if healthResult["ready"] != true || healthResult["db_ok"] != true || healthResult["runtime_ok"] != true {
+		t.Fatalf("health.check result = %#v", healthResult)
+	}
+	bundle := asMap(t, healthResult["bundle"])
+	if bundle["fingerprint"] != "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("bundle identity = %#v", bundle)
+	}
+	if raw, _ := json.Marshal(healthResult); strings.Contains(string(raw), "/") {
+		t.Fatalf("health.check leaked path-like content: %s", raw)
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"run.get","params":{"run_id":"run-1"}}`)
+	if get.Error != nil {
+		t.Fatalf("run.get error = %#v", get.Error)
+	}
+	if got := asMap(t, asMap(t, get.Result)["run"])["trigger_event_id"]; got != eventID {
+		t.Fatalf("run.get trigger_event_id = %v, want %s", got, eventID)
+	}
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"run.list","params":{"limit":1}}`)
+	if list.Error != nil {
+		t.Fatalf("run.list error = %#v", list.Error)
+	}
+	runs, ok := asMap(t, list.Result)["runs"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("run.list runs = %#v, want one run", asMap(t, list.Result)["runs"])
+	}
+	if fakeRuns.lastListOpts.Limit != 1 {
+		t.Fatalf("run.list limit = %d, want 1", fakeRuns.lastListOpts.Limit)
+	}
+
+	diagnose := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"run.diagnose","params":{"run_id":"run-1"}}`)
+	if diagnose.Error != nil {
+		t.Fatalf("run.diagnose error = %#v", diagnose.Error)
+	}
+	if got := asMap(t, diagnose.Result)["operational_state"]; got != "running" {
+		t.Fatalf("run.diagnose operational_state = %v, want running", got)
+	}
+}
+
+func TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:    func() bool { return true },
+			Database: fakePinger{err: nil},
+			Runs: &fakeRunReadStore{
+				notFound: map[string]bool{"missing": true},
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.2.3",
+				Fingerprint:     "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		}),
+	})
+
+	missing := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"missing","method":"run.get","params":{"run_id":"missing"}}`)
+	if missing.Error == nil {
+		t.Fatal("run.get missing error = nil, want RUN_NOT_FOUND")
+	}
+	data := asMap(t, missing.Error.Data)
+	if data["code"] != RunNotFoundCode || asMap(t, data["details"])["run_id"] != "missing" {
+		t.Fatalf("run.get missing data = %#v", data)
+	}
+
+	start := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"event_name":"system.started","payload":{}}}`)
+	if start.Error == nil {
+		t.Fatal("run.start error = nil, want METHOD_UNAVAILABLE")
+	}
+	if data := asMap(t, start.Error.Data); data["code"] != MethodUnavailableCode {
+		t.Fatalf("run.start error data = %#v, want METHOD_UNAVAILABLE", data)
+	}
+}
+
+func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode rpc response: %v body=%s", err, rec.Body.String())
+	}
+	return resp
+}
+
+type fakePinger struct {
+	err error
+}
+
+func (p fakePinger) Ping(context.Context) error {
+	return p.err
+}
+
+type fakeRunReadStore struct {
+	headers      map[string]store.RunHeader
+	reports      map[string]store.RunDebugReport
+	notFound     map[string]bool
+	lastListOpts store.RunHeaderListOptions
+}
+
+func (s *fakeRunReadStore) LoadRunHeader(_ context.Context, runID string) (store.RunHeader, error) {
+	if s.notFound[runID] {
+		return store.RunHeader{}, store.ErrRunNotFound
+	}
+	header, ok := s.headers[runID]
+	if !ok {
+		return store.RunHeader{}, store.ErrRunNotFound
+	}
+	return header, nil
+}
+
+func (s *fakeRunReadStore) ListRunHeaders(_ context.Context, opts store.RunHeaderListOptions) ([]store.RunHeader, string, error) {
+	s.lastListOpts = opts
+	out := make([]store.RunHeader, 0, len(s.headers))
+	for _, header := range s.headers {
+		out = append(out, header)
+	}
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		return out[:opts.Limit], "next", nil
+	}
+	return out, "", nil
+}
+
+func (s *fakeRunReadStore) LoadRunDebugReport(_ context.Context, runID string, _ store.RunDebugQueryOptions) (store.RunDebugReport, error) {
+	if s.notFound[runID] {
+		return store.RunDebugReport{}, store.ErrRunNotFound
+	}
+	report, ok := s.reports[runID]
+	if !ok {
+		return store.RunDebugReport{}, store.ErrRunNotFound
+	}
+	return report, nil
 }
 
 func testHandler(t *testing.T, opts Options) *Handler {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -376,6 +376,50 @@ func TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable(t *testing.T
 	}
 }
 
+func TestOperatorReadHandlersRunListRejectsInvalidFilters(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:    func() bool { return true },
+			Database: fakePinger{err: nil},
+			Runs: &fakeRunReadStore{
+				headers: map[string]store.RunHeader{},
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.2.3",
+				Fingerprint:     "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			},
+		}),
+	})
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "unknown status",
+			body: `{"jsonrpc":"2.0","id":"bad-status","method":"run.list","params":{"status":"runnning"}}`,
+		},
+		{
+			name: "numeric since",
+			body: `{"jsonrpc":"2.0","id":"bad-since","method":"run.list","params":{"since":123}}`,
+		},
+		{
+			name: "numeric until",
+			body: `{"jsonrpc":"2.0","id":"bad-until","method":"run.list","params":{"until":123}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := rpcCall(t, handler, tc.body)
+			if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+				t.Fatalf("run.list error = %#v, want invalid params", resp.Error)
+			}
+		})
+	}
+}
+
 func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {
 	t.Helper()
 	rec := httptest.NewRecorder()

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -1,0 +1,218 @@
+package apiv1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+)
+
+type Pinger interface {
+	Ping(context.Context) error
+}
+
+type RunReadStore interface {
+	LoadRunHeader(context.Context, string) (store.RunHeader, error)
+	ListRunHeaders(context.Context, store.RunHeaderListOptions) ([]store.RunHeader, string, error)
+	LoadRunDebugReport(context.Context, string, store.RunDebugQueryOptions) (store.RunDebugReport, error)
+}
+
+type OperatorReadOptions struct {
+	Now      func() time.Time
+	Ready    func() bool
+	Database Pinger
+	Runs     RunReadStore
+	Bundle   runtimecontracts.BundleIdentity
+}
+
+type healthPingResult struct {
+	OK bool   `json:"ok"`
+	TS string `json:"ts"`
+}
+
+type healthCheckResult struct {
+	Alive     bool                            `json:"alive"`
+	Ready     bool                            `json:"ready"`
+	DBOK      bool                            `json:"db_ok"`
+	RuntimeOK bool                            `json:"runtime_ok"`
+	Bundle    runtimecontracts.BundleIdentity `json:"bundle"`
+}
+
+type runGetResult struct {
+	Run store.RunHeader `json:"run"`
+}
+
+type runListResult struct {
+	Runs       []store.RunHeader `json:"runs"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type runDiagnosis struct {
+	Run              store.RunHeader `json:"run"`
+	OperationalState string          `json:"operational_state"`
+	BlockingLayer    string          `json:"blocking_layer"`
+	BlockingReason   string          `json:"blocking_reason"`
+	Heuristics       []string        `json:"heuristics"`
+}
+
+func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	ready := opts.Ready
+	if ready == nil {
+		ready = func() bool { return false }
+	}
+	return map[string]MethodHandler{
+		"health.ping": func(context.Context, Request) (any, error) {
+			return healthPingResult{OK: true, TS: now().UTC().Format(time.RFC3339Nano)}, nil
+		},
+		"health.check": func(ctx context.Context, _ Request) (any, error) {
+			runtimeOK := ready()
+			dbOK := false
+			if opts.Database != nil {
+				dbOK = opts.Database.Ping(ctx) == nil
+			}
+			return healthCheckResult{
+				Alive:     true,
+				Ready:     runtimeOK && dbOK,
+				DBOK:      dbOK,
+				RuntimeOK: runtimeOK,
+				Bundle:    opts.Bundle,
+			}, nil
+		},
+		"run.get": func(ctx context.Context, req Request) (any, error) {
+			runs, err := requireRunReadStore(opts.Runs)
+			if err != nil {
+				return nil, err
+			}
+			runID := stringParam(req.Params, "run_id")
+			header, err := runs.LoadRunHeader(ctx, runID)
+			if errors.Is(err, store.ErrRunNotFound) {
+				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return runGetResult{Run: header}, nil
+		},
+		"run.list": func(ctx context.Context, req Request) (any, error) {
+			runs, err := requireRunReadStore(opts.Runs)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := runHeaderListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			headers, nextCursor, err := runs.ListRunHeaders(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidRunListCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid run list cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if headers == nil {
+				headers = []store.RunHeader{}
+			}
+			return runListResult{Runs: headers, NextCursor: nextCursor}, nil
+		},
+		"run.diagnose": func(ctx context.Context, req Request) (any, error) {
+			runs, err := requireRunReadStore(opts.Runs)
+			if err != nil {
+				return nil, err
+			}
+			runID := stringParam(req.Params, "run_id")
+			header, err := runs.LoadRunHeader(ctx, runID)
+			if errors.Is(err, store.ErrRunNotFound) {
+				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			report, err := runs.LoadRunDebugReport(ctx, runID, store.RunDebugQueryOptions{})
+			if errors.Is(err, store.ErrRunNotFound) {
+				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			status := store.ProjectRunOperationalStatus(report)
+			return runDiagnosis{
+				Run:              header,
+				OperationalState: strings.TrimSpace(status.State),
+				BlockingLayer:    strings.TrimSpace(status.BlockingLayer),
+				BlockingReason:   strings.TrimSpace(status.BlockingReason),
+				Heuristics:       status.Heuristics,
+			}, nil
+		},
+	}
+}
+
+func requireRunReadStore(runs RunReadStore) (RunReadStore, error) {
+	if runs == nil {
+		return nil, fmt.Errorf("run read store is required")
+	}
+	return runs, nil
+}
+
+func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListOptions, error) {
+	out := store.RunHeaderListOptions{
+		Status: strings.ToLower(strings.TrimSpace(stringParam(params, "status"))),
+		Cursor: strings.TrimSpace(stringParam(params, "cursor")),
+	}
+	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
+		limit, ok := integerParam(raw)
+		if !ok || limit < 1 || limit > 500 {
+			return store.RunHeaderListOptions{}, NewInvalidParamsError(map[string]any{"field": "limit", "reason": "must be an integer from 1 to 500"})
+		}
+		out.Limit = limit
+	}
+	var err error
+	if out.Since, err = timestampParam(params, "since"); err != nil {
+		return store.RunHeaderListOptions{}, err
+	}
+	if out.Until, err = timestampParam(params, "until"); err != nil {
+		return store.RunHeaderListOptions{}, err
+	}
+	return out, nil
+}
+
+func timestampParam(params map[string]any, name string) (*time.Time, error) {
+	raw := strings.TrimSpace(stringParam(params, name))
+	if raw == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return nil, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be RFC3339 timestamp"})
+	}
+	value := parsed.UTC()
+	return &value, nil
+}
+
+func stringParam(params map[string]any, name string) string {
+	if params == nil {
+		return ""
+	}
+	value, _ := params[name].(string)
+	return strings.TrimSpace(value)
+}
+
+func integerParam(value any) (int, bool) {
+	switch typed := value.(type) {
+	case float64:
+		if math.Trunc(typed) != typed {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -60,6 +60,15 @@ type runDiagnosis struct {
 	Heuristics       []string        `json:"heuristics"`
 }
 
+var runListStatuses = map[string]struct{}{
+	"running":   {},
+	"paused":    {},
+	"completed": {},
+	"failed":    {},
+	"cancelled": {},
+	"forked":    {},
+}
+
 func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	now := opts.Now
 	if now == nil {
@@ -163,10 +172,23 @@ func requireRunReadStore(runs RunReadStore) (RunReadStore, error) {
 }
 
 func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListOptions, error) {
-	out := store.RunHeaderListOptions{
-		Status: strings.ToLower(strings.TrimSpace(stringParam(params, "status"))),
-		Cursor: strings.TrimSpace(stringParam(params, "cursor")),
+	out := store.RunHeaderListOptions{}
+	status, _, err := optionalStringParam(params, "status")
+	if err != nil {
+		return store.RunHeaderListOptions{}, err
 	}
+	status = strings.ToLower(status)
+	if status != "" {
+		if _, ok := runListStatuses[status]; !ok {
+			return store.RunHeaderListOptions{}, NewInvalidParamsError(map[string]any{"field": "status", "reason": "must be a valid RunStatus"})
+		}
+		out.Status = status
+	}
+	cursor, _, err := optionalStringParam(params, "cursor")
+	if err != nil {
+		return store.RunHeaderListOptions{}, err
+	}
+	out.Cursor = cursor
 	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
 		limit, ok := integerParam(raw)
 		if !ok || limit < 1 || limit > 500 {
@@ -174,7 +196,6 @@ func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListO
 		}
 		out.Limit = limit
 	}
-	var err error
 	if out.Since, err = timestampParam(params, "since"); err != nil {
 		return store.RunHeaderListOptions{}, err
 	}
@@ -185,8 +206,11 @@ func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListO
 }
 
 func timestampParam(params map[string]any, name string) (*time.Time, error) {
-	raw := strings.TrimSpace(stringParam(params, name))
-	if raw == "" {
+	raw, present, err := optionalStringParam(params, name)
+	if err != nil {
+		return nil, err
+	}
+	if !present || raw == "" {
 		return nil, nil
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, raw)
@@ -195,6 +219,21 @@ func timestampParam(params map[string]any, name string) (*time.Time, error) {
 	}
 	value := parsed.UTC()
 	return &value, nil
+}
+
+func optionalStringParam(params map[string]any, name string) (string, bool, error) {
+	if params == nil {
+		return "", false, nil
+	}
+	value, ok := params[name]
+	if !ok || isEmptyParam(value) {
+		return "", ok, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", true, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be a string"})
+	}
+	return strings.TrimSpace(text), true, nil
 }
 
 func stringParam(params map[string]any, name string) string {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -10,7 +10,10 @@ import (
 	"swarm/internal/apispec"
 )
 
-const MethodUnavailableCode = "METHOD_UNAVAILABLE"
+const (
+	MethodUnavailableCode = "METHOD_UNAVAILABLE"
+	RunNotFoundCode       = "RUN_NOT_FOUND"
+)
 
 type Registry struct {
 	api        *apispec.APISpecification
@@ -38,8 +41,10 @@ func NewRegistry(api *apispec.APISpecification) (*Registry, error) {
 		methods[strings.TrimSpace(name)] = method
 	}
 	errorCodes := apispec.ApplicationErrorCodes(api.Components.Errors)
-	if _, ok := errorCodes[MethodUnavailableCode]; !ok {
-		return nil, fmt.Errorf("api specification missing components.errors.%s", MethodUnavailableCode)
+	for _, required := range []string{MethodUnavailableCode, RunNotFoundCode} {
+		if _, ok := errorCodes[required]; !ok {
+			return nil, fmt.Errorf("api specification missing components.errors.%s", required)
+		}
 	}
 	return &Registry{
 		api:        api,

--- a/internal/runtime/contracts/bundle_identity.go
+++ b/internal/runtime/contracts/bundle_identity.go
@@ -1,0 +1,251 @@
+package contracts
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type BundleIdentity struct {
+	WorkflowName    string `json:"workflow_name"`
+	WorkflowVersion string `json:"workflow_version"`
+	Fingerprint     string `json:"fingerprint"`
+}
+
+type bundleIdentityEntry struct {
+	Label string
+	Path  string
+}
+
+func BootBundleIdentity(bundle *WorkflowContractBundle) (BundleIdentity, error) {
+	if bundle == nil {
+		return BundleIdentity{}, fmt.Errorf("workflow contract bundle is required")
+	}
+	fingerprint, err := BundleFingerprint(bundle)
+	if err != nil {
+		return BundleIdentity{}, err
+	}
+	return BundleIdentity{
+		WorkflowName:    strings.TrimSpace(bundle.Semantics.Name),
+		WorkflowVersion: strings.TrimSpace(bundle.Semantics.Version),
+		Fingerprint:     fingerprint,
+	}, nil
+}
+
+func BundleFingerprint(bundle *WorkflowContractBundle) (string, error) {
+	entries, err := bundleIdentityEntries(bundle)
+	if err != nil {
+		return "", err
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("workflow contract bundle has no identity inputs")
+	}
+	hasher := sha256.New()
+	for _, entry := range entries {
+		canonical, err := canonicalBundleIdentityContent(entry.Path)
+		if err != nil {
+			return "", fmt.Errorf("canonicalize %s: %w", entry.Label, err)
+		}
+		hasher.Write([]byte(entry.Label))
+		hasher.Write([]byte{0})
+		hasher.Write(canonical)
+		hasher.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func bundleIdentityEntries(bundle *WorkflowContractBundle) ([]bundleIdentityEntry, error) {
+	if bundle == nil {
+		return nil, fmt.Errorf("workflow contract bundle is required")
+	}
+	seen := map[string]struct{}{}
+	var entries []bundleIdentityEntry
+	addFile := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		clean, err := filepath.Abs(path)
+		if err != nil {
+			clean = filepath.Clean(path)
+		}
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		if stat, err := os.Stat(clean); err != nil || stat.IsDir() {
+			return
+		}
+		seen[clean] = struct{}{}
+		entries = append(entries, bundleIdentityEntry{
+			Label: bundleIdentityLabel(bundle.Paths, clean),
+			Path:  clean,
+		})
+	}
+	addDir := func(dir string) error {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return nil
+		}
+		if stat, err := os.Stat(dir); err != nil || !stat.IsDir() {
+			return nil
+		}
+		return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d == nil || d.IsDir() {
+				return nil
+			}
+			addFile(path)
+			return nil
+		})
+	}
+
+	paths := bundle.Paths
+	addFile(paths.PlatformSpecFile)
+	addFile(paths.ProjectPackageFile)
+	addFile(paths.RootSchemaFile)
+	addFile(paths.RootTypesFile)
+	addFile(paths.RootEntitiesFile)
+	addFile(paths.ProjectNodesFile)
+	addFile(paths.ProjectEventsFile)
+	addFile(paths.ProjectAgentsFile)
+	addFile(paths.ProjectToolsFile)
+	addFile(paths.ProjectPolicyFile)
+	if err := addDir(paths.ProjectPromptsDir); err != nil {
+		return nil, err
+	}
+	for _, pkg := range paths.ProjectPackages {
+		addFile(pkg.PackageFile)
+		addFile(pkg.ProjectNodesFile)
+		addFile(pkg.ProjectEventsFile)
+		addFile(pkg.ProjectAgentsFile)
+		addFile(pkg.ProjectToolsFile)
+		addFile(pkg.ProjectPolicyFile)
+		if err := addDir(pkg.ProjectPromptsDir); err != nil {
+			return nil, err
+		}
+		for _, flow := range pkg.Flows {
+			addFlowIdentityFiles(flow, addFile)
+			if err := addDir(flow.PromptsDir); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, flow := range paths.Flows {
+		addFlowIdentityFiles(flow, addFile)
+		if err := addDir(flow.PromptsDir); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Label == entries[j].Label {
+			return entries[i].Path < entries[j].Path
+		}
+		return entries[i].Label < entries[j].Label
+	})
+	return entries, nil
+}
+
+func addFlowIdentityFiles(flow FlowContractPaths, addFile func(string)) {
+	addFile(flow.SchemaFile)
+	addFile(flow.TypesFile)
+	addFile(flow.EntitiesFile)
+	addFile(flow.NodesFile)
+	addFile(flow.EventsFile)
+	addFile(flow.AgentsFile)
+	addFile(flow.ToolsFile)
+	addFile(flow.PolicyFile)
+}
+
+func bundleIdentityLabel(paths ContractPaths, path string) string {
+	if root := strings.TrimSpace(paths.ContractsRoot); root != "" {
+		if rel, err := filepath.Rel(root, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "bundle/" + filepath.ToSlash(filepath.Clean(rel))
+		}
+	}
+	if platform := strings.TrimSpace(paths.PlatformSpecFile); platform != "" {
+		if sameFilePath(platform, path) {
+			return "platform/" + filepath.Base(path)
+		}
+	}
+	return "external/" + filepath.Base(path)
+}
+
+func sameFilePath(left, right string) bool {
+	leftAbs, leftErr := filepath.Abs(left)
+	rightAbs, rightErr := filepath.Abs(right)
+	if leftErr == nil && rightErr == nil {
+		return filepath.Clean(leftAbs) == filepath.Clean(rightAbs)
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+func canonicalBundleIdentityContent(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".yaml", ".yml":
+		var decoded any
+		if err := yaml.Unmarshal(raw, &decoded); err != nil {
+			return nil, err
+		}
+		normalized := normalizeYAMLForJSON(decoded)
+		out, err := json.Marshal(normalized)
+		if err != nil {
+			return nil, err
+		}
+		return out, nil
+	default:
+		return []byte(normalizeTextContent(string(raw))), nil
+	}
+}
+
+func normalizeYAMLForJSON(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[key] = normalizeYAMLForJSON(value)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[fmt.Sprint(key)] = normalizeYAMLForJSON(value)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, value := range typed {
+			out[i] = normalizeYAMLForJSON(value)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func normalizeTextContent(raw string) string {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	raw = strings.ReplaceAll(raw, "\r", "\n")
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/internal/runtime/contracts/bundle_identity_test.go
+++ b/internal/runtime/contracts/bundle_identity_test.go
@@ -1,0 +1,91 @@
+package contracts
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestBootBundleIdentityStableAcrossRootsAndFileOrder(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	platformSpec := filepath.Join(repo, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+
+	writeBundleIdentityFile(t, filepath.Join(rootA, "package.yaml"), "name: identity-test\nversion: 1.0.0\nflows: []\n")
+	writeBundleIdentityFile(t, filepath.Join(rootA, "prompts", "a.md"), "alpha\n")
+	writeBundleIdentityFile(t, filepath.Join(rootA, "prompts", "b.md"), "beta\n")
+
+	writeBundleIdentityFile(t, filepath.Join(rootB, "prompts", "b.md"), "beta\r\n")
+	writeBundleIdentityFile(t, filepath.Join(rootB, "prompts", "a.md"), "alpha\r\n")
+	writeBundleIdentityFile(t, filepath.Join(rootB, "package.yaml"), "flows: []\r\nversion: 1.0.0\r\nname: identity-test\r\n")
+
+	bundleA, err := LoadWorkflowContractBundleWithOverrides(repo, rootA, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle A: %v", err)
+	}
+	bundleB, err := LoadWorkflowContractBundleWithOverrides(repo, rootB, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle B: %v", err)
+	}
+	identityA, err := BootBundleIdentity(bundleA)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity A: %v", err)
+	}
+	identityB, err := BootBundleIdentity(bundleB)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity B: %v", err)
+	}
+	if identityA.WorkflowName != "identity-test" || identityA.WorkflowVersion != "1.0.0" {
+		t.Fatalf("identity labels = %#v", identityA)
+	}
+	if identityA.Fingerprint != identityB.Fingerprint {
+		t.Fatalf("fingerprint drifted across equivalent roots:\nA=%s\nB=%s", identityA.Fingerprint, identityB.Fingerprint)
+	}
+	if !regexp.MustCompile(`^sha256:[a-f0-9]{64}$`).MatchString(identityA.Fingerprint) {
+		t.Fatalf("fingerprint = %q, want sha256-prefixed hex", identityA.Fingerprint)
+	}
+}
+
+func TestBootBundleIdentityChangesWithLoadedContent(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	platformSpec := filepath.Join(repo, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+
+	writeBundleIdentityFile(t, filepath.Join(rootA, "package.yaml"), "name: identity-test\nversion: 1.0.0\nflows: []\n")
+	writeBundleIdentityFile(t, filepath.Join(rootA, "prompts", "a.md"), "alpha\n")
+	writeBundleIdentityFile(t, filepath.Join(rootB, "package.yaml"), "name: identity-test\nversion: 1.0.0\nflows: []\n")
+	writeBundleIdentityFile(t, filepath.Join(rootB, "prompts", "a.md"), "changed\n")
+
+	bundleA, err := LoadWorkflowContractBundleWithOverrides(repo, rootA, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle A: %v", err)
+	}
+	bundleB, err := LoadWorkflowContractBundleWithOverrides(repo, rootB, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle B: %v", err)
+	}
+	identityA, err := BootBundleIdentity(bundleA)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity A: %v", err)
+	}
+	identityB, err := BootBundleIdentity(bundleB)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity B: %v", err)
+	}
+	if identityA.Fingerprint == identityB.Fingerprint {
+		t.Fatalf("fingerprint did not change after loaded content changed: %s", identityA.Fingerprint)
+	}
+}
+
+func writeBundleIdentityFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -3,3 +3,7 @@ package store
 import "errors"
 
 var ErrUnknownSchemaType = errors.New("store: unknown schema type")
+
+var ErrRunNotFound = errors.New("store: run not found")
+
+var ErrInvalidRunListCursor = errors.New("store: invalid run list cursor")

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -62,6 +62,9 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 }
 
 func (s *PostgresStore) Ping(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
 	return s.DB.PingContext(ctx)
 }
 

--- a/internal/store/run_api_read_surface.go
+++ b/internal/store/run_api_read_surface.go
@@ -1,0 +1,266 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type RunHeader struct {
+	RunID            string     `json:"run_id"`
+	Status           string     `json:"status"`
+	TriggerEventType string     `json:"trigger_event_type"`
+	TriggerEventID   string     `json:"trigger_event_id"`
+	EntityCount      int        `json:"entity_count"`
+	EventCount       int        `json:"event_count"`
+	StartedAt        time.Time  `json:"started_at"`
+	EndedAt          *time.Time `json:"ended_at,omitempty"`
+	ForkedFromRunID  string     `json:"forked_from_run_id,omitempty"`
+	ErrorSummary     string     `json:"error_summary,omitempty"`
+}
+
+type RunHeaderListOptions struct {
+	Status string
+	Since  *time.Time
+	Until  *time.Time
+	Limit  int
+	Cursor string
+}
+
+type runHeaderCursor struct {
+	StartedAt string `json:"started_at"`
+	RunID     string `json:"run_id"`
+}
+
+func defaultRunHeaderListOptions(opts RunHeaderListOptions) RunHeaderListOptions {
+	opts.Status = strings.ToLower(strings.TrimSpace(opts.Status))
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts
+}
+
+func (s *PostgresStore) requireRunHeaderCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	if !caps.Events.LogRunID {
+		return fmt.Errorf("run api read surface requires canonical events.run_id")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"runs":   {"run_id", "status", "trigger_event_id", "trigger_event_type", "forked_from_run_id", "entity_count", "event_count", "error_summary", "started_at", "ended_at"},
+		"events": {"run_id", "event_id", "event_name", "created_at"},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("run api read surface requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) LoadRunHeader(ctx context.Context, runID string) (RunHeader, error) {
+	if s == nil || s.DB == nil {
+		return RunHeader{}, fmt.Errorf("postgres store is required")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return RunHeader{}, ErrRunNotFound
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return RunHeader{}, ErrRunNotFound
+	}
+	if err := s.requireRunHeaderCapabilities(ctx); err != nil {
+		return RunHeader{}, err
+	}
+	row := s.DB.QueryRowContext(ctx, runHeaderSelectSQL()+`
+WHERE r.run_id = $1::uuid
+`, runID)
+	header, err := scanRunHeader(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return RunHeader{}, ErrRunNotFound
+	}
+	if err != nil {
+		return RunHeader{}, err
+	}
+	if strings.TrimSpace(header.TriggerEventID) == "" || strings.TrimSpace(header.TriggerEventType) == "" {
+		return RunHeader{}, fmt.Errorf("run %s is missing trigger event identity", runID)
+	}
+	return header, nil
+}
+
+func (s *PostgresStore) ListRunHeaders(ctx context.Context, opts RunHeaderListOptions) ([]RunHeader, string, error) {
+	if s == nil || s.DB == nil {
+		return nil, "", fmt.Errorf("postgres store is required")
+	}
+	if err := s.requireRunHeaderCapabilities(ctx); err != nil {
+		return nil, "", err
+	}
+	opts = defaultRunHeaderListOptions(opts)
+	args := make([]any, 0, 6)
+	where := []string{"(r.trigger_event_id IS NOT NULL OR root.event_id IS NOT NULL)"}
+	if opts.Status != "" {
+		args = append(args, opts.Status)
+		where = append(where, fmt.Sprintf("lower(r.status) = $%d", len(args)))
+	}
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		where = append(where, fmt.Sprintf("r.started_at >= $%d", len(args)))
+	}
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		where = append(where, fmt.Sprintf("r.started_at <= $%d", len(args)))
+	}
+	if opts.Cursor != "" {
+		startedAt, runID, err := decodeRunHeaderCursor(opts.Cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		args = append(args, startedAt.UTC(), runID)
+		where = append(where, fmt.Sprintf("(r.started_at < $%d OR (r.started_at = $%d AND r.run_id::text < $%d))", len(args)-1, len(args)-1, len(args)))
+	}
+	args = append(args, opts.Limit+1)
+	query := runHeaderSelectSQL() + "\nWHERE " + strings.Join(where, " AND ") + fmt.Sprintf(`
+ORDER BY r.started_at DESC, r.run_id::text DESC
+LIMIT $%d
+`, len(args))
+	rows, err := s.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+	headers := make([]RunHeader, 0, opts.Limit)
+	for rows.Next() {
+		header, err := scanRunHeader(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		if strings.TrimSpace(header.TriggerEventID) == "" || strings.TrimSpace(header.TriggerEventType) == "" {
+			return nil, "", fmt.Errorf("run %s is missing trigger event identity", header.RunID)
+		}
+		headers = append(headers, header)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	nextCursor := ""
+	if len(headers) > opts.Limit {
+		headers = headers[:opts.Limit]
+		nextCursor = encodeRunHeaderCursor(headers[len(headers)-1])
+	}
+	return headers, nextCursor, nil
+}
+
+func runHeaderSelectSQL() string {
+	return `
+SELECT
+	r.run_id::text,
+	lower(r.status),
+	COALESCE(r.trigger_event_type, root.event_name, ''),
+	COALESCE(r.trigger_event_id::text, root.event_id::text, ''),
+	COALESCE(r.entity_count, 0),
+	COALESCE(NULLIF(r.event_count, 0), summary.event_count, 0),
+	r.started_at,
+	r.ended_at,
+	COALESCE(r.forked_from_run_id::text, ''),
+	COALESCE(r.error_summary, '')
+FROM runs r
+LEFT JOIN LATERAL (
+	SELECT e.event_id, e.event_name
+	FROM events e
+	WHERE e.run_id = r.run_id
+	ORDER BY e.created_at ASC, e.event_id ASC
+	LIMIT 1
+) root ON TRUE
+LEFT JOIN LATERAL (
+	SELECT COUNT(*)::integer AS event_count
+	FROM events e
+	WHERE e.run_id = r.run_id
+) summary ON TRUE
+`
+}
+
+type runHeaderScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRunHeader(row runHeaderScanner) (RunHeader, error) {
+	var header RunHeader
+	var endedAt sql.NullTime
+	if err := row.Scan(
+		&header.RunID,
+		&header.Status,
+		&header.TriggerEventType,
+		&header.TriggerEventID,
+		&header.EntityCount,
+		&header.EventCount,
+		&header.StartedAt,
+		&endedAt,
+		&header.ForkedFromRunID,
+		&header.ErrorSummary,
+	); err != nil {
+		return RunHeader{}, err
+	}
+	header.Status = strings.ToLower(strings.TrimSpace(header.Status))
+	header.TriggerEventType = strings.TrimSpace(header.TriggerEventType)
+	header.TriggerEventID = strings.TrimSpace(header.TriggerEventID)
+	header.ForkedFromRunID = strings.TrimSpace(header.ForkedFromRunID)
+	header.ErrorSummary = strings.TrimSpace(header.ErrorSummary)
+	if endedAt.Valid {
+		value := endedAt.Time.UTC()
+		header.EndedAt = &value
+	}
+	header.StartedAt = header.StartedAt.UTC()
+	return header, nil
+}
+
+func encodeRunHeaderCursor(header RunHeader) string {
+	raw, _ := json.Marshal(runHeaderCursor{
+		StartedAt: header.StartedAt.UTC().Format(time.RFC3339Nano),
+		RunID:     strings.TrimSpace(header.RunID),
+	})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeRunHeaderCursor(cursor string) (time.Time, string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(cursor))
+	if err != nil {
+		return time.Time{}, "", ErrInvalidRunListCursor
+	}
+	var decoded runHeaderCursor
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return time.Time{}, "", ErrInvalidRunListCursor
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(decoded.StartedAt))
+	if err != nil {
+		return time.Time{}, "", ErrInvalidRunListCursor
+	}
+	runID := strings.TrimSpace(decoded.RunID)
+	if runID == "" {
+		return time.Time{}, "", ErrInvalidRunListCursor
+	}
+	return startedAt, runID, nil
+}

--- a/internal/store/run_api_read_surface_test.go
+++ b/internal/store/run_api_read_surface_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	now := time.Unix(1700000000, 0).UTC()
+	newer := uuid.NewString()
+	middle := uuid.NewString()
+	older := uuid.NewString()
+	newerEvent := uuid.NewString()
+	middleEvent := uuid.NewString()
+	olderEvent := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, status, trigger_event_id, trigger_event_type, forked_from_run_id, entity_count, event_count, error_summary, started_at, ended_at
+		)
+		VALUES
+			($1::uuid, 'running', $2::uuid, 'scan.requested', NULL, 3, 2, NULL, $3, NULL),
+			($4::uuid, 'completed', $5::uuid, 'scan.requested', $1::uuid, 5, 1, NULL, $6, $7),
+			($8::uuid, 'failed', $9::uuid, 'scan.failed', NULL, 1, 1, 'boom', $10, $11)
+	`, newer, newerEvent, now, middle, middleEvent, now.Add(-time.Hour), now.Add(-30*time.Minute), older, olderEvent, now.Add(-2*time.Hour), now.Add(-90*time.Minute)); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $3),
+			($1::uuid, gen_random_uuid(), 'scan.completed', 'global', '{}'::jsonb, 'test', 'agent', $4),
+			($5::uuid, $6::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $7),
+			($8::uuid, $9::uuid, 'scan.failed', 'global', '{}'::jsonb, 'test', 'agent', $10)
+	`, newer, newerEvent, now.Add(time.Second), now.Add(2*time.Second), middle, middleEvent, now.Add(-time.Hour+time.Second), older, olderEvent, now.Add(-2*time.Hour+time.Second)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	header, err := pg.LoadRunHeader(ctx, middle)
+	if err != nil {
+		t.Fatalf("LoadRunHeader: %v", err)
+	}
+	if header.RunID != middle || header.Status != "completed" || header.TriggerEventID != middleEvent || header.ForkedFromRunID != newer {
+		t.Fatalf("header = %#v", header)
+	}
+	if header.EndedAt == nil {
+		t.Fatalf("header.EndedAt = nil, want terminal timestamp")
+	}
+
+	firstPage, cursor, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Status: "running", Limit: 1})
+	if err != nil {
+		t.Fatalf("ListRunHeaders first page: %v", err)
+	}
+	if len(firstPage) != 1 || firstPage[0].RunID != newer {
+		t.Fatalf("first page = %#v, want newer running run", firstPage)
+	}
+	if cursor != "" {
+		t.Fatalf("running-only cursor = %q, want empty", cursor)
+	}
+
+	allFirstPage, cursor, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ListRunHeaders all first page: %v", err)
+	}
+	if len(allFirstPage) != 2 || allFirstPage[0].RunID != newer || allFirstPage[1].RunID != middle {
+		t.Fatalf("all first page = %#v", allFirstPage)
+	}
+	if cursor == "" {
+		t.Fatal("cursor empty for truncated run list")
+	}
+	allSecondPage, next, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Limit: 2, Cursor: cursor})
+	if err != nil {
+		t.Fatalf("ListRunHeaders all second page: %v", err)
+	}
+	if len(allSecondPage) != 1 || allSecondPage[0].RunID != older || next != "" {
+		t.Fatalf("all second page = %#v cursor=%q, want older only and no next cursor", allSecondPage, next)
+	}
+
+	since := now.Add(-90 * time.Minute)
+	recent, _, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Since: &since})
+	if err != nil {
+		t.Fatalf("ListRunHeaders since: %v", err)
+	}
+	if len(recent) != 2 {
+		t.Fatalf("recent runs len = %d, want 2: %#v", len(recent), recent)
+	}
+}
+
+func TestRunAPIReadSurface_LoadRunHeaderNotFound(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	_, err := pg.LoadRunHeader(context.Background(), uuid.NewString())
+	if !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("LoadRunHeader error = %v, want ErrRunNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary

Part of #665.

Implements Slice 3 read-only operator RPC methods on the v1 JSON-RPC transport:

- `health.ping` and `health.check` now return authenticated operator health and boot bundle identity.
- `run.get`, `run.list`, and `run.diagnose` now route through canonical persisted run/debug store ownership.
- `run.start` remains unimplemented and returns canonical `METHOD_UNAVAILABLE`.
- Boot bundle identity is computed as a deterministic `sha256:<hex>` content fingerprint with no filesystem path exposure.

## Governing Context

Authoritative spec refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.process_probes`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.bundle_fingerprint`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.BundleIdentity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.HealthCheckResult`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.RunHeader`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.RunDiagnosis`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.errors.METHOD_UNAVAILABLE`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.errors.RUN_NOT_FOUND`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.health.ping`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.health.check`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.diagnose`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.start`

## Semantic Ownership

New canonical owner: `internal/runtime/contracts.BootBundleIdentity` / `BundleFingerprint` for boot-time v1 bundle identity.

Old producer/reader/writer paths now invalid for this slice:

- CLI/dashboard health DTOs are not used as v1 health owners.
- Server-local contract paths are not exposed as v1 bundle identity.
- `run.start` does not fake business behavior and remains unavailable until its later mutating slice.

Production paths checked for surviving old behavior:

- `/healthz` and `/readyz` remain unauthenticated infrastructure probes.
- `/v1/rpc` dispatch still uses the generated method registry.
- v1 run methods consume `internal/store` persisted run/debug facts and `ProjectRunOperationalStatus`.

Migration complete for this Slice 3 first read-only operator surface. Parent #665 remains open for business methods, idempotency store, subscriptions, CLI/dashboard migration, and mutating run controls.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/runtime/contracts -count=1`
- `go test ./internal/store -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`