### PR TITLE
[agent-b][issue #665] Add v1 run.start admission

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -195,6 +195,7 @@ func main() {
 			Mailbox:               stores.Postgres,
 			Idempotency:           stores.Postgres,
 			Events:                rt.Bus,
+			Source:                source,
 			MailboxApprovalRoutes: mailboxApprovalRoutes,
 			Bundle:                bootBundleIdentity,
 		}),

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 )
 
@@ -30,6 +31,7 @@ type OperatorReadOptions struct {
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
+	Source                semanticview.Source
 	MailboxApprovalRoutes map[string]string
 	Bundle                runtimecontracts.BundleIdentity
 }
@@ -167,6 +169,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		},
 	}
 	for name, handler := range OperatorMailboxHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorRunStartHandlers(opts) {
 		handlers[name] = handler
 	}
 	return handlers

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -199,9 +199,14 @@ func runStartPayload(params map[string]any, runID string) (json.RawMessage, stri
 	for key, value := range payload {
 		cloned[key] = value
 	}
-	entityID := strings.TrimSpace(runStartPayloadString(cloned["entity_id"]))
-	if entityID == "" {
+	entityID, supplied, err := runStartPayloadEntityID(cloned["entity_id"])
+	if err != nil {
+		return nil, "", err
+	}
+	if !supplied {
 		entityID = strings.TrimSpace(runID)
+		cloned["entity_id"] = entityID
+	} else {
 		cloned["entity_id"] = entityID
 	}
 	encoded, err := json.Marshal(cloned)
@@ -211,9 +216,23 @@ func runStartPayload(params map[string]any, runID string) (json.RawMessage, stri
 	return encoded, entityID, nil
 }
 
-func runStartPayloadString(value any) string {
-	text, _ := value.(string)
-	return text
+func runStartPayloadEntityID(value any) (string, bool, error) {
+	if value == nil {
+		return "", false, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false, NewInvalidParamsError(map[string]any{"field": "payload.entity_id", "reason": "must be a UUID string"})
+	}
+	entityID := strings.TrimSpace(text)
+	if entityID == "" {
+		return "", false, nil
+	}
+	parsed, err := uuid.Parse(entityID)
+	if err != nil {
+		return "", false, NewInvalidParamsError(map[string]any{"field": "payload.entity_id", "reason": "must be a UUID string"})
+	}
+	return parsed.String(), true, nil
 }
 
 func runStartIdempotencyError(err error) error {

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -1,0 +1,237 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimerunstart "swarm/internal/runtime/runstart"
+	"swarm/internal/store"
+)
+
+const runStartIDempotencyTTL = 24 * time.Hour
+
+var sha256FingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+
+type runStartResult struct {
+	RunID  string `json:"run_id"`
+	Status string `json:"status"`
+}
+
+type runStartParams struct {
+	BundleFingerprint string
+	EventName         string
+	Payload           json.RawMessage
+	EntityID          string
+	RunID             string
+	IdempotencyKey    string
+}
+
+func OperatorRunStartHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if !runStartConfigured(opts) {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"run.start": func(ctx context.Context, req Request) (any, error) {
+			return executeRunStart(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func runStartConfigured(opts OperatorReadOptions) bool {
+	return opts.Source != nil &&
+		opts.Events != nil &&
+		opts.Idempotency != nil &&
+		strings.TrimSpace(opts.Bundle.Fingerprint) != ""
+}
+
+func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	params, err := runStartParamsFromRequest(req, opts.Bundle.Fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
+	if err != nil {
+		return nil, NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+			"event_name":      params.EventName,
+			"declared_events": set.Declared,
+		})
+	}
+	result := runStartResult{RunID: params.RunID, Status: "running"}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: params.IdempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     params.RunID,
+		TTL:            runStartIDempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		if err := opts.Events.Publish(ctx, events.Event{
+			ID:          uuid.NewString(),
+			RunID:       params.RunID,
+			Type:        events.EventType(params.EventName),
+			SourceAgent: "api.v1",
+			Payload:     params.Payload,
+			CreatedAt:   now,
+		}.WithEntityID(params.EntityID)); err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		response, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: params.RunID,
+			Response:   response,
+		}, nil
+	})
+	if err != nil {
+		return nil, runStartExecutionError(params.EventName, err)
+	}
+	if replay {
+		var stored runStartResult
+		if err := json.Unmarshal(completion.Response, &stored); err != nil {
+			return nil, fmt.Errorf("decode run.start idempotency response: %w", err)
+		}
+		return stored, nil
+	}
+	return result, nil
+}
+
+func runStartParamsFromRequest(req Request, bootFingerprint string) (runStartParams, error) {
+	eventName := stringParam(req.Params, "event_name")
+	if eventName == "" {
+		return runStartParams{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
+	}
+	fingerprint, err := bundleFingerprintParam(req.Params)
+	if err != nil {
+		return runStartParams{}, err
+	}
+	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
+		return runStartParams{}, NewApplicationError(BundleMismatchCode, false, map[string]any{
+			"provided_fingerprint": fingerprint,
+			"boot_fingerprint":     strings.TrimSpace(bootFingerprint),
+		})
+	}
+	runID, _, err := optionalStringParam(req.Params, "run_id")
+	if err != nil {
+		return runStartParams{}, err
+	}
+	if runID == "" {
+		runID = uuid.NewString()
+	}
+	payload, entityID, err := runStartPayload(req.Params, runID)
+	if err != nil {
+		return runStartParams{}, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return runStartParams{}, err
+	}
+	return runStartParams{
+		BundleFingerprint: fingerprint,
+		EventName:         eventName,
+		Payload:           payload,
+		EntityID:          entityID,
+		RunID:             runID,
+		IdempotencyKey:    idempotencyKey,
+	}, nil
+}
+
+func bundleFingerprintParam(params map[string]any) (string, error) {
+	if params == nil {
+		return "", nil
+	}
+	raw, ok := params["bundle_ref"]
+	if !ok || isEmptyParam(raw) {
+		return "", nil
+	}
+	ref, ok := raw.(map[string]any)
+	if !ok {
+		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref must be an object"})
+	}
+	if len(ref) != 1 {
+		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref supports fingerprint only"})
+	}
+	rawFingerprint, ok := ref["fingerprint"].(string)
+	fingerprint := strings.TrimSpace(rawFingerprint)
+	if !ok || fingerprint == "" {
+		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref.fingerprint is required"})
+	}
+	if !sha256FingerprintPattern.MatchString(fingerprint) {
+		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref.fingerprint must be sha256:<64 lowercase hex>"})
+	}
+	return fingerprint, nil
+}
+
+func runStartPayload(params map[string]any, runID string) (json.RawMessage, string, error) {
+	if params == nil {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
+	}
+	raw, ok := params["payload"]
+	if !ok || isEmptyParam(raw) {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
+	}
+	payload, ok := raw.(map[string]any)
+	if !ok {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "must be an object"})
+	}
+	cloned := make(map[string]any, len(payload)+1)
+	for key, value := range payload {
+		cloned[key] = value
+	}
+	entityID := strings.TrimSpace(runStartPayloadString(cloned["entity_id"]))
+	if entityID == "" {
+		entityID = strings.TrimSpace(runID)
+		cloned["entity_id"] = entityID
+	}
+	encoded, err := json.Marshal(cloned)
+	if err != nil {
+		return nil, "", err
+	}
+	return encoded, entityID, nil
+}
+
+func runStartPayloadString(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func runStartExecutionError(eventName string, err error) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	if errors.Is(err, runtimebus.ErrPayloadValidation) || strings.Contains(err.Error(), "validate event payload") {
+		return NewApplicationError(PayloadValidationFailedCode, false, map[string]any{
+			"violations": []map[string]any{{
+				"field_path": "$",
+				"rule":       "event_payload_schema",
+				"message":    strings.TrimSpace(err.Error()),
+			}},
+		})
+	}
+	if strings.Contains(err.Error(), "invalid event type") {
+		return NewApplicationError(EventNotDeclaredCode, false, map[string]any{"event_name": eventName})
+	}
+	return err
+}

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -57,27 +57,30 @@ func runStartConfigured(opts OperatorReadOptions) bool {
 }
 
 func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
