### PR TITLE
[agent-b][issue #682] Implement runtime ingress control owner

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -12,8 +12,8 @@ import (
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
-	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeingress "swarm/internal/runtime/ingress"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	workspace "swarm/internal/runtime/workspace"
@@ -262,8 +262,29 @@ type dashboardDynamicRuntimeControl struct {
 	supervisor *runtimeProjectSupervisor
 }
 
-func (c dashboardDynamicRuntimeControl) PauseIngress()  { runtimebus.PauseRuntimeIngress() }
-func (c dashboardDynamicRuntimeControl) ResumeIngress() { runtimebus.ResumeRuntimeIngress() }
+func (c dashboardDynamicRuntimeControl) PauseIngress() error {
+	rt := c.supervisor.CurrentRuntime()
+	if rt == nil || rt.RuntimeIngress == nil {
+		return fmt.Errorf("runtime ingress controller unavailable")
+	}
+	_, err := rt.RuntimeIngress.Pause(context.Background(), runtimeingress.TransitionRequest{
+		Reason:       "dashboard_action",
+		ControlledBy: "dashboard",
+	})
+	return err
+}
+
+func (c dashboardDynamicRuntimeControl) ResumeIngress() error {
+	rt := c.supervisor.CurrentRuntime()
+	if rt == nil || rt.RuntimeIngress == nil {
+		return fmt.Errorf("runtime ingress controller unavailable")
+	}
+	_, err := rt.RuntimeIngress.Resume(context.Background(), runtimeingress.TransitionRequest{
+		Reason:       "dashboard_action",
+		ControlledBy: "dashboard",
+	})
+	return err
+}
 
 func (c dashboardDynamicRuntimeControl) ResetState() error {
 	rt := c.supervisor.CurrentRuntime()

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -62,14 +62,15 @@ type storeBundle struct {
 
 func (s storeBundle) runtimeStores() runtime.Stores {
 	return runtime.Stores{
-		SQLDB:             s.SQLDB,
-		EventStore:        s.EventStore,
-		SessionRegistry:   s.SessionRegistry,
-		ConversationStore: s.ConversationStore,
-		ManagerStore:      s.ManagerStore,
-		ScheduleStore:     s.ScheduleStore,
-		StartupOwnership:  s.Postgres,
-		TurnStore:         s.TurnStore,
+		SQLDB:               s.SQLDB,
+		EventStore:          s.EventStore,
+		SessionRegistry:     s.SessionRegistry,
+		ConversationStore:   s.ConversationStore,
+		ManagerStore:        s.ManagerStore,
+		ScheduleStore:       s.ScheduleStore,
+		StartupOwnership:    s.Postgres,
+		RuntimeIngressStore: s.Postgres,
+		TurnStore:           s.TurnStore,
 	}
 }
 
@@ -195,6 +196,7 @@ func main() {
 			Mailbox:               stores.Postgres,
 			Idempotency:           stores.Postgres,
 			Events:                rt.Bus,
+			RuntimeIngress:        rt.RuntimeIngress,
 			Source:                source,
 			MailboxApprovalRoutes: mailboxApprovalRoutes,
 			Bundle:                bootBundleIdentity,

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -12,6 +12,9 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeingress "swarm/internal/runtime/ingress"
+	runtimemanager "swarm/internal/runtime/manager"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -281,11 +284,185 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 	}
 }
 
+func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	ctx := context.Background()
+	agentID := "mailbox-approval-agent"
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, agentID)
+	ch := bus.Subscribe(agentID, events.EventType("mailbox.item_decided"))
+	defer bus.Unsubscribe(agentID)
+
+	interceptorCalls := 0
+	bus.SetInterceptors(interceptorFunc(func(_ context.Context, evt events.Event) (bool, []events.Event, error) {
+		if evt.Type == events.EventType("mailbox.item_decided") {
+			interceptorCalls++
+		}
+		return true, nil, nil
+	}))
+
+	now := time.Now().UTC()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   runID,
+		Payload: json.RawMessage(`{"request":true}`),
+	}.WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   sourceEventID,
+		EntityID:  entityID,
+		FromAgent: "empire-agent",
+		Type:      "review_request",
+		Priority:  "high",
+		Context:   []byte(`{"title":"review this"}`),
+		Summary:   "needs approval",
+	})
+	if err != nil {
+		t.Fatalf("insert mailbox: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE mailbox SET flow_instance = 'empire/review' WHERE item_id = $1::uuid`, mailboxID); err != nil {
+		t.Fatalf("set flow instance: %v", err)
+	}
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+		Now:          now,
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:      func() time.Time { return now },
+			Ready:    func() bool { return true },
+			Database: fakePinger{},
+			Mailbox:  pg,
+			Events:   bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "empire",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+		}),
+	})
+
+	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-paused-approve"}}`
+	approved := rpcCall(t, handler, approveBody)
+	if approved.Error != nil {
+		t.Fatalf("mailbox.approve while paused error = %#v", approved.Error)
+	}
+	downstreamID, _ := asMap(t, approved.Result)["downstream_event_id"].(string)
+	if downstreamID == "" {
+		t.Fatalf("mailbox.approve downstream event id = %#v", approved.Result)
+	}
+	if interceptorCalls != 0 {
+		t.Fatalf("interceptor calls while paused = %d, want 0", interceptorCalls)
+	}
+	select {
+	case got := <-ch:
+		t.Fatalf("paused mailbox approval delivered event %s before resume", got.ID)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, downstreamID); got != 1 {
+		t.Fatalf("mailbox approval event deliveries while paused = %d, want 1", got)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, downstreamID); got != 0 {
+		t.Fatalf("mailbox approval pipeline receipts while paused = %d, want 0", got)
+	}
+	if got := countAPIIdempotencyRows(t, db); got != 1 {
+		t.Fatalf("api_idempotency rows after paused approve = %d, want 1", got)
+	}
+
+	replay := rpcCall(t, handler, approveBody)
+	if replay.Error != nil {
+		t.Fatalf("mailbox.approve paused replay error = %#v", replay.Error)
+	}
+	if got := asMap(t, replay.Result)["downstream_event_id"]; got != downstreamID {
+		t.Fatalf("paused replay downstream_event_id = %v, want %s", got, downstreamID)
+	}
+	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
+		t.Fatalf("mailbox.item_decided event count after replay = %d, want 1", count)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+		Now:          now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != downstreamID {
+			t.Fatalf("released mailbox approval event = %s, want %s", got.ID, downstreamID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for queued mailbox approval release")
+	}
+	if interceptorCalls != 0 {
+		t.Fatalf("interceptor calls after resume release = %d, want 0", interceptorCalls)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, downstreamID); got != 1 {
+		t.Fatalf("mailbox approval pipeline receipts after resume = %d, want 1", got)
+	}
+}
+
 func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
 	t.Helper()
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = $1`, eventName).Scan(&count); err != nil {
 		t.Fatalf("count events %s: %v", eventName, err)
+	}
+	return count
+}
+
+func countEventDeliveriesForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count event deliveries for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func countPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count pipeline receipts for %s: %v", eventID, err)
 	}
 	return count
 }
@@ -307,4 +484,28 @@ func (failingTxPublisher) Publish(context.Context, events.Event) error {
 
 func (failingTxPublisher) PublishTx(context.Context, *sql.Tx, events.Event) error {
 	return errors.New("publish failed")
+}
+
+type interceptorFunc func(context.Context, events.Event) (bool, []events.Event, error)
+
+func (f interceptorFunc) Intercept(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
+	return f(ctx, evt)
+}
+
+func seedActiveAPIV1RuntimeBusAgent(t *testing.T, ctx context.Context, pg *store.PostgresStore, agentID string) {
+	t.Helper()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:     agentID,
+			Role:   "observer",
+			Mode:   "global",
+			Type:   "stub",
+			Config: []byte(`{}`),
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
 }

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -31,6 +31,7 @@ type OperatorReadOptions struct {
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
+	RuntimeIngress        RuntimeIngressController
 	Source                semanticview.Source
 	MailboxApprovalRoutes map[string]string
 	Bundle                runtimecontracts.BundleIdentity
@@ -172,6 +173,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorRunStartHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorRuntimeControlHandlers(opts) {
 		handlers[name] = handler
 	}
 	return handlers

--- a/internal/apiv1/operator_runtime_control.go
+++ b/internal/apiv1/operator_runtime_control.go
@@ -1,0 +1,112 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	runtimeingress "swarm/internal/runtime/ingress"
+	"swarm/internal/store"
+)
+
+const runtimeControlIdempotencyTTL = 24 * time.Hour
+
+type RuntimeIngressController interface {
+	Pause(context.Context, runtimeingress.TransitionRequest) (runtimeingress.TransitionResult, error)
+	Resume(context.Context, runtimeingress.TransitionRequest) (runtimeingress.TransitionResult, error)
+}
+
+type okResult struct {
+	OK bool `json:"ok"`
+}
+
+func OperatorRuntimeControlHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.RuntimeIngress == nil || opts.Idempotency == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"runtime.pause": func(ctx context.Context, req Request) (any, error) {
+			return executeRuntimeIngressControl(ctx, req, opts, now().UTC(), true)
+		},
+		"runtime.resume": func(ctx context.Context, req Request) (any, error) {
+			return executeRuntimeIngressControl(ctx, req, opts, now().UTC(), false)
+		},
+	}
+}
+
+func executeRuntimeIngressControl(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time, pause bool) (any, error) {
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		TTL:            runtimeControlIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		var result runtimeingress.TransitionResult
+		var err error
+		controlReq := runtimeingress.TransitionRequest{
+			Reason:       "operator_request",
+			ControlledBy: "api.v1",
+			Now:          now,
+		}
+		if pause {
+			result, err = opts.RuntimeIngress.Pause(ctx, controlReq)
+		} else {
+			result, err = opts.RuntimeIngress.Resume(ctx, controlReq)
+		}
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, runtimeIngressControlError(err)
+		}
+		response, err := json.Marshal(okResult{OK: true})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: string(result.Status),
+			Response:   response,
+		}, nil
+	})
+	if err != nil {
+		return nil, runtimeIngressControlError(err)
+	}
+	var stored okResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode %s idempotency response: %w", req.Method, err)
+		}
+		return nil, fmt.Errorf("decode %s response: %w", req.Method, err)
+	}
+	return stored, nil
+}
+
+func runtimeIngressControlError(err error) error {
+	switch {
+	case errors.Is(err, runtimeingress.ErrAlreadyPaused):
+		return NewApplicationError(RuntimeAlreadyPausedCode, false, nil)
+	case errors.Is(err, runtimeingress.ErrNotPaused):
+		return NewApplicationError(RuntimeNotPausedCode, false, nil)
+	}
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	return err
+}

--- a/internal/apiv1/operator_runtime_control_test.go
+++ b/internal/apiv1/operator_runtime_control_test.go
@@ -1,0 +1,103 @@
+package apiv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeingress "swarm/internal/runtime/ingress"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ingress := runtimeingress.NewController(pg, bus, runtimeingress.Options{
+		Now: func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+	})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(ingress)
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:            func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready:          func() bool { return true },
+			Database:       fakePinger{},
+			Idempotency:    pg,
+			RuntimeIngress: ingress,
+		}),
+	})
+
+	pauseBody := `{"jsonrpc":"2.0","id":"pause","method":"runtime.pause","params":{"idempotency_key":"idem-pause"}}`
+	pause := rpcCall(t, handler, pauseBody)
+	if pause.Error != nil {
+		t.Fatalf("runtime.pause error = %#v", pause.Error)
+	}
+	if result := asMap(t, pause.Result); result["ok"] != true {
+		t.Fatalf("runtime.pause result = %#v", result)
+	}
+	if state, err := pg.LoadRuntimeIngressState(context.Background()); err != nil {
+		t.Fatalf("LoadRuntimeIngressState: %v", err)
+	} else if state.Status != runtimeingress.StatusPaused {
+		t.Fatalf("runtime ingress status = %q, want paused", state.Status)
+	}
+	if count := countEventsByName(t, db, "platform.paused"); count != 1 {
+		t.Fatalf("platform.paused events = %d, want 1", count)
+	}
+
+	replay := rpcCall(t, handler, pauseBody)
+	if replay.Error != nil {
+		t.Fatalf("runtime.pause replay error = %#v", replay.Error)
+	}
+	if count := countEventsByName(t, db, "platform.paused"); count != 1 {
+		t.Fatalf("platform.paused events after replay = %d, want 1", count)
+	}
+
+	duplicatePause := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"pause-again","method":"runtime.pause","params":{}}`)
+	if duplicatePause.Error == nil {
+		t.Fatal("fresh duplicate runtime.pause error = nil")
+	}
+	if data := asMap(t, duplicatePause.Error.Data); data["code"] != RuntimeAlreadyPausedCode {
+		t.Fatalf("fresh duplicate runtime.pause data = %#v, want %s", data, RuntimeAlreadyPausedCode)
+	}
+
+	resumeBody := `{"jsonrpc":"2.0","id":"resume","method":"runtime.resume","params":{"idempotency_key":"idem-resume"}}`
+	resume := rpcCall(t, handler, resumeBody)
+	if resume.Error != nil {
+		t.Fatalf("runtime.resume error = %#v", resume.Error)
+	}
+	if result := asMap(t, resume.Result); result["ok"] != true {
+		t.Fatalf("runtime.resume result = %#v", result)
+	}
+	if state, err := pg.LoadRuntimeIngressState(context.Background()); err != nil {
+		t.Fatalf("LoadRuntimeIngressState: %v", err)
+	} else if state.Status != runtimeingress.StatusRunning {
+		t.Fatalf("runtime ingress status = %q, want running", state.Status)
+	}
+	if count := countEventsByName(t, db, "platform.resumed"); count != 1 {
+		t.Fatalf("platform.resumed events = %d, want 1", count)
+	}
+
+	resumeReplay := rpcCall(t, handler, resumeBody)
+	if resumeReplay.Error != nil {
+		t.Fatalf("runtime.resume replay error = %#v", resumeReplay.Error)
+	}
+	if count := countEventsByName(t, db, "platform.resumed"); count != 1 {
+		t.Fatalf("platform.resumed events after replay = %d, want 1", count)
+	}
+
+	duplicateResume := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"resume-again","method":"runtime.resume","params":{}}`)
+	if duplicateResume.Error == nil {
+		t.Fatal("fresh duplicate runtime.resume error = nil")
+	}
+	if data := asMap(t, duplicateResume.Error.Data); data["code"] != RuntimeNotPausedCode {
+		t.Fatalf("fresh duplicate runtime.resume data = %#v, want %s", data, RuntimeNotPausedCode)
+	}
+}

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -22,6 +22,8 @@ const (
 	MailboxApprovalEventUnconfiguredCode = "MAILBOX_APPROVAL_EVENT_UNCONFIGURED"
 	InvalidDeferUntilCode                = "INVALID_DEFER_UNTIL"
 	IdempotencyConflictCode              = "IDEMPOTENCY_CONFLICT"
+	RuntimeAlreadyPausedCode             = "RUNTIME_ALREADY_PAUSED"
+	RuntimeNotPausedCode                 = "RUNTIME_NOT_PAUSED"
 )
 
 type Registry struct {

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -21,8 +21,8 @@ type InstanceReader interface {
 }
 
 type RuntimeController interface {
-	PauseIngress()
-	ResumeIngress()
+	PauseIngress() error
+	ResumeIngress() error
 	ResetState() error
 }
 
@@ -177,15 +177,13 @@ func NewHandler(opts Options) http.Handler {
 				if h.runtime == nil {
 					return errUnavailable("runtime controller is not configured")
 				}
-				h.runtime.PauseIngress()
-				return nil
+				return h.runtime.PauseIngress()
 			},
 			func() error {
 				if h.runtime == nil {
 					return errUnavailable("runtime controller is not configured")
 				}
-				h.runtime.ResumeIngress()
-				return nil
+				return h.runtime.ResumeIngress()
 			},
 			opts.RunDebug,
 		)

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -184,8 +184,8 @@ type AgentController interface {
 }
 
 type RuntimeController interface {
-	PauseIngress()
-	ResumeIngress()
+	PauseIngress() error
+	ResumeIngress() error
 	ResetState() error
 }
 
@@ -931,10 +931,16 @@ func (h *Handler) handleRuntimeAction(w http.ResponseWriter, r *http.Request) {
 	}
 	switch strings.TrimSpace(req.Action) {
 	case "pause":
-		h.runtime.PauseIngress()
+		if err := h.runtime.PauseIngress(); err != nil {
+			writeJSONError(w, http.StatusConflict, err)
+			return
+		}
 		writeJSON(w, http.StatusOK, controlResult{OK: true, Message: "runtime paused"})
 	case "resume":
-		h.runtime.ResumeIngress()
+		if err := h.runtime.ResumeIngress(); err != nil {
+			writeJSONError(w, http.StatusConflict, err)
+			return
+		}
 		writeJSON(w, http.StatusOK, controlResult{OK: true, Message: "runtime resumed"})
 	case "reset_state":
 		if err := h.runtime.ResetState(); err != nil {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -464,8 +464,14 @@ type stubRuntimeControl struct {
 	resumeCalls int
 }
 
-func (s *stubRuntimeControl) PauseIngress()  { s.pauseCalls++ }
-func (s *stubRuntimeControl) ResumeIngress() { s.resumeCalls++ }
+func (s *stubRuntimeControl) PauseIngress() error {
+	s.pauseCalls++
+	return nil
+}
+func (s *stubRuntimeControl) ResumeIngress() error {
+	s.resumeCalls++
+	return nil
+}
 func (s *stubRuntimeControl) ResetState() error {
 	s.resetCalls++
 	return nil

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -40,6 +40,7 @@ type EventBus struct {
 	payloadValidator            PayloadValidator
 	recipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
 	recipientPlanGuard          PublishRecipientPlanGuard
+	runtimeIngressDispatchGate  RuntimeIngressDispatchGate
 	outboxSweeperActive         bool
 	inFlightPublishes           atomic.Int64
 }
@@ -54,6 +55,10 @@ type PublishRecipientPlan struct {
 type PublishRecipientPlanAdmissionGuard func(context.Context, events.Event) error
 type PublishRecipientPlanGuard func(context.Context, events.Event, PublishRecipientPlan) error
 
+type RuntimeIngressDispatchGate interface {
+	QueueableIngressPaused(context.Context) (bool, error)
+}
+
 type EventBusOptions struct {
 	Logger                      LoggerHook
 	Interceptors                []EventInterceptor
@@ -63,6 +68,7 @@ type EventBusOptions struct {
 	PayloadValidator            PayloadValidator
 	RecipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
 	RecipientPlanGuard          PublishRecipientPlanGuard
+	RuntimeIngressDispatchGate  RuntimeIngressDispatchGate
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -126,9 +132,19 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		payloadValidator:            opts.PayloadValidator,
 		recipientPlanAdmissionGuard: opts.RecipientPlanAdmissionGuard,
 		recipientPlanGuard:          opts.RecipientPlanGuard,
+		runtimeIngressDispatchGate:  opts.RuntimeIngressDispatchGate,
 	}
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil
+}
+
+func (eb *EventBus) SetRuntimeIngressDispatchGate(gate RuntimeIngressDispatchGate) {
+	if eb == nil {
+		return
+	}
+	eb.mu.Lock()
+	eb.runtimeIngressDispatchGate = gate
+	eb.mu.Unlock()
 }
 
 func (eb *EventBus) Store() EventStore {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -217,6 +217,16 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	} else if replayScopePersistenceRequired(eb.store) {
 		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
 	}
+	if paused, err := eb.runtimeIngressDispatchPaused(txctx, evt); err != nil {
+		return err
+	} else if paused {
+		eb.logRuntime(txctx, "debug", "Runtime ingress is paused; transactional event persisted without dispatch", "eventbus", "runtime_ingress_queued", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+			"transactional":    true,
+			"recipients_count": len(inboundPlan.Recipients),
+			"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
+		}, "", 0)
+		return nil
+	}
 	passthrough, deferred, err := eb.runInterceptors(txctx, evt)
 	if err != nil {
 		return err

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -38,6 +38,32 @@ func pipelineReceiptStatus(ctx context.Context, publishErr error) (string, strin
 	return "processed", ""
 }
 
+var ErrRuntimeIngressPaused = errors.New("runtime ingress is paused")
+
+func (eb *EventBus) runtimeIngressDispatchPaused(ctx context.Context, evt events.Event) (bool, error) {
+	if eb == nil || runtimeIngressDispatchBypass(evt) {
+		return false, nil
+	}
+	eb.mu.RLock()
+	gate := eb.runtimeIngressDispatchGate
+	eb.mu.RUnlock()
+	if gate == nil {
+		return false, nil
+	}
+	paused, err := gate.QueueableIngressPaused(ctx)
+	if err != nil {
+		return false, err
+	}
+	return paused, nil
+}
+
+func runtimeIngressDispatchBypass(evt events.Event) bool {
+	if strings.TrimSpace(evt.SourceAgent) != "runtime" {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(string(evt.Type)), "platform.")
+}
+
 func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
@@ -84,9 +110,13 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	}
 
 	persisted := false
+	queued := false
 	passthrough := true
 	deferred := []events.Event{}
 	defer func() {
+		if queued {
+			return
+		}
 		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
@@ -104,9 +134,11 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	}
 
 	if passthrough {
-		if err := eb.publishSubscribedNonTransactional(ictx, evt); err != nil {
+		var publishQueued bool
+		if publishQueued, err = eb.publishSubscribedNonTransactional(ictx, evt); err != nil {
 			return err
 		}
+		queued = publishQueued
 		persisted = true
 	} else {
 		if err := eb.persistEventRecord(ictx, evt, nil, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
@@ -291,7 +323,21 @@ func (eb *EventBus) publishTransactional(
 		runtimepipeline.FlushDeferredPipelineTransitions(ctx, *deferredTransitions)
 	}
 
+	queued := false
 	if passthrough {
+		paused, err := eb.runtimeIngressDispatchPaused(ctx, evt)
+		if err != nil {
+			return err
+		}
+		if paused {
+			queued = true
+			eb.logRuntime(ctx, "debug", "Runtime ingress is paused; event persisted without dispatch", "eventbus", "runtime_ingress_queued", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+				"recipients_count": len(inboundPlan.Recipients),
+				"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
+			}, "", 0)
+		}
+	}
+	if passthrough && !queued {
 		if len(inboundPlan.Recipients) > 0 {
 			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
 			if err := eb.deliverToAgents(ctx, evt, inboundPlan.Recipients); err != nil {
@@ -314,6 +360,9 @@ func (eb *EventBus) publishTransactional(
 		if err := eb.publishDeferred(ctx, d); err != nil {
 			return err
 		}
+	}
+	if queued {
+		return nil
 	}
 	status, errText := pipelineReceiptStatus(txctx, nil)
 	if err := txStore.UpsertPipelineReceiptTx(ctx, nil, evt.ID, status, errText); err != nil {
@@ -397,7 +446,11 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		evt.SourceAgent = "runtime"
 	}
 	persisted := false
+	queued := false
 	defer func() {
+		if queued {
+			return
+		}
 		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
@@ -417,9 +470,11 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		return err
 	}
 	if passthrough {
-		if err := eb.deliverSubscribedPublishPlan(ctx, evt, plan); err != nil {
+		var deliverQueued bool
+		if deliverQueued, err = eb.deliverSubscribedPublishPlan(ctx, evt, plan); err != nil {
 			return err
 		}
+		queued = deliverQueued
 	}
 	eb.logPublished(ctx, evt, 0)
 	for _, d := range deferred {
@@ -438,13 +493,13 @@ func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, duration
 	}, "", durationUS)
 }
 
-func (eb *EventBus) publishSubscribedNonTransactional(ctx context.Context, evt events.Event) error {
+func (eb *EventBus) publishSubscribedNonTransactional(ctx context.Context, evt events.Event) (bool, error) {
 	plan, err := eb.planSubscribedPublish(ctx, evt)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := eb.persistSubscribedPublishPlan(ctx, evt, plan); err != nil {
-		return err
+		return false, err
 	}
 	return eb.deliverSubscribedPublishPlan(ctx, evt, plan)
 }
@@ -491,22 +546,33 @@ func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events
 	return nil
 }
 
-func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
+func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) (bool, error) {
+	paused, err := eb.runtimeIngressDispatchPaused(ctx, evt)
+	if err != nil {
+		return false, err
+	}
+	if paused {
+		eb.logRuntime(ctx, "debug", "Runtime ingress is paused; event persisted without dispatch", "eventbus", "runtime_ingress_queued", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+			"recipients_count": len(plan.Recipients),
+			"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
+		}, "", 0)
+		return true, nil
+	}
 	if len(plan.Recipients) > 0 {
 		if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
-			return err
+			return false, err
 		}
 		eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
 	}
 	if plan.BlockedByCycle && plan.CycleEscalation != nil {
 		if err := eb.publishDeferred(ctx, *plan.CycleEscalation); err != nil {
-			return err
+			return false, err
 		}
 	}
 	if strings.TrimSpace(plan.ContradictionReason) != "" {
 		_ = eb.emitContradiction(ctx, evt, plan.ContradictionReason)
 	}
-	return nil
+	return false, nil
 }
 
 func (eb *EventBus) persistEventRecord(
@@ -718,7 +784,11 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	}
 	start := time.Now()
 	persisted := false
+	queued := false
 	defer func() {
+		if queued {
+			return
+		}
 		if !shouldPersistPipelineReceipt(persisted, err) {
 			return
 		}
@@ -752,6 +822,17 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	}
 	persisted = true
 	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "direct_publish", plan.ExtraDetail)
+	if paused, err := eb.runtimeIngressDispatchPaused(ctx, evt); err != nil {
+		return err
+	} else if paused {
+		queued = true
+		eb.logRuntime(ctx, "debug", "Runtime ingress is paused; direct event persisted without dispatch", "eventbus", "runtime_ingress_queued", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+			"direct":           true,
+			"recipients_count": len(plan.Recipients),
+			"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
+		}, "", 0)
+		return nil
+	}
 	if err := eb.deliverToAgents(ctx, evt, plan.Recipients); err != nil {
 		return err
 	}
@@ -786,6 +867,11 @@ func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.E
 	}
 	if evt.CreatedAt.IsZero() {
 		evt.CreatedAt = time.Now()
+	}
+	if paused, err := eb.runtimeIngressDispatchPaused(ctx, evt); err != nil {
+		return err
+	} else if paused {
+		return ErrRuntimeIngressPaused
 	}
 	scope, err := eb.authoritativeReplayScopeForEvent(ctx, evt.ID)
 	if err != nil {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -21,6 +21,7 @@ import (
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
 	"swarm/internal/runtime/flowmodel"
+	runtimeingress "swarm/internal/runtime/ingress"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
@@ -340,6 +341,21 @@ func countEventDeliveriesForEvent(t *testing.T, ctx context.Context, db *sql.DB,
 		  AND subscriber_type = 'agent'
 	`, eventID).Scan(&count); err != nil {
 		t.Fatalf("count event deliveries for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func countPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count pipeline receipts for %s: %v", eventID, err)
 	}
 	return count
 }
