### PR TITLE
[agent-b][issue #696] Add persisted observability read owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -193,6 +193,7 @@ func main() {
 			},
 			Database:              stores.Postgres,
 			Runs:                  stores.Postgres,
+			Observability:         stores.Postgres,
 			Mailbox:               stores.Postgres,
 			Idempotency:           stores.Postgres,
 			Events:                rt.Bus,

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -1,0 +1,209 @@
+package apiv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarm/internal/store"
+)
+
+func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	observability := &fakeObservabilityReadStore{
+		traceRows: map[string][]store.RunDebugTraceRow{
+			"run-1": {{
+				EventID:        "evt-1",
+				EventName:      "scan.requested",
+				EventCreatedAt: now,
+			}},
+		},
+		events: map[string]store.OperatorEventFull{
+			"evt-1": {
+				EventID:   "evt-1",
+				EventName: "scan.requested",
+				RunID:     "run-1",
+				CreatedAt: now,
+				Source:    "runtime",
+				Payload:   map[string]any{"ok": true},
+				Deliveries: []store.OperatorEventDelivery{{
+					DeliveryID:     "del-1",
+					SubscriberType: "agent",
+					SubscriberID:   "agent-1",
+					Status:         "delivered",
+				}},
+				DeadLetters: []store.OperatorDeadLetterRecord{},
+			},
+		},
+		logs: []store.OperatorRuntimeLogEntry{{
+			LogID:     "log-1",
+			TS:        now,
+			Level:     "warn",
+			Component: "scheduler",
+			Source:    "runtime",
+			RunID:     "run-1",
+			ErrorCode: "retry_exhausted",
+			Message:   "retry exhausted",
+			Details:   map[string]any{"action": "dispatch"},
+		}},
+		incidents: []store.OperatorRuntimeIncident{{
+			IncidentID:    "inc-1",
+			FirstSeen:     now,
+			LastSeen:      now,
+			Count:         1,
+			Level:         "warn",
+			Component:     "scheduler",
+			ErrorCode:     "retry_exhausted",
+			SampleMessage: "retry exhausted",
+			SampleLogIDs:  []string{"log-1"},
+		}},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Observability: observability,
+		}),
+	})
+
+	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1}}`)
+	if trace.Error != nil {
+		t.Fatalf("run.trace error = %#v", trace.Error)
+	}
+	if rows, _ := asMap(t, trace.Result)["trace"].([]any); len(rows) != 1 {
+		t.Fatalf("run.trace rows = %#v", asMap(t, trace.Result)["trace"])
+	}
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"filter":{"run_id":"run-1","event_name":"scan.requested","has_dead_letter":false},"limit":10}}`)
+	if list.Error != nil {
+		t.Fatalf("event.list error = %#v", list.Error)
+	}
+	if events, _ := asMap(t, list.Result)["events"].([]any); len(events) != 1 {
+		t.Fatalf("event.list events = %#v", asMap(t, list.Result)["events"])
+	}
+	if observability.lastEventList.Filter.RunID != "run-1" || observability.lastEventList.Filter.EventName != "scan.requested" || observability.lastEventList.Filter.HasDeadLetter == nil || *observability.lastEventList.Filter.HasDeadLetter {
+		t.Fatalf("event.list filter = %#v", observability.lastEventList.Filter)
+	}
+
+	eventGet := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"event","method":"event.get","params":{"event_id":"evt-1"}}`)
+	if eventGet.Error != nil {
+		t.Fatalf("event.get error = %#v", eventGet.Error)
+	}
+	if got := asMap(t, eventGet.Result)["event_id"]; got != "evt-1" {
+		t.Fatalf("event.get event_id = %#v", got)
+	}
+
+	logs := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":"run-1","component":"scheduler","level":"warn","limit":5}}`)
+	if logs.Error != nil {
+		t.Fatalf("runtime.logs error = %#v", logs.Error)
+	}
+	if rows, _ := asMap(t, logs.Result)["logs"].([]any); len(rows) != 1 {
+		t.Fatalf("runtime.logs rows = %#v", asMap(t, logs.Result)["logs"])
+	}
+	if observability.lastRuntimeLogs.RunID != "run-1" || observability.lastRuntimeLogs.Component != "scheduler" {
+		t.Fatalf("runtime.logs options = %#v", observability.lastRuntimeLogs)
+	}
+
+	incidents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"incidents","method":"runtime.incidents","params":{"since_hours":24,"component":"scheduler","limit":5}}`)
+	if incidents.Error != nil {
+		t.Fatalf("runtime.incidents error = %#v", incidents.Error)
+	}
+	if rows, _ := asMap(t, incidents.Result)["incidents"].([]any); len(rows) != 1 {
+		t.Fatalf("runtime.incidents rows = %#v", asMap(t, incidents.Result)["incidents"])
+	}
+	if observability.lastIncidents.Component != "scheduler" || observability.lastIncidents.SinceHours != 24 {
+		t.Fatalf("runtime.incidents options = %#v", observability.lastIncidents)
+	}
+}
+
+func TestOperatorObservabilityHandlersTypedErrors(t *testing.T) {
+	observability := &fakeObservabilityReadStore{
+		traceErr: store.ErrRunNotFound,
+		eventErr: store.ErrEventNotFound,
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Observability: observability,
+		}),
+	})
+
+	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"missing"}}`)
+	if trace.Error == nil {
+		t.Fatal("run.trace error = nil, want RUN_NOT_FOUND")
+	}
+	if data := asMap(t, trace.Error.Data); data["code"] != RunNotFoundCode {
+		t.Fatalf("run.trace error data = %#v", data)
+	}
+
+	eventGet := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"event","method":"event.get","params":{"event_id":"missing"}}`)
+	if eventGet.Error == nil {
+		t.Fatal("event.get error = nil, want EVENT_NOT_FOUND")
+	}
+	if data := asMap(t, eventGet.Error.Data); data["code"] != EventNotFoundCode {
+		t.Fatalf("event.get error data = %#v", data)
+	}
+
+	observability.listErr = store.ErrInvalidObservabilityCursor
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"cursor":"bad"}}`)
+	if list.Error == nil || list.Error.Code != codeInvalidParams {
+		t.Fatalf("event.list error = %#v, want invalid params", list.Error)
+	}
+}
+
+type fakeObservabilityReadStore struct {
+	traceRows map[string][]store.RunDebugTraceRow
+	traceErr  error
+
+	events   map[string]store.OperatorEventFull
+	eventErr error
+	listErr  error
+
+	logs      []store.OperatorRuntimeLogEntry
+	incidents []store.OperatorRuntimeIncident
+
+	lastEventList   store.OperatorEventListOptions
+	lastRuntimeLogs store.OperatorRuntimeLogListOptions
+	lastIncidents   store.OperatorRuntimeIncidentListOptions
+}
+
+func (s *fakeObservabilityReadStore) LoadRunDebugTracePage(_ context.Context, runID string, _ store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, string, error) {
+	if s.traceErr != nil {
+		return nil, "", s.traceErr
+	}
+	return s.traceRows[runID], "", nil
+}
+
+func (s *fakeObservabilityReadStore) ListOperatorEvents(_ context.Context, opts store.OperatorEventListOptions) (store.OperatorEventListResult, error) {
+	s.lastEventList = opts
+	if s.listErr != nil {
+		return store.OperatorEventListResult{}, s.listErr
+	}
+	out := make([]store.OperatorEventFull, 0, len(s.events))
+	for _, event := range s.events {
+		out = append(out, event)
+	}
+	return store.OperatorEventListResult{Events: out}, nil
+}
+
+func (s *fakeObservabilityReadStore) LoadOperatorEvent(_ context.Context, eventID string) (store.OperatorEventFull, error) {
+	if s.eventErr != nil {
+		return store.OperatorEventFull{}, s.eventErr
+	}
+	event, ok := s.events[eventID]
+	if !ok {
+		return store.OperatorEventFull{}, store.ErrEventNotFound
+	}
+	return event, nil
+}
+
+func (s *fakeObservabilityReadStore) ListOperatorRuntimeLogs(_ context.Context, opts store.OperatorRuntimeLogListOptions) (store.OperatorRuntimeLogListResult, error) {
+	s.lastRuntimeLogs = opts
+	return store.OperatorRuntimeLogListResult{Logs: s.logs}, nil
+}
+
+func (s *fakeObservabilityReadStore) ListOperatorRuntimeIncidents(_ context.Context, opts store.OperatorRuntimeIncidentListOptions) (store.OperatorRuntimeIncidentListResult, error) {
+	s.lastIncidents = opts
+	return store.OperatorRuntimeIncidentListResult{Incidents: s.incidents}, nil
+}
+
+var _ ObservabilityReadStore = (*fakeObservabilityReadStore)(nil)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -23,11 +23,20 @@ type RunReadStore interface {
 	LoadRunDebugReport(context.Context, string, store.RunDebugQueryOptions) (store.RunDebugReport, error)
 }
 
+type ObservabilityReadStore interface {
+	LoadRunDebugTracePage(context.Context, string, store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, string, error)
+	ListOperatorEvents(context.Context, store.OperatorEventListOptions) (store.OperatorEventListResult, error)
+	LoadOperatorEvent(context.Context, string) (store.OperatorEventFull, error)
+	ListOperatorRuntimeLogs(context.Context, store.OperatorRuntimeLogListOptions) (store.OperatorRuntimeLogListResult, error)
+	ListOperatorRuntimeIncidents(context.Context, store.OperatorRuntimeIncidentListOptions) (store.OperatorRuntimeIncidentListResult, error)
+}
+
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
 	Database              Pinger
 	Runs                  RunReadStore
