### PR TITLE
[agent-b][issue #665] Add v1 mailbox RPC decision owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -179,6 +179,10 @@ func main() {
 			log.Printf("runtime shutdown failed: %v", err)
 		}
 	}()
+	mailboxApprovalRoutes, err := apiv1.MailboxApprovalRoutesFromSpec(resolvedPlatformSpecPath)
+	if err != nil {
+		log.Fatalf("load v1 api mailbox approval routes: %v", err)
+	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
 		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
@@ -186,9 +190,13 @@ func main() {
 			Ready: func() bool {
 				return ready.Load()
 			},
-			Database: stores.Postgres,
-			Runs:     stores.Postgres,
-			Bundle:   bootBundleIdentity,
+			Database:              stores.Postgres,
+			Runs:                  stores.Postgres,
+			Mailbox:               stores.Postgres,
+			Idempotency:           stores.Postgres,
+			Events:                rt.Bus,
+			MailboxApprovalRoutes: mailboxApprovalRoutes,
+			Bundle:                bootBundleIdentity,
 		}),
 	})
 	if err != nil {

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -665,7 +665,7 @@
       },
       "errors": [
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1146,7 +1146,7 @@
     },
     {
       "name": "mailbox.approve",
-      "description": "Approve a pending mailbox item. Triggers the downstream event configured for the item's type.",
+      "description": "Approve a pending mailbox item. Triggers the downstream event configured for the item's type by api_specification.conventions.mailbox.approval_event_routes.",
       "params": [
         {
           "name": "mailbox_id",
@@ -1181,7 +1181,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1254,6 +1254,48 @@
                   "mailbox_id",
                   "existing_decision",
                   "decided_at"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32009,
+          "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "item_type": {
+                    "type": "string"
+                  },
+                  "mailbox_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "mailbox_id",
+                  "item_type"
                 ],
                 "type": "object"
               },
@@ -1366,7 +1408,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1582,7 +1624,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1737,7 +1779,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1935,7 +1977,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1973,7 +2015,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2096,7 +2138,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2165,7 +2207,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2298,7 +2340,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2336,7 +2378,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2378,7 +2420,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2582,7 +2624,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2661,7 +2703,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2807,7 +2849,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2845,7 +2887,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2976,7 +3018,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3053,7 +3095,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3288,7 +3330,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3400,7 +3442,7 @@
       },
       "errors": [
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5147,8 +5189,50 @@
           "type": "object"
         }
       },