@@ -1120,6 +1136,80 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 				t.Fatalf("run status for %s = %q, want completed", tc.eventType, runStatus)
 			}
 		})
+	}
+}
+
+func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	eb, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, eb, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	eb.SetRuntimeIngressDispatchGate(controller)
+
+	agentID := "agent-paused-queue"
+	eventType := events.EventType("custom.paused")
+	seedActiveRuntimeBusAgent(t, ctx, pg, agentID)
+	ch := eb.Subscribe(agentID, eventType)
+	defer eb.Unsubscribe(agentID)
+
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	eventID := "21000000-0000-0000-0000-000000000001"
+	if err := eb.Publish(ctx, events.Event{
+		ID:          eventID,
+		RunID:       eventBusTestRunID,
+		Type:        eventType,
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID("21000000-0000-0000-0000-000000000002")); err != nil {
+		t.Fatalf("Publish while paused: %v", err)
+	}
+
+	select {
+	case got := <-ch:
+		t.Fatalf("paused runtime delivered event %s before resume", got.ID)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("event deliveries while paused = %d, want 1", got)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts while paused = %d, want 0", got)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for queued event release")
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
 	}
 }
 

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -76,6 +76,13 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 	if eb == nil || eb.store == nil {
 		return 0, nil
 	}