+	Observability         ObservabilityReadStore
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
@@ -58,6 +67,11 @@ type runGetResult struct {
 type runListResult struct {
 	Runs       []store.RunHeader `json:"runs"`
 	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type runTraceListResult struct {
+	Trace      []store.RunDebugTraceRow `json:"trace"`
+	NextCursor string                   `json:"next_cursor,omitempty"`
 }
 
 type runDiagnosis struct {
@@ -182,6 +196,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorRuntimeControlHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorObservabilityHandlers(opts) {
+		handlers[name] = handler
+	}
 	return handlers
 }
 
@@ -190,6 +207,248 @@ func requireRunReadStore(runs RunReadStore) (RunReadStore, error) {
 		return nil, fmt.Errorf("run read store is required")
 	}
 	return runs, nil
+}
+
+func requireObservabilityReadStore(reads ObservabilityReadStore) (ObservabilityReadStore, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("observability read store is required")
+	}
+	return reads, nil
+}
+
+func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.Observability == nil {
+		return nil
+	}
+	return map[string]MethodHandler{
+		"run.trace": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireObservabilityReadStore(opts.Observability)
+			if err != nil {
+				return nil, err
+			}
+			runID := stringParam(req.Params, "run_id")
+			limit, err := boundedIntegerParam(req.Params, "limit", 1, 2000)
+			if err != nil {
+				return nil, err
+			}
+			cursor, _, err := optionalStringParam(req.Params, "cursor")
+			if err != nil {
+				return nil, err
+			}
+			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor})
+			if errors.Is(err, store.ErrRunNotFound) {
+				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
+			}
+			if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid run trace cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if rows == nil {
+				rows = []store.RunDebugTraceRow{}
+			}
+			return runTraceListResult{Trace: rows, NextCursor: nextCursor}, nil
+		},
+		"event.list": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireObservabilityReadStore(opts.Observability)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorEventListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorEvents(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid event list cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"event.get": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireObservabilityReadStore(opts.Observability)
+			if err != nil {
+				return nil, err
+			}
+			eventID := stringParam(req.Params, "event_id")
+			event, err := reads.LoadOperatorEvent(ctx, eventID)
+			if errors.Is(err, store.ErrEventNotFound) {
+				return nil, NewApplicationError(EventNotFoundCode, false, map[string]any{"event_id": eventID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return event, nil
+		},
+		"runtime.logs": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireObservabilityReadStore(opts.Observability)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorRuntimeLogListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorRuntimeLogs(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid runtime log cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"runtime.incidents": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireObservabilityReadStore(opts.Observability)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorRuntimeIncidentListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorRuntimeIncidents(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid runtime incident cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	}
+}
+
+func operatorEventListOptionsFromParams(params map[string]any) (store.OperatorEventListOptions, error) {
+	out := store.OperatorEventListOptions{}
+	filter, err := eventListFilterParam(params)
+	if err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
+	out.Filter = filter
+	limit, err := boundedIntegerParam(params, "limit", 1, 1000)
+	if err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
+	out.Limit = limit
+	cursor, _, err := optionalStringParam(params, "cursor")
+	if err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
+	out.Cursor = cursor
+	if out.Since, err = timestampParam(params, "since"); err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
+	if out.Until, err = timestampParam(params, "until"); err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
+	return out, nil
+}
+
+func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter, error) {
+	raw, ok := params["filter"]
+	if !ok || isEmptyParam(raw) {
+		return store.OperatorEventListFilter{}, nil
+	}
+	filter, ok := raw.(map[string]any)
+	if !ok {
+		return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter", "reason": "must be an object"})
+	}
+	out := store.OperatorEventListFilter{}
+	var err error
+	if out.RunID, _, err = optionalStringParam(filter, "run_id"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.EntityID, _, err = optionalStringParam(filter, "entity_id"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.EventName, _, err = optionalStringParam(filter, "event_name"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.DeliveryStatus, _, err = optionalStringParam(filter, "delivery_status"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.SubscriberID, _, err = optionalStringParam(filter, "subscriber_id"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.SubscriberType, _, err = optionalStringParam(filter, "subscriber_type"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if out.ReasonCode, _, err = optionalStringParam(filter, "reason_code"); err != nil {
+		return store.OperatorEventListFilter{}, err
+	}
+	if rawBool, ok := filter["has_dead_letter"]; ok && !isEmptyParam(rawBool) {
+		value, ok := rawBool.(bool)
+		if !ok {
+			return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.has_dead_letter", "reason": "must be a boolean"})
+		}
+		out.HasDeadLetter = &value
+	}
+	return out, nil
+}
+
+func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.OperatorRuntimeLogListOptions, error) {
+	out := store.OperatorRuntimeLogListOptions{}
+	var err error
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Level, _, err = optionalStringParam(params, "level"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.ErrorCode, _, err = optionalStringParam(params, "error_code"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Source, _, err = optionalStringParam(params, "source"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Order, _, err = optionalStringParam(params, "order"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 1000); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	return out, nil
+}
+
+func operatorRuntimeIncidentListOptionsFromParams(params map[string]any) (store.OperatorRuntimeIncidentListOptions, error) {
+	out := store.OperatorRuntimeIncidentListOptions{}
+	var err error
+	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
+	if out.Level, _, err = optionalStringParam(params, "level"); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
+	if rawBool, ok := params["mcp_only"]; ok && !isEmptyParam(rawBool) {
+		value, ok := rawBool.(bool)
+		if !ok {
+			return store.OperatorRuntimeIncidentListOptions{}, NewInvalidParamsError(map[string]any{"field": "mcp_only", "reason": "must be a boolean"})
+		}
+		out.MCPOnly = value
+	}
+	if out.SinceHours, err = boundedIntegerParam(params, "since_hours", 1, 720); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
+	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 500); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
+	return out, nil
 }
 
 func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListOptions, error) {
@@ -267,6 +526,10 @@ func stringParam(params map[string]any, name string) string {
 
 func integerParam(value any) (int, bool) {
 	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
 	case float64:
 		if math.Trunc(typed) != typed {
 			return 0, false
@@ -275,4 +538,22 @@ func integerParam(value any) (int, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func boundedIntegerParam(params map[string]any, name string, minValue, maxValue int) (int, error) {
+	if params == nil {
+		return 0, nil
+	}
+	raw, ok := params[name]
+	if !ok || isEmptyParam(raw) {
+		return 0, nil
+	}
+	value, ok := integerParam(raw)
+	if !ok || value < minValue || value > maxValue {
+		return 0, NewInvalidParamsError(map[string]any{
+			"field":  name,
+			"reason": fmt.Sprintf("must be an integer from %d to %d", minValue, maxValue),
+		})
+	}
+	return value, nil
 }

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -15,6 +15,7 @@ const (
 	BundleMismatchCode                   = "BUNDLE_MISMATCH"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
+	EventNotFoundCode                    = "EVENT_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -3,13 +3,9 @@ package server
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
-	"fmt"
-	"sort"
 	"strings"
 	"time"
 
-	runtimepkg "swarm/internal/runtime"
 	"swarm/internal/store"
 )
 
@@ -150,16 +146,6 @@ func (r *SQLObservabilityReader) resolveCapabilities(ctx context.Context) (store
 	return r.capSource.ResolveSchemaCapabilities(ctx)
 }
 
-func applyDeliveryLifecycle(record *eventRecord, lifecycle deliveryLifecycleSummary) {
-	if record == nil {
-		return
-	}
-	record.DeliveryLifecycle = lifecycle
-	record.PendingCount = lifecycle.Pending
-	record.ErrorCount = lifecycle.Failed
-	record.DeadCount = lifecycle.DeadLetter
-}
-
 func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFilter, limit int) ([]eventRecord, error) {
 	if r == nil || r.db == nil {
 		return []eventRecord{}, nil
@@ -171,92 +157,24 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 	if err := requireObservabilityEventCapabilities(caps); err != nil {
 		return nil, err
 	}
-	if limit <= 0 {
-		limit = 200
-	}
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT
-			e.event_id::text,
-			e.event_name,
-			e.created_at,
-			COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, COALESCE(e.payload->>'entity_id', '')),
-			COALESCE(e.scope, ''),
-			COALESCE(e.source_event_id::text, '') AS parent_event_id,
-			COALESCE(e.payload, '{}'::jsonb),
-			COALESCE(dl.pending_count, 0),
-			COALESCE(dl.in_progress_count, 0),
-			COALESCE(dl.delivered_count, 0),
-			COALESCE(dl.failed_count, 0),
-			COALESCE(dl.dead_letter_count, 0)
-		FROM events e
-		LEFT JOIN LATERAL (
-			SELECT
-				COUNT(*) FILTER (WHERE d.status = 'pending')::int AS pending_count,
-				COUNT(*) FILTER (WHERE d.status = 'in_progress')::int AS in_progress_count,
-				COUNT(*) FILTER (WHERE d.status = 'delivered')::int AS delivered_count,
-				COUNT(*) FILTER (WHERE d.status = 'failed')::int AS failed_count,
-				COUNT(*) FILTER (WHERE d.status = 'dead_letter')::int AS dead_letter_count
-			FROM event_deliveries d
-			WHERE d.event_id = e.event_id
-		) dl ON TRUE
-		WHERE e.event_name <> 'platform.runtime_log'
-		  AND ($1 = '' OR e.event_name = $1)
-		  AND ($2 = '' OR COALESCE(e.produced_by, '') = $2)
-		  AND ($3 = '' OR EXISTS (
-				SELECT 1
-				FROM event_deliveries d
-				WHERE d.event_id = e.event_id
-				  AND d.subscriber_id = $3
-		  ))
-		  AND ($4 = '' OR COALESCE(e.entity_id::text, COALESCE(e.payload->>'entity_id', '')) = $4)
-		  AND ($5::timestamptz IS NULL OR e.created_at > $5)
-		ORDER BY e.created_at DESC
-		LIMIT $6
-	`, strings.TrimSpace(filter.Type), strings.TrimSpace(filter.Source), strings.TrimSpace(filter.Subscriber), strings.TrimSpace(filter.EntityID), nullableTime(filter.After), limit)
+	owner := &store.PostgresStore{DB: r.db}
+	result, err := owner.ListOperatorEvents(ctx, store.OperatorEventListOptions{
+		Filter: store.OperatorEventListFilter{
+			EntityID:     filter.EntityID,
+			EventName:    filter.Type,
+			SubscriberID: filter.Subscriber,
+		},
+		Source:             filter.Source,
+		Since:              dashboardTimePtr(filter.After),
+		Limit:              limit,
+		ExcludeRuntimeLogs: true,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("list events: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
-
-	out := make([]eventRecord, 0, limit)
-	for rows.Next() {
-		var (
-			item       eventRecord
-			payloadRaw []byte
-			lifecycle  deliveryLifecycleSummary
-		)
-		if err := rows.Scan(
-			&item.ID,
-			&item.Type,
-			&item.CreatedAt,
-			&item.SourceAgent,
-			&item.EntityID,
-			&item.Scope,
-			&item.ParentEventID,
-			&payloadRaw,
-			&lifecycle.Pending,
-			&lifecycle.InProgress,
-			&lifecycle.Delivered,
-			&lifecycle.Failed,
-			&lifecycle.DeadLetter,
-		); err != nil {
-			return nil, fmt.Errorf("scan event: %w", err)
-		}
-		item.EventID = item.ID
-		payloadMap, err := decodeJSONMap(payloadRaw)
-		if err != nil {
-			return nil, fmt.Errorf("decode event payload: %w", err)
-		}
-		item.Payload = payloadMap
-		if strings.TrimSpace(item.EntityID) == "" {
-			item.EntityID = readString(payloadMap["entity_id"])
-		}
-		applyDeliveryLifecycle(&item, lifecycle)
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("list event rows: %w", err)
+	out := make([]eventRecord, 0, len(result.Events))
+	for _, event := range result.Events {
+		out = append(out, dashboardEventRecord(event))
 	}
 	return out, nil
 }
@@ -276,78 +194,15 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 	if id == "" {
 		return eventRecord{}, false, nil
 	}
-	row := r.db.QueryRowContext(ctx, `
-		SELECT
-			e.event_id::text,
-			e.event_name,
-			e.created_at,
-			COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, COALESCE(e.payload->>'entity_id', '')),
-			COALESCE(e.scope, ''),
-			COALESCE(e.source_event_id::text, '') AS parent_event_id,
-			COALESCE(e.payload, '{}'::jsonb)
-		FROM events e
-		WHERE e.event_id::text = $1
-		LIMIT 1
-	`, id)
-	var (
-		item       eventRecord
-		payloadRaw []byte
-	)
-	if err := row.Scan(&item.ID, &item.Type, &item.CreatedAt, &item.SourceAgent, &item.EntityID, &item.Scope, &item.ParentEventID, &payloadRaw); err == sql.ErrNoRows {
+	owner := &store.PostgresStore{DB: r.db}
+	event, err := owner.LoadOperatorEvent(ctx, id)
+	if err == store.ErrEventNotFound {
 		return eventRecord{}, false, nil
-	} else if err != nil {
-		return eventRecord{}, false, fmt.Errorf("get event: %w", err)
 	}
-	item.EventID = item.ID
-	payloadMap, err := decodeJSONMap(payloadRaw)
-	if err != nil {
-		return eventRecord{}, false, fmt.Errorf("decode event payload: %w", err)
-	}
-	item.Payload = payloadMap
-	if strings.TrimSpace(item.EntityID) == "" {
-		item.EntityID = readString(payloadMap["entity_id"])
-	}
-
-	deliveries, lifecycle, err := r.loadEventDeliveries(ctx, id)
 	if err != nil {
 		return eventRecord{}, false, err
 	}
-	item.Deliveries = deliveries
-	applyDeliveryLifecycle(&item, lifecycle)
-	return item, true, nil
-}
-
-func (r *SQLObservabilityReader) loadEventDeliveries(ctx context.Context, id string) ([]eventDeliveryRecord, deliveryLifecycleSummary, error) {
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT
-			d.subscriber_id,
-			COALESCE(d.status, 'pending'),
-			COALESCE(d.last_error, ''),
-			COALESCE(d.retry_count, 0)
-		FROM event_deliveries d
-		WHERE d.event_id::text = $1
-		ORDER BY d.created_at ASC, d.subscriber_id ASC
-	`, id)
-	if err != nil {
-		return nil, deliveryLifecycleSummary{}, fmt.Errorf("load event deliveries: %w", err)
-	}
-	defer rows.Close()
-
-	out := []eventDeliveryRecord{}
-	var lifecycle deliveryLifecycleSummary
-	for rows.Next() {
-		var item eventDeliveryRecord
-		if err := rows.Scan(&item.AgentID, &item.Status, &item.Error, &item.RetryCount); err != nil {
-			return nil, deliveryLifecycleSummary{}, fmt.Errorf("scan event delivery: %w", err)
-		}
-		lifecycle.record(item.Status)
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, deliveryLifecycleSummary{}, fmt.Errorf("event delivery rows: %w", err)
-	}
-	return out, lifecycle, nil
+	return dashboardEventRecord(event), true, nil
 }
 
 func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter RuntimeLogFilter, limit int) ([]runtimeLogRecord, error) {
@@ -361,55 +216,24 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
 	}
-	if limit <= 0 {
-		limit = 200
-	}
-	order := "DESC"
-	if strings.EqualFold(strings.TrimSpace(filter.Order), "asc") {
-		order = "ASC"
-	}
-	query := fmt.Sprintf(`
-		SELECT
-			e.event_id::text,
-			e.created_at,
-			COALESCE(e.payload, '{}'::jsonb)
-		FROM events e
-		WHERE e.event_name = 'platform.runtime_log'
-		  AND ($1::timestamptz IS NULL OR e.created_at > $1)
-		ORDER BY e.created_at %s
-	`, order)
-	rows, err := r.db.QueryContext(ctx, query,
-		nullableTime(filter.After),
-	)
+	owner := &store.PostgresStore{DB: r.db}
+	result, err := owner.ListOperatorRuntimeLogs(ctx, store.OperatorRuntimeLogListOptions{
+		EntityID:          filter.EntityID,
+		Component:         filter.Component,
+		Level:             filter.Level,
+		ErrorCode:         filter.ErrorCode,
+		Source:            filter.Source,
+		ActionOrEventType: filter.Type,
+		Since:             dashboardTimePtr(filter.After),
+		Limit:             limit,
+		Order:             filter.Order,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("list runtime logs: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
-
-	out := make([]runtimeLogRecord, 0, limit)
-	for rows.Next() {
-		var (
-			eventID    string
-			createdAt  time.Time
-			payloadRaw []byte
-		)
-		if err := rows.Scan(&eventID, &createdAt, &payloadRaw); err != nil {
-			return nil, fmt.Errorf("scan runtime log: %w", err)
-		}
-		item, err := decodeRuntimeLogRecord(eventID, createdAt, payloadRaw)
-		if err != nil {
-			return nil, err
-		}
-		if !matchesRuntimeLogFilter(item, filter) {
-			continue
-		}
-		out = append(out, item)
-		if len(out) >= limit {
-			break
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("runtime log rows: %w", err)
+	out := make([]runtimeLogRecord, 0, len(result.Logs))
+	for _, log := range result.Logs {
+		out = append(out, dashboardRuntimeLogRecord(log))
 	}
 	return out, nil
 }
@@ -425,138 +249,108 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
 	}
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 2000
-	}
-	sinceHours := filter.SinceHours
-	if sinceHours <= 0 {
-		sinceHours = 24
-	}
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT
-			e.event_id::text,
-			e.created_at,
-			COALESCE(e.payload, '{}'::jsonb)
-		FROM events e
-		WHERE e.event_name = 'platform.runtime_log'
-		  AND e.created_at >= now() - make_interval(hours => $1)
-		ORDER BY e.created_at DESC
-	`, sinceHours)
-	if err != nil {
-		return nil, fmt.Errorf("list incidents: %w", err)
-	}
-	defer rows.Close()
-
-	type incidentAggregate struct {
-		record        incidentRecord
-		firstSeen     time.Time
-		lastSeen      time.Time
-		agentsSet     map[string]struct{}
-		componentsSet map[string]struct{}
-		actionsSet    map[string]struct{}
-	}
-
-	aggregates := map[string]*incidentAggregate{}
-	for rows.Next() {
-		var (
-			eventID    string
-			createdAt  time.Time
-			payloadRaw []byte
-		)
-		if err := rows.Scan(&eventID, &createdAt, &payloadRaw); err != nil {
-			return nil, fmt.Errorf("scan runtime log for incidents: %w", err)
-		}
-		logRecord, err := decodeRuntimeLogRecord(eventID, createdAt, payloadRaw)
-		if err != nil {
-			return nil, err
-		}
-		if !matchesIncidentFilter(logRecord, filter) {
-			continue
-		}
-		if strings.TrimSpace(logRecord.ErrorCode) == "" {
-			continue
-		}
-		agg := aggregates[logRecord.ErrorCode]
-		if agg == nil {
-			agg = &incidentAggregate{
-				record: incidentRecord{
-					Code:      logRecord.ErrorCode,
-					RootCause: firstNonEmpty(logRecord.Error, logRecord.Message),
-					Component: strings.TrimSpace(logRecord.Component),
-					Level:     strings.TrimSpace(logRecord.Level),
-				},
-				firstSeen:     createdAt,
-				lastSeen:      createdAt,
-				agentsSet:     map[string]struct{}{},
-				componentsSet: map[string]struct{}{},
-				actionsSet:    map[string]struct{}{},
-			}
-			aggregates[logRecord.ErrorCode] = agg
-		}
-		agg.record.Count++
-		if createdAt.Before(agg.firstSeen) {
-			agg.firstSeen = createdAt
-		}
-		if createdAt.After(agg.lastSeen) {
-			agg.lastSeen = createdAt
-		}
-		if agg.record.RootCause == "" {
-			agg.record.RootCause = firstNonEmpty(logRecord.Error, logRecord.Message)
-		}
-		if agg.record.Component == "" {
-			agg.record.Component = strings.TrimSpace(logRecord.Component)
-		}
-		if agg.record.Level == "" {
-			agg.record.Level = strings.TrimSpace(logRecord.Level)
-		}
-		if v := strings.TrimSpace(logRecord.AgentID); v != "" {
-			agg.agentsSet[v] = struct{}{}
-		}
-		if v := strings.TrimSpace(logRecord.Component); v != "" {
-			agg.componentsSet[v] = struct{}{}
-		}
-		if v := strings.TrimSpace(logRecord.Action); v != "" {
-			agg.actionsSet[v] = struct{}{}
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("incident runtime log rows: %w", err)
-	}
-
-	sorted := make([]*incidentAggregate, 0, len(aggregates))
-	for _, agg := range aggregates {
-		sorted = append(sorted, agg)
-	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if !sorted[i].lastSeen.Equal(sorted[j].lastSeen) {
-			return sorted[i].lastSeen.After(sorted[j].lastSeen)
-		}
-		return sorted[i].record.Code < sorted[j].record.Code
+	owner := &store.PostgresStore{DB: r.db}
+	result, err := owner.ListOperatorRuntimeIncidents(ctx, store.OperatorRuntimeIncidentListOptions{
+		SinceHours: filter.SinceHours,
+		Component:  filter.Component,
+		Level:      filter.Level,
+		MCPOnly:    filter.MCPOnly,
+		Limit:      filter.Limit,
 	})
-	out := make([]incidentRecord, 0, len(sorted))
-	for _, agg := range sorted {
-		agg.record.Agents = sortedStringSet(agg.agentsSet)
-		agg.record.Components = sortedStringSet(agg.componentsSet)
-		agg.record.Actions = sortedStringSet(agg.actionsSet)
-		agg.record.FirstSeen = formatTime(agg.firstSeen)
-		agg.record.LastSeen = formatTime(agg.lastSeen)
-		out = append(out, agg.record)
+	if err != nil {
+		return nil, err
 	}
-	if len(out) > limit {
-		out = out[:limit]
+	out := make([]incidentRecord, 0, len(result.Incidents))
+	for _, incident := range result.Incidents {
+		out = append(out, dashboardIncidentRecord(incident))
 	}
 	return out, nil
 }
 
-func nullableTime(ts time.Time) any {
+func dashboardEventRecord(event store.OperatorEventFull) eventRecord {
+	record := eventRecord{
+		ID:          event.EventID,
+		EventID:     event.EventID,
+		Type:        event.EventName,
+		CreatedAt:   formatTime(event.CreatedAt),
+		SourceAgent: event.Source,
+		EntityID:    event.EntityID,
+		Payload:     event.Payload,
+		Deliveries:  make([]eventDeliveryRecord, 0, len(event.Deliveries)),
+	}
+	for _, delivery := range event.Deliveries {
+		record.Deliveries = append(record.Deliveries, eventDeliveryRecord{
+			AgentID:    delivery.SubscriberID,
+			Status:     delivery.Status,
+			Error:      delivery.LastError,
+			RetryCount: delivery.RetryCount,
+		})
+		record.DeliveryLifecycle.record(delivery.Status)
+	}
+	record.PendingCount = record.DeliveryLifecycle.Pending
+	record.ErrorCount = record.DeliveryLifecycle.Failed
+	record.DeadCount = record.DeliveryLifecycle.DeadLetter
+	return record
+}
+
+func dashboardRuntimeLogRecord(log store.OperatorRuntimeLogEntry) runtimeLogRecord {
+	details := log.Details
+	if details == nil {
+		details = map[string]any{}
+	}
+	return runtimeLogRecord{
+		ID:            log.LogID,
+		EventID:       readString(details["event_id"]),
+		TS:            formatTime(log.TS),
+		Level:         log.Level,
+		Component:     log.Component,
+		Action:        readString(details["action"]),
+		EventType:     firstString(readString(details["event_name"]), readString(details["event_type"])),
+		ParentEventID: readString(details["parent_event_id"]),
+		HandlerID:     readString(details["handler_id"]),
+		Error:         readString(details["error"]),
+		ErrorCode:     log.ErrorCode,
+		AgentID:       readString(details["agent_id"]),
+		EntityID:      log.EntityID,
+		SessionID:     readString(details["session_id"]),
+		DurationUS:    readInt(details["duration_us"]),
+		Source:        log.Source,
+		Message:       log.Message,
+		DeliveryState: readString(details["delivery_state"]),
+		PreviousState: readString(details["delivery_previous_state"]),
+		Transition:    readString(details["delivery_transition"]),
+		Reason:        readString(details["delivery_reason"]),
+		Terminal:      readString(details["delivery_terminal_outcome"]),
+		RetryCount:    readInt(details["retry_count"]),
+		Detail:        details,
+		Correlation:   details["correlation"],
+	}
+}
+
+func dashboardIncidentRecord(incident store.OperatorRuntimeIncident) incidentRecord {
+	return incidentRecord{
+		Code:       incident.ErrorCode,
+		Count:      incident.Count,
+		RootCause:  incident.SampleMessage,
+		Component:  incident.Component,
+		Level:      incident.Level,
+		Agents:     incident.Agents,
+		Components: incident.Components,
+		Actions:    incident.Actions,
+		FirstSeen:  formatTime(incident.FirstSeen),
+		LastSeen:   formatTime(incident.LastSeen),
+	}
+}
+
+func dashboardTimePtr(ts time.Time) *time.Time {
 	if ts.IsZero() {
 		return nil
 	}
-	return ts.UTC()
+	value := ts.UTC()
+	return &value
 }
 
-func firstNonEmpty(values ...string) string {
+func firstString(values ...string) string {
 	for _, value := range values {
 		if strings.TrimSpace(value) != "" {
 			return strings.TrimSpace(value)
@@ -565,106 +359,15 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func decodeJSONAny(raw []byte) (any, error) {
-	if len(raw) == 0 {
-		return map[string]any{}, nil
+func readInt(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	default:
+		return 0
 	}
-	var out any
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func decodeRuntimeLogRecord(rowID string, createdAt time.Time, payloadRaw []byte) (runtimeLogRecord, error) {
-	payload, err := runtimepkg.DecodeCanonicalRuntimeLogPayload(payloadRaw)
-	if err != nil {
-		return runtimeLogRecord{}, fmt.Errorf("decode canonical runtime log payload: %w", err)
-	}
-	record := runtimeLogRecord{
-		ID:            strings.TrimSpace(rowID),
-		EventID:       payload.EventID,
-		TS:            formatTime(createdAt),
-		Level:         payload.LogLevel,
-		Component:     payload.Component,
-		Action:        payload.Action,
-		EventType:     payload.EventType,
-		ParentEventID: payload.ParentEventID,
-		HandlerID:     payload.HandlerID,
-		Error:         payload.Error,
-		ErrorCode:     payload.ErrorCode,
-		AgentID:       payload.AgentID,
-		EntityID:      payload.EntityID,
-		SessionID:     payload.SessionID,
-		DurationUS:    payload.DurationUS,
-		Source:        payload.AgentID,
-		Message:       payload.Message,
-		DeliveryState: payload.DeliveryState,
-		PreviousState: payload.PreviousState,
-		Transition:    payload.Transition,
-		Reason:        payload.Reason,
-		Terminal:      payload.Terminal,
-		RetryCount:    payload.RetryCount,
-		Detail:        payload.Detail,
-		Correlation:   payload.Correlation,
-	}
-	return record, nil
-}
-
-func matchesRuntimeLogFilter(item runtimeLogRecord, filter RuntimeLogFilter) bool {
-	typeFilter := strings.TrimSpace(filter.Type)
-	if typeFilter != "" && strings.TrimSpace(item.EventType) != typeFilter && strings.TrimSpace(item.Action) != typeFilter {
-		return false
-	}
-	sourceFilter := strings.TrimSpace(filter.Source)
-	if sourceFilter != "" && strings.TrimSpace(item.Source) != sourceFilter {
-		return false
-	}
-	entityFilter := strings.TrimSpace(filter.EntityID)
-	if entityFilter != "" && strings.TrimSpace(item.EntityID) != entityFilter {
-		return false
-	}
-	componentFilter := strings.TrimSpace(filter.Component)
-	if componentFilter != "" && strings.TrimSpace(item.Component) != componentFilter {
-		return false
-	}
-	levelFilter := strings.TrimSpace(filter.Level)
-	if levelFilter != "" && strings.TrimSpace(item.Level) != levelFilter {
-		return false
-	}
-	errorCodeFilter := strings.TrimSpace(filter.ErrorCode)
-	if errorCodeFilter != "" && strings.TrimSpace(item.ErrorCode) != errorCodeFilter {
-		return false
-	}
-	return true
-}
-
-func matchesIncidentFilter(item runtimeLogRecord, filter IncidentFilter) bool {
-	levelFilter := strings.TrimSpace(filter.Level)
-	if levelFilter != "" && strings.TrimSpace(item.Level) != levelFilter {
-		return false
-	}
-	componentFilter := strings.TrimSpace(filter.Component)
-	if componentFilter != "" && strings.TrimSpace(item.Component) != componentFilter {
-		return false
-	}
-	if filter.MCPOnly && !strings.HasPrefix(strings.TrimSpace(item.Component), "mcp") {
-		return false
-	}
-	return true
-}
-
-func sortedStringSet(values map[string]struct{}) []string {
-	if len(values) == 0 {
-		return []string{}
-	}
-	out := make([]string, 0, len(values))
-	for value := range values {
-		value = strings.TrimSpace(value)
-		if value != "" {
-			out = append(out, value)
-		}
-	}
-	sort.Strings(out)
-	return out
 }

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -7,3 +7,7 @@ var ErrUnknownSchemaType = errors.New("store: unknown schema type")
 var ErrRunNotFound = errors.New("store: run not found")
 
 var ErrInvalidRunListCursor = errors.New("store: invalid run list cursor")
+
+var ErrEventNotFound = errors.New("store: event not found")
+
+var ErrInvalidObservabilityCursor = errors.New("store: invalid observability cursor")

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -246,7 +246,7 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 	}
 	if opts.Since != nil {
 		n := add(opts.Since.UTC())
-		where = append(where, fmt.Sprintf("e.created_at >= $%d", n))
+		where = append(where, fmt.Sprintf("e.created_at > $%d", n))
 	}
 	if opts.Until != nil {
 		n := add(opts.Until.UTC())
@@ -445,7 +445,7 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType}
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
-		cursorClause += fmt.Sprintf(" AND e.created_at >= $%d", len(args))
+		cursorClause += fmt.Sprintf(" AND e.created_at > $%d", len(args))
 	}
 	if opts.Cursor != "" {
 		cursor, err := decodeObservabilityPositionCursor(opts.Cursor, "runtime.logs")
@@ -543,16 +543,25 @@ func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts O
 	}
 	opts = defaultOperatorRuntimeIncidentListOptions(opts)
 	cutoff := time.Now().UTC().Add(-time.Duration(opts.SinceHours) * time.Hour)
-	logs, err := s.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
-		Component: opts.Component,
-		Level:     opts.Level,
-		Since:     &cutoff,
-		Limit:     10000,
-		Order:     "desc",
-	})
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id::text,
+			COALESCE(e.run_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			e.created_at,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.payload, '{}'::jsonb)
+		FROM events e
+		WHERE e.event_name = 'platform.runtime_log'
+		  AND e.created_at >= $1
+		  AND ($2 = '' OR COALESCE(e.payload->'details'->>'component', '') = $2)
+		  AND ($3 = '' OR COALESCE(e.payload->>'log_level', '') = $3)
+		ORDER BY e.created_at DESC, e.event_id::text DESC
+	`, cutoff, opts.Component, opts.Level)
 	if err != nil {
-		return OperatorRuntimeIncidentListResult{}, err
+		return OperatorRuntimeIncidentListResult{}, fmt.Errorf("list operator runtime incident logs: %w", err)
 	}
+	defer rows.Close()
 	type aggregate struct {
 		item       OperatorRuntimeIncident
 		agents     map[string]struct{}
@@ -560,7 +569,22 @@ func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts O
 		components map[string]struct{}
 	}
 	aggregates := map[string]*aggregate{}
-	for _, logEntry := range logs.Logs {
+	for rows.Next() {
+		var (
+			eventID    string
+			runID      string
+			entityID   string
+			createdAt  time.Time
+			producedBy string
+			payloadRaw []byte
+		)
+		if err := rows.Scan(&eventID, &runID, &entityID, &createdAt, &producedBy, &payloadRaw); err != nil {
+			return OperatorRuntimeIncidentListResult{}, fmt.Errorf("scan operator runtime incident log: %w", err)
+		}
+		logEntry, err := operatorRuntimeLogEntry(eventID, runID, entityID, producedBy, createdAt, payloadRaw)
+		if err != nil {
+			return OperatorRuntimeIncidentListResult{}, err
+		}
 		if opts.MCPOnly && !strings.HasPrefix(strings.TrimSpace(logEntry.Component), "mcp") {
 			continue
 		}
@@ -609,6 +633,9 @@ func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts O
 		if logEntry.Component != "" {
 			agg.components[logEntry.Component] = struct{}{}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorRuntimeIncidentListResult{}, fmt.Errorf("read operator runtime incident logs: %w", err)
 	}
 	out := make([]OperatorRuntimeIncident, 0, len(aggregates))
 	for _, agg := range aggregates {

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -1,0 +1,814 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	runtimepkg "swarm/internal/runtime"
+)
+
+type OperatorEventListFilter struct {
+	RunID          string
+	EntityID       string
+	EventName      string
+	DeliveryStatus string
+	SubscriberID   string
+	SubscriberType string
+	ReasonCode     string
+	HasDeadLetter  *bool
+}
+
+type OperatorEventListOptions struct {
+	Filter             OperatorEventListFilter
+	Source             string
+	Since              *time.Time
+	Until              *time.Time
+	Limit              int
+	Cursor             string
+	ExcludeRuntimeLogs bool
+}
+
+type OperatorEventListResult struct {
+	Events     []OperatorEventFull `json:"events"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+type OperatorEventFull struct {
+	EventID     string                     `json:"event_id"`
+	EventName   string                     `json:"event_name"`
+	EntityID    string                     `json:"entity_id,omitempty"`
+	RunID       string                     `json:"run_id,omitempty"`
+	CreatedAt   time.Time                  `json:"created_at"`
+	Source      string                     `json:"source"`
+	Payload     map[string]any             `json:"payload"`
+	Deliveries  []OperatorEventDelivery    `json:"deliveries"`
+	DeadLetters []OperatorDeadLetterRecord `json:"dead_letters"`
+}
+
+type OperatorEventDelivery struct {
+	DeliveryID     string `json:"delivery_id"`
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	Status         string `json:"status"`
+	ReasonCode     string `json:"reason_code,omitempty"`
+	LastError      string `json:"last_error,omitempty"`
+	RetryCount     int    `json:"-"`
+}
+
+type OperatorDeadLetterRecord struct {
+	DeadLetterID string    `json:"dead_letter_id"`
+	FailureType  string    `json:"failure_type"`
+	ErrorMessage string    `json:"error_message,omitempty"`
+	RetryCount   int       `json:"retry_count"`
+	ChainDepth   int       `json:"chain_depth"`
+	HandlerNode  string    `json:"handler_node,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type OperatorRuntimeLogListOptions struct {
+	RunID             string
+	EntityID          string
+	Component         string
+	Level             string
+	ErrorCode         string
+	Source            string
+	ActionOrEventType string
+	Since             *time.Time
+	Limit             int
+	Cursor            string
+	Order             string
+}
+
+type OperatorRuntimeLogListResult struct {
+	Logs       []OperatorRuntimeLogEntry `json:"logs"`
+	NextCursor string                    `json:"next_cursor,omitempty"`
+}
+
+type OperatorRuntimeLogEntry struct {
+	LogID     string         `json:"log_id"`
+	TS        time.Time      `json:"ts"`
+	Level     string         `json:"level"`
+	Component string         `json:"component"`
+	Source    string         `json:"source"`
+	RunID     string         `json:"run_id,omitempty"`
+	EntityID  string         `json:"entity_id,omitempty"`
+	ErrorCode string         `json:"error_code,omitempty"`
+	Message   string         `json:"message"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+type OperatorRuntimeIncidentListOptions struct {
+	SinceHours int
+	Component  string
+	Level      string
+	MCPOnly    bool
+	Limit      int
+	Cursor     string
+}
+
+type OperatorRuntimeIncidentListResult struct {
+	Incidents  []OperatorRuntimeIncident `json:"incidents"`
+	NextCursor string                    `json:"next_cursor,omitempty"`
+}
+
+type OperatorRuntimeIncident struct {
+	IncidentID    string    `json:"incident_id"`
+	FirstSeen     time.Time `json:"first_seen"`
+	LastSeen      time.Time `json:"last_seen"`
+	Count         int       `json:"count"`
+	Level         string    `json:"level"`
+	Component     string    `json:"component"`
+	ErrorCode     string    `json:"error_code,omitempty"`
+	SampleMessage string    `json:"sample_message"`
+	SampleLogIDs  []string  `json:"sample_log_ids"`
+
+	Agents     []string `json:"-"`
+	Actions    []string `json:"-"`
+	Components []string `json:"-"`
+}
+
+type observabilityPositionCursor struct {
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Order     string `json:"order,omitempty"`
+	LastSeen  string `json:"last_seen,omitempty"`
+}
+
+func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case !caps.Events.LogRunID:
+		return fmt.Errorf("operator observability read surface requires canonical events.run_id")
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	case !caps.Events.DeliveryRunID:
+		return fmt.Errorf("operator observability read surface requires canonical event_deliveries.run_id")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"events": {
+			"event_id", "run_id", "event_name", "entity_id", "scope", "payload",
+			"produced_by", "produced_by_type", "source_event_id", "created_at",
+		},
+		"event_deliveries": {
+			"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id",
+			"status", "retry_count", "reason_code", "last_error", "created_at",
+		},
+		"dead_letters": {
+			"dead_letter_id", "original_event_id", "failure_type", "error_message",
+			"retry_count", "chain_depth", "handler_node", "created_at",
+		},
+	}
+	for tableName, columns := range required {
+		if catalog.hasColumns(tableName, columns...) {
+			continue
+		}
+		return fmt.Errorf("operator observability read surface requires %s columns %v", tableName, columns)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {
+	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+		return OperatorEventListResult{}, err
+	}
+	opts = defaultOperatorEventListOptions(opts)
+	args := make([]any, 0, 16)
+	where := []string{"TRUE"}
+	add := func(value any) int {
+		args = append(args, value)
+		return len(args)
+	}
+	if opts.Filter.RunID != "" {
+		n := add(opts.Filter.RunID)
+		where = append(where, fmt.Sprintf("e.run_id::text = $%d", n))
+	}
+	if opts.Filter.EntityID != "" {
+		n := add(opts.Filter.EntityID)
+		where = append(where, fmt.Sprintf("COALESCE(e.entity_id::text, e.payload->>'entity_id', '') = $%d", n))
+	}
+	if opts.Filter.EventName != "" {
+		n := add(opts.Filter.EventName)
+		where = append(where, fmt.Sprintf("e.event_name = $%d", n))
+	}
+	if opts.Source != "" {
+		n := add(opts.Source)
+		where = append(where, fmt.Sprintf("COALESCE(e.produced_by, '') = $%d", n))
+	}
+	if opts.Filter.DeliveryStatus != "" {
+		n := add(opts.Filter.DeliveryStatus)
+		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.status = $%d)", n))
+	}
+	if opts.Filter.SubscriberID != "" {
+		n := add(opts.Filter.SubscriberID)
+		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.subscriber_id = $%d)", n))
+	}
+	if opts.Filter.SubscriberType != "" {
+		n := add(opts.Filter.SubscriberType)
+		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.subscriber_type = $%d)", n))
+	}
+	if opts.Filter.ReasonCode != "" {
+		n := add(opts.Filter.ReasonCode)
+		where = append(where, fmt.Sprintf(`(
+			EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.reason_code = $%d)
+			OR EXISTS (SELECT 1 FROM dead_letters dl WHERE dl.original_event_id = e.event_id AND dl.failure_type = $%d)
+		)`, n, n))
+	}
+	if opts.Filter.HasDeadLetter != nil {
+		exists := "EXISTS"
+		if !*opts.Filter.HasDeadLetter {
+			exists = "NOT EXISTS"
+		}
+		where = append(where, fmt.Sprintf("%s (SELECT 1 FROM dead_letters dl WHERE dl.original_event_id = e.event_id)", exists))
+	}
+	if opts.ExcludeRuntimeLogs {
+		where = append(where, "e.event_name <> 'platform.runtime_log'")
+	}
+	if opts.Since != nil {
+		n := add(opts.Since.UTC())
+		where = append(where, fmt.Sprintf("e.created_at >= $%d", n))
+	}
+	if opts.Until != nil {
+		n := add(opts.Until.UTC())
+		where = append(where, fmt.Sprintf("e.created_at <= $%d", n))
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeObservabilityPositionCursor(opts.Cursor, "event.list")
+		if err != nil {
+			return OperatorEventListResult{}, err
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, cursor.CreatedAt)
+		if err != nil || strings.TrimSpace(cursor.ID) == "" {
+			return OperatorEventListResult{}, ErrInvalidObservabilityCursor
+		}
+		nTime := add(createdAt.UTC())
+		nID := add(cursor.ID)
+		where = append(where, fmt.Sprintf("(e.created_at < $%d OR (e.created_at = $%d AND e.event_id::text < $%d))", nTime, nTime, nID))
+	}
+	limitArg := add(opts.Limit + 1)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT e.event_id::text
+		FROM events e
+		WHERE `+strings.Join(where, " AND ")+fmt.Sprintf(`
+		ORDER BY e.created_at DESC, e.event_id::text DESC
+		LIMIT $%d
+	`, limitArg), args...)
+	if err != nil {
+		return OperatorEventListResult{}, fmt.Errorf("list operator events: %w", err)
+	}
+	defer rows.Close()
+	ids := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return OperatorEventListResult{}, fmt.Errorf("scan operator event id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEventListResult{}, fmt.Errorf("read operator event ids: %w", err)
+	}
+	events := make([]OperatorEventFull, 0, minInt(len(ids), opts.Limit))
+	for _, id := range ids {
+		event, err := s.LoadOperatorEvent(ctx, id)
+		if err != nil {
+			return OperatorEventListResult{}, err
+		}
+		events = append(events, event)
+	}
+	nextCursor := ""
+	if len(events) > opts.Limit {
+		events = events[:opts.Limit]
+		last := events[len(events)-1]
+		nextCursor = encodeObservabilityPositionCursor(observabilityPositionCursor{
+			Kind:      "event.list",
+			CreatedAt: last.CreatedAt.UTC().Format(time.RFC3339Nano),
+			ID:        last.EventID,
+		})
+	}
+	if events == nil {
+		events = []OperatorEventFull{}
+	}
+	return OperatorEventListResult{Events: events, NextCursor: nextCursor}, nil
+}
+
+func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (OperatorEventFull, error) {
+	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+		return OperatorEventFull{}, err
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return OperatorEventFull{}, ErrEventNotFound
+	}
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT
+			e.event_id::text,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.entity_id::text, ''),
+			COALESCE(e.run_id::text, ''),
+			e.created_at,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.produced_by_type, ''),
+			COALESCE(e.payload, '{}'::jsonb)
+		FROM events e
+		WHERE e.event_id::text = $1
+	`, eventID)
+	var (
+		event          OperatorEventFull
+		producedBy     string
+		producedByType string
+		payloadRaw     []byte
+	)
+	if err := row.Scan(&event.EventID, &event.EventName, &event.EntityID, &event.RunID, &event.CreatedAt, &producedBy, &producedByType, &payloadRaw); err == sql.ErrNoRows {
+		return OperatorEventFull{}, ErrEventNotFound
+	} else if err != nil {
+		return OperatorEventFull{}, fmt.Errorf("load operator event: %w", err)
+	}
+	event.Source = firstNonEmptyStore(producedBy, producedByType, "unknown")
+	payload, err := decodeStoreJSONMap(payloadRaw)
+	if err != nil {
+		return OperatorEventFull{}, fmt.Errorf("decode operator event payload: %w", err)
+	}
+	event.Payload = payload
+	if event.EntityID == "" {
+		event.EntityID = readStoreString(payload["entity_id"])
+	}
+	deliveries, err := s.loadOperatorEventDeliveries(ctx, event.EventID)
+	if err != nil {
+		return OperatorEventFull{}, err
+	}
+	deadLetters, err := s.loadOperatorEventDeadLetters(ctx, event.EventID)
+	if err != nil {
+		return OperatorEventFull{}, err
+	}
+	event.Deliveries = deliveries
+	event.DeadLetters = deadLetters
+	if event.Deliveries == nil {
+		event.Deliveries = []OperatorEventDelivery{}
+	}
+	if event.DeadLetters == nil {
+		event.DeadLetters = []OperatorDeadLetterRecord{}
+	}
+	return event, nil
+}
+
+func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID string) ([]OperatorEventDelivery, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			d.delivery_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0)
+		FROM event_deliveries d
+		WHERE d.event_id::text = $1
+		ORDER BY d.created_at ASC, d.delivery_id::text ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load operator event deliveries: %w", err)
+	}
+	defer rows.Close()
+	out := []OperatorEventDelivery{}
+	for rows.Next() {
+		var item OperatorEventDelivery
+		if err := rows.Scan(&item.DeliveryID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.LastError, &item.RetryCount); err != nil {
+			return nil, fmt.Errorf("scan operator event delivery: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read operator event deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) loadOperatorEventDeadLetters(ctx context.Context, eventID string) ([]OperatorDeadLetterRecord, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			dl.dead_letter_id::text,
+			COALESCE(dl.failure_type, ''),
+			COALESCE(dl.error_message, ''),
+			COALESCE(dl.retry_count, 0),
+			COALESCE(dl.chain_depth, 0),
+			COALESCE(dl.handler_node, ''),
+			dl.created_at
+		FROM dead_letters dl
+		WHERE dl.original_event_id::text = $1
+		ORDER BY dl.created_at ASC, dl.dead_letter_id::text ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load operator event dead letters: %w", err)
+	}
+	defer rows.Close()
+	out := []OperatorDeadLetterRecord{}
+	for rows.Next() {
+		var item OperatorDeadLetterRecord
+		if err := rows.Scan(&item.DeadLetterID, &item.FailureType, &item.ErrorMessage, &item.RetryCount, &item.ChainDepth, &item.HandlerNode, &item.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan operator event dead letter: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read operator event dead letters: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts OperatorRuntimeLogListOptions) (OperatorRuntimeLogListResult, error) {
+	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+		return OperatorRuntimeLogListResult{}, err
+	}
+	opts = defaultOperatorRuntimeLogListOptions(opts)
+	cursorClause := ""
+	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType}
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		cursorClause += fmt.Sprintf(" AND e.created_at >= $%d", len(args))
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeObservabilityPositionCursor(opts.Cursor, "runtime.logs")
+		if err != nil {
+			return OperatorRuntimeLogListResult{}, err
+		}
+		if cursor.Order != opts.Order {
+			return OperatorRuntimeLogListResult{}, ErrInvalidObservabilityCursor
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, cursor.CreatedAt)
+		if err != nil || strings.TrimSpace(cursor.ID) == "" {
+			return OperatorRuntimeLogListResult{}, ErrInvalidObservabilityCursor
+		}
+		args = append(args, createdAt.UTC(), cursor.ID)
+		if opts.Order == "asc" {
+			cursorClause += fmt.Sprintf(" AND (e.created_at > $%d OR (e.created_at = $%d AND e.event_id::text > $%d))", len(args)-1, len(args)-1, len(args))
+		} else {
+			cursorClause += fmt.Sprintf(" AND (e.created_at < $%d OR (e.created_at = $%d AND e.event_id::text < $%d))", len(args)-1, len(args)-1, len(args))
+		}
+	}
+	orderSQL := "DESC"
+	compareOrder := "DESC"
+	if opts.Order == "asc" {
+		orderSQL = "ASC"
+		compareOrder = "ASC"
+	}
+	args = append(args, opts.Limit+1)
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			e.event_id::text,
+			COALESCE(e.run_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			e.created_at,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.payload, '{}'::jsonb)
+		FROM events e
+		WHERE e.event_name = 'platform.runtime_log'
+		  AND ($1 = '' OR e.run_id::text = $1)
+		  AND ($2 = '' OR COALESCE(e.entity_id::text, e.payload->'details'->>'entity_id', '') = $2)
+		  AND ($3 = '' OR COALESCE(e.payload->'details'->>'component', '') = $3)
+		  AND ($4 = '' OR COALESCE(e.payload->>'log_level', '') = $4)
+		  AND ($5 = '' OR COALESCE(e.payload->'details'->>'error_code', '') = $5)
+		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'agent_id', e.produced_by, '') = $6)
+		  AND ($7 = '' OR COALESCE(e.payload->'details'->>'action', '') = $7 OR COALESCE(e.payload->'details'->>'event_name', e.payload->'details'->>'event_type', '') = $7)
+		  %s
+		ORDER BY e.created_at %s, e.event_id::text %s
+		LIMIT $%d
+	`, cursorClause, orderSQL, compareOrder, len(args)), args...)
+	if err != nil {
+		return OperatorRuntimeLogListResult{}, fmt.Errorf("list operator runtime logs: %w", err)
+	}
+	defer rows.Close()
+	logs := []OperatorRuntimeLogEntry{}
+	for rows.Next() {
+		var (
+			eventID    string
+			runID      string
+			entityID   string
+			createdAt  time.Time
+			producedBy string
+			payloadRaw []byte
+		)
+		if err := rows.Scan(&eventID, &runID, &entityID, &createdAt, &producedBy, &payloadRaw); err != nil {
+			return OperatorRuntimeLogListResult{}, fmt.Errorf("scan operator runtime log: %w", err)
+		}
+		entry, err := operatorRuntimeLogEntry(eventID, runID, entityID, producedBy, createdAt, payloadRaw)
+		if err != nil {
+			return OperatorRuntimeLogListResult{}, err
+		}
+		logs = append(logs, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorRuntimeLogListResult{}, fmt.Errorf("read operator runtime logs: %w", err)
+	}
+	nextCursor := ""
+	if len(logs) > opts.Limit {
+		logs = logs[:opts.Limit]
+		last := logs[len(logs)-1]
+		nextCursor = encodeObservabilityPositionCursor(observabilityPositionCursor{
+			Kind:      "runtime.logs",
+			CreatedAt: last.TS.UTC().Format(time.RFC3339Nano),
+			ID:        last.LogID,
+			Order:     opts.Order,
+		})
+	}
+	if logs == nil {
+		logs = []OperatorRuntimeLogEntry{}
+	}
+	return OperatorRuntimeLogListResult{Logs: logs, NextCursor: nextCursor}, nil
+}
+
+func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts OperatorRuntimeIncidentListOptions) (OperatorRuntimeIncidentListResult, error) {
+	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+		return OperatorRuntimeIncidentListResult{}, err
+	}
+	opts = defaultOperatorRuntimeIncidentListOptions(opts)
+	cutoff := time.Now().UTC().Add(-time.Duration(opts.SinceHours) * time.Hour)
+	logs, err := s.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		Component: opts.Component,
+		Level:     opts.Level,
+		Since:     &cutoff,
+		Limit:     10000,
+		Order:     "desc",
+	})
+	if err != nil {
+		return OperatorRuntimeIncidentListResult{}, err
+	}
+	type aggregate struct {
+		item       OperatorRuntimeIncident
+		agents     map[string]struct{}
+		actions    map[string]struct{}
+		components map[string]struct{}
+	}
+	aggregates := map[string]*aggregate{}
+	for _, logEntry := range logs.Logs {
+		if opts.MCPOnly && !strings.HasPrefix(strings.TrimSpace(logEntry.Component), "mcp") {
+			continue
+		}
+		if strings.TrimSpace(logEntry.ErrorCode) == "" {
+			continue
+		}
+		key := strings.Join([]string{logEntry.ErrorCode, logEntry.Component, logEntry.Level}, "\x00")
+		agg := aggregates[key]
+		if agg == nil {
+			agg = &aggregate{
+				item: OperatorRuntimeIncident{
+					IncidentID:    operatorIncidentID(key),
+					FirstSeen:     logEntry.TS,
+					LastSeen:      logEntry.TS,
+					Level:         logEntry.Level,
+					Component:     logEntry.Component,
+					ErrorCode:     logEntry.ErrorCode,
+					SampleMessage: firstNonEmptyStore(readStoreString(logEntry.Details["error"]), logEntry.Message),
+					SampleLogIDs:  []string{},
+				},
+				agents:     map[string]struct{}{},
+				actions:    map[string]struct{}{},
+				components: map[string]struct{}{},
+			}
+			aggregates[key] = agg
+		}
+		agg.item.Count++
+		if logEntry.TS.Before(agg.item.FirstSeen) {
+			agg.item.FirstSeen = logEntry.TS
+		}
+		if logEntry.TS.After(agg.item.LastSeen) {
+			agg.item.LastSeen = logEntry.TS
+		}
+		if len(agg.item.SampleLogIDs) < 5 {
+			agg.item.SampleLogIDs = append(agg.item.SampleLogIDs, logEntry.LogID)
+		}
+		if agg.item.SampleMessage == "" {
+			agg.item.SampleMessage = firstNonEmptyStore(readStoreString(logEntry.Details["error"]), logEntry.Message)
+		}
+		if agentID := readStoreString(logEntry.Details["agent_id"]); agentID != "" {
+			agg.agents[agentID] = struct{}{}
+		}
+		if action := readStoreString(logEntry.Details["action"]); action != "" {
+			agg.actions[action] = struct{}{}
+		}
+		if logEntry.Component != "" {
+			agg.components[logEntry.Component] = struct{}{}
+		}
+	}
+	out := make([]OperatorRuntimeIncident, 0, len(aggregates))
+	for _, agg := range aggregates {
+		agg.item.Agents = sortedStoreStringSet(agg.agents)
+		agg.item.Actions = sortedStoreStringSet(agg.actions)
+		agg.item.Components = sortedStoreStringSet(agg.components)
+		out = append(out, agg.item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].LastSeen.Equal(out[j].LastSeen) {
+			return out[i].LastSeen.After(out[j].LastSeen)
+		}
+		return out[i].IncidentID < out[j].IncidentID
+	})
+	if opts.Cursor != "" {
+		cursor, err := decodeObservabilityPositionCursor(opts.Cursor, "runtime.incidents")
+		if err != nil {
+			return OperatorRuntimeIncidentListResult{}, err
+		}
+		lastSeen, err := time.Parse(time.RFC3339Nano, cursor.LastSeen)
+		if err != nil || cursor.ID == "" {
+			return OperatorRuntimeIncidentListResult{}, ErrInvalidObservabilityCursor
+		}
+		filtered := out[:0]
+		for _, item := range out {
+			if item.LastSeen.Before(lastSeen) || (item.LastSeen.Equal(lastSeen) && item.IncidentID > cursor.ID) {
+				filtered = append(filtered, item)
+			}
+		}
+		out = filtered
+	}
+	nextCursor := ""
+	if len(out) > opts.Limit {
+		out = out[:opts.Limit]
+		last := out[len(out)-1]
+		nextCursor = encodeObservabilityPositionCursor(observabilityPositionCursor{
+			Kind:     "runtime.incidents",
+			LastSeen: last.LastSeen.UTC().Format(time.RFC3339Nano),
+			ID:       last.IncidentID,
+		})
+	}
+	if out == nil {
+		out = []OperatorRuntimeIncident{}
+	}
+	return OperatorRuntimeIncidentListResult{Incidents: out, NextCursor: nextCursor}, nil
+}
+
+func operatorRuntimeLogEntry(eventID, runID, rowEntityID, producedBy string, createdAt time.Time, payloadRaw []byte) (OperatorRuntimeLogEntry, error) {
+	payload, err := runtimepkg.DecodeCanonicalRuntimeLogPayload(payloadRaw)
+	if err != nil {
+		return OperatorRuntimeLogEntry{}, fmt.Errorf("decode canonical runtime log payload: %w", err)
+	}
+	details := map[string]any{}
+	for key, value := range payload.Detail {
+		details[key] = value
+	}
+	return OperatorRuntimeLogEntry{
+		LogID:     strings.TrimSpace(eventID),
+		TS:        createdAt.UTC(),
+		Level:     strings.TrimSpace(payload.LogLevel),
+		Component: strings.TrimSpace(payload.Component),
+		Source:    firstNonEmptyStore(payload.AgentID, producedBy, "runtime"),
+		RunID:     strings.TrimSpace(runID),
+		EntityID:  firstNonEmptyStore(payload.EntityID, rowEntityID),
+		ErrorCode: strings.TrimSpace(payload.ErrorCode),
+		Message:   strings.TrimSpace(payload.Message),
+		Details:   details,
+	}, nil
+}
+
+func defaultOperatorEventListOptions(opts OperatorEventListOptions) OperatorEventListOptions {
+	opts.Filter.RunID = strings.TrimSpace(opts.Filter.RunID)
+	opts.Filter.EntityID = strings.TrimSpace(opts.Filter.EntityID)
+	opts.Filter.EventName = strings.TrimSpace(opts.Filter.EventName)
+	opts.Filter.DeliveryStatus = strings.TrimSpace(opts.Filter.DeliveryStatus)
+	opts.Filter.SubscriberID = strings.TrimSpace(opts.Filter.SubscriberID)
+	opts.Filter.SubscriberType = strings.TrimSpace(opts.Filter.SubscriberType)
+	opts.Filter.ReasonCode = strings.TrimSpace(opts.Filter.ReasonCode)
+	opts.Source = strings.TrimSpace(opts.Source)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
+		opts.Limit = 1000
+	}
+	return opts
+}
+
+func defaultOperatorRuntimeLogListOptions(opts OperatorRuntimeLogListOptions) OperatorRuntimeLogListOptions {
+	opts.RunID = strings.TrimSpace(opts.RunID)
+	opts.EntityID = strings.TrimSpace(opts.EntityID)
+	opts.Component = strings.TrimSpace(opts.Component)
+	opts.Level = strings.TrimSpace(opts.Level)
+	opts.ErrorCode = strings.TrimSpace(opts.ErrorCode)
+	opts.Source = strings.TrimSpace(opts.Source)
+	opts.ActionOrEventType = strings.TrimSpace(opts.ActionOrEventType)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	opts.Order = strings.ToLower(strings.TrimSpace(opts.Order))
+	if opts.Order == "" {
+		opts.Order = "desc"
+	}
+	if opts.Order != "asc" {
+		opts.Order = "desc"
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
+		opts.Limit = 1000
+	}
+	return opts
+}
+
+func defaultOperatorRuntimeIncidentListOptions(opts OperatorRuntimeIncidentListOptions) OperatorRuntimeIncidentListOptions {
+	opts.Component = strings.TrimSpace(opts.Component)
+	opts.Level = strings.TrimSpace(opts.Level)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.SinceHours <= 0 {
+		opts.SinceHours = 24
+	}
+	if opts.SinceHours > 720 {
+		opts.SinceHours = 720
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts
+}
+
+func encodeObservabilityPositionCursor(cursor observabilityPositionCursor) string {
+	raw, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeObservabilityPositionCursor(raw string, kind string) (observabilityPositionCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return observabilityPositionCursor{}, ErrInvalidObservabilityCursor
+	}
+	var cursor observabilityPositionCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return observabilityPositionCursor{}, ErrInvalidObservabilityCursor
+	}
+	if strings.TrimSpace(cursor.Kind) != kind {
+		return observabilityPositionCursor{}, ErrInvalidObservabilityCursor
+	}
+	return cursor, nil
+}
+
+func operatorIncidentID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return "inc_" + hex.EncodeToString(sum[:8])
+}
+
+func decodeStoreJSONMap(raw []byte) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = map[string]any{}
+	}
+	return out, nil
+}
+
+func readStoreString(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func firstNonEmptyStore(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sortedStoreStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -1,0 +1,211 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	olderEventID := uuid.NewString()
+	newerEventID := uuid.NewString()
+	base := time.Unix(1700000000, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			($1::uuid, $2::uuid, 'task.failed', $3::uuid, 'entity', '{"entity_id":"`+entityID+`","n":1}'::jsonb, 'agent-a', 'agent', $4),
+			($5::uuid, $2::uuid, 'task.completed', $3::uuid, 'entity', '{"entity_id":"`+entityID+`","n":2}'::jsonb, 'agent-b', 'agent', $6)
+	`, olderEventID, runID, entityID, base, newerEventID, base.Add(time.Minute)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, created_at)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-a', 'dead_letter', 3, 'retry_exhausted', 'boom', $3)
+	`, runID, olderEventID, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dead_letters (
+			original_event_id, original_event, original_payload, entity_id, flow_instance,
+			failure_type, error_message, retry_count, chain_depth, handler_node, created_at
+		) VALUES (
+			$1::uuid, 'task.failed', '{}'::jsonb, $2::uuid, 'flow-1',
+			'retry_exhausted', 'boom', 3, 1, 'handler-a', $3
+		)
+	`, olderEventID, entityID, base.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed dead letter: %v", err)
+	}
+
+	hasDead := true
+	filtered, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{
+		Filter: OperatorEventListFilter{
+			RunID:          runID,
+			DeliveryStatus: "dead_letter",
+			ReasonCode:     "retry_exhausted",
+			HasDeadLetter:  &hasDead,
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents filtered: %v", err)
+	}
+	if len(filtered.Events) != 1 {
+		t.Fatalf("filtered events len = %d, want 1: %#v", len(filtered.Events), filtered.Events)
+	}
+	got := filtered.Events[0]
+	if got.EventID != olderEventID || got.Source != "agent-a" || got.Deliveries[0].ReasonCode != "retry_exhausted" || len(got.DeadLetters) != 1 {
+		t.Fatalf("filtered event = %#v", got)
+	}
+
+	page1, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents page1: %v", err)
+	}
+	if len(page1.Events) != 1 || page1.Events[0].EventID != newerEventID || page1.NextCursor == "" {
+		t.Fatalf("page1 = %#v", page1)
+	}
+	page2, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 1, Cursor: page1.NextCursor})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents page2: %v", err)
+	}
+	if len(page2.Events) != 1 || page2.Events[0].EventID != olderEventID {
+		t.Fatalf("page2 = %#v", page2)
+	}
+
+	if _, err := pg.LoadOperatorEvent(ctx, uuid.NewString()); !errors.Is(err, ErrEventNotFound) {
+		t.Fatalf("LoadOperatorEvent missing error = %v, want ErrEventNotFound", err)
+	}
+}
+
+func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	insertLog := func(code string, createdAt time.Time) string {
+		t.Helper()
+		eventID := uuid.NewString()
+		payload := `{
+			"log_level":"error",
+			"message":"runtime failed",
+			"details":{
+				"component":"mcp-gateway",
+				"action":"request_failed",
+				"agent_id":"agent-1",
+				"entity_id":"` + uuid.NewString() + `",
+				"error":"runtime failed",
+				"error_code":"` + code + `"
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'platform.runtime_log', 'global', $3::jsonb, 'runtime', 'platform', $4)
+		`, eventID, runID, payload, createdAt); err != nil {
+			t.Fatalf("seed runtime log: %v", err)
+		}
+		return eventID
+	}
+	olderLog := insertLog("old_code", base)
+	newerLog := insertLog("new_code", base.Add(time.Minute))
+
+	page1, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "mcp-gateway",
+		Level:     "error",
+		Limit:     1,
+		Order:     "desc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs page1: %v", err)
+	}
+	if len(page1.Logs) != 1 || page1.Logs[0].LogID != newerLog || page1.NextCursor == "" {
+		t.Fatalf("runtime log page1 = %#v", page1)
+	}
+	page2, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "mcp-gateway",
+		Level:     "error",
+		Limit:     1,
+		Order:     "desc",
+		Cursor:    page1.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs page2: %v", err)
+	}
+	if len(page2.Logs) != 1 || page2.Logs[0].LogID != olderLog {
+		t.Fatalf("runtime log page2 = %#v", page2)
+	}
+
+	incidents, err := pg.ListOperatorRuntimeIncidents(ctx, OperatorRuntimeIncidentListOptions{
+		SinceHours: 2,
+		MCPOnly:    true,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeIncidents: %v", err)
+	}
+	if len(incidents.Incidents) != 2 {
+		t.Fatalf("incidents len = %d, want 2: %#v", len(incidents.Incidents), incidents.Incidents)
+	}
+	if incidents.Incidents[0].ErrorCode != "new_code" || len(incidents.Incidents[0].SampleLogIDs) != 1 {
+		t.Fatalf("first incident = %#v", incidents.Incidents[0])
+	}
+}
+
+func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	base := time.Unix(1700000300, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	firstEvent := uuid.NewString()
+	secondEvent := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			($1::uuid, $2::uuid, 'first.event', 'global', '{}'::jsonb, 'runtime', 'platform', $3),
+			($4::uuid, $2::uuid, 'second.event', 'global', '{}'::jsonb, 'runtime', 'platform', $5)
+	`, firstEvent, runID, base, secondEvent, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed trace events: %v", err)
+	}
+
+	page1, next, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage page1: %v", err)
+	}
+	if len(page1) != 1 || page1[0].EventID != firstEvent || next == "" {
+		t.Fatalf("trace page1 rows=%#v next=%q", page1, next)
+	}
+	page2, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 1, Cursor: next})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage page2: %v", err)
+	}
+	if len(page2) != 1 || page2[0].EventID != secondEvent {
+		t.Fatalf("trace page2 = %#v", page2)
+	}
+	if _, _, err := pg.LoadRunDebugTracePage(ctx, uuid.NewString(), RunDebugTraceQueryOptions{}); !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("missing run error = %v, want ErrRunNotFound", err)
+	}
+}

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -84,6 +84,18 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 	if len(page2.Events) != 1 || page2.Events[0].EventID != olderEventID {
 		t.Fatalf("page2 = %#v", page2)
 	}
