### PR TITLE
[agent-a][issue #678] Admit same-source fork-point delivery coupling

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3467,7 +3467,9 @@ run_model:
         idempotency effects, and emitted follow-ups under the fork run_id. Post-fork source session, turn, and
         conversation-audit facts may be classified only by the separate
         runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy owner as lineage/no-action
-        branch-divergence evidence.'
+        branch-divergence evidence. Same-source in-progress delivery coupling admitted by
+        runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy is also
+        branch-divergence lineage evidence and not executable delivery/session truth.'
     selected_contract_source_advanced_conversation_history_policy: 'Mutating selected-contract timestamp-fork execution
       may consume runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy to classify
       post-fork-T source agent_sessions, agent_turns, and agent_conversation_audits as source-advanced branch-divergence
@@ -3478,6 +3480,18 @@ run_model:
       Pending or in-progress source delivery/session coupling, fork-local pre-existing conversation rows, generic/state-only
       activation, full historical replay/resume, timers, routes, non-agent replay, restart recovery, and operator surfaces
       remain fail-closed or split siblings unless separately approved.'
+    selected_contract_active_source_delivery_conversation_coupling_policy: 'Mutating selected-contract timestamp-fork
+      execution may consume runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy
+      to classify exactly one narrow at-T active delivery/session coupling case as lineage/no-action and branch-divergence
+      evidence: the in-progress source agent delivery is for the source event referenced by the fork-point event
+      source_event_id, the fork-point event was produced by the same agent subscriber, the delivery started at/before T,
+      and the delivery row has no active_session_id, receipt, receipt outcome, or delivered_at at T. The policy does not
+      authorize copying source delivery rows, sessions, turns, audits, provider session IDs, transcripts, receipts,
+      outcomes, or conversation audits into the fork and does not let a source terminal outcome after T suppress or decide
+      selected fork execution. Unrelated in-flight deliveries, active_session_id coupling, partial receipt/outcome state,
+      fork-local pre-existing conversation rows, post-T source conversation facts outside the source-advanced
+      conversation-history owner, non-agent replay, timers, routes, retry/idempotency, follow-up policy, restart recovery,
+      and operator surfaces remain fail-closed or split siblings unless separately approved.'
     selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source route facts
       as evidence-only fail-closed blockers until a separately approved route reconstruction owner exists. Active source
       timers may be reconstructed only by runtime.run_fork.historical_replay_execution.timer_reconstruction, which
@@ -3495,7 +3509,9 @@ run_model:
       only. This policy is selected-contract execution only and is not session, turn, or audit reconstruction. It applies
       only when selected-contract execution regenerates fresh fork-local work through canonical owners and no pending or
       in-progress source delivery at T requires live session continuity through active_session_id, started_at, partial
-      receipt/outcome state, or equivalent active execution evidence. Source session, turn, audit, provider-session,
+      receipt/outcome state, or equivalent active execution evidence, except for the separately owned same-source
+      fork-point emission case admitted by runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy.
+      Source session, turn, audit, provider-session,
       transcript, receipt, outcome, or task-audit rows MUST NOT be copied into the fork, reused as fork-local runtime
       truth, or used as selected-fork suppressors. Fork-local conversation rows before the selected execution owner
       creates them remain fail-closed. Post-T source session, turn, and conversation-audit facts are outside this
@@ -3784,13 +3800,15 @@ run_model:
         facts may be admitted only as source-advanced branch-divergence lineage/no-action evidence by the separate
         selected-contract source-advanced conversation-history policy. At/before-T source committed replay-scope marker
         rows may be admitted only as lineage/no-action evidence by the separate selected-contract committed replay-scope
-        marker policy.'
+        marker policy. Same-source in-progress source delivery coupling at the fork-point emission boundary may be
+        admitted only by the separate selected-contract active source delivery conversation-coupling policy.'
       3h1_selected_contract_session_turn_audit_lineage_policy: 'For selected-contract timestamp-fork execution,
         runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy consumes the
         canonical replay_resume_admission session_history, active_turn_history, and conversation_audit_history facts and
         may demote those at/before-T source facts from fail-closed blockers to lineage/no-action evidence only. The owner
         must keep pending/in-progress delivery session coupling and fork-local pre-existing conversation rows
-        fail-closed. It must not copy or reuse source session IDs, provider session IDs, transcripts, task audits, turns,
+        fail-closed except when the separate selected-contract active source delivery conversation-coupling policy has
+        admitted the same-source fork-point emission case. It must not copy or reuse source session IDs, provider session IDs, transcripts, task audits, turns,
         receipts, outcomes, or source audit rows as fork-local runtime truth or suppressors. Fresh fork-local sessions,
         turns, and audits may appear only through normal selected fork runtime execution under the fork run_id. Post-T
         source conversation facts are outside this at/before-T owner and may be admitted only by
@@ -3820,6 +3838,18 @@ run_model:
         generic non-agent replay, delivery-event replay, committed replay-scope marker policy, sessions, turns, audits,
         timers, routes, retry/idempotency, follow-up policy, restart recovery, contract-swap boot/resume, and operator
         surfaces remain separate fail-closed or split siblings unless independently approved.'
+      3h4_selected_contract_active_source_delivery_conversation_coupling_policy: 'For selected-contract timestamp-fork
+        execution, runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy
+        consumes replay_resume_admission delivery_in_progress_history evidence and fork-point source-event causality to
+        admit only the same-source delivery fork-point emission case: the source delivery is in progress at T, belongs to
+        the fork-point event source_event_id, and its agent subscriber produced the fork-point event, with no
+        active_session_id, receipt, receipt outcome, or delivered_at at T. This owner may demote that delivery fact from a
+        generic delivery_history_unproven blocker to lineage/no-action evidence and may allow the session/turn/audit
+        lineage policy to classify at/before-T source conversation rows. It records the admitted case as selected-contract
+        branch-divergence evidence. It must not copy source delivery/session/turn/audit rows, use source terminal outcomes
+        after T as fork suppressors, or admit unrelated active deliveries, active_session_id coupling, post-T source
+        conversation facts, fork-local pre-existing rows, non-agent replay, timers, routes, retry/idempotency, follow-up
+        policy, restart recovery, or operator surfaces.'
       3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
         readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
         replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -205,6 +205,11 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 678
+    title: Gate selected-contract active source delivery conversation-coupling policy
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -370,6 +375,7 @@ nodes:
       - selected-contract committed replay-scope marker policy needs runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy to classify at/before-T source committed replay-scope marker rows by underlying source event position as lineage/no-action only, including delayed marker delivery write-skew after T, while keeping those marker rows out of generic selected-contract source_deliveries_advanced_after_fork_point evidence and preserving source marker copying, fork-local recovery proof reuse, marker rows whose source event is after T, same-run recovery, and full replay/resume as split or fail-closed
       - selected-contract diagnostic platform outcome policy needs runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy to classify at/before-T source platform.runtime_log/platform.inbound_recorded outcome facts as lineage/no-action before route topology, recipient planning, and selected execution, while preserving real frontier unresolved-route blockers and generic non-agent/dead-letter replay blockers
       - selected-contract source-advanced conversation-history policy needs runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy to classify post-T source agent_sessions, agent_turns, and agent_conversation_audits as branch-divergence lineage/no-action evidence while keeping source row copy/reuse, source suppressors, active delivery/session coupling, fork-local pre-existing rows, full reconstruction, and non-selected surfaces split or fail-closed
+      - selected-contract active source delivery conversation-coupling policy needs runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy to classify only the same-source in-progress delivery that emitted the fork-point event as lineage/no-action and branch-divergence evidence, while preserving fail-closed behavior for unrelated active deliveries, active_session_id/receipt/outcome coupling, source row copy/reuse, source outcome suppressors, fork-local pre-existing rows, post-T conversation facts outside #671, full reconstruction, and non-selected surfaces
     representative_issues:
       - 564
       - 565
@@ -403,6 +409,7 @@ nodes:
       - 663
       - 668
       - 671
+      - 678
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -572,6 +572,153 @@ func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(
 	}
 }
 