-	params, err := runStartParamsFromRequest(req, opts.Bundle.Fingerprint)
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return nil, err
 	}
-	set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
-	if err != nil {
-		return nil, NewApplicationError(EventNotDeclaredCode, false, map[string]any{
-			"event_name":      params.EventName,
-			"declared_events": set.Declared,
-		})
-	}
-	result := runStartResult{RunID: params.RunID, Status: "running"}
 	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
 		Method:         req.Method,
 		ActorTokenID:   req.ActorTokenID,
-		IdempotencyKey: params.IdempotencyKey,
+		IdempotencyKey: idempotencyKey,
 		RequestHash:    req.RequestHash,
-		ResourceID:     params.RunID,
 		TTL:            runStartIDempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		params, err := runStartParamsFromRequest(req, opts.Bundle.Fingerprint)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+				"event_name":      params.EventName,
+				"declared_events": set.Declared,
+			})
+		}
+		result := runStartResult{RunID: params.RunID, Status: "running"}
 		if err := opts.Events.Publish(ctx, events.Event{
 			ID:          uuid.NewString(),
 			RunID:       params.RunID,
@@ -86,7 +89,7 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 			Payload:     params.Payload,
 			CreatedAt:   now,
 		}.WithEntityID(params.EntityID)); err != nil {
-			return store.APIIdempotencyCompletion{}, err
+			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
 		}
 		response, err := json.Marshal(result)
 		if err != nil {
@@ -98,16 +101,16 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 		}, nil
 	})
 	if err != nil {
-		return nil, runStartExecutionError(params.EventName, err)
+		return nil, runStartIdempotencyError(err)
 	}