+	sinceBase := base
+	afterBase, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{
+		Filter: OperatorEventListFilter{RunID: runID},
+		Since:  &sinceBase,
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents since: %v", err)
+	}
+	if len(afterBase.Events) != 1 || afterBase.Events[0].EventID != newerEventID {
+		t.Fatalf("since events = %#v, want only newer event", afterBase.Events)
+	}
 
 	if _, err := pg.LoadOperatorEvent(ctx, uuid.NewString()); !errors.Is(err, ErrEventNotFound) {
 		t.Fatalf("LoadOperatorEvent missing error = %v, want ErrEventNotFound", err)
@@ -153,6 +165,21 @@ func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	if len(page2.Logs) != 1 || page2.Logs[0].LogID != olderLog {
 		t.Fatalf("runtime log page2 = %#v", page2)
 	}
+	sinceBase := base
+	afterBase, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "mcp-gateway",
+		Level:     "error",
+		Since:     &sinceBase,
+		Limit:     10,
+		Order:     "desc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs since: %v", err)
+	}
+	if len(afterBase.Logs) != 1 || afterBase.Logs[0].LogID != newerLog {
+		t.Fatalf("since logs = %#v, want only newer log", afterBase.Logs)
+	}
 
 	incidents, err := pg.ListOperatorRuntimeIncidents(ctx, OperatorRuntimeIncidentListOptions{
 		SinceHours: 2,
@@ -167,6 +194,44 @@ func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	}
 	if incidents.Incidents[0].ErrorCode != "new_code" || len(incidents.Incidents[0].SampleLogIDs) != 1 {
 		t.Fatalf("first incident = %#v", incidents.Incidents[0])
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		SELECT gen_random_uuid(), $1::uuid, 'platform.runtime_log', 'global',
+			jsonb_build_object(
+				'log_level', 'error',
+				'message', 'bulk runtime failed',
+				'details', jsonb_build_object(
+					'component', 'mcp-gateway',
+					'action', 'request_failed',
+					'agent_id', 'agent-1',
+					'error', 'bulk runtime failed',
+					'error_code', 'bulk_code'
+				)
+			),
+			'runtime', 'platform', $2::timestamptz + (g * interval '1 millisecond')
+		FROM generate_series(1, 1005) AS g
+	`, runID, base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("seed bulk runtime logs: %v", err)
+	}
+	bulkIncidents, err := pg.ListOperatorRuntimeIncidents(ctx, OperatorRuntimeIncidentListOptions{
+		SinceHours: 2,
+		MCPOnly:    true,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeIncidents bulk: %v", err)
+	}
+	var bulk *OperatorRuntimeIncident
+	for idx := range bulkIncidents.Incidents {
+		if bulkIncidents.Incidents[idx].ErrorCode == "bulk_code" {
+			bulk = &bulkIncidents.Incidents[idx]
+			break
+		}
+	}
+	if bulk == nil || bulk.Count != 1005 {
+		t.Fatalf("bulk incident = %#v, want count 1005 in %#v", bulk, bulkIncidents.Incidents)
 	}
 }
 

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -3,11 +3,13 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
 
@@ -126,7 +128,8 @@ type RunDebugReport struct {
 }
 
 type RunDebugTraceQueryOptions struct {
-	Limit int
+	Limit  int
+	Cursor string
 }
 
 type RunDebugTraceRow struct {
@@ -182,8 +185,12 @@ func defaultRunDebugQueryOptions(opts RunDebugQueryOptions) RunDebugQueryOptions
 }
 
 func defaultRunDebugTraceQueryOptions(opts RunDebugTraceQueryOptions) RunDebugTraceQueryOptions {
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
 	if opts.Limit <= 0 {
 		opts.Limit = 200
+	}
+	if opts.Limit > 2000 {
+		opts.Limit = 2000
 	}
 	return opts
 }
@@ -579,23 +586,71 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 }
 
 func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, error) {
+	rows, _, err := s.LoadRunDebugTracePage(ctx, runID, opts)
+	return rows, err
+}
+
+func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, string, error) {
 	if s == nil || s.DB == nil {
-		return nil, fmt.Errorf("postgres store is required")
+		return nil, "", fmt.Errorf("postgres store is required")
 	}
 	if err := s.requireRunDebugCapabilities(ctx); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		return nil, fmt.Errorf("run_id is required")
+		return nil, "", ErrRunNotFound
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return nil, "", ErrRunNotFound
 	}
 	opts = defaultRunDebugTraceQueryOptions(opts)
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM runs WHERE run_id = $1::uuid)`, runID).Scan(&exists); err != nil {
+		return nil, "", fmt.Errorf("check run debug trace run: %w", err)
+	}
+	if !exists {
+		return nil, "", ErrRunNotFound
+	}
 
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	sessionSources := runDebugTraceSessionSources(caps)
+	args := []any{runID}
+	cursorWhere := ""
+	if opts.Cursor != "" {
+		cursor, err := decodeRunDebugTraceCursor(opts.Cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		args = append(args,
+			cursor.EventCreatedAt,
+			cursor.EventID,
+			nullableCursorTimestamp(cursor.DeliveryCreatedAt),
+			cursor.DeliveryID,
+			nullableCursorTimestamp(cursor.TurnCreatedAt),
+			cursor.TurnID,
+		)
+		cursorWhere = fmt.Sprintf(`
+		  AND (
+			e.created_at > $%d::timestamptz
+			OR (e.created_at = $%d::timestamptz AND e.event_id::text > $%d)
+			OR (e.created_at = $%d::timestamptz AND e.event_id::text = $%d AND COALESCE(d.created_at, '-infinity'::timestamptz) > $%d::timestamptz)
+			OR (e.created_at = $%d::timestamptz AND e.event_id::text = $%d AND COALESCE(d.created_at, '-infinity'::timestamptz) = $%d::timestamptz AND COALESCE(d.delivery_id::text, '') > $%d)
+			OR (e.created_at = $%d::timestamptz AND e.event_id::text = $%d AND COALESCE(d.created_at, '-infinity'::timestamptz) = $%d::timestamptz AND COALESCE(d.delivery_id::text, '') = $%d AND COALESCE(t.created_at, '-infinity'::timestamptz) > $%d::timestamptz)
+			OR (e.created_at = $%d::timestamptz AND e.event_id::text = $%d AND COALESCE(d.created_at, '-infinity'::timestamptz) = $%d::timestamptz AND COALESCE(d.delivery_id::text, '') = $%d AND COALESCE(t.created_at, '-infinity'::timestamptz) = $%d::timestamptz AND COALESCE(t.turn_id::text, '') > $%d)
+		  )`,
+			2, 2, 3,
+			2, 3, 4,
+			2, 3, 4, 5,
+			2, 3, 4, 5, 6,
+			2, 3, 4, 5, 6, 7,
+		)
+	}
+	args = append(args, opts.Limit+1)
+	limitArg := len(args)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
 		WITH trace_sessions AS (
 			%s
@@ -654,6 +709,7 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 				OR sess.run_id IS NULL
 		   )
 		WHERE e.run_id = $1::uuid
+		%s
 		ORDER BY
 			e.created_at ASC,
 			e.event_id ASC,
@@ -661,14 +717,14 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 			d.delivery_id ASC NULLS FIRST,
 			t.created_at ASC NULLS FIRST,
 			t.turn_id ASC NULLS FIRST
-		LIMIT $2
-	`, sessionSources), runID, opts.Limit)
+		LIMIT $%d
+	`, sessionSources, cursorWhere, limitArg), args...)
 	if err != nil {
-		return nil, fmt.Errorf("load run debug trace: %w", err)
+		return nil, "", fmt.Errorf("load run debug trace: %w", err)
 	}
 	defer rows.Close()
 
