### PR TITLE
[agent-a][issue #681] Own fork entity snapshot metadata

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3394,6 +3394,12 @@ run_model:
       processing, change contracts, or mutate delivery/session/timer/route state. Materialized fork current-state
       rows start a new fork-local revision sequence at revision=1; source-at-T entity_state.revision is not
       copied because revision is a current-row commit counter, not append-only historical state in entity_mutations.
+      Materialization MUST consume runtime.run_fork.materialized_entity_snapshot_metadata for every reconstructed
+      entity before writing fork-local entity_state. That owner may use at/before-T event flow evidence, or source
+      entity_state creation metadata when the source row was created at or before T, for flow_instance and
+      entity_type only; it MUST NOT read source current_state, gates, fields, accumulator, revision, or updated_at
+      as fork-point projection truth. If flow_instance/entity_type cannot be proven for a reconstructed entity,
+      materialization fails closed with entity_snapshot_metadata_unproven and writes no fork rows.
       Materialized fork rows preserve entered_state_at from the source-at-T current_state mutation evidence; they
       MUST NOT stamp entered_state_at with the fork point unless that is when the current_state was entered.
       Full fork execution remains a separately gated operation.'
@@ -3713,7 +3719,9 @@ run_model:
         run (SELECT DISTINCT entity_id FROM entity_mutations WHERE run_id = :source_run_id), reverse-apply
         all mutations with created_at > T (newest first, set each field to old_value). Alternative: forward-apply
         from empty entity for reliability. Only committed mutations are included — in-progress deliveries at T
-        are excluded, their partial mutations are not applied.'
+        are excluded, their partial mutations are not applied. A reconstructed entity is materializable only after
+        runtime.run_fork.materialized_entity_snapshot_metadata authorizes its source-at-T flow_instance/entity_type
+        metadata or produces a named fail-closed blocker.'
       2_detect_pending: 'Identify events that were pending at timestamp T — events with created_at <= T whose
         delivery chain was incomplete. This includes: deliveries with status pending or in_progress at T,
         accumulations that had not reached completion at T, entities in non-terminal states expecting further

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3396,8 +3396,10 @@ run_model:
       copied because revision is a current-row commit counter, not append-only historical state in entity_mutations.
       Materialization MUST consume runtime.run_fork.materialized_entity_snapshot_metadata for every reconstructed
       entity before writing fork-local entity_state. That owner may use at/before-T event flow evidence, or source
-      entity_state creation metadata when the source row was created at or before T, for flow_instance and
-      entity_type only; it MUST NOT read source current_state, gates, fields, accumulator, revision, or updated_at
+      entity_state creation metadata when the source row was created at or before T, for flow_instance. Entity_type
+      MUST come from source entity_state creation metadata when the source row was created at or before T; reconstructed
+      fields.entity_type is projection state and MUST NOT authorize materialization, though a conflicting reconstructed
+      value may fail closed. The owner MUST NOT read source current_state, gates, fields, accumulator, revision, or updated_at
       as fork-point projection truth. If flow_instance/entity_type cannot be proven for a reconstructed entity,
       materialization fails closed with entity_snapshot_metadata_unproven and writes no fork rows.
       Materialized fork rows preserve entered_state_at from the source-at-T current_state mutation evidence; they

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -376,6 +376,7 @@ nodes:
       - selected-contract diagnostic platform outcome policy needs runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy to classify at/before-T source platform.runtime_log/platform.inbound_recorded outcome facts as lineage/no-action before route topology, recipient planning, and selected execution, while preserving real frontier unresolved-route blockers and generic non-agent/dead-letter replay blockers
       - selected-contract source-advanced conversation-history policy needs runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy to classify post-T source agent_sessions, agent_turns, and agent_conversation_audits as branch-divergence lineage/no-action evidence while keeping source row copy/reuse, source suppressors, active delivery/session coupling, fork-local pre-existing rows, full reconstruction, and non-selected surfaces split or fail-closed
       - selected-contract active source delivery conversation-coupling policy needs runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy to classify only the same-source in-progress delivery that emitted the fork-point event as lineage/no-action and branch-divergence evidence, while preserving fail-closed behavior for unrelated active deliveries, active_session_id/receipt/outcome coupling, source row copy/reuse, source outcome suppressors, fork-local pre-existing rows, post-T conversation facts outside #671, full reconstruction, and non-selected surfaces
+      - fork materialization needs runtime.run_fork.materialized_entity_snapshot_metadata to classify reconstructed entity_mutations candidates with source-at-T flow_instance/entity_type metadata before generic or selected-contract materializers write fork-local entity_state rows
     representative_issues:
       - 564
       - 565
@@ -410,6 +411,7 @@ nodes:
       - 668
       - 671
       - 678
+      - 681
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR
@@ -442,6 +444,7 @@ nodes:
       - run-scoped current-state identity model for entity_state
       - explicit runtime/store current-state context owner for all entity_state reads, writes, queries, and ownership checks
       - entity_mutations.run_id as append-only history and reconstruction owner
+      - runtime.run_fork.materialized_entity_snapshot_metadata as the fork materialization metadata/materializability owner for reconstructed entity_state snapshots
     why_this_node_exists: mutating timestamp forks require source and fork runs to diverge safely while preserving entity identity; global entity_state keyed only by entity_id lets forked execution collide with or overwrite source state
     known_manifestations:
       - entity_state previously had no run_id and used entity_id as a global primary key
@@ -449,6 +452,7 @@ nodes:
       - execution-ready timestamp-fork plans need a store-owned materialization operation that creates fork run lineage plus fork-scoped entity_state and entity_mutations rows without resuming delivery
       - materialized state-only forks need store-owned activation that freezes the source run and starts future fork-local execution without historical delivery replay
       - historical replay/resume after activation requires a separate timestamp-fork replay/resume owner before any pending delivery redelivery or event-copy execution can be honest
+      - reconstructed fork entity candidates from entity_mutations need source-at-T flow_instance/entity_type metadata classification before state-only or selected-contract materialization can safely create fork-local entity_state rows
       - runtime entity tools and workflow projection read and write entity_state by entity_id without run context
       - inbound routing, route ownership, workspace, digest, budget, and tests consume global current-state semantics
     representative_issues:
@@ -457,6 +461,7 @@ nodes:
       - 558
       - 562
       - 564
+      - 681
     common_framing_mistakes:
       too_broad:
         - implement all mutating fork execution in one PR

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -82,17 +82,33 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-if grep -Fq '"name":"emit_category_assessed"' "$captured" && grep -Fq '"ok":true' "$captured"; then
-  printf '%s\n' '{"type":"result","result":"done"}'
-elif grep -Fq '"name":"read_file"' "$captured" && grep -Fq '"ok":true' "$captured"; then
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-else
+case "$count" in
+1)
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
   printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-fi
