### PR TITLE
[agent-b][issue #700] Add entity read-model owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -184,6 +184,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("load v1 api mailbox approval routes: %v", err)
 	}
+	var apiEntities apiv1.EntityReadStore
+	if stores.Postgres != nil {
+		apiEntities = stores.Postgres
+	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
 		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
@@ -194,6 +198,7 @@ func main() {
 			Database:              stores.Postgres,
 			Runs:                  stores.Postgres,
 			Observability:         stores.Postgres,
+			Entities:              apiEntities,
 			Mailbox:               stores.Postgres,
 			Idempotency:           stores.Postgres,
 			Events:                rt.Bus,
@@ -1615,9 +1620,15 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		runtimeProvider = supervisor.CurrentRuntime
 		projectControl = supervisor
 	}
+	var builderEntities builderpkg.EntityReader
+	var dashboardEntities dashboardserver.EntityReader
+	if stores.Postgres != nil {
+		builderEntities = stores.Postgres
+		dashboardEntities = stores.Postgres
+	}
 	builderHandler := builderpkg.NewHandler(builderpkg.Options{
 		Health:         healthFn,
-		Instances:      runtimepipeline.NewWorkflowInstanceStore(stores.SQLDB),
+		Entities:       builderEntities,
 		Runtime:        runtimeCtl,
 		Credentials:    credentialStore,
 		AuthToken:      strings.TrimSpace(os.Getenv("SWARM_BUILDER_AUTH_TOKEN")),
@@ -1632,7 +1643,7 @@ func dashboardServerOptions(supervisor *runtimeProjectSupervisor, stores storeBu
 		Agents:        agents,
 		AgentControl:  agentControl,
 		Mailbox:       mailbox,
-		Instances:     runtimepipeline.NewWorkflowInstanceStore(stores.SQLDB),
+		Entities:      dashboardEntities,
 		Conversations: conversations,
 		Observability: observability,
 		RunTrace:      stores.Postgres,

--- a/internal/apiv1/operator_entity_test.go
+++ b/internal/apiv1/operator_entity_test.go
@@ -1,0 +1,170 @@
+package apiv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarm/internal/store"
+)
+
+type fakeEntityReadStore struct {
+	listResult    store.OperatorEntityListResult
+	listErr       error
+	getResult     store.OperatorEntityFull
+	getErr        error
+	aggregate     store.OperatorEntityAggregateResult
+	aggregateErr  error
+	lastList      store.OperatorEntityListOptions
+	lastEntityID  string
+	lastRunID     string
+	lastAggregate store.OperatorEntityAggregateOptions
+}
+
+func (s *fakeEntityReadStore) ListOperatorEntities(_ context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error) {
+	s.lastList = opts
+	return s.listResult, s.listErr
+}
+
+func (s *fakeEntityReadStore) LoadOperatorEntity(_ context.Context, entityID, runID string) (store.OperatorEntityFull, error) {
+	s.lastEntityID = entityID
+	s.lastRunID = runID
+	return s.getResult, s.getErr
+}
+
+func (s *fakeEntityReadStore) AggregateOperatorEntities(_ context.Context, opts store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error) {
+	s.lastAggregate = opts
+	return s.aggregate, s.aggregateErr
+}
+
+func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	entities := &fakeEntityReadStore{
+		listResult: store.OperatorEntityListResult{
+			Entities: []store.OperatorEntitySummary{{
+				EntityID:     "entity-1",
+				RunID:        "run-1",
+				FlowInstance: "review/primary",
+				EntityType:   "mvp_spec",
+				CurrentState: "collecting",
+				Revision:     2,
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}},
+			NextCursor: "next",
+		},
+		getResult: store.OperatorEntityFull{
+			Entity:      store.OperatorEntitySummary{EntityID: "entity-1", RunID: "run-1", CurrentState: "collecting"},
+			Fields:      map[string]any{"priority": "high"},
+			Gates:       map[string]bool{"approved": true},
+			Accumulated: map[string]any{"notes": []any{"a"}},
+		},
+		aggregate: store.OperatorEntityAggregateResult{Counts: map[string]int{"collecting": 1}},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Entities: entities,
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"entity.list","params":{"run_id":"run-1","flow":"review","type":"mvp_spec","current_state":"collecting","limit":10,"cursor":"abc"}}`)
+	if list.Error != nil {
+		t.Fatalf("entity.list error = %#v", list.Error)
+	}
+	listResult := asMap(t, list.Result)
+	if rows, _ := listResult["entities"].([]any); len(rows) != 1 || listResult["next_cursor"] != "next" {
+		t.Fatalf("entity.list result = %#v", list.Result)
+	}
+	if entities.lastList.RunID != "run-1" || entities.lastList.Flow != "review" || entities.lastList.Type != "mvp_spec" || entities.lastList.CurrentState != "collecting" || entities.lastList.Limit != 10 || entities.lastList.Cursor != "abc" {
+		t.Fatalf("entity.list options = %#v", entities.lastList)
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"entity.get","params":{"entity_id":"entity-1","run_id":"run-1"}}`)
+	if get.Error != nil {
+		t.Fatalf("entity.get error = %#v", get.Error)
+	}
+	getResult := asMap(t, get.Result)
+	if fields := asMap(t, getResult["fields"]); fields["priority"] != "high" {
+		t.Fatalf("entity.get result = %#v", get.Result)
+	}
+	if entities.lastEntityID != "entity-1" || entities.lastRunID != "run-1" {
+		t.Fatalf("entity.get args = entity_id=%q run_id=%q", entities.lastEntityID, entities.lastRunID)
+	}
+
+	aggregate := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agg","method":"entity.aggregate","params":{"run_id":"run-1","group_by":"current_state","type":"mvp_spec"}}`)
+	if aggregate.Error != nil {
+		t.Fatalf("entity.aggregate error = %#v", aggregate.Error)
+	}
+	counts := asMap(t, asMap(t, aggregate.Result)["counts"])
+	if counts["collecting"] != float64(1) {
+		t.Fatalf("entity.aggregate result = %#v", aggregate.Result)
+	}
+	if entities.lastAggregate.RunID != "run-1" || entities.lastAggregate.GroupBy != "current_state" || entities.lastAggregate.Type != "mvp_spec" {
+		t.Fatalf("entity.aggregate options = %#v", entities.lastAggregate)
+	}
+}
+
+func TestOperatorEntityHandlersTypedErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		body     string
+		store    *fakeEntityReadStore
+		wantCode int
+		wantApp  string
+	}{
+		{
+			name:    "entity get missing",
+			method:  "entity.get",
+			body:    `{"jsonrpc":"2.0","id":"get","method":"entity.get","params":{"entity_id":"missing"}}`,
+			store:   &fakeEntityReadStore{getErr: store.ErrEntityNotFound},
+			wantApp: EntityNotFoundCode,
+		},
+		{
+			name:     "entity get ambiguous",
+			method:   "entity.get",
+			body:     `{"jsonrpc":"2.0","id":"get","method":"entity.get","params":{"entity_id":"reused"}}`,
+			store:    &fakeEntityReadStore{getErr: store.ErrAmbiguousEntityRunID},
+			wantCode: codeInvalidParams,
+		},
+		{
+			name:     "entity list bad cursor",
+			method:   "entity.list",
+			body:     `{"jsonrpc":"2.0","id":"list","method":"entity.list","params":{"cursor":"bad"}}`,
+			store:    &fakeEntityReadStore{listErr: store.ErrInvalidEntityCursor},
+			wantCode: codeInvalidParams,
+		},
+		{
+			name:     "entity aggregate bad group",
+			method:   "entity.aggregate",
+			body:     `{"jsonrpc":"2.0","id":"agg","method":"entity.aggregate","params":{"group_by":"bad"}}`,
+			store:    &fakeEntityReadStore{aggregateErr: &store.EntityReadParamError{Field: "group_by", Reason: "unsupported entity aggregate group_by"}},
+			wantCode: codeInvalidParams,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					Entities: tc.store,
+				}),
+			})
+			resp := rpcCall(t, handler, tc.body)
+			if resp.Error == nil {
+				t.Fatalf("expected rpc error")
+			}
+			if tc.wantApp != "" {
+				data := asMap(t, resp.Error.Data)
+				if data["code"] != tc.wantApp {
+					t.Fatalf("application code = %#v, want %s", data["code"], tc.wantApp)
+				}
+				return
+			}
+			if resp.Error.Code != tc.wantCode {
+				t.Fatalf("error code = %d, want %d: %#v", resp.Error.Code, tc.wantCode, resp.Error)
+			}
+		})
+	}
+}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -31,12 +31,19 @@ type ObservabilityReadStore interface {
 	ListOperatorRuntimeIncidents(context.Context, store.OperatorRuntimeIncidentListOptions) (store.OperatorRuntimeIncidentListResult, error)
 }
 