-	out := make([]RunDebugTraceRow, 0, opts.Limit)
+	out := make([]RunDebugTraceRow, 0, opts.Limit+1)
 	for rows.Next() {
 		var (
 			item                RunDebugTraceRow
@@ -712,7 +768,7 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 			&item.TurnError,
 			&turnCreatedAt,
 		); err != nil {
-			return nil, fmt.Errorf("scan run debug trace: %w", err)
+			return nil, "", fmt.Errorf("scan run debug trace: %w", err)
 		}
 		item.DeliveryCreatedAt = nullableTimePtr(deliveryCreatedAt)
 		item.DeliveryStartedAt = nullableTimePtr(deliveryStartedAt)
@@ -722,9 +778,73 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read run debug trace: %w", err)
+		return nil, "", fmt.Errorf("read run debug trace: %w", err)
 	}
-	return out, nil
+	nextCursor := ""
+	if len(out) > opts.Limit {
+		out = out[:opts.Limit]
+		nextCursor = encodeRunDebugTraceCursor(out[len(out)-1])
+	}
+	return out, nextCursor, nil
+}
+
+type runDebugTraceCursor struct {
+	EventCreatedAt    string `json:"event_created_at"`
+	EventID           string `json:"event_id"`
+	DeliveryCreatedAt string `json:"delivery_created_at,omitempty"`
+	DeliveryID        string `json:"delivery_id,omitempty"`
+	TurnCreatedAt     string `json:"turn_created_at,omitempty"`
+	TurnID            string `json:"turn_id,omitempty"`
+}
+
+func encodeRunDebugTraceCursor(row RunDebugTraceRow) string {
+	cursor := runDebugTraceCursor{
+		EventCreatedAt: row.EventCreatedAt.UTC().Format(time.RFC3339Nano),
+		EventID:        strings.TrimSpace(row.EventID),
+		DeliveryID:     strings.TrimSpace(row.DeliveryID),
+		TurnID:         strings.TrimSpace(row.TurnID),
+	}
+	if row.DeliveryCreatedAt != nil {
+		cursor.DeliveryCreatedAt = row.DeliveryCreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if row.TurnCreatedAt != nil {
+		cursor.TurnCreatedAt = row.TurnCreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	raw, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeRunDebugTraceCursor(cursor string) (runDebugTraceCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(cursor))
+	if err != nil {
+		return runDebugTraceCursor{}, ErrInvalidObservabilityCursor
+	}
+	var decoded runDebugTraceCursor
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return runDebugTraceCursor{}, ErrInvalidObservabilityCursor
+	}
+	if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(decoded.EventCreatedAt)); err != nil {
+		return runDebugTraceCursor{}, ErrInvalidObservabilityCursor
+	}
+	if strings.TrimSpace(decoded.EventID) == "" {
+		return runDebugTraceCursor{}, ErrInvalidObservabilityCursor
+	}
+	for _, timestamp := range []string{decoded.DeliveryCreatedAt, decoded.TurnCreatedAt} {
+		if strings.TrimSpace(timestamp) == "" {
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(timestamp)); err != nil {
+			return runDebugTraceCursor{}, ErrInvalidObservabilityCursor
+		}
+	}
+	return decoded, nil
+}
+
+func nullableCursorTimestamp(timestamp string) string {
+	if strings.TrimSpace(timestamp) == "" {
+		return "-infinity"
+	}
+	return strings.TrimSpace(timestamp)
 }
 
 func runDebugTraceSessionSources(caps StoreSchemaCapabilities) string {


### PR DESCRIPTION
## Summary

Closes #696
Part of #665
Related to #694

Implements the approved #696 first-slice read-model owner for:

- `run.trace`
- `event.list`
- `event.get`
- `runtime.logs`
- `runtime.incidents`

This does not claim closure of full #665 Slice 6. Entity-native reads, agent/conversation reads, subscriptions, and CLI migration remain split under #694/#665.

## Governing refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.trace`, `event.list`, `event.get`, `runtime.logs`, `runtime.incidents`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EventListFilter`, `RunTraceRow`, `RunTraceListResult`, `EventFull`, `LogEntry`, `Incident`
- #694 gate outcome: approved as first slice for #696 only

## Semantic migration

- New canonical owner: `internal/store/operator_observability_read_surface.go` for persisted event/runtime observability reads, plus the existing `internal/store/run_debug_read_surface.go` trace owner extended with cursor/not-found support.
- Old non-authoritative path invalidated: dashboard-local event/runtime SQL interpretation in `internal/dashboard/server/observability_sql.go`; dashboard endpoints now consume the shared owner as adapters.
- Production paths checked: v1 operator read handlers, dashboard run trace, dashboard events, dashboard event detail, dashboard runtime logs/incidents, OpenRPC generated catalog.
- Migration completeness: complete for the approved persisted observability/read owner slice only.

## Validation

- `git diff --check`
- `go test ./internal/store -run 'OperatorObservability|RunDebugTracePage|RunDebugTrace' -count=1`
- `go test ./internal/apiv1 -run 'OperatorObservability|OperatorRead|MethodUnavailable' -count=1`
- `go test ./internal/dashboard/server -run 'SQLObservabilityReader|RunTrace|RuntimeLog|Event' -count=1`
- `go test ./internal/runtime/conformance -run 'CanonicalRuntimeLogSurface|StartupTimerRecoveryAftermathSurface|StartupManagerReplayAftermathSurface' -count=1`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./... -count=1`