+func TestExecuteSelectedContractRunForkAdmitsSameSourceActiveDeliveryForkPointEmission(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier1-primitives/test-emits-multiple")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700002303, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, conversation_mode, status, created_at)
+		VALUES ('validation-coordinator', 'test-agent', 'tier1', 'session_per_entity', 'active', $1)
+		ON CONFLICT (agent_id) DO NOTHING
+	`, at); err != nil {
+		t.Fatalf("seed source session agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'validation-coordinator', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'session_per_entity', 'active', $4, $4)
+	`, sessionID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'validation-coordinator', $3::uuid, 'flow-a/1', $3::text, 'entity',
+			'task', '{}'::jsonb, 'active', $4, $4)
+	`, auditID, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed source conversation audit: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'validation-coordinator', $3::uuid, 'session_per_entity', $4::text, $4::uuid,
+			$5::uuid, 'item.received', 'task-a', $6)
+	`, turnID, sourceRunID, sessionID, entityID, sourceEventID, at); err != nil {
+		t.Fatalf("seed source turn: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'validation-coordinator', 'in_progress', $3, $3)
+	`, sourceRunID, sourceEventID, at.Add(5*time.Second)); err != nil {
+		t.Fatalf("seed in-progress source delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'item.received', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           forkPointEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.Materialization.ForkRunID == "" || !result.Activation.Activated {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	for _, code := range []string{
+		store.RunForkBlockerDeliveryHistoryUnproven,
+		store.RunForkBlockerSessionHistoryUnproven,
+		store.RunForkBlockerConversationAuditUnproven,
+		store.RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if selectedExecutionResultHasBlocker(result, code) {
+			t.Fatalf("selected execution retained %s: materialization=%#v activation=%#v", code, result.Materialization.UnsupportedBlockers, result.Activation.UnsupportedBlockers)
+		}
+	}
+	if !result.Activation.SourceAdvancedAfterFork ||
+		result.Activation.BranchDivergence == nil ||
+		!containsString(result.Activation.BranchDivergence.SourceAdvancedFacts, store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification) {
+		t.Fatalf("activation branch divergence = %#v, want #678 same-source active delivery fact", result.Activation.BranchDivergence)
+	}
+
+	var copiedSessions, copiedAudits, copiedTurns, copiedSourceSubscriberDeliveries int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_sessions WHERE run_id = $1::uuid OR session_id = $2::uuid
+	`, result.Materialization.ForkRunID, sessionID).Scan(&copiedSessions); err != nil {
+		t.Fatalf("count session copies: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_conversation_audits WHERE run_id = $1::uuid OR session_id = $2::uuid
+	`, result.Materialization.ForkRunID, auditID).Scan(&copiedAudits); err != nil {
+		t.Fatalf("count audit copies: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM agent_turns WHERE run_id = $1::uuid OR turn_id = $2::uuid
+	`, result.Materialization.ForkRunID, turnID).Scan(&copiedTurns); err != nil {
+		t.Fatalf("count turn copies: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND subscriber_id = 'validation-coordinator'
+		  AND status = 'in_progress'
+	`, result.Materialization.ForkRunID).Scan(&copiedSourceSubscriberDeliveries); err != nil {
+		t.Fatalf("count copied source delivery: %v", err)
+	}
+	if copiedSessions != 1 || copiedAudits != 1 || copiedTurns != 1 || copiedSourceSubscriberDeliveries != 0 {
+		t.Fatalf("copied source rows sessions=%d audits=%d turns=%d sourceDeliveries=%d, want source-only conversation rows and no source delivery copies", copiedSessions, copiedAudits, copiedTurns, copiedSourceSubscriberDeliveries)
+	}
+}
+
 func TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBranchDivergence(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -325,6 +325,16 @@ func historicalReplayEventDeliveriesAdmission(replay store.RunForkReplayResumeAd
 			Message:     "at/before-T source committed replay-scope marker rows are lineage/no-action evidence only for selected-contract timestamp forks; fork-local recovery proof must be written under the fork run_id",
 		}
 	}
+	if disposition, ok := replayDispositionForFact(replay, store.RunForkReplayResumeFactDeliveryInProgressHistory, store.RunForkReplayResumeDispositionLineageOnly); ok &&
+		strings.TrimSpace(disposition.Owner) == store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner {
+		return store.RunForkHistoricalReplayFactAdmission{
+			Fact:        store.RunForkHistoricalReplayFactEventDeliveries,
+			Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+			SourceOwner: store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner,
+			Tracker:     "#678",
+			Message:     "same-source in-progress delivery that emitted the fork-point event is selected-contract branch-divergence lineage only; source delivery/session/receipt/outcome rows are not copied or resumed",
+		}
+	}
 	return historicalReplayLineageFact(store.RunForkHistoricalReplayFactEventDeliveries, store.RunForkReplayResumeAdmissionOwner, "source delivery history is lineage/no-op evidence unless the canonical replay taxonomy admits the pending unstarted agent-delivery primitive")
 }
 

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -366,6 +366,49 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractReplaySco
 	}
 }
 
+func TestBuildHistoricalReplayExecutionAdmissionReportsActiveSourceDeliveryCouplingOwner(t *testing.T) {
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(testContractSwapSelection())
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                   store.RunForkReplayResumeAdmissionOwner,
+		StateOnlyExecutionReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:           store.RunForkReplayResumeFactDeliveryInProgressHistory,
+			Disposition:    store.RunForkReplayResumeDispositionLineageOnly,
+			Owner:          store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner,
+			Classification: store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification,
+			Message:        "selected-contract same-source active delivery lineage/no-action evidence",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+
+	admission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	item, ok := historicalReplayFactAdmission(admission.FactAdmissions, store.RunForkHistoricalReplayFactEventDeliveries)
+	if !ok {
+		t.Fatalf("missing event_deliveries admission: %#v", admission.FactAdmissions)
+	}
+	if item.Admission != store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence ||
+		item.SourceOwner != store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner ||
+		item.Tracker != "#678" {
+		t.Fatalf("event_deliveries admission = %#v, want #678 active source delivery owner", item)
+	}
+}
+
 func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation(t *testing.T) {
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -49,10 +49,13 @@ type RunForkPlan struct {
 }
 
 type RunForkPoint struct {
-	Input     string    `json:"input"`
-	EventID   string    `json:"event_id"`
-	EventName string    `json:"event_name,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
+	Input          string    `json:"input"`
+	EventID        string    `json:"event_id"`
+	EventName      string    `json:"event_name,omitempty"`
+	SourceEventID  string    `json:"source_event_id,omitempty"`
+	ProducedBy     string    `json:"produced_by,omitempty"`
+	ProducedByType string    `json:"produced_by_type,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
 }
 
 type RunForkEntityState struct {
@@ -89,9 +92,12 @@ type RunForkUnsupportedBlocker struct {
 }
 
 type runForkEventCursor struct {
-	EventID   string
-	EventName string
-	CreatedAt time.Time
+	EventID        string
+	EventName      string
+	SourceEventID  string
+	ProducedBy     string
+	ProducedByType string
+	CreatedAt      time.Time
 }
 
 type runForkAdmissionEvidence struct {
@@ -126,7 +132,7 @@ func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, ca
 	}
 	required := map[string][]string{
 		"runs":             {"run_id", "status"},
-		"events":           {"event_id", "run_id", "event_name", "created_at"},
+		"events":           {"event_id", "run_id", "event_name", "source_event_id", "produced_by", "produced_by_type", "created_at"},
 		"event_deliveries": {"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count", "reason_code", "active_session_id", "started_at", "delivered_at", "created_at"},
 		"event_receipts":   {"event_id", "subscriber_type", "subscriber_id", "outcome", "reason_code", "processed_at"},
 		"dead_letters":     {"original_event_id", "handler_node", "created_at"},
@@ -182,10 +188,13 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 		return RunForkPlan{}, err
 	}
 	plan.ForkPoint = RunForkPoint{
-		Input:     at,
-		EventID:   cursor.EventID,
-		EventName: cursor.EventName,
-		Timestamp: cursor.CreatedAt,
+		Input:          at,
+		EventID:        cursor.EventID,
+		EventName:      cursor.EventName,
+		SourceEventID:  cursor.SourceEventID,
+		ProducedBy:     cursor.ProducedBy,
+		ProducedByType: cursor.ProducedByType,
+		Timestamp:      cursor.CreatedAt,
 	}
 	if err := s.DB.QueryRowContext(ctx, `
 		SELECT COUNT(*)
@@ -247,11 +256,17 @@ func (s *PostgresStore) resolveRunForkPoint(ctx context.Context, runID, at strin
 	if _, err := uuid.Parse(at); err == nil {
 		var cursor runForkEventCursor
 		if err := s.DB.QueryRowContext(ctx, `
-			SELECT event_id::text, event_name, created_at
+			SELECT
+				event_id::text,
+				event_name,
+				COALESCE(source_event_id::text, ''),
+				COALESCE(produced_by, ''),
+				COALESCE(produced_by_type, ''),
+				created_at
 			FROM events
 			WHERE run_id = $1::uuid
 			  AND event_id = $2::uuid
-		`, runID, at).Scan(&cursor.EventID, &cursor.EventName, &cursor.CreatedAt); err != nil {
+		`, runID, at).Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt); err != nil {
 			if err == sql.ErrNoRows {
 				return runForkEventCursor{}, fmt.Errorf("fork point event %s not found in source run %s", at, runID)
 			}
@@ -265,13 +280,19 @@ func (s *PostgresStore) resolveRunForkPoint(ctx context.Context, runID, at strin
 	}
 	var cursor runForkEventCursor
 	if err := s.DB.QueryRowContext(ctx, `
-		SELECT event_id::text, event_name, created_at
+		SELECT
+			event_id::text,
+			event_name,
+			COALESCE(source_event_id::text, ''),
+			COALESCE(produced_by, ''),
+			COALESCE(produced_by_type, ''),
+			created_at
 		FROM events
 		WHERE run_id = $1::uuid
 		  AND created_at <= $2::timestamptz
 		ORDER BY created_at DESC, event_id DESC
 		LIMIT 1
-	`, runID, atTime).Scan(&cursor.EventID, &cursor.EventName, &cursor.CreatedAt); err != nil {
+	`, runID, atTime).Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt); err != nil {
 		if err == sql.ErrNoRows {
 			return runForkEventCursor{}, fmt.Errorf("no source-run event exists at or before fork timestamp %s", at)
 		}

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -63,6 +63,10 @@ type RunForkReplayResumeDisposition struct {
 	Owner          string `json:"owner,omitempty"`
 	BlockerCode    string `json:"blocker_code,omitempty"`
 	Classification string `json:"classification,omitempty"`
+	EventID        string `json:"event_id,omitempty"`
+	DeliveryID     string `json:"delivery_id,omitempty"`
+	SubscriberType string `json:"subscriber_type,omitempty"`
+	SubscriberID   string `json:"subscriber_id,omitempty"`
 	Message        string `json:"message"`
 }
 
@@ -178,22 +182,26 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 }
 
 func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunForkReplayResumeDisposition {
+	disposition := RunForkReplayResumeDisposition{
+		EventID:        strings.TrimSpace(item.EventID),
+		DeliveryID:     strings.TrimSpace(item.DeliveryID),
+		SubscriberType: strings.TrimSpace(item.SubscriberType),
+		SubscriberID:   strings.TrimSpace(item.SubscriberID),
+	}
 	switch item.Classification {
 	case RunForkPendingClassificationDeliveredCompleted:
-		return RunForkReplayResumeDisposition{
-			Fact:           RunForkReplayResumeFactDeliveryCompletedHistory,
-			Disposition:    RunForkReplayResumeDispositionLineageOnly,
-			Classification: item.Classification,
-			Message:        "completed delivery and receipt facts are preserved as source-run lineage/proof only; they are not redelivered into the fork",
-		}
+		disposition.Fact = RunForkReplayResumeFactDeliveryCompletedHistory
+		disposition.Disposition = RunForkReplayResumeDispositionLineageOnly
+		disposition.Classification = item.Classification
+		disposition.Message = "completed delivery and receipt facts are preserved as source-run lineage/proof only; they are not redelivered into the fork"
+		return disposition
 	case RunForkPendingClassificationPending:
 		if runForkPendingWorkReplayable(item) {
-			return RunForkReplayResumeDisposition{
-				Fact:           RunForkReplayResumeFactDeliveryPendingHistory,
-				Disposition:    RunForkReplayResumeDispositionForkReplay,
-				Classification: item.Classification,
-				Message:        "pending unstarted source delivery can be replayed by creating fork-local event and delivery rows with explicit source lineage",
-			}
+			disposition.Fact = RunForkReplayResumeFactDeliveryPendingHistory
+			disposition.Disposition = RunForkReplayResumeDispositionForkReplay
+			disposition.Classification = item.Classification
+			disposition.Message = "pending unstarted source delivery can be replayed by creating fork-local event and delivery rows with explicit source lineage"
+			return disposition
 		}
 		if runForkPendingWorkIsNonAgent(item) {
 			return runForkReplayResumeNonAgentBlocker(item, RunForkReplayResumeFactDeliveryPendingHistory)
@@ -260,6 +268,10 @@ func runForkReplayResumePendingBlocker(item RunForkPendingWork, fact string) Run
 		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
 		BlockerCode:    blocker.Code,
 		Classification: item.Classification,
+		EventID:        strings.TrimSpace(item.EventID),
+		DeliveryID:     strings.TrimSpace(item.DeliveryID),
+		SubscriberType: strings.TrimSpace(item.SubscriberType),
+		SubscriberID:   strings.TrimSpace(item.SubscriberID),
 		Message:        blocker.Message,
 	}
 }
@@ -271,6 +283,10 @@ func runForkReplayResumeNonAgentBlocker(item RunForkPendingWork, fact string) Ru
 		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
 		BlockerCode:    blocker.Code,
 		Classification: item.Classification,
+		EventID:        strings.TrimSpace(item.EventID),
+		DeliveryID:     strings.TrimSpace(item.DeliveryID),
+		SubscriberType: strings.TrimSpace(item.SubscriberType),
+		SubscriberID:   strings.TrimSpace(item.SubscriberID),
 		Message:        blocker.Message,
 	}
 }
@@ -282,6 +298,10 @@ func runForkReplayResumeCommittedReplayScopeBlocker(item RunForkPendingWork) Run
 		Disposition:    RunForkReplayResumeDispositionFailClosedBlocker,
 		BlockerCode:    blocker.Code,
 		Classification: item.Classification,
+		EventID:        strings.TrimSpace(item.EventID),
+		DeliveryID:     strings.TrimSpace(item.DeliveryID),
+		SubscriberType: strings.TrimSpace(item.SubscriberType),
+		SubscriberID:   strings.TrimSpace(item.SubscriberID),
 		Message:        blocker.Message,
 	}
 }

--- a/internal/store/run_fork_selected_contract_conversation_lineage.go
+++ b/internal/store/run_fork_selected_contract_conversation_lineage.go
@@ -16,11 +16,14 @@ var runForkSelectedContractConversationLineageFacts = map[string]string{
 // RunForkSelectedContractSessionTurnAuditLineageAdmission applies the selected-contract
 // conversation-history policy after the store replay taxonomy has identified source facts.
 func RunForkSelectedContractSessionTurnAuditLineageAdmission(plan RunForkPlan) RunForkReplayResumeAdmission {
-	admission := plan.ReplayResumeAdmission
+	return runForkSelectedContractSessionTurnAuditLineageAdmission(plan, plan.ReplayResumeAdmission)
+}
+
+func runForkSelectedContractSessionTurnAuditLineageAdmission(plan RunForkPlan, admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
 	if strings.TrimSpace(admission.Owner) == "" {
 		admission.Owner = RunForkReplayResumeAdmissionOwner
 	}
-	if runForkSelectedContractHasActiveDeliverySessionCoupling(plan.PendingWork) {
+	if runForkSelectedContractHasUnsafeActiveDeliverySessionCoupling(plan) {
 		return admission
 	}
 
@@ -60,6 +63,47 @@ func RunForkSelectedContractSessionTurnAuditLineageAdmission(plan RunForkPlan) R
 	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
 }
 
+// RunForkSelectedContractActiveSourceDeliveryConversationCouplingAdmission admits
+// only the narrow #678 case: the in-progress source delivery is the same agent
+// delivery that emitted the selected fork-point event, and it carries no live
+// session/receipt/outcome state that would have to be resumed in the fork.
+func RunForkSelectedContractActiveSourceDeliveryConversationCouplingAdmission(plan RunForkPlan, admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
+	policy := runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicy(plan)
+	if len(policy.admitted) == 0 {
+		return admission
+	}
+	if strings.TrimSpace(admission.Owner) == "" {
+		admission.Owner = RunForkReplayResumeAdmissionOwner
+	}
+
+	changed := false
+	for i := range admission.Dispositions {
+		disposition := &admission.Dispositions[i]
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		if strings.TrimSpace(disposition.BlockerCode) != RunForkBlockerDeliveryHistoryUnproven {
+			continue
+		}
+		if strings.TrimSpace(disposition.Fact) != RunForkReplayResumeFactDeliveryInProgressHistory {
+			continue
+		}
+		if !policy.admitted[runForkSelectedContractDispositionKey(*disposition)] {
+			continue
+		}
+		disposition.Disposition = RunForkReplayResumeDispositionLineageOnly
+		disposition.Owner = RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner
+		disposition.BlockerCode = ""
+		disposition.Classification = RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification
+		disposition.Message = fmt.Sprintf("%s classifies the same in-progress source delivery that emitted the fork-point event as selected-contract branch-divergence lineage only; source sessions, receipts, outcomes, and delivery rows are not copied or used as fork-local truth", RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner)
+		changed = true
+	}
+	if !changed {
+		return admission
+	}
+	return runForkReplayResumeAdmissionPruneResolvedBlockers(admission)
+}
+
 func runForkSelectedContractConversationLineageBlocker(code string) bool {
 	for _, blockerCode := range runForkSelectedContractConversationLineageFacts {
 		if code == blockerCode {
@@ -69,25 +113,136 @@ func runForkSelectedContractConversationLineageBlocker(code string) bool {
 	return false
 }
 
-func runForkSelectedContractHasActiveDeliverySessionCoupling(pending []RunForkPendingWork) bool {
-	for _, item := range pending {
-		classification := strings.TrimSpace(item.Classification)
-		switch classification {
-		case RunForkPendingClassificationInProgress:
-			return true
-		case RunForkPendingClassificationPending:
-		default:
+func runForkSelectedContractHasUnsafeActiveDeliverySessionCoupling(plan RunForkPlan) bool {
+	return runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicy(plan).unsafe
+}
+
+func runForkSelectedContractActiveSourceDeliveryConversationCouplingAdmitted(plan RunForkPlan, item RunForkPendingWork) bool {
+	return runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicy(plan).admitted[runForkSelectedContractPendingWorkKey(item)]
+}
+
+func runForkSelectedContractActiveSourceDeliveryConversationCouplingFacts(admission RunForkReplayResumeAdmission) []string {
+	facts := []string{}
+	for _, disposition := range admission.Dispositions {
+		if strings.TrimSpace(disposition.Fact) != RunForkReplayResumeFactDeliveryInProgressHistory {
 			continue
 		}
-		if strings.TrimSpace(item.ActiveSessionID) != "" ||
-			item.StartedAt != nil ||
-			item.DeliveredAt != nil ||
-			item.ReceiptAt != nil ||
-			strings.TrimSpace(item.ReceiptOutcome) != "" {
-			return true
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionLineageOnly {
+			continue
+		}
+		if strings.TrimSpace(disposition.Owner) != RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner {
+			continue
+		}
+		classification := strings.TrimSpace(disposition.Classification)
+		if classification == "" {
+			classification = RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification
+		}
+		facts = append(facts, classification)
+	}
+	return uniqueNonEmptyStrings(facts)
+}
+
+type runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyResult struct {
+	admitted map[string]bool
+	unsafe   bool
+}
+
+func runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicy(plan RunForkPlan) runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyResult {
+	result := runForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyResult{
+		admitted: map[string]bool{},
+	}
+	for _, item := range plan.PendingWork {
+		if !runForkSelectedContractPendingWorkHasActiveDeliverySessionCoupling(item) {
+			continue
+		}
+		if runForkSelectedContractSameSourceDeliveryForkPointEmission(plan, item) {
+			result.admitted[runForkSelectedContractPendingWorkKey(item)] = true
+			continue
+		}
+		result.unsafe = true
+	}
+	return result
+}
+
+func runForkSelectedContractPendingWorkHasActiveDeliverySessionCoupling(item RunForkPendingWork) bool {
+	classification := strings.TrimSpace(item.Classification)
+	switch classification {
+	case RunForkPendingClassificationInProgress:
+		return true
+	case RunForkPendingClassificationPending:
+	default:
+		return false
+	}
+	return strings.TrimSpace(item.ActiveSessionID) != "" ||
+		item.StartedAt != nil ||
+		item.DeliveredAt != nil ||
+		item.ReceiptAt != nil ||
+		strings.TrimSpace(item.ReceiptOutcome) != ""
+}
+
+func runForkSelectedContractSameSourceDeliveryForkPointEmission(plan RunForkPlan, item RunForkPendingWork) bool {
+	if strings.TrimSpace(item.Classification) != RunForkPendingClassificationInProgress {
+		return false
+	}
+	if strings.TrimSpace(item.EventID) == "" ||
+		strings.TrimSpace(item.EventID) != strings.TrimSpace(plan.ForkPoint.SourceEventID) {
+		return false
+	}
+	if strings.TrimSpace(item.DeliveryID) == "" || strings.TrimSpace(item.SubscriberType) != "agent" {
+		return false
+	}
+	if strings.TrimSpace(plan.ForkPoint.ProducedByType) != "agent" ||
+		strings.TrimSpace(item.SubscriberID) == "" ||
+		strings.TrimSpace(item.SubscriberID) != strings.TrimSpace(plan.ForkPoint.ProducedBy) {
+		return false
+	}
+	if strings.TrimSpace(item.ActiveSessionID) != "" ||
+		item.StartedAt == nil ||
+		item.StartedAt.After(plan.ForkPoint.Timestamp) ||
+		item.DeliveredAt != nil ||
+		item.ReceiptAt != nil ||
+		strings.TrimSpace(item.ReceiptOutcome) != "" {
+		return false
+	}
+	return true
+}
+
+func runForkSelectedContractPendingWorkKey(item RunForkPendingWork) string {
+	return strings.Join([]string{
+		strings.TrimSpace(item.EventID),
+		strings.TrimSpace(item.DeliveryID),
+		strings.TrimSpace(item.SubscriberType),
+		strings.TrimSpace(item.SubscriberID),
+	}, "\x00")
+}
+
+func runForkSelectedContractDispositionKey(item RunForkReplayResumeDisposition) string {
+	return strings.Join([]string{
+		strings.TrimSpace(item.EventID),
+		strings.TrimSpace(item.DeliveryID),
+		strings.TrimSpace(item.SubscriberType),
+		strings.TrimSpace(item.SubscriberID),
+	}, "\x00")
+}
+
+func runForkReplayResumeAdmissionPruneResolvedBlockers(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
+	unresolved := map[string]bool{}
+	for _, disposition := range admission.Dispositions {
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		if code := strings.TrimSpace(disposition.BlockerCode); code != "" {
+			unresolved[code] = true
 		}
 	}
-	return false
+	filtered := make([]RunForkUnsupportedBlocker, 0, len(admission.UnsupportedBlockers))
+	for _, blocker := range admission.UnsupportedBlockers {
+		if unresolved[strings.TrimSpace(blocker.Code)] {
+			filtered = append(filtered, blocker)
+		}
+	}
+	admission.UnsupportedBlockers = filtered
+	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
 }
 
 func runForkReplayResumeAdmissionRecalculateReadiness(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -10,21 +10,22 @@ import (
 )
 
 const (
-	RunForkSelectedContractExecutionModelOwner                          = "runtime.run_fork.selected_contract_execution_model"
-	RunForkSelectedContractExecutionAdmissionOwner                      = "runtime.run_fork.selected_contract_execution_admission"
-	RunForkSelectedContractExecutionActivationGateOwner                 = "runtime.run_fork.selected_contract_execution.activation_gate"
-	RunForkSelectedContractExecutionOwner                               = "runtime.run_fork.selected_contract_execution"
-	RunForkSelectedContractRouteAdmissionOwner                          = "runtime.run_fork.selected_contract_route_admission"
-	RunForkSelectedContractRouteTopologyOwner                           = "runtime.run_fork.selected_contract_route_topology"
-	RunForkSelectedContractDynamicRouteTopologyOwner                    = "runtime.run_fork.selected_contract_dynamic_route_topology"
-	RunForkSelectedContractRecipientPlanningOwner                       = "runtime.run_fork.selected_contract_recipient_planning"
-	RunForkContractSwapBootResumeAdmissionOwner                         = "runtime.run_fork.contract_swap_boot_resume_admission"
-	RunForkHistoricalReplayExecutionAdmissionOwner                      = "runtime.run_fork.historical_replay_execution_admission"
-	RunForkHistoricalReplayExecutionOwner                               = "runtime.run_fork.historical_replay_execution"
-	RunForkHistoricalReplayContractSwapBootResumeOwner                  = RunForkHistoricalReplayExecutionOwner + ".contract_swap_boot_resume"
-	RunForkHistoricalReplayTimerReconstructionOwner                     = RunForkHistoricalReplayExecutionOwner + ".timer_reconstruction"
-	RunForkSelectedContractBranchDivergenceOwner                        = "store.run_fork.selected_contract_branch_divergence"
-	RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner = RunForkSelectedContractExecutionOwner + ".source_advanced_conversation_history_policy"
+	RunForkSelectedContractExecutionModelOwner                                 = "runtime.run_fork.selected_contract_execution_model"
+	RunForkSelectedContractExecutionAdmissionOwner                             = "runtime.run_fork.selected_contract_execution_admission"
+	RunForkSelectedContractExecutionActivationGateOwner                        = "runtime.run_fork.selected_contract_execution.activation_gate"
+	RunForkSelectedContractExecutionOwner                                      = "runtime.run_fork.selected_contract_execution"
+	RunForkSelectedContractRouteAdmissionOwner                                 = "runtime.run_fork.selected_contract_route_admission"
+	RunForkSelectedContractRouteTopologyOwner                                  = "runtime.run_fork.selected_contract_route_topology"
+	RunForkSelectedContractDynamicRouteTopologyOwner                           = "runtime.run_fork.selected_contract_dynamic_route_topology"
+	RunForkSelectedContractRecipientPlanningOwner                              = "runtime.run_fork.selected_contract_recipient_planning"
+	RunForkContractSwapBootResumeAdmissionOwner                                = "runtime.run_fork.contract_swap_boot_resume_admission"
+	RunForkHistoricalReplayExecutionAdmissionOwner                             = "runtime.run_fork.historical_replay_execution_admission"
+	RunForkHistoricalReplayExecutionOwner                                      = "runtime.run_fork.historical_replay_execution"
+	RunForkHistoricalReplayContractSwapBootResumeOwner                         = RunForkHistoricalReplayExecutionOwner + ".contract_swap_boot_resume"
+	RunForkHistoricalReplayTimerReconstructionOwner                            = RunForkHistoricalReplayExecutionOwner + ".timer_reconstruction"
+	RunForkSelectedContractBranchDivergenceOwner                               = "store.run_fork.selected_contract_branch_divergence"
+	RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner        = RunForkSelectedContractExecutionOwner + ".source_advanced_conversation_history_policy"
+	RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner = RunForkSelectedContractExecutionOwner + ".active_source_delivery_conversation_coupling_policy"
 
 	RunForkSelectedContractExecutionAdmissionUseEvidenceOnly   = "prerequisite_evidence_only"
 	RunForkSelectedContractExecutionAdmissionUseDurableBinding = "durable_binding_and_frontier_evidence"
@@ -49,6 +50,8 @@ const (
 	RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating = "historical_replay_execution_admission_non_mutating"
 
 	RunForkSelectedContractSourceAdvancedBranchPolicy = "selected_contract_source_advanced_branch"
+
+	RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification = "same_source_delivery_fork_point_emission"
 )
 
 const (

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -874,6 +874,14 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 		if runForkSelectedContractActiveSourceDeliveryConversationCouplingAdmitted(plan, item) {
 			continue
 		}
+		if runForkSelectedContractPendingWorkHasActiveDeliverySessionCoupling(item) {
+			if blocker, ok := runForkSelectedContractAdmissionBlockerForPendingWork(admission, item); ok {
+				blockers = appendRunForkBlocker(blockers, blocker)
+			} else {
+				blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(RunForkBlockerDeliveryHistoryUnproven))
+			}
+			continue
+		}
 		if len(allowedEvents) == 0 {
 			continue
 		}
@@ -885,6 +893,22 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 		}
 	}
 	return blockers
+}
+
+func runForkSelectedContractAdmissionBlockerForPendingWork(admission RunForkReplayResumeAdmission, item RunForkPendingWork) (RunForkUnsupportedBlocker, bool) {
+	key := runForkSelectedContractPendingWorkKey(item)
+	for _, disposition := range admission.Dispositions {
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionFailClosedBlocker {
+			continue
+		}
+		if runForkSelectedContractDispositionKey(disposition) != key {
+			continue
+		}
+		if code := strings.TrimSpace(disposition.BlockerCode); code != "" {
+			return runForkReplayResumeBlocker(code), true
+		}
+	}
+	return RunForkUnsupportedBlocker{}, false
 }
 
 func (s *PostgresStore) EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, sourceRunID, forkEventID string, forkTime time.Time) error {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -344,7 +344,9 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		}
 		return result, err
 	}
-	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, catalog, lineage, conversationAdvancedFacts)
+	sourceAdvancedAdmissionFacts := append([]string{}, conversationAdvancedFacts...)
+	sourceAdvancedAdmissionFacts = append(sourceAdvancedAdmissionFacts, runForkSelectedContractActiveSourceDeliveryConversationCouplingFacts(result.ReplayResumeAdmission)...)
+	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, catalog, lineage, sourceAdvancedAdmissionFacts)
 	if err != nil {
 		return result, err
 	}
@@ -867,6 +869,9 @@ func runForkSelectedContractExecutionPlanBlockersFromAdmission(plan RunForkPlan,
 				continue
 			}
 			blockers = appendRunForkBlocker(blockers, runForkReplayResumeBlocker(RunForkBlockerCommittedReplayScopeReplayUnsupported))
+			continue
+		}
+		if runForkSelectedContractActiveSourceDeliveryConversationCouplingAdmitted(plan, item) {
 			continue
 		}
 		if len(allowedEvents) == 0 {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -211,6 +211,162 @@ func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCoupl
 	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
+func TestSelectedContractExecutionMaterializationAdmitsSameSourceDeliveryForkPointEmission(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700002425, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, sourceEventID, at)
+	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, sourceEventID, sessionID, auditID, turnID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'validation-coordinator', 'in_progress', $3, $3)
+	`, sourceRunID, sourceEventID, at.Add(5*time.Second)); err != nil {
+		t.Fatalf("seed in-progress source delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          forkPointEventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+	for _, code := range []string{
+		RunForkBlockerDeliveryHistoryUnproven,
+		RunForkBlockerSessionHistoryUnproven,
+		RunForkBlockerConversationAuditUnproven,
+		RunForkBlockerActiveTurnHistoryUnproven,
+	} {
+		if runForkTestHasMaterializationBlocker(materialized, code) {
+			t.Fatalf("selected-contract materialization kept %s: %#v", code, materialized.UnsupportedBlockers)
+		}
+	}
+	if !runForkTestHasLineageDispositionOwnerClassification(
+		materialized.ReplayResumeAdmission,
+		RunForkReplayResumeFactDeliveryInProgressHistory,
+		RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner,
+		RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification,
+	) {
+		t.Fatalf("admission missing #678 active delivery lineage owner: %#v", materialized.ReplayResumeAdmission)
+	}
+	for _, fact := range []string{
+		RunForkReplayResumeFactSessionHistory,
+		RunForkReplayResumeFactConversationAuditHistory,
+		RunForkReplayResumeFactActiveTurnHistory,
+	} {
+		if !runForkTestHasLineageDispositionOwner(materialized.ReplayResumeAdmission, fact, RunForkSelectedContractSessionTurnAuditLineagePolicyOwner) {
+			t.Fatalf("admission missing %s #661 lineage owner: %#v", fact, materialized.ReplayResumeAdmission)
+		}
+	}
+	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
+}
+
+func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliveryFailClosed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	unrelatedEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700002427, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, sourceEventID, at)
+	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, sourceEventID, sessionID, auditID, turnID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'unrelated.started', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
+		)
+	`, sourceRunID, unrelatedEventID, entityID, at.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed unrelated event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'validation-coordinator', 'in_progress', $3, $3)
+	`, sourceRunID, unrelatedEventID, at.Add(11*time.Second)); err != nil {
+		t.Fatalf("seed unrelated in-progress delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          forkPointEventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerSessionHistoryUnproven) {
+		t.Fatalf("materialization error = %v, want conversation history blocked by unrelated active delivery", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite unrelated active coupling: %#v", materialized)
+	}
+	if !runForkTestHasMaterializationBlocker(materialized, RunForkBlockerSessionHistoryUnproven) ||
+		!runForkTestHasMaterializationBlocker(materialized, RunForkBlockerActiveTurnHistoryUnproven) {
+		t.Fatalf("materialization blockers = %#v, want conversation blockers", materialized.UnsupportedBlockers)
+	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
+}
+
 func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsActiveSessionCoupling(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1022,6 +1178,81 @@ func TestPostTSourceConversationHistoryActivatesAsBranchDivergence(t *testing.T)
 	}
 }
 
+func TestSelectedContractExecutionActivationRecordsSameSourceDeliveryCouplingAsBranchDivergence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	auditID := uuid.NewString()
+	turnID := uuid.NewString()
+	at := time.Unix(1700003622, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, sourceEventID, at)
+	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, sourceEventID, sessionID, auditID, turnID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'validation-coordinator', 'in_progress', $3, $3)
+	`, sourceRunID, sourceEventID, at.Add(5*time.Second)); err != nil {
+		t.Fatalf("seed in-progress source delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          forkPointEventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, forkPointEventID, entityID, forkAt)
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{forkPointEventID},
+	})
+	if err != nil {
+		t.Fatalf("ActivateRunForkForSelectedContractExecution: %v", err)
+	}
+	if !activation.Activated || !activation.SourceAdvancedAfterFork || activation.BranchDivergence == nil {
+		t.Fatalf("activation = %#v, want active-coupling branch divergence", activation)
+	}
+	if !runForkTestHasLineageDispositionOwnerClassification(
+		activation.ReplayResumeAdmission,
+		RunForkReplayResumeFactDeliveryInProgressHistory,
+		RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner,
+		RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification,
+	) {
+		t.Fatalf("activation replay admission missing #678 owner: %#v", activation.ReplayResumeAdmission)
+	}
+	if !containsString(activation.BranchDivergence.SourceAdvancedFacts, RunForkSelectedContractActiveSourceDeliveryConversationCouplingClassification) {
+		t.Fatalf("branch divergence facts = %#v, want #678 classification", activation.BranchDivergence.SourceAdvancedFacts)
+	}
+	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
+}
+
 func TestPostTSourceConversationHistoryActivationKeepsActiveCouplingFailClosed(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -1201,6 +1432,20 @@ func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testin
 
 func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
 	t.Helper()
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, eventID, at)
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'node', 'test-node', 'pending', $3)
+	`, sourceRunID, eventID, at); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+}
+
+func seedSelectedContractExecutionStoreSourceWithoutDelivery(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -1215,14 +1460,6 @@ func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, so
 		VALUES ($1::uuid, $2::uuid, 'item.received', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, sourceRunID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed source event: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, created_at
-		)
-		VALUES ($1::uuid, $2::uuid, 'node', 'test-node', 'pending', $3)
-	`, sourceRunID, eventID, at); err != nil {
-		t.Fatalf("seed delivery: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_mutations (

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -367,6 +367,74 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
+func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliveryWithoutConversationHistoryFailClosed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	unrelatedEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	at := time.Unix(1700002428, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, sourceEventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'unrelated.started', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
+		)
+	`, sourceRunID, unrelatedEventID, entityID, at.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed unrelated event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'unrelated-agent', 'in_progress', $3, $3)
+	`, sourceRunID, unrelatedEventID, at.Add(11*time.Second)); err != nil {
+		t.Fatalf("seed unrelated in-progress delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          forkPointEventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerDeliveryHistoryUnproven) {
+		t.Fatalf("materialization error = %v, want unrelated active delivery blocker", err)
+	}
+	if materialized.ForkRunID != "" {
+		t.Fatalf("materialized fork despite unrelated active delivery: %#v", materialized)
+	}
+	if !runForkTestHasMaterializationBlocker(materialized, RunForkBlockerDeliveryHistoryUnproven) {
+		t.Fatalf("materialization blockers = %#v, want delivery history blocker", materialized.UnsupportedBlockers)
+	}
+	assertNoSelectedContractForkRows(t, db, sourceRunID)
+}
+
 func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsActiveSessionCoupling(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -426,6 +494,80 @@ func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsA
 		}
 	}
 	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