-      "MAILBOX_NOT_FOUND": {
+      "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
         "code": -32009,
+        "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "item_type": {
+                  "type": "string"
+                },
+                "mailbox_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                }
+              },
+              "required": [
+                "mailbox_id",
+                "item_type"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "MAILBOX_NOT_FOUND": {
+        "code": -32010,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5186,7 +5270,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -5224,7 +5308,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -5282,7 +5366,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5313,7 +5397,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5344,7 +5428,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5382,7 +5466,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -5424,7 +5508,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5462,7 +5546,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5504,7 +5588,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5542,7 +5626,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3091,6 +3091,14 @@ platform_tables:
         \    INDEX idx_mailbox_status (status, severity, created_at),\n    INDEX idx_mailbox_entity (entity_id) WHERE entity_id\
         \ IS NOT NULL,\n    INDEX idx_mailbox_type (item_type, status),\n    INDEX idx_mailbox_global (scope, status) WHERE\
         \ scope = 'global'\n);"
+    api_idempotency:
+      description: 'Reusable v1 API idempotency replay store. One row per (method, actor token id, idempotency key). Stores
+        the canonical request hash and original completed response for the TTL window required by api_specification.conventions.idempotency.'
+      ddl: "CREATE TABLE api_idempotency (\n    method            TEXT NOT NULL,\n    actor_token_id    TEXT NOT NULL,\n\
+        \    idempotency_key   TEXT NOT NULL,\n    request_hash      TEXT NOT NULL,\n    resource_id       TEXT NOT NULL,\n\
+        \    response          JSONB NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    expires_at\
+        \        TIMESTAMPTZ NOT NULL,\n    PRIMARY KEY (method, actor_token_id, idempotency_key),\n    INDEX idx_api_idempotency_expires\
+        \ (expires_at)\n);"
     spend_ledger:
       description: LLM token and API cost tracking. One row per agent invocation.
       ddl: "CREATE TABLE spend_ledger (\n    ledger_id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    entity_id\
@@ -4886,6 +4894,17 @@ api_specification:
       - agent.replay_backlog
       - runtime.pause
       - runtime.resume
+    mailbox:
+      status_storage_model: 'The storage table keeps terminal defer decisions as status = decided and decision = deferred.
+        v1 read projections expose that row as MailboxStatus deferred. Approval/reject terminal rows remain status = decided
+        with decision approved/rejected; expired/cancelled rows project as expired.'
+      approval_event_routes:
+      - item_type: review_request
+        event_name: mailbox.item_decided
+      - item_type: approval
+        event_name: mailbox.item_decided
+      - item_type: operational_decision
+        event_name: mailbox.item_decided
     scopes:
       vocabulary: action-resource (read:<resource>, write:<resource>, control:<resource>, admin:<resource>, approve:<resource>,
         verify:<resource>)
@@ -6097,6 +6116,17 @@ api_specification:
             - expired
           decided_at:
             $ref: '#/components/schemas/Timestamp'
+      MAILBOX_APPROVAL_EVENT_UNCONFIGURED:
+        type: object
+        additionalProperties: false
+        required:
+        - mailbox_id
+        - item_type
+        properties:
+          mailbox_id:
+            $ref: '#/components/schemas/OpaqueId'
+          item_type:
+            type: string
       INVALID_DEFER_UNTIL:
         type: object
         additionalProperties: false
@@ -6810,7 +6840,7 @@ api_specification:
       - MAILBOX_NOT_FOUND
     mailbox.approve:
       tier: must_have
-      description: Approve a pending mailbox item. Triggers the downstream event configured for the item's type.
+      description: Approve a pending mailbox item. Triggers the downstream event configured for the item's type by api_specification.conventions.mailbox.approval_event_routes.
       scope:
         required:
         - approve:mailbox
@@ -6838,6 +6868,7 @@ api_specification:
       errors:
       - MAILBOX_NOT_FOUND
       - MAILBOX_ALREADY_DECIDED
+      - MAILBOX_APPROVAL_EVENT_UNCONFIGURED
       - IDEMPOTENCY_CONFLICT
     mailbox.reject:
       tier: must_have

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -42,6 +42,15 @@ type Conventions struct {
 	Scopes struct {
 		Catalog []string `yaml:"catalog" json:"catalog"`
 	} `yaml:"scopes" json:"scopes"`
+	Mailbox struct {
+		StatusStorageModel  string                      `yaml:"status_storage_model" json:"status_storage_model,omitempty"`
+		ApprovalEventRoutes []MailboxApprovalEventRoute `yaml:"approval_event_routes" json:"approval_event_routes,omitempty"`
+	} `yaml:"mailbox" json:"mailbox,omitempty"`
+}
+
+type MailboxApprovalEventRoute struct {
+	ItemType  string `yaml:"item_type" json:"item_type"`
+	EventName string `yaml:"event_name" json:"event_name"`
 }
 
 type Method struct {
@@ -218,6 +227,7 @@ func Validate(api *APISpecification) (ValidationReport, error) {
 			problems = append(problems, fmt.Sprintf("conventions.idempotency.mutating_methods references missing method %s", mutating))
 		}
 	}
+	problems = append(problems, validateMailboxConventions(api.Conventions.Mailbox.ApprovalEventRoutes)...)
 	if _, ok := api.MethodCatalog["rpc.unsubscribe"]; !ok {
 		problems = append(problems, "rpc.unsubscribe is described by subscription conventions but missing from method_catalog")
 	}
@@ -228,6 +238,30 @@ func Validate(api *APISpecification) (ValidationReport, error) {
 		return report, fmt.Errorf("api specification validation failed:\n- %s", strings.Join(problems, "\n- "))
 	}
 	return report, nil
+}
+
+func validateMailboxConventions(routes []MailboxApprovalEventRoute) []string {
+	var problems []string
+	seen := map[string]struct{}{}
+	for i, route := range routes {
+		itemType := strings.TrimSpace(route.ItemType)
+		eventName := strings.TrimSpace(route.EventName)
+		if itemType == "" {
+			problems = append(problems, fmt.Sprintf("conventions.mailbox.approval_event_routes[%d] missing item_type", i))
+		}
+		if eventName == "" {
+			problems = append(problems, fmt.Sprintf("conventions.mailbox.approval_event_routes[%d] missing event_name", i))
+		}
+		if itemType == "" {
+			continue
+		}
+		if _, ok := seen[itemType]; ok {
+			problems = append(problems, fmt.Sprintf("conventions.mailbox.approval_event_routes duplicate item_type %q", itemType))
+			continue
+		}
+		seen[itemType] = struct{}{}
+	}
+	return problems
 }
 
 func GenerateOpenRPC(api *APISpecification) ([]byte, error) {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -22,8 +22,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 49 {
 		t.Fatalf("schema count = %d, want 49", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 20 {
-		t.Fatalf("error code count = %d, want 20", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 21 {
+		t.Fatalf("error code count = %d, want 21", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 12 {
 		t.Fatalf("mutating method count = %d, want 12", report.MutatingMethodCount)
@@ -67,8 +67,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 49 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 49", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 20 {
-		t.Fatalf("generated OpenRPC errors = %d, want 20", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 21 {
+		t.Fatalf("generated OpenRPC errors = %d, want 21", len(doc.Components.Errors))
 	}
 }
 

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -3,6 +3,8 @@ package apiv1
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,6 +51,8 @@ type Request struct {
 	Params        map[string]any
 	CorrelationID string
 	Transport     string
+	ActorTokenID  string
+	RequestHash   string
 }
 
 type rpcRequest struct {
@@ -154,7 +158,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleRPC(w http.ResponseWriter, r *http.Request) {
 	correlationID := requestCorrelationID(r, nil)
 	w.Header().Set("X-Correlation-ID", correlationID)
-	if failure := h.authorize(r); failure != nil {
+	token, failure := h.authorize(r)
+	if failure != nil {
 		writeAuthFailure(w, failure)
 		return
 	}
@@ -163,12 +168,13 @@ func (h *Handler) handleRPC(w http.ResponseWriter, r *http.Request) {
 		writeRPC(w, rpcResponse{JSONRPC: jsonRPCVersion, ID: nil, Error: h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "read body failed"})})
 		return
 	}
-	resp := h.dispatch(r.Context(), raw, "http", correlationID)
+	resp := h.dispatch(r.Context(), raw, "http", correlationID, actorTokenID(token))
 	writeRPC(w, resp)
 }
 
 func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
-	if failure := h.authorize(r); failure != nil {
+	token, failure := h.authorize(r)
+	if failure != nil {
 		writeAuthFailure(w, failure)
 		return
 	}
@@ -182,19 +188,21 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return
 		}
-		resp := h.dispatch(r.Context(), raw, "websocket", requestCorrelationID(r, nil))
+		resp := h.dispatch(r.Context(), raw, "websocket", requestCorrelationID(r, nil), actorTokenID(token))
 		if err := conn.WriteJSON(resp); err != nil {
 			return
 		}
 	}
 }
 
-func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackCorrelationID string) rpcResponse {
+func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackCorrelationID, actorTokenID string) rpcResponse {
 	req, id, correlationID, rpcErr := h.parseRequest(raw, fallbackCorrelationID)
 	if rpcErr != nil {
 		return rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Error: rpcErr}
 	}
 	req.Transport = transport
+	req.ActorTokenID = strings.TrimSpace(actorTokenID)
+	req.RequestHash = requestBodyHash(req.Method, req.Params)
 	if method, ok := h.registry.Method(req.Method); ok {
 		if rpcErr := validateParams(method, req.Params, req.CorrelationID); rpcErr != nil {
 			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
@@ -487,22 +495,23 @@ type authFailure struct {
 	message string
 }
 
-func (h *Handler) authorize(r *http.Request) *authFailure {
+func (h *Handler) authorize(r *http.Request) (string, *authFailure) {
 	if len(h.tokens) == 0 {
-		return &authFailure{status: http.StatusServiceUnavailable, message: "v1 API auth is not configured"}
+		return "", &authFailure{status: http.StatusServiceUnavailable, message: "v1 API auth is not configured"}
 	}
 	authz := strings.TrimSpace(r.Header.Get("Authorization"))
 	if authz == "" {
-		return &authFailure{status: http.StatusUnauthorized, message: "missing authorization bearer token"}
+		return "", &authFailure{status: http.StatusUnauthorized, message: "missing authorization bearer token"}
 	}
 	const prefix = "bearer "
 	if !strings.HasPrefix(strings.ToLower(authz), prefix) {
-		return &authFailure{status: http.StatusUnauthorized, message: "invalid authorization header"}
+		return "", &authFailure{status: http.StatusUnauthorized, message: "invalid authorization header"}
 	}
-	if _, ok := h.tokens[strings.TrimSpace(authz[len(prefix):])]; !ok {
-		return &authFailure{status: http.StatusUnauthorized, message: "invalid bearer token"}
+	token := strings.TrimSpace(authz[len(prefix):])
+	if _, ok := h.tokens[token]; !ok {
+		return "", &authFailure{status: http.StatusUnauthorized, message: "invalid bearer token"}
 	}
-	return nil
+	return token, nil
 }
 
 func writeAuthFailure(w http.ResponseWriter, failure *authFailure) {
@@ -559,4 +568,26 @@ func tokenSet(tokens []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func actorTokenID(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func requestBodyHash(method string, params map[string]any) string {
+	body := map[string]any{
+		"method": strings.TrimSpace(method),
+		"params": params,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		raw = []byte(strings.TrimSpace(method))
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -2,6 +2,7 @@ package apiv1
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -27,6 +28,10 @@ type APIIdempotencyStore interface {
 
 type EventPublisher interface {
 	Publish(context.Context, events.Event) error
+}
+
+type TransactionalEventPublisher interface {
+	PublishTx(context.Context, *sql.Tx, events.Event) error
 }
 
 type mailboxListResult struct {
@@ -111,49 +116,26 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 
 func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadOptions, decision store.MailboxV1DecisionRequest) (any, error) {
 	idempotencyKey := stringParam(req.Params, "idempotency_key")
-	execute := func(context.Context) (any, error) {
-		outcome, err := opts.Mailbox.DecideV1MailboxItem(ctx, decision)
-		if err != nil {
-			return nil, mailboxDecisionError(decision.MailboxID, err)
+	action := strings.ToLower(strings.TrimSpace(decision.Action))
+	if action == "approved" || action == "approve" {
+		txPublisher, ok := opts.Events.(TransactionalEventPublisher)
+		if !ok || txPublisher == nil {
+			return nil, errors.New("transactional event publisher is required for mailbox approval")
 		}
-		if outcome.ApprovalEvent != nil {
-			if opts.Events == nil {
-				return nil, errors.New("event publisher is required for mailbox approval")
-			}
-			if err := opts.Events.Publish(ctx, *outcome.ApprovalEvent); err != nil {
-				return nil, err
-			}
-		}
-		return outcome.Result, nil
+		decision.ApprovalEventTx = txPublisher.PublishTx
 	}
-	if strings.TrimSpace(idempotencyKey) == "" {
-		return execute(ctx)
-	}
-	if opts.Idempotency == nil {
-		return nil, errors.New("api idempotency store is required")
-	}
-	completion, _, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
-		Method:         req.Method,
-		ActorTokenID:   req.ActorTokenID,
-		IdempotencyKey: idempotencyKey,
-		RequestHash:    req.RequestHash,
-		ResourceID:     decision.MailboxID,
-		TTL:            24 * time.Hour,
-		Now:            decision.Now,
-	}, func(context.Context) (store.APIIdempotencyCompletion, error) {
-		result, err := execute(ctx)
-		if err != nil {
-			return store.APIIdempotencyCompletion{}, err
+	if strings.TrimSpace(idempotencyKey) != "" {
+		decision.Idempotency = &store.APIIdempotencyRequest{
+			Method:         req.Method,
+			ActorTokenID:   req.ActorTokenID,
+			IdempotencyKey: idempotencyKey,
+			RequestHash:    req.RequestHash,
+			ResourceID:     decision.MailboxID,
+			TTL:            24 * time.Hour,
+			Now:            decision.Now,
 		}
-		raw, err := json.Marshal(result)
-		if err != nil {
-			return store.APIIdempotencyCompletion{}, err
-		}
-		return store.APIIdempotencyCompletion{
-			ResourceID: decision.MailboxID,
-			Response:   raw,
-		}, nil
-	})
+	}
+	outcome, err := opts.Mailbox.DecideV1MailboxItem(ctx, decision)
 	if err != nil {
 		var conflict *store.APIIdempotencyConflictError
 		if errors.As(err, &conflict) {
@@ -166,13 +148,9 @@ func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadO
 				},
 			})
 		}
-		return nil, err
+		return nil, mailboxDecisionError(decision.MailboxID, err)
 	}
-	var replayed any
-	if err := json.Unmarshal(completion.Response, &replayed); err != nil {
-		return nil, err
-	}
-	return replayed, nil
+	return outcome.Result, nil
 }
 
 func mailboxDecisionError(mailboxID string, err error) error {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -1,0 +1,289 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"swarm/internal/events"
+	"swarm/internal/store"
+)
+
+type MailboxAPIStore interface {
+	ListV1MailboxItems(context.Context, store.MailboxV1ListOptions) ([]store.MailboxV1Item, string, error)
+	GetV1MailboxItem(context.Context, string) (store.MailboxV1ItemDetail, error)
+	DecideV1MailboxItem(context.Context, store.MailboxV1DecisionRequest) (store.MailboxV1DecisionOutcome, error)
+}
+
+type APIIdempotencyStore interface {
+	WithAPIIdempotency(
+		context.Context,
+		store.APIIdempotencyRequest,
+		func(context.Context) (store.APIIdempotencyCompletion, error),
+	) (store.APIIdempotencyCompletion, bool, error)
+}
+
+type EventPublisher interface {
+	Publish(context.Context, events.Event) error
+}
+
+type mailboxListResult struct {
+	Items      []store.MailboxV1Item `json:"items"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.Mailbox == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"mailbox.list": func(ctx context.Context, req Request) (any, error) {
+			listOpts, err := mailboxListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			items, nextCursor, err := opts.Mailbox.ListV1MailboxItems(ctx, listOpts)
+			if errors.Is(err, store.ErrMailboxV1InvalidCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid mailbox cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if items == nil {
+				items = []store.MailboxV1Item{}
+			}
+			return mailboxListResult{Items: items, NextCursor: nextCursor}, nil
+		},
+		"mailbox.get": func(ctx context.Context, req Request) (any, error) {
+			detail, err := opts.Mailbox.GetV1MailboxItem(ctx, stringParam(req.Params, "mailbox_id"))
+			if errors.Is(err, store.ErrMailboxV1NotFound) {
+				return nil, NewApplicationError(MailboxNotFoundCode, false, map[string]any{"mailbox_id": stringParam(req.Params, "mailbox_id")})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return detail, nil
+		},
+		"mailbox.approve": func(ctx context.Context, req Request) (any, error) {
+			payload, err := optionalObjectRaw(req.Params, "decision_payload")
+			if err != nil {
+				return nil, err
+			}
+			return executeMailboxDecision(ctx, req, opts, store.MailboxV1DecisionRequest{
+				MailboxID:         stringParam(req.Params, "mailbox_id"),
+				Action:            "approved",
+				ActorTokenID:      req.ActorTokenID,
+				DecisionPayload:   payload,
+				Now:               now().UTC(),
+				ApprovalEventType: mailboxApprovalEventType(opts.MailboxApprovalRoutes, stringParam(req.Params, "mailbox_id"), opts.Mailbox, ctx),
+			})
+		},
+		"mailbox.reject": func(ctx context.Context, req Request) (any, error) {
+			return executeMailboxDecision(ctx, req, opts, store.MailboxV1DecisionRequest{
+				MailboxID:    stringParam(req.Params, "mailbox_id"),
+				Action:       "rejected",
+				ActorTokenID: req.ActorTokenID,
+				Reason:       stringParam(req.Params, "reason"),
+				Now:          now().UTC(),
+			})
+		},
+		"mailbox.defer": func(ctx context.Context, req Request) (any, error) {
+			until, err := requiredTimestampParam(req.Params, "until")
+			if err != nil {
+				return nil, err
+			}
+			return executeMailboxDecision(ctx, req, opts, store.MailboxV1DecisionRequest{
+				MailboxID:    stringParam(req.Params, "mailbox_id"),
+				Action:       "deferred",
+				ActorTokenID: req.ActorTokenID,
+				DeferUntil:   until,
+				Now:          now().UTC(),
+			})
+		},
+	}
+}
+
+func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadOptions, decision store.MailboxV1DecisionRequest) (any, error) {
+	idempotencyKey := stringParam(req.Params, "idempotency_key")
+	execute := func(context.Context) (any, error) {
+		outcome, err := opts.Mailbox.DecideV1MailboxItem(ctx, decision)
+		if err != nil {
+			return nil, mailboxDecisionError(decision.MailboxID, err)
+		}
+		if outcome.ApprovalEvent != nil {
+			if opts.Events == nil {
+				return nil, errors.New("event publisher is required for mailbox approval")
+			}
+			if err := opts.Events.Publish(ctx, *outcome.ApprovalEvent); err != nil {
+				return nil, err
+			}
+		}
+		return outcome.Result, nil
+	}
+	if strings.TrimSpace(idempotencyKey) == "" {
+		return execute(ctx)
+	}
+	if opts.Idempotency == nil {
+		return nil, errors.New("api idempotency store is required")
+	}
+	completion, _, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     decision.MailboxID,
+		TTL:            24 * time.Hour,
+		Now:            decision.Now,
+	}, func(context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := execute(ctx)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: decision.MailboxID,
+			Response:   raw,
+		}, nil
+	})
+	if err != nil {
+		var conflict *store.APIIdempotencyConflictError
+		if errors.As(err, &conflict) {
+			return nil, NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+				"original_request_hash":    conflict.OriginalRequestHash,
+				"conflicting_request_hash": conflict.ConflictingRequestHash,
+				"original_response_ref": map[string]any{
+					"method":      conflict.Method,
+					"resource_id": conflict.ResourceID,
+				},
+			})
+		}
+		return nil, err
+	}
+	var replayed any
+	if err := json.Unmarshal(completion.Response, &replayed); err != nil {
+		return nil, err
+	}
+	return replayed, nil
+}
+
+func mailboxDecisionError(mailboxID string, err error) error {
+	if errors.Is(err, store.ErrMailboxV1NotFound) {
+		return NewApplicationError(MailboxNotFoundCode, false, map[string]any{"mailbox_id": mailboxID})
+	}
+	var already *store.MailboxV1AlreadyDecidedError
+	if errors.As(err, &already) {
+		return NewApplicationError(MailboxAlreadyDecidedCode, false, map[string]any{
+			"mailbox_id":        already.MailboxID,
+			"existing_decision": already.ExistingDecision,
+			"decided_at":        already.DecidedAt.UTC().Format(time.RFC3339Nano),
+		})
+	}
+	var invalidDefer *store.MailboxV1InvalidDeferUntilError
+	if errors.As(err, &invalidDefer) {
+		details := map[string]any{"reason": invalidDefer.Reason}
+		if invalidDefer.MaxUntil != nil {
+			details["max_until"] = invalidDefer.MaxUntil.UTC().Format(time.RFC3339Nano)
+		}
+		return NewApplicationError(InvalidDeferUntilCode, false, details)
+	}
+	var route *store.MailboxV1ApprovalRouteError
+	if errors.As(err, &route) {
+		return NewApplicationError(MailboxApprovalEventUnconfiguredCode, false, map[string]any{
+			"mailbox_id": route.MailboxID,
+			"item_type":  route.ItemType,
+		})
+	}
+	return err
+}
+
+func mailboxListOptionsFromParams(params map[string]any) (store.MailboxV1ListOptions, error) {
+	out := store.MailboxV1ListOptions{}
+	var err error
+	if out.Status, _, err = optionalStringParam(params, "status"); err != nil {
+		return out, err
+	}
+	out.Status = strings.TrimSpace(strings.ToLower(out.Status))
+	if out.Status != "" && out.Status != "pending" && out.Status != "decided" && out.Status != "expired" && out.Status != "deferred" {
+		return out, NewInvalidParamsError(map[string]any{"field": "status", "reason": "must be a valid MailboxStatus"})
+	}
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return out, err
+	}
+	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
+		return out, err
+	}
+	if out.Type, _, err = optionalStringParam(params, "type"); err != nil {
+		return out, err
+	}
+	if out.Priority, _, err = optionalStringParam(params, "priority"); err != nil {
+		return out, err
+	}
+	out.Priority = strings.TrimSpace(strings.ToLower(out.Priority))
+	if out.Priority != "" && out.Priority != "normal" && out.Priority != "high" && out.Priority != "critical" {
+		return out, NewInvalidParamsError(map[string]any{"field": "priority", "reason": "must be a valid MailboxPriority"})
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return out, err
+	}
+	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
+		limit, ok := integerParam(raw)
+		if !ok || limit < 1 || limit > 200 {
+			return out, NewInvalidParamsError(map[string]any{"field": "limit", "reason": "must be an integer from 1 to 200"})
+		}
+		out.Limit = limit
+	}
+	return out, nil
+}
+
+func optionalObjectRaw(params map[string]any, name string) (json.RawMessage, error) {
+	if params == nil {
+		return nil, nil
+	}
+	value, ok := params[name]
+	if !ok || isEmptyParam(value) {
+		return nil, nil
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return nil, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be an object"})
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func requiredTimestampParam(params map[string]any, name string) (time.Time, error) {
+	value, present, err := optionalStringParam(params, name)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !present || strings.TrimSpace(value) == "" {
+		return time.Time{}, NewInvalidParamsError(map[string]any{"field": name, "reason": "required parameter is missing"})
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be RFC3339 timestamp"})
+	}
+	return parsed.UTC(), nil
+}
+
+func mailboxApprovalEventType(routes map[string]string, mailboxID string, mailbox MailboxAPIStore, ctx context.Context) string {
+	if len(routes) == 0 || mailbox == nil {
+		return ""
+	}
+	detail, err := mailbox.GetV1MailboxItem(ctx, mailboxID)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(routes[detail.Item.Type])
+}

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -1,0 +1,175 @@
+package apiv1
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   runID,
+		Payload: json.RawMessage(`{"request":true}`),
+	}.WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   sourceEventID,
+		EntityID:  entityID,
+		FromAgent: "empire-agent",
+		Type:      "review_request",
+		Priority:  "high",
+		Context:   []byte(`{"title":"review this"}`),
+		Summary:   "needs approval",
+	})
+	if err != nil {
+		t.Fatalf("insert mailbox: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE mailbox SET flow_instance = 'empire/review' WHERE item_id = $1::uuid`, mailboxID); err != nil {
+		t.Fatalf("set flow instance: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now: func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready: func() bool {
+				return true
+			},
+			Database:    fakePinger{},
+			Mailbox:     pg,
+			Idempotency: pg,
+			Events:      bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "empire",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"mailbox.list","params":{"status":"pending","run_id":"`+runID+`","entity_id":"`+entityID+`","type":"review_request","priority":"high","limit":1}}`)
+	if list.Error != nil {
+		t.Fatalf("mailbox.list error = %#v", list.Error)
+	}
+	items := asMap(t, list.Result)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("mailbox.list items = %#v", items)
+	}
+	item := asMap(t, items[0])
+	if item["mailbox_id"] != mailboxID || item["source_flow"] != "empire/review" || item["priority"] != "high" {
+		t.Fatalf("mailbox.list item = %#v", item)
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"mailbox.get","params":{"mailbox_id":"`+mailboxID+`"}}`)
+	if get.Error != nil {
+		t.Fatalf("mailbox.get error = %#v", get.Error)
+	}
+	if got := asMap(t, asMap(t, get.Result)["item"])["mailbox_id"]; got != mailboxID {
+		t.Fatalf("mailbox.get mailbox_id = %v", got)
+	}
+	if history := asMap(t, get.Result)["history"].([]any); len(history) != 1 {
+		t.Fatalf("mailbox.get history = %#v", history)
+	}
+
+	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-approve"}}`
+	approved := rpcCall(t, handler, approveBody)
+	if approved.Error != nil {
+		t.Fatalf("mailbox.approve error = %#v", approved.Error)
+	}
+	approvedResult := asMap(t, approved.Result)
+	downstreamID, _ := approvedResult["downstream_event_id"].(string)
+	if downstreamID == "" || approvedResult["status"] != "decided" {
+		t.Fatalf("mailbox.approve result = %#v", approvedResult)
+	}
+	replay := rpcCall(t, handler, approveBody)
+	if replay.Error != nil {
+		t.Fatalf("mailbox.approve replay error = %#v", replay.Error)
+	}
+	if got := asMap(t, replay.Result)["downstream_event_id"]; got != downstreamID {
+		t.Fatalf("idempotency replay downstream_event_id = %v, want %s", got, downstreamID)
+	}
+	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
+		t.Fatalf("mailbox.item_decided event count = %d, want 1", count)
+	}
+
+	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"conflict","method":"mailbox.approve","params":{"mailbox_id":"`+mailboxID+`","decision_payload":{"approved":false},"idempotency_key":"idem-approve"}}`)
+	if conflict.Error == nil {
+		t.Fatal("mailbox.approve conflicting idempotency error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("idempotency conflict data = %#v", data)
+	}
+
+	rejectAlready := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"reject","method":"mailbox.reject","params":{"mailbox_id":"`+mailboxID+`","reason":"too late"}}`)
+	if rejectAlready.Error == nil {
+		t.Fatal("mailbox.reject already-decided error = nil")
+	}
+	if data := asMap(t, rejectAlready.Error.Data); data["code"] != MailboxAlreadyDecidedCode {
+		t.Fatalf("already decided data = %#v", data)
+	}
+
+	deferID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		Type:    "approval",
+		Summary: "defer me",
+		Context: []byte(`{"title":"defer"}`),
+	})
+	if err != nil {
+		t.Fatalf("insert defer mailbox: %v", err)
+	}
+	past := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"past","method":"mailbox.defer","params":{"mailbox_id":"`+deferID+`","until":"2026-05-10T11:59:59Z","idempotency_key":"idem-past"}}`)
+	if past.Error == nil {
+		t.Fatal("mailbox.defer in past error = nil")
+	}
+	if data := asMap(t, past.Error.Data); data["code"] != InvalidDeferUntilCode {
+		t.Fatalf("invalid defer data = %#v", data)
+	}
+	deferred := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"defer","method":"mailbox.defer","params":{"mailbox_id":"`+deferID+`","until":"2026-05-10T13:00:00Z","idempotency_key":"idem-defer"}}`)
+	if deferred.Error != nil {
+		t.Fatalf("mailbox.defer error = %#v", deferred.Error)
+	}
+	if status := asMap(t, deferred.Result)["status"]; status != "deferred" {
+		t.Fatalf("mailbox.defer status = %v, want deferred", status)
+	}
+
+	empty := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"empty","method":"mailbox.list","params":{"status":"pending","type":"review_request"}}`)
+	if empty.Error != nil {
+		t.Fatalf("empty mailbox.list error = %#v", empty.Error)
+	}
+	if items := asMap(t, empty.Result)["items"].([]any); len(items) != 0 {
+		t.Fatalf("empty mailbox.list items = %#v", items)
+	}
+}
+
+func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = $1`, eventName).Scan(&count); err != nil {
+		t.Fatalf("count events %s: %v", eventName, err)
+	}
+	return count
+}

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -156,6 +156,34 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if status := asMap(t, deferred.Result)["status"]; status != "deferred" {
 		t.Fatalf("mailbox.defer status = %v, want deferred", status)
 	}
+	laterHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now: func() time.Time { return time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC) },
+			Ready: func() bool {
+				return true
+			},
+			Database:    fakePinger{},
+			Mailbox:     pg,
+			Idempotency: pg,
+			Events:      bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "empire",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+		}),
+	})
+	deferReplay := rpcCall(t, laterHandler, `{"jsonrpc":"2.0","id":"defer-replay","method":"mailbox.defer","params":{"mailbox_id":"`+deferID+`","until":"2026-05-10T13:00:00Z","idempotency_key":"idem-defer"}}`)
+	if deferReplay.Error != nil {
+		t.Fatalf("mailbox.defer replay after until passed error = %#v", deferReplay.Error)
+	}
+	if status := asMap(t, deferReplay.Result)["status"]; status != "deferred" {
+		t.Fatalf("mailbox.defer replay status = %v, want deferred", status)
+	}
 
 	empty := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"empty","method":"mailbox.list","params":{"status":"pending","type":"review_request"}}`)
 	if empty.Error != nil {

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -165,6 +166,93 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	}
 }
 
+func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceEventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   uuid.NewString(),
+		Payload: json.RawMessage(`{"request":true}`),
+	}); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID: sourceEventID,
+		Type:    "review_request",
+		Summary: "needs approval",
+		Context: []byte(`{"title":"review this"}`),
+	})
+	if err != nil {
+		t.Fatalf("insert mailbox: %v", err)
+	}
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	failingHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:      func() time.Time { return now },
+			Ready:    func() bool { return true },
+			Database: fakePinger{},
+			Mailbox:  pg,
+			Events:   failingTxPublisher{},
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+		}),
+	})
+	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-publish-fails"}}`
+	failed := rpcCall(t, failingHandler, approveBody)
+	if failed.Error == nil {
+		t.Fatal("mailbox.approve with failing publisher error = nil")
+	}
+	detail, err := pg.GetV1MailboxItem(ctx, mailboxID)
+	if err != nil {
+		t.Fatalf("get mailbox after failed publish: %v", err)
+	}
+	if detail.Item.Status != "pending" {
+		t.Fatalf("mailbox status after failed publish = %s, want pending", detail.Item.Status)
+	}
+	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 0 {
+		t.Fatalf("mailbox.item_decided event count after failed publish = %d, want 0", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 0 {
+		t.Fatalf("api_idempotency rows after failed publish = %d, want 0", count)
+	}
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	successHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:      func() time.Time { return now },
+			Ready:    func() bool { return true },
+			Database: fakePinger{},
+			Mailbox:  pg,
+			Events:   bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+		}),
+	})
+	succeeded := rpcCall(t, successHandler, approveBody)
+	if succeeded.Error != nil {
+		t.Fatalf("mailbox.approve retry after failed publish error = %#v", succeeded.Error)
+	}
+	if status := asMap(t, succeeded.Result)["status"]; status != "decided" {
+		t.Fatalf("mailbox.approve retry status = %v, want decided", status)
+	}
+	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
+		t.Fatalf("mailbox.item_decided event count after retry = %d, want 1", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after retry = %d, want 1", count)
+	}
+}
+
 func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
 	t.Helper()
 	var count int