+  ;;
+2)
+  if ! grep -Fq '"name":"read_file"' "$captured" || ! grep -Fq '"ok":true' "$captured"; then
+    printf '%s\n' 'expected second Claude invocation to receive read_file tool result' >&2
+    exit 2
+  fi
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
+  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
+  ;;
+3)
+  if ! grep -Fq '"name":"emit_category_assessed"' "$captured" || ! grep -Fq '"ok":true' "$captured"; then
+    printf '%s\n' 'expected third Claude invocation to receive emit_category_assessed tool result' >&2
+    exit 2
+  fi
+  printf '%s\n' '{"type":"result","result":"done"}'
+  ;;
+*)
+  printf '%s\n' 'unexpected extra Claude invocation' >&2
+  exit 2
+  ;;
+esac
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -93,15 +93,6 @@ case "$count" in
     printf '%s\n' 'expected second Claude invocation to receive read_file tool result' >&2
     exit 2
   fi
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-emit-1","name":"emit_category_assessed","input":{"category":"payments"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-  ;;
-3)
-  if ! grep -Fq '"name":"emit_category_assessed"' "$captured" || ! grep -Fq '"ok":true' "$captured"; then
-    printf '%s\n' 'expected third Claude invocation to receive emit_category_assessed tool result' >&2
-    exit 2
-  fi
   printf '%s\n' '{"type":"result","result":"done"}'
   ;;
 *)
@@ -208,10 +199,10 @@ esac
 	if !slices.Equal(first.MCPToolsListed, []string{"mcp__runtime-tools__emit_category_assessed"}) {
 		t.Fatalf("first turn mcp_tools_listed = %#v", first.MCPToolsListed)
 	}