+type EntityReadStore interface {
+	ListOperatorEntities(context.Context, store.OperatorEntityListOptions) (store.OperatorEntityListResult, error)
+	LoadOperatorEntity(context.Context, string, string) (store.OperatorEntityFull, error)
+	AggregateOperatorEntities(context.Context, store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error)
+}
+
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
 	Database              Pinger
 	Runs                  RunReadStore
 	Observability         ObservabilityReadStore
+	Entities              EntityReadStore
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
@@ -199,6 +206,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorObservabilityHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorEntityHandlers(opts) {
+		handlers[name] = handler
+	}
 	return handlers
 }
 
@@ -214,6 +224,85 @@ func requireObservabilityReadStore(reads ObservabilityReadStore) (ObservabilityR
 		return nil, fmt.Errorf("observability read store is required")
 	}
 	return reads, nil
+}
+
+func requireEntityReadStore(reads EntityReadStore) (EntityReadStore, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("entity read store is required")
+	}
+	return reads, nil
+}
+
+func OperatorEntityHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.Entities == nil {
+		return nil
+	}
+	return map[string]MethodHandler{
+		"entity.list": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireEntityReadStore(opts.Entities)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorEntityListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorEntities(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidEntityCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid entity list cursor"})
+			}
+			if paramErr := entityReadParamError(err); paramErr != nil {
+				return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"entity.get": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireEntityReadStore(opts.Entities)
+			if err != nil {
+				return nil, err
+			}
+			entityID := stringParam(req.Params, "entity_id")
+			runID, _, err := optionalStringParam(req.Params, "run_id")
+			if err != nil {
+				return nil, err
+			}
+			entity, err := reads.LoadOperatorEntity(ctx, entityID, runID)
+			if errors.Is(err, store.ErrEntityNotFound) {
+				return nil, NewApplicationError(EntityNotFoundCode, false, map[string]any{"entity_id": entityID})
+			}
+			if errors.Is(err, store.ErrAmbiguousEntityRunID) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "required when entity_id exists in multiple runs"})
+			}
+			if paramErr := entityReadParamError(err); paramErr != nil {
+				return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return entity, nil
+		},
+		"entity.aggregate": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireEntityReadStore(opts.Entities)
+			if err != nil {
+				return nil, err
+			}
+			aggregateOpts, err := operatorEntityAggregateOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.AggregateOperatorEntities(ctx, aggregateOpts)
+			if paramErr := entityReadParamError(err); paramErr != nil {
+				return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	}
 }
 
 func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -320,6 +409,60 @@ func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHa
 			return result, nil
 		},
 	}
+}
+
+func operatorEntityListOptionsFromParams(params map[string]any) (store.OperatorEntityListOptions, error) {
+	out := store.OperatorEntityListOptions{}
+	var err error
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorEntityListOptions{}, err
+	}
+	if out.Flow, _, err = optionalStringParam(params, "flow"); err != nil {
+		return store.OperatorEntityListOptions{}, err
+	}
+	if out.Type, _, err = optionalStringParam(params, "type"); err != nil {
+		return store.OperatorEntityListOptions{}, err
+	}
+	if out.CurrentState, _, err = optionalStringParam(params, "current_state"); err != nil {
+		return store.OperatorEntityListOptions{}, err
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.OperatorEntityListOptions{}, err
+	}
+	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
+		limit, ok := integerParam(raw)
+		if !ok || limit < 1 || limit > 500 {
+			return store.OperatorEntityListOptions{}, NewInvalidParamsError(map[string]any{"field": "limit", "reason": "must be an integer from 1 to 500"})
+		}
+		out.Limit = limit
+	}
+	return out, nil
+}
+
+func operatorEntityAggregateOptionsFromParams(params map[string]any) (store.OperatorEntityAggregateOptions, error) {
+	out := store.OperatorEntityAggregateOptions{}
+	var err error
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorEntityAggregateOptions{}, err
+	}
+	if out.GroupBy, _, err = optionalStringParam(params, "group_by"); err != nil {
+		return store.OperatorEntityAggregateOptions{}, err
+	}
+	if out.Type, _, err = optionalStringParam(params, "type"); err != nil {
+		return store.OperatorEntityAggregateOptions{}, err
+	}
+	return out, nil
+}
+
+func entityReadParamError(err error) *store.EntityReadParamError {
+	if err == nil {
+		return nil
+	}
+	var paramErr *store.EntityReadParamError
+	if errors.As(err, &paramErr) {
+		return paramErr
+	}
+	return nil
 }
 
 func operatorEventListOptionsFromParams(params map[string]any) (store.OperatorEventListOptions, error) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -16,6 +16,7 @@ const (
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
 	EventNotFoundCode                    = "EVENT_NOT_FOUND"
+	EntityNotFoundCode                   = "ENTITY_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -8,16 +8,15 @@ import (
 
 	runtimepkg "swarm/internal/runtime"
 	runtimecredentials "swarm/internal/runtime/credentials"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 )
 
 type HealthChecker func(ctx context.Context) (map[string]any, error)
 
