### PR TITLE
[agent-d][issue #689] Add service-owned entity selection

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -619,7 +619,7 @@ handler_specification:
   dependency_graph:
     description: Arrows mean "must complete before". Steps at the same level are independent — the implementer may execute
       them in any order.
-    graph: "\ncreate_entity (optional — mint new entity before any state operations)\n  └→ query (optional — pre-fetch cross-entity\
+    graph: "\nentity acquisition (optional — create_entity mints a new entity; select_entity resolves exactly one target-flow-owned existing entity)\n  └→ query (optional — pre-fetch cross-entity\
       \ data into handler context)\n       └→ clear_gates (optional — reset gates before guard)\n            └→ guard\n            └→ accumulate\n                 └→ filter (optional — prune accumulated\
       \ items)\n                      └→ reduce (optional — aggregate filtered items to single value)\n                  \
       \         └→ count (optional — count items)\n                                └→ compute\n                          \
@@ -692,6 +692,46 @@ handler_specification:
         Without it, the first event arriving from outside the flow has no entity to write to unless the runtime creates one
         implicitly. create_entity makes this explicit and unambiguous. For dynamic instances (mode: template), entity
         creation happens in create_flow_instance step 9 — create_entity is not needed on those flows.'
+    select_entity:
+      field: select_entity
+      type: object
+      purpose: Resolve exactly one existing entity owned by the receiving flow before any other handler processing. This is
+        the service-owned acquisition primitive for stateful typed input-pin handlers where the incoming cross-flow request
+        addresses an existing target-flow resource by declared business key, not by source-provided entity identity.
+      default: absent — handler operates on the inbound event entity context unless create_entity is declared
+      when_to_use: When an event arriving from outside the flow represents a request against an already-existing service
+        entity owned by the receiving flow. Example — OpCo emits a typed spend event with vertical_id, and Treasury selects
+        its own budget entity whose vertical_id matches the payload. The source flow must not provide the target entity_id,
+        entity_type, or flow_instance.
+      schema:
+        by: map of target entity field name to explicit payload reference. Each key MUST be a declared field on the receiving
+          flow's entity contract. Each value MUST be a payload.* reference from the triggering event schema.
+      execution_position: First step in the dependency graph. Runs before query, guard, accumulate, data_accumulation,
+        advances_to, emit, and action. Establishes the entity context for the entire handler.
+      entity_selection:
+        ownership_scope: Only entities owned by the receiving flow are candidates. Source-flow entities, source event envelope
+          identity, arbitrary parent/child path inference, and caller-provided target entity identity are not authoritative.
+        matching: Every select_entity.by binding must match exactly one receiving-flow entity field value. Zero matches fail
+          closed. More than one match fails closed. Missing payload refs fail closed.
+        selected_context: The selected entity_id and flow_instance become the handler entity context for state, guard,
+          data_accumulation, emit.fields, and state transition processing.
+      restrictions:
+        lifecycle_scope: Valid only on stateful static-flow input-pin handlers. Stateless flows do not have stateful entity
+          acquisition. Template flows acquire entities through create_flow_instance.
+        with_create_entity: PROHIBITED. A handler must either mint a new entity with create_entity or select an existing
+          target-flow-owned entity with select_entity, never both.
+        source_authority: PROHIBITED. select_entity keys must not target platform envelope/control fields such as entity_id,
+          entity_type, flow_instance, current_state, workflow_name, or workflow_version. Payload refs must not be
+          payload.entity_id, payload.entity_type, or payload.flow_instance.
+        compatibility: PROHIBITED. select_entity does not restore generic existing-entity cross-flow continuation and does
+          not allow a source flow to directly name or mutate another flow's entity row.
+      interactions:
+        with_accumulate: ALLOWED. Accumulate operates on the selected target-flow-owned entity after acquisition.
+        with_guard: ALLOWED. Guards evaluate against the selected entity state before same-handler writes.
+        with_data_accumulation: ALLOWED. Writes are validated against the selected entity's receiving-flow contract and remain
+          subject to same-flow ownership enforcement.
+        with_advances_to: ALLOWED. State transitions advance only the selected receiving-flow entity.
+        with_query: ALLOWED. Query runs after acquisition and cannot replace select_entity ownership checks.
     guard:
       field: guard
       type: object — single check OR list of checks
@@ -1987,9 +2027,9 @@ engine:
     - id: handler_field_compliance
       severity: error
       scope: per-flow
-      trigger: A handler uses a field name not in the defined handler_fields set (create_entity, guard, accumulate, fan_out,
-        filter, reduce, count, compute, on_complete, rules, advances_to, sets_gate, data_accumulation, emit, action,
-        clear_gates, clear, query, description, evidence_target).
+      trigger: A handler uses a field name not in the defined handler_fields set (create_entity, select_entity, guard,
+        accumulate, fan_out, filter, reduce, count, compute, on_complete, rules, advances_to, sets_gate, data_accumulation,
+        emit, action, clear_gates, clear, query, description, evidence_target).
       when: boot-only
     - id: tool_resolution
       severity: warning
@@ -2031,7 +2071,8 @@ engine:
       severity: error
       scope: per-node
       trigger: A handler uses on_complete as a map (dict) instead of a list (ordered). Or uses both on_complete and rules
-        on the same handler. Or uses both create_entity and accumulate on the same handler.
+        on the same handler. Or uses both create_entity and accumulate on the same handler. Or uses both create_entity and
+        select_entity on the same handler.
       when: boot-only
     - id: single_node_per_event
       severity: error
@@ -2768,17 +2809,29 @@ flow_model:
         the owning flow. No flow_states disambiguation needed.'
     cross_flow_handoff:
       description: 'When a business object moves from one flow to the next, the transition is an explicit
-        handoff via events. The receiving flow creates its own entity.'
+        handoff via events. The receiving flow creates its own entity or, for service-owned request handlers,
+        selects one existing receiving-flow-owned entity by declared business key.'
       pattern:
       - '1. Source flow handler emits a cross-flow event (output pin). Example: scoring emits vertical.shortlisted.'
       - '2. Destination flow handler receives the event (input pin) with create_entity: true.'
       - '3. Destination creates its OWN entity row — new entity_id, own current_state, own fields.'
       - '4. Data from the source entity is passed via the event payload or create_flow_instance
         config_from bindings. Direct runtime entity reads do not cross flow ownership boundaries.'
-      enforcement: 'Input pin events that introduce a new business object into a static flow (mode: static)
-        with initial_state MUST use create_entity: true on the receiving handler. Boot error otherwise.
-        Exemptions: (1) stateless flows (initial_state: null) — no entity state machine. (2) Template flows
-        (mode: template) — entity creation happens via create_flow_instance, not create_entity.'
+      service_request_pattern:
+      - '1. Source flow emits a typed request event containing declared business keys, not target entity_id,
+        entity_type, or flow_instance.'
+      - '2. Destination static-flow input-pin handler declares select_entity.by bindings from payload.* to
+        receiving-flow entity fields.'
+      - '3. Runtime resolves exactly one receiving-flow-owned entity. Zero or multiple matches fail closed.
+        The selected entity becomes the handler context.'
+      - '4. Handler writes and transitions remain same-flow owned. select_entity does not authorize generic
+        cross-flow existing-entity continuation.'
+      enforcement: 'Input pin events into a stateful static flow (mode: static) MUST declare either
+        create_entity: true when the event introduces a new receiving-flow entity, or select_entity when the
+        event addresses exactly one existing receiving-flow-owned service entity by declared business key. Boot
+        error otherwise. Exemptions: (1) stateless flows (initial_state: null) — no entity state machine. (2)
+        Template flows (mode: template) — entity creation happens via create_flow_instance, not create_entity
+        or select_entity.'
     cross_flow_writes:
       description: 'Cross-flow entity writes are prohibited by the platform.'
       rule: 'save_entity_field checks that the target entity''s stored flow_instance resolves to the same
@@ -4526,6 +4579,9 @@ static_analyzer:
     source_state_derivation:
       create_entity_handlers:
         rule: create_entity handlers source from initial_state only.
+      select_entity_handlers:
+        rule: select_entity handlers source from all non-terminal declared states because they operate on an existing
+          receiving-flow-owned entity selected at runtime.
       non_create_entity_handlers:
         rule: non-create_entity handlers source from all non-terminal declared states.
       terminal_states:

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -238,6 +238,7 @@ var bootCheckRegistry = []Check{
 	{ID: "gate_schema_validation", Severity: "error", Run: checkGateSchemaValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "cross_flow_pin_ambiguity_validation", Severity: "error", Run: checkCrossFlowPinAmbiguityValidation},
+	{ID: "select_entity_validation", Severity: "error", Run: checkSelectEntityValidation},
 	{ID: "flow_boundary_create_entity_validation", Severity: "error", Run: checkFlowBoundaryCreateEntityValidation},
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3158,6 +3158,119 @@ func TestRun_AllowsCreateEntityForStatefulInputPinHandlers(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsSelectEntityForStatefulInputPinHandlers(t *testing.T) {
+	root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      select_entity:
+        by:
+          vertical_id: payload.vertical_id
+      data_accumulation:
+        writes:
+          - source_field: amount_usd
+            target_field: spent_usd
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "flow_boundary_create_entity_validation", "must declare create_entity: true") {
+		t.Fatalf("unexpected flow_boundary_create_entity_validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "select_entity_validation", "") {
+		t.Fatalf("unexpected select_entity_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSelectEntityWithSourceEnvelopeAuthority(t *testing.T) {
+	root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      select_entity:
+        by:
+          vertical_id: payload.entity_id
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "select_entity_validation", "must not use source envelope authority") {
+		t.Fatalf("expected select_entity source authority error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSelectEntityWithEnvelopeTargetField(t *testing.T) {
+	root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      select_entity:
+        by:
+          entity_id: payload.vertical_id
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "select_entity_validation", "is not an entity contract field selection target") {
+		t.Fatalf("expected select_entity envelope target field error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSelectEntityWithUndeclaredPayloadRef(t *testing.T) {
+	root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      select_entity:
+        by:
+          vertical_id: payload.missing_vertical_id
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "select_entity_validation", "references undeclared payload field") {
+		t.Fatalf("expected select_entity undeclared payload field error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSelectEntityWithCreateEntity(t *testing.T) {
+	root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      create_entity: true
+      select_entity:
+        by:
+          vertical_id: payload.vertical_id
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, filepath.Join(repoRootForBootverifyTest(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "select_entity_validation", "must not declare both create_entity and select_entity") {
+		t.Fatalf("expected create_entity/select_entity error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsTemplateFlowInputPinHandlersWithoutCreateEntity(t *testing.T) {
 	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-pin-wiring"))
 	flowID := "child"
@@ -3361,8 +3474,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 48 {
-		t.Fatalf("bootCheckRegistry count = %d, want 48", got)
+	if got := len(bootCheckRegistry); got != 49 {
+		t.Fatalf("bootCheckRegistry count = %d, want 49", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)
@@ -3452,6 +3565,56 @@ func repoRootForBootverifyTest(t *testing.T) string {
 		t.Fatalf("getwd: %v", err)
 	}
 	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+}
+
+func writeSelectEntityInputPinFixture(t *testing.T, treasuryNodes string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: select-entity-fixture
+version: 1.0.0
+platform_version: ">=1.1.0"
+flows:
+  - id: treasury
+    flow: treasury
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: select-entity-fixture\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+opco.spend_requested:
+  vertical_id: string
+  amount_usd: number
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "treasury", "schema.yaml"), `
+name: treasury
+mode: static
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events: [opco.spend_requested]
+  outputs:
+    events: []
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "treasury", "events.yaml"), `
+opco.spend_requested:
+  vertical_id: string
+  amount_usd: number
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "treasury", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "treasury", "entities.yaml"), `
+opco_budget:
+  vertical_id:
+    type: text
+  spent_usd:
+    type: number
+    initial: 0
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "treasury", "nodes.yaml"), treasuryNodes)
+	return root
 }
 
 func writeBootverifyFixtureFile(t *testing.T, path, contents string) {

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -6,6 +6,8 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
+	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -16,6 +18,9 @@ func checkCrossFlowPinAmbiguityValidation(c *checkerContext) []Finding {
 }
 func checkFlowBoundaryCreateEntityValidation(c *checkerContext) []Finding {
 	return c.flowBoundaryCreateEntityValidation()
+}
+func checkSelectEntityValidation(c *checkerContext) []Finding {
+	return c.selectEntityValidation()
 }
 
 func (c *checkerContext) writePinOwnership() []Finding {
@@ -422,6 +427,196 @@ func flowHasScopedInputEscapeHatch(source semanticview.Source, flowID, eventType
 	return false
 }
 
+func (c *checkerContext) selectEntityValidation() []Finding {
+	findings := []Finding{}
+	for flowID, schema := range c.source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		inputs := normalizeStringSet(c.source.FlowInputEvents(flowID))
+		scope, ok := c.source.FlowScopeByID(flowID)
+		if !ok {
+			continue
+		}
+		for nodeID, node := range scope.Nodes {
+			nodeID = strings.TrimSpace(nodeID)
+			for eventType, handler := range node.EventHandlers {
+				eventType = strings.TrimSpace(eventType)
+				if handler.SelectEntity == nil || handler.SelectEntity.Empty() {
+					continue
+				}
+				location := flowID
+				if handler.CreateEntity {
+					findings = append(findings, Finding{
+						CheckID:  "select_entity_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("flow %s handler %s on node %s must not declare both create_entity and select_entity", flowID, eventType, nodeID),
+						Location: location,
+					})
+				}
+				if strings.EqualFold(strings.TrimSpace(schema.Mode), "template") {
+					findings = append(findings, Finding{
+						CheckID:  "select_entity_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("flow %s handler %s on node %s uses select_entity, but template flows must use create_flow_instance routing rather than service-owned static entity selection", flowID, eventType, nodeID),
+						Location: location,
+					})
+				}
+				if strings.TrimSpace(schema.InitialState) == "" {
+					findings = append(findings, Finding{
+						CheckID:  "select_entity_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("flow %s handler %s on node %s uses select_entity, but stateless flows do not have stateful input-pin entity acquisition", flowID, eventType, nodeID),
+						Location: location,
+					})
+				}
+				if _, ok := inputs[eventType]; !ok {
+					findings = append(findings, Finding{
+						CheckID:  "select_entity_validation",
+						Severity: "error",
+						Message:  fmt.Sprintf("flow %s handler %s on node %s uses select_entity outside a declared input pin", flowID, eventType, nodeID),
+						Location: location,
+					})
+				}
+				findings = append(findings, validateSelectEntityBindings(c.source, flowID, eventType, nodeID, handler.SelectEntity)...)
+			}
+		}
+	}
+	return findings
+}
+
+func validateSelectEntityBindings(source semanticview.Source, flowID, eventType, nodeID string, spec *runtimecontracts.SelectEntitySpec) []Finding {
+	if spec == nil || spec.Empty() {
+		return nil
+	}
+	location := strings.TrimSpace(flowID)
+	contract, ok := entityruntime.ResolveForFlow(source, flowID)
+	if !ok {
+		return []Finding{{
+			CheckID:  "select_entity_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("flow %s handler %s on node %s uses select_entity but the target flow entity contract is unavailable", flowID, eventType, nodeID),
+			Location: location,
+		}}
+	}
+	findings := []Finding{}
+	seen := map[string]struct{}{}
+	for _, binding := range spec.Bindings {
+		field := strings.TrimSpace(binding.Field)
+		ref := strings.TrimSpace(binding.Ref)
+		if _, ok := seen[field]; ok {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s is declared more than once", flowID, eventType, nodeID, field),
+				Location: location,
+			})
+			continue
+		}
+		seen[field] = struct{}{}
+		if selectEntityReservedTargetField(field) {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s is not an entity contract field selection target", flowID, eventType, nodeID, field),
+				Location: location,
+			})
+			continue
+		}
+		if _, err := entityruntime.ResolveLeafField(contract, field); err != nil {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s is invalid: %v", flowID, eventType, nodeID, field, err),
+				Location: location,
+			})
+		}
+		parsed := binding.RefPath
+		if parsed.IsZero() {
+			parsed = paths.Parse(ref)
+		}
+		if !parsed.HasExplicitRoot() || parsed.Root != paths.RootPayload {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s must resolve from payload.*, got %q", flowID, eventType, nodeID, field, ref),
+				Location: location,
+			})
+			continue
+		}
+		if len(parsed.Segments) == 0 {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s has an empty payload ref", flowID, eventType, nodeID, field),
+				Location: location,
+			})
+			continue
+		}
+		if selectEntityReservedPayloadRef(parsed) {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s must not use source envelope authority %q", flowID, eventType, nodeID, field, ref),
+				Location: location,
+			})
+			continue
+		}
+		if !selectEntityPayloadFieldDeclared(source, flowID, eventType, parsed.Segments[0]) {
+			findings = append(findings, Finding{
+				CheckID:  "select_entity_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s handler %s on node %s select_entity field %s references undeclared payload field %q", flowID, eventType, nodeID, field, parsed.Segments[0]),
+				Location: location,
+			})
+		}
+	}
+	return findings
+}
+
+func selectEntityReservedTargetField(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "entity_type", "flow_instance", "current_state", "workflow_name", "workflow_version":
+		return true
+	default:
+		return false
+	}
+}
+
+func selectEntityPayloadFieldDeclared(source semanticview.Source, flowID, eventType, field string) bool {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return false
+	}
+	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+	if !resolution.HasSchema {
+		return false
+	}
+	rawProps, ok := resolution.Schema.Schema["properties"]
+	if !ok || rawProps == nil {
+		return false
+	}
+	props, ok := rawProps.(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = props[field]
+	return ok
+}
+
+func selectEntityReservedPayloadRef(parsed paths.Path) bool {
+	if parsed.Root != paths.RootPayload || len(parsed.Segments) == 0 {
+		return false
+	}
+	switch strings.TrimSpace(parsed.Segments[0]) {
+	case "entity_id", "entity_type", "flow_instance":
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 	if c.flowBoundaryCreateEntityLoaded {
 		return c.flowBoundaryCreateEntityFindings
@@ -459,10 +654,13 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 				if handler.CreateEntity {
 					continue
 				}
+				if handler.SelectEntity != nil && !handler.SelectEntity.Empty() {
+					continue
+				}
 				c.flowBoundaryCreateEntityFindings = append(c.flowBoundaryCreateEntityFindings, Finding{
 					CheckID:  "flow_boundary_create_entity_validation",
 					Severity: "error",
-					Message:  fmt.Sprintf("flow %s input pin handler %s on node %s must declare create_entity: true", flowID, eventType, nodeID),
+					Message:  fmt.Sprintf("flow %s input pin handler %s on node %s must declare create_entity: true or select_entity", flowID, eventType, nodeID),
 					Location: flowID,
 				})
 			}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -106,6 +106,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				FlowID:           strings.TrimSpace(source.FlowID),
 				EventType:        rawEventType,
 				Action:           handler.Action,
+				SelectEntity:     handler.SelectEntity,
 				Guard:            handler.Guard,
 				AdvancesTo:       strings.TrimSpace(handler.AdvancesTo),
 				SetsGate:         handler.SetsGate,

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -107,6 +107,7 @@ type HandlerTransitionSemantic struct {
 	FlowID           string
 	EventType        string
 	Action           ActionSpec
+	SelectEntity     *SelectEntitySpec
 	Guard            *GuardSpec
 	AdvancesTo       string
 	SetsGate         *GateSpec
@@ -239,6 +240,21 @@ type ConfigBinding struct {
 	Key     string
 	Ref     string
 	RefPath paths.Path
+}
+
+type SelectEntitySpec struct {
+	By       map[string]string        `yaml:"by"`
+	Bindings []SelectEntityKeyBinding `yaml:"-"`
+}
+
+type SelectEntityKeyBinding struct {
+	Field   string
+	Ref     string
+	RefPath paths.Path
+}
+
+func (s *SelectEntitySpec) Empty() bool {
+	return s == nil || len(s.Bindings) == 0
 }
 
 func cloneStringMap(in map[string]string) map[string]string {
@@ -829,6 +845,7 @@ type SystemNodeContract struct {
 type SystemNodeEventHandler struct {
 	Action           ActionSpec               `yaml:"action"`
 	CreateEntity     bool                     `yaml:"create_entity"`
+	SelectEntity     *SelectEntitySpec        `yaml:"select_entity"`
 	Description      string                   `yaml:"description"`
 	EvidenceTarget   string                   `yaml:"evidence_target"`
 	Emit             EmitSpec                 `yaml:"emit"`

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -282,6 +282,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 	var aux struct {
 		Action           yaml.Node                `yaml:"action"`
 		CreateEntity     bool                     `yaml:"create_entity"`
+		SelectEntity     yaml.Node                `yaml:"select_entity"`
 		Template         string                   `yaml:"template"`
 		InstanceIDFrom   string                   `yaml:"instance_id_from"`
 		ConfigFrom       yaml.Node                `yaml:"config_from"`
@@ -332,6 +333,9 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		Count:            aux.Count,
 	}
 	var err error
+	if h.SelectEntity, err = decodeSelectEntitySpecNode(&aux.SelectEntity); err != nil {
+		return err
+	}
 	if h.Action, err = decodeActionSpecNode(&aux.Action); err != nil {
 		return err
 	}
@@ -611,6 +615,7 @@ func validateHandlerFieldNodes(node *yaml.Node) error {
 		"_note":             {},
 		"evidence_target":   {},
 		"create_entity":     {},
+		"select_entity":     {},
 		"emit":              {},
 		"guard":             {},
 		"advances_to":       {},
@@ -786,6 +791,57 @@ func decodeQuerySpecNode(node *yaml.Node) (*QuerySpec, error) {
 	default:
 		return nil, fmt.Errorf("unsupported query yaml node kind %d", node.Kind)
 	}
+}
+
+func decodeSelectEntitySpecNode(node *yaml.Node) (*SelectEntitySpec, error) {
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("INVALID-SELECT-ENTITY: select_entity must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"by": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return nil, fmt.Errorf("UNDEFINED-FIELD: select_entity field %q not in platform spec", key)
+		}
+	}
+	var aux struct {
+		By map[string]string `yaml:"by"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return nil, err
+	}
+	if len(aux.By) == 0 {
+		return nil, fmt.Errorf("INVALID-SELECT-ENTITY: select_entity.by must declare at least one binding")
+	}
+	spec := &SelectEntitySpec{
+		By:       cloneStringMap(aux.By),
+		Bindings: make([]SelectEntityKeyBinding, 0, len(aux.By)),
+	}
+	for field, ref := range aux.By {
+		field = strings.TrimSpace(field)
+		ref = strings.TrimSpace(ref)
+		if field == "" {
+			return nil, fmt.Errorf("INVALID-SELECT-ENTITY: select_entity.by contains an empty entity field")
+		}
+		if ref == "" {
+			return nil, fmt.Errorf("INVALID-SELECT-ENTITY: select_entity.by.%s requires a payload ref", field)
+		}
+		parsed := paths.Parse(ref)
+		spec.Bindings = append(spec.Bindings, SelectEntityKeyBinding{
+			Field:   field,
+			Ref:     ref,
+			RefPath: parsed,
+		})
+	}
+	return spec, nil
 }
 
 func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -440,6 +440,43 @@ emit: scoring.requested
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_PreservesSelectEntity(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+select_entity:
+  by:
+    vertical_id: payload.vertical_id
+emit: treasury.spend_approved
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if handler.SelectEntity == nil {
+		t.Fatal("expected select_entity to decode")
+	}
+	if got := len(handler.SelectEntity.Bindings); got != 1 {
+		t.Fatalf("len(select_entity bindings) = %d, want 1", got)
+	}
+	binding := handler.SelectEntity.Bindings[0]
+	if binding.Field != "vertical_id" || binding.Ref != "payload.vertical_id" {
+		t.Fatalf("binding = %+v, want vertical_id -> payload.vertical_id", binding)
+	}
+	if binding.RefPath.Root.String() != "payload" {
+		t.Fatalf("binding root = %q, want payload", binding.RefPath.Root.String())
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnknownSelectEntityField(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+select_entity:
+  where:
+    vertical_id: payload.vertical_id
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
 func TestHandlerRuleEntryDecode_RejectsEmitFieldsWithoutEvent(t *testing.T) {
 	var rule HandlerRuleEntry
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -136,6 +136,9 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	if req.Handler.CreateEntity && req.Handler.Accumulate != nil {
 		return fmt.Errorf("%w: handler declares both create_entity and accumulate", ErrInvalidConfig)
 	}
+	if req.Handler.CreateEntity && req.Handler.SelectEntity != nil && !req.Handler.SelectEntity.Empty() {
+		return fmt.Errorf("%w: handler declares both create_entity and select_entity", ErrInvalidConfig)
+	}
 	if err := validateHandlerComputeSpecs(req.Handler); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -315,6 +315,31 @@ func TestExecutor_ValidateRequestRejectsCreateEntityWithAccumulate(t *testing.T)
 	}
 }
 
+func TestExecutor_ValidateRequestRejectsCreateEntityWithSelectEntity(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	err = exec.ValidateRequest(ExecutionRequest{
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			CreateEntity: true,
+			SelectEntity: &runtimecontracts.SelectEntitySpec{
+				Bindings: []runtimecontracts.SelectEntityKeyBinding{{Field: "vertical_id", Ref: "payload.vertical_id"}},
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "declares both create_entity and select_entity") {
+		t.Fatalf("ValidateRequest error = %v, want create_entity/select_entity error", err)
+	}
+}
+
 func TestExecutor_ValidateRequestRejectsTieredWeightedAverageWithoutDimensionKey(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSource(),

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -151,9 +151,18 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 		workflowEventEntityID(triggerCtx.Event),
 		triggerCtx.State.EntityID,
 	))
+	source := pc.SemanticSource()
+	if handler.SelectEntity != nil && !handler.SelectEntity.Empty() {
+		selected, err := pc.selectHandlerEntityForFlow(ctx, flowID, nodeID, handler, triggerCtx.Event)
+		if err != nil {
+			return contractHandlerExecutionResult{}, err
+		}
+		entityID = selected.EntityID
+		triggerCtx.Event = selected.Event
+		triggerCtx.State = selected.State
+	}
 	originalEntityID := entityID
 	originalStateEntityID := strings.TrimSpace(triggerCtx.State.EntityID)
-	source := pc.SemanticSource()
 	entityID, triggerCtx.Event = resolveHandlerEntityIDForFlow(source, flowID, handler, entityID, triggerCtx.Event, &triggerCtx.State)
 	if !handler.CreateEntity && entityID != "" && originalStateEntityID != "" && originalStateEntityID != entityID {
 		triggerCtx.State = pc.currentWorkflowState(ctx, entityID)

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -284,6 +284,14 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 	}
 	entityID := workflowEventEntityID(evt)
 	flowID := workflowNodeFlowID(e.coordinator.SemanticSource(), e.nodeID)
+	if handler.SelectEntity != nil && !handler.SelectEntity.Empty() {
+		selected, err := e.coordinator.selectHandlerEntityForFlow(ctx, flowID, e.nodeID, handler, evt)
+		if err != nil {
+			return nil, err
+		}
+		entityID = selected.EntityID
+		evt = selected.Event
+	}
 	entityID, evt = ensureHandlerEntityID(e.coordinator.SemanticSource(), flowID, handler, entityID, evt)
 	ctx = withPipelineFlowScope(ctx, flowID)
 	currentState := e.coordinator.currentWorkflowState(ctx, entityID)

--- a/internal/runtime/pipeline/select_entity.go
+++ b/internal/runtime/pipeline/select_entity.go
@@ -7,6 +7,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/entityruntime"
 )
@@ -33,7 +34,12 @@ func (pc *PipelineCoordinator) selectHandlerEntityForFlow(ctx context.Context, f
 	if err != nil {
 		return selectedHandlerEntity{}, fmt.Errorf("select_entity_invalid: node %s flow %s: %w", nodeID, flowID, err)
 	}
-	candidates, err := pc.workflowStore.List(ctx)
+	candidates, err := pc.workflowStore.selectActiveByFields(
+		ctx,
+		runtimeflowidentity.ScopeKey(pc.SemanticSource(), flowID),
+		selectEntityFieldSelectors(expected),
+		selectEntityTerminalStates(pc, flowID),
+	)
 	if err != nil {
 		return selectedHandlerEntity{}, fmt.Errorf("select_entity_lookup_failed: node %s flow %s: %w", nodeID, flowID, err)
 	}
@@ -106,4 +112,27 @@ func selectEntityCandidateMatches(candidate WorkflowInstance, expected map[strin
 		}
 	}
 	return true
+}
+
+func selectEntityFieldSelectors(expected map[string]any) []workflowInstanceFieldSelector {
+	out := make([]workflowInstanceFieldSelector, 0, len(expected))
+	for field, value := range expected {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		out = append(out, workflowInstanceFieldSelector{Field: field, Value: value})
+	}
+	return out
+}
+
+func selectEntityTerminalStates(pc *PipelineCoordinator, flowID string) []string {
+	if pc == nil {
+		return nil
+	}
+	source := pc.SemanticSource()
+	if source == nil {
+		return nil
+	}
+	return source.FlowTerminalStages(flowID)
 }

--- a/internal/runtime/pipeline/select_entity.go
+++ b/internal/runtime/pipeline/select_entity.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/events"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/values"
+	"swarm/internal/runtime/entityruntime"
+)
+
+type selectedHandlerEntity struct {
+	EntityID string
+	State    WorkflowState
+	Event    events.Event
+}
+
+func (pc *PipelineCoordinator) selectHandlerEntityForFlow(ctx context.Context, flowID, nodeID string, handler runtimecontracts.SystemNodeEventHandler, evt events.Event) (selectedHandlerEntity, error) {
+	if handler.SelectEntity == nil || handler.SelectEntity.Empty() {
+		return selectedHandlerEntity{}, nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	nodeID = strings.TrimSpace(nodeID)
+	if handler.CreateEntity {
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_invalid: node %s flow %s declares both create_entity and select_entity", nodeID, flowID)
+	}
+	if pc == nil || pc.workflowStore == nil || !pc.workflowStore.Enabled() {
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_unavailable: workflow instance store is required for node %s flow %s", nodeID, flowID)
+	}
+	expected, err := selectEntityExpectedValues(handler.SelectEntity, evt)
+	if err != nil {
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_invalid: node %s flow %s: %w", nodeID, flowID, err)
+	}
+	candidates, err := pc.workflowStore.List(ctx)
+	if err != nil {
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_lookup_failed: node %s flow %s: %w", nodeID, flowID, err)
+	}
+	matches := make([]WorkflowInstance, 0, 1)
+	for _, candidate := range candidates {
+		if !workflowInstanceOwnedByFlow(pc.SemanticSource(), candidate, flowID) {
+			continue
+		}
+		if !selectEntityCandidateMatches(candidate, expected) {
+			continue
+		}
+		matches = append(matches, candidate)
+	}
+	switch len(matches) {
+	case 0:
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_no_match: node %s flow %s found no %s entity matching declared key", nodeID, flowID, flowID)
+	case 1:
+	default:
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_ambiguous: node %s flow %s found %d entities matching declared key", nodeID, flowID, len(matches))
+	}
+	selected := matches[0]
+	entityID := strings.TrimSpace(FlowInstanceEntityID(selected.StorageRef))
+	if entityID == "" {
+		entityID = strings.TrimSpace(selected.InstanceID)
+	}
+	if entityID == "" {
+		return selectedHandlerEntity{}, fmt.Errorf("select_entity_no_match: node %s flow %s selected entity has empty entity_id", nodeID, flowID)
+	}
+	state := pc.currentWorkflowState(ctx, entityID)
+	if strings.TrimSpace(state.EntityID) == "" {
+		state.EntityID = entityID
+	}
+	selectedEvent := evt.WithEntityID(entityID)
+	if storageRef := strings.TrimSpace(selected.StorageRef); storageRef != "" {
+		selectedEvent = selectedEvent.WithFlowInstance(storageRef)
+	}
+	return selectedHandlerEntity{
+		EntityID: entityID,
+		State:    state,
+		Event:    selectedEvent,
+	}, nil
+}
+
+func selectEntityExpectedValues(spec *runtimecontracts.SelectEntitySpec, evt events.Event) (map[string]any, error) {
+	payload := values.NewContext().WithPayload(parsePayloadMap(evt.Payload))
+	out := make(map[string]any, len(spec.Bindings))
+	for _, binding := range spec.Bindings {
+		field := strings.TrimSpace(binding.Field)
+		ref := strings.TrimSpace(binding.Ref)
+		if field == "" || ref == "" {
+			return nil, fmt.Errorf("empty select_entity binding")
+		}
+		value, ok := payload.Lookup(binding.RefPath)
+		if !ok {
+			return nil, fmt.Errorf("missing required payload ref %q for field %s", ref, field)
+		}
+		out[field] = value
+	}
+	return out, nil
+}
+
+func selectEntityCandidateMatches(candidate WorkflowInstance, expected map[string]any) bool {
+	for field, value := range expected {
+		actual, ok := entityruntime.PathValue(candidate.Metadata, field)
+		if !ok {
+			return false
+		}
+		if !workflowJSONValuesEqual(actual, value) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -1,0 +1,268 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"sync"
+	"testing"
+
+	"swarm/internal/events"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/testutil"
+)
+
+func TestExecuteNodeContractHandlerSelectEntityUpdatesTargetOwnedEntity(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	budgetEntityID := seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
+
+	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}),
+		}.WithEntityID("22222222-2222-2222-2222-222222222222"),
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected selected handler to run")
+	}
+
+	instance, ok, err := pc.workflowStore.Load(ctx, budgetEntityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected budget entity to exist")
+	}
+	if got := instance.Metadata["spent_usd"]; got != float64(42) && got != 42 {
+		t.Fatalf("spent_usd = %#v, want 42", got)
+	}
+	if got := FlowInstanceEntityID(instance.StorageRef); got != budgetEntityID {
+		t.Fatalf("selected entity storage identity = %q, want %q", got, budgetEntityID)
+	}
+	assertEntityStateRowCount(t, db, 1)
+}
+
+func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	budgetEntityID := seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
+
+	for _, amount := range []int{42, 99} {
+		result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+			Event: events.Event{
+				Type:    events.EventType("opco.spend_recorded"),
+				Payload: mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}),
+			}.WithEntityID("22222222-2222-2222-2222-222222222222"),
+			State: WorkflowState{},
+		}, false)
+		if err != nil {
+			t.Fatalf("executeNodeContractHandler amount %d: %v", amount, err)
+		}
+		if !result.Handled {
+			t.Fatalf("expected selected handler to run for amount %d", amount)
+		}
+		assertEntityStateRowCount(t, db, 1)
+	}
+
+	instance, ok, err := pc.workflowStore.Load(ctx, budgetEntityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected budget entity to exist")
+	}
+	if got := instance.Metadata["spent_usd"]; got != float64(99) && got != 99 {
+		t.Fatalf("spent_usd after replay = %#v, want 99", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
+
+	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"vertical_id": "missing", "amount_usd": 42}),
+		},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "select_entity_no_match") {
+		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_no_match", err)
+	}
+}
+
+func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnMissingPayloadRef(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
+
+	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"amount_usd": 42}),
+		},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "missing required payload ref") {
+		t.Fatalf("executeNodeContractHandler error = %v, want missing payload ref", err)
+	}
+}
+
+func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnAmbiguousMatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-1", "vertical-1", 0)
+	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-2", "vertical-1", 0)
+
+	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}),
+		},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "select_entity_ambiguous") {
+		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_ambiguous", err)
+	}
+}
+
+func newSelectEntityTestCoordinator(t *testing.T, db *sql.DB) (*PipelineCoordinator, semanticview.Source) {
+	t.Helper()
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `
+name: runtime-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: treasury
+    flow: treasury
+    mode: static
+`,
+		"schema.yaml": "name: runtime-test\n",
+		"flows/treasury/schema.yaml": `
+name: treasury
+mode: static
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events: [opco.spend_recorded]
+`,
+		"flows/treasury/events.yaml": `
+opco.spend_recorded:
+  vertical_id: string
+  amount_usd: number
+`,
+		"flows/treasury/entities.yaml": `
+opco_budget:
+  vertical_id:
+    type: text
+  spent_usd:
+    type: number
+    initial: 0
+`,
+		"flows/treasury/nodes.yaml": `
+treasury-orchestrator:
+  id: treasury-orchestrator
+  execution_type: system_node
+  subscribes_to: [opco.spend_recorded]
+`,
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected temp workflow bundle")
+	}
+	pc := &PipelineCoordinator{
+		bus:            &recordingPipelineBus{},
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("treasury", []WorkflowStage{
+				{Name: "active"},
+			}, nil),
+		},
+	}
+	return pc, source
+}
+
+func selectEntitySpendHandler() runtimecontracts.SystemNodeEventHandler {
+	return runtimecontracts.SystemNodeEventHandler{
+		SelectEntity: &runtimecontracts.SelectEntitySpec{
+			By: map[string]string{"vertical_id": "payload.vertical_id"},
+			Bindings: []runtimecontracts.SelectEntityKeyBinding{{
+				Field:   "vertical_id",
+				Ref:     "payload.vertical_id",
+				RefPath: runtimecontracts.RefExpression("payload.vertical_id").RefPath,
+			}},
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				SourceField: "amount_usd",
+				TargetField: "spent_usd",
+			}},
+		},
+	}
+}
+
+func seedSelectEntityBudget(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, verticalID string, spent any) string {
+	t.Helper()
+	return seedSelectEntityBudgetWithInstance(t, store, ctx, source, "budget-1", verticalID, spent)
+}
+
+func seedSelectEntityBudgetWithInstance(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID, verticalID string, spent any) string {
+	t.Helper()
+	identity := DeriveFlowInstanceIdentity(source, "treasury", instanceID)
+	instance := WorkflowInstance{
+		InstanceID:      identity.EntityID,
+		StorageRef:      identity.InstancePath,
+		WorkflowName:    "treasury",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "active",
+		Metadata: map[string]any{
+			"flow_path":   identity.InstancePath,
+			"instance_id": identity.InstanceID,
+			"vertical_id": verticalID,
+			"spent_usd":   spent,
+			"storage_ref": identity.InstancePath,
+			"entity_type": "opco_budget",
+		},
+	}
+	if err := store.Upsert(ctx, instance); err != nil {
+		t.Fatalf("seed budget entity: %v", err)
+	}
+	return identity.EntityID
+}
+
+func assertEntityStateRowCount(t *testing.T, db *sql.DB, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM entity_state`).Scan(&got); err != nil {
+		t.Fatalf("count entity_state: %v", err)
+	}
+	if got != want {
+		t.Fatalf("entity_state row count = %d, want %d", got, want)
+	}
+}

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -88,6 +89,73 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 	}
 }
 
+func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatches(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	activeBudgetID := seedSelectEntityBudgetWithState(t, pc.workflowStore, ctx, source, "budget-active", "vertical-1", 0, "active")
+	terminalBudgetID := seedSelectEntityBudgetWithState(t, pc.workflowStore, ctx, source, "budget-archived", "vertical-1", 10, "archived")
+	terminatedBudgetID := seedSelectEntityBudgetWithState(t, pc.workflowStore, ctx, source, "budget-terminated", "vertical-1", 20, "active")
+	terminated, ok, err := pc.workflowStore.Load(ctx, terminatedBudgetID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load terminated: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected terminated budget entity to exist")
+	}
+	if err := pc.workflowStore.MarkTerminated(ctx, terminated.StorageRef, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkTerminated: %v", err)
+	}
+
+	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}),
+		},
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected selected handler to run")
+	}
+
+	active, ok, err := pc.workflowStore.Load(ctx, activeBudgetID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load active: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected active budget entity to exist")
+	}
+	if got := active.Metadata["spent_usd"]; got != float64(42) && got != 42 {
+		t.Fatalf("active spent_usd = %#v, want 42", got)
+	}
+	terminal, ok, err := pc.workflowStore.Load(ctx, terminalBudgetID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load terminal: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected terminal budget entity to exist")
+	}
+	if got := terminal.Metadata["spent_usd"]; got != float64(10) && got != 10 {
+		t.Fatalf("terminal spent_usd = %#v, want unchanged 10", got)
+	}
+	reloadedTerminated, ok, err := pc.workflowStore.Load(ctx, terminatedBudgetID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load terminated after select: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected terminated budget entity to exist")
+	}
+	if got := reloadedTerminated.Metadata["spent_usd"]; got != float64(20) && got != 20 {
+		t.Fatalf("terminated spent_usd = %#v, want unchanged 20", got)
+	}
+	assertEntityStateRowCount(t, db, 3)
+}
+
 func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -163,7 +231,8 @@ flows:
 name: treasury
 mode: static
 initial_state: active
-states: [active]
+states: [active, archived]
+terminal_states: [archived]
 pins:
   inputs:
     events: [opco.spend_recorded]
@@ -234,13 +303,18 @@ func seedSelectEntityBudget(t *testing.T, store *WorkflowInstanceStore, ctx cont
 
 func seedSelectEntityBudgetWithInstance(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID, verticalID string, spent any) string {
 	t.Helper()
+	return seedSelectEntityBudgetWithState(t, store, ctx, source, instanceID, verticalID, spent, "active")
+}
+
+func seedSelectEntityBudgetWithState(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID, verticalID string, spent any, currentState string) string {
+	t.Helper()
 	identity := DeriveFlowInstanceIdentity(source, "treasury", instanceID)
 	instance := WorkflowInstance{
 		InstanceID:      identity.EntityID,
 		StorageRef:      identity.InstancePath,
 		WorkflowName:    "treasury",
 		WorkflowVersion: "1.0.0",
-		CurrentState:    "active",
+		CurrentState:    strings.TrimSpace(currentState),
 		Metadata: map[string]any{
 			"flow_path":   identity.InstancePath,
 			"instance_id": identity.InstanceID,

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
@@ -87,6 +88,54 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 	if got := instance.Metadata["spent_usd"]; got != float64(99) && got != 99 {
 		t.Fatalf("spent_usd after replay = %#v, want 99", got)
 	}
+}
+
+func TestBackgroundWorkflowNodeSelectEntityDuplicateSameEventIsReceiptIdempotent(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	pc.eventReceiptsCapability = eventReceiptsCapabilityStub{enabled: true}.resolve
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	budgetEntityID := seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
+	evt := seedSelectEntitySpendEvent(t, db, ctx, map[string]any{"vertical_id": "vertical-1", "amount_usd": 42})
+	runner := newSelectEntityBackgroundNode(t, pc, source, db)
+	runner.SetRetryPolicyForTest(1, func(int) time.Duration { return 0 })
+
+	runner.ProcessEventForTest(ctx, evt)
+	instance, ok, err := pc.workflowStore.Load(ctx, budgetEntityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load after first delivery: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected budget entity to exist after first delivery")
+	}
+	if got := instance.Metadata["spent_usd"]; got != float64(42) && got != 42 {
+		t.Fatalf("spent_usd after first delivery = %#v, want 42", got)
+	}
+
+	if err := pc.workflowStore.Mutate(ctx, budgetEntityID, func(instance *WorkflowInstance) {
+		if instance.Metadata == nil {
+			instance.Metadata = map[string]any{}
+		}
+		instance.Metadata["spent_usd"] = 7
+	}); err != nil {
+		t.Fatalf("workflowStore.Mutate between duplicate deliveries: %v", err)
+	}
+
+	runner.ProcessEventForTest(ctx, evt)
+	instance, ok, err = pc.workflowStore.Load(ctx, budgetEntityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load after duplicate delivery: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected budget entity to exist after duplicate delivery")
+	}
+	if got := instance.Metadata["spent_usd"]; got != float64(7) && got != 7 {
+		t.Fatalf("spent_usd after duplicate same-event delivery = %#v, want unchanged 7", got)
+	}
+	assertSelectEntityReceiptRow(t, db, evt.ID, "treasury-orchestrator")
+	assertEntityStateRowCount(t, db, 1)
 }
 
 func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatches(t *testing.T) {
@@ -255,6 +304,15 @@ treasury-orchestrator:
   id: treasury-orchestrator
   execution_type: system_node
   subscribes_to: [opco.spend_recorded]
+  event_handlers:
+    opco.spend_recorded:
+      select_entity:
+        by:
+          vertical_id: payload.vertical_id
+      data_accumulation:
+        writes:
+          - source_field: amount_usd
+            target_field: spent_usd
 `,
 	})
 	bundle, ok := semanticview.Bundle(source)