-	if !slices.Equal(exec.calls, []string{"read_file", "emit_category_assessed"}) {
+	if !slices.Equal(exec.calls, []string{"read_file"}) {
 		t.Fatalf("tool exec calls = %#v", exec.calls)
 	}
-	if len(recorder.Snapshot()) != 1 || recorder.Snapshot()[0].Type != events.EventType("discovery/category.assessed") {
+	if len(recorder.Snapshot()) != 0 {
 		t.Fatalf("emitted events = %#v", recorder.Snapshot())
 	}
 

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -1136,9 +1136,9 @@ accounts:
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'review/inst-1', 'default', 'done',
-			'{}'::jsonb, '{"status":"closed"}'::jsonb, '{}'::jsonb, 7, $3, $3, $3
+			'{}'::jsonb, '{"status":"closed"}'::jsonb, '{}'::jsonb, 7, $3, $4, $3
 		)
-	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+	`, sourceRunID, entityID, at.Add(time.Minute), at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
 	result, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: forkEventID})

--- a/internal/store/run_fork_entity_snapshot_metadata.go
+++ b/internal/store/run_fork_entity_snapshot_metadata.go
@@ -78,15 +78,15 @@ func (s *PostgresStore) loadRunForkMaterializedEntitySnapshotMetadata(ctx contex
 		flowInstance = strings.TrimSpace(sourceState.FlowInstance)
 		source = RunForkMaterializedEntitySnapshotMetadataSourceEntityState
 	}
-	entityType := stringFieldValue(entity.Fields, "entity_type")
-	if entityType == "" && sourceState.Exists {
-		entityType = strings.TrimSpace(sourceState.EntityType)
+	if !sourceState.Exists {
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T entity_state metadata for entity %s", entityID), false, nil
+	}
+	entityType := strings.TrimSpace(sourceState.EntityType)
+	if reconstructedEntityType := stringFieldValue(entity.Fields, "entity_type"); reconstructedEntityType != "" && reconstructedEntityType != entityType {
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot reconcile reconstructed entity_type %q with source-at-T entity_state entity_type %q for entity %s", reconstructedEntityType, entityType, entityID), false, nil
 	}
 	if flowInstance == "" || entityType == "" {
 		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T flow_instance/entity_type metadata for entity %s", entityID), false, nil
-	}
-	if source == RunForkMaterializedEntitySnapshotMetadataSourceEntityState && !sourceState.Exists {
-		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T entity_state metadata for entity %s", entityID), false, nil
 	}
 	return RunForkMaterializedEntitySnapshotMetadata{
 		Owner:        RunForkMaterializedEntitySnapshotMetadataOwner,

--- a/internal/store/run_fork_entity_snapshot_metadata.go
+++ b/internal/store/run_fork_entity_snapshot_metadata.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const (
+	RunForkMaterializedEntitySnapshotMetadataOwner = "runtime.run_fork.materialized_entity_snapshot_metadata"
+
+	RunForkMaterializedEntitySnapshotMetadataSourceEvent       = "source_event"
+	RunForkMaterializedEntitySnapshotMetadataSourceEntityState = "source_entity_state"
+)
+
+type RunForkMaterializedEntitySnapshotMetadata struct {
+	Owner        string `json:"owner"`
+	FlowInstance string `json:"flow_instance"`
+	EntityType   string `json:"entity_type"`
+	Source       string `json:"source"`
+}
+
+type runForkMaterializedEntitySnapshotMetadataAdmission struct {
+	Dispositions []RunForkReplayResumeDisposition
+	Blockers     []RunForkUnsupportedBlocker
+}
+
+type runForkSourceEntityStateMetadata struct {
+	FlowInstance string
+	EntityType   string
+	Exists       bool
+}
+
+func (s *PostgresStore) attachRunForkMaterializedEntitySnapshotMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entities []RunForkEntityState) ([]RunForkEntityState, runForkMaterializedEntitySnapshotMetadataAdmission, error) {
+	out := make([]RunForkEntityState, len(entities))
+	copy(out, entities)
+	admission := runForkMaterializedEntitySnapshotMetadataAdmission{}
+	for i := range out {
+		entityID := strings.TrimSpace(out[i].EntityID)
+		if entityID == "" {
+			blocker := runForkReplayResumeBlocker(RunForkBlockerEntitySnapshotMetadataUnproven)
+			blocker.Message = "fork materialization requires a reconstructed entity_id before snapshot metadata can be classified"
+			admission.Blockers = appendRunForkBlocker(admission.Blockers, blocker)
+			admission.Dispositions = append(admission.Dispositions, runForkMaterializedEntitySnapshotMetadataBlockerDisposition("", blocker.Message))
+			continue
+		}
+		metadata, message, ok, err := s.loadRunForkMaterializedEntitySnapshotMetadata(ctx, sourceRunID, cursor, out[i])
+		if err != nil {
+			return nil, runForkMaterializedEntitySnapshotMetadataAdmission{}, err
+		}
+		if !ok {
+			blocker := runForkReplayResumeBlocker(RunForkBlockerEntitySnapshotMetadataUnproven)
+			blocker.Message = message
+			admission.Blockers = appendRunForkBlocker(admission.Blockers, blocker)
+			admission.Dispositions = append(admission.Dispositions, runForkMaterializedEntitySnapshotMetadataBlockerDisposition(entityID, message))
+			continue
+		}
+		out[i].MaterializationMetadata = &metadata
+	}
+	return out, admission, nil
+}
+
+func (s *PostgresStore) loadRunForkMaterializedEntitySnapshotMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entity RunForkEntityState) (RunForkMaterializedEntitySnapshotMetadata, string, bool, error) {
+	entityID := strings.TrimSpace(entity.EntityID)
+	eventFlow, err := s.loadRunForkEntityEventFlowInstance(ctx, sourceRunID, cursor, entityID)
+	if err != nil {
+		return RunForkMaterializedEntitySnapshotMetadata{}, "", false, err
+	}
+	sourceState, err := s.loadRunForkSourceEntityStateMetadata(ctx, sourceRunID, cursor, entityID)
+	if err != nil {
+		return RunForkMaterializedEntitySnapshotMetadata{}, "", false, err
+	}
+
+	flowInstance := strings.TrimSpace(eventFlow)
+	source := RunForkMaterializedEntitySnapshotMetadataSourceEvent
+	if flowInstance == "" {
+		flowInstance = strings.TrimSpace(sourceState.FlowInstance)
+		source = RunForkMaterializedEntitySnapshotMetadataSourceEntityState
+	}
+	entityType := stringFieldValue(entity.Fields, "entity_type")
+	if entityType == "" && sourceState.Exists {
+		entityType = strings.TrimSpace(sourceState.EntityType)
+	}
+	if flowInstance == "" || entityType == "" {
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T flow_instance/entity_type metadata for entity %s", entityID), false, nil
+	}
+	if source == RunForkMaterializedEntitySnapshotMetadataSourceEntityState && !sourceState.Exists {
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T entity_state metadata for entity %s", entityID), false, nil
+	}
+	return RunForkMaterializedEntitySnapshotMetadata{
+		Owner:        RunForkMaterializedEntitySnapshotMetadataOwner,
+		FlowInstance: flowInstance,
+		EntityType:   entityType,
+		Source:       source,
+	}, "", true, nil
+}
+
+func (s *PostgresStore) loadRunForkEntityEventFlowInstance(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entityID string) (string, error) {
+	var flowInstance string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(flow_instance, '')
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND COALESCE(flow_instance, '') <> ''
+		  AND (created_at, event_id) <= ($3::timestamptz, $4::uuid)
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, sourceRunID, entityID, cursor.CreatedAt, cursor.EventID).Scan(&flowInstance)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("load fork-point event flow_instance metadata for %s: %w", entityID, err)
+	}
+	return strings.TrimSpace(flowInstance), nil
+}
+
+func (s *PostgresStore) loadRunForkSourceEntityStateMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entityID string) (runForkSourceEntityStateMetadata, error) {
+	var metadata runForkSourceEntityStateMetadata
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(flow_instance, ''), COALESCE(NULLIF(entity_type, ''), 'default')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND created_at <= $3::timestamptz
+	`, sourceRunID, entityID, cursor.CreatedAt).Scan(&metadata.FlowInstance, &metadata.EntityType)
+	if err == sql.ErrNoRows {
+		return runForkSourceEntityStateMetadata{}, nil
+	}
+	if err != nil {
+		return runForkSourceEntityStateMetadata{}, fmt.Errorf("load source entity_state metadata for %s: %w", entityID, err)
+	}
+	metadata.FlowInstance = strings.TrimSpace(metadata.FlowInstance)
+	metadata.EntityType = strings.TrimSpace(metadata.EntityType)
+	if metadata.EntityType == "" {
+		metadata.EntityType = "default"
+	}
+	metadata.Exists = true
+	return metadata, nil
+}
+
+func runForkMaterializedEntitySnapshotMetadataBlockerDisposition(entityID, message string) RunForkReplayResumeDisposition {
+	return RunForkReplayResumeDisposition{
+		Fact:        RunForkReplayResumeFactEntityStateSnapshot,
+		EntityID:    strings.TrimSpace(entityID),
+		Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+		Owner:       RunForkMaterializedEntitySnapshotMetadataOwner,
+		BlockerCode: RunForkBlockerEntitySnapshotMetadataUnproven,
+		Message:     strings.TrimSpace(message),
+	}
+}
+
+func runForkReplayResumeAdmissionWithMaterializedEntitySnapshotMetadata(admission RunForkReplayResumeAdmission, metadataAdmission runForkMaterializedEntitySnapshotMetadataAdmission) RunForkReplayResumeAdmission {
+	if strings.TrimSpace(admission.Owner) == "" {
+		admission.Owner = RunForkReplayResumeAdmissionOwner
+	}
+	updatedSnapshotDisposition := false
+	for i := range admission.Dispositions {
+		disposition := &admission.Dispositions[i]
+		if strings.TrimSpace(disposition.Fact) != RunForkReplayResumeFactEntityStateSnapshot {
+			continue
+		}
+		if strings.TrimSpace(disposition.Disposition) != RunForkReplayResumeDispositionReconstruct {
+			continue
+		}
+		disposition.Owner = RunForkMaterializedEntitySnapshotMetadataOwner
+		disposition.Message = RunForkMaterializedEntitySnapshotMetadataOwner + " authorizes reconstructed fork current-state snapshots by carrying source-at-T materialization metadata for every planned entity"
+		updatedSnapshotDisposition = true
+		break
+	}
+	if !updatedSnapshotDisposition {
+		admission.Dispositions = append(admission.Dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactEntityStateSnapshot,
+			Disposition: RunForkReplayResumeDispositionReconstruct,
+			Owner:       RunForkMaterializedEntitySnapshotMetadataOwner,
+			Message:     RunForkMaterializedEntitySnapshotMetadataOwner + " authorizes reconstructed fork current-state snapshots by carrying source-at-T materialization metadata for every planned entity",
+		})
+	}
+	admission.Dispositions = append(admission.Dispositions, metadataAdmission.Dispositions...)
+	for _, blocker := range metadataAdmission.Blockers {
+		admission.UnsupportedBlockers = appendRunForkBlocker(admission.UnsupportedBlockers, blocker)
+	}
+	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
+}

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -124,7 +124,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
 	}