-type InstanceReader interface {
-	List(ctx context.Context) ([]runtimepipeline.WorkflowInstance, error)
-	Load(ctx context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error)
+type EntityReader interface {
+	ListOperatorEntities(ctx context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error)
+	LoadOperatorEntity(ctx context.Context, entityID, runID string) (store.OperatorEntityFull, error)
 }
 
 type RuntimeController interface {
@@ -50,7 +49,7 @@ type ProjectController interface {
 
 type Options struct {
 	Health         HealthChecker
-	Instances      InstanceReader
+	Entities       EntityReader
 	Runtime        RuntimeController
 	Credentials    runtimecredentials.Store
 	AuthToken      string
@@ -151,7 +150,7 @@ type EngineHealth struct {
 func NewHandler(opts Options) http.Handler {
 	h := &handler{
 		health:         opts.Health,
-		instances:      opts.Instances,
+		entities:       opts.Entities,
 		runtime:        opts.Runtime,
 		credentials:    opts.Credentials,
 		authToken:      strings.TrimSpace(opts.AuthToken),

--- a/internal/builder/handler.go
+++ b/internal/builder/handler.go
@@ -11,7 +11,7 @@ import (
 
 type handler struct {
 	health         HealthChecker
-	instances      InstanceReader
+	entities       EntityReader
 	runtime        RuntimeController
 	credentials    runtimecredentials.Store
 	authToken      string

--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -203,11 +203,11 @@ func (h *handler) dispatchRPC(ctx context.Context, method string, params map[str
 		if h.entities == nil {
 			return nil, methodUnavailable("entity reader is not configured")
 		}
-		result, err := h.entities.ListOperatorEntities(ctx, store.OperatorEntityListOptions{})
+		rows, err := h.legacyBuilderListEntities(ctx)
 		if err != nil {
 			return nil, internalError(err)
 		}
-		return map[string]any{"instances": result.Entities}, nil
+		return map[string]any{"instances": rows}, nil
 	case "state.get_entity":
 		if h.entities == nil {
 			return nil, methodUnavailable("entity reader is not configured")

--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -3,11 +3,14 @@ package builder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimerunstart "swarm/internal/runtime/runstart"
+	"swarm/internal/store"
 )
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -197,33 +200,36 @@ func (h *handler) dispatchRPC(ctx context.Context, method string, params map[str
 		}
 		return map[string]any{"run_id": runID, "status": "running"}, nil
 	case "state.list_instances", "state.get_instances":
-		if h.instances == nil {
-			return nil, methodUnavailable("instance reader is not configured")
+		if h.entities == nil {
+			return nil, methodUnavailable("entity reader is not configured")
 		}
-		rows, err := h.instances.List(ctx)
+		result, err := h.entities.ListOperatorEntities(ctx, store.OperatorEntityListOptions{})
 		if err != nil {
 			return nil, internalError(err)
 		}
-		return map[string]any{"instances": rows}, nil
+		return map[string]any{"instances": result.Entities}, nil
 	case "state.get_entity":
-		if h.instances == nil {
-			return nil, methodUnavailable("instance reader is not configured")
+		if h.entities == nil {
+			return nil, methodUnavailable("entity reader is not configured")
 		}
 		instanceID := strings.TrimSpace(asString(params["instance_id"]))
 		if instanceID == "" {
 			return nil, &RPCError{Code: -32602, Message: "instance_id is required"}
 		}
-		instance, ok, err := h.instances.Load(ctx, instanceID)
+		entity, err := h.entities.LoadOperatorEntity(ctx, runtimeflowidentity.EntityID(instanceID), strings.TrimSpace(asString(params["run_id"])))
+		if errors.Is(err, store.ErrEntityNotFound) {
+			return nil, &RPCError{Code: -32004, Message: "instance not found", Data: map[string]any{"instance_id": instanceID}}
+		}
+		if errors.Is(err, store.ErrAmbiguousEntityRunID) || errors.Is(err, store.ErrInvalidEntityReadParam) {
+			return nil, &RPCError{Code: -32602, Message: err.Error()}
+		}
 		if err != nil {
 			return nil, internalError(err)
 		}
-		if !ok {
-			return nil, &RPCError{Code: -32004, Message: "instance not found", Data: map[string]any{"instance_id": instanceID}}
-		}
 		return map[string]any{
-			"entity":      entityPayload(instance),
-			"gates":       entityGates(instance),
-			"accumulated": entityAccumulated(instance),
+			"entity":      legacyBuilderEntityPayload(entity),
+			"gates":       entity.Gates,
+			"accumulated": entity.Accumulated,
 		}, nil
 	case "credentials.list":
 		if h.credentials == nil {

--- a/internal/builder/handler_state.go
+++ b/internal/builder/handler_state.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -106,6 +107,25 @@ func legacyBuilderEntityPayload(full store.OperatorEntityFull) map[string]any {
 		entity["entity_type"] = full.Entity.EntityType
 	}
 	return entity
+}
+
+func (h *handler) legacyBuilderListEntities(ctx context.Context) ([]store.OperatorEntitySummary, error) {
+	if h == nil || h.entities == nil {
+		return nil, fmt.Errorf("entity reader is not configured")
+	}
+	opts := store.OperatorEntityListOptions{Limit: 500}
+	out := []store.OperatorEntitySummary{}
+	for {
+		result, err := h.entities.ListOperatorEntities(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, result.Entities...)
+		if strings.TrimSpace(result.NextCursor) == "" {
+			return out, nil
+		}
+		opts.Cursor = result.NextCursor
+	}
 }
 
 func (h *handler) healthSnapshot(ctx context.Context) EngineHealth {

--- a/internal/builder/handler_state.go
+++ b/internal/builder/handler_state.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	runtimebootverify "swarm/internal/runtime/bootverify"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
 )
 
 func (h *handler) builderVersion() string {
@@ -87,43 +87,25 @@ func (h *handler) runFullValidation(_ context.Context) ValidationResult {
 	return result
 }
 
-func entityPayload(instance runtimepipeline.WorkflowInstance) map[string]any {
-	entity := map[string]any{"state": strings.TrimSpace(instance.CurrentState)}
-	for key, value := range instance.Metadata {
+func legacyBuilderEntityPayload(full store.OperatorEntityFull) map[string]any {
+	entity := map[string]any{"state": strings.TrimSpace(full.Entity.CurrentState)}
+	for key, value := range full.Fields {
 		key = strings.TrimSpace(key)
 		if key == "" || key == "gates" {
 			continue
 		}
-		switch key {
-		case "slug", "name", "entity_type", "storage_ref", "instance_id", "flow_path", "instance_kind", "template_version", "last_source_event", "status", "transition_history":
-			continue
-		}
 		entity[key] = value
 	}
+	if full.Entity.Slug != "" {
+		entity["slug"] = full.Entity.Slug
+	}
+	if full.Entity.Name != "" {
+		entity["name"] = full.Entity.Name
+	}
+	if full.Entity.EntityType != "" {
+		entity["entity_type"] = full.Entity.EntityType
+	}
 	return entity
-}
-
-func entityGates(instance runtimepipeline.WorkflowInstance) map[string]any {
-	gates, _ := instance.Metadata["gates"].(map[string]any)
-	if len(gates) == 0 {
-		return map[string]any{}
-	}
-	out := make(map[string]any, len(gates))
-	for key, value := range gates {
-		out[key] = value
-	}
-	return out
-}
-
-func entityAccumulated(instance runtimepipeline.WorkflowInstance) map[string]any {
-	if len(instance.StateBuckets) == 0 {
-		return map[string]any{}
-	}
-	out := make(map[string]any, len(instance.StateBuckets))
-	for key, value := range instance.StateBuckets {
-		out[key] = value
-	}
-	return out
 }
 
 func (h *handler) healthSnapshot(ctx context.Context) EngineHealth {

--- a/internal/builder/handler_test.go
+++ b/internal/builder/handler_test.go
@@ -12,9 +12,28 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
 )
 
 const testBuilderAuthToken = "builder-test-token"
+
+type pagedEntityReader struct {
+	pages []store.OperatorEntityListResult
+	calls int
+}
+
+func (r *pagedEntityReader) ListOperatorEntities(_ context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error) {
+	if r.calls >= len(r.pages) {
+		return store.OperatorEntityListResult{Entities: []store.OperatorEntitySummary{}}, nil
+	}
+	page := r.pages[r.calls]
+	r.calls++
+	return page, nil
+}
+
+func (r *pagedEntityReader) LoadOperatorEntity(context.Context, string, string) (store.OperatorEntityFull, error) {
+	return store.OperatorEntityFull{}, store.ErrEntityNotFound
+}
 
 func TestHandler_CredentialsListSetDelete(t *testing.T) {
 	ctx := context.Background()
@@ -98,6 +117,33 @@ func TestHandler_CredentialsListSetDelete(t *testing.T) {
 	credential = extractSingleCredentialRecord(t, deleteResult["credential"])
 	if credential.Present {
 		t.Fatalf("expected credential to be deleted, got %+v", credential)
+	}
+}
+
+func TestHandler_StateListInstancesDrainsCanonicalEntityPages(t *testing.T) {
+	page1 := make([]store.OperatorEntitySummary, 50)
+	for i := range page1 {
+		page1[i] = store.OperatorEntitySummary{EntityID: "entity-page-1"}
+	}
+	reader := &pagedEntityReader{
+		pages: []store.OperatorEntityListResult{
+			{Entities: page1, NextCursor: "next"},
+			{Entities: []store.OperatorEntitySummary{{EntityID: "entity-page-2"}}},
+		},
+	}
+	handler := NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Entities:  reader,
+	})
+
+	resp := callBuilderRPC(t, handler, Request{JSONRPC: "2.0", ID: "1", Method: "state.list_instances"})
+	result, _ := resp.Result.(map[string]any)
+	rows, ok := result["instances"].([]any)
+	if !ok || len(rows) != 51 {
+		t.Fatalf("instances = %#v, want 51 rows", result["instances"])
+	}
+	if reader.calls != 2 {
+		t.Fatalf("ListOperatorEntities calls = %d, want 2", reader.calls)
 	}
 }
 

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimemanager "swarm/internal/runtime/manager"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 )
@@ -28,9 +28,10 @@ type MailboxReader interface {
 	GetMailboxItem(ctx context.Context, id string) (runtimetools.MailboxItem, error)
 }
 
-type InstanceReader interface {
-	List(ctx context.Context) ([]runtimepipeline.WorkflowInstance, error)
-	Load(ctx context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error)
+type EntityReader interface {
+	ListOperatorEntities(ctx context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error)
+	LoadOperatorEntity(ctx context.Context, entityID, runID string) (store.OperatorEntityFull, error)
+	AggregateOperatorEntities(ctx context.Context, opts store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error)
 }
 
 type ConversationSummary struct {
@@ -194,7 +195,7 @@ type Options struct {
 	Agents        AgentReader
 	AgentControl  AgentController
 	Mailbox       MailboxReader
-	Instances     InstanceReader
+	Entities      EntityReader
 	Conversations ConversationReader
 	Observability ObservabilityReader
 	RunTrace      RunTraceReader
@@ -209,7 +210,7 @@ type Handler struct {
 	agents        AgentReader
 	agentControl  AgentController
 	mailbox       MailboxReader
-	instances     InstanceReader
+	entities      EntityReader
 	conversations ConversationReader
 	observability ObservabilityReader
 	runTrace      RunTraceReader
@@ -226,7 +227,7 @@ func NewHandler(opts Options) http.Handler {
 		agents:        opts.Agents,
 		agentControl:  opts.AgentControl,
 		mailbox:       opts.Mailbox,
-		instances:     opts.Instances,
+		entities:      opts.Entities,
 		conversations: opts.Conversations,
 		observability: opts.Observability,
 		runTrace:      opts.RunTrace,
@@ -848,22 +849,28 @@ func (h *Handler) handleMailboxDetail(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleInstances(w http.ResponseWriter, r *http.Request) {
-	if h.instances == nil {
-		writeJSONError(w, http.StatusNotImplemented, errors.New("instance reader is not configured"))
+	if h.entities == nil {
+		writeJSONError(w, http.StatusNotImplemented, errors.New("entity reader is not configured"))
 		return
 	}
-	rows, err := h.instances.List(r.Context())
+	opts, err := dashboardEntityListOptions(r)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
+		writeJSONError(w, http.StatusBadRequest, err)
 		return
 	}
-	rows = filterInstances(rows, r)
-	writeJSON(w, http.StatusOK, map[string]any{"instances": rows})
+	result, err := h.entities.ListOperatorEntities(r.Context(), opts)
+	if handleDashboardEntityReadError(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"instances":   result.Entities,
+		"next_cursor": result.NextCursor,
+	})
 }
 
 func (h *Handler) handleInstanceDetail(w http.ResponseWriter, r *http.Request) {
-	if h.instances == nil {
-		writeJSONError(w, http.StatusNotImplemented, errors.New("instance reader is not configured"))
+	if h.entities == nil {
+		writeJSONError(w, http.StatusNotImplemented, errors.New("entity reader is not configured"))
 		return
 	}
 	id := strings.TrimSpace(r.PathValue("id"))
@@ -871,40 +878,33 @@ func (h *Handler) handleInstanceDetail(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, errors.New("instance id is required"))
 		return
 	}
-	row, ok, err := h.instances.Load(r.Context(), id)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
-		return
-	}
-	if !ok {
-		writeJSONError(w, http.StatusNotFound, errors.New("instance not found"))
+	row, err := h.entities.LoadOperatorEntity(r.Context(), runtimeflowidentity.EntityID(id), strings.TrimSpace(r.URL.Query().Get("run_id")))
+	if handleDashboardEntityReadError(w, err) {
 		return
 	}
 	writeJSON(w, http.StatusOK, row)
 }
 
 func (h *Handler) handleInstanceAggregate(w http.ResponseWriter, r *http.Request) {
-	if h.instances == nil {
-		writeJSONError(w, http.StatusNotImplemented, errors.New("instance reader is not configured"))
+	if h.entities == nil {
+		writeJSONError(w, http.StatusNotImplemented, errors.New("entity reader is not configured"))
 		return
 	}
 	groupBy := strings.TrimSpace(r.URL.Query().Get("group_by"))
 	if groupBy == "" {
 		groupBy = "current_state"
 	}
-	rows, err := h.instances.List(r.Context())
+	opts, err := dashboardEntityAggregateOptions(r, groupBy)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
+		writeJSONError(w, http.StatusBadRequest, err)
 		return
 	}
-	rows = filterInstances(rows, r)
-	counts := map[string]int{}
-	for _, row := range rows {
-		key := aggregateKey(row, groupBy)
-		counts[key]++
+	result, err := h.entities.AggregateOperatorEntities(r.Context(), opts)
+	if handleDashboardEntityReadError(w, err) {
+		return
 	}
-	out := make([]instanceAggregateGroup, 0, len(counts))
-	for key, count := range counts {
+	out := make([]instanceAggregateGroup, 0, len(result.Counts))
+	for key, count := range result.Counts {
 		out = append(out, instanceAggregateGroup{Key: key, Count: count})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -953,56 +953,58 @@ func (h *Handler) handleRuntimeAction(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func filterInstances(rows []runtimepipeline.WorkflowInstance, r *http.Request) []runtimepipeline.WorkflowInstance {
-	workflowName := strings.TrimSpace(r.URL.Query().Get("workflow_name"))
-	currentState := strings.TrimSpace(r.URL.Query().Get("current_state"))
-	entityID := strings.TrimSpace(r.URL.Query().Get("entity_id"))
-	limit := intQuery(r, "limit", 0)
-	out := make([]runtimepipeline.WorkflowInstance, 0, len(rows))
-	for _, row := range rows {
-		if workflowName != "" && row.WorkflowName != workflowName {
-			continue
-		}
-		if currentState != "" && row.CurrentState != currentState {
-			continue
-		}
-		if entityID != "" && row.InstanceID != entityID {
-			continue
-		}
-		out = append(out, row)
+func dashboardEntityListOptions(r *http.Request) (store.OperatorEntityListOptions, error) {
+	opts := store.OperatorEntityListOptions{
+		RunID:        strings.TrimSpace(r.URL.Query().Get("run_id")),
+		Flow:         strings.TrimSpace(r.URL.Query().Get("flow")),
+		Type:         strings.TrimSpace(r.URL.Query().Get("type")),
+		CurrentState: strings.TrimSpace(r.URL.Query().Get("current_state")),
+		Cursor:       strings.TrimSpace(r.URL.Query().Get("cursor")),
+		Limit:        intQuery(r, "limit", 0),
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
-			return out[i].InstanceID < out[j].InstanceID
-		}
-		return out[i].UpdatedAt.After(out[j].UpdatedAt)
-	})
-	if limit > 0 && len(out) > limit {
-		return out[:limit]
+	if opts.Flow == "" {
+		opts.Flow = strings.TrimSpace(r.URL.Query().Get("workflow_name"))
 	}
-	return out
+	if entityID := strings.TrimSpace(r.URL.Query().Get("entity_id")); entityID != "" {
+		opts.EntityID = runtimeflowidentity.EntityID(entityID)
+	}
+	return opts, nil
 }
 
-func aggregateKey(row runtimepipeline.WorkflowInstance, groupBy string) string {
-	switch groupBy {
+func dashboardEntityAggregateOptions(r *http.Request, groupBy string) (store.OperatorEntityAggregateOptions, error) {
+	return store.OperatorEntityAggregateOptions{
+		RunID:   strings.TrimSpace(r.URL.Query().Get("run_id")),
+		GroupBy: dashboardEntityAggregateGroupBy(groupBy),
+		Type:    strings.TrimSpace(r.URL.Query().Get("type")),
+	}, nil
+}
+
+func dashboardEntityAggregateGroupBy(groupBy string) string {
+	switch strings.TrimSpace(groupBy) {
 	case "workflow_name":
-		if strings.TrimSpace(row.WorkflowName) == "" {
-			return "unknown"
-		}
-		return row.WorkflowName
+		return "flow_instance"
 	case "workflow_version":
-		if strings.TrimSpace(row.WorkflowVersion) == "" {
-			return "unknown"
-		}
-		return row.WorkflowVersion
-	case "current_state":
-		fallthrough
+		return "fields.workflow_version"
 	default:
-		if strings.TrimSpace(row.CurrentState) == "" {
-			return "unknown"
-		}
-		return row.CurrentState
+		return strings.TrimSpace(groupBy)
 	}
+}
+
+func handleDashboardEntityReadError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, store.ErrEntityNotFound):
+		writeJSONError(w, http.StatusNotFound, errors.New("entity not found"))
+	case errors.Is(err, store.ErrAmbiguousEntityRunID):
+		writeJSONError(w, http.StatusBadRequest, errors.New("run_id is required when entity_id exists in multiple runs"))
+	case errors.Is(err, store.ErrInvalidEntityCursor), errors.Is(err, store.ErrInvalidEntityReadParam):
+		writeJSONError(w, http.StatusBadRequest, err)
+	default:
+		writeJSONError(w, http.StatusInternalServerError, err)
+	}
+	return true
 }
 
 func intQuery(r *http.Request, key string, fallback int) int {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -982,9 +982,9 @@ func dashboardEntityAggregateOptions(r *http.Request, groupBy string) (store.Ope
 func dashboardEntityAggregateGroupBy(groupBy string) string {
 	switch strings.TrimSpace(groupBy) {
 	case "workflow_name":
-		return "flow_instance"
+		return "workflow_name"
 	case "workflow_version":
-		return "fields.workflow_version"
+		return "workflow_version"
 	default:
 		return strings.TrimSpace(groupBy)
 	}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -23,11 +23,11 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/toolcapabilities"
 	"swarm/internal/runtime/flowmodel"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimeruncontrol "swarm/internal/runtime/runcontrol"
 	"swarm/internal/runtime/semanticview"
 	runtimesessions "swarm/internal/runtime/sessions"
@@ -97,17 +97,73 @@ func (s stubMailbox) GetMailboxItem(_ context.Context, id string) (runtimetools.
 }
 
 type stubInstances struct {
-	rows []runtimepipeline.WorkflowInstance
-	byID map[string]runtimepipeline.WorkflowInstance
+	rows []store.OperatorEntitySummary
+	byID map[string]store.OperatorEntityFull
 }
 
-func (s stubInstances) List(context.Context) ([]runtimepipeline.WorkflowInstance, error) {
-	return s.rows, nil
+func (s stubInstances) ListOperatorEntities(_ context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error) {
+	rows := make([]store.OperatorEntitySummary, 0, len(s.rows))
+	for _, row := range s.rows {
+		if opts.RunID != "" && row.RunID != opts.RunID {
+			continue
+		}
+		if opts.EntityID != "" && row.EntityID != opts.EntityID {
+			continue
+		}
+		if opts.Flow != "" && row.FlowInstance != opts.Flow && !strings.HasPrefix(row.FlowInstance, opts.Flow+"/") {
+			continue
+		}
+		if opts.Type != "" && row.EntityType != opts.Type {
+			continue
+		}
+		if opts.CurrentState != "" && row.CurrentState != opts.CurrentState {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	if opts.Limit > 0 && len(rows) > opts.Limit {
+		rows = rows[:opts.Limit]
+	}
+	return store.OperatorEntityListResult{Entities: rows}, nil
 }
 
-func (s stubInstances) Load(_ context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error) {
-	item, ok := s.byID[instanceID]
-	return item, ok, nil
+func (s stubInstances) LoadOperatorEntity(_ context.Context, entityID, runID string) (store.OperatorEntityFull, error) {
+	item, ok := s.byID[entityID]
+	if !ok {
+		return store.OperatorEntityFull{}, store.ErrEntityNotFound
+	}
+	if runID != "" && item.Entity.RunID != runID {
+		return store.OperatorEntityFull{}, store.ErrEntityNotFound
+	}
+	return item, nil
+}
+
+func (s stubInstances) AggregateOperatorEntities(_ context.Context, opts store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error) {
+	counts := map[string]int{}
+	for _, row := range s.rows {
+		if opts.RunID != "" && row.RunID != opts.RunID {
+			continue
+		}
+		if opts.Type != "" && row.EntityType != opts.Type {
+			continue
+		}
+		key := row.CurrentState
+		switch opts.GroupBy {
+		case "flow", "flow_instance":
+			key = row.FlowInstance
+		case "type", "entity_type":
+			key = row.EntityType
+		case "slug":
+			key = row.Slug
+		case "name":
+			key = row.Name
+		}
+		if strings.TrimSpace(key) == "" {
+			key = "unknown"
+		}
+		counts[key]++
+	}
+	return store.OperatorEntityAggregateResult{Counts: counts}, nil
 }
 
 type stubConversations struct {
@@ -619,7 +675,7 @@ func (s *stubProjectControl) CurrentProject() builderpkg.ProjectStatus {
 
 func newBuilderHandlerForTest(
 	health HealthChecker,
-	instances InstanceReader,
+	entities EntityReader,
 	version string,
 	runtimeCtl RuntimeController,
 	rt *runtimepkg.Runtime,
@@ -638,7 +694,7 @@ func newBuilderHandlerForTest(
 	}
 	return builderpkg.NewHandler(builderpkg.Options{
 		Health:         builderpkg.HealthChecker(health),
-		Instances:      instances,
+		Entities:       entities,
 		Runtime:        runtimeCtl,
 		AuthToken:      testBuilderAuthToken,
 		Version:        version,
@@ -735,13 +791,13 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 				Count: 1,
 			}},
 		},
-		Instances: stubInstances{
-			rows: []runtimepipeline.WorkflowInstance{
-				{InstanceID: "wf-1", WorkflowName: "order", CurrentState: "active", UpdatedAt: now},
-				{InstanceID: "wf-2", WorkflowName: "order", CurrentState: "done", UpdatedAt: now.Add(-time.Minute)},
+		Entities: stubInstances{
+			rows: []store.OperatorEntitySummary{
+				{EntityID: "wf-1", FlowInstance: "order", CurrentState: "active", UpdatedAt: now},
+				{EntityID: "wf-2", FlowInstance: "order", CurrentState: "done", UpdatedAt: now.Add(-time.Minute)},
 			},
-			byID: map[string]runtimepipeline.WorkflowInstance{
-				"wf-1": {InstanceID: "wf-1", WorkflowName: "order", CurrentState: "active", UpdatedAt: now},
+			byID: map[string]store.OperatorEntityFull{
+				"wf-1": {Entity: store.OperatorEntitySummary{EntityID: "wf-1", FlowInstance: "order", CurrentState: "active", UpdatedAt: now}},
 			},
 		},
 		Runtime: &stubRuntimeControl{},
@@ -2794,23 +2850,22 @@ func TestSQLConversationReader_GetFailsClosedWhenCapabilityOwnerReportsUnavailab
 
 func TestHandler_BuilderRPC(t *testing.T) {
 	projectCtl := &stubProjectControl{}
+	entityID := runtimeflowidentity.EntityID("wf-1")
 	instances := stubInstances{
-		rows: []runtimepipeline.WorkflowInstance{
-			{InstanceID: "wf-1", WorkflowName: "order", CurrentState: "active"},
+		rows: []store.OperatorEntitySummary{
+			{EntityID: entityID, FlowInstance: "order", CurrentState: "active"},
 		},
-		byID: map[string]runtimepipeline.WorkflowInstance{
-			"wf-1": {
-				InstanceID:   "wf-1",
-				WorkflowName: "order",
-				CurrentState: "active",
-				Metadata: map[string]any{
-					"score": 3.7,
-					"gates": map[string]any{"review_gate": true},
-					"slug":  "order-1",
+		byID: map[string]store.OperatorEntityFull{
+			entityID: {
+				Entity: store.OperatorEntitySummary{
+					EntityID:     entityID,
+					FlowInstance: "order",
+					CurrentState: "active",
+					Slug:         "order-1",
 				},
-				StateBuckets: map[string]any{
-					"accumulator": map[string]any{"count": 2},
-				},
+				Fields:      map[string]any{"score": 3.7},
+				Gates:       map[string]bool{"review_gate": true},
+				Accumulated: map[string]any{"accumulator": map[string]any{"count": 2}},
 			},
 		},
 	}
@@ -2819,7 +2874,8 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 	handler := NewHandler(Options{
 		Health:    health,
-		Instances: instances,
+		Entities:  instances,
+		AuthToken: testOperatorAuthToken,
 		Version:   "swarm-test",
 		Builder:   newBuilderHandlerForTest(health, instances, "swarm-test", nil, nil, projectCtl),
 	})
@@ -2840,6 +2896,36 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 	if result["status"] != "ok" || result["version"] != "swarm-test" {
 		t.Fatalf("unexpected ping result: %#v", result)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/instances?workflow_name=order&current_state=active&limit=1", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dashboard instances status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var dashboardInstances map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &dashboardInstances); err != nil {
+		t.Fatalf("unmarshal dashboard instances: %v", err)
+	}
+	if rows, ok := dashboardInstances["instances"].([]any); !ok || len(rows) != 1 {
+		t.Fatalf("unexpected dashboard instances payload: %#v", dashboardInstances)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/instances/wf-1", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dashboard entity detail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var dashboardEntity store.OperatorEntityFull
+	if err := json.Unmarshal(rec.Body.Bytes(), &dashboardEntity); err != nil {
+		t.Fatalf("unmarshal dashboard entity detail: %v", err)
+	}
+	if dashboardEntity.Entity.EntityID != entityID || dashboardEntity.Fields["score"] != float64(3.7) || !dashboardEntity.Gates["review_gate"] {
+		t.Fatalf("unexpected dashboard entity detail: %#v", dashboardEntity)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -97,8 +97,9 @@ func (s stubMailbox) GetMailboxItem(_ context.Context, id string) (runtimetools.
 }
 
 type stubInstances struct {
-	rows []store.OperatorEntitySummary
-	byID map[string]store.OperatorEntityFull
+	rows          []store.OperatorEntitySummary
+	byID          map[string]store.OperatorEntityFull
+	lastAggregate *store.OperatorEntityAggregateOptions
 }
 
 func (s stubInstances) ListOperatorEntities(_ context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error) {
@@ -139,6 +140,9 @@ func (s stubInstances) LoadOperatorEntity(_ context.Context, entityID, runID str
 }
 
 func (s stubInstances) AggregateOperatorEntities(_ context.Context, opts store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error) {
+	if s.lastAggregate != nil {
+		*s.lastAggregate = opts
+	}
 	counts := map[string]int{}
 	for _, row := range s.rows {
 		if opts.RunID != "" && row.RunID != opts.RunID {
@@ -2851,6 +2855,7 @@ func TestSQLConversationReader_GetFailsClosedWhenCapabilityOwnerReportsUnavailab
 func TestHandler_BuilderRPC(t *testing.T) {
 	projectCtl := &stubProjectControl{}
 	entityID := runtimeflowidentity.EntityID("wf-1")
+	lastAggregate := &store.OperatorEntityAggregateOptions{}
 	instances := stubInstances{
 		rows: []store.OperatorEntitySummary{
 			{EntityID: entityID, FlowInstance: "order", CurrentState: "active"},
@@ -2868,6 +2873,7 @@ func TestHandler_BuilderRPC(t *testing.T) {
 				Accumulated: map[string]any{"accumulator": map[string]any{"count": 2}},
 			},
 		},
+		lastAggregate: lastAggregate,
 	}
 	health := func(context.Context) (map[string]any, error) {
 		return map[string]any{"runtime": map[string]any{"ready": true}}, nil
@@ -2926,6 +2932,17 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	}
 	if dashboardEntity.Entity.EntityID != entityID || dashboardEntity.Fields["score"] != float64(3.7) || !dashboardEntity.Gates["review_gate"] {
 		t.Fatalf("unexpected dashboard entity detail: %#v", dashboardEntity)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/instances/aggregate?group_by=workflow_version", nil)
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dashboard workflow_version aggregate status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if lastAggregate.GroupBy != "workflow_version" {
+		t.Fatalf("dashboard workflow_version aggregate group_by = %q, want workflow_version", lastAggregate.GroupBy)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -82,7 +82,8 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-if grep -Fq '"name":"read_file"' "$captured" && grep -Fq '"ok":true' "$captured"; then
+first_nonspace="$(sed -n 's/^[[:space:]]*//; /^$/d; s/^\(.\).*$/\1/p; q' "$captured")"
+if [ "$first_nonspace" = "[" ] && grep -Fq '"name":"read_file"' "$captured" && grep -Fq '"ok":true' "$captured"; then
   printf '%s\n' '{"type":"result","result":"done"}'
 else
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -11,3 +11,27 @@ var ErrInvalidRunListCursor = errors.New("store: invalid run list cursor")
 var ErrEventNotFound = errors.New("store: event not found")
 
 var ErrInvalidObservabilityCursor = errors.New("store: invalid observability cursor")
+
+var ErrEntityNotFound = errors.New("store: entity not found")
+
+var ErrAmbiguousEntityRunID = errors.New("store: ambiguous entity run_id")
+
+var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")
+
+var ErrInvalidEntityReadParam = errors.New("store: invalid entity read parameter")
+
+type EntityReadParamError struct {
+	Field  string
+	Reason string
+}
+
+func (e *EntityReadParamError) Error() string {
+	if e == nil {
+		return ErrInvalidEntityReadParam.Error()
+	}
+	return ErrInvalidEntityReadParam.Error() + ": " + e.Field + ": " + e.Reason
+}
+
+func (e *EntityReadParamError) Is(target error) bool {
+	return target == ErrInvalidEntityReadParam
+}

--- a/internal/store/operator_entity_read_surface.go
+++ b/internal/store/operator_entity_read_surface.go
@@ -1,0 +1,489 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type OperatorEntityListOptions struct {
+	RunID        string
+	EntityID     string
+	Flow         string
+	Type         string
+	CurrentState string
+	Limit        int
+	Cursor       string
+}
+
+type OperatorEntityListResult struct {
+	Entities   []OperatorEntitySummary `json:"entities"`
+	NextCursor string                  `json:"next_cursor,omitempty"`
+}
+
+type OperatorEntitySummary struct {
+	EntityID     string    `json:"entity_id"`
+	RunID        string    `json:"run_id"`
+	FlowInstance string    `json:"flow_instance"`
+	EntityType   string    `json:"entity_type"`
+	CurrentState string    `json:"current_state"`
+	Revision     int       `json:"revision"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Slug         string    `json:"slug,omitempty"`
+	Name         string    `json:"name,omitempty"`
+}
+
+type OperatorEntityFull struct {
+	Entity      OperatorEntitySummary `json:"entity"`
+	Fields      map[string]any        `json:"fields"`
+	Gates       map[string]bool       `json:"gates"`
+	Accumulated map[string]any        `json:"accumulated"`
+}
+
+type OperatorEntityAggregateOptions struct {
+	RunID   string
+	GroupBy string
+	Type    string
+}
+
+type OperatorEntityAggregateResult struct {
+	Counts map[string]int `json:"counts"`
+}
+
+type entityPositionCursor struct {
+	Kind      string `json:"kind"`
+	UpdatedAt string `json:"updated_at"`
+	EntityID  string `json:"entity_id"`
+	RunID     string `json:"run_id"`
+}
+
+type entityAggregateGroup struct {
+	Expr string
+}
+
+var entityAggregateFieldPattern = regexp.MustCompile(`^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$`)
+
+func (s *PostgresStore) requireOperatorEntityCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case caps.EntityState != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("entity_state", caps.EntityState)
+	case !caps.EntityRunID:
+		return fmt.Errorf("operator entity read surface requires canonical entity_state.run_id")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	required := []string{
+		"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name",
+		"current_state", "gates", "fields", "accumulator", "revision",
+		"created_at", "updated_at",
+	}
+	if !catalog.hasColumns("entity_state", required...) {
+		return fmt.Errorf("operator entity read surface requires entity_state columns %v", required)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListOperatorEntities(ctx context.Context, opts OperatorEntityListOptions) (OperatorEntityListResult, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityListResult{}, err
+	}
+	opts, err := defaultOperatorEntityListOptions(opts)
+	if err != nil {
+		return OperatorEntityListResult{}, err
+	}
+	args := make([]any, 0, 12)
+	where := []string{"TRUE"}
+	add := func(value any) int {
+		args = append(args, value)
+		return len(args)
+	}
+	if opts.RunID != "" {
+		n := add(opts.RunID)
+		where = append(where, fmt.Sprintf("es.run_id = $%d::uuid", n))
+	}
+	if opts.EntityID != "" {
+		n := add(opts.EntityID)
+		where = append(where, fmt.Sprintf("es.entity_id = $%d::uuid", n))
+	}
+	if opts.Flow != "" {
+		n := add(opts.Flow)
+		where = append(where, fmt.Sprintf("(es.flow_instance = $%d OR es.flow_instance LIKE $%d || '/%%')", n, n))
+	}
+	if opts.Type != "" {
+		n := add(opts.Type)
+		where = append(where, fmt.Sprintf("es.entity_type = $%d", n))
+	}
+	if opts.CurrentState != "" {
+		n := add(opts.CurrentState)
+		where = append(where, fmt.Sprintf("es.current_state = $%d", n))
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeEntityPositionCursor(opts.Cursor, "entity.list")
+		if err != nil {
+			return OperatorEntityListResult{}, err
+		}
+		updatedAt, err := time.Parse(time.RFC3339Nano, cursor.UpdatedAt)
+		if err != nil || strings.TrimSpace(cursor.EntityID) == "" || strings.TrimSpace(cursor.RunID) == "" {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		if _, err := uuid.Parse(cursor.EntityID); err != nil {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		if _, err := uuid.Parse(cursor.RunID); err != nil {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		nTime := add(updatedAt.UTC())
+		nEntity := add(cursor.EntityID)
+		nRun := add(cursor.RunID)
+		where = append(where, fmt.Sprintf(`(
+			es.updated_at < $%d
+			OR (
+				es.updated_at = $%d
+				AND (
+					es.entity_id::text > $%d
+					OR (es.entity_id::text = $%d AND es.run_id::text > $%d)
+				)
+			)
+		)`, nTime, nTime, nEntity, nEntity, nRun))
+	}
+	limitArg := add(opts.Limit + 1)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			es.entity_id::text,
+			es.run_id::text,
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			COALESCE(es.current_state, ''),
+			COALESCE(es.revision, 0),
+			es.created_at,
+			es.updated_at,
+			COALESCE(es.slug, ''),
+			COALESCE(es.name, '')
+		FROM entity_state es
+		WHERE `+strings.Join(where, " AND ")+fmt.Sprintf(`
+		ORDER BY es.updated_at DESC, es.entity_id::text ASC, es.run_id::text ASC
+		LIMIT $%d
+	`, limitArg), args...)
+	if err != nil {
+		return OperatorEntityListResult{}, fmt.Errorf("list operator entities: %w", err)
+	}
+	defer rows.Close()
+	entities := []OperatorEntitySummary{}
+	for rows.Next() {
+		var item OperatorEntitySummary
+		if err := rows.Scan(
+			&item.EntityID,
+			&item.RunID,
+			&item.FlowInstance,
+			&item.EntityType,
+			&item.CurrentState,
+			&item.Revision,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&item.Slug,
+			&item.Name,
+		); err != nil {
+			return OperatorEntityListResult{}, fmt.Errorf("scan operator entity summary: %w", err)
+		}
+		entities = append(entities, item)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityListResult{}, fmt.Errorf("read operator entity summaries: %w", err)
+	}
+	nextCursor := ""
+	if len(entities) > opts.Limit {
+		entities = entities[:opts.Limit]
+		last := entities[len(entities)-1]
+		nextCursor = encodeEntityPositionCursor(entityPositionCursor{
+			Kind:      "entity.list",
+			UpdatedAt: last.UpdatedAt.UTC().Format(time.RFC3339Nano),
+			EntityID:  last.EntityID,
+			RunID:     last.RunID,
+		})
+	}
+	if entities == nil {
+		entities = []OperatorEntitySummary{}
+	}
+	return OperatorEntityListResult{Entities: entities, NextCursor: nextCursor}, nil
+}
+
+func (s *PostgresStore) LoadOperatorEntity(ctx context.Context, entityID, runID string) (OperatorEntityFull, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityFull{}, err
+	}
+	entityID = strings.TrimSpace(entityID)
+	runID = strings.TrimSpace(runID)
+	if entityID == "" {
+		return OperatorEntityFull{}, ErrEntityNotFound
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return OperatorEntityFull{}, &EntityReadParamError{Field: "entity_id", Reason: "must be a UUID"}
+	}
+	if runID != "" {
+		if _, err := uuid.Parse(runID); err != nil {
+			return OperatorEntityFull{}, &EntityReadParamError{Field: "run_id", Reason: "must be a UUID"}
+		}
+		return s.loadOperatorEntityRow(ctx, entityID, runID)
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT es.run_id::text
+		FROM entity_state es
+		WHERE es.entity_id = $1::uuid
+		ORDER BY es.updated_at DESC, es.run_id::text ASC
+		LIMIT 2
+	`, entityID)
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("resolve operator entity run scope: %w", err)
+	}
+	defer rows.Close()
+	matches := []string{}
+	for rows.Next() {
+		var match string
+		if err := rows.Scan(&match); err != nil {
+			return OperatorEntityFull{}, fmt.Errorf("scan operator entity run scope: %w", err)
+		}
+		matches = append(matches, match)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("read operator entity run scopes: %w", err)
+	}
+	switch len(matches) {
+	case 0:
+		return OperatorEntityFull{}, ErrEntityNotFound
+	case 1:
+		return s.loadOperatorEntityRow(ctx, entityID, matches[0])
+	default:
+		return OperatorEntityFull{}, ErrAmbiguousEntityRunID
+	}
+}
+
+func (s *PostgresStore) AggregateOperatorEntities(ctx context.Context, opts OperatorEntityAggregateOptions) (OperatorEntityAggregateResult, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	opts, err := defaultOperatorEntityAggregateOptions(opts)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	args := make([]any, 0, 6)
+	where := []string{"TRUE"}
+	add := func(value any) int {
+		args = append(args, value)
+		return len(args)
+	}
+	if opts.RunID != "" {
+		n := add(opts.RunID)
+		where = append(where, fmt.Sprintf("es.run_id = $%d::uuid", n))
+	}
+	if opts.Type != "" {
+		n := add(opts.Type)
+		where = append(where, fmt.Sprintf("es.entity_type = $%d", n))
+	}
+	group, err := operatorEntityAggregateGroup(opts.GroupBy, add)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(`+group.Expr+`, 'unknown') AS bucket, COUNT(*)::int
+		FROM entity_state es
+		WHERE `+strings.Join(where, " AND ")+`
+		GROUP BY bucket
+		ORDER BY COUNT(*) DESC, bucket ASC
+	`, args...)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, fmt.Errorf("aggregate operator entities: %w", err)
+	}
+	defer rows.Close()
+	counts := map[string]int{}
+	for rows.Next() {
+		var (
+			key   string
+			count int
+		)
+		if err := rows.Scan(&key, &count); err != nil {
+			return OperatorEntityAggregateResult{}, fmt.Errorf("scan operator entity aggregate: %w", err)
+		}
+		counts[key] = count
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityAggregateResult{}, fmt.Errorf("read operator entity aggregate: %w", err)
+	}
+	return OperatorEntityAggregateResult{Counts: counts}, nil
+}
+
+func (s *PostgresStore) loadOperatorEntityRow(ctx context.Context, entityID, runID string) (OperatorEntityFull, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT
+			es.entity_id::text,
+			es.run_id::text,
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			COALESCE(es.current_state, ''),
+			COALESCE(es.revision, 0),
+			es.created_at,
+			es.updated_at,
+			COALESCE(es.slug, ''),
+			COALESCE(es.name, ''),
+			COALESCE(es.fields, '{}'::jsonb),
+			COALESCE(es.gates, '{}'::jsonb),
+			COALESCE(es.accumulator, '{}'::jsonb)
+		FROM entity_state es
+		WHERE es.entity_id = $1::uuid
+		  AND es.run_id = $2::uuid
+	`, entityID, runID)
+	var (
+		out     OperatorEntityFull
+		fields  []byte
+		gates   []byte
+		accum   []byte
+		summary = &out.Entity
+	)
+	if err := row.Scan(
+		&summary.EntityID,
+		&summary.RunID,
+		&summary.FlowInstance,
+		&summary.EntityType,
+		&summary.CurrentState,
+		&summary.Revision,
+		&summary.CreatedAt,
+		&summary.UpdatedAt,
+		&summary.Slug,
+		&summary.Name,
+		&fields,
+		&gates,
+		&accum,
+	); err == sql.ErrNoRows {
+		return OperatorEntityFull{}, ErrEntityNotFound
+	} else if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("load operator entity: %w", err)
+	}
+	decodedFields, err := decodeStoreJSONMap(fields)
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode operator entity fields: %w", err)
+	}
+	decodedGates, err := decodeStoreJSONBoolMap(gates)
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode operator entity gates: %w", err)
+	}
+	decodedAccumulated, err := decodeStoreJSONMap(accum)
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode operator entity accumulated: %w", err)
+	}
+	out.Fields = decodedFields
+	out.Gates = decodedGates
+	out.Accumulated = decodedAccumulated
+	return out, nil
+}
+
+func defaultOperatorEntityListOptions(opts OperatorEntityListOptions) (OperatorEntityListOptions, error) {
+	opts.RunID = strings.TrimSpace(opts.RunID)
+	opts.EntityID = strings.TrimSpace(opts.EntityID)
+	opts.Flow = strings.Trim(strings.TrimSpace(opts.Flow), "/")
+	opts.Type = strings.TrimSpace(opts.Type)
+	opts.CurrentState = strings.TrimSpace(opts.CurrentState)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.RunID != "" {
+		if _, err := uuid.Parse(opts.RunID); err != nil {
+			return OperatorEntityListOptions{}, &EntityReadParamError{Field: "run_id", Reason: "must be a UUID"}
+		}
+	}
+	if opts.EntityID != "" {
+		if _, err := uuid.Parse(opts.EntityID); err != nil {
+			return OperatorEntityListOptions{}, &EntityReadParamError{Field: "entity_id", Reason: "must be a UUID"}
+		}
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts, nil
+}
+
+func defaultOperatorEntityAggregateOptions(opts OperatorEntityAggregateOptions) (OperatorEntityAggregateOptions, error) {
+	opts.RunID = strings.TrimSpace(opts.RunID)
+	opts.Type = strings.TrimSpace(opts.Type)
+	opts.GroupBy = strings.TrimSpace(opts.GroupBy)
+	if opts.GroupBy == "" {
+		opts.GroupBy = "current_state"
+	}
+	if opts.RunID != "" {
+		if _, err := uuid.Parse(opts.RunID); err != nil {
+			return OperatorEntityAggregateOptions{}, &EntityReadParamError{Field: "run_id", Reason: "must be a UUID"}
+		}
+	}
+	return opts, nil
+}
+
+func operatorEntityAggregateGroup(groupBy string, add func(any) int) (entityAggregateGroup, error) {
+	switch strings.TrimSpace(groupBy) {
+	case "current_state":
+		return entityAggregateGroup{Expr: "NULLIF(es.current_state, '')"}, nil
+	case "flow", "flow_instance":
+		return entityAggregateGroup{Expr: "NULLIF(es.flow_instance, '')"}, nil
+	case "type", "entity_type":
+		return entityAggregateGroup{Expr: "NULLIF(es.entity_type, '')"}, nil
+	case "slug":
+		return entityAggregateGroup{Expr: "NULLIF(es.slug, '')"}, nil
+	case "name":
+		return entityAggregateGroup{Expr: "NULLIF(es.name, '')"}, nil
+	default:
+		if path, ok := strings.CutPrefix(strings.TrimSpace(groupBy), "fields."); ok && entityAggregateFieldPattern.MatchString(path) {
+			n := add(path)
+			return entityAggregateGroup{Expr: fmt.Sprintf("NULLIF(es.fields #>> string_to_array($%d, '.'), '')", n)}, nil
+		}
+		return entityAggregateGroup{}, &EntityReadParamError{Field: "group_by", Reason: "unsupported entity aggregate group_by"}
+	}
+}
+
+func encodeEntityPositionCursor(cursor entityPositionCursor) string {
+	raw, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeEntityPositionCursor(raw string, kind string) (entityPositionCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return entityPositionCursor{}, ErrInvalidEntityCursor
+	}
+	var cursor entityPositionCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return entityPositionCursor{}, ErrInvalidEntityCursor
+	}
+	if strings.TrimSpace(cursor.Kind) != kind {
+		return entityPositionCursor{}, ErrInvalidEntityCursor
+	}
+	return cursor, nil
+}
+
+func decodeStoreJSONBoolMap(raw []byte) (map[string]bool, error) {
+	if len(raw) == 0 {
+		return map[string]bool{}, nil
+	}
+	var out map[string]bool
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = map[string]bool{}
+	}
+	return out, nil
+}

--- a/internal/store/operator_entity_read_surface.go
+++ b/internal/store/operator_entity_read_surface.go
@@ -67,6 +67,7 @@ type entityPositionCursor struct {
 
 type entityAggregateGroup struct {
 	Expr string
+	Join string
 }
 
 var entityAggregateFieldPattern = regexp.MustCompile(`^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$`)
@@ -303,6 +304,7 @@ func (s *PostgresStore) AggregateOperatorEntities(ctx context.Context, opts Oper
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT COALESCE(`+group.Expr+`, 'unknown') AS bucket, COUNT(*)::int
 		FROM entity_state es
+		`+group.Join+`
 		WHERE `+strings.Join(where, " AND ")+`
 		GROUP BY bucket
 		ORDER BY COUNT(*) DESC, bucket ASC
@@ -439,6 +441,16 @@ func operatorEntityAggregateGroup(groupBy string, add func(any) int) (entityAggr
 		return entityAggregateGroup{Expr: "NULLIF(es.current_state, '')"}, nil
 	case "flow", "flow_instance":
 		return entityAggregateGroup{Expr: "NULLIF(es.flow_instance, '')"}, nil
+	case "workflow_name":
+		return entityAggregateGroup{
+			Expr: "NULLIF(fi.flow_template, '')",
+			Join: "LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance",
+		}, nil
+	case "workflow_version":
+		return entityAggregateGroup{
+			Expr: "NULLIF(fi.config->>'workflow_version', '')",
+			Join: "LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance",
+		}, nil
 	case "type", "entity_type":
 		return entityAggregateGroup{Expr: "NULLIF(es.entity_type, '')"}, nil
 	case "slug":

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -48,6 +48,15 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	seedEntity(runA, entityB, "review/secondary", "mvp_spec", "done", `{"priority":"low"}`, `{}`, `{}`, base)
 	seedEntity(runA, sharedEntity, "triage", "ticket", "collecting", `{"priority":"high"}`, `{}`, `{}`, base.Add(-time.Minute))
 	seedEntity(runB, sharedEntity, "triage", "ticket", "done", `{"priority":"low"}`, `{}`, `{}`, base.Add(-2*time.Minute))
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('review/primary', 'review', 'template', '{"workflow_version":"v1"}'::jsonb, 'active', $1),
+			('review/secondary', 'review', 'template', '{"workflow_version":"v2"}'::jsonb, 'active', $1),
+			('triage', 'triage', 'static', '{"workflow_version":"v1"}'::jsonb, 'active', $1)
+	`, base); err != nil {
+		t.Fatalf("seed flow instances: %v", err)
+	}
 
 	page1, err := pg.ListOperatorEntities(ctx, OperatorEntityListOptions{
 		RunID: runA,
@@ -102,6 +111,20 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	}
 	if fieldAgg.Counts["high"] != 2 || fieldAgg.Counts["low"] != 1 {
 		t.Fatalf("field aggregate = %#v", fieldAgg.Counts)
+	}
+	versionAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "workflow_version"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities workflow_version: %v", err)
+	}
+	if versionAgg.Counts["v1"] != 2 || versionAgg.Counts["v2"] != 1 {
+		t.Fatalf("workflow version aggregate = %#v", versionAgg.Counts)
+	}
+	nameAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "workflow_name"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities workflow_name: %v", err)
+	}
+	if nameAgg.Counts["review"] != 2 || nameAgg.Counts["triage"] != 1 {
+		t.Fatalf("workflow name aggregate = %#v", nameAgg.Counts)
 	}
 	if _, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority->unsafe"}); !errors.Is(err, ErrInvalidEntityReadParam) {
 		t.Fatalf("AggregateOperatorEntities unsafe group = %v, want ErrInvalidEntityReadParam", err)

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityA := uuid.NewString()
+	entityB := uuid.NewString()
+	sharedEntity := uuid.NewString()
+	base := time.Unix(1700000000, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at) VALUES
+			($1::uuid, 'running', $3),
+			($2::uuid, 'running', $3)
+	`, runA, runB, base); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	seedEntity := func(runID, entityID, flow, entityType, state, fields, gates, accumulated string, createdAt time.Time) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name,
+				current_state, gates, fields, accumulator, revision,
+				entered_state_at, created_at, updated_at
+			) VALUES (
+				$1::uuid, $2::uuid, $3, $4, NULL, NULL,
+				$5, $6::jsonb, $7::jsonb, $8::jsonb, 1,
+				$9, $9, $9
+			)
+		`, runID, entityID, flow, entityType, state, gates, fields, accumulated, createdAt); err != nil {
+			t.Fatalf("seed entity %s/%s: %v", runID, entityID, err)
+		}
+	}
+	seedEntity(runA, entityA, "review/primary", "mvp_spec", "collecting", `{"priority":"high","score":3}`, `{"approved":true}`, `{"notes":["a"]}`, base.Add(time.Minute))
+	seedEntity(runA, entityB, "review/secondary", "mvp_spec", "done", `{"priority":"low"}`, `{}`, `{}`, base)
+	seedEntity(runA, sharedEntity, "triage", "ticket", "collecting", `{"priority":"high"}`, `{}`, `{}`, base.Add(-time.Minute))
+	seedEntity(runB, sharedEntity, "triage", "ticket", "done", `{"priority":"low"}`, `{}`, `{}`, base.Add(-2*time.Minute))
+
+	page1, err := pg.ListOperatorEntities(ctx, OperatorEntityListOptions{
+		RunID: runA,
+		Flow:  "review",
+		Type:  "mvp_spec",
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEntities page1: %v", err)
+	}
+	if len(page1.Entities) != 1 || page1.Entities[0].EntityID != entityA || page1.NextCursor == "" {
+		t.Fatalf("page1 = %#v", page1)
+	}
+	page2, err := pg.ListOperatorEntities(ctx, OperatorEntityListOptions{
+		RunID:  runA,
+		Flow:   "review",
+		Type:   "mvp_spec",
+		Limit:  1,
+		Cursor: page1.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEntities page2: %v", err)
+	}
+	if len(page2.Entities) != 1 || page2.Entities[0].EntityID != entityB {
+		t.Fatalf("page2 = %#v", page2)
+	}
+
+	full, err := pg.LoadOperatorEntity(ctx, entityA, runA)
+	if err != nil {
+		t.Fatalf("LoadOperatorEntity: %v", err)
+	}
+	if full.Entity.FlowInstance != "review/primary" || full.Fields["priority"] != "high" || !full.Gates["approved"] {
+		t.Fatalf("full entity = %#v", full)
+	}
+	if _, err := pg.LoadOperatorEntity(ctx, sharedEntity, ""); !errors.Is(err, ErrAmbiguousEntityRunID) {
+		t.Fatalf("LoadOperatorEntity ambiguous = %v, want ErrAmbiguousEntityRunID", err)
+	}
+	if _, err := pg.LoadOperatorEntity(ctx, uuid.NewString(), ""); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("LoadOperatorEntity missing = %v, want ErrEntityNotFound", err)
+	}
+
+	stateAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "current_state"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities current_state: %v", err)
+	}
+	if stateAgg.Counts["collecting"] != 2 || stateAgg.Counts["done"] != 1 {
+		t.Fatalf("state aggregate = %#v", stateAgg.Counts)
+	}
+	fieldAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities fields.priority: %v", err)
+	}
+	if fieldAgg.Counts["high"] != 2 || fieldAgg.Counts["low"] != 1 {
+		t.Fatalf("field aggregate = %#v", fieldAgg.Counts)
+	}
+	if _, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority->unsafe"}); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("AggregateOperatorEntities unsafe group = %v, want ErrInvalidEntityReadParam", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the #700 entity-native operator read slice:

- Adds `internal/store` as the canonical entity read/projection owner over persisted `entity_state` for `entity.list`, `entity.get`, and `entity.aggregate`.
- Wires v1 JSON-RPC `entity.*` methods to that owner with typed `ENTITY_NOT_FOUND`, invalid cursor/group/filter handling, run-scoped disambiguation, and aggregate group allowlisting.
- Moves dashboard `/api/instances*` and Builder `state.list_instances`, `state.get_instances`, `state.get_entity` to consume the same owner as deprecated adapters instead of `WorkflowInstanceStore`/local reshape helpers.

Closes #700
Part of #665
Related to #694

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `method_catalog.entity.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `method_catalog.entity.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `method_catalog.entity.aggregate`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EntitySummary`, `EntityFull`, `EntityAggregateResult`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `tables.entity_state`, `conventions.entity_registry_policy`, `conventions.entity_lifecycle_scoping`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` API transition mapping for `state.list_instances`, `state.get_entity`, and `/api/instances*`

## Semantic Migration

- New canonical owner: `internal/store/operator_entity_read_surface.go`.
- Old non-authoritative paths invalidated: dashboard `InstanceReader`/`filterInstances`/`aggregateKey`, Builder `InstanceReader`/`entityPayload`/`entityGates`/`entityAccumulated`, and cmd wiring through `runtimepipeline.NewWorkflowInstanceStore` for operator entity reads.
- Production paths checked: v1 API handler wiring, dashboard REST adapters, Builder RPC adapters, cmd wiring, and grep proof for removed old helper names.
- Migration complete for #700 only; remaining #665 Slice 6 families stay with their existing trackers/gates.

## Tests

- `go test ./internal/store -run TestOperatorEntityReadOwnerListGetAggregateAndCursor -count=1`
- `go test ./internal/apiv1 -run TestOperatorEntityHandlers -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_(ConversationsAndAggregates|BuilderRPC)' -count=1`
- `go test ./internal/builder -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./internal/store -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./... -count=1`