+}
+
+func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWithoutConversationHistoryFailClosed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	forkPointEventID := uuid.NewString()
+	unrelatedEventID := uuid.NewString()
+	at := time.Unix(1700002435, 0).UTC()
+	forkAt := at.Add(30 * time.Second)
+	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, sourceEventID, at)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			$4::uuid, $5
+		)
+	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          forkPointEventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'unrelated.started', $3::uuid,
+			'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
+		)
+	`, sourceRunID, unrelatedEventID, entityID, at.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed unrelated event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, started_at, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'unrelated-agent', 'in_progress', $3, $3)
+	`, sourceRunID, unrelatedEventID, at.Add(11*time.Second)); err != nil {
+		t.Fatalf("seed unrelated in-progress delivery: %v", err)
+	}
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID: materialized.ForkRunID,
+	})
+	if err == nil || !strings.Contains(err.Error(), RunForkBlockerDeliveryHistoryUnproven) {
+		t.Fatalf("activation error = %v, want unrelated active delivery blocker", err)
+	}
+	if activation.Activated || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want blocked before branch divergence", activation)
+	}
+	if !runForkTestHasActivationBlocker(activation, RunForkBlockerDeliveryHistoryUnproven) {
+		t.Fatalf("activation blockers = %#v, want delivery history blocker", activation.UnsupportedBlockers)
+	}
 }
 
 func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *testing.T) {

--- a/internal/store/run_fork_selected_contract_replay_scope_marker.go
+++ b/internal/store/run_fork_selected_contract_replay_scope_marker.go
@@ -11,9 +11,9 @@ const RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner = "runtime.ru
 // replay/resume policies that are allowed to reinterpret source-run facts before
 // any selected-contract fork mutation.
 func RunForkSelectedContractReplayResumeAdmission(plan RunForkPlan) RunForkReplayResumeAdmission {
-	return RunForkSelectedContractCommittedReplayScopeMarkerAdmission(
-		RunForkSelectedContractSessionTurnAuditLineageAdmission(plan),
-	)
+	admission := RunForkSelectedContractActiveSourceDeliveryConversationCouplingAdmission(plan, plan.ReplayResumeAdmission)
+	admission = runForkSelectedContractSessionTurnAuditLineageAdmission(plan, admission)
+	return RunForkSelectedContractCommittedReplayScopeMarkerAdmission(admission)
 }
 
 // RunForkSelectedContractCommittedReplayScopeMarkerAdmission treats at/before-T


### PR DESCRIPTION
## Summary

Closes #678.

This PR adds the selected-contract first-slice owner for the exact same-source active delivery case approved by the gate:

`runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy`

The policy admits only the source in-progress agent delivery that emitted the selected fork-point event as lineage/no-action and branch-divergence evidence. It preserves fail-closed behavior for unrelated active deliveries, `active_session_id`/receipt/outcome coupling, fork-local pre-existing conversation rows, post-T conversation facts outside #671, source row copy/reuse, and source outcome suppressors.

## Governing Refs

Exact authoritative spec refs updated in this PR:

- `run_model.fork.selected_contract_active_source_delivery_conversation_coupling_policy`
- `run_model.fork.operations.3h4_selected_contract_active_source_delivery_conversation_coupling_policy`
- Adjacent binding refs: `3h_selected_contract_supported_execution`, `3h1_selected_contract_session_turn_audit_lineage_policy`, `3j_historical_replay_execution_admission`, and materialize/activation admission sections.

Tracker/watchlist refs:

- Parent trackers: #564 and #549.
- Gate record: #678, approved as first slice.
- Watchlist node updated: `timestamp_fork_replay_resume_ownership` in `docs/watchlists/runtime-operations.yaml`.

## Semantic Migration

New canonical owner:

`runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy`

Old non-authoritative path now invalid:

- Local suppression of `session_history_unproven`, `conversation_audit_history_unproven`, or `active_turn_history_unproven` without typed delivery/fork-point identity proof.
- Treating #661 active delivery coupling as a blanket permanent blocker for the exact same-source fork-point emission case.

Production paths checked for surviving old behavior:

- replay/resume admission disposition identity
- selected-contract replay admission sequencing
- materialization blocker derivation
- activation/branch-divergence recording
- runtime historical replay admission
- supported `swarm fork --contracts ... --json` Empire proof path

Migration completeness:

- Complete for the approved #678 first-slice class.
- Parent #564/#549 remain open for unrelated active deliveries, full session/turn/audit reconstruction, broader replay/resume, routes, timers, non-agent replay, restart recovery, and operator/API surfaces.

## Verification

- `go test ./internal/store -run 'RunForkPlanner|SelectedContractExecution' -count=1`
- `go test ./internal/runtime/runforkexecution -count=1`
- `go run ./cmd/swarm verify --contracts /Users/youmew/dev/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Supported Empire proof rerun on `swarm_empire_issue678_readyfork_1778452689` for source run `3724c2d6-d8fb-49bc-aada-56f6f85b9b92` at fork event `07e8042a-6449-4979-9c45-0501f19f6799`.

Empire proof result: the #678 blockers are removed; execution now stops on a separate current-state materialization metadata blocker:

`fork failed: fork-point flow_instance metadata for entity 3724c2d6-d8fb-49bc-aada-56f6f85b9b92 is required for fork materialization`

Non-corruption proof: no fork run and no selected-contract mutation rows were written in the proof DB.