@@ -277,6 +335,23 @@ treasury-orchestrator:
 	return pc, source
 }
 
+func newSelectEntityBackgroundNode(t *testing.T, pc *PipelineCoordinator, source semanticview.Source, db *sql.DB) *backgroundWorkflowNode {
+	t.Helper()
+	contract, ok := source.NodeEntries()["treasury-orchestrator"]
+	if !ok {
+		t.Fatal("expected treasury-orchestrator node contract")
+	}
+	executor := NewNode(contract, pc.SemanticSource(), newCoordinatorHandlerExecutionEngine(pc, "treasury-orchestrator"), nil)
+	if executor == nil {
+		t.Fatal("expected treasury-orchestrator node executor")
+	}
+	runner := newBackgroundWorkflowNodeWithRetryBase(executor, &recordingPipelineBus{}, db, pc.eventReceiptsCapability, 0)
+	if runner == nil {
+		t.Fatal("expected treasury-orchestrator background runner")
+	}
+	return runner
+}
+
 func selectEntitySpendHandler() runtimecontracts.SystemNodeEventHandler {
 	return runtimecontracts.SystemNodeEventHandler{
 		SelectEntity: &runtimecontracts.SelectEntitySpec{
@@ -294,6 +369,25 @@ func selectEntitySpendHandler() runtimecontracts.SystemNodeEventHandler {
 			}},
 		},
 	}
+}
+
+func seedSelectEntitySpendEvent(t *testing.T, db *sql.DB, ctx context.Context, payload map[string]any) events.Event {
+	t.Helper()
+	entityID := uuid.NewString()
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		Type:        events.EventType("opco.spend_recorded"),
+		SourceAgent: "opco",
+		Payload:     mustJSON(payload),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2, $3::uuid, 'opco/vertical-1', 'entity', $4::jsonb, 'opco', 'node', now())
+	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
+		t.Fatalf("seed select_entity spend event: %v", err)
+	}
+	return evt
 }
 
 func seedSelectEntityBudget(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, verticalID string, spent any) string {
@@ -328,6 +422,24 @@ func seedSelectEntityBudgetWithState(t *testing.T, store *WorkflowInstanceStore,
 		t.Fatalf("seed budget entity: %v", err)
 	}
 	return identity.EntityID
+}
+
+func assertSelectEntityReceiptRow(t *testing.T, db *sql.DB, eventID, nodeID string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND idempotency_key = $2 || ':' || $1
+	`, eventID, nodeID).Scan(&count); err != nil {
+		t.Fatalf("count select_entity event_receipts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("select_entity event_receipts rows = %d, want 1", count)
+	}
 }
 
 func assertEntityStateRowCount(t *testing.T, db *sql.DB, want int) {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -92,6 +93,11 @@ type WorkflowInstanceStore struct {
 	db *sql.DB
 }
 
+type workflowInstanceFieldSelector struct {
+	Field string
+	Value any
+}
+
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
 const workflowInstanceTimerOwnerNode = "workflow_instance_store"
@@ -148,6 +154,13 @@ func (s *WorkflowInstanceStore) List(ctx context.Context) ([]WorkflowInstance, e
 		return nil, nil
 	}
 	return s.listSpec(ctx)
+}
+
+func (s *WorkflowInstanceStore) selectActiveByFields(ctx context.Context, scopeKey string, selectors []workflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	return s.selectActiveByFieldsSpec(ctx, scopeKey, selectors, excludedStates)
 }
 
 func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowInstance) error {
@@ -411,6 +424,61 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 	if err != nil {
 		return nil, err
 	}
+	return s.querySpec(ctx, runID, `
+		WHERE es.run_id = $1::uuid
+		ORDER BY es.created_at ASC
+	`, runID)
+}
+
+func (s *WorkflowInstanceStore) selectActiveByFieldsSpec(ctx context.Context, scopeKey string, selectors []workflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scopeKey = strings.Trim(strings.TrimSpace(scopeKey), "/")
+	if scopeKey == "" {
+		return nil, nil
+	}
+	selectors = normalizeWorkflowInstanceFieldSelectors(selectors)
+	if len(selectors) == 0 {
+		return nil, nil
+	}
+	args := []any{runID, scopeKey, scopeKey + "/%"}
+	var where strings.Builder
+	where.WriteString(`
+		WHERE es.run_id = $1::uuid
+		  AND (es.flow_instance = $2 OR es.flow_instance LIKE $3)
+		  AND COALESCE(fi.status, 'active') NOT IN ('terminated', 'inactive')
+		  AND fi.terminated_at IS NULL
+	`)
+	terminalStates := normalizeWorkflowInstanceExcludedStates(excludedStates)
+	if len(terminalStates) > 0 {
+		args = append(args, pq.Array(terminalStates))
+		where.WriteString(fmt.Sprintf(`
+		  AND NOT (LOWER(COALESCE(es.current_state, '')) = ANY($%d::text[]))
+		`, len(args)))
+	}
+	for _, selector := range selectors {
+		segments := workflowInstanceFieldSelectorPath(selector.Field)
+		if len(segments) == 0 {
+			return nil, fmt.Errorf("workflow instance selector field is required")
+		}
+		valueJSON, err := json.Marshal(selector.Value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal workflow instance selector %s: %w", selector.Field, err)
+		}
+		args = append(args, pq.Array(segments), string(valueJSON))
+		where.WriteString(fmt.Sprintf(`
+		  AND es.fields #> $%d::text[] = $%d::jsonb
+		`, len(args)-1, len(args)))
+	}
+	where.WriteString(`
+		ORDER BY es.created_at ASC
+	`)
+	return s.querySpec(ctx, runID, where.String(), args...)
+}
+
+func (s *WorkflowInstanceStore) querySpec(ctx context.Context, runID, where string, args ...any) ([]WorkflowInstance, error) {
 	rows, err := dbQueryContext(ctx, s.db, `
 		SELECT
 			es.entity_id::text,
@@ -432,9 +500,7 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 			es.updated_at
 		FROM entity_state es
 		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
-		WHERE es.run_id = $1::uuid
-		ORDER BY es.created_at ASC
-	`, runID)
+	`+where, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -520,6 +586,52 @@ func (s *WorkflowInstanceStore) listSpec(ctx context.Context) ([]WorkflowInstanc
 		return nil, err
 	}
 	return out, nil
+}
+
+func normalizeWorkflowInstanceFieldSelectors(selectors []workflowInstanceFieldSelector) []workflowInstanceFieldSelector {
+	out := make([]workflowInstanceFieldSelector, 0, len(selectors))
+	for _, selector := range selectors {
+		field := strings.TrimSpace(selector.Field)
+		if field == "" {
+			continue
+		}
+		out = append(out, workflowInstanceFieldSelector{Field: field, Value: selector.Value})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Field < out[j].Field
+	})
+	return out
+}
+
+func normalizeWorkflowInstanceExcludedStates(states []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(states))
+	for _, state := range states {
+		state = strings.ToLower(strings.TrimSpace(state))
+		if state == "" {
+			continue
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		out = append(out, state)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func workflowInstanceFieldSelectorPath(field string) []string {
+	parts := strings.Split(strings.TrimSpace(field), ".")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		out = append(out, part)
+	}
+	return out
 }
 
 func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRef string, instance WorkflowInstance) error {


### PR DESCRIPTION
## Summary

Adds the Swarm `select_entity` handler primitive for service-owned existing-entity acquisition on stateful typed input-pin handlers. This lets a target service flow select exactly one of its own entities by declared payload-to-entity key bindings before guard/accumulate/data writes, without restoring generic cross-flow existing-entity continuation.

Closes #689

## Governing refs / context

Authoritative spec updated in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:

- `handler_specification.dependency_graph`
- `handler_specification.handler_fields.select_entity`
- `engine.boot_checks.handler_field_compliance`
- `engine.boot_checks.dialect_compliance`
- `flow_model.state_composition.cross_flow_handoff`
- `static_analyzer.slice_4_state_reachability.source_state_derivation`

Binding issue context: #689 pre-audit and independent gate approval. Historical regression boundary: #426 primitive-only cross-flow migration; this PR does not restore parent-retarget/backprop/subject-link/generic existing-entity continuation.

## Semantic migration

- New canonical owner: `platform-spec.yaml` `select_entity` plus Swarm contract decoding, bootverify validation, and runtime handler entity-context resolution.
- Old invalid paths: using `create_entity: true` as a per-request workaround for existing service state; source-flow supplied `entity_id`/`entity_type`/`flow_instance`; agent generic entity tools; #426-style cross-flow continuation.
- Production paths checked: handler YAML decoding, bootverify input-pin acquisition validation, runtime engine bridge, declarative node executor, engine `ValidateRequest`, same-flow write enforcement through existing `ensureFlowOwnsEntity` consumer.
- Migration complete for the Swarm primitive. Empire #63 must still consume the primitive before Treasury behavior can claim product-side closure.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline ./internal/runtime/engine`
- `go test ./internal/runtime/pipeline -run 'TestExecuteNodeContractHandlerSelectEntity'`
- `go test ./internal/runtime/bootverify ./internal/runtime/pipeline`
- `go test ./...`