@@ -172,4 +260,23 @@ func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
 		t.Fatalf("count events %s: %v", eventName, err)
 	}
 	return count
+}
+
+func countAPIIdempotencyRows(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM api_idempotency`).Scan(&count); err != nil {
+		t.Fatalf("count api_idempotency rows: %v", err)
+	}
+	return count
+}
+
+type failingTxPublisher struct{}
+
+func (failingTxPublisher) Publish(context.Context, events.Event) error {
+	return nil
+}
+
+func (failingTxPublisher) PublishTx(context.Context, *sql.Tx, events.Event) error {
+	return errors.New("publish failed")
 }

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -23,11 +23,15 @@ type RunReadStore interface {
 }
 
 type OperatorReadOptions struct {
-	Now      func() time.Time
-	Ready    func() bool
-	Database Pinger
-	Runs     RunReadStore
-	Bundle   runtimecontracts.BundleIdentity
+	Now                   func() time.Time
+	Ready                 func() bool
+	Database              Pinger
+	Runs                  RunReadStore
+	Mailbox               MailboxAPIStore
+	Idempotency           APIIdempotencyStore
+	Events                EventPublisher
+	MailboxApprovalRoutes map[string]string
+	Bundle                runtimecontracts.BundleIdentity
 }
 
 type healthPingResult struct {
@@ -78,7 +82,7 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	if ready == nil {
 		ready = func() bool { return false }
 	}
-	return map[string]MethodHandler{
+	handlers := map[string]MethodHandler{
 		"health.ping": func(context.Context, Request) (any, error) {
 			return healthPingResult{OK: true, TS: now().UTC().Format(time.RFC3339Nano)}, nil
 		},
@@ -162,6 +166,10 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 			}, nil
 		},
 	}
+	for name, handler := range OperatorMailboxHandlers(opts) {
+		handlers[name] = handler
+	}
+	return handlers
 }
 
 func requireRunReadStore(runs RunReadStore) (RunReadStore, error) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -11,8 +11,13 @@ import (
 )
 
 const (
-	MethodUnavailableCode = "METHOD_UNAVAILABLE"
-	RunNotFoundCode       = "RUN_NOT_FOUND"
+	MethodUnavailableCode                = "METHOD_UNAVAILABLE"
+	RunNotFoundCode                      = "RUN_NOT_FOUND"
+	MailboxNotFoundCode                  = "MAILBOX_NOT_FOUND"
+	MailboxAlreadyDecidedCode            = "MAILBOX_ALREADY_DECIDED"
+	MailboxApprovalEventUnconfiguredCode = "MAILBOX_APPROVAL_EVENT_UNCONFIGURED"
+	InvalidDeferUntilCode                = "INVALID_DEFER_UNTIL"
+	IdempotencyConflictCode              = "IDEMPOTENCY_CONFLICT"
 )
 
 type Registry struct {
@@ -81,6 +86,22 @@ func (r *Registry) ApplicationErrorCode(code string) (int, bool) {
 	return numeric, ok
 }
 
+func (r *Registry) MailboxApprovalEventRoutes() map[string]string {
+	out := map[string]string{}
+	if r == nil || r.api == nil {
+		return out
+	}
+	for _, route := range r.api.Conventions.Mailbox.ApprovalEventRoutes {
+		itemType := strings.TrimSpace(route.ItemType)
+		eventName := strings.TrimSpace(route.EventName)
+		if itemType == "" || eventName == "" {
+			continue
+		}
+		out[itemType] = eventName
+	}
+	return out
+}
+
 func OpenRPCMethodNames(path string) ([]string, error) {
 	raw, err := os.ReadFile(strings.TrimSpace(path))
 	if err != nil {
@@ -96,4 +117,12 @@ func OpenRPCMethodNames(path string) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+func MailboxApprovalRoutesFromSpec(path string) (map[string]string, error) {
+	registry, err := LoadRegistry(path)
+	if err != nil {
+		return nil, err
+	}
+	return registry.MailboxApprovalEventRoutes(), nil
 }

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -125,6 +125,83 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
 }
 
+// PublishTx persists the canonical event record and recipient manifest in a
+// caller-owned transaction. Callers use this when another persisted state
+// transition must commit atomically with event emission.
+func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	ctx = WithCurrentRuntimeEpoch(ctx)
+	if err := ensurePublishEpoch(ctx); err != nil {
+		return err
+	}
+	if tx == nil {
+		return errors.New("publish tx is required")
+	}
+	if evt.Type == "" {
+		return errors.New("event type is required")
+	}
+	if !isValidEventTypeName(string(evt.Type)) {
+		return fmt.Errorf("invalid event type: %s", strings.TrimSpace(string(evt.Type)))
+	}
+	if eb.payloadValidator != nil {
+		if err := eb.payloadValidator(string(evt.Type), evt.Payload); err != nil {
+			return fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type)), err)
+		}
+	}
+	if evt.ID == "" {
+		evt.ID = uuid.NewString()
+	}
+	if evt.CreatedAt.IsZero() {
+		evt.CreatedAt = time.Now()
+	}
+	ictx, evt := runtimecorrelation.CorrelateEvent(ctx, evt)
+	txStore, ok := eb.store.(TransactionalEventStore)
+	if !ok || txStore == nil {
+		return errors.New("transactional event store is required")
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ictx, tx)
+	if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+		return fmt.Errorf("persist event: %w", err)
+	}
+	if err := eb.authorizePublishRecipientPlanning(txctx, evt); err != nil {
+		return err
+	}
+	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
+	if err != nil {
+		return err
+	}
+	if err := eb.authorizePublishRecipientPlan(txctx, evt, inboundPlan); err != nil {
+		return err
+	}
+	eb.recordPublishDiagnostic(txctx, evt, inboundPlan)
+	if len(inboundPlan.PersistedRecipients) > 0 {
+		if err := txStore.InsertEventDeliveriesTx(txctx, tx, evt.ID, inboundPlan.PersistedRecipients); err != nil {
+			return fmt.Errorf("persist event deliveries: %w", err)
+		}
+	}
+	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
+		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+			return fmt.Errorf("persist committed replay scope: %w", err)
+		}
+	} else if replayScopePersistenceRequired(eb.store) {
+		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+	}
+	passthrough, deferred, err := eb.runInterceptors(txctx, evt)
+	if err != nil {
+		return err
+	}
+	if !passthrough {
+		return errors.New("transactional publish interceptors cannot consume v1 API events")
+	}
+	if len(deferred) > 0 {
+		return errors.New("transactional publish interceptors cannot defer v1 API events")
+	}
+	status, errText := pipelineReceiptStatus(txctx, nil)
+	if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID, status, errText); err != nil {
+		return fmt.Errorf("persist pipeline receipt: %w", err)
+	}
+	return nil
+}
+
 func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, error) {
 	if eb == nil || eb.store == nil {
 		return nil

--- a/internal/store/api_idempotency.go
+++ b/internal/store/api_idempotency.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const apiIdempotencyLockNamespace = "swarm:api-idempotency:"
+
+var ErrAPIIdempotencyConflict = errors.New("api idempotency conflict")
+
+type APIIdempotencyRequest struct {
+	Method         string
+	ActorTokenID   string
+	IdempotencyKey string
+	RequestHash    string
+	ResourceID     string
+	TTL            time.Duration
+	Now            time.Time
+}
+
+type APIIdempotencyCompletion struct {
+	ResourceID string
+	Response   json.RawMessage
+}
+
+type APIIdempotencyConflictError struct {
+	OriginalRequestHash    string
+	ConflictingRequestHash string
+	Method                 string
+	ResourceID             string
+}
+
+func (e *APIIdempotencyConflictError) Error() string {
+	return "api idempotency conflict"
+}
+
+func (e *APIIdempotencyConflictError) Is(target error) bool {
+	return target == ErrAPIIdempotencyConflict
+}
+
+func (s *PostgresStore) WithAPIIdempotency(
+	ctx context.Context,
+	req APIIdempotencyRequest,
+	execute func(context.Context) (APIIdempotencyCompletion, error),
+) (APIIdempotencyCompletion, bool, error) {
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		completion, err := execute(ctx)
+		return completion, false, err
+	}
+	if s == nil || s.DB == nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("postgres store is required")
+	}
+	if execute == nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency executor is required")
+	}
+	req.Method = strings.TrimSpace(req.Method)
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	req.RequestHash = strings.TrimSpace(req.RequestHash)
+	req.ResourceID = strings.TrimSpace(req.ResourceID)
+	if req.Method == "" || req.ActorTokenID == "" || req.RequestHash == "" {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("method, actor token id, and request hash are required")
+	}
+	if req.TTL <= 0 {
+		req.TTL = 24 * time.Hour
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+
+	conn, err := s.DB.Conn(ctx)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("acquire api idempotency connection: %w", err)
+	}
+	defer conn.Close()
+
+	lockKey := apiIdempotencyLockKey(req.Method, req.ActorTokenID, req.IdempotencyKey)
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtext($1))`, lockKey); err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("lock api idempotency key: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(hashtext($1))`, lockKey)
+	}()
+
+	if err := purgeExpiredAPIIdempotency(ctx, conn, req.Now); err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	existing, ok, err := loadAPIIdempotency(ctx, conn, req)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	if ok {
+		if existing.RequestHash != req.RequestHash {
+			return APIIdempotencyCompletion{}, false, &APIIdempotencyConflictError{
+				OriginalRequestHash:    existing.RequestHash,
+				ConflictingRequestHash: req.RequestHash,
+				Method:                 req.Method,
+				ResourceID:             existing.ResourceID,
+			}
+		}
+		return APIIdempotencyCompletion{
+			ResourceID: existing.ResourceID,
+			Response:   append(json.RawMessage(nil), existing.Response...),
+		}, true, nil
+	}
+
+	completion, err := execute(ctx)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	if len(completion.Response) == 0 {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency response is required")
+	}
+	if strings.TrimSpace(completion.ResourceID) == "" {
+		completion.ResourceID = req.ResourceID
+	}
+	if err := storeAPIIdempotency(ctx, conn, req, completion); err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	return completion, false, nil
+}
+
+type apiIdempotencyRecord struct {
+	RequestHash string
+	ResourceID  string
+	Response    json.RawMessage
+}
+
+func loadAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {
+	var record apiIdempotencyRecord
+	err := q.QueryRowContext(ctx, `
+		SELECT request_hash, resource_id, response
+		FROM api_idempotency
+		WHERE method = $1
+		  AND actor_token_id = $2
+		  AND idempotency_key = $3
+		  AND expires_at > $4
+	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.Now).Scan(&record.RequestHash, &record.ResourceID, &record.Response)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return apiIdempotencyRecord{}, false, nil
+	case err != nil:
+		return apiIdempotencyRecord{}, false, fmt.Errorf("load api idempotency response: %w", err)
+	default:
+		return record, true, nil
+	}
+}
+
+func storeAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyRequest, completion APIIdempotencyCompletion) error {
+	_, err := q.ExecContext(ctx, `
+		INSERT INTO api_idempotency (
+			method, actor_token_id, idempotency_key, request_hash,
+			resource_id, response, created_at, expires_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.RequestHash, strings.TrimSpace(completion.ResourceID), string(completion.Response), req.Now, req.Now.Add(req.TTL))
+	if err != nil {
+		return fmt.Errorf("store api idempotency response: %w", err)
+	}
+	return nil
+}
+
+func purgeExpiredAPIIdempotency(ctx context.Context, q *sql.Conn, now time.Time) error {
+	_, err := q.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= $1`, now)
+	if err != nil {
+		return fmt.Errorf("purge expired api idempotency responses: %w", err)
+	}
+	return nil
+}
+
+func apiIdempotencyLockKey(method, actorTokenID, idempotencyKey string) string {
+	return apiIdempotencyLockNamespace + strings.Join([]string{
+		strings.TrimSpace(method),
+		strings.TrimSpace(actorTokenID),
+		strings.TrimSpace(idempotencyKey),
+	}, "|")
+}

--- a/internal/store/api_idempotency.go
+++ b/internal/store/api_idempotency.go
@@ -132,7 +132,7 @@ type apiIdempotencyRecord struct {
 	Response    json.RawMessage
 }
 
-func loadAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {
+func loadAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {
 	var record apiIdempotencyRecord
 	err := q.QueryRowContext(ctx, `
 		SELECT request_hash, resource_id, response
@@ -152,7 +152,7 @@ func loadAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyRequ
 	}
 }
 