-	if replay {
-		var stored runStartResult
-		if err := json.Unmarshal(completion.Response, &stored); err != nil {
+	var stored runStartResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
 			return nil, fmt.Errorf("decode run.start idempotency response: %w", err)
 		}
-		return stored, nil
+		return nil, fmt.Errorf("decode run.start response: %w", err)
 	}
-	return result, nil
+	return stored, nil
 }
 
 func runStartParamsFromRequest(req Request, bootFingerprint string) (runStartParams, error) {
@@ -131,6 +134,10 @@ func runStartParamsFromRequest(req Request, bootFingerprint string) (runStartPar
 	}
 	if runID == "" {
 		runID = uuid.NewString()
+	} else if parsed, err := uuid.Parse(runID); err != nil {
+		return runStartParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "must be a UUID"})
+	} else {
+		runID = parsed.String()
 	}
 	payload, entityID, err := runStartPayload(req.Params, runID)
 	if err != nil {
@@ -209,7 +216,7 @@ func runStartPayloadString(value any) string {
 	return text
 }
 
-func runStartExecutionError(eventName string, err error) error {
+func runStartIdempotencyError(err error) error {
 	var conflict *store.APIIdempotencyConflictError
 	if errors.As(err, &conflict) {
 		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
@@ -221,6 +228,10 @@ func runStartExecutionError(eventName string, err error) error {
 			},
 		})
 	}
+	return err
+}
+
+func runStartPublishError(eventName string, err error) error {
 	if errors.Is(err, runtimebus.ErrPayloadValidation) || strings.Contains(err.Error(), "validate event payload") {
 		return NewApplicationError(PayloadValidationFailedCode, false, map[string]any{
 			"violations": []map[string]any{{

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -143,6 +143,39 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 }
 
+func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := runStartTestHandler(t, pg, bus, source)
+	runID := uuid.NewString()
+	cases := []struct {
+		method string
+		params string
+	}{
+		{method: "run.stop", params: fmt.Sprintf(`{"run_id":%q,"idempotency_key":"idem-stop"}`, runID)},
+		{method: "run.pause", params: fmt.Sprintf(`{"run_id":%q,"idempotency_key":"idem-pause"}`, runID)},
+		{method: "run.continue", params: fmt.Sprintf(`{"run_id":%q,"idempotency_key":"idem-continue"}`, runID)},
+		{method: "runtime.pause", params: `{"idempotency_key":"idem-runtime-pause"}`},
+		{method: "runtime.resume", params: `{"idempotency_key":"idem-runtime-resume"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			resp := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"control","method":%q,"params":%s}`, tc.method, tc.params))
+			if resp.Error == nil {
+				t.Fatalf("%s error = nil, want METHOD_UNAVAILABLE", tc.method)
+			}
+			if data := asMap(t, resp.Error.Data); data["code"] != MethodUnavailableCode {
+				t.Fatalf("%s data = %#v, want METHOD_UNAVAILABLE", tc.method, data)
+			}
+		})
+	}
+}
+
 func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source) *Handler {
 	t.Helper()
 	return testHandler(t, Options{

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -68,6 +68,25 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count after conflict = %d, want 1", count)
 	}
+
+	conflictBundle := rpcCall(t, handler, runStartBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "idem-start"))
+	if conflictBundle.Error == nil {
+		t.Fatal("run.start bundle-change idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflictBundle.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("run.start bundle-change conflict data = %#v", data)
+	}
+
+	conflictEvent := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.missing", `{"topic":"medicine"}`, "idem-start"))
+	if conflictEvent.Error == nil {
+		t.Fatal("run.start event-change idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflictEvent.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("run.start event-change conflict data = %#v", data)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after body-domain conflicts = %d, want 1", count)
+	}
 }
 
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
@@ -140,6 +159,37 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 			t.Fatalf("payload validation data = %#v", data)
 		}
 		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("invalid caller run id", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, runStartBody("abc", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-invalid-run-id"))
+		if resp.Error == nil {
+			t.Fatal("run.start invalid run_id error = nil")
+		}
+		if resp.Error.Code != codeInvalidParams {
+			t.Fatalf("invalid run_id error code = %d, want invalid params", resp.Error.Code)
+		}
+		if details := asMap(t, resp.Error.Data)["details"]; asMap(t, details)["field"] != "run_id" {
+			t.Fatalf("invalid run_id details = %#v", details)
+		}
+		if count := countAllRunRows(t, db); count != 0 {
+			t.Fatalf("run rows after invalid run_id = %d, want 0", count)
+		}
+		if count := countEventsByName(t, db, "scan.requested"); count != 0 {
+			t.Fatalf("event rows after invalid run_id = %d, want 0", count)
+		}
+		if count := countAPIIdempotencyRows(t, db); count != 0 {
+			t.Fatalf("api_idempotency rows after invalid run_id = %d, want 0", count)
+		}
 	})
 }
 