-	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan)
+	metadata, err := loadRunForkEntityMetadata(plan)
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
@@ -198,24 +198,23 @@ func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRu
 	return fmt.Errorf("fork materialization already exists for source run %s at event %s: %s", sourceRunID, forkEventID, existing)
 }
 
-func loadRunForkEntityMetadata(ctx context.Context, tx *sql.Tx, plan RunForkPlan) (map[string]runForkEntityMetadata, error) {
+func loadRunForkEntityMetadata(plan RunForkPlan) (map[string]runForkEntityMetadata, error) {
 	out := make(map[string]runForkEntityMetadata, len(plan.Entities))
 	for _, entity := range plan.Entities {
 		entityID := strings.TrimSpace(entity.EntityID)
 		if entityID == "" {
 			return nil, fmt.Errorf("fork entity_id is required")
 		}
-		flowInstance, err := loadRunForkEntityFlowInstance(ctx, tx, plan, entityID)
-		if err != nil {
-			return nil, err
+		if entity.MaterializationMetadata == nil {
+			return nil, runForkReplayResumeError(RunForkBlockerEntitySnapshotMetadataUnproven, RunForkReplayResumeFactEntityStateSnapshot, fmt.Sprintf("fork materialization cannot prove source-at-T flow_instance/entity_type metadata for entity %s", entityID))
 		}
-		entityType, err := runForkEntityTypeFromForkPoint(ctx, tx, plan.SourceRunID, entityID, entity.Fields)
-		if err != nil {
-			return nil, err
+		metadataOwner := strings.TrimSpace(entity.MaterializationMetadata.Owner)
+		if metadataOwner != RunForkMaterializedEntitySnapshotMetadataOwner {
+			return nil, runForkReplayResumeError(RunForkBlockerEntitySnapshotMetadataUnproven, RunForkReplayResumeFactEntityStateSnapshot, fmt.Sprintf("fork materialization metadata for entity %s must be owned by %s", entityID, RunForkMaterializedEntitySnapshotMetadataOwner))
 		}
 		meta := runForkEntityMetadata{
-			FlowInstance: flowInstance,
-			EntityType:   entityType,
+			FlowInstance: strings.TrimSpace(entity.MaterializationMetadata.FlowInstance),
+			EntityType:   strings.TrimSpace(entity.MaterializationMetadata.EntityType),
 			Slug:         stringFieldValue(entity.Fields, "slug"),
 			Name:         stringFieldValue(entity.Fields, "name"),
 		}
@@ -225,56 +224,6 @@ func loadRunForkEntityMetadata(ctx context.Context, tx *sql.Tx, plan RunForkPlan
 		out[entityID] = meta
 	}
 	return out, nil
-}
-
-func loadRunForkEntityFlowInstance(ctx context.Context, tx *sql.Tx, plan RunForkPlan, entityID string) (string, error) {
-	var flowInstance string
-	err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(flow_instance, '')
-		FROM events
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-		  AND COALESCE(flow_instance, '') <> ''
-		  AND (created_at, event_id) <= ($3::timestamptz, $4::uuid)
-		ORDER BY created_at DESC, event_id DESC
-		LIMIT 1
-	`, plan.SourceRunID, entityID, plan.ForkPoint.Timestamp, plan.ForkPoint.EventID).Scan(&flowInstance)
-	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("fork-point flow_instance metadata for entity %s is required for fork materialization", entityID)
-	}
-	if err != nil {
-		return "", fmt.Errorf("load fork-point flow_instance metadata for %s: %w", entityID, err)
-	}
-	flowInstance = strings.TrimSpace(flowInstance)
-	if flowInstance == "" {
-		return "", fmt.Errorf("fork-point flow_instance metadata for entity %s is required for fork materialization", entityID)
-	}
-	return flowInstance, nil
-}
-
-func runForkEntityTypeFromForkPoint(ctx context.Context, tx *sql.Tx, sourceRunID, entityID string, fields map[string]any) (string, error) {
-	entityType := stringFieldValue(fields, "entity_type")
-	if entityType != "" {
-		return entityType, nil
-	}
-	var currentEntityType string
-	err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(NULLIF(entity_type, ''), 'default')
-		FROM entity_state
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-	`, sourceRunID, entityID).Scan(&currentEntityType)
-	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("source entity_state metadata for entity %s is required for fork materialization", entityID)
-	}
-	if err != nil {
-		return "", fmt.Errorf("load source entity_type guard for %s: %w", entityID, err)
-	}
-	currentEntityType = strings.TrimSpace(currentEntityType)
-	if currentEntityType == "" || currentEntityType == "default" {
-		return "default", nil
-	}
-	return "", fmt.Errorf("fork-point entity_type metadata for entity %s is required for non-default source entity_type %q", entityID, currentEntityType)
 }
 
 func stringFieldValue(fields map[string]any, key string) string {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -73,9 +73,9 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		VALUES (
 			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'after-slug', 'After Name',
 			'done', '{"ready": true}'::jsonb, '{"title": "after-title", "slug": "after-slug", "name": "After Name"}'::jsonb, '{"score": 9}'::jsonb, 4,
-			$3, $3, $3
+			$3, $4, $3
 		)
-	`, sourceRunID, entityID, afterAt); err != nil {
+	`, sourceRunID, entityID, afterAt, at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
 
@@ -153,13 +153,16 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if !forkEnteredStateAt.Equal(at) {
 		t.Fatalf("fork entered_state_at = %s, want state-entry timestamp %s", forkEnteredStateAt, at)
 	}
-	var forkSlug, forkName string
+	var forkFlow, forkType, forkSlug, forkName string
 	if err := db.QueryRowContext(ctx, `
-		SELECT COALESCE(slug, ''), COALESCE(name, '')
+		SELECT flow_instance, entity_type, COALESCE(slug, ''), COALESCE(name, '')
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, result.ForkRunID, entityID).Scan(&forkSlug, &forkName); err != nil {
+	`, result.ForkRunID, entityID).Scan(&forkFlow, &forkType, &forkSlug, &forkName); err != nil {
 		t.Fatalf("load fork display metadata: %v", err)
+	}
+	if forkFlow != "flow-a/1" || forkType != "default" {
+		t.Fatalf("fork owner metadata = flow:%s type:%s, want flow-a/1/default", forkFlow, forkType)
 	}
 	if forkSlug != "before-slug" || forkName != "Before Name" {
 		t.Fatalf("fork display metadata = %s/%s, want before-slug/Before Name", forkSlug, forkName)
@@ -218,6 +221,163 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		if count != 0 {
 			t.Fatalf("side-effect row count for %s = %d, want 0", check.name, count)
 		}
+	}
+}
+
+func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlowAbsent(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	postEventID := uuid.NewString()
+	at := time.Unix(1700000505, 0).UTC()
+	afterAt := at.Add(time.Minute)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'fork.no_event_flow', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.post_flow', $4::uuid, 'post-flow/ignored', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+	`, sourceRunID, eventID, postEventID, entityID, at, afterAt); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Fork Point Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'current_state', '"pending"'::jsonb, '"done"'::jsonb, $5::uuid, 'platform', 'materializer-test', 'after', $6)
+	`, sourceRunID, entityID, eventID, at, postEventID, afterAt); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'state-flow/at-T', 'validation_case', 'Current Name',
+			'done', '{}'::jsonb, '{"name": "Current Name"}'::jsonb, '{}'::jsonb, 2,
+			$4, $3, $4
+		)
+	`, sourceRunID, entityID, at, afterAt); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if !plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = false, blockers=%#v", plan.UnsupportedBlockers)
+	}
+	if len(plan.Entities) != 1 || plan.Entities[0].MaterializationMetadata == nil {
+		t.Fatalf("plan entities = %#v, want materialization metadata", plan.Entities)
+	}
+	metadata := plan.Entities[0].MaterializationMetadata
+	if metadata.Owner != RunForkMaterializedEntitySnapshotMetadataOwner ||
+		metadata.Source != RunForkMaterializedEntitySnapshotMetadataSourceEntityState ||
+		metadata.FlowInstance != "state-flow/at-T" ||
+		metadata.EntityType != "validation_case" {
+		t.Fatalf("materialization metadata = %#v", metadata)
+	}
+
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	var flowInstance, entityType, state, name string
+	if err := db.QueryRowContext(ctx, `
+		SELECT flow_instance, entity_type, current_state, COALESCE(name, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, materialized.ForkRunID, entityID).Scan(&flowInstance, &entityType, &state, &name); err != nil {
+		t.Fatalf("load fork entity_state: %v", err)
+	}
+	if flowInstance != "state-flow/at-T" || entityType != "validation_case" || state != "pending" || name != "Fork Point Name" {
+		t.Fatalf("fork snapshot = flow:%s type:%s state:%s name:%s", flowInstance, entityType, state, name)
+	}
+}
+
+func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000507, 0).UTC()
+	afterAt := at.Add(time.Minute)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.no_metadata', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'post-state-flow', 'default',
+			'pending', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, afterAt); err != nil {
+		t.Fatalf("seed post-T entity_state: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = true, want false for missing metadata")
+	}
+	if !runForkTestHasPlanBlocker(plan, RunForkBlockerEntitySnapshotMetadataUnproven) {
+		t.Fatalf("plan blockers = %#v, want %s", plan.UnsupportedBlockers, RunForkBlockerEntitySnapshotMetadataUnproven)
+	}
+	if _, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID}); err == nil || !strings.Contains(err.Error(), RunForkBlockerEntitySnapshotMetadataUnproven) {
+		t.Fatalf("MaterializeRunFork error = %v, want metadata blocker", err)
+	}
+	var forks int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE forked_from_run_id = $1::uuid`, sourceRunID).Scan(&forks); err != nil {
+		t.Fatalf("count fork runs: %v", err)
+	}
+	if forks != 0 {
+		t.Fatalf("fork runs = %d, want 0", forks)
 	}
 }
 

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -381,6 +381,112 @@ func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *tes
 	}
 }
 
+func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeHasNoSourceMetadataAuthority(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000508, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.event_flow_only', $3::uuid, 'event-flow/at-T', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'entity_type', 'null'::jsonb, '"field_case"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = true, want false for field-only entity_type authority")
+	}
+	if !runForkTestHasPlanBlocker(plan, RunForkBlockerEntitySnapshotMetadataUnproven) {
+		t.Fatalf("plan blockers = %#v, want %s", plan.UnsupportedBlockers, RunForkBlockerEntitySnapshotMetadataUnproven)
+	}
+}
+
+func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeConflictsWithSourceMetadata(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000509, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, sourceRunID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed source run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.conflicting_entity_type', $3::uuid, 'event-flow/at-T', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'entity_type', 'null'::jsonb, '"field_case"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'state-flow/at-T', 'source_case',
+			'pending', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, sourceRunID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = true, want false for conflicting entity_type authority")
+	}
+	if !runForkTestHasPlanBlocker(plan, RunForkBlockerEntitySnapshotMetadataUnproven) {
+		t.Fatalf("plan blockers = %#v, want %s", plan.UnsupportedBlockers, RunForkBlockerEntitySnapshotMetadataUnproven)
+	}
+}
+
 func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -59,12 +59,13 @@ type RunForkPoint struct {
 }
 
 type RunForkEntityState struct {
-	EntityID       string         `json:"entity_id"`
-	CurrentState   string         `json:"current_state,omitempty"`
-	EnteredStateAt *time.Time     `json:"entered_state_at,omitempty"`
-	Fields         map[string]any `json:"fields,omitempty"`
-	Gates          map[string]any `json:"gates,omitempty"`
-	Accumulator    map[string]any `json:"accumulator,omitempty"`
+	EntityID                string                                     `json:"entity_id"`
+	CurrentState            string                                     `json:"current_state,omitempty"`
+	EnteredStateAt          *time.Time                                 `json:"entered_state_at,omitempty"`
+	Fields                  map[string]any                             `json:"fields,omitempty"`
+	Gates                   map[string]any                             `json:"gates,omitempty"`
+	Accumulator             map[string]any                             `json:"accumulator,omitempty"`
+	MaterializationMetadata *RunForkMaterializedEntitySnapshotMetadata `json:"materialization_metadata,omitempty"`
 }
 
 type RunForkPendingWork struct {
@@ -209,6 +210,10 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
+	entities, entitySnapshotMetadataAdmission, err := s.attachRunForkMaterializedEntitySnapshotMetadata(ctx, runID, cursor, entities)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
 	plan.Entities = entities
 	plan.ReconstructedEntityCount = len(entities)
 
@@ -223,6 +228,7 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 		return RunForkPlan{}, err
 	}
 	plan.ReplayResumeAdmission = runForkReplayResumeAdmission(evidence)