-func storeAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyRequest, completion APIIdempotencyCompletion) error {
+func storeAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest, completion APIIdempotencyCompletion) error {
 	_, err := q.ExecContext(ctx, `
 		INSERT INTO api_idempotency (
 			method, actor_token_id, idempotency_key, request_hash,
@@ -166,7 +166,7 @@ func storeAPIIdempotency(ctx context.Context, q *sql.Conn, req APIIdempotencyReq
 	return nil
 }
 
-func purgeExpiredAPIIdempotency(ctx context.Context, q *sql.Conn, now time.Time) error {
+func purgeExpiredAPIIdempotency(ctx context.Context, q execQueryer, now time.Time) error {
 	_, err := q.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= $1`, now)
 	if err != nil {
 		return fmt.Errorf("purge expired api idempotency responses: %w", err)

--- a/internal/store/mailbox.go
+++ b/internal/store/mailbox.go
@@ -427,9 +427,11 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 }
 
 func normalizeMailboxSeverity(priority string) string {
-	switch strings.TrimSpace(priority) {
-	case "critical", "urgent":
-		return strings.TrimSpace(priority)
+	switch strings.TrimSpace(strings.ToLower(priority)) {
+	case "critical":
+		return "critical"
+	case "urgent", "high":
+		return "urgent"
 	default:
 		return "normal"
 	}

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -1,0 +1,651 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+)
+
+var ErrMailboxV1NotFound = errors.New("mailbox item not found")
+var ErrMailboxV1InvalidCursor = errors.New("invalid mailbox cursor")
+var ErrMailboxV1ApprovalRouteUnconfigured = errors.New("mailbox approval event route is not configured")
+
+type MailboxV1ListOptions struct {
+	Status   string
+	RunID    string
+	EntityID string
+	Type     string
+	Priority string
+	Limit    int
+	Cursor   string
+}
+
+type MailboxV1Item struct {
+	MailboxID      string         `json:"mailbox_id"`
+	Type           string         `json:"type"`
+	Status         string         `json:"status"`
+	Priority       string         `json:"priority"`
+	SourceEventID  string         `json:"source_event_id"`
+	SourceFlow     string         `json:"source_flow"`
+	SourceEntityID string         `json:"source_entity_id,omitempty"`
+	Payload        map[string]any `json:"payload"`
+	CreatedAt      string         `json:"created_at"`
+	DecidedAt      string         `json:"decided_at,omitempty"`
+	Decision       string         `json:"decision,omitempty"`
+}
+
+type MailboxV1HistoryEntry struct {
+	Action          string         `json:"action"`
+	ActorTokenID    string         `json:"actor_token_id"`
+	TS              string         `json:"ts"`
+	DecisionPayload map[string]any `json:"decision_payload,omitempty"`
+	Reason          string         `json:"reason,omitempty"`
+}
+
+type MailboxV1ItemDetail struct {
+	Item    MailboxV1Item           `json:"item"`
+	Payload map[string]any          `json:"payload"`
+	History []MailboxV1HistoryEntry `json:"history"`
+}
+
+type MailboxV1DecisionRequest struct {
+	MailboxID         string
+	Action            string
+	ActorTokenID      string
+	Reason            string
+	DecisionPayload   json.RawMessage
+	DeferUntil        time.Time
+	Now               time.Time
+	ApprovalEventType string
+}
+
+type MailboxV1DecisionResult struct {
+	OK                bool   `json:"ok"`
+	MailboxDecisionID string `json:"mailbox_decision_id"`
+	DownstreamEventID string `json:"downstream_event_id,omitempty"`
+	Status            string `json:"status"`
+}
+
+type MailboxV1DecisionOutcome struct {
+	Result        MailboxV1DecisionResult
+	ApprovalEvent *events.Event
+}
+
+type MailboxV1AlreadyDecidedError struct {
+	MailboxID        string
+	ExistingDecision string
+	DecidedAt        time.Time
+}
+
+func (e *MailboxV1AlreadyDecidedError) Error() string {
+	return "mailbox item is already decided"
+}
+
+type MailboxV1InvalidDeferUntilError struct {
+	Reason   string
+	MaxUntil *time.Time
+}
+
+func (e *MailboxV1InvalidDeferUntilError) Error() string {
+	return "invalid mailbox defer timestamp"
+}
+
+type MailboxV1ApprovalRouteError struct {
+	MailboxID string
+	ItemType  string
+}
+
+func (e *MailboxV1ApprovalRouteError) Error() string {
+	return "mailbox approval event route is not configured"
+}
+
+func (e *MailboxV1ApprovalRouteError) Is(target error) bool {
+	return target == ErrMailboxV1ApprovalRouteUnconfigured
+}
+
+func (s *PostgresStore) ListV1MailboxItems(ctx context.Context, opts MailboxV1ListOptions) ([]MailboxV1Item, string, error) {
+	if s == nil || s.DB == nil {
+		return nil, "", fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return nil, "", unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return nil, "", err
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 200 {
+		opts.Limit = 200
+	}
+	cursor, err := decodeMailboxV1Cursor(opts.Cursor)
+	if err != nil {
+		return nil, "", err
+	}
+	where, args := mailboxV1ListWhere(opts, cursor)
+	args = append(args, opts.Limit+1)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			m.item_id::text,
+			m.item_type,
+			m.status,
+			COALESCE(m.decision, ''),
+			COALESCE(m.severity, 'normal'),
+			COALESCE(m.source_event_id::text, ''),
+			COALESCE(m.flow_instance, ''),
+			COALESCE(m.entity_id::text, ''),
+			COALESCE(m.payload, '{}'::jsonb),
+			m.created_at,
+			m.decided_at,
+			COALESCE(m.decided_by, ''),
+			COALESCE(m.decision_notes, ''),
+			COALESCE(m.from_agent, ''),
+			COALESCE(e.run_id::text, '')
+		FROM mailbox m
+		LEFT JOIN events e ON e.event_id = m.source_event_id
+		`+where+`
+		ORDER BY m.created_at ASC, m.item_id ASC
+		LIMIT $`+fmt.Sprint(len(args))+`
+	`, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("list v1 mailbox items: %w", err)
+	}
+	defer rows.Close()
+	rowItems, err := scanMailboxV1Rows(rows)
+	if err != nil {
+		return nil, "", err
+	}
+	nextCursor := ""
+	if len(rowItems) > opts.Limit {
+		next := rowItems[opts.Limit-1]
+		nextCursor = encodeMailboxV1Cursor(next.CreatedAtTime, next.ID)
+		rowItems = rowItems[:opts.Limit]
+	}
+	items := make([]MailboxV1Item, 0, len(rowItems))
+	for _, row := range rowItems {
+		items = append(items, row.projectItem())
+	}
+	return items, nextCursor, nil
+}
+
+func (s *PostgresStore) GetV1MailboxItem(ctx context.Context, id string) (MailboxV1ItemDetail, error) {
+	if s == nil || s.DB == nil {
+		return MailboxV1ItemDetail{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return MailboxV1ItemDetail{}, unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if strings.TrimSpace(id) == "" {
+		return MailboxV1ItemDetail{}, ErrMailboxV1NotFound
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	row, err := s.loadMailboxV1Row(ctx, id)
+	if err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	return row.projectDetail(), nil
+}
+
+func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1DecisionRequest) (MailboxV1DecisionOutcome, error) {
+	if s == nil || s.DB == nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return MailboxV1DecisionOutcome{}, unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if input.Now.IsZero() {
+		input.Now = time.Now().UTC()
+	}
+	input.Now = input.Now.UTC()
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	row, err := s.loadMailboxV1Row(ctx, input.MailboxID)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if row.Status != "pending" {
+		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
+			MailboxID:        row.ID,
+			ExistingDecision: row.existingDecision(),
+			DecidedAt:        row.decisionTime(input.Now),
+		}
+	}
+
+	action := strings.TrimSpace(strings.ToLower(input.Action))
+	switch action {
+	case "approve", "approved":
+		action = "approved"
+	case "reject", "rejected":
+		action = "rejected"
+	case "defer", "deferred":
+		action = "deferred"
+	default:
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("unsupported mailbox decision action %q", input.Action)
+	}
+	if action == "deferred" && !input.DeferUntil.After(input.Now) {
+		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
+	}
+	if action == "approved" && strings.TrimSpace(input.ApprovalEventType) == "" {
+		return MailboxV1DecisionOutcome{}, &MailboxV1ApprovalRouteError{MailboxID: row.ID, ItemType: row.Type}
+	}
+
+	decisionID := uuid.NewString()
+	outcome := MailboxV1DecisionOutcome{
+		Result: MailboxV1DecisionResult{
+			OK:                true,
+			MailboxDecisionID: decisionID,
+			Status:            mailboxV1APIStatus("decided", action),
+		},
+	}
+	var expiresAt any
+	notes := strings.TrimSpace(input.Reason)
+	if action == "deferred" {
+		expiresAt = input.DeferUntil.UTC()
+		if notes == "" {
+			notes = "Deferred until " + input.DeferUntil.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	if action == "approved" {
+		eventID := uuid.NewString()
+		evt, err := row.approvalEvent(eventID, decisionID, strings.TrimSpace(input.ApprovalEventType), input.ActorTokenID, input.DecisionPayload, input.Now)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		outcome.Result.DownstreamEventID = eventID
+		outcome.ApprovalEvent = &evt
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE mailbox
+		SET status = 'decided',
+		    decision = $2,
+		    decision_notes = NULLIF($3, ''),
+		    decided_by = NULLIF($4, ''),
+		    decided_at = $5,
+		    expires_at = COALESCE($6::timestamptz, expires_at)
+		WHERE item_id = $1::uuid
+		  AND status = 'pending'
+	`, row.ID, action, notes, strings.TrimSpace(input.ActorTokenID), input.Now, expiresAt)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("decide v1 mailbox item: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		latest, latestErr := s.loadMailboxV1Row(ctx, row.ID)
+		if latestErr != nil {
+			return MailboxV1DecisionOutcome{}, latestErr
+		}
+		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
+			MailboxID:        latest.ID,
+			ExistingDecision: latest.existingDecision(),
+			DecidedAt:        latest.decisionTime(input.Now),
+		}
+	}
+	return outcome, nil
+}
+
+type mailboxV1Cursor struct {
+	CreatedAt time.Time `json:"created_at"`
+	MailboxID string    `json:"mailbox_id"`
+}
+
+func decodeMailboxV1Cursor(raw string) (mailboxV1Cursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return mailboxV1Cursor{}, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return mailboxV1Cursor{}, ErrMailboxV1InvalidCursor
+	}
+	var cursor mailboxV1Cursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return mailboxV1Cursor{}, ErrMailboxV1InvalidCursor
+	}
+	if cursor.CreatedAt.IsZero() || strings.TrimSpace(cursor.MailboxID) == "" {
+		return mailboxV1Cursor{}, ErrMailboxV1InvalidCursor
+	}
+	return cursor, nil
+}
+
+func encodeMailboxV1Cursor(createdAt time.Time, mailboxID string) string {
+	raw, _ := json.Marshal(mailboxV1Cursor{CreatedAt: createdAt.UTC(), MailboxID: strings.TrimSpace(mailboxID)})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func mailboxV1ListWhere(opts MailboxV1ListOptions, cursor mailboxV1Cursor) (string, []any) {
+	clauses := []string{"1=1"}
+	args := []any{}
+	add := func(clause string, value any) {
+		args = append(args, value)
+		clauses = append(clauses, fmt.Sprintf(clause, len(args)))
+	}
+	switch strings.TrimSpace(strings.ToLower(opts.Status)) {
+	case "":
+	case "pending":
+		clauses = append(clauses, "m.status = 'pending'")
+	case "decided":
+		clauses = append(clauses, "m.status = 'decided' AND COALESCE(m.decision, '') <> 'deferred'")
+	case "expired":
+		clauses = append(clauses, "m.status = 'expired'")
+	case "deferred":
+		clauses = append(clauses, "m.status = 'decided' AND COALESCE(m.decision, '') = 'deferred'")
+	default:
+		clauses = append(clauses, "false")
+	}
+	if runID := strings.TrimSpace(opts.RunID); runID != "" {
+		add("e.run_id = $%d::uuid", runID)
+	}
+	if entityID := strings.TrimSpace(opts.EntityID); entityID != "" {
+		add("m.entity_id = $%d::uuid", entityID)
+	}
+	if itemType := strings.TrimSpace(opts.Type); itemType != "" {
+		add("m.item_type = $%d", itemType)
+	}
+	if priority := mailboxV1SeverityForPriority(opts.Priority); priority != "" {
+		add("COALESCE(m.severity, 'normal') = $%d", priority)
+	}
+	if !cursor.CreatedAt.IsZero() {
+		args = append(args, cursor.CreatedAt.UTC(), strings.TrimSpace(cursor.MailboxID))
+		clauses = append(clauses, fmt.Sprintf("(m.created_at, m.item_id) > ($%d, $%d::uuid)", len(args)-1, len(args)))
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+type mailboxV1Row struct {
+	ID            string
+	Type          string
+	Status        string
+	Decision      string
+	Priority      string
+	SourceEventID string
+	FlowInstance  string
+	EntityID      string
+	Payload       map[string]any
+	RawPayload    json.RawMessage
+	CreatedAtTime time.Time
+	DecidedAt     sql.NullTime
+	DecidedBy     string
+	DecisionNotes string
+	FromAgent     string
+	RunID         string
+}
+
+func (s *PostgresStore) loadMailboxV1Row(ctx context.Context, id string) (mailboxV1Row, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			m.item_id::text,
+			m.item_type,
+			m.status,
+			COALESCE(m.decision, ''),
+			COALESCE(m.severity, 'normal'),
+			COALESCE(m.source_event_id::text, ''),
+			COALESCE(m.flow_instance, ''),
+			COALESCE(m.entity_id::text, ''),
+			COALESCE(m.payload, '{}'::jsonb),
+			m.created_at,
+			m.decided_at,
+			COALESCE(m.decided_by, ''),
+			COALESCE(m.decision_notes, ''),
+			COALESCE(m.from_agent, ''),
+			COALESCE(e.run_id::text, '')
+		FROM mailbox m
+		LEFT JOIN events e ON e.event_id = m.source_event_id
+		WHERE m.item_id = $1::uuid
+	`, strings.TrimSpace(id))
+	if err != nil {
+		return mailboxV1Row{}, fmt.Errorf("load v1 mailbox item: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanMailboxV1Rows(rows)
+	if err != nil {
+		return mailboxV1Row{}, err
+	}
+	if len(items) == 0 {
+		return mailboxV1Row{}, ErrMailboxV1NotFound
+	}
+	return items[0], nil
+}
+
+func scanMailboxV1Rows(rows *sql.Rows) ([]mailboxV1Row, error) {
+	out := make([]mailboxV1Row, 0)
+	for rows.Next() {
+		var row mailboxV1Row
+		if err := rows.Scan(
+			&row.ID,
+			&row.Type,
+			&row.Status,
+			&row.Decision,
+			&row.Priority,
+			&row.SourceEventID,
+			&row.FlowInstance,
+			&row.EntityID,
+			&row.RawPayload,
+			&row.CreatedAtTime,
+			&row.DecidedAt,
+			&row.DecidedBy,
+			&row.DecisionNotes,
+			&row.FromAgent,
+			&row.RunID,
+		); err != nil {
+			return nil, fmt.Errorf("scan v1 mailbox item: %w", err)
+		}
+		row.Payload = map[string]any{}
+		if len(row.RawPayload) > 0 {
+			_ = json.Unmarshal(row.RawPayload, &row.Payload)
+		}
+		if row.Payload == nil {
+			row.Payload = map[string]any{}
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate v1 mailbox items: %w", err)
+	}
+	return out, nil
+}
+
+func (r mailboxV1Row) projectItem() MailboxV1Item {
+	item := MailboxV1Item{
+		MailboxID:      strings.TrimSpace(r.ID),
+		Type:           strings.TrimSpace(r.Type),
+		Status:         mailboxV1APIStatus(r.Status, r.Decision),
+		Priority:       mailboxV1PriorityForSeverity(r.Priority),
+		SourceEventID:  strings.TrimSpace(r.SourceEventID),
+		SourceFlow:     mailboxV1SourceFlow(r.FlowInstance),
+		SourceEntityID: strings.TrimSpace(r.EntityID),
+		Payload:        cloneMailboxV1Payload(r.Payload),
+		CreatedAt:      r.CreatedAtTime.UTC().Format(time.RFC3339Nano),
+		Decision:       mailboxV1Decision(r.Status, r.Decision),
+	}
+	if r.DecidedAt.Valid {
+		item.DecidedAt = r.DecidedAt.Time.UTC().Format(time.RFC3339Nano)
+	}
+	return item
+}
+
+func (r mailboxV1Row) projectDetail() MailboxV1ItemDetail {
+	history := []MailboxV1HistoryEntry{{
+		Action:       "created",
+		ActorTokenID: strings.TrimSpace(coalesce(r.FromAgent, "system")),
+		TS:           r.CreatedAtTime.UTC().Format(time.RFC3339Nano),
+	}}
+	if r.DecidedAt.Valid {
+		entry := MailboxV1HistoryEntry{
+			Action:       mailboxV1Decision(r.Status, r.Decision),
+			ActorTokenID: strings.TrimSpace(coalesce(r.DecidedBy, "unknown")),
+			TS:           r.DecidedAt.Time.UTC().Format(time.RFC3339Nano),
+		}
+		if strings.TrimSpace(r.DecisionNotes) != "" {
+			entry.Reason = strings.TrimSpace(r.DecisionNotes)
+		}
+		history = append(history, entry)
+	}
+	return MailboxV1ItemDetail{
+		Item:    r.projectItem(),
+		Payload: cloneMailboxV1Payload(r.Payload),
+		History: history,
+	}
+}
+
+func (r mailboxV1Row) existingDecision() string {
+	if decision := mailboxV1Decision(r.Status, r.Decision); decision != "" {
+		return decision
+	}
+	if strings.TrimSpace(r.Status) == "expired" {
+		return "expired"
+	}
+	return "expired"
+}
+
+func (r mailboxV1Row) decisionTime(fallback time.Time) time.Time {
+	if r.DecidedAt.Valid {
+		return r.DecidedAt.Time.UTC()
+	}
+	if !fallback.IsZero() {
+		return fallback.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (r mailboxV1Row) approvalEvent(eventID, decisionID, eventType, actorTokenID string, decisionPayload json.RawMessage, now time.Time) (events.Event, error) {
+	payloadMap := map[string]any{}
+	if len(decisionPayload) > 0 {
+		if err := json.Unmarshal(decisionPayload, &payloadMap); err != nil {
+			return events.Event{}, fmt.Errorf("decode decision payload: %w", err)
+		}
+	}
+	if payloadMap == nil {
+		payloadMap = map[string]any{}
+	}
+	eventPayload := map[string]any{
+		"mailbox_id":          strings.TrimSpace(r.ID),
+		"mailbox_decision_id": strings.TrimSpace(decisionID),
+		"decision":            "approved",
+		"decision_payload":    payloadMap,
+		"item_type":           strings.TrimSpace(r.Type),
+		"payload":             cloneMailboxV1Payload(r.Payload),
+		"source_event_id":     strings.TrimSpace(r.SourceEventID),
+		"source_flow":         mailboxV1SourceFlow(r.FlowInstance),
+		"source_entity_id":    strings.TrimSpace(r.EntityID),
+		"decided_by":          strings.TrimSpace(actorTokenID),
+		"decided_at":          now.UTC().Format(time.RFC3339Nano),
+	}
+	raw, err := json.Marshal(eventPayload)
+	if err != nil {
+		return events.Event{}, err
+	}
+	evt := events.Event{
+		ID:            strings.TrimSpace(eventID),
+		Type:          events.EventType(strings.TrimSpace(eventType)),
+		SourceAgent:   "mailbox_human",
+		Payload:       raw,
+		RunID:         strings.TrimSpace(r.RunID),
+		ParentEventID: strings.TrimSpace(r.SourceEventID),
+		CreatedAt:     now.UTC(),
+	}
+	if entityID := strings.TrimSpace(r.EntityID); entityID != "" {
+		evt = evt.WithEntityID(entityID)
+	}
+	if flowInstance := strings.TrimSpace(r.FlowInstance); flowInstance != "" {
+		evt = evt.WithFlowInstance(flowInstance)
+	}
+	return evt, nil
+}
+
+func mailboxV1APIStatus(status, decision string) string {
+	status = strings.TrimSpace(status)
+	decision = strings.TrimSpace(decision)
+	switch {
+	case status == "decided" && decision == "deferred":
+		return "deferred"
+	case status == "expired" || status == "cancelled":
+		return "expired"
+	case status == "decided":
+		return "decided"
+	default:
+		return "pending"
+	}
+}
+
+func mailboxV1Decision(status, decision string) string {
+	status = strings.TrimSpace(status)
+	decision = strings.TrimSpace(decision)
+	switch decision {
+	case "approve":
+		return "approved"
+	case "reject":
+		return "rejected"
+	case "approved", "rejected", "deferred", "expired":
+		return decision
+	}
+	if status == "expired" || status == "cancelled" {
+		return "expired"
+	}
+	return ""
+}
+
+func mailboxV1PriorityForSeverity(severity string) string {
+	switch strings.TrimSpace(severity) {
+	case "critical":
+		return "critical"
+	case "urgent", "high":
+		return "high"
+	default:
+		return "normal"
+	}
+}
+
+func mailboxV1SeverityForPriority(priority string) string {
+	switch strings.TrimSpace(strings.ToLower(priority)) {
+	case "":
+		return ""
+	case "critical":
+		return "critical"
+	case "high", "urgent":
+		return "urgent"
+	default:
+		return "normal"
+	}
+}
+
+func mailboxV1SourceFlow(flowInstance string) string {
+	flowInstance = strings.TrimSpace(flowInstance)
+	if flowInstance == "" {
+		return "global"
+	}
+	return flowInstance
+}
+
+func cloneMailboxV1Payload(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 var ErrMailboxV1NotFound = errors.New("mailbox item not found")
@@ -65,6 +66,8 @@ type MailboxV1DecisionRequest struct {
 	DeferUntil        time.Time
 	Now               time.Time
 	ApprovalEventType string
+	ApprovalEventTx   func(context.Context, *sql.Tx, events.Event) error
+	Idempotency       *APIIdempotencyRequest
 }
 
 type MailboxV1DecisionResult struct {
@@ -77,6 +80,7 @@ type MailboxV1DecisionResult struct {
 type MailboxV1DecisionOutcome struct {
 	Result        MailboxV1DecisionResult
 	ApprovalEvent *events.Event
+	Replayed      bool
 }
 
 type MailboxV1AlreadyDecidedError struct {
@@ -223,17 +227,6 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
 		return MailboxV1DecisionOutcome{}, err
 	}
-	row, err := s.loadMailboxV1Row(ctx, input.MailboxID)
-	if err != nil {
-		return MailboxV1DecisionOutcome{}, err
-	}
-	if row.Status != "pending" {
-		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
-			MailboxID:        row.ID,
-			ExistingDecision: row.existingDecision(),
-			DecidedAt:        row.decisionTime(input.Now),
-		}
-	}
 
 	action := strings.TrimSpace(strings.ToLower(input.Action))
 	switch action {
@@ -248,6 +241,65 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	}
 	if action == "deferred" && !input.DeferUntil.After(input.Now) {
 		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("begin v1 mailbox decision tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	idempotencyReq, hasIdempotency, err := prepareMailboxV1IdempotencyRequest(input)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if hasIdempotency {
+		if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, apiIdempotencyLockKey(idempotencyReq.Method, idempotencyReq.ActorTokenID, idempotencyReq.IdempotencyKey)); err != nil {
+			return MailboxV1DecisionOutcome{}, fmt.Errorf("lock api idempotency key: %w", err)
+		}
+		if err := purgeExpiredAPIIdempotency(ctx, tx, idempotencyReq.Now); err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		existing, ok, err := loadAPIIdempotency(ctx, tx, idempotencyReq)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		if ok {
+			if existing.RequestHash != idempotencyReq.RequestHash {
+				return MailboxV1DecisionOutcome{}, &APIIdempotencyConflictError{
+					OriginalRequestHash:    existing.RequestHash,
+					ConflictingRequestHash: idempotencyReq.RequestHash,
+					Method:                 idempotencyReq.Method,
+					ResourceID:             existing.ResourceID,
+				}
+			}
+			var result MailboxV1DecisionResult
+			if err := json.Unmarshal(existing.Response, &result); err != nil {
+				return MailboxV1DecisionOutcome{}, fmt.Errorf("decode api idempotency mailbox response: %w", err)
+			}
+			if err := tx.Commit(); err != nil {
+				return MailboxV1DecisionOutcome{}, fmt.Errorf("commit v1 mailbox idempotency replay tx: %w", err)
+			}
+			committed = true
+			return MailboxV1DecisionOutcome{Result: result, Replayed: true}, nil
+		}
+	}
+
+	row, err := s.loadMailboxV1RowTx(ctx, tx, input.MailboxID, true)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if row.Status != "pending" {
+		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
+			MailboxID:        row.ID,
+			ExistingDecision: row.existingDecision(),
+			DecidedAt:        row.decisionTime(input.Now),
+		}
 	}
 	if action == "approved" && strings.TrimSpace(input.ApprovalEventType) == "" {
 		return MailboxV1DecisionOutcome{}, &MailboxV1ApprovalRouteError{MailboxID: row.ID, ItemType: row.Type}
@@ -278,7 +330,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		outcome.Result.DownstreamEventID = eventID
 		outcome.ApprovalEvent = &evt
 	}
-	res, err := s.DB.ExecContext(ctx, `
+	res, err := tx.ExecContext(ctx, `
 		UPDATE mailbox
 		SET status = 'decided',
 		    decision = $2,
@@ -293,7 +345,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("decide v1 mailbox item: %w", err)
 	}
 	if rows, _ := res.RowsAffected(); rows == 0 {
-		latest, latestErr := s.loadMailboxV1Row(ctx, row.ID)
+		latest, latestErr := s.loadMailboxV1RowTx(ctx, tx, row.ID, false)
 		if latestErr != nil {
 			return MailboxV1DecisionOutcome{}, latestErr
 		}
@@ -303,7 +355,74 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 			DecidedAt:        latest.decisionTime(input.Now),
 		}
 	}
+	if outcome.ApprovalEvent != nil {
+		publishTx := input.ApprovalEventTx
+		if publishTx == nil {
+			publishTx = s.appendMailboxV1ApprovalEventTx
+		}
+		if err := publishTx(ctx, tx, *outcome.ApprovalEvent); err != nil {
+			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish v1 mailbox approval event: %w", err)
+		}
+	}
+	if hasIdempotency {
+		raw, err := json.Marshal(outcome.Result)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		if err := storeAPIIdempotency(ctx, tx, idempotencyReq, APIIdempotencyCompletion{
+			ResourceID: row.ID,
+			Response:   raw,
+		}); err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("commit v1 mailbox decision tx: %w", err)
+	}
+	committed = true
 	return outcome, nil
+}
+
+func prepareMailboxV1IdempotencyRequest(input MailboxV1DecisionRequest) (APIIdempotencyRequest, bool, error) {
+	if input.Idempotency == nil || strings.TrimSpace(input.Idempotency.IdempotencyKey) == "" {
+		return APIIdempotencyRequest{}, false, nil
+	}
+	req := *input.Idempotency
+	req.Method = strings.TrimSpace(req.Method)
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	req.RequestHash = strings.TrimSpace(req.RequestHash)
+	req.ResourceID = strings.TrimSpace(req.ResourceID)
+	if req.ResourceID == "" {
+		req.ResourceID = strings.TrimSpace(input.MailboxID)
+	}
+	if req.Method == "" || req.ActorTokenID == "" || req.RequestHash == "" {
+		return APIIdempotencyRequest{}, false, fmt.Errorf("method, actor token id, and request hash are required")
+	}
+	if req.TTL <= 0 {
+		req.TTL = 24 * time.Hour
+	}
+	if req.Now.IsZero() {
+		req.Now = input.Now
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+	req.Now = req.Now.UTC()
+	return req, true, nil
+}
+
+func (s *PostgresStore) appendMailboxV1ApprovalEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+		return err
+	}
+	if err := s.UpsertPipelineReceiptTx(ctx, tx, evt.ID, "processed", ""); err != nil {
+		return err
+	}
+	return nil
 }
 
 type mailboxV1Cursor struct {
@@ -393,8 +512,24 @@ type mailboxV1Row struct {
 	RunID         string
 }
 
+type mailboxV1RowQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 func (s *PostgresStore) loadMailboxV1Row(ctx context.Context, id string) (mailboxV1Row, error) {
-	rows, err := s.DB.QueryContext(ctx, `
+	return s.loadMailboxV1RowTx(ctx, nil, id, false)
+}
+
+func (s *PostgresStore) loadMailboxV1RowTx(ctx context.Context, tx *sql.Tx, id string, forUpdate bool) (mailboxV1Row, error) {
+	var q mailboxV1RowQueryer = s.DB
+	if tx != nil {
+		q = tx
+	}
+	lockClause := ""
+	if forUpdate {
+		lockClause = " FOR UPDATE OF m"
+	}
+	rows, err := q.QueryContext(ctx, `
 		SELECT
 			m.item_id::text,
 			m.item_type,
@@ -414,6 +549,7 @@ func (s *PostgresStore) loadMailboxV1Row(ctx context.Context, id string) (mailbo
 		FROM mailbox m
 		LEFT JOIN events e ON e.event_id = m.source_event_id
 		WHERE m.item_id = $1::uuid
+		`+lockClause+`
 	`, strings.TrimSpace(id))
 	if err != nil {
 		return mailboxV1Row{}, fmt.Errorf("load v1 mailbox item: %w", err)

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -239,9 +239,6 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	default:
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("unsupported mailbox decision action %q", input.Action)
 	}
-	if action == "deferred" && !input.DeferUntil.After(input.Now) {
-		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
-	}
 
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -288,6 +285,9 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 			committed = true
 			return MailboxV1DecisionOutcome{Result: result, Replayed: true}, nil
 		}
+	}
+	if action == "deferred" && !input.DeferUntil.After(input.Now) {
+		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
 	}
 
 	row, err := s.loadMailboxV1RowTx(ctx, tx, input.MailboxID, true)

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	runID := uuid.NewString()
+	if err := s.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   runID,
+		Payload: json.RawMessage(`{"request":true}`),
+	}.WithEntityID(entityID).WithFlowInstance("main/review")); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+
+	firstID, err := s.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   sourceEventID,
+		EntityID:  entityID,
+		FromAgent: "review-agent",
+		Type:      "review_request",
+		Priority:  "high",
+		Context:   []byte(`{"title":"check"}`),
+		Summary:   "review this",
+	})
+	if err != nil {
+		t.Fatalf("insert first mailbox item: %v", err)
+	}
+	secondID, err := s.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   sourceEventID,
+		EntityID:  entityID,
+		FromAgent: "review-agent",
+		Type:      "approval",
+		Priority:  "critical",
+		Context:   []byte(`{"title":"approve"}`),
+		Summary:   "approve this",
+	})
+	if err != nil {
+		t.Fatalf("insert second mailbox item: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE mailbox SET flow_instance = 'main/review' WHERE item_id IN ($1::uuid, $2::uuid)`, firstID, secondID); err != nil {
+		t.Fatalf("set flow instance: %v", err)
+	}
+
+	page1, cursor, err := s.ListV1MailboxItems(ctx, MailboxV1ListOptions{
+		Status:   "pending",
+		RunID:    runID,
+		EntityID: entityID,
+		Type:     "review_request",
+		Priority: "high",
+		Limit:    1,
+	})
+	if err != nil {
+		t.Fatalf("list v1 mailbox page1: %v", err)
+	}
+	if len(page1) != 1 || page1[0].MailboxID != firstID || page1[0].Priority != "high" || page1[0].SourceFlow != "main/review" {
+		t.Fatalf("unexpected page1=%#v", page1)
+	}
+	if cursor != "" {
+		t.Fatalf("single filtered item produced cursor %q", cursor)
+	}
+
+	pageAll, cursor, err := s.ListV1MailboxItems(ctx, MailboxV1ListOptions{Status: "pending", Limit: 1})
+	if err != nil {
+		t.Fatalf("list all page1: %v", err)
+	}
+	if len(pageAll) != 1 || cursor == "" {
+		t.Fatalf("page all len=%d cursor=%q", len(pageAll), cursor)
+	}
+	page2, next, err := s.ListV1MailboxItems(ctx, MailboxV1ListOptions{Status: "pending", Cursor: cursor, Limit: 1})
+	if err != nil {
+		t.Fatalf("list all page2: %v", err)
+	}
+	if len(page2) != 1 || page2[0].MailboxID == pageAll[0].MailboxID || next != "" {
+		t.Fatalf("page2=%#v next=%q page1=%#v", page2, next, pageAll)
+	}
+
+	detail, err := s.GetV1MailboxItem(ctx, firstID)
+	if err != nil {
+		t.Fatalf("get v1 mailbox: %v", err)
+	}
+	if detail.Item.Payload["title"] != "check" || len(detail.History) != 1 || detail.History[0].Action != "created" {
+		t.Fatalf("unexpected detail=%#v", detail)
+	}
+
+	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+		MailboxID:    firstID,
+		Action:       "approved",
+		ActorTokenID: "actor-1",
+		Now:          now,
+	}); !errors.Is(err, ErrMailboxV1ApprovalRouteUnconfigured) {
+		t.Fatalf("approve without route error = %v, want route unconfigured", err)
+	}
+
+	outcome, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+		MailboxID:         firstID,
+		Action:            "approved",
+		ActorTokenID:      "actor-1",
+		DecisionPayload:   json.RawMessage(`{"ok":true}`),
+		Now:               now,
+		ApprovalEventType: "mailbox.item_decided",
+	})
+	if err != nil {
+		t.Fatalf("approve with route: %v", err)
+	}
+	if !outcome.Result.OK || outcome.Result.Status != "decided" || outcome.Result.DownstreamEventID == "" || outcome.ApprovalEvent == nil {
+		t.Fatalf("unexpected approve outcome=%#v", outcome)
+	}
+	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+		MailboxID:         firstID,
+		Action:            "approved",
+		ActorTokenID:      "actor-1",
+		Now:               now,
+		ApprovalEventType: "mailbox.item_decided",
+	}); err == nil {
+		t.Fatal("second approve error = nil, want already decided")
+	} else {
+		var already *MailboxV1AlreadyDecidedError
+		if !errors.As(err, &already) || already.ExistingDecision != "approved" {
+			t.Fatalf("second approve error = %v, want approved already-decided", err)
+		}
+	}
+
+	pastID, err := s.InsertMailboxItem(ctx, runtimetools.MailboxItem{Type: "approval", Summary: "later"})
+	if err != nil {
+		t.Fatalf("insert defer mailbox item: %v", err)
+	}
+	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+		MailboxID:    pastID,
+		Action:       "deferred",
+		ActorTokenID: "actor-1",
+		DeferUntil:   now.Add(-time.Second),
+		Now:          now,
+	}); err == nil {
+		t.Fatal("defer in past error = nil, want invalid defer")
+	} else {
+		var invalid *MailboxV1InvalidDeferUntilError
+		if !errors.As(err, &invalid) || invalid.Reason != "in_past" {
+			t.Fatalf("defer in past error = %v, want in_past", err)
+		}
+	}
+	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+		MailboxID:    pastID,
+		Action:       "deferred",
+		ActorTokenID: "actor-1",
+		DeferUntil:   now.Add(time.Hour),
+		Now:          now,
+	}); err != nil {
+		t.Fatalf("defer future: %v", err)
+	}
+	deferred, err := s.GetV1MailboxItem(ctx, pastID)
+	if err != nil {
+		t.Fatalf("get deferred: %v", err)
+	}
+	if deferred.Item.Status != "deferred" || deferred.Item.Decision != "deferred" {
+		t.Fatalf("deferred projection = %#v", deferred.Item)
+	}
+}
+
+func TestPostgresStore_APIIdempotencyReplaysAndConflicts(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	req := APIIdempotencyRequest{
+		Method:         "mailbox.approve",
+		ActorTokenID:   "actor-1",
+		IdempotencyKey: "idem-1",
+		RequestHash:    "sha256:first",
+		ResourceID:     "mailbox-1",
+		Now:            now,
+	}
+	calls := 0
+	first, replay, err := s.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		calls++
+		return APIIdempotencyCompletion{ResourceID: "mailbox-1", Response: json.RawMessage(`{"ok":true,"n":1}`)}, nil
+	})
+	if err != nil || replay || calls != 1 || string(first.Response) == "" {
+		t.Fatalf("first idempotency completion=%#v replay=%v calls=%d err=%v", first, replay, calls, err)
+	}
+	second, replay, err := s.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		calls++
+		return APIIdempotencyCompletion{ResourceID: "mailbox-1", Response: json.RawMessage(`{"ok":true,"n":2}`)}, nil
+	})
+	if err != nil || !replay || calls != 1 || !sameJSON(first.Response, second.Response) {
+		t.Fatalf("replay completion=%s replay=%v calls=%d err=%v", second.Response, replay, calls, err)
+	}
+	req.RequestHash = "sha256:second"
+	if _, _, err := s.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		calls++
+		return APIIdempotencyCompletion{}, nil
+	}); err == nil {
+		t.Fatal("conflicting idempotency request error = nil")
+	} else {
+		var conflict *APIIdempotencyConflictError
+		if !errors.As(err, &conflict) || conflict.OriginalRequestHash != "sha256:first" || conflict.ConflictingRequestHash != "sha256:second" {
+			t.Fatalf("conflict error = %#v", err)
+		}
+	}
+}
+
+func sameJSON(left, right json.RawMessage) bool {
+	var l any
+	var r any
+	if err := json.Unmarshal(left, &l); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(right, &r); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(l, r)
+}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -347,6 +347,8 @@ func platformTableOrder(name string) int {
 		return 95
 	case "mailbox":
 		return 100
+	case "api_idempotency":
+		return 105
 	case "spend_ledger":
 		return 110
 	case "timers":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -537,6 +537,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 95
 	case "mailbox":
 		return 100
+	case "api_idempotency":
+		return 105
 	case "spend_ledger":
 		return 110
 	case "timers":


### PR DESCRIPTION
## Summary

Implements #665 Slice 4 for the v1 mailbox read/action RPC surface:

- adds `mailbox.list`, `mailbox.get`, `mailbox.approve`, `mailbox.reject`, and `mailbox.defer` handlers on `/v1/rpc`
- adds a canonical v1 mailbox store owner for reads and decisions, including `deferred` API projection over the existing mailbox storage model
- adds reusable API idempotency persistence for mutating RPC calls with replay and conflict detection
- promotes mailbox approval event routing into authoritative `platform-spec.yaml` and regenerates `openrpc.json`

## Governing Context

Part of #665.

Binding refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `api_specification.conventions.idempotency`
- `api_specification.conventions.mailbox.approval_event_routes`
- `api_specification.method_catalog.mailbox.list/get/approve/reject/defer`
- `platform_tables.mailbox`
- `platform_tables.api_idempotency`
- #665 Slice 4 pre-audit and independent gate

Semantic migration accounting:

- New canonical owner for this slice: v1 `/v1/rpc` mailbox handlers backed by `PostgresStore.ListV1MailboxItems`, `GetV1MailboxItem`, `DecideV1MailboxItem`, and `WithAPIIdempotency`.
- Old producer/reader/writer paths now non-authoritative for this v1 surface: legacy mailbox helpers and tool-local human-task decision paths remain split siblings and are not claimed closed here.
- Production paths checked for surviving old behavior: v1 RPC handler registry, cmd/swarm route wiring, platform spec/OpenRPC generation, store mailbox read/decision path, and event publication path.
- Migration is complete for the approved Slice 4 v1 mailbox RPC surface only; the broader #665 parent remains open.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'Mailbox|Idempotency|JSONRPC' -count=1`
- `go test ./internal/store -run 'V1Mailbox|APIIdempotency|Mailbox' -count=1`
- `go test ./internal/apiv1 ./internal/apispec ./cmd/swarm-openrpc-gen ./cmd/swarm -count=1`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`