+	paused, err := eb.runtimeIngressDispatchPaused(ctx, events.Event{Type: events.EventType("__runtime_ingress_probe__")})
+	if err != nil {
+		return 0, err
+	}
+	if paused {
+		return 0, nil
+	}
 	replayStore, participates, err := runtimereplayclaim.RequireStore(eb.store)
 	if err != nil {
 		return 0, err
@@ -115,6 +122,10 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 			return redelivered, err
 		}
 		if err := eb.PublishPersistedRecipients(ctx, evt, recipients); err != nil {
+			if errors.Is(err, ErrRuntimeIngressPaused) {
+				_ = lease.Release(ctx)
+				return redelivered, nil
+			}
 			if errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
 				if recordErr := eb.markCommittedReplayScopeUnavailable(ctx, evt, err); recordErr != nil {
 					_ = lease.Release(ctx)
@@ -137,6 +148,10 @@ func (eb *EventBus) SweepUndispatched(ctx context.Context, lookback time.Duratio
 		redelivered++
 	}
 	return redelivered, nil
+}
+
+func (eb *EventBus) ReleaseRuntimeIngressQueue(ctx context.Context, lookback time.Duration, limit int) (int, error) {
+	return eb.SweepUndispatched(ctx, lookback, limit)
 }
 
 func (eb *EventBus) markCommittedReplayScopeUnavailable(ctx context.Context, evt events.Event, cause error) error {

--- a/internal/runtime/cataloge2e/runtime_harness.go
+++ b/internal/runtime/cataloge2e/runtime_harness.go
@@ -178,15 +178,16 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 	}
 
 	rt, err := runtime.NewRuntime(ctx, cfg, runtime.Stores{
-		SQLDB:             db,
-		EventStore:        pg,
-		SessionRegistry:   sessions.NewPostgresRegistry(db, cfg.LLM.Session.LockTTL),
-		ManagerStore:      pg,
-		ScheduleStore:     pg,
-		StartupOwnership:  pg,
-		MailboxStore:      pg,
-		ConversationStore: nil,
-		TurnStore:         nil,
+		SQLDB:               db,
+		EventStore:          pg,
+		SessionRegistry:     sessions.NewPostgresRegistry(db, cfg.LLM.Session.LockTTL),
+		ManagerStore:        pg,
+		ScheduleStore:       pg,
+		StartupOwnership:    pg,
+		MailboxStore:        pg,
+		RuntimeIngressStore: pg,
+		ConversationStore:   nil,
+		TurnStore:           nil,
 	}, runtime.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeingress "swarm/internal/runtime/ingress"
 )
 
 type InboundPersistence interface {
@@ -58,6 +59,7 @@ type InboundGateway struct {
 	store                   InboundPersistence
 	logger                  *RuntimeLogger
 	shutdownAdmissionClosed func() bool
+	runtimeIngress          *runtimeingress.Controller
 }
 
 func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
@@ -80,14 +82,23 @@ func (g *InboundGateway) Handler() http.Handler {
 	return g.mux
 }
 
+func (g *InboundGateway) SetRuntimeIngress(controller *runtimeingress.Controller) {
+	if g == nil {
+		return
+	}
+	g.runtimeIngress = controller
+}
+
 func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	if g.shutdownAdmissionClosed != nil && g.shutdownAdmissionClosed() {
 		http.Error(w, "runtime shutting down", http.StatusServiceUnavailable)
 		return
 	}
-	if runtimebus.RuntimeIngressPaused() {
-		http.Error(w, "runtime reset in progress", http.StatusServiceUnavailable)
-		return
+	if g.runtimeIngress != nil {
+		if err := g.runtimeIngress.AdmitQueueableIngress(r.Context(), "inbound.webhook"); err != nil {
+			http.Error(w, "runtime ingress unavailable", http.StatusServiceUnavailable)
+			return
+		}
 	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -11,6 +11,7 @@ import (
 
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimeingress "swarm/internal/runtime/ingress"
 )
 
 type failingInboundEventStore struct{}
@@ -93,5 +94,38 @@ func TestInboundGateway_Returns503WhenRuntimeShutdownAdmissionClosed(t *testing.
 	}
 	if store.recorded {
 		t.Fatal("did not expect inbound event recording after shutdown admission closed")
+	}
+}
+
+func TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(nil, bus, runtimeingress.Options{})
+	bus.SetRuntimeIngressDispatchGate(controller)
+	if _, err := controller.Pause(context.Background(), runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	store := &rollbackTrackingInboundStore{}
+	g := NewInboundGateway(bus, nil, nil, store)
+	g.SetRuntimeIngress(controller)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected inbound event to be recorded while paused")
+	}
+	if store.rolled {
+		t.Fatal("did not expect inbound marker rollback for queued paused ingress")
 	}
 }

--- a/internal/runtime/ingress/controller.go
+++ b/internal/runtime/ingress/controller.go
@@ -1,0 +1,311 @@
+package ingress
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+const (
+	StatusRunning Status = "running"
+	StatusPaused  Status = "paused"
+)
+
+var (
+	ErrAlreadyPaused = errors.New("runtime ingress already paused")
+	ErrNotPaused     = errors.New("runtime ingress is not paused")
+)
+
+type Status string
+
+type State struct {
+	Status            Status
+	Reason            string
+	ControlledBy      string
+	TransitionEventID string
+	UpdatedAt         time.Time
+}
+
+type TransitionRequest struct {
+	Reason       string
+	ControlledBy string
+	Now          time.Time
+}
+
+type TransitionResult struct {
+	Status        Status
+	TransitionID  string
+	ReleasedCount int
+}
+
+type Store interface {
+	EnsureRuntimeIngressState(context.Context, time.Time) (State, error)
+	LoadRuntimeIngressState(context.Context) (State, error)
+	TransitionRuntimeIngressState(context.Context, Status, string, string, time.Time) (State, bool, error)
+	SetRuntimeIngressTransitionEvent(context.Context, string, time.Time) error
+}
+
+type EventPublisher interface {
+	Publish(context.Context, events.Event) error
+	ReleaseRuntimeIngressQueue(context.Context, time.Duration, int) (int, error)
+}
+
+type Options struct {
+	Now             func() time.Time
+	ReleaseLookback time.Duration
+	ReleaseLimit    int
+}
+
+type Controller struct {
+	mu              sync.Mutex
+	store           Store
+	publisher       EventPublisher
+	now             func() time.Time
+	releaseLookback time.Duration
+	releaseLimit    int
+	memory          State
+	memoryInit      bool
+}
+
+func NewController(store Store, publisher EventPublisher, opts Options) *Controller {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	lookback := opts.ReleaseLookback
+	if lookback <= 0 {
+		lookback = 24 * time.Hour
+	}
+	limit := opts.ReleaseLimit
+	if limit <= 0 {
+		limit = 200
+	}
+	return &Controller{
+		store:           store,
+		publisher:       publisher,
+		now:             now,
+		releaseLookback: lookback,
+		releaseLimit:    limit,
+	}
+}
+
+func (c *Controller) SyncState(ctx context.Context) error {
+	state, err := c.ensureState(ctx, c.currentTime())
+	if err != nil {
+		return err
+	}
+	syncRuntimeBus(state.Status)
+	return nil
+}
+
+func (c *Controller) Pause(ctx context.Context, req TransitionRequest) (TransitionResult, error) {
+	return c.transition(ctx, StatusPaused, req, ErrAlreadyPaused)
+}
+
+func (c *Controller) Resume(ctx context.Context, req TransitionRequest) (TransitionResult, error) {
+	return c.transition(ctx, StatusRunning, req, ErrNotPaused)
+}
+
+// SafetyPause is used by internal safety triggers such as auth breakers. It
+// consumes the same owner but intentionally does not expose public API
+// idempotency/resource-state semantics.
+func (c *Controller) SafetyPause(ctx context.Context, req TransitionRequest) (TransitionResult, error) {
+	return c.transition(ctx, StatusPaused, req, nil)
+}
+
+func (c *Controller) QueueableIngressPaused(ctx context.Context) (bool, error) {
+	state, err := c.ensureState(ctx, c.currentTime())
+	if err != nil {
+		return false, err
+	}
+	syncRuntimeBus(state.Status)
+	return state.Status == StatusPaused, nil
+}
+
+func (c *Controller) RequestResponseIngressPaused(ctx context.Context) (bool, error) {
+	return c.QueueableIngressPaused(ctx)
+}
+
+func (c *Controller) AdmitQueueableIngress(ctx context.Context, _ string) error {
+	_, err := c.ensureState(ctx, c.currentTime())
+	return err
+}
+
+func (c *Controller) transition(ctx context.Context, target Status, req TransitionRequest, alreadyErr error) (TransitionResult, error) {
+	if c == nil {
+		return TransitionResult{}, fmt.Errorf("runtime ingress controller is required")
+	}
+	now := req.Now
+	if now.IsZero() {
+		now = c.currentTime()
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		reason = "operator_request"
+	}
+	controlledBy := strings.TrimSpace(req.ControlledBy)
+	if controlledBy == "" {
+		controlledBy = "api.v1"
+	}
+	state, changed, err := c.transitionState(ctx, target, reason, controlledBy, now)
+	if err != nil {
+		return TransitionResult{}, err
+	}
+	syncRuntimeBus(state.Status)
+	result := TransitionResult{Status: state.Status, TransitionID: state.TransitionEventID}
+	if !changed {
+		if alreadyErr != nil {
+			return result, alreadyErr
+		}
+		return result, nil
+	}
+	eventID, err := c.publishTransitionEvent(ctx, target, reason, controlledBy, now)
+	if err != nil {
+		return result, err
+	}
+	result.TransitionID = eventID
+	if eventID != "" {
+		if err := c.setTransitionEvent(ctx, eventID, now); err != nil {
+			return result, err
+		}
+	}
+	if target == StatusRunning {
+		released, err := c.releaseQueued(ctx)
+		if err != nil {
+			return result, err
+		}
+		result.ReleasedCount = released
+	}
+	return result, nil
+}
+
+func (c *Controller) transitionState(ctx context.Context, target Status, reason, controlledBy string, now time.Time) (State, bool, error) {
+	if c.store != nil {
+		return c.store.TransitionRuntimeIngressState(ctx, target, reason, controlledBy, now)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.memoryInit {
+		c.memory = State{Status: StatusRunning, ControlledBy: "runtime", UpdatedAt: now}
+		c.memoryInit = true
+	}
+	if c.memory.Status == target {
+		return c.memory, false, nil
+	}
+	c.memory.Status = target
+	c.memory.Reason = reason
+	c.memory.ControlledBy = controlledBy
+	c.memory.TransitionEventID = ""
+	c.memory.UpdatedAt = now
+	return c.memory, true, nil
+}
+
+func (c *Controller) ensureState(ctx context.Context, now time.Time) (State, error) {
+	if c == nil {
+		return State{Status: StatusRunning}, nil
+	}
+	if c.store != nil {
+		return c.store.EnsureRuntimeIngressState(ctx, now)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.memoryInit {
+		status := StatusRunning
+		if runtimebus.RuntimeIngressPaused() {
+			status = StatusPaused
+		}
+		c.memory = State{Status: status, ControlledBy: "runtime", UpdatedAt: now}
+		c.memoryInit = true
+	}
+	return c.memory, nil
+}
+
+func (c *Controller) setTransitionEvent(ctx context.Context, eventID string, now time.Time) error {
+	if strings.TrimSpace(eventID) == "" {
+		return nil
+	}
+	if c.store != nil {
+		return c.store.SetRuntimeIngressTransitionEvent(ctx, eventID, now)
+	}
+	c.mu.Lock()
+	c.memory.TransitionEventID = strings.TrimSpace(eventID)
+	c.memory.UpdatedAt = now
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Controller) publishTransitionEvent(ctx context.Context, target Status, reason, controlledBy string, now time.Time) (string, error) {
+	if c.publisher == nil {
+		return "", nil
+	}
+	eventType := events.EventType("platform.paused")
+	payload := map[string]any{
+		"reason":    reason,
+		"paused_by": controlledBy,
+		"timestamp": now.Format(time.RFC3339Nano),
+	}
+	if target == StatusRunning {
+		eventType = events.EventType("platform.resumed")
+		payload = map[string]any{
+			"reason":     reason,
+			"resumed_by": controlledBy,
+			"timestamp":  now.Format(time.RFC3339Nano),
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	eventID := uuid.NewString()
+	if err := c.publisher.Publish(ctx, events.Event{
+		ID:          eventID,
+		Type:        eventType,
+		SourceAgent: "runtime",
+		Payload:     raw,
+		CreatedAt:   now,
+	}); err != nil {
+		return "", err
+	}
+	return eventID, nil
+}
+
+func (c *Controller) releaseQueued(ctx context.Context) (int, error) {
+	if c == nil || c.publisher == nil {
+		return 0, nil
+	}
+	total := 0
+	for {
+		n, err := c.publisher.ReleaseRuntimeIngressQueue(ctx, c.releaseLookback, c.releaseLimit)
+		total += n
+		if err != nil {
+			return total, err
+		}
+		if n < c.releaseLimit {
+			return total, nil
+		}
+	}
+}
+
+func (c *Controller) currentTime() time.Time {
+	if c == nil || c.now == nil {
+		return time.Now().UTC()
+	}
+	return c.now().UTC()
+}
+
+func syncRuntimeBus(status Status) {
+	switch status {
+	case StatusPaused:
+		runtimebus.PauseRuntimeIngress()
+	default:
+		runtimebus.ResumeRuntimeIngress()
+	}
+}

--- a/internal/runtime/ingress/controller.go
+++ b/internal/runtime/ingress/controller.go
@@ -50,7 +50,7 @@ type Store interface {
 	EnsureRuntimeIngressState(context.Context, time.Time) (State, error)
 	LoadRuntimeIngressState(context.Context) (State, error)
 	TransitionRuntimeIngressState(context.Context, Status, string, string, time.Time) (State, bool, error)
-	SetRuntimeIngressTransitionEvent(context.Context, string, time.Time) error
+	SetRuntimeIngressTransitionEvent(context.Context, Status, string, time.Time) (bool, error)
 }
 
 type EventPublisher interface {
@@ -167,20 +167,21 @@ func (c *Controller) transition(ctx context.Context, target Status, req Transiti
 		}
 		return result, nil
 	}
+	// Once the owner state has committed, callers must see the transition as
+	// successful so API idempotency can record and replay the completed write.
 	eventID, err := c.publishTransitionEvent(ctx, target, reason, controlledBy, now)
 	if err != nil {
-		return result, err
+		return result, nil
 	}
 	result.TransitionID = eventID
 	if eventID != "" {
-		if err := c.setTransitionEvent(ctx, eventID, now); err != nil {
-			return result, err
-		}
+		_, _ = c.setTransitionEvent(ctx, target, eventID, state.UpdatedAt)
 	}
 	if target == StatusRunning {
 		released, err := c.releaseQueued(ctx)
 		if err != nil {
-			return result, err
+			result.ReleasedCount = released
+			return result, nil
 		}
 		result.ReleasedCount = released
 	}
@@ -228,18 +229,21 @@ func (c *Controller) ensureState(ctx context.Context, now time.Time) (State, err
 	return c.memory, nil
 }
 
-func (c *Controller) setTransitionEvent(ctx context.Context, eventID string, now time.Time) error {
+func (c *Controller) setTransitionEvent(ctx context.Context, target Status, eventID string, now time.Time) (bool, error) {
 	if strings.TrimSpace(eventID) == "" {
-		return nil
+		return false, nil
 	}
 	if c.store != nil {
-		return c.store.SetRuntimeIngressTransitionEvent(ctx, eventID, now)
+		return c.store.SetRuntimeIngressTransitionEvent(ctx, target, eventID, now)
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.memory.Status != target || !c.memory.UpdatedAt.Equal(now) {
+		return false, nil
+	}
 	c.memory.TransitionEventID = strings.TrimSpace(eventID)
 	c.memory.UpdatedAt = now
-	c.mu.Unlock()
-	return nil
+	return true, nil
 }
 
 func (c *Controller) publishTransitionEvent(ctx context.Context, target Status, reason, controlledBy string, now time.Time) (string, error) {

--- a/internal/runtime/ingress/controller_test.go
+++ b/internal/runtime/ingress/controller_test.go
@@ -1,0 +1,56 @@
+package ingress
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+)
+
+type transitionFailurePublisher struct {
+	publishErr error
+	releaseN   int
+	releaseErr error
+}
+
+func (p *transitionFailurePublisher) Publish(context.Context, events.Event) error {
+	return p.publishErr
+}
+
+func (p *transitionFailurePublisher) ReleaseRuntimeIngressQueue(context.Context, time.Duration, int) (int, error) {
+	return p.releaseN, p.releaseErr
+}
+
+func TestTransitionPostCommitFailuresRemainCallerSuccess(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC)
+	publisher := &transitionFailurePublisher{publishErr: errors.New("publish unavailable")}
+	controller := NewController(nil, publisher, Options{Now: func() time.Time { return now }})
+
+	if _, err := controller.Pause(ctx, TransitionRequest{Now: now}); err != nil {
+		t.Fatalf("Pause post-commit publish failure error = %v, want nil", err)
+	}
+	if paused, err := controller.QueueableIngressPaused(ctx); err != nil {
+		t.Fatalf("QueueableIngressPaused: %v", err)
+	} else if !paused {
+		t.Fatal("runtime ingress paused = false, want true after committed pause")
+	}
+
+	publisher.publishErr = nil
+	publisher.releaseN = 1
+	publisher.releaseErr = errors.New("release unavailable")
+	resumed, err := controller.Resume(ctx, TransitionRequest{Now: now.Add(time.Second)})
+	if err != nil {
+		t.Fatalf("Resume post-commit release failure error = %v, want nil", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want partial count 1", resumed.ReleasedCount)
+	}
+	if paused, err := controller.QueueableIngressPaused(ctx); err != nil {
+		t.Fatalf("QueueableIngressPaused after resume: %v", err)
+	} else if paused {
+		t.Fatal("runtime ingress paused = true, want false after committed resume")
+	}
+}

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -32,6 +32,7 @@ type AgentManager struct {
 	budget                          BudgetGuard
 	resetRuntimeOwnedState          func()
 	runtimeShutdownAdmissionClosed  func() bool
+	runtimeIngressSafetyPause       func(context.Context, string) error
 	runtimeMode                     string
 	throttleSuppressPrefixes        []string
 	inFlightMu                      sync.Mutex
@@ -110,6 +111,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		budget:                          opts.Budget,
 		resetRuntimeOwnedState:          opts.ResetRuntimeOwnedState,
 		runtimeShutdownAdmissionClosed:  opts.RuntimeShutdownAdmissionClosed,
+		runtimeIngressSafetyPause:       opts.RuntimeIngressSafetyPause,
 		throttleSuppressPrefixes:        throttleSuppressPrefixes,
 		inFlight:                        make(map[string]struct{}),
 		loopCancel:                      make(map[string]context.CancelFunc),

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
-	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
@@ -314,7 +313,34 @@ func (am *AgentManager) maybeTripAuthCircuitBreaker(agentID, eventID string, err
 	running := am.running
 	am.runMu.Unlock()
 
-	runtimebus.PauseRuntimeIngress()
+	if am.runtimeIngressSafetyPause != nil {
+		if pauseErr := am.runtimeIngressSafetyPause(am.runtimeContext(), reason); pauseErr != nil {
+			if am.bus != nil {
+				am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
+					Level:     "error",
+					Component: "agent-manager",
+					Action:    "runtime_pause_owner_failed",
+					EventID:   strings.TrimSpace(eventID),
+					AgentID:   strings.TrimSpace(agentID),
+					Error:     strings.TrimSpace(pauseErr.Error()),
+					Detail: map[string]any{
+						"reason": reason,
+					},
+				})
+			}
+		}
+	} else if am.bus != nil {
+		am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
+			Level:     "warn",
+			Component: "agent-manager",
+			Action:    "runtime_pause_owner_missing",
+			EventID:   strings.TrimSpace(eventID),
+			AgentID:   strings.TrimSpace(agentID),
+			Detail: map[string]any{
+				"reason": reason,
+			},
+		})
+	}
 	if am.bus != nil {
 		am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
 			Level:     "error",
@@ -365,32 +391,6 @@ func (am *AgentManager) maybeTripAuthCircuitBreaker(agentID, eventID string, err
 					Error:     strings.TrimSpace(err.Error()),
 				})
 			}
-		}
-	}
-	if err := am.bus.Publish(am.runtimeContext(), events.Event{
-		ID:          uuid.NewString(),
-		Type:        events.EventType("platform.paused"),
-		SourceAgent: "runtime",
-		Payload: mustJSON(map[string]any{
-			"reason":    reason,
-			"paused_by": "runtime",
-			"timestamp": now.Format(time.RFC3339Nano),
-		}),
-		CreatedAt: now,
-	}); err != nil {
-		if am.bus != nil {
-			am.bus.LogRuntime(am.runtimeContext(), runtimepipeline.RuntimeLogEntry{
-				Level:     "error",
-				Component: "agent-manager",
-				Action:    "publish_paused_failed",
-				EventID:   strings.TrimSpace(eventID),
-				AgentID:   strings.TrimSpace(agentID),
-				EntityID:  entityID,
-				Error:     strings.TrimSpace(err.Error()),
-				Detail: map[string]any{
-					"reason": reason,
-				},
-			})
 		}
 	}
 	if running {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -96,7 +96,22 @@ func (a panicStubAgent) OnEvent(context.Context, events.Event) ([]events.Event, 
 
 func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.T) {
 	bus := &recordingReceiptBus{}
-	am := NewAgentManager(bus, nil)
+	pauseCalls := 0
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		RuntimeIngressSafetyPause: func(ctx context.Context, reason string) error {
+			pauseCalls++
+			return bus.Publish(ctx, events.Event{
+				Type:        events.EventType("platform.paused"),
+				SourceAgent: "runtime",
+				Payload: mustJSON(map[string]any{
+					"reason":    reason,
+					"paused_by": "runtime",
+					"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+				}),
+				CreatedAt: time.Now().UTC(),
+			})
+		},
+	})
 	am.agentCfg["agent-a"] = runtimeactors.AgentConfig{
 		ID:       "agent-a",
 		EntityID: "ent-123",
@@ -108,9 +123,17 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 	if len(bus.published) != 2 {
 		t.Fatalf("published events = %d, want 2", len(bus.published))
 	}
-	authEvt := bus.published[0]
+	if pauseCalls != 1 {
+		t.Fatalf("runtime ingress safety pause calls = %d, want 1", pauseCalls)
+	}
+	var authEvt events.Event
+	for _, evt := range bus.published {
+		if evt.Type == events.EventType("platform.auth_required") {
+			authEvt = evt
+		}
+	}
 	if authEvt.Type != events.EventType("platform.auth_required") {
-		t.Fatalf("first event type = %s, want platform.auth_required", authEvt.Type)
+		t.Fatalf("published events = %#v, want platform.auth_required", bus.published)
 	}
 	if got := authEvt.EntityID(); got != "ent-123" {
 		t.Fatalf("auth event entity_id = %q, want ent-123", got)

--- a/internal/runtime/manager/runtime_ingress_safety_test.go
+++ b/internal/runtime/manager/runtime_ingress_safety_test.go
@@ -1,0 +1,35 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	runtimebus "swarm/internal/runtime/bus"
+)
+
+func TestAuthBreakerConsumesRuntimeIngressSafetyPauseOwner(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	pauseCalls := 0
+	var pauseReason string
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
+		RuntimeIngressSafetyPause: func(_ context.Context, reason string) error {
+			pauseCalls++
+			pauseReason = reason
+			return nil
+		},
+	})
+
+	am.maybeTripAuthCircuitBreaker("agent-1", "evt-1", errors.New("claude auth required"))
+	am.maybeTripAuthCircuitBreaker("agent-1", "evt-2", errors.New("claude auth required"))
+
+	if pauseCalls != 1 {
+		t.Fatalf("runtime ingress safety pause calls = %d, want 1", pauseCalls)
+	}
+	if pauseReason != "claude_auth_required" {
+		t.Fatalf("runtime ingress safety pause reason = %q, want claude_auth_required", pauseReason)
+	}
+}

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -134,6 +134,7 @@ type AgentManagerOptions struct {
 	Budget                         BudgetGuard
 	ResetRuntimeOwnedState         func()
 	RuntimeShutdownAdmissionClosed func() bool
+	RuntimeIngressSafetyPause      func(context.Context, string) error
 	ThrottleSuppressPrefixes       []string
 	DisableSpinupControl           bool
 	EnableLegacySpinupControl      bool

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -21,7 +21,7 @@ import (
 )
 
 type GatewayHooks struct {
-	RuntimeIngressPaused           func() bool
+	RuntimeIngressRequestPaused    func(context.Context) (bool, error)
 	RuntimeShutdownAdmissionClosed func() bool
 	FormatError                    func(error) string
 	NewRuntimeError                func(code, operation string, retryable bool, cause error, format string, args ...any) error
@@ -104,7 +104,7 @@ func (g *Gateway) handleTool(w http.ResponseWriter, r *http.Request) {
 		WriteJSON(w, http.StatusServiceUnavailable, ToolGatewayResponse{OK: false, Error: "runtime shutting down"})
 		return
 	}
-	if g.runtimeIngressPaused() {
+	if g.runtimeIngressPaused(r.Context()) {
 		WriteJSON(w, http.StatusServiceUnavailable, ToolGatewayResponse{OK: false, Error: "runtime reset in progress"})
 		return
 	}
@@ -170,7 +170,7 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 			WriteRPCError(w, nil, -32002, "runtime shutting down")
 			return
 		}
-		if g.runtimeIngressPaused() {
+		if g.runtimeIngressPaused(r.Context()) {
 			WriteRPCError(w, nil, -32002, "runtime reset in progress")
 			return
 		}
@@ -810,11 +810,15 @@ func (g *Gateway) logMCP(r *http.Request, level, action string, err error, detai
 	g.hooks.Log(r.Context(), strings.ToLower(strings.TrimSpace(level)), strings.TrimSpace(action), agentID, entityID, detail, errText)
 }
 
-func (g *Gateway) runtimeIngressPaused() bool {
-	if g == nil || g.hooks.RuntimeIngressPaused == nil {
+func (g *Gateway) runtimeIngressPaused(ctx context.Context) bool {
+	if g == nil {
 		return false
 	}
-	return g.hooks.RuntimeIngressPaused()
+	if g.hooks.RuntimeIngressRequestPaused != nil {
+		paused, err := g.hooks.RuntimeIngressRequestPaused(ctx)
+		return err != nil || paused
+	}
+	return false
 }
 
 func (g *Gateway) runtimeShutdownAdmissionClosed() bool {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -1870,6 +1870,38 @@ func TestGatewayHandleTool_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T
 	}
 }
 
+func TestGatewayHandleTool_DeniesThroughRuntimeIngressOwnerRead(t *testing.T) {
+	callCount := 0
+	readCount := 0
+	g := NewGateway(testToolExecutor(func(_ context.Context, name string, input any) (any, error) {
+		callCount++
+		return map[string]any{"ok": true, "name": name, "input": input}, nil
+	}), testGatewayToken, GatewayHooks{
+		RuntimeIngressRequestPaused: func(context.Context) (bool, error) {
+			readCount++
+			return true, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/tools/query_entities", strings.NewReader(`{"input":{"query":"kind='vertical'"}}`))
+	authorizeGatewayRequest(req)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "runtime reset in progress") {
+		t.Fatalf("body = %s, want runtime reset in progress", rec.Body.String())
+	}
+	if readCount != 1 {
+		t.Fatalf("runtime ingress owner reads = %d, want 1", readCount)
+	}
+	if callCount != 0 {
+		t.Fatalf("executor call count = %d, want 0", callCount)
+	}
+}
+
 func TestGatewayHandleMCP_DeniesToolCallWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
 	registry := newTestTurnContextRegistry()
 	callCount := 0

--- a/internal/runtime/mcp_hooks.go
+++ b/internal/runtime/mcp_hooks.go
@@ -8,6 +8,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/diaglog"
+	runtimeingress "swarm/internal/runtime/ingress"
 	llm "swarm/internal/runtime/llm"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimetools "swarm/internal/runtime/tools"
@@ -30,12 +31,18 @@ func newMCPRuntimeError(code, operation string, retryable bool, cause error, for
 	return WrapRuntimeError(code, "mcp-gateway", operation, retryable, cause, format, args...)
 }
 
-func RuntimeMCPGatewayHooks(logger *RuntimeLogger, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), runtimeShutdownAdmissionClosed func() bool, emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
+func RuntimeMCPGatewayHooks(logger *RuntimeLogger, runtimeIngress *runtimeingress.Controller, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool), runtimeShutdownAdmissionClosed func() bool, emitRegistry *runtimetools.EmitRegistry, turnContexts *runtimemcp.TurnContextRegistry) runtimemcp.GatewayHooks {
 	if emitRegistry == nil {
 		emitRegistry = runtimetools.NewEmitRegistry(nil, nil)
 	}
+	runtimeIngressRequestPaused := func(ctx context.Context) (bool, error) {
+		if runtimeIngress == nil {
+			return false, nil
+		}
+		return runtimeIngress.RequestResponseIngressPaused(ctx)
+	}
 	return runtimemcp.GatewayHooks{
-		RuntimeIngressPaused:           runtimebus.RuntimeIngressPaused,
+		RuntimeIngressRequestPaused:    runtimeIngressRequestPaused,
 		RuntimeShutdownAdmissionClosed: runtimeShutdownAdmissionClosed,
 		FormatError:                    FormatRuntimeError,
 		NewRuntimeError:                newMCPRuntimeError,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -24,6 +24,7 @@ import (
 	"swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimecredentials "swarm/internal/runtime/credentials"
+	runtimeingress "swarm/internal/runtime/ingress"
 	llm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
@@ -36,16 +37,17 @@ import (
 )
 
 type Stores struct {
-	SQLDB             *sql.DB
-	EventStore        runtimebus.EventStore
-	SessionRegistry   sessions.Registry
-	ConversationStore llm.ConversationPersistence
-	ManagerStore      runtimemanager.ManagerPersistence
-	ScheduleStore     runtimepipeline.SchedulePersistence
-	StartupOwnership  runtimestartupownership.Store
-	MailboxStore      runtimetools.MailboxPersistence
-	InboundStore      InboundPersistence
-	TurnStore         llm.TurnPersistence
+	SQLDB               *sql.DB
+	EventStore          runtimebus.EventStore
+	SessionRegistry     sessions.Registry
+	ConversationStore   llm.ConversationPersistence
+	ManagerStore        runtimemanager.ManagerPersistence
+	ScheduleStore       runtimepipeline.SchedulePersistence
+	StartupOwnership    runtimestartupownership.Store
+	MailboxStore        runtimetools.MailboxPersistence
+	InboundStore        InboundPersistence
+	RuntimeIngressStore runtimeingress.Store
+	TurnStore           llm.TurnPersistence
 }
 
 type runtimeLogSchemaCapabilityProvider interface {
@@ -88,6 +90,7 @@ type Runtime struct {
 	LLM            llm.Runtime
 	ToolExecutor   *runtimetools.Executor
 	Manager        *runtimemanager.AgentManager
+	RuntimeIngress *runtimeingress.Controller
 	InboundGateway *InboundGateway
 	ToolGateway    *runtimemcp.Gateway
 	MCPTurns       *runtimemcp.TurnContextRegistry
@@ -269,6 +272,11 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		return nil, fmt.Errorf("build event bus: %w", err)
 	}
 	rt.Bus = bus
+	rt.RuntimeIngress = runtimeingress.NewController(stores.RuntimeIngressStore, rt.Bus, runtimeingress.Options{})
+	rt.Bus.SetRuntimeIngressDispatchGate(rt.RuntimeIngress)
+	if err := rt.RuntimeIngress.SyncState(ctx); err != nil {
+		return nil, fmt.Errorf("sync runtime ingress state: %w", err)
+	}
 
 	var managerRef *runtimemanager.AgentManager
 	rt.Scheduler = runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
@@ -418,16 +426,24 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			}
 		},
 		RuntimeShutdownAdmissionClosed: rt.shutdownAdmissionClosed,
-		ThrottleSuppressPrefixes:       runtimeThrottleSuppressPrefixes(source),
-		DisableSpinupControl:           true,
+		RuntimeIngressSafetyPause: func(ctx context.Context, reason string) error {
+			_, err := rt.RuntimeIngress.SafetyPause(ctx, runtimeingress.TransitionRequest{
+				Reason:       reason,
+				ControlledBy: "runtime",
+			})
+			return err
+		},
+		ThrottleSuppressPrefixes: runtimeThrottleSuppressPrefixes(source),
+		DisableSpinupControl:     true,
 	}, stores.ManagerStore)
 	managerRef = rt.Manager
 
 	if stores.InboundStore != nil {
 		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed, stores.InboundStore)
+		rt.InboundGateway.SetRuntimeIngress(rt.RuntimeIngress)
 	}
 	if opts.EnableToolGateway {
-		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, strings.TrimSpace(opts.ToolGatewayToken), RuntimeMCPGatewayHooks(rt.Logger, func(agentID string) (runtimeactors.AgentConfig, bool) {
+		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, strings.TrimSpace(opts.ToolGatewayToken), RuntimeMCPGatewayHooks(rt.Logger, rt.RuntimeIngress, func(agentID string) (runtimeactors.AgentConfig, bool) {
 			if rt.Manager == nil {
 				return runtimeactors.AgentConfig{}, false
 			}

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -238,7 +238,7 @@ func startupProbeCaps() map[string]toolcapabilities.Capability {
 func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManager, exec *startupProbeToolExecutor, gatewayToken string) *runtimemcp.TurnContextRegistry {
 	t.Helper()
 	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
-	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, manager.GetAgentConfig, nil, nil, turns))
+	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, nil, manager.GetAgentConfig, nil, nil, turns))
 	server := httptest.NewServer(gateway.Handler())
 	t.Cleanup(server.Close)
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -895,6 +895,7 @@ func isStandaloneRuntimePlatformEventType(eventType string) bool {
 		"platform.agent_failed",
 		"platform.auth_required",
 		"platform.paused",
+		"platform.resumed",
 		"platform.dead_letter_escalation",
 		"platform.budget_threshold_crossed":
 		return true

--- a/internal/store/runtime_ingress_state.go
+++ b/internal/store/runtime_ingress_state.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimeingress "swarm/internal/runtime/ingress"
+)
+
+func (s *PostgresStore) EnsureRuntimeIngressState(ctx context.Context, now time.Time) (runtimeingress.State, error) {
+	if s == nil || s.DB == nil {
+		return runtimeingress.State{}, fmt.Errorf("postgres store is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		INSERT INTO runtime_ingress_state (id, status, controlled_by, updated_at)
+		VALUES (1, 'running', 'runtime', $1)
+		ON CONFLICT (id) DO NOTHING
+	`, now.UTC()); err != nil {
+		return runtimeingress.State{}, fmt.Errorf("ensure runtime ingress state: %w", err)
+	}
+	return s.LoadRuntimeIngressState(ctx)
+}
+
+func (s *PostgresStore) LoadRuntimeIngressState(ctx context.Context) (runtimeingress.State, error) {
+	if s == nil || s.DB == nil {
+		return runtimeingress.State{}, fmt.Errorf("postgres store is required")
+	}
+	state, err := scanRuntimeIngressState(s.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id::text, ''), updated_at
+		FROM runtime_ingress_state
+		WHERE id = 1
+	`))
+	if err == nil {
+		return state, nil
+	}
+	if err == sql.ErrNoRows {
+		return runtimeingress.State{}, fmt.Errorf("runtime ingress state is not initialized")
+	}
+	return runtimeingress.State{}, fmt.Errorf("load runtime ingress state: %w", err)
+}
+
+func (s *PostgresStore) TransitionRuntimeIngressState(ctx context.Context, target runtimeingress.Status, reason, controlledBy string, now time.Time) (runtimeingress.State, bool, error) {
+	if s == nil || s.DB == nil {
+		return runtimeingress.State{}, false, fmt.Errorf("postgres store is required")
+	}
+	if target != runtimeingress.StatusRunning && target != runtimeingress.StatusPaused {
+		return runtimeingress.State{}, false, fmt.Errorf("unsupported runtime ingress status: %s", target)
+	}
+	reason = strings.TrimSpace(reason)
+	controlledBy = strings.TrimSpace(controlledBy)
+	if controlledBy == "" {
+		controlledBy = "runtime"
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("begin runtime ingress transition: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runtime_ingress_state (id, status, controlled_by, updated_at)
+		VALUES (1, 'running', 'runtime', $1)
+		ON CONFLICT (id) DO NOTHING
+	`, now.UTC()); err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("ensure runtime ingress state: %w", err)
+	}
+	state, err := scanRuntimeIngressState(tx.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id::text, ''), updated_at
+		FROM runtime_ingress_state
+		WHERE id = 1
+		FOR UPDATE
+	`))
+	if err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("lock runtime ingress state: %w", err)
+	}
+	if state.Status == target {
+		if err := tx.Commit(); err != nil {
+			return runtimeingress.State{}, false, fmt.Errorf("commit runtime ingress no-op: %w", err)
+		}
+		committed = true
+		return state, false, nil
+	}
+	state, err = scanRuntimeIngressState(tx.QueryRowContext(ctx, `
+		UPDATE runtime_ingress_state
+		SET status = $1,
+		    reason = NULLIF($2, ''),
+		    controlled_by = $3,
+		    transition_event_id = NULL,
+		    updated_at = $4
+		WHERE id = 1
+		RETURNING status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id::text, ''), updated_at
+	`, string(target), reason, controlledBy, now.UTC()))
+	if err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("update runtime ingress state: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("commit runtime ingress transition: %w", err)
+	}
+	committed = true
+	return state, true, nil
+}
+
+func (s *PostgresStore) SetRuntimeIngressTransitionEvent(ctx context.Context, eventID string, now time.Time) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		UPDATE runtime_ingress_state
+		SET transition_event_id = $1::uuid,
+		    updated_at = $2
+		WHERE id = 1
+	`, eventID, now.UTC()); err != nil {
+		return fmt.Errorf("set runtime ingress transition event: %w", err)
+	}
+	return nil
+}
+
+type runtimeIngressStateScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRuntimeIngressState(row runtimeIngressStateScanner) (runtimeingress.State, error) {
+	var state runtimeingress.State
+	var status string
+	if err := row.Scan(&status, &state.Reason, &state.ControlledBy, &state.TransitionEventID, &state.UpdatedAt); err != nil {
+		return runtimeingress.State{}, err
+	}
+	state.Status = runtimeingress.Status(strings.TrimSpace(status))
+	return state, nil
+}

--- a/internal/store/runtime_ingress_state.go
+++ b/internal/store/runtime_ingress_state.go
@@ -113,26 +113,36 @@ func (s *PostgresStore) TransitionRuntimeIngressState(ctx context.Context, targe
 	return state, true, nil
 }
 
-func (s *PostgresStore) SetRuntimeIngressTransitionEvent(ctx context.Context, eventID string, now time.Time) error {
+func (s *PostgresStore) SetRuntimeIngressTransitionEvent(ctx context.Context, target runtimeingress.Status, eventID string, transitionAt time.Time) (bool, error) {
 	if s == nil || s.DB == nil {
-		return fmt.Errorf("postgres store is required")
+		return false, fmt.Errorf("postgres store is required")
 	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
-		return nil
+		return false, nil
 	}
-	if now.IsZero() {
-		now = time.Now().UTC()
+	if target != runtimeingress.StatusRunning && target != runtimeingress.StatusPaused {
+		return false, fmt.Errorf("unsupported runtime ingress status: %s", target)
 	}
-	if _, err := s.DB.ExecContext(ctx, `
-		UPDATE runtime_ingress_state
-		SET transition_event_id = $1::uuid,
-		    updated_at = $2
-		WHERE id = 1
-	`, eventID, now.UTC()); err != nil {
-		return fmt.Errorf("set runtime ingress transition event: %w", err)
+	if transitionAt.IsZero() {
+		return false, fmt.Errorf("runtime ingress transition timestamp is required")
 	}
-	return nil
+	res, err := s.DB.ExecContext(ctx, `
+			UPDATE runtime_ingress_state
+			SET transition_event_id = $1::uuid,
+			    updated_at = $3
+			WHERE id = 1
+			  AND status = $2
+			  AND updated_at = $3
+		`, eventID, string(target), transitionAt.UTC())
+	if err != nil {
+		return false, fmt.Errorf("set runtime ingress transition event: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("set runtime ingress transition event rows: %w", err)
+	}
+	return rows > 0, nil
 }
 
 type runtimeIngressStateScanner interface {

--- a/internal/store/runtime_ingress_state_test.go
+++ b/internal/store/runtime_ingress_state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"swarm/internal/events"
 	runtimeingress "swarm/internal/runtime/ingress"
 	"swarm/internal/testutil"
 )
@@ -31,6 +32,27 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 	if !changed || state.Status != runtimeingress.StatusPaused || state.Reason != "operator_request" || state.ControlledBy != "api.v1" {
 		t.Fatalf("paused transition = %#v changed=%v", state, changed)
 	}
+	pausedAt := state.UpdatedAt
+	pausedEventID := "11111111-1111-1111-1111-111111111111"
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          pausedEventID,
+		Type:        events.EventType("platform.paused"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{}`),
+		CreatedAt:   pausedAt,
+	}); err != nil {
+		t.Fatalf("AppendEvent(paused): %v", err)
+	}
+	if ok, err := pg.SetRuntimeIngressTransitionEvent(ctx, runtimeingress.StatusPaused, pausedEventID, pausedAt); err != nil {
+		t.Fatalf("SetRuntimeIngressTransitionEvent(paused): %v", err)
+	} else if !ok {
+		t.Fatal("SetRuntimeIngressTransitionEvent(paused) ok = false, want true")
+	}
+	if state, err := pg.LoadRuntimeIngressState(ctx); err != nil {
+		t.Fatalf("LoadRuntimeIngressState(paused event): %v", err)
+	} else if state.TransitionEventID != pausedEventID {
+		t.Fatalf("paused transition event id = %q, want %q", state.TransitionEventID, pausedEventID)
+	}
 
 	state, changed, err = pg.TransitionRuntimeIngressState(ctx, runtimeingress.StatusPaused, "operator_request", "api.v1", now.Add(2*time.Second))
 	if err != nil {
@@ -46,6 +68,33 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 	}
 	if !changed || state.Status != runtimeingress.StatusRunning {
 		t.Fatalf("running transition = %#v changed=%v", state, changed)
+	}
+	runningAt := state.UpdatedAt
+	stalePausedEventID := "22222222-2222-2222-2222-222222222222"
+	if ok, err := pg.SetRuntimeIngressTransitionEvent(ctx, runtimeingress.StatusPaused, stalePausedEventID, pausedAt); err != nil {
+		t.Fatalf("SetRuntimeIngressTransitionEvent(stale paused): %v", err)
+	} else if ok {
+		t.Fatal("SetRuntimeIngressTransitionEvent(stale paused) ok = true, want false")
+	}
+	if state, err := pg.LoadRuntimeIngressState(ctx); err != nil {
+		t.Fatalf("LoadRuntimeIngressState(after stale event): %v", err)
+	} else if state.Status != runtimeingress.StatusRunning || state.TransitionEventID == stalePausedEventID {
+		t.Fatalf("state after stale event update = %#v", state)
+	}
+	runningEventID := "33333333-3333-3333-3333-333333333333"
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          runningEventID,
+		Type:        events.EventType("platform.resumed"),
+		SourceAgent: "runtime",
+		Payload:     []byte(`{}`),
+		CreatedAt:   runningAt,
+	}); err != nil {
+		t.Fatalf("AppendEvent(running): %v", err)
+	}
+	if ok, err := pg.SetRuntimeIngressTransitionEvent(ctx, runtimeingress.StatusRunning, runningEventID, runningAt); err != nil {
+		t.Fatalf("SetRuntimeIngressTransitionEvent(running): %v", err)
+	} else if !ok {
+		t.Fatal("SetRuntimeIngressTransitionEvent(running) ok = false, want true")
 	}
 
 	if _, _, err := pg.TransitionRuntimeIngressState(ctx, runtimeingress.Status("stopped"), "", "", now); err == nil {

--- a/internal/store/runtime_ingress_state_test.go
+++ b/internal/store/runtime_ingress_state_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimeingress "swarm/internal/runtime/ingress"
+	"swarm/internal/testutil"
+)
+
+func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+
+	state, err := pg.EnsureRuntimeIngressState(ctx, now)
+	if err != nil {
+		t.Fatalf("EnsureRuntimeIngressState: %v", err)
+	}
+	if state.Status != runtimeingress.StatusRunning {
+		t.Fatalf("initial status = %q, want running", state.Status)
+	}
+
+	state, changed, err := pg.TransitionRuntimeIngressState(ctx, runtimeingress.StatusPaused, "operator_request", "api.v1", now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("TransitionRuntimeIngressState(paused): %v", err)
+	}
+	if !changed || state.Status != runtimeingress.StatusPaused || state.Reason != "operator_request" || state.ControlledBy != "api.v1" {
+		t.Fatalf("paused transition = %#v changed=%v", state, changed)
+	}
+
+	state, changed, err = pg.TransitionRuntimeIngressState(ctx, runtimeingress.StatusPaused, "operator_request", "api.v1", now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("TransitionRuntimeIngressState(paused no-op): %v", err)
+	}
+	if changed || state.Status != runtimeingress.StatusPaused {
+		t.Fatalf("paused no-op = %#v changed=%v", state, changed)
+	}
+
+	state, changed, err = pg.TransitionRuntimeIngressState(ctx, runtimeingress.StatusRunning, "operator_request", "api.v1", now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("TransitionRuntimeIngressState(running): %v", err)
+	}
+	if !changed || state.Status != runtimeingress.StatusRunning {
+		t.Fatalf("running transition = %#v changed=%v", state, changed)
+	}
+
+	if _, _, err := pg.TransitionRuntimeIngressState(ctx, runtimeingress.Status("stopped"), "", "", now); err == nil {
+		t.Fatal("unsupported runtime ingress status error = nil")
+	}
+}

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -349,6 +349,8 @@ func platformTableOrder(name string) int {
 		return 100
 	case "api_idempotency":
 		return 105
+	case "runtime_ingress_state":
+		return 108
 	case "spend_ledger":
 		return 110
 	case "timers":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -539,6 +539,8 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 100
 	case "api_idempotency":
 		return 105
+	case "runtime_ingress_state":
+		return 108
 	case "spend_ledger":
 		return 110
 	case "timers":


### PR DESCRIPTION
## Summary

Closes #682.
Part of #677 and #665. Keeps run.stop, run.pause, and run.continue split to #683.

Implements the canonical runtime ingress owner approved by the #682 gate after #685:
- Adds `internal/runtime/ingress` as the typed owner for persisted `runtime_ingress_state`, `runtime.pause` / `runtime.resume`, `RUNTIME_ALREADY_PAUSED`, `RUNTIME_NOT_PAUSED`, `platform.paused`, and `platform.resumed`.
- Wires `/v1/rpc` `runtime.pause` and `runtime.resume` through API idempotency and the owner.
- Gates EventBus dispatch so queueable event-producing ingress is persisted while paused and released once on resume.
- Moves inbound webhook admission, MCP/tool fail-closed checks, dashboard/builder runtime actions, and auth-breaker safety pause consumption to the owner.
- Leaves runtimebus pause state only as owner-private/reset compatibility plumbing.

## Governing Context

Exact spec refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.runtime_ingress`
- `platform_tables.tables.runtime_ingress_state`
- `events.platform.paused` and `events.platform.resumed`
- `method_catalog.runtime.pause` and `method_catalog.runtime.resume`
- `components.errors.RUNTIME_ALREADY_PAUSED`, `RUNTIME_NOT_PAUSED`, and `IDEMPOTENCY_CONFLICT`

Semantic migration accounting:
- New canonical owner: `internal/runtime/ingress.Controller` plus `store.PostgresStore` `runtime_ingress_state` methods.
- Old producer/reader/writer paths now invalid as semantic owners: raw dashboard/builder runtimebus calls, inbound raw paused rejection, MCP raw paused rejection, auth-breaker direct pause/event emission, EventBus immediate paused dispatch.
- Production paths checked/moved: v1 RPC, dashboard `/api/runtime/actions`, builder runtime controller wrapper, inbound webhook, MCP/tool gateway, auth-breaker safety trigger, EventBus publish/replay/sweeper, platform event allowlist.
- Migration complete for #682 approved boundary; #683 remains the run-scoped lifecycle sibling.

## Tests

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/store -run 'TestRuntimeIngressStatePersistsTypedTransitions|TestGeneratePlatformTableDDLs' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency|TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusRuntimeIngressPauseQueuesAndResumeReleases|TestSweepUndispatched' -count=1`
- `go test ./internal/runtime ./internal/runtime/mcp ./internal/runtime/manager ./internal/dashboard/server ./internal/builder -run 'TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook|TestGatewayHandleTool_DeniesThroughRuntimeIngressOwnerRead|RuntimeAction|AuthBreaker|Pause|Resume' -count=1`
- `go test ./internal/apiv1 ./internal/runtime/bus ./internal/runtime ./internal/runtime/mcp ./internal/runtime/manager ./internal/dashboard/server ./internal/builder ./internal/store -count=1`
- `go test ./... -count=1`