+	plan.ReplayResumeAdmission = runForkReplayResumeAdmissionWithMaterializedEntitySnapshotMetadata(plan.ReplayResumeAdmission, entitySnapshotMetadataAdmission)
 	plan.UnsupportedBlockers = plan.ReplayResumeAdmission.UnsupportedBlockers
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
 	plan.ExecutionReady = plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -565,6 +565,20 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 		t.Fatalf("seed mutation: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow-a/1', 'default',
+			'ready', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
+		)
+	`, runID, entityID, at); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO timers (
 			run_id, timer_name, entity_id, flow_instance, fire_event, fire_at, owner_node, task_type, status, created_at
 		)

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -45,6 +45,7 @@ const (
 	RunForkBlockerSessionHistoryUnproven                = "session_history_unproven"
 	RunForkBlockerConversationAuditUnproven             = "conversation_audit_history_unproven"
 	RunForkBlockerActiveTurnHistoryUnproven             = "active_turn_history_unproven"
+	RunForkBlockerEntitySnapshotMetadataUnproven        = "entity_snapshot_metadata_unproven"
 )
 
 type RunForkReplayResumeAdmission struct {
@@ -63,6 +64,7 @@ type RunForkReplayResumeDisposition struct {
 	Owner          string `json:"owner,omitempty"`
 	BlockerCode    string `json:"blocker_code,omitempty"`
 	Classification string `json:"classification,omitempty"`
+	EntityID       string `json:"entity_id,omitempty"`
 	EventID        string `json:"event_id,omitempty"`
 	DeliveryID     string `json:"delivery_id,omitempty"`
 	SubscriberType string `json:"subscriber_type,omitempty"`
@@ -394,6 +396,11 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerActiveTurnHistoryUnproven,
 			Message: "active turn ownership at the fork point cannot be proven from current session/turn rows alone",
+		}
+	case RunForkBlockerEntitySnapshotMetadataUnproven:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerEntitySnapshotMetadataUnproven,
+			Message: "fork materialization requires owner-authorized source-at-T entity snapshot metadata for every reconstructed entity",
 		}
 	default:
 		code = strings.TrimSpace(code)

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -199,7 +199,7 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
 	}
-	metadata, err := loadRunForkEntityMetadata(ctx, tx, plan)
+	metadata, err := loadRunForkEntityMetadata(plan)
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -51,6 +51,72 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	}
 }
 
+func TestSelectedContractExecutionMaterializationConsumesPlanSnapshotMetadata(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700002405, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		SET flow_instance = ''
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID); err != nil {
+		t.Fatalf("clear event flow metadata: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE entity_state
+		SET flow_instance = 'selected-state-flow/at-T',
+		    entity_type = 'selected_case',
+		    updated_at = $3
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
+		t.Fatalf("update source entity_state metadata: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if len(plan.Entities) != 1 || plan.Entities[0].MaterializationMetadata == nil {
+		t.Fatalf("plan entities = %#v, want materialization metadata", plan.Entities)
+	}
+	if got := plan.Entities[0].MaterializationMetadata.Source; got != RunForkMaterializedEntitySnapshotMetadataSourceEntityState {
+		t.Fatalf("metadata source = %q, want source entity_state", got)
+	}
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
+	}
+	var flowInstance, entityType string
+	if err := db.QueryRowContext(ctx, `
+		SELECT flow_instance, entity_type
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, materialized.ForkRunID, entityID).Scan(&flowInstance, &entityType); err != nil {
+		t.Fatalf("load selected fork entity_state: %v", err)
+	}
+	if flowInstance != "selected-state-flow/at-T" || entityType != "selected_case" {
+		t.Fatalf("selected fork metadata = flow:%s type:%s", flowInstance, entityType)
+	}
+}
+
 func TestSelectedContractExecutionMaterializationTreatsSourceConversationHistoryAsLineage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary

Closes #681.

This PR promotes `runtime.run_fork.materialized_entity_snapshot_metadata` as the canonical metadata/materializability owner for reconstructed fork `entity_state` snapshots. `PlanRunFork` now classifies every reconstructed entity with owner-authorized materialization metadata or emits `entity_snapshot_metadata_unproven`; both generic materialize-only and selected-contract materialization consume that plan-owned metadata instead of locally re-deriving flow metadata.

## Governing refs / context

Exact governing spec sections updated and consumed:

- `platform-spec.yaml` `run_model.fork.materialize_only_admission`
- `platform-spec.yaml` `run_model.fork.semantics.1_reconstruct_state`
- `platform-spec.yaml` `run_model.fork.isolation`
- `platform-spec.yaml` `mutation_log.write_contract`

Parent context: #564 and #549 remain open. Gate outcome on #681: `approved as first slice`.

## Semantic migration

New canonical owner: `runtime.run_fork.materialized_entity_snapshot_metadata`.

Old non-authoritative paths now invalid:

- `loadRunForkEntityFlowInstance` as an event-only materializer helper.
- `runForkEntityTypeFromForkPoint` as a separate entity_type interpreter.
- Treating `entity_mutations` candidates as materializable before metadata classification.

Production paths checked for surviving old behavior:

- Generic `MaterializeRunFork` now consumes plan metadata.
- Selected-contract `MaterializeRunForkForSelectedContractExecution` now consumes the same plan metadata.
- `PlanRunFork` attaches metadata or blockers before materialization.
- CLI/API/dashboard remain consumers only.

Migration complete for the approved #681 first-slice owner. Timers/routes/sessions/turns/audits/non-agent replay and full #564/#549 replay/resume remain split.

## Proof

Focused tests:

```sh
go test ./internal/store -run 'RunFork(Materializer|Planner)|SelectedContractExecutionMaterialization' -count=1
go test ./internal/store -count=1
go test ./internal/runtime/runforkexecution -count=1
go test ./internal/runtime/pipeline -run 'Fork|Recovery' -count=1
go test ./cmd/swarm -run 'Fork|RunFork|fork' -count=1
go test ./internal/runtime/tools -count=1
```

Supported Empire proof:

```sh
go run ./cmd/swarm verify --contracts /Users/youmew/dev/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
SWARM_DB_NAME=swarm_empire_issue681_readyfork_1778459462 \
SWARM_DB_HOST=127.0.0.1 SWARM_DB_PORT=5432 \
SWARM_DB_USER=postgres SWARM_DB_PASSWORD=postgres \
go run ./cmd/swarm fork \
  --run 3724c2d6-d8fb-49bc-aada-56f6f85b9b92 \
  --at 07e8042a-6449-4979-9c45-0501f19f6799 \
  --contracts /Users/youmew/dev/empire/contracts \
  --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml \
  --json
```

Result: the #681 metadata blocker is cleared. The proof now reaches the separate parent-tail blocker `authoritative delivery incomplete: missing=validation-coordinator`. Cleanup/non-corruption check after that failure shows zero fork runs, bindings, executions, divergences, route recoveries, delivery replays, fork events, fork deliveries, and fork entity_state rows.