@@ -268,6 +318,15 @@ func countEventRowsByRunID(t *testing.T, db *sql.DB, runID string) int {
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
 		t.Fatalf("count event rows: %v", err)
+	}
+	return count
+}
+
+func countAllRunRows(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM runs`).Scan(&count); err != nil {
+		t.Fatalf("count all run rows: %v", err)
 	}
 	return count
 }

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -191,6 +191,38 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 			t.Fatalf("api_idempotency rows after invalid run_id = %d, want 0", count)
 		}
 	})
+
+	t.Run("invalid payload entity id", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"entity_id":"not-a-uuid","topic":"medicine"}`, "idem-invalid-entity-id"))
+		assertInvalidRunStartParam(t, resp, "payload.entity_id")
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("non-string payload entity id", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"entity_id":123,"topic":"medicine"}`, "idem-non-string-entity-id"))
+		assertInvalidRunStartParam(t, resp, "payload.entity_id")
+		assertNoRunStartPersistence(t, db, runID)
+	})
 }
 
 func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.T) {
@@ -256,6 +288,19 @@ func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string)
 		runID,
 		idempotencyKey,
 	)
+}
+
+func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("run.start invalid %s error = nil", field)
+	}
+	if resp.Error.Code != codeInvalidParams {
+		t.Fatalf("invalid %s error code = %d, want invalid params", field, resp.Error.Code)
+	}
+	if details := asMap(t, resp.Error.Data)["details"]; asMap(t, details)["field"] != field {
+		t.Fatalf("invalid %s details = %#v", field, details)
+	}
 }
 
 func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName string) {

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -1,0 +1,276 @@
+package apiv1
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+const runStartTestFingerprint = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := runStartTestHandler(t, pg, bus, source)
+	runID := uuid.NewString()
+	body := runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-start")
+
+	started := rpcCall(t, handler, body)
+	if started.Error != nil {
+		t.Fatalf("run.start error = %#v", started.Error)
+	}
+	result := asMap(t, started.Result)
+	if result["run_id"] != runID || result["status"] != "running" {
+		t.Fatalf("run.start result = %#v", result)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count = %d, want 1", count)
+	}
+	assertRunStartPersistence(t, db, runID, "scan.requested")
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows = %d, want 1", count)
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("run.start replay error = %#v", replay.Error)
+	}
+	if replayResult := asMap(t, replay.Result); replayResult["run_id"] != runID || replayResult["status"] != "running" {
+		t.Fatalf("run.start replay result = %#v", replayResult)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
+	}
+
+	conflict := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"changed"}`, "idem-start"))
+	if conflict.Error == nil {
+		t.Fatal("run.start idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("run.start conflict data = %#v", data)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after conflict = %d, want 1", count)
+	}
+}
+
+func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
+	t.Run("bundle mismatch", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "idem-mismatch"))
+		if resp.Error == nil {
+			t.Fatal("run.start bundle mismatch error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
+			t.Fatalf("bundle mismatch data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("undeclared event", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.missing", `{"topic":"medicine"}`, "idem-missing-event"))
+		if resp.Error == nil {
+			t.Fatal("run.start undeclared event error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != EventNotDeclaredCode {
+			t.Fatalf("undeclared event data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("payload validation", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+			ContractBundle: source,
+			PayloadValidator: func(eventType string, payload []byte) error {
+				if eventType != "scan.requested" {
+					return fmt.Errorf("unexpected event type %q", eventType)
+				}
+				return errors.New("schema violation")
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-invalid-payload"))
+		if resp.Error == nil {
+			t.Fatal("run.start payload validation error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != PayloadValidationFailedCode {
+			t.Fatalf("payload validation data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+}
+
+func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source) *Handler {
+	t.Helper()
+	return testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:         func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready:       func() bool { return true },
+			Database:    fakePinger{},
+			Runs:        pg,
+			Idempotency: pg,
+			Events:      bus,
+			Source:      source,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     runStartTestFingerprint,
+			},
+		}),
+	})
+}
+
+func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_ref":{"fingerprint":%q},"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		fingerprint,
+		eventName,
+		payload,
+		runID,
+		idempotencyKey,
+	)
+}
+
+func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName string) {
+	t.Helper()
+	var runStatus, triggerType string
+	if err := db.QueryRow(`SELECT status, trigger_event_type FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType); err != nil {
+		t.Fatalf("load run row: %v", err)
+	}
+	if runStatus != "running" || triggerType != eventName {
+		t.Fatalf("run row status=%q trigger=%q, want running/%s", runStatus, triggerType, eventName)
+	}
+	var entityID, producedBy string
+	var payload json.RawMessage
+	if err := db.QueryRow(`
+		SELECT entity_id::text, produced_by, payload
+		FROM events
+		WHERE run_id = $1::uuid AND event_name = $2
+	`, runID, eventName).Scan(&entityID, &producedBy, &payload); err != nil {
+		t.Fatalf("load run.start event row: %v", err)
+	}
+	if entityID != runID {
+		t.Fatalf("event entity_id = %q, want run_id %q", entityID, runID)
+	}
+	if producedBy != "api.v1" {
+		t.Fatalf("event produced_by = %q, want api.v1", producedBy)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode persisted payload: %v", err)
+	}
+	if decoded["entity_id"] != runID || decoded["topic"] != "medicine" {
+		t.Fatalf("persisted payload = %#v", decoded)
+	}
+}
+
+func assertNoRunStartPersistence(t *testing.T, db *sql.DB, runID string) {
+	t.Helper()
+	if count := countRunRowsByID(t, db, runID); count != 0 {
+		t.Fatalf("run rows for %s = %d, want 0", runID, count)
+	}
+	if count := countEventRowsByRunID(t, db, runID); count != 0 {
+		t.Fatalf("event rows for %s = %d, want 0", runID, count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 0 {
+		t.Fatalf("api_idempotency rows = %d, want 0", count)
+	}
+}
+
+func countRunRowsByID(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM runs WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count run rows: %v", err)
+	}
+	return count
+}
+
+func countEventRowsByRunID(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count event rows: %v", err)
+	}
+	return count
+}
+
+func runStartTestBundle(eventName string) *runtimecontracts.WorkflowContractBundle {
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "discovery", Flow: "discovery"},
+		Path:  "discovery",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": {
+				ID:           "scan-orchestrator",
+				SubscribesTo: []string{eventName},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	return &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{Name: "review", Version: "1.0.0"},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"scan-orchestrator": flow.Nodes["scan-orchestrator"],
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{eventName}},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"discovery": &root.Children[0],
+			},
+		},
+	}
+}

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -12,6 +12,10 @@ import (
 
 const (
 	MethodUnavailableCode                = "METHOD_UNAVAILABLE"
+	BundleMismatchCode                   = "BUNDLE_MISMATCH"
+	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
+	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
+	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	MailboxNotFoundCode                  = "MAILBOX_NOT_FOUND"
 	MailboxAlreadyDecidedCode            = "MAILBOX_ALREADY_DECIDED"


### PR DESCRIPTION
## Summary

Part of #665.

Implements only the independently approved first-slice boundary for `run.start` admission on `/v1/rpc`. `run.stop`, `run.pause`, `run.continue`, `runtime.pause`, and `runtime.resume` remain unimplemented and continue to return `METHOD_UNAVAILABLE`; the split control tail is tracked in #677.

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.idempotency`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.bundle_fingerprint`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.BundleRef`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `method_catalog.run.start`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.errors.BUNDLE_MISMATCH`, `UNSUPPORTED_BUNDLE_REF`, `EVENT_NOT_DECLARED`, `PAYLOAD_VALIDATION_FAILED`, `IDEMPOTENCY_CONFLICT`
- #665 pre-audit and gate comment approving `run.start` only

## Semantic Migration Notes

- New canonical v1 entrypoint: `internal/apiv1` `run.start` handler.
- Canonical owners consumed: API idempotency store, boot bundle fingerprint identity, root input validation via `runtime/runstart`, EventBus publish path, and persisted run lifecycle rows.
- Old producer/interpreter paths invalidated: none in this PR; legacy builder/dashboard/helper control paths remain adapter surfaces and are not claimed migrated here.
- Production paths checked for surviving same-concept behavior: v1 registration, builder RPC run.start, dashboard/helper legacy triggers, EventBus publish/store lifecycle, and split control methods.
- Migration completeness: complete only for the approved v1 `run.start` admission first slice, not full Slice 5.

## Tests

- `go test ./internal/apiv1 -run 'TestOperatorRunStart|TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable|TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/runtime/runstart ./internal/runtime/bus ./internal/runtime/contracts ./internal/store -run 'TestValidateInputEvents|TestEventBusPublish_PayloadValidatorFailureAbortsPublish|TestRuntimePayloadValidator|TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersistence|TestAPIIdempotency|TestBundle' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 ./internal/runtime/runstart ./internal/runtime/bus ./internal/runtime/contracts ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`