### PR TITLE
[agent-a][issue #690] Execute selected-fork agent handlers

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -517,6 +517,14 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			return 1
 		}
 		source := semanticview.Wrap(bundle)
+		credentialStore, err := buildCredentialStore()
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: configure credentials: %v\n", err)
+			}
+			return 1
+		}
+		workspaces := configuredWorkspaceLifecycle(stores.SQLDB, repo, contractsRoot, source)
 		result, err := runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
 			SourceRunID: strings.TrimSpace(*runID),
 			At:          strings.TrimSpace(*at),
@@ -526,6 +534,17 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 				PlatformSpecPath: resolvePath(repo, *platformSpecPath),
 			},
 			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
+			AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
+				Config:            cfg,
+				SQLDB:             stores.SQLDB,
+				SessionRegistry:   stores.SessionRegistry,
+				ConversationStore: stores.ConversationStore,
+				TurnStore:         stores.TurnStore,
+				ScheduleStore:     stores.ScheduleStore,
+				MailboxStore:      stores.Postgres,
+				Workspace:         workspaces,
+				Credentials:       credentialStore,
+			},
 		})
 		if err != nil {
 			if out != nil {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3611,20 +3611,40 @@ run_model:
       materialization is owned by runtime.run_fork.selected_contract_execution.authoritative_agent_delivery_materialization
       as a mutating-execution gate after runtime.run_fork.selected_contract_recipient_planning and before any fork
       materialization. It consumes only canonical selected-recipient planning to identify required agent recipients for
-      selected frontier events. If a selected-fork handler materializer is unavailable for any authoritative agent
-      recipient, the owner MUST fail closed before creating fork runs, selected-contract bindings, route recoveries,
-      fork events, fork deliveries, branch-divergence rows, or fork entity_state. Live source event_deliveries, source
-      subscriptions, current EventBus channels, active agent descriptors, CLI/dry-run JSON, and dashboard/API state are
-      not executable handler-availability truth. Node/system handler execution, route topology, timers, sessions,
-      turns, audits, non-agent replay, retry/idempotency/follow-up policy, restart recovery, and UI/API behavior remain
-      separate owners or split siblings.'
+      selected frontier events. It may pass only when
+      runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor proves every planned
+      selected agent recipient has fork-local handler construction and execution support. If that materializer/executor
+      is unavailable for any authoritative agent recipient, the owner MUST fail closed before creating fork runs,
+      selected-contract bindings, route recoveries, fork events, fork deliveries, branch-divergence rows, or fork
+      entity_state. Live source event_deliveries, source subscriptions, current EventBus channels, active agent
+      descriptors alone, CLI/dry-run JSON, and dashboard/API state are not executable handler-availability truth.
+      Node/system handler execution, route topology, timers, sessions, turns, audits, non-agent replay,
+      retry/idempotency/follow-up policy, restart recovery, and UI/API behavior remain separate owners or split
+      siblings.'
+    selected_contract_fork_local_agent_runtime_materializer_executor: 'Selected-contract fork-local agent runtime
+      materialization and execution is owned by
+      runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor. It consumes
+      runtime.run_fork.selected_contract_recipient_planning as the only selected-fork recipient truth, factors ordinary
+      static contract-agent materialization semantics for ID rendering, subscriptions, emit events, permissions, native
+      tools, flow path, role/model/session scope, prompt resolution, and runtime descriptor normalization, and constructs
+      ephemeral fork-local handlers through the normal AgentManager/buildAgent/applyContractPrompt/factory execution
+      path before selected fork publish. It may register only fork-local in-memory handler channels and runtime-active
+      descriptors for the selected-fork EventBus; it MUST NOT persist those handlers into ordinary current-runtime
+      agents, read source event_deliveries or source outcomes as executable truth, synthesize delivered/processed
+      receipts, or let live subscriptions/active descriptors alone become recipient truth. Fresh event_deliveries,
+      receipts, dead letters, sessions, turns, audits, idempotency state, and emitted follow-ups may appear only as
+      fork-local outputs of actual selected-fork handler execution under the fork run_id. Flow-instance-scoped agent
+      materialization, restart recovery of fork-local handlers, session/turn/audit reconstruction, timers, non-agent
+      replay, retry/idempotency/follow-up policy beyond normal execution, and UI/API behavior remain split unless this
+      owner has explicit fork-local proof for that subcase.'
     selected_contract_supported_execution: 'The supported selected-contract timestamp-fork execution surface is
       swarm fork --contracts. It is owned by runtime.run_fork.selected_contract_execution, not by CLI, route helpers,
       delivery-row helpers, or source-row replay. The owner consumes store.run_fork.selected_contract_binding,
       selected_contract_execution_admission, selected_contract_route_topology, selected_contract_dynamic_route_topology,
       runtime.run_fork.selected_contract_recipient_planning, and
-      runtime.run_fork.selected_contract_execution.authoritative_agent_delivery_materialization before publishing
-      selected frontier work. It creates fresh
+      runtime.run_fork.selected_contract_execution.authoritative_agent_delivery_materialization plus
+      runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor when planned selected
+      agent recipients exist before publishing selected frontier work. It creates fresh
       fork-local events and event_deliveries under the fork run_id, records selected source-to-fork lineage in
       run_fork_selected_contract_executions, runs selected handlers through the normal runtime pipeline, writes fork-local
       outcomes, and regenerates emitted follow-ups under the fork run_id. Source events are payload/lineage inputs only;
@@ -3821,12 +3841,25 @@ run_model:
         still non-mutating: it does not persist route rows, write deliveries, run handlers, or own receipts, dead
         letters, idempotency, emitted follow-ups, timers, sessions, turns, source-advanced policy, contract swap, or
         UI/API execution state.'
+      3g1_selected_contract_fork_local_agent_runtime_materializer_executor: 'For selected-contract mutating fork
+        execution, planned selected agent recipients may execute only through
+        runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor after recipient
+        planning and before selected fork publish. This owner consumes recipient planning as authoritative recipient
+        truth, factors ordinary static contract-agent config/materialization semantics, constructs ephemeral fork-local
+        handlers through the same runtime build/execution primitives as normal agents, and registers only fork-local
+        EventBus channels/descriptors needed for authoritative delivery under the fork run_id. It must not persist
+        selected handlers into ordinary current-runtime agents, use source deliveries/outcomes/live subscriptions as
+        execution truth, synthesize receipts, or claim restart recovery. Flow-instance-scoped materialization without
+        explicit fork-local proof, session/turn/audit reconstruction, timers, non-agent replay, retry/idempotency,
+        follow-up policy beyond normal handler output, and UI/API consumers remain split siblings.'
       3h_selected_contract_supported_execution: 'For the supported swarm fork --contracts surface, selected-contract
         execution is a runtime-owned mutating path after selected binding, execution admission, route topology, dynamic
-        topology proof or fail-closed classification, and recipient planning. It mints fresh fork-local event IDs, writes
-        fork event and delivery rows under the fork run_id, gates EventBus.Publish through recipient-planning evidence,
-        runs selected handlers through the normal runtime pipeline, records selected execution lineage, writes fork-local
-        outcomes, and regenerates follow-up events under the fork run_id. This is not full historical resume: route
+        topology proof or fail-closed classification, recipient planning, authoritative agent delivery materialization,
+        and fork-local selected agent runtime materializer/executor proof when selected agent recipients exist. It mints
+        fresh fork-local event IDs, writes fork event and delivery rows under the fork run_id, gates EventBus.Publish
+        through recipient-planning evidence, runs selected handlers through the normal runtime pipeline, records selected
+        execution lineage, writes fork-local outcomes, and regenerates follow-up events under the fork run_id. This is
+        not full historical resume: route
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
         parents or siblings. At/before-T source session/turn/audit facts may be admitted only as lineage/no-action

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -215,6 +215,11 @@ active_issues:
     maps_to:
       - timestamp_fork_replay_resume_ownership
       - delivery_and_replay_ownership
+  - id: 690
+    title: Gate selected-contract fork-local agent handler materializer/executor
+    maps_to:
+      - timestamp_fork_replay_resume_ownership
+      - delivery_and_replay_ownership
   - id: 571
     title: get_entity truncates large current-entity reads and hides required fields
     maps_to:
@@ -313,6 +318,7 @@ nodes:
       - contract-swap historical replay execution must consume runtime.run_fork.historical_replay_execution plus selected recipient planning before EventBus.Publish writes selected fork deliveries; source delivery subscribers remain lineage only and store.run_fork.delivery_event_replay is not sufficient for selected recipient truth
       - selected-contract diagnostic/non-routed platform event outcome facts such as platform.runtime_log and platform.inbound_recorded are lineage/no-action evidence under frontier admission; they are not routed, copied, replayed, or used as selected-fork suppressors, while non-diagnostic platform/node/system outcomes remain split or fail-closed
       - selected-contract authoritative agent delivery materialization is owned by runtime.run_fork.selected_contract_execution.authoritative_agent_delivery_materialization before any selected fork delivery write; it consumes runtime.run_fork.selected_contract_recipient_planning, treats planned selected agent recipients as authoritative, and fails closed before fork mutation when no selected-fork handler materializer exists, while source event_deliveries, source subscriptions, active EventBus channels, active descriptors, and CLI/API/dashboard state remain invalid delivery truth
+      - selected-contract fork-local agent runtime materializer/executor is owned by runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor; it consumes recipient planning, factors static contract-agent materialization/config semantics, registers only ephemeral fork-local EventBus handlers/descriptors, and allows fresh fork-local agent receipts/follow-ups only from actual selected-fork execution under the fork run_id
     representative_issues:
       - 112
       - 144
@@ -332,6 +338,7 @@ nodes:
       - 639
       - 668
       - 686
+      - 690
     common_framing_mistakes:
       too_broad:
         - delivery is flaky
@@ -385,6 +392,7 @@ nodes:
       - selected-contract source-advanced conversation-history policy needs runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy to classify post-T source agent_sessions, agent_turns, and agent_conversation_audits as branch-divergence lineage/no-action evidence while keeping source row copy/reuse, source suppressors, active delivery/session coupling, fork-local pre-existing rows, full reconstruction, and non-selected surfaces split or fail-closed
       - selected-contract active source delivery conversation-coupling policy needs runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy to classify only the same-source in-progress delivery that emitted the fork-point event as lineage/no-action and branch-divergence evidence, while preserving fail-closed behavior for unrelated active deliveries, active_session_id/receipt/outcome coupling, source row copy/reuse, source outcome suppressors, fork-local pre-existing rows, post-T conversation facts outside #671, full reconstruction, and non-selected surfaces
       - fork materialization needs runtime.run_fork.materialized_entity_snapshot_metadata to classify reconstructed entity_mutations candidates with source-at-T flow_instance/entity_type metadata before generic or selected-contract materializers write fork-local entity_state rows
+      - selected-contract fork-local agent runtime materializer/executor needs runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor to consume selected recipient planning, construct ephemeral fork-local handlers through factored static contract-agent semantics, and execute planned selected agent recipients under the fork run_id without persisting ordinary current-runtime agents or using source deliveries/outcomes/live subscriptions as execution truth
     representative_issues:
       - 564
       - 565
@@ -421,6 +429,7 @@ nodes:
       - 678
       - 681
       - 686
+      - 690
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -31,6 +31,7 @@ type EventBus struct {
 	subscriptionKinds           map[string]inMemorySubscriberKind
 	pendingInternalByID         map[string][]string
 	routeTable                  *RouteTable
+	runtimeAgentDescriptors     map[string]ActiveAgentDescriptor
 	deliveryPlanner             deliveryPlanner
 	interceptors                []EventInterceptor
 	interceptorProvider         func() []EventInterceptor
@@ -122,6 +123,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		agentChans:                  make(map[string]chan events.Event),
 		subscriptions:               make(map[string][]events.EventType),
 		subscriptionKinds:           make(map[string]inMemorySubscriberKind),
+		runtimeAgentDescriptors:     make(map[string]ActiveAgentDescriptor),
 		pendingInternalByID:         make(map[string][]string),
 		routeTable:                  routeTable,
 		store:                       store,

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -15,15 +15,19 @@ import (
 var errAuthoritativeDeliveryIncomplete = errors.New("authoritative delivery incomplete")
 
 func (eb *EventBus) activeAgentDescriptors(ctx context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+	ephemeral := eb.runtimeActiveAgentDescriptors()
 	lister, ok := eb.store.(ActiveAgentDescriptorLister)
 	if !ok {
+		if len(ephemeral) > 0 {
+			return ephemeral, true, nil
+		}
 		return nil, false, nil
 	}
 	descriptors, err := lister.ListActiveAgentDescriptors(ctx)
 	if err != nil {
 		return nil, true, err
 	}
-	set := make(map[string]ActiveAgentDescriptor, len(descriptors))
+	set := make(map[string]ActiveAgentDescriptor, len(descriptors)+len(ephemeral))
 	for _, descriptor := range descriptors {
 		descriptor = descriptor.Normalized()
 		if descriptor.AgentID == "" {
@@ -31,7 +35,46 @@ func (eb *EventBus) activeAgentDescriptors(ctx context.Context) (map[string]Acti
 		}
 		set[descriptor.AgentID] = descriptor
 	}
+	for id, descriptor := range ephemeral {
+		set[id] = descriptor
+	}
 	return set, true, nil
+}
+
+// RegisterRuntimeActiveAgentDescriptor adds in-memory active-agent metadata for
+// handlers that are intentionally not persisted as ordinary current-runtime
+// agents. Delivery planning still uses the normal authoritative recipient
+// policy; this only supplies runtime-local descriptor evidence to that policy.
+func (eb *EventBus) RegisterRuntimeActiveAgentDescriptor(descriptor ActiveAgentDescriptor) {
+	if eb == nil {
+		return
+	}
+	descriptor = descriptor.Normalized()
+	if descriptor.AgentID == "" {
+		return
+	}
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	if eb.runtimeAgentDescriptors == nil {
+		eb.runtimeAgentDescriptors = make(map[string]ActiveAgentDescriptor)
+	}
+	eb.runtimeAgentDescriptors[descriptor.AgentID] = descriptor
+}
+
+func (eb *EventBus) runtimeActiveAgentDescriptors() map[string]ActiveAgentDescriptor {
+	if eb == nil {
+		return nil
+	}
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	if len(eb.runtimeAgentDescriptors) == 0 {
+		return nil
+	}
+	out := make(map[string]ActiveAgentDescriptor, len(eb.runtimeAgentDescriptors))
+	for id, descriptor := range eb.runtimeAgentDescriptors {
+		out[id] = descriptor
+	}
+	return out
 }
 
 func filterRecipientsForExplicitAgentScope(evt events.Event, recipients []string, descriptors map[string]ActiveAgentDescriptor) []string {

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -188,6 +188,15 @@ func (am *AgentManager) SpawnAgentForEntity(entityID string, cfg models.AgentCon
 	return am.SpawnAgent(cfg)
 }
 
+// RegisterEphemeralAgentForExecution constructs an in-memory agent with the
+// normal runtime construction path without persisting it as current-run truth.
+func (am *AgentManager) RegisterEphemeralAgentForExecution(ctx context.Context, rec PersistedAgent) error {
+	if am == nil {
+		return errors.New("agent manager is required")
+	}
+	return am.spawnAgentInternal(ctx, rec, false)
+}
+
 // SpawnEphemeralClone creates a task-scoped clone of a base agent. Ephemeral
 // clones are persisted with status=ephemeral so crash recovery does not hydrate
 // them as permanent agents.

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -234,27 +234,40 @@ func (am *AgentManager) EnsureStaticFlowRequiredAgents(ctx context.Context, sour
 	if am == nil || source == nil {
 		return nil
 	}
-	for _, scope := range source.ProjectScopes() {
-		if err := am.ensureStaticRequiredAgentsForScope(ctx, source, "", "", scope.Agents, source.RequiredAgents()); err != nil {
-			return err
-		}
+	records, err := StaticFlowRequiredAgentMaterializationRecords(source)
+	if err != nil {
+		return err
 	}
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
-			continue
-		}
-		if err := am.ensureStaticRequiredAgentsForScope(ctx, source, flowID, strings.Trim(scope.Path, "/"), scope.Agents, source.FlowRequiredAgents(flowID)); err != nil {
-			return err
-		}
-	}
-	return nil
+	return am.spawnStaticAgentRecords(ctx, records)
 }
 
 func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticview.Source) error {
 	if am == nil || source == nil {
 		return nil
 	}
+	records, err := StaticAgentMaterializationRecords(source)
+	if err != nil {
+		return err
+	}
+	return am.spawnStaticAgentRecords(ctx, records)
+}
+
+func (am *AgentManager) spawnStaticAgentRecords(ctx context.Context, records []PersistedAgent) error {
+	for _, rec := range records {
+		if err := am.spawnAgentInternal(ctx, rec, true); err != nil && !strings.Contains(err.Error(), "already exists") {
+			return err
+		}
+	}
+	return nil
+}
+
+// StaticAgentMaterializationRecords derives the ordinary runtime static-agent
+// materialization records without mutating the manager or persistence store.
+func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedAgent, error) {
+	if source == nil {
+		return nil, nil
+	}
+	records := []PersistedAgent{}
 	for _, scope := range source.ProjectScopes() {
 		projectAgents := make(map[string]runtimecontracts.AgentRegistryEntry, len(scope.Agents))
 		packageFlowAgents := map[string]staticAgentFlowGroup{}
@@ -280,9 +293,11 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 			}
 			projectAgents[strings.TrimSpace(logicalID)] = entry
 		}
-		if err := am.ensureStaticAgentsForScope(ctx, source, "", "", projectAgents); err != nil {
-			return err
+		scopeRecords, err := staticAgentsForScope(source, "", "", projectAgents)
+		if err != nil {
+			return nil, err
 		}
+		records = append(records, scopeRecords...)
 		groupKeys := make([]string, 0, len(packageFlowAgents))
 		for key := range packageFlowAgents {
 			groupKeys = append(groupKeys, key)
@@ -290,9 +305,11 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 		sort.Strings(groupKeys)
 		for _, key := range groupKeys {
 			group := packageFlowAgents[key]
-			if err := am.ensureStaticAgentsForScope(ctx, source, group.FlowID, group.FlowPath, group.Agents); err != nil {
-				return err
+			scopeRecords, err := staticAgentsForScope(source, group.FlowID, group.FlowPath, group.Agents)
+			if err != nil {
+				return nil, err
 			}
+			records = append(records, scopeRecords...)
 		}
 	}
 	for _, scope := range source.FlowScopes() {
@@ -303,11 +320,41 @@ func (am *AgentManager) EnsureStaticAgents(ctx context.Context, source semanticv
 		proof := semanticview.ResolveAgentSessionScopeProof(source, semanticview.AgentSessionScopeLocator{
 			FlowID: flowID,
 		})
-		if err := am.ensureStaticAgentsForScope(ctx, source, proof.OwningFlowID, proof.FlowPath, scope.Agents); err != nil {
-			return err
+		scopeRecords, err := staticAgentsForScope(source, proof.OwningFlowID, proof.FlowPath, scope.Agents)
+		if err != nil {
+			return nil, err
 		}
+		records = append(records, scopeRecords...)
 	}
-	return nil
+	return records, nil
+}
+
+// StaticFlowRequiredAgentMaterializationRecords derives the ordinary runtime
+// required-flow-agent materialization records without mutating runtime state.
+func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) ([]PersistedAgent, error) {
+	if source == nil {
+		return nil, nil
+	}
+	records := []PersistedAgent{}
+	for _, scope := range source.ProjectScopes() {
+		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", scope.Agents, source.RequiredAgents())
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, scopeRecords...)
+	}
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+			continue
+		}
+		scopeRecords, err := staticRequiredAgentsForScope(source, flowID, strings.Trim(scope.Path, "/"), scope.Agents, source.FlowRequiredAgents(flowID))
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, scopeRecords...)
+	}
+	return records, nil
 }
 
 type staticAgentFlowGroup struct {
@@ -497,32 +544,44 @@ func (am *AgentManager) ensureStaticRequiredAgentsForScope(
 	agents map[string]runtimecontracts.AgentRegistryEntry,
 	required []runtimecontracts.FlowRequiredAgent,
 ) error {
+	records, err := staticRequiredAgentsForScope(source, flowID, flowPath, agents, required)
+	if err != nil {
+		return err
+	}
+	return am.spawnStaticAgentRecords(ctx, records)
+}
+
+func staticRequiredAgentsForScope(
+	source semanticview.Source,
+	flowID string,
+	flowPath string,
+	agents map[string]runtimecontracts.AgentRegistryEntry,
+	required []runtimecontracts.FlowRequiredAgent,
+) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
 	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
 	if len(required) == 0 || len(agents) == 0 {
-		return nil
+		return nil, nil
 	}
 	localEvents := staticFlowLocalEventSet(agents)
+	records := make([]PersistedAgent, 0, len(required))
 	for _, requiredAgent := range required {
 		logicalID, entry, ok := resolveRequiredAgentEntry(agents, requiredAgent)
 		if !ok {
-			return fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
+			return nil, fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
 		}
 		cfg, err := buildStaticFlowAgentConfig(source, flowID, flowPath, logicalID, entry, localEvents)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		rec := PersistedAgent{
+		records = append(records, PersistedAgent{
 			Config:          cfg,
 			Status:          "active",
 			HiredBy:         "static-flow-required-agent",
 			TemplateVersion: "",
-		}
-		if err := am.spawnAgentInternal(ctx, rec, true); err != nil && !strings.Contains(err.Error(), "already exists") {
-			return err
-		}
+		})
 	}
-	return nil
+	return records, nil
 }
 
 func (am *AgentManager) ensureStaticAgentsForScope(
@@ -532,10 +591,23 @@ func (am *AgentManager) ensureStaticAgentsForScope(
 	flowPath string,
 	agents map[string]runtimecontracts.AgentRegistryEntry,
 ) error {
+	records, err := staticAgentsForScope(source, flowID, flowPath, agents)
+	if err != nil {
+		return err
+	}
+	return am.spawnStaticAgentRecords(ctx, records)
+}
+
+func staticAgentsForScope(
+	source semanticview.Source,
+	flowID string,
+	flowPath string,
+	agents map[string]runtimecontracts.AgentRegistryEntry,
+) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
 	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
 	if len(agents) == 0 {
-		return nil
+		return nil, nil
 	}
 	localEvents := staticFlowLocalEventSet(agents)
 	logicalIDs := make([]string, 0, len(agents))
@@ -546,23 +618,21 @@ func (am *AgentManager) ensureStaticAgentsForScope(
 		}
 	}
 	sort.Strings(logicalIDs)
+	records := make([]PersistedAgent, 0, len(logicalIDs))
 	for _, logicalID := range logicalIDs {
 		entry := agents[logicalID]
 		cfg, err := buildStaticFlowAgentConfig(source, flowID, flowPath, logicalID, entry, localEvents)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		rec := PersistedAgent{
+		records = append(records, PersistedAgent{
 			Config:          cfg,
 			Status:          "active",
 			HiredBy:         "static-flow-agent",
 			TemplateVersion: "",
-		}
-		if err := am.spawnAgentInternal(ctx, rec, true); err != nil && !strings.Contains(err.Error(), "already exists") {
-			return err
-		}
+		})
 	}
-	return nil
+	return records, nil
 }
 
 func buildStaticFlowAgentConfig(

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -467,6 +467,45 @@ func (am *AgentManager) Run(ctx context.Context) {
 	}()
 }
 
+// RunAuthoritativeDeliveryOnly starts agent loops with authoritative recipient
+// channels only. It intentionally avoids live subscription patterns and
+// retry/recovery loops so selected-fork execution can consume canonical
+// recipient planning without reintroducing subscription-derived recipient truth.
+func (am *AgentManager) RunAuthoritativeDeliveryOnly(ctx context.Context) {
+	am.runMu.Lock()
+	if am.running || am.shutdownAdmissionClosedLocked() {
+		am.runMu.Unlock()
+		return
+	}
+	runRoot := runtimebus.WithRuntimeEpoch(ctx, runtimebus.CurrentRuntimeEpoch())
+	am.runCtx, am.cancelRun = context.WithCancel(runRoot)
+	am.running = true
+	am.authBreakerTripped = false
+	am.runMu.Unlock()
+
+	am.mu.RLock()
+	agents := make([]Agent, 0, len(am.agents))
+	for _, a := range am.agents {
+		agents = append(agents, a)
+	}
+	am.mu.RUnlock()
+
+	for _, a := range agents {
+		am.startAgentLoopWithSubscriptions(am.runCtx, a, nil)
+	}
+
+	go func() {
+		<-am.runCtx.Done()
+		am.runMu.Lock()
+		am.running = false
+		for id, cancel := range am.loopCancel {
+			cancel()
+			delete(am.loopCancel, id)
+		}
+		am.runMu.Unlock()
+	}()
+}
+
 func (am *AgentManager) Recover(ctx context.Context) error {
 	_, err := am.recover(ctx, false)
 	return err
@@ -946,6 +985,10 @@ func resetOrphanedSessionsDetail(summary sessions.ResetSummary, source string, r
 }
 
 func (am *AgentManager) startAgentLoop(parent context.Context, agent Agent) {
+	am.startAgentLoopWithSubscriptions(parent, agent, agent.Subscriptions())
+}
+
+func (am *AgentManager) startAgentLoopWithSubscriptions(parent context.Context, agent Agent, subscriptions []events.EventType) {
 	loopCtx, cancel := context.WithCancel(parent)
 
 	am.runMu.Lock()
@@ -955,7 +998,7 @@ func (am *AgentManager) startAgentLoop(parent context.Context, agent Agent) {
 	am.loopCancel[agent.ID()] = cancel
 	am.runMu.Unlock()
 
-	ch := am.bus.Subscribe(agent.ID(), agent.Subscriptions()...)
+	ch := am.bus.Subscribe(agent.ID(), subscriptions...)
 	am.runWG.Add(1)
 	go func() {
 		defer am.runWG.Done()

--- a/internal/runtime/runforkexecution/agent_delivery_materialization.go
+++ b/internal/runtime/runforkexecution/agent_delivery_materialization.go
@@ -11,6 +11,7 @@ import (
 
 type SelectedContractAgentDeliveryMaterializationRequest struct {
 	RecipientPlanning store.RunForkSelectedContractRecipientPlanning
+	AgentRuntime      SelectedContractAgentRuntimeMaterialization
 }
 
 type SelectedContractAgentDeliveryMaterialization struct {
@@ -41,12 +42,42 @@ func RequireSelectedContractAgentDeliveryMaterialization(ctx context.Context, re
 	if len(agents) == 0 {
 		return result, nil
 	}
+	if selectedContractAgentRuntimeCoversRecipients(req.AgentRuntime, agents) {
+		result.MaterializationSupported = true
+		return result, nil
+	}
 	blocker := store.RunForkUnsupportedBlocker{
 		Code:    store.RunForkBlockerSelectedContractAgentHandlerMaterializationUnsupported,
 		Message: fmt.Sprintf("%s requires selected-fork handler materialization for authoritative agent recipients before fork mutation; missing selected-fork handler materializer for %s", store.RunForkSelectedContractAuthoritativeAgentDeliveryMaterializationOwner, strings.Join(agents, ",")),
 	}
 	result.UnsupportedBlockers = []store.RunForkUnsupportedBlocker{blocker}
 	return result, fmt.Errorf("%s: %s", blocker.Code, blocker.Message)
+}
+
+func selectedContractAgentRuntimeCoversRecipients(runtime SelectedContractAgentRuntimeMaterialization, agents []string) bool {
+	if strings.TrimSpace(runtime.Owner) != store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner ||
+		!runtime.MaterializationSupported {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, id := range runtime.ConfiguredAgentIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	for _, id := range runtime.AgentRecipients {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	for _, agent := range agents {
+		if _, ok := seen[strings.TrimSpace(agent)]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func selectedContractPlannedAgentRecipients(planning store.RunForkSelectedContractRecipientPlanning) []string {

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -1,0 +1,401 @@
+package runforkexecution
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"swarm/internal/config"
+	swaruntime "swarm/internal/runtime"
+	runtimeagents "swarm/internal/runtime/agents"
+	runtimeauthority "swarm/internal/runtime/authority"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecredentials "swarm/internal/runtime/credentials"
+	runtimellm "swarm/internal/runtime/llm"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimemcp "swarm/internal/runtime/mcp"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	runtimesessions "swarm/internal/runtime/sessions"
+	runtimetools "swarm/internal/runtime/tools"
+	workspace "swarm/internal/runtime/workspace"
+	"swarm/internal/store"
+)
+
+const selectedContractAgentRuntimeDefaultQuiescenceTimeout = 2 * time.Minute
+
+var selectedContractAgentRuntimeGatewayEnvMu sync.Mutex
+
+type SelectedContractAgentRuntimeOptions struct {
+	Config            *config.Config
+	SQLDB             *sql.DB
+	SessionRegistry   runtimesessions.Registry
+	ConversationStore runtimellm.ConversationPersistence
+	TurnStore         runtimellm.TurnPersistence
+	ScheduleStore     runtimepipeline.SchedulePersistence
+	MailboxStore      runtimetools.MailboxPersistence
+	Workspace         workspace.Lifecycle
+	Credentials       runtimecredentials.Store
+	LLMRuntime        runtimellm.Runtime
+	MCPClient         *runtimemcp.Client
+
+	AgentFactory        runtimemanager.AgentFactory
+	AgentManagerOptions runtimemanager.AgentManagerOptions
+	QuiescenceTimeout   time.Duration
+}
+
+type SelectedContractAgentRuntimeMaterialization struct {
+	Owner                    string   `json:"owner"`
+	RecipientPlanningOwner   string   `json:"recipient_planning_owner"`
+	ExecutionOwner           string   `json:"execution_owner"`
+	AgentRecipients          []string `json:"agent_recipients,omitempty"`
+	ConfiguredAgentIDs       []string `json:"configured_agent_ids,omitempty"`
+	MissingAgentRecipients   []string `json:"missing_agent_recipients,omitempty"`
+	MaterializationRequired  bool     `json:"materialization_required"`
+	MaterializationSupported bool     `json:"materialization_supported"`
+	EphemeralForkLocal       bool     `json:"ephemeral_fork_local"`
+}
+
+type selectedContractAgentRuntimePlan struct {
+	Proof   SelectedContractAgentRuntimeMaterialization
+	Records []runtimemanager.PersistedAgent
+	Options SelectedContractAgentRuntimeOptions
+}
+
+type selectedContractAgentRuntime struct {
+	manager *runtimemanager.AgentManager
+	cleanup func()
+}
+
+type selectedContractAgentRuntimeFactory struct {
+	factory     runtimemanager.AgentFactory
+	options     runtimemanager.AgentManagerOptions
+	bindManager func(runtimetools.Manager)
+	cleanup     func()
+}
+
+func prepareSelectedContractAgentRuntimeMaterialization(ctx context.Context, loaded LoadedSelectedContractSource, planning store.RunForkSelectedContractRecipientPlanning, options SelectedContractAgentRuntimeOptions) (selectedContractAgentRuntimePlan, error) {
+	if err := ctx.Err(); err != nil {
+		return selectedContractAgentRuntimePlan{}, err
+	}
+	if strings.TrimSpace(planning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return selectedContractAgentRuntimePlan{}, fmt.Errorf("selected-contract agent runtime materialization requires %s; got %q", store.RunForkSelectedContractRecipientPlanningOwner, planning.Owner)
+	}
+	agents := selectedContractPlannedAgentRecipients(planning)
+	proof := SelectedContractAgentRuntimeMaterialization{
+		Owner:                    store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner,
+		RecipientPlanningOwner:   planning.Owner,
+		ExecutionOwner:           store.RunForkSelectedContractExecutionOwner,
+		AgentRecipients:          agents,
+		MaterializationRequired:  len(agents) > 0,
+		MaterializationSupported: len(agents) == 0,
+		EphemeralForkLocal:       true,
+	}
+	if len(agents) == 0 {
+		return selectedContractAgentRuntimePlan{Proof: proof, Options: options}, nil
+	}
+	records, err := selectedContractStaticAgentRecords(loaded.Source)
+	if err != nil {
+		return selectedContractAgentRuntimePlan{Proof: proof, Options: options}, err
+	}
+	recordsByID := map[string]runtimemanager.PersistedAgent{}
+	configured := make([]string, 0, len(records))
+	for _, rec := range records {
+		id := strings.TrimSpace(rec.Config.ID)
+		if id == "" {
+			continue
+		}
+		if _, exists := recordsByID[id]; exists {
+			continue
+		}
+		rec.Status = "ephemeral"
+		rec.HiredBy = "selected-contract-fork-agent-runtime"
+		recordsByID[id] = rec
+		configured = append(configured, id)
+	}
+	sort.Strings(configured)
+	proof.ConfiguredAgentIDs = configured
+
+	selected := make([]runtimemanager.PersistedAgent, 0, len(agents))
+	missing := []string{}
+	for _, id := range agents {
+		rec, ok := recordsByID[id]
+		if !ok {
+			missing = append(missing, id)
+			continue
+		}
+		selected = append(selected, rec)
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		proof.MissingAgentRecipients = missing
+		return selectedContractAgentRuntimePlan{Proof: proof, Records: selected, Options: options}, selectedContractAgentRuntimeUnsupportedError(missing, "missing selected-source static contract-agent materialization record")
+	}
+	if options.AgentFactory == nil && options.Config == nil {
+		return selectedContractAgentRuntimePlan{Proof: proof, Records: selected, Options: options}, selectedContractAgentRuntimeUnsupportedError(agents, "missing selected-fork agent factory/runtime configuration")
+	}
+	proof.MaterializationSupported = true
+	return selectedContractAgentRuntimePlan{Proof: proof, Records: selected, Options: options}, nil
+}
+
+func selectedContractStaticAgentRecords(source semanticview.Source) ([]runtimemanager.PersistedAgent, error) {
+	staticRecords, err := runtimemanager.StaticAgentMaterializationRecords(source)
+	if err != nil {
+		return nil, err
+	}
+	requiredRecords, err := runtimemanager.StaticFlowRequiredAgentMaterializationRecords(source)
+	if err != nil {
+		return nil, err
+	}
+	return append(staticRecords, requiredRecords...), nil
+}
+
+func selectedContractAgentRuntimeUnsupportedError(agents []string, reason string) error {
+	agents = append([]string(nil), agents...)
+	sort.Strings(agents)
+	return fmt.Errorf("%s: %s requires selected-fork handler materialization for authoritative agent recipients before fork mutation; %s for %s",
+		store.RunForkBlockerSelectedContractAgentHandlerMaterializationUnsupported,
+		store.RunForkSelectedContractAuthoritativeAgentDeliveryMaterializationOwner,
+		strings.TrimSpace(reason),
+		strings.Join(agents, ","),
+	)
+}
+
+func startSelectedContractAgentRuntime(ctx context.Context, req publishSelectedContractForkEventsRequest, bus *runtimebus.EventBus) (*selectedContractAgentRuntime, error) {
+	if len(req.AgentRuntime.Records) == 0 {
+		return nil, nil
+	}
+	builder, err := buildSelectedContractAgentRuntimeFactory(req, bus)
+	if err != nil {
+		return nil, err
+	}
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, builder.factory, builder.options, req.Store)
+	if builder.bindManager != nil {
+		builder.bindManager(manager)
+	}
+	for _, rec := range req.AgentRuntime.Records {
+		if err := manager.RegisterEphemeralAgentForExecution(ctx, rec); err != nil && !strings.Contains(err.Error(), "agent already exists") {
+			return nil, fmt.Errorf("%s materialize agent %s: %w", store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner, strings.TrimSpace(rec.Config.ID), err)
+		}
+		bus.RegisterRuntimeActiveAgentDescriptor(runtimebus.ActiveAgentDescriptor{
+			AgentID:      rec.Config.ID,
+			EntityID:     rec.Config.EffectiveEntityID(),
+			FlowInstance: rec.Config.CanonicalFlowPath(),
+		})
+	}
+	manager.RunAuthoritativeDeliveryOnly(ctx)
+	return &selectedContractAgentRuntime{manager: manager, cleanup: builder.cleanup}, nil
+}
+
+func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEventsRequest, bus *runtimebus.EventBus) (selectedContractAgentRuntimeFactory, error) {
+	options := req.AgentRuntime.Options
+	source := req.LoadedSource.Source
+	promptResolver, err := selectedContractPromptResolver(source)
+	if err != nil {
+		return selectedContractAgentRuntimeFactory{}, err
+	}
+	managerOptions := options.AgentManagerOptions
+	if managerOptions.SemanticSource == nil {
+		managerOptions.SemanticSource = source
+	}
+	if managerOptions.PromptResolver == nil {
+		managerOptions.PromptResolver = promptResolver
+	}
+	if managerOptions.Sessions == nil {
+		managerOptions.Sessions = options.SessionRegistry
+	}
+	if managerOptions.Workspaces == nil {
+		managerOptions.Workspaces = options.Workspace
+	}
+	if options.Config != nil && strings.TrimSpace(managerOptions.RuntimeMode) == "" {
+		managerOptions.RuntimeMode = strings.TrimSpace(options.Config.LLM.RuntimeMode)
+	}
+	if options.AgentFactory != nil {
+		return selectedContractAgentRuntimeFactory{factory: options.AgentFactory, options: managerOptions}, nil
+	}
+	if options.Config == nil {
+		return selectedContractAgentRuntimeFactory{}, selectedContractAgentRuntimeUnsupportedError(req.AgentRuntime.Proof.AgentRecipients, "missing selected-fork agent factory/runtime configuration")
+	}
+
+	authority := runtimeauthority.NewSourceProvider(source)
+	emitRegistry := runtimetools.NewEmitRegistry(source, authority)
+	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	credentials := options.Credentials
+	if credentials == nil {
+		credentials = runtimecredentials.NewEnvStore()
+	}
+	modelRuntime := options.LLMRuntime
+	if modelRuntime == nil {
+		modelRuntime, err = runtimellm.RuntimeFactory{
+			Cfg:           options.Config,
+			Sessions:      options.SessionRegistry,
+			Turns:         options.TurnStore,
+			Conversations: options.ConversationStore,
+			Workspaces:    options.Workspace,
+			Events:        bus,
+			MCPTurns:      mcpTurns,
+		}.Build()
+		if err != nil {
+			return selectedContractAgentRuntimeFactory{}, fmt.Errorf("build selected-fork agent runtime: %w", err)
+		}
+	}
+	var managerRef runtimetools.Manager
+	exec := runtimetools.NewExecutorWithOptions(bus, nil, runtimetools.ExecutorOptions{
+		Config:            options.Config,
+		Credentials:       credentials,
+		MailboxStore:      options.MailboxStore,
+		MCPClient:         options.MCPClient,
+		SQLDB:             options.SQLDB,
+		WorkflowSource:    source,
+		WorkspaceResolver: options.Workspace,
+		AuthorityProvider: authority,
+		EmitRegistry:      emitRegistry,
+		ManagerProvider: func() runtimetools.Manager {
+			return managerRef
+		},
+	}, options.ScheduleStore)
+	cleanup, err := startSelectedContractAgentRuntimeGateway(exec, emitRegistry, mcpTurns, func(agentID string) (runtimeactors.AgentConfig, bool) {
+		if managerRef == nil {
+			return runtimeactors.AgentConfig{}, false
+		}
+		return managerRef.GetAgentConfig(agentID)
+	})
+	if err != nil {
+		return selectedContractAgentRuntimeFactory{}, fmt.Errorf("start selected-fork tool gateway: %w", err)
+	}
+	factory := runtimeagents.NewLLMAgentFactory(modelRuntime, exec, exec.ToolDefinitions(), runtimeagents.LLMAgentOptions{
+		PromptResolver:    promptResolver,
+		AuthorityProvider: authority,
+		EmitRegistry:      emitRegistry,
+	})
+	return selectedContractAgentRuntimeFactory{
+		factory: factory,
+		options: managerOptions,
+		bindManager: func(manager runtimetools.Manager) {
+			managerRef = manager
+		},
+		cleanup: cleanup,
+	}, nil
+}
+
+func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitRegistry *runtimetools.EmitRegistry, mcpTurns *runtimemcp.TurnContextRegistry, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool)) (func(), error) {
+	if exec == nil {
+		return nil, nil
+	}
+	selectedContractAgentRuntimeGatewayEnvMu.Lock()
+	unlock := true
+	defer func() {
+		if unlock {
+			selectedContractAgentRuntimeGatewayEnvMu.Unlock()
+		}
+	}()
+
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return nil, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	hostURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	containerURL := fmt.Sprintf("http://host.docker.internal:%d", port)
+	prevHostURL, prevHostSet := os.LookupEnv("SWARM_TOOL_GATEWAY_URL")
+	prevContainerURL, prevContainerSet := os.LookupEnv("SWARM_TOOL_GATEWAY_CONTAINER_URL")
+	if err := os.Setenv("SWARM_TOOL_GATEWAY_URL", hostURL); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	if err := os.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", containerURL); err != nil {
+		restoreEnv("SWARM_TOOL_GATEWAY_URL", prevHostURL, prevHostSet)
+		_ = ln.Close()
+		return nil, err
+	}
+
+	gateway := runtimemcp.NewGateway(exec, strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")), swaruntime.RuntimeMCPGatewayHooks(nil, nil, resolveActorConfig, nil, emitRegistry, mcpTurns))
+	server := &http.Server{Handler: gateway.Handler()}
+	go func() {
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			_ = server.Close()
+		}
+	}()
+	unlock = false
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = server.Shutdown(ctx)
+		cancel()
+		restoreEnv("SWARM_TOOL_GATEWAY_CONTAINER_URL", prevContainerURL, prevContainerSet)
+		restoreEnv("SWARM_TOOL_GATEWAY_URL", prevHostURL, prevHostSet)
+		selectedContractAgentRuntimeGatewayEnvMu.Unlock()
+	}, nil
+}
+
+func restoreEnv(key, value string, existed bool) {
+	if existed {
+		_ = os.Setenv(key, value)
+		return
+	}
+	_ = os.Unsetenv(key)
+}
+
+func selectedContractPromptResolver(source semanticview.Source) (runtimecontracts.PromptResolver, error) {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		return nil, nil
+	}
+	return runtimecontracts.NewBundlePromptResolver(bundle), nil
+}
+
+func (r *selectedContractAgentRuntime) Shutdown() error {
+	if r == nil || r.manager == nil {
+		return nil
+	}
+	err := r.manager.Shutdown()
+	if r.cleanup != nil {
+		r.cleanup()
+		r.cleanup = nil
+	}
+	return err
+}
+
+func (r *selectedContractAgentRuntime) WaitForQuiescence(ctx context.Context, bus *runtimebus.EventBus) error {
+	if r == nil || r.manager == nil {
+		return nil
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	stable := 0
+	for {
+		if bus != nil {
+			if err := bus.WaitForQuiescence(ctx); err != nil {
+				return err
+			}
+		}
+		if err := r.manager.WaitForQuiescence(ctx); err != nil {
+			return err
+		}
+		pending := 0
+		if bus != nil {
+			pending = bus.PendingAgentDeliveries()
+		}
+		if pending == 0 {
+			stable++
+			if stable >= 3 {
+				return nil
+			}
+		} else {
+			stable = 0
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -182,6 +182,19 @@ func startSelectedContractAgentRuntime(ctx context.Context, req publishSelectedC
 	if builder.bindManager != nil {
 		builder.bindManager(manager)
 	}
+	started := false
+	cleanup := func() {
+		_ = manager.Shutdown()
+		if builder.cleanup != nil {
+			builder.cleanup()
+			builder.cleanup = nil
+		}
+	}
+	defer func() {
+		if !started {
+			cleanup()
+		}
+	}()
 	for _, rec := range req.AgentRuntime.Records {
 		if err := manager.RegisterEphemeralAgentForExecution(ctx, rec); err != nil && !strings.Contains(err.Error(), "agent already exists") {
 			return nil, fmt.Errorf("%s materialize agent %s: %w", store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner, strings.TrimSpace(rec.Config.ID), err)
@@ -193,6 +206,7 @@ func startSelectedContractAgentRuntime(ctx context.Context, req publishSelectedC
 		})
 	}
 	manager.RunAuthoritativeDeliveryOnly(ctx)
+	started = true
 	return &selectedContractAgentRuntime{manager: manager, cleanup: builder.cleanup}, nil
 }
 

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -23,6 +23,7 @@ type SelectedContractExecutionRequest struct {
 	Store             *store.PostgresStore
 	SourceLoader      SelectedContractSourceLoader
 	ContractSelection store.RunForkContractSelection
+	AgentRuntime      SelectedContractAgentRuntimeOptions
 }
 
 type SelectedContractExecutionForkEvent struct {
@@ -36,6 +37,7 @@ type SelectedContractExecutionResult struct {
 	Materialization                    store.RunForkMaterialization                     `json:"materialization"`
 	Activation                         store.RunForkActivation                          `json:"activation"`
 	SelectedContractExecutionAdmission *store.RunForkSelectedContractExecutionAdmission `json:"selected_contract_execution_admission,omitempty"`
+	AgentRuntimeMaterialization        *SelectedContractAgentRuntimeMaterialization     `json:"selected_agent_runtime_materialization,omitempty"`
 	ExecutedEventCount                 int                                              `json:"executed_event_count"`
 	ForkEvents                         []SelectedContractExecutionForkEvent             `json:"fork_events,omitempty"`
 }
@@ -104,10 +106,21 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if err != nil {
 		return SelectedContractExecutionResult{}, err
 	}
+	agentRuntime, err := prepareSelectedContractAgentRuntimeMaterialization(ctx, loadedSource, *model.RecipientPlanning, req.AgentRuntime)
+	if err != nil {
+		return SelectedContractExecutionResult{
+			Owner:                       store.RunForkSelectedContractExecutionOwner,
+			AgentRuntimeMaterialization: &agentRuntime.Proof,
+		}, err
+	}
 	if _, err := RequireSelectedContractAgentDeliveryMaterialization(ctx, SelectedContractAgentDeliveryMaterializationRequest{
 		RecipientPlanning: *model.RecipientPlanning,
+		AgentRuntime:      agentRuntime.Proof,
 	}); err != nil {
-		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner}, err
+		return SelectedContractExecutionResult{
+			Owner:                       store.RunForkSelectedContractExecutionOwner,
+			AgentRuntimeMaterialization: &agentRuntime.Proof,
+		}, err
 	}
 	sourceEventIDs := selectedContractExecutionFrontierEventIDs(frontier.FrontierEvents)
 	materialization, err := req.Store.MaterializeRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionMaterializeRequest{
@@ -142,12 +155,14 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 			Owner:                              store.RunForkSelectedContractExecutionOwner,
 			Materialization:                    materialization,
 			SelectedContractExecutionAdmission: &admission,
+			AgentRuntimeMaterialization:        &agentRuntime.Proof,
 		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
 	}
 	published, err := publishSelectedContractForkEvents(ctx, publishSelectedContractForkEventsRequest{
 		Store:             req.Store,
 		LoadedSource:      loadedSource,
 		RecipientPlanning: *model.RecipientPlanning,
+		AgentRuntime:      agentRuntime,
 		SourceRunID:       plan.SourceRunID,
 		ForkRunID:         materialization.ForkRunID,
 		ForkEventID:       plan.ForkPoint.EventID,
@@ -160,6 +175,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 			Owner:                              store.RunForkSelectedContractExecutionOwner,
 			Materialization:                    materialization,
 			SelectedContractExecutionAdmission: &admission,
+			AgentRuntimeMaterialization:        &agentRuntime.Proof,
 			ExecutedEventCount:                 len(published),
 			ForkEvents:                         published,
 		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
@@ -174,6 +190,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 			Materialization:                    materialization,
 			Activation:                         activation,
 			SelectedContractExecutionAdmission: &admission,
+			AgentRuntimeMaterialization:        &agentRuntime.Proof,
 			ExecutedEventCount:                 len(published),
 			ForkEvents:                         published,
 		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
@@ -183,6 +200,7 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		Materialization:                    materialization,
 		Activation:                         activation,
 		SelectedContractExecutionAdmission: &admission,
+		AgentRuntimeMaterialization:        &agentRuntime.Proof,
 		ExecutedEventCount:                 len(published),
 		ForkEvents:                         published,
 	}
@@ -222,6 +240,7 @@ type publishSelectedContractForkEventsRequest struct {
 	Store             *store.PostgresStore
 	LoadedSource      LoadedSelectedContractSource
 	RecipientPlanning store.RunForkSelectedContractRecipientPlanning
+	AgentRuntime      selectedContractAgentRuntimePlan
 	SourceRunID       string
 	ForkRunID         string
 	ForkEventID       string
@@ -258,6 +277,15 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 	bus.SetInterceptors(pipeline)
 
 	runCtx := runtimecorrelation.WithRunID(ctx, req.ForkRunID)
+	agentRuntime, err := startSelectedContractAgentRuntime(runCtx, req, bus)
+	if err != nil {
+		return nil, err
+	}
+	if agentRuntime != nil {
+		defer func() {
+			_ = agentRuntime.Shutdown()
+		}()
+	}
 	out := make([]SelectedContractExecutionForkEvent, 0, len(sourceEvents))
 	for _, sourceEvent := range sourceEvents {
 		forkEventID := uuid.NewString()
@@ -283,6 +311,17 @@ func publishSelectedContractForkEvents(ctx context.Context, req publishSelectedC
 			ForkEventID:   forkEventID,
 			EventName:     sourceEvent.EventName,
 		})
+	}
+	if agentRuntime != nil {
+		timeout := req.AgentRuntime.Options.QuiescenceTimeout
+		if timeout <= 0 {
+			timeout = selectedContractAgentRuntimeDefaultQuiescenceTimeout
+		}
+		waitCtx, cancel := context.WithTimeout(runCtx, timeout)
+		defer cancel()
+		if err := agentRuntime.WaitForQuiescence(waitCtx, bus); err != nil {
+			return out, fmt.Errorf("%s wait for selected-fork agent runtime quiescence: %w", store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner, err)
+		}
 	}
 	return out, nil
 }

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 
 	"swarm/internal/events"
 	"swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/runtime/runforkadmission"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -235,6 +238,150 @@ func TestExecuteSelectedContractRunForkFailsClosedBeforeMaterializationForAgentR
 		t.Fatalf("result mutated before selected agent materialization rejection: %#v", result)
 	}
 	assertNoSelectedContractExecutionMutationForSource(t, db, sourceRunID, sourceEventID)
+}
+
+func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRuntime(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	contractsRoot := filepath.Join(repoRoot, "tests/tier7-composition/test-agent-emits-to-node")
+	platformSpecPath := filepath.Join(repoRoot, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")
+	loader := ContractBundleSourceLoader{RepoRoot: repoRoot, PlatformSpecPath: platformSpecPath}
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, store.RunForkContractSelection{
+		Mode:          "selected_contracts",
+		ContractsRoot: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
+	}
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700002202, 0).UTC()
+	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "task.assigned", at)
+	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+
+	agent := &selectedContractForkTestAgent{}
+	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
+		SourceRunID:  sourceRunID,
+		At:           sourceEventID,
+		Store:        pg,
+		SourceLoader: loader,
+		ContractSelection: runforkadmission.SelectedContractSelection(
+			loaded.Source,
+			contractsRoot,
+		),
+		AgentRuntime: SelectedContractAgentRuntimeOptions{
+			AgentFactory: func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+				agent.Configure(cfg)
+				return agent, nil
+			},
+			QuiescenceTimeout: 5 * time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	}
+	if result.AgentRuntimeMaterialization == nil ||
+		result.AgentRuntimeMaterialization.Owner != store.RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner ||
+		result.AgentRuntimeMaterialization.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		result.AgentRuntimeMaterialization.ExecutionOwner != store.RunForkSelectedContractExecutionOwner ||
+		!result.AgentRuntimeMaterialization.MaterializationRequired ||
+		!result.AgentRuntimeMaterialization.MaterializationSupported ||
+		!result.AgentRuntimeMaterialization.EphemeralForkLocal ||
+		!containsString(result.AgentRuntimeMaterialization.AgentRecipients, "test-agent") ||
+		!containsString(result.AgentRuntimeMaterialization.ConfiguredAgentIDs, "test-agent") {
+		t.Fatalf("agent runtime materialization = %#v", result.AgentRuntimeMaterialization)
+	}
+	if result.Owner != store.RunForkSelectedContractExecutionOwner ||
+		result.Materialization.ForkRunID == "" ||
+		!result.Activation.Activated ||
+		result.ExecutedEventCount != 1 ||
+		len(result.ForkEvents) != 1 {
+		t.Fatalf("selected execution result = %#v", result)
+	}
+	if got := agent.SeenRunIDs(); len(got) != 1 || got[0] != result.Materialization.ForkRunID {
+		t.Fatalf("agent saw run ids = %#v, want fork run %s", got, result.Materialization.ForkRunID)
+	}
+	if got := agent.SeenEventIDs(); len(got) != 1 || got[0] != result.ForkEvents[0].ForkEventID {
+		t.Fatalf("agent saw event ids = %#v, want fork event %s", got, result.ForkEvents[0].ForkEventID)
+	}
+
+	var persistedAgents int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agents
+		WHERE agent_id = 'test-agent'
+	`).Scan(&persistedAgents); err != nil {
+		t.Fatalf("count persisted selected agent rows: %v", err)
+	}
+	if persistedAgents != 0 {
+		t.Fatalf("selected-fork runtime persisted current-runtime agent rows = %d, want 0", persistedAgents)
+	}
+
+	forkEventID := result.ForkEvents[0].ForkEventID
+	var sourceCopiedEvents int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+	`, result.Materialization.ForkRunID, sourceEventID).Scan(&sourceCopiedEvents); err != nil {
+		t.Fatalf("count copied source event ids: %v", err)
+	}
+	if sourceCopiedEvents != 0 {
+		t.Fatalf("copied source event ids into fork run = %d, want 0", sourceCopiedEvents)
+	}
+
+	var agentDeliveries, agentReceipts int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'test-agent'
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&agentDeliveries); err != nil {
+		t.Fatalf("count fork agent deliveries: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'test-agent'
+		  AND outcome = 'success'
+	`, forkEventID).Scan(&agentReceipts); err != nil {
+		t.Fatalf("count fork agent receipts: %v", err)
+	}
+	if agentDeliveries != 1 || agentReceipts != 1 {
+		t.Fatalf("fork-local agent outcomes deliveries=%d receipts=%d, want 1/1", agentDeliveries, agentReceipts)
+	}
+
+	var agentFollowUps, finalizedEvents int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'task.completed'
+		  AND source_event_id = $2::uuid
+		  AND produced_by = 'test-agent'
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&agentFollowUps); err != nil {
+		t.Fatalf("count fork-local agent follow-ups: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'task.finalized'
+	`, result.Materialization.ForkRunID).Scan(&finalizedEvents); err != nil {
+		t.Fatalf("count finalized events: %v", err)
+	}
+	if agentFollowUps != 1 || finalizedEvents != 1 {
+		t.Fatalf("fork-local follow-ups task.completed=%d task.finalized=%d, want 1/1", agentFollowUps, finalizedEvents)
+	}
 }
 
 func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(t *testing.T) {
@@ -1487,6 +1634,73 @@ func assertSelectedContractExecutionCleanup(t *testing.T, db *sql.DB, sourceRunI
 		t.Fatalf("cleanup left fork rows runs:%d events:%d deliveries:%d receipts:%d state:%d mutations:%d bindings:%d lineage:%d route_recoveries:%d",
 			forkRows, forkEvents, forkDeliveries, forkReceipts, forkState, forkMutations, bindingRows, lineageRows, routeRecoveryRows)
 	}
+}
+
+type selectedContractForkTestAgent struct {
+	mu       sync.Mutex
+	cfg      runtimeactors.AgentConfig
+	runIDs   []string
+	eventIDs []string
+}
+
+func (a *selectedContractForkTestAgent) Configure(cfg runtimeactors.AgentConfig) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cfg = cfg
+}
+
+func (a *selectedContractForkTestAgent) ID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.cfg.ID
+}
+
+func (a *selectedContractForkTestAgent) Type() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.cfg.Type
+}
+
+func (a *selectedContractForkTestAgent) Subscriptions() []events.EventType {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]events.EventType, 0, len(a.cfg.Subscriptions))
+	for _, raw := range a.cfg.Subscriptions {
+		if eventType := strings.TrimSpace(raw); eventType != "" {
+			out = append(out, events.EventType(eventType))
+		}
+	}
+	return out
+}
+
+func (a *selectedContractForkTestAgent) OnEvent(ctx context.Context, evt events.Event) ([]events.Event, error) {
+	a.mu.Lock()
+	a.runIDs = append(a.runIDs, strings.TrimSpace(evt.RunID))
+	a.eventIDs = append(a.eventIDs, strings.TrimSpace(evt.ID))
+	agentID := strings.TrimSpace(a.cfg.ID)
+	a.mu.Unlock()
+
+	return []events.Event{{
+		Type:          events.EventType("task.completed"),
+		SourceAgent:   agentID,
+		Payload:       json.RawMessage(`{}`),
+		RunID:         evt.RunID,
+		ParentEventID: evt.ID,
+		CreatedAt:     time.Now().UTC(),
+		Envelope:      evt.NormalizedEnvelope(),
+	}}, nil
+}
+
+func (a *selectedContractForkTestAgent) SeenRunIDs() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.runIDs...)
+}
+
+func (a *selectedContractForkTestAgent) SeenEventIDs() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.eventIDs...)
 }
 
 func runForkExecutionRepoRoot(t *testing.T) string {

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -12,9 +13,11 @@ import (
 
 	"github.com/google/uuid"
 
+	"swarm/internal/config"
 	"swarm/internal/events"
 	"swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/runtime/runforkadmission"
 	"swarm/internal/store"
@@ -382,6 +385,68 @@ func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRunt
 	if agentFollowUps != 1 || finalizedEvents != 1 {
 		t.Fatalf("fork-local follow-ups task.completed=%d task.finalized=%d, want 1/1", agentFollowUps, finalizedEvents)
 	}
+}
+
+func TestStartSelectedContractAgentRuntimeCleansGatewayOnRegistrationFailure(t *testing.T) {
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:9998")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:9998")
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	eventBus, err := bus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	_, err = startSelectedContractAgentRuntime(context.Background(), publishSelectedContractForkEventsRequest{
+		AgentRuntime: selectedContractAgentRuntimePlan{
+			Proof: SelectedContractAgentRuntimeMaterialization{
+				AgentRecipients: []string{"bad-agent"},
+			},
+			Records: []runtimemanager.PersistedAgent{{
+				Config: runtimeactors.AgentConfig{
+					ID:            "bad-agent",
+					Role:          "worker",
+					LLMBackend:    "cli_test",
+					ModelTier:     "standard",
+					Subscriptions: []string{"item.received"},
+				},
+			}},
+			Options: SelectedContractAgentRuntimeOptions{
+				Config:     &config.Config{},
+				LLMRuntime: selectedContractCleanupRuntime{},
+			},
+		},
+	}, eventBus)
+	if err == nil || !strings.Contains(err.Error(), "missing required system_prompt") {
+		t.Fatalf("startSelectedContractAgentRuntime error = %v, want registration failure", err)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != "http://127.0.0.1:9998" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want restored original", got)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL")); got != "http://host.docker.internal:9998" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want restored original", got)
+	}
+
+	unlocked := make(chan struct{})
+	go func() {
+		selectedContractAgentRuntimeGatewayEnvMu.Lock()
+		defer selectedContractAgentRuntimeGatewayEnvMu.Unlock()
+		close(unlocked)
+	}()
+	select {
+	case <-unlocked:
+	case <-time.After(time.Second):
+		t.Fatal("selected-fork runtime gateway mutex remained locked after registration failure")
+	}
+}
+
+type selectedContractCleanupRuntime struct{}
+
+func (selectedContractCleanupRuntime) StartSession(context.Context, string, string, []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	return &runtimellm.Session{}, nil
+}
+
+func (selectedContractCleanupRuntime) ContinueSession(context.Context, *runtimellm.Session, runtimellm.Message) (*runtimellm.Response, error) {
+	return &runtimellm.Response{}, nil
 }
 
 func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(t *testing.T) {

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -19,6 +19,7 @@ const (
 	RunForkSelectedContractDynamicRouteTopologyOwner                           = "runtime.run_fork.selected_contract_dynamic_route_topology"
 	RunForkSelectedContractRecipientPlanningOwner                              = "runtime.run_fork.selected_contract_recipient_planning"
 	RunForkSelectedContractAuthoritativeAgentDeliveryMaterializationOwner      = RunForkSelectedContractExecutionOwner + ".authoritative_agent_delivery_materialization"
+	RunForkSelectedContractForkLocalAgentRuntimeMaterializerExecutorOwner      = RunForkSelectedContractExecutionOwner + ".fork_local_agent_runtime_materializer_executor"
 	RunForkContractSwapBootResumeAdmissionOwner                                = "runtime.run_fork.contract_swap_boot_resume_admission"
 	RunForkHistoricalReplayExecutionAdmissionOwner                             = "runtime.run_fork.historical_replay_execution_admission"
 	RunForkHistoricalReplayExecutionOwner                                      = "runtime.run_fork.historical_replay_execution"

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -199,6 +199,9 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
 	}
+	if err := ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, forkRunID); err != nil {
+		return RunForkMaterialization{}, err
+	}
 	metadata, err := loadRunForkEntityMetadata(plan)
 	if err != nil {
 		return RunForkMaterialization{}, err
@@ -1095,27 +1098,9 @@ func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sq
 	if len(allowedEvents) == 0 {
 		return ensureRunForkActivationNoForkReplayState(ctx, tx, catalog, forkRunID)
 	}
-	for _, check := range []struct {
-		code  string
-		table string
-		query string
-	}{
-		{"fork_sessions_already_exist", "agent_sessions", `SELECT EXISTS (SELECT 1 FROM agent_sessions WHERE run_id = $1::uuid)`},
-		{"fork_conversation_audits_already_exist", "agent_conversation_audits", `SELECT EXISTS (SELECT 1 FROM agent_conversation_audits WHERE run_id = $1::uuid)`},
-		{"fork_turns_already_exist", "agent_turns", `SELECT EXISTS (SELECT 1 FROM agent_turns WHERE run_id = $1::uuid)`},
-	} {
-		if !catalog.hasColumns(check.table, "run_id") {
-			continue
-		}
-		var exists bool
-		if err := tx.QueryRowContext(ctx, check.query, forkRunID).Scan(&exists); err != nil {
-			return fmt.Errorf("check %s: %w", check.code, err)
-		}
-		if exists {
-			return runForkReplayResumeError(check.code, RunForkReplayResumeFactForkReplayState, fmt.Sprintf("fork activation blocked: %s", check.code))
-		}
-	}
 
+	// Materialization preflights empty fork-local replay state. At activation
+	// time, sessions/turns/audits may be fresh outputs from selected execution.
 	var missingLineage int
 	if err := tx.QueryRowContext(ctx, `
 		SELECT COUNT(*)
@@ -1135,7 +1120,17 @@ func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sq
 
 	var strayEvents int
 	if err := tx.QueryRowContext(ctx, `
-		WITH RECURSIVE selected_tree AS (
+		WITH RECURSIVE selected_agents AS (
+			SELECT DISTINCT d.subscriber_id AS agent_id
+			FROM event_deliveries d
+			INNER JOIN run_fork_selected_contract_executions x
+				ON x.fork_event_id = d.event_id
+			   AND x.fork_run_id = $1::uuid
+			   AND x.source_event_id = ANY($2::uuid[])
+			WHERE d.run_id = $1::uuid
+			  AND d.subscriber_type = 'agent'
+		),
+		selected_tree AS (
 			SELECT e.event_id
 			FROM events e
 			INNER JOIN run_fork_selected_contract_executions x
@@ -1143,6 +1138,12 @@ func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sq
 			   AND x.fork_run_id = $1::uuid
 			   AND x.source_event_id = ANY($2::uuid[])
 			WHERE e.run_id = $1::uuid
+			UNION
+			SELECT e.event_id
+			FROM events e
+			INNER JOIN selected_agents a ON a.agent_id = e.produced_by
+			WHERE e.run_id = $1::uuid
+			  AND e.produced_by_type = 'agent'
 			UNION
 			SELECT child.event_id
 			FROM events child

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -1544,6 +1544,109 @@ func TestSelectedContractActivationTreatsSameEventReplayScopeMarkerWriteSkewAsLi
 	assertNoCopiedReplayScopeMarkers(t, db, materialized.ForkRunID)
 }
 
+func TestSelectedContractActivationAllowsFreshForkConversationRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700003627, 0).UTC()
+	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	forkEventID := seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, eventID, entityID, at)
+	sessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, llm_backend, conversation_mode, status, created_at)
+		VALUES ('agent-a', 'worker', 'standard', 'mock', 'session_per_entity', 'active', $1)
+		ON CONFLICT (agent_id) DO NOTHING
+	`, at); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-a', 'delivered', $3)
+	`, materialized.ForkRunID, forkEventID, at.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed selected agent delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent.follow_up', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb,
+			'agent-a', 'agent', $4
+		)
+	`, materialized.ForkRunID, uuid.NewString(), entityID, at.Add(4*time.Second)); err != nil {
+		t.Fatalf("seed selected agent follow-up: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', 'agent-a:entity', 'entity',
+			'[]'::jsonb, 1, 'session_per_entity', '{}'::jsonb, 'active', $4, $4
+		)
+	`, sessionID, materialized.ForkRunID, entityID, at.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed fork session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-a', $3::uuid, 'flow-a/1', 'agent-a:entity', 'entity',
+			'[]'::jsonb, 1, 'task', '{}'::jsonb, 'active', $4, $4
+		)
+	`, uuid.NewString(), materialized.ForkRunID, entityID, at.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed fork conversation audit: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, available_tools, tool_calls, emitted_events,
+			mcp_servers, mcp_tools_listed, mcp_tools_visible, parse_ok, latency_ms, retry_count, created_at
+		)
+		VALUES (
+			$1::uuid, 'agent-a', $2::uuid, 'task', 'agent-a:entity', $3::uuid,
+			$4::uuid, 'item.received', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			'{}'::jsonb, '[]'::jsonb, '[]'::jsonb, true, 1, 0, $5
+		)
+	`, materialized.ForkRunID, sessionID, entityID, forkEventID, at.Add(3*time.Second)); err != nil {
+		t.Fatalf("seed fork turn: %v", err)
+	}
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{eventID},
+	})
+	if err != nil {
+		t.Fatalf("ActivateRunForkForSelectedContractExecution: %v", err)
+	}
+	if !activation.Activated {
+		t.Fatalf("activation = %#v, want activated", activation)
+	}
+}
+
 func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
Closes #690

## Summary
- Adds canonical owner `runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor` for selected-contract fork-local agent runtime materialization/execution.
- Factors ordinary static contract-agent materialization into reusable records, builds ephemeral fork-local agents through normal `AgentManager`/factory/prompt/tool semantics, and registers only selected-fork EventBus handlers/descriptors.
- Moves the #686 authoritative agent delivery gate to consume the new owner, keeps selected recipient planning as the sole recipient truth, and preserves fail-closed behavior for unsupported/missing selected agent materialization.
- Allows fresh fork-local sessions/turns/audits and selected-agent follow-up events produced by actual selected-fork execution while preflighting stale fork-local rows before materialization.

## Governing refs/context
- Issue audit: #690 repaired Pre-Implementation Coverage Audit and independent gate outcome `approved as first slice`.
- Parent trackers: #564 and #549.
- Authoritative spec sections updated/consumed: `selected_contract_recipient_planning`, `selected_contract_authoritative_agent_delivery_materialization`, `selected_contract_fork_local_agent_runtime_materializer_executor`, `selected_contract_supported_execution`, `3g_selected_contract_recipient_planning`, `3g1_selected_contract_fork_local_agent_runtime_materializer_executor`, `3h_selected_contract_supported_execution`.

## Semantic migration
- New canonical owner: `runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor`.
- Old invalid paths: source `event_deliveries`/outcomes, live subscriptions, active descriptors alone, CLI/API/dashboard/dry-run JSON, synthetic receipts, and persisted ordinary `agents` rows as selected-fork execution proof.
- Checked production paths: `swarm fork --contracts`, #686 materialization gate, selected publish guard, EventBus delivery planning, normal AgentManager materialization/execution, static/flow-required agent materialization, selected activation cleanup.
- Migration completeness: complete for the approved first slice. Restart recovery, flow-instance-scoped dynamic agent materialization, historical session/turn/audit reconstruction, non-agent replay, retry/idempotency/follow-up policy beyond normal fresh execution, and API/dashboard consumers remain split under #564/#549.

## Proof
- `go test ./internal/runtime/runforkexecution ./internal/runtime/bus ./internal/runtime/manager ./internal/store ./cmd/swarm -count=1`
- `go test ./... -count=1`
- `git diff --check`
- `swarm verify --contracts /Users/youmew/dev/empire/contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- Supported Empire proof used Swarm base `afe1201aa18526bb036e70ea0c9b74c1f177a97d` plus this PR, Empire `28728d1833e1bb7665a4a647798f816a55904d4f`, source run `3724c2d6-d8fb-49bc-aada-56f6f85b9b92`.
- Package-ready and mailbox boundaries still fail earlier on already tracked `source_committed_replay_scope_advanced_after_fork_point`.
- Pre-OpCo boundary reaches selected agent materialization/delivery for `validation-coordinator`; the remaining failure is `fork_events_not_selected_contract_lineage` caused by an uncorrelated `platform.auth_required` environment event. Cleanup proof shows zero surviving fork events, deliveries, bindings, entity_state, sessions, turns, or audits after failure.
