### PR TITLE
[agent-d][issue #699] Add artifact repo commit action

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -13,7 +13,7 @@ vocabulary:
     - escalate:{event}
   action:
     description: 'A platform-provided operation executed as the final step of a handler. Valid actions are create_flow_instance,
-      record_evidence, and mailbox_write. Product-specific actions are not supported.'
+      record_evidence, mailbox_write, and artifact_repo_commit. Product-specific actions are not supported.'
   timer:
     description: 'A time-based trigger attached to a stage. When the delay elapses, the platform emits the timer''s event,
       which can trigger a transition.
@@ -1011,8 +1011,8 @@ handler_specification:
     action:
       field: action
       type: string or object
-      purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write. The platform executes
-        the named action. NOT for platform actions — all behavior must be declarative.'
+      purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write, artifact_repo_commit. The
+        platform executes the named action. NOT for platform actions — all behavior must be declarative.'
       emit_interaction: If the resolved runtime action instruction emits a follow-up event, that event uses the action-originated
         emitted-event payload rules under observation_model.emitted_events.payload_rules. The action field itself does not
         declare authored payload fields; runtime-owned action instructions construct and validate any follow-up payload.
@@ -1046,6 +1046,46 @@ handler_specification:
           behavior: Inserts a pending public.mailbox row inside the system-node handler transaction. source_event_id is the
             triggering event id. from_agent is the deterministic system node identity. item_id is deterministic for source_event_id
             and materializer node so duplicate/replayed node delivery does not create duplicate mailbox rows.
+        artifact_repo_commit:
+          description: Deterministically materialize service-owned typed file artifacts into a local git repository and expose
+            an opaque artifact URL plus immutable git ref on the owning entity.
+          required_mapping:
+            action.id: artifact_repo_commit
+            action.artifact_repo: object — typed artifact repository commit declaration.
+          provider:
+            v1: local_git only. Unsupported providers fail closed at decode/verify/runtime.
+            product_surface: Consumers receive `swarm-artifact://...` URLs and 40-character git commit SHAs, not raw host paths.
+          artifact_repo_fields:
+            provider: string — must be local_git.
+            repo_id: expression value resolving to the service-owned repository UUID. Required.
+            run_id: optional expression value resolving to the run UUID. Defaults to the triggering event run_id.
+            vertical_id: expression value resolving to the vertical UUID. Required for deterministic path partitioning.
+            business_slug: optional expression value used only as a sanitized local path hint. Not authoritative identity.
+            source_validation_case_id: expression value resolving to the source validation case UUID. Required for provenance.
+            request_id: expression value resolving to the business idempotency UUID. Required.
+            author: optional expression value used for git author display only.
+            allowed_paths: list of repository-relative paths allowed for this service action. Required. Absolute paths and
+              traversal are prohibited.
+            files: list of `{path, content, content_type, max_bytes}` entries. path and content are explicit expression values;
+              content_type is yaml, markdown, or text. The resolved path must be allowlisted.
+            limits: optional max_yaml_bytes, max_markdown_bytes, max_text_bytes, and max_repo_bytes.
+            output: mapping of entity field names for repo_url, current_ref, file_manifest, status, failure_reason,
+              last_request_id, and last_source_event_id.
+            failure_event: optional event name emitted when runtime execution fails after request/source identity resolution.
+            failure_payload: optional mapping of additional failure event payload fields to expression values. Runtime always
+              includes repo_id, run_id, vertical_id, source_validation_case_id, request_id, source_event_id, and failure_reason.
+          behavior: The runtime normalizes file content, writes only allowlisted paths under the service-owned repo root,
+            commits staged files atomically, verifies the resulting ref is a 40-character git SHA, and persists only the declared
+            output fields on the selected/owned entity. Duplicate replay for the same source_event_id is a no-op. Reusing a
+            request_id with different content fails closed. Content hashes are diagnostic and do not replace request/source
+            idempotency.
+          operation_state: The selected/owned entity is the contract-visible operation/ref ledger surface for V1. The service
+            contract must declare the output fields it wants persisted; status is committed or failed, failure_reason records
+            runtime failure detail when available, and current_ref updates only after git commit/ref verification succeeds.
+            If failure_event is declared, the runtime also emits that typed event after persisting failed status.
+          fail_closed: Invalid provider, missing or non-UUID identities, invalid root, traversal, symlink/root escape, allowlist
+            miss, unsupported content type, size-limit violation, git write/commit failure, invalid ref, and idempotency conflict
+            all fail closed. No agent prompt, native_tools, shell command, or product-local git syntax may bypass this action.
     retired_fields:
       description: Legacy declarative emit carriers retired by the structured emit grammar.
       rule: These fields are retired compatibility syntax, not alternate current-contract forms.
@@ -2214,6 +2254,8 @@ compliance:
     - Guards evaluated before state advancement — block if false
     - Events, including action-originated emits, validated against payload schema before publish
     - mailbox_write handler actions preserve source_event_id and are row-idempotent for the same source event and materializer
+    - artifact_repo_commit handler actions expose only opaque artifact URLs and immutable git refs, reject unsafe paths/providers,
+      and are idempotent by source_event_id plus request_id/content identity
     - Accumulation is idempotent — duplicate events do not double-count
     - Permission checks read from agent.permissions, not hardcoded policy functions
     - Product behavior read from policy configuration, not hardcoded
@@ -2228,6 +2270,8 @@ compliance:
     - Every state state_change follows declared advances_to paths
     - Every emitted event has a payload schema in events.yaml
     - mailbox_write materializes exactly one mailbox row per source event/materializer and rejects unsupported declarations
+    - artifact_repo_commit writes only allowlisted files, produces a pinned git ref, rejects unsupported declarations and unsafe
+      paths, and preserves replay/idempotency invariants
     - Every agent subscription resolves to an event some node or agent produces
     - Permission enforcement blocks unauthorized tool calls
     - Accumulation is idempotent under duplicate event delivery
@@ -2400,6 +2444,8 @@ tool_model:
         create_flow_instance: Create a new dynamic flow instance from a template.
         record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler.
         mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler action only.
+        artifact_repo_commit: Deterministically commit allowlisted service-owned artifact files to a local git repository and
+          persist opaque artifact URL/ref metadata. Handler action only.
     planned_tools:
       description: Tools planned for future platform versions. Not yet implemented. The permission may exist (as an authorization
         gate) before the tool does.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1066,28 +1066,34 @@ handler_specification:
             author: optional expression value used for git author display only.
             allowed_paths: list of repository-relative paths allowed for this service action. Required. Absolute paths and
               traversal are prohibited.
-            files: list of `{path, content, content_type, max_bytes}` entries. path and content are explicit expression values;
-              content_type is yaml, markdown, or text. The resolved path must be allowlisted.
+            files: list of `{path, content, content_type, schema, max_bytes}` entries. path and content are explicit expression
+              values; content_type is yaml, markdown, or text. The resolved path must be allowlisted. yaml files must declare
+              schema.type must be object; schema.required_fields names top-level keys that must be present before commit.
             limits: optional max_yaml_bytes, max_markdown_bytes, max_text_bytes, and max_repo_bytes.
             output: mapping of entity field names for repo_url, current_ref, file_manifest, status, failure_reason,
               last_request_id, and last_source_event_id.
             failure_event: optional event name emitted when runtime execution fails after request/source identity resolution.
             failure_payload: optional mapping of additional failure event payload fields to expression values. Runtime always
               includes repo_id, run_id, vertical_id, source_validation_case_id, request_id, source_event_id, and failure_reason.
-          behavior: The runtime normalizes file content, writes only allowlisted paths under the service-owned repo root,
+          behavior: The runtime normalizes file content, validates yaml content against the declared file schema, writes only
+            allowlisted paths under the service-owned repo root, verifies the projected git tree stays within max_repo_bytes,
             commits staged files atomically, verifies the resulting ref is a 40-character git SHA, and persists only the declared
-            output fields on the selected/owned entity. Duplicate replay for the same source_event_id is a no-op. Reusing a
-            request_id with different content fails closed even when that request is not the latest operation. Content hashes
-            are diagnostic and do not replace request/source idempotency.
+            output fields on the selected/owned entity. Duplicate replay for the same source_event_id is a no-op only when the
+            contract-visible committed output state is already present. Reusing a request_id with different content fails closed
+            even when that request is not the latest operation. Content hashes are diagnostic and do not replace request/source
+            idempotency.
           operation_state: The selected/owned entity is the contract-visible operation/ref ledger surface for V1. The service
             contract must declare the output fields it wants persisted; status is committed or failed, failure_reason records
             runtime failure detail when available, and current_ref updates only after git commit/ref verification succeeds.
-            Provider history must record request_id and content/tree identity durably enough to reject historical request-id
-            conflicts after intervening commits.
+            Provider history must record every accepted request_id and content/tree identity durably enough to reject historical
+            request-id conflicts after intervening commits, including accepted same-tree/no-op requests. If git history contains
+            the accepted request but entity output persistence is missing or stale, retry reconstructs and persists the
+            contract-visible repo_url, current_ref, file_manifest, status, and last_source_event_id from durable provider history.
             If failure_event is declared, the runtime also emits that typed event after persisting failed status.
           fail_closed: Invalid provider, missing or non-UUID identities, invalid root, traversal, symlink/root escape, allowlist
-            miss, unsupported content type, size-limit violation, git write/commit failure, invalid ref, and idempotency conflict
-            all fail closed. No agent prompt, native_tools, shell command, or product-local git syntax may bypass this action.
+            miss, unsupported content type, missing/failed yaml schema validation, size-limit violation, git write/commit failure,
+            invalid ref, and idempotency conflict all fail closed. No agent prompt, native_tools, shell command, or product-local
+            git syntax may bypass this action.
     retired_fields:
       description: Legacy declarative emit carriers retired by the structured emit grammar.
       rule: These fields are retired compatibility syntax, not alternate current-contract forms.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1077,11 +1077,13 @@ handler_specification:
           behavior: The runtime normalizes file content, writes only allowlisted paths under the service-owned repo root,
             commits staged files atomically, verifies the resulting ref is a 40-character git SHA, and persists only the declared
             output fields on the selected/owned entity. Duplicate replay for the same source_event_id is a no-op. Reusing a
-            request_id with different content fails closed. Content hashes are diagnostic and do not replace request/source
-            idempotency.
+            request_id with different content fails closed even when that request is not the latest operation. Content hashes
+            are diagnostic and do not replace request/source idempotency.
           operation_state: The selected/owned entity is the contract-visible operation/ref ledger surface for V1. The service
             contract must declare the output fields it wants persisted; status is committed or failed, failure_reason records
             runtime failure detail when available, and current_ref updates only after git commit/ref verification succeeds.
+            Provider history must record request_id and content/tree identity durably enough to reject historical request-id
+            conflicts after intervening commits.
             If failure_event is declared, the runtime also emits that typed event after persisting failed status.
           fail_closed: Invalid provider, missing or non-UUID identities, invalid root, traversal, symlink/root escape, allowlist
             miss, unsupported content type, size-limit violation, git write/commit failure, invalid ref, and idempotency conflict

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1150,6 +1150,16 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 						Location: nodeID,
 					})
 				}
+				if normalizeWorkflowBuiltinActionID(actionID) == "artifact_repo_commit" {
+					c.handlerFindings = append(c.handlerFindings, validateArtifactRepoActionSpec(nodeID, eventType, handler.Action)...)
+				} else if handler.Action.ArtifactRepo != nil {
+					c.handlerFindings = append(c.handlerFindings, Finding{
+						CheckID:  "handler_field_compliance",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s handler %s artifact_repo declaration requires action artifact_repo_commit", nodeID, eventType),
+						Location: nodeID,
+					})
+				}
 				if !handlerActionExecutable(c.source, actionID) {
 					c.handlerFindings = append(c.handlerFindings, Finding{
 						CheckID:  "handler_field_compliance",
@@ -2269,6 +2279,141 @@ func handlerActionExecutable(source semanticview.Source, actionID string) bool {
 	}
 	entry, ok := source.ActionInstructionByID(actionID)
 	return ok && entry.Executable()
+}
+
+func validateArtifactRepoActionSpec(nodeID, eventType string, action runtimecontracts.ActionSpec) []Finding {
+	spec := action.ArtifactRepo
+	if spec == nil {
+		return []Finding{artifactRepoFinding(nodeID, eventType, "artifact_repo_commit is missing artifact_repo")}
+	}
+	findings := []Finding{}
+	provider := strings.TrimSpace(spec.Provider)
+	if provider == "" {
+		findings = append(findings, artifactRepoFinding(nodeID, eventType, "artifact_repo_commit is missing artifact_repo.provider"))
+	} else if provider != "local_git" {
+		findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo_commit provider %s is unsupported", provider)))
+	}
+	for label, expr := range map[string]runtimecontracts.ExpressionValue{
+		"repo_id":                   spec.RepoID,
+		"request_id":                spec.RequestID,
+		"vertical_id":               spec.VerticalID,
+		"source_validation_case_id": spec.SourceValidationCaseID,
+	} {
+		if expr.IsZero() {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo_commit is missing artifact_repo.%s", label)))
+		}
+	}
+	if len(spec.AllowedPaths) == 0 {
+		findings = append(findings, artifactRepoFinding(nodeID, eventType, "artifact_repo_commit requires at least one artifact_repo.allowed_paths entry"))
+	}
+	seenAllowed := map[string]struct{}{}
+	for _, raw := range spec.AllowedPaths {
+		cleaned, err := validateArtifactRepoDeclaredPath(raw)
+		if err != nil {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.allowed_paths %q is invalid: %v", raw, err)))
+			continue
+		}
+		if _, ok := seenAllowed[cleaned]; ok {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.allowed_paths contains duplicate canonical path %s", cleaned)))
+		}
+		seenAllowed[cleaned] = struct{}{}
+	}
+	if len(spec.Files) == 0 {
+		findings = append(findings, artifactRepoFinding(nodeID, eventType, "artifact_repo_commit requires at least one artifact_repo.files entry"))
+	}
+	seenFiles := map[string]struct{}{}
+	for i, file := range spec.Files {
+		if file.Path.IsZero() {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d] is missing path", i)))
+		} else if pathValue, ok := artifactRepoLiteralString(file.Path); ok {
+			cleaned, err := validateArtifactRepoDeclaredPath(pathValue)
+			if err != nil {
+				findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].path %q is invalid: %v", i, pathValue, err)))
+			} else {
+				if _, allowed := seenAllowed[cleaned]; len(seenAllowed) > 0 && !allowed {
+					findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].path %s is not in artifact_repo.allowed_paths", i, cleaned)))
+				}
+				if _, exists := seenFiles[cleaned]; exists {
+					findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files contains duplicate canonical path %s", cleaned)))
+				}
+				seenFiles[cleaned] = struct{}{}
+			}
+		}
+		if file.Content.IsZero() {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d] is missing content", i)))
+		}
+		switch contentType := strings.TrimSpace(file.ContentType); contentType {
+		case "yaml", "markdown", "text":
+		default:
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].content_type %q is unsupported", i, contentType)))
+		}
+		if file.MaxBytes < 0 {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].max_bytes must be non-negative", i)))
+		}
+	}
+	for _, field := range []struct {
+		label string
+		value string
+	}{
+		{"output.repo_url", spec.Output.RepoURL},
+		{"output.current_ref", spec.Output.CurrentRef},
+		{"output.file_manifest", spec.Output.FileManifest},
+		{"output.status", spec.Output.Status},
+		{"output.failure_reason", spec.Output.FailureReason},
+		{"output.last_request_id", spec.Output.LastRequestID},
+		{"output.last_source_event_id", spec.Output.LastSourceEventID},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo_commit is missing artifact_repo.%s", field.label)))
+		}
+	}
+	if spec.Limits.MaxYAMLBytes < 0 || spec.Limits.MaxMarkdownBytes < 0 || spec.Limits.MaxTextBytes < 0 || spec.Limits.MaxRepoBytes < 0 {
+		findings = append(findings, artifactRepoFinding(nodeID, eventType, "artifact_repo.limits values must be non-negative"))
+	}
+	return findings
+}
+
+func artifactRepoFinding(nodeID, eventType, message string) Finding {
+	return Finding{
+		CheckID:  "handler_field_compliance",
+		Severity: "error",
+		Message:  fmt.Sprintf("node %s handler %s %s", nodeID, eventType, message),
+		Location: nodeID,
+	}
+}
+
+func artifactRepoLiteralString(expr runtimecontracts.ExpressionValue) (string, bool) {
+	if expr.Kind != runtimecontracts.ExpressionKindLiteral {
+		return "", false
+	}
+	value := strings.TrimSpace(fmt.Sprint(expr.Literal))
+	return value, value != ""
+}
+
+func validateArtifactRepoDeclaredPath(raw string) (string, error) {
+	value := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	if value == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	parts := []string{}
+	for _, part := range strings.Split(value, "/") {
+		part = strings.TrimSpace(part)
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			return "", fmt.Errorf("path traversal is not allowed")
+		default:
+			parts = append(parts, part)
+		}
+	}
+	if len(parts) == 0 {
+		return "", fmt.Errorf("path is required")
+	}
+	return strings.Join(parts, "/"), nil
 }
 
 func workflowFindEventCyclesLocal(graph map[string]map[string]struct{}) [][]string {

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -2344,8 +2344,30 @@ func validateArtifactRepoActionSpec(nodeID, eventType string, action runtimecont
 		}
 		switch contentType := strings.TrimSpace(file.ContentType); contentType {
 		case "yaml", "markdown", "text":
+			schemaType := strings.TrimSpace(file.Schema.Type)
+			if contentType == "yaml" {
+				if schemaType == "" {
+					findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].schema.type is required for yaml content", i)))
+				} else if schemaType != "object" {
+					findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].schema.type %q is unsupported", i, schemaType)))
+				}
+			} else if schemaType != "" || len(file.Schema.RequiredFields) > 0 {
+				findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].schema is only supported for yaml content", i)))
+			}
 		default:
 			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].content_type %q is unsupported", i, contentType)))
+		}
+		seenRequired := map[string]struct{}{}
+		for _, field := range file.Schema.RequiredFields {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].schema.required_fields contains an empty field", i)))
+				continue
+			}
+			if _, exists := seenRequired[field]; exists {
+				findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].schema.required_fields contains duplicate field %s", i, field)))
+			}
+			seenRequired[field] = struct{}{}
 		}
 		if file.MaxBytes < 0 {
 			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.files[%d].max_bytes must be non-negative", i)))

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -833,6 +833,50 @@ func TestRun_ReportsArtifactRepoCommitInvalidShape(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsArtifactRepoCommitYAMLFileMissingSchema(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"artifact-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"spec_file.commit_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID: "artifact_repo_commit",
+							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
+								Provider:               "local_git",
+								RepoID:                 runtimecontracts.RefExpression("entity.spec_repo_id"),
+								RequestID:              runtimecontracts.RefExpression("payload.request_id"),
+								VerticalID:             runtimecontracts.RefExpression("entity.vertical_id"),
+								SourceValidationCaseID: runtimecontracts.RefExpression("entity.source_validation_case_id"),
+								AllowedPaths:           []string{"specs/mvp.yaml"},
+								Files: []runtimecontracts.ArtifactRepoFileSpec{{
+									Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
+									Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
+									ContentType: "yaml",
+								}},
+								Output: runtimecontracts.ArtifactRepoOutputSpec{
+									RepoURL:           "repo_url",
+									CurrentRef:        "current_ref",
+									FileManifest:      "file_manifest",
+									Status:            "status",
+									FailureReason:     "failure_reason",
+									LastRequestID:     "last_request_id",
+									LastSourceEventID: "last_source_event_id",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "schema.type is required for yaml content") {
+		t.Fatalf("expected yaml schema requirement error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsArtifactRepoDeclarationOnNonArtifactAction(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -763,6 +763,102 @@ func TestRun_ReportsMailboxDeclarationOnNonMailboxAction(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsArtifactRepoCommitMissingSpec(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"artifact-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"spec_file.commit_requested": {
+						Action: runtimecontracts.ActionSpec{ID: "artifact_repo_commit"},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo_commit is missing artifact_repo") {
+		t.Fatalf("expected handler_field_compliance missing artifact_repo error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsArtifactRepoCommitInvalidShape(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"artifact-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"spec_file.commit_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID: "artifact_repo_commit",
+							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
+								Provider:     "s3",
+								RepoID:       runtimecontracts.RefExpression("entity.spec_repo_id"),
+								RequestID:    runtimecontracts.RefExpression("payload.request_id"),
+								VerticalID:   runtimecontracts.RefExpression("entity.vertical_id"),
+								AllowedPaths: []string{"../escape.yaml"},
+								Files: []runtimecontracts.ArtifactRepoFileSpec{{
+									Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
+									Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
+									ContentType: "json",
+								}},
+								Output: runtimecontracts.ArtifactRepoOutputSpec{
+									RepoURL: "repo_url",
+									Status:  "status",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "provider s3 is unsupported") {
+		t.Fatalf("expected unsupported provider error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "missing artifact_repo.source_validation_case_id") {
+		t.Fatalf("expected missing source_validation_case_id error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "path traversal is not allowed") {
+		t.Fatalf("expected traversal allowlist error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "content_type \"json\" is unsupported") {
+		t.Fatalf("expected unsupported content_type error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "missing artifact_repo.output.current_ref") {
+		t.Fatalf("expected missing current_ref output error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsArtifactRepoDeclarationOnNonArtifactAction(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"artifact-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"spec_file.commit_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID: "record_evidence",
+							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
+								Provider: "local_git",
+							},
+						},
+						EvidenceTarget: "evidence",
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo declaration requires action artifact_repo_commit") {
+		t.Fatalf("expected handler_field_compliance artifact/action mismatch error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsPromptStubToPromptExistsWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-prompt-stub")
 

--- a/internal/runtime/contracts/system_node_contract_vocab.go
+++ b/internal/runtime/contracts/system_node_contract_vocab.go
@@ -13,7 +13,7 @@ func NormalizeHandlerActionID(id string) string {
 
 func IsSupportedHandlerActionID(id string) bool {
 	switch NormalizeHandlerActionID(id) {
-	case "create_flow_instance", "record_evidence", "mailbox_write":
+	case "create_flow_instance", "record_evidence", "mailbox_write", "artifact_repo_commit":
 		return true
 	default:
 		return false

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -349,10 +349,16 @@ type ArtifactRepoSpec struct {
 }
 
 type ArtifactRepoFileSpec struct {
-	Path        ExpressionValue `yaml:"path"`
-	Content     ExpressionValue `yaml:"content"`
-	ContentType string          `yaml:"content_type"`
-	MaxBytes    int             `yaml:"max_bytes"`
+	Path        ExpressionValue        `yaml:"path"`
+	Content     ExpressionValue        `yaml:"content"`
+	ContentType string                 `yaml:"content_type"`
+	Schema      ArtifactRepoSchemaSpec `yaml:"schema"`
+	MaxBytes    int                    `yaml:"max_bytes"`
+}
+
+type ArtifactRepoSchemaSpec struct {
+	Type           string   `yaml:"type"`
+	RequiredFields []string `yaml:"required_fields"`
 }
 
 type ArtifactRepoOutputSpec struct {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -319,6 +319,7 @@ type ActionSpec struct {
 	InstanceIDPath paths.Path        `yaml:"-"`
 	ConfigFrom     *ConfigFromSpec   `yaml:"config_from"`
 	Mailbox        *MailboxWriteSpec `yaml:"mailbox"`
+	ArtifactRepo   *ArtifactRepoSpec `yaml:"artifact_repo"`
 }
 
 type MailboxWriteSpec struct {
@@ -329,6 +330,48 @@ type MailboxWriteSpec struct {
 	FlowInstance ExpressionValue            `yaml:"flow_instance"`
 	Payload      map[string]ExpressionValue `yaml:"payload"`
 }
+
+type ArtifactRepoSpec struct {
+	Provider               string                     `yaml:"provider"`
+	RepoID                 ExpressionValue            `yaml:"repo_id"`
+	RunID                  ExpressionValue            `yaml:"run_id"`
+	VerticalID             ExpressionValue            `yaml:"vertical_id"`
+	BusinessSlug           ExpressionValue            `yaml:"business_slug"`
+	SourceValidationCaseID ExpressionValue            `yaml:"source_validation_case_id"`
+	RequestID              ExpressionValue            `yaml:"request_id"`
+	Author                 ExpressionValue            `yaml:"author"`
+	AllowedPaths           []string                   `yaml:"allowed_paths"`
+	Files                  []ArtifactRepoFileSpec     `yaml:"files"`
+	Output                 ArtifactRepoOutputSpec     `yaml:"output"`
+	Limits                 ArtifactRepoLimitsSpec     `yaml:"limits"`
+	FailureEvent           string                     `yaml:"failure_event"`
+	FailurePayload         map[string]ExpressionValue `yaml:"failure_payload"`
+}
+
+type ArtifactRepoFileSpec struct {
+	Path        ExpressionValue `yaml:"path"`
+	Content     ExpressionValue `yaml:"content"`
+	ContentType string          `yaml:"content_type"`
+	MaxBytes    int             `yaml:"max_bytes"`
+}
+
+type ArtifactRepoOutputSpec struct {
+	RepoURL           string `yaml:"repo_url"`
+	CurrentRef        string `yaml:"current_ref"`
+	FileManifest      string `yaml:"file_manifest"`
+	Status            string `yaml:"status"`
+	FailureReason     string `yaml:"failure_reason"`
+	LastRequestID     string `yaml:"last_request_id"`
+	LastSourceEventID string `yaml:"last_source_event_id"`
+}
+
+type ArtifactRepoLimitsSpec struct {
+	MaxYAMLBytes     int `yaml:"max_yaml_bytes"`
+	MaxMarkdownBytes int `yaml:"max_markdown_bytes"`
+	MaxTextBytes     int `yaml:"max_text_bytes"`
+	MaxRepoBytes     int `yaml:"max_repo_bytes"`
+}
+
 type EntitySchema struct {
 	Groups []EntitySchemaGroup `yaml:"groups"`
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -227,6 +227,159 @@ func decodeMailboxExpressionValueNode(node *yaml.Node) (ExpressionValue, error) 
 	return value, nil
 }
 
+func (s *ArtifactRepoSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*s = ArtifactRepoSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"provider":                  {},
+		"repo_id":                   {},
+		"run_id":                    {},
+		"vertical_id":               {},
+		"business_slug":             {},
+		"source_validation_case_id": {},
+		"request_id":                {},
+		"author":                    {},
+		"allowed_paths":             {},
+		"files":                     {},
+		"output":                    {},
+		"limits":                    {},
+		"failure_event":             {},
+		"failure_payload":           {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo field %q not in platform spec", key)
+		}
+	}
+	type alias ArtifactRepoSpec
+	var out alias
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*s = ArtifactRepoSpec(out)
+	return nil
+}
+
+func (f *ArtifactRepoFileSpec) UnmarshalYAML(node *yaml.Node) error {
+	if f == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*f = ArtifactRepoFileSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.files entries must be mappings")
+	}
+	allowed := map[string]struct{}{
+		"path":         {},
+		"content":      {},
+		"content_type": {},
+		"max_bytes":    {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.files field %q not in platform spec", key)
+		}
+	}
+	type alias ArtifactRepoFileSpec
+	var out alias
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*f = ArtifactRepoFileSpec(out)
+	return nil
+}
+
+func (o *ArtifactRepoOutputSpec) UnmarshalYAML(node *yaml.Node) error {
+	if o == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*o = ArtifactRepoOutputSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.output must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"repo_url":             {},
+		"current_ref":          {},
+		"file_manifest":        {},
+		"status":               {},
+		"failure_reason":       {},
+		"last_request_id":      {},
+		"last_source_event_id": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.output field %q not in platform spec", key)
+		}
+	}
+	type alias ArtifactRepoOutputSpec
+	var out alias
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*o = ArtifactRepoOutputSpec(out)
+	return nil
+}
+
+func (l *ArtifactRepoLimitsSpec) UnmarshalYAML(node *yaml.Node) error {
+	if l == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*l = ArtifactRepoLimitsSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.limits must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"max_yaml_bytes":     {},
+		"max_markdown_bytes": {},
+		"max_text_bytes":     {},
+		"max_repo_bytes":     {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.limits field %q not in platform spec", key)
+		}
+	}
+	type alias ArtifactRepoLimitsSpec
+	var out alias
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*l = ArtifactRepoLimitsSpec(out)
+	return nil
+}
+
 func decodeEmitFieldValueNode(node *yaml.Node) (ExpressionValue, error) {
 	if node == nil {
 		return ExpressionValue{}, nil
@@ -865,6 +1018,7 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			"instance_id_from": {},
 			"config_from":      {},
 			"mailbox":          {},
+			"artifact_repo":    {},
 		}
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
@@ -887,6 +1041,7 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			InstanceIDFrom string            `yaml:"instance_id_from"`
 			ConfigFrom     yaml.Node         `yaml:"config_from"`
 			Mailbox        *MailboxWriteSpec `yaml:"mailbox"`
+			ArtifactRepo   *ArtifactRepoSpec `yaml:"artifact_repo"`
 		}
 		if err := node.Decode(&aux); err != nil {
 			return ActionSpec{}, err
@@ -909,6 +1064,7 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 			InstanceIDPath: paths.Parse(aux.InstanceIDFrom),
 			ConfigFrom:     configFrom,
 			Mailbox:        aux.Mailbox,
+			ArtifactRepo:   aux.ArtifactRepo,
 		}, nil
 	default:
 		return ActionSpec{}, fmt.Errorf("unsupported action yaml node kind %d", node.Kind)

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -287,6 +287,7 @@ func (f *ArtifactRepoFileSpec) UnmarshalYAML(node *yaml.Node) error {
 		"path":         {},
 		"content":      {},
 		"content_type": {},
+		"schema":       {},
 		"max_bytes":    {},
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
@@ -304,6 +305,39 @@ func (f *ArtifactRepoFileSpec) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*f = ArtifactRepoFileSpec(out)
+	return nil
+}
+
+func (s *ArtifactRepoSchemaSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*s = ArtifactRepoSchemaSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.files.schema must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"type":            {},
+		"required_fields": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.files.schema field %q not in platform spec", key)
+		}
+	}
+	type alias ArtifactRepoSchemaSpec
+	var out alias
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*s = ArtifactRepoSchemaSpec(out)
 	return nil
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -843,6 +843,10 @@ action:
         content:
           ref: payload.mvp_yaml
         content_type: yaml
+        schema:
+          type: object
+          required_fields:
+            - name
         max_bytes: 4096
     output:
       repo_url: repo_url
@@ -873,6 +877,9 @@ action:
 	}
 	if got := handler.Action.ArtifactRepo.Files[0].Path.Literal; got != "specs/mvp.yaml" {
 		t.Fatalf("ArtifactRepo.Files[0].Path = %#v", got)
+	}
+	if got := handler.Action.ArtifactRepo.Files[0].Schema.Type; got != "object" {
+		t.Fatalf("ArtifactRepo.Files[0].Schema.Type = %q", got)
 	}
 	if got := handler.Action.ArtifactRepo.Output.CurrentRef; got != "current_ref" {
 		t.Fatalf("ArtifactRepo.Output.CurrentRef = %q", got)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -814,6 +814,88 @@ action: increment_revision_count
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_PreservesArtifactRepoCommitAction(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+action:
+  id: artifact_repo_commit
+  artifact_repo:
+    provider: local_git
+    repo_id:
+      ref: entity.spec_repo_id
+    run_id:
+      ref: event.run_id
+    vertical_id:
+      ref: entity.vertical_id
+    business_slug:
+      ref: entity.business_slug
+    source_validation_case_id:
+      ref: entity.source_validation_case_id
+    request_id:
+      ref: payload.request_id
+    author:
+      literal: validation-agent
+    allowed_paths:
+      - specs/mvp.yaml
+    files:
+      - path:
+          literal: specs/mvp.yaml
+        content:
+          ref: payload.mvp_yaml
+        content_type: yaml
+        max_bytes: 4096
+    output:
+      repo_url: repo_url
+      current_ref: current_ref
+      file_manifest: file_manifest
+      status: status
+      failure_reason: failure_reason
+      last_request_id: last_request_id
+      last_source_event_id: last_source_event_id
+    limits:
+      max_yaml_bytes: 4096
+      max_repo_bytes: 1048576
+    failure_event: spec_repo.commit_failed
+    failure_payload:
+      request_id:
+        ref: payload.request_id
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := handler.Action.ID; got != "artifact_repo_commit" {
+		t.Fatalf("Action.ID = %q", got)
+	}
+	if handler.Action.ArtifactRepo == nil {
+		t.Fatal("expected ArtifactRepo")
+	}
+	if got := handler.Action.ArtifactRepo.Provider; got != "local_git" {
+		t.Fatalf("ArtifactRepo.Provider = %q", got)
+	}
+	if got := handler.Action.ArtifactRepo.Files[0].Path.Literal; got != "specs/mvp.yaml" {
+		t.Fatalf("ArtifactRepo.Files[0].Path = %#v", got)
+	}
+	if got := handler.Action.ArtifactRepo.Output.CurrentRef; got != "current_ref" {
+		t.Fatalf("ArtifactRepo.Output.CurrentRef = %q", got)
+	}
+	if got := handler.Action.ArtifactRepo.FailureEvent; got != "spec_repo.commit_failed" {
+		t.Fatalf("ArtifactRepo.FailureEvent = %q", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnknownArtifactRepoField(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action:
+  id: artifact_repo_commit
+  artifact_repo:
+    provider: local_git
+    shell: git commit
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
 func TestEntityFieldDeclDecode_PreservesMaterializeFromProjection(t *testing.T) {
 	var field EntityFieldDecl
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -1,0 +1,594 @@
+package pipeline
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/identity"
+	"swarm/internal/runtime/core/paths"
+	runtimeengine "swarm/internal/runtime/engine"
+)
+
+const (
+	artifactRepoProviderLocalGit = "local_git"
+	artifactRepoPublicScheme     = "swarm-artifact://spec-repos/"
+	defaultArtifactRoot          = "/data/swarm/artifacts"
+	defaultYAMLMaxBytes          = 1 << 20
+	defaultMarkdownMaxBytes      = 5 << 20
+	defaultTextMaxBytes          = 1 << 20
+	defaultRepoMaxBytes          = 50 << 20
+)
+
+type artifactRepoPreparedFile struct {
+	Path        string
+	Content     []byte
+	ContentType string
+	SHA256      string
+	Size        int
+}
+
+func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action runtimecontracts.ActionSpec, execCtx runtimeengine.ExecutionContext) error {
+	if pc == nil {
+		return fmt.Errorf("artifact_repo_commit requires pipeline coordinator")
+	}
+	if pc.workflowStore == nil || !pc.workflowStore.Enabled() {
+		return fmt.Errorf("artifact_repo_commit requires workflow instance store")
+	}
+	spec := action.ArtifactRepo
+	if spec == nil {
+		return fmt.Errorf("artifact_repo_commit requires artifact_repo declaration")
+	}
+	if strings.TrimSpace(spec.Provider) != artifactRepoProviderLocalGit {
+		return fmt.Errorf("artifact_repo_commit provider %q is unsupported", strings.TrimSpace(spec.Provider))
+	}
+	sourceEventID := strings.TrimSpace(execCtx.Request.Event.ID)
+	if _, err := uuid.Parse(sourceEventID); err != nil {
+		return fmt.Errorf("artifact_repo_commit requires UUID source event id: %w", err)
+	}
+	repoID, err := requiredArtifactUUID(execCtx.Base, spec.RepoID, "artifact_repo.repo_id")
+	if err != nil {
+		return err
+	}
+	runID, err := artifactRunID(execCtx, spec)
+	if err != nil {
+		return err
+	}
+	verticalID, err := requiredArtifactUUID(execCtx.Base, spec.VerticalID, "artifact_repo.vertical_id")
+	if err != nil {
+		return err
+	}
+	sourceValidationCaseID, err := requiredArtifactUUID(execCtx.Base, spec.SourceValidationCaseID, "artifact_repo.source_validation_case_id")
+	if err != nil {
+		return err
+	}
+	requestID, err := requiredArtifactUUID(execCtx.Base, spec.RequestID, "artifact_repo.request_id")
+	if err != nil {
+		return err
+	}
+	fail := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		_ = pc.persistArtifactRepoResult(ctx, execCtx, spec, map[string]any{
+			spec.Output.Status:            "failed",
+			spec.Output.FailureReason:     err.Error(),
+			spec.Output.LastRequestID:     requestID,
+			spec.Output.LastSourceEventID: sourceEventID,
+		})
+		if failureEvent := strings.TrimSpace(spec.FailureEvent); failureEvent != "" {
+			_ = pc.publish(ctx, failureEvent, execCtx.Request.EntityID.String(), artifactRepoFailurePayload(execCtx.Base, spec, repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, err))
+		}
+		return err
+	}
+	if previous := strings.TrimSpace(asString(execCtx.Request.State.StateCarrier.Metadata[spec.Output.LastSourceEventID])); previous == sourceEventID {
+		return nil
+	}
+	files, treeHash, err := prepareArtifactRepoFiles(execCtx.Base, spec)
+	if err != nil {
+		return fail(err)
+	}
+	if previousRequest := strings.TrimSpace(asString(execCtx.Request.State.StateCarrier.Metadata[spec.Output.LastRequestID])); previousRequest == requestID {
+		if currentManifest, ok := execCtx.Request.State.StateCarrier.Metadata[spec.Output.FileManifest].(map[string]any); ok {
+			if previousTree := strings.TrimSpace(asString(currentManifest["tree_hash"])); previousTree != "" && previousTree != treeHash {
+				return fail(fmt.Errorf("artifact_repo_commit request_id %s conflicts with previously committed tree %s", requestID, previousTree))
+			}
+		}
+	}
+	businessSlug := optionalArtifactString(execCtx.Base, spec.BusinessSlug)
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), runID, verticalID, businessSlug, repoID)
+	if err != nil {
+		return fail(err)
+	}
+	if err := ensureArtifactRepoInitialized(ctx, repoPath, commitTime(execCtx.Request.Event.CreatedAt)); err != nil {
+		return fail(err)
+	}
+	if err := writeArtifactRepoFiles(repoPath, files); err != nil {
+		return fail(err)
+	}
+	ref, err := commitArtifactRepoFiles(ctx, repoPath, files, sourceEventID, requestID, optionalArtifactString(execCtx.Base, spec.Author), commitTime(execCtx.Request.Event.CreatedAt))
+	if err != nil {
+		return fail(err)
+	}
+	repoURL := artifactRepoPublicScheme + repoID
+	manifest := artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash, files)
+	return pc.persistArtifactRepoResult(ctx, execCtx, spec, map[string]any{
+		spec.Output.RepoURL:           repoURL,
+		spec.Output.CurrentRef:        ref,
+		spec.Output.FileManifest:      manifest,
+		spec.Output.Status:            "committed",
+		spec.Output.LastRequestID:     requestID,
+		spec.Output.LastSourceEventID: sourceEventID,
+		spec.Output.FailureReason:     "",
+	})
+}
+
+func (pc *PipelineCoordinator) artifactRepoRoot() string {
+	if pc != nil && strings.TrimSpace(pc.artifactRoot) != "" {
+		return strings.TrimSpace(pc.artifactRoot)
+	}
+	if env := strings.TrimSpace(os.Getenv("SWARM_ARTIFACT_ROOT")); env != "" {
+		return env
+	}
+	return defaultArtifactRoot
+}
+
+func artifactRunID(execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec) (string, error) {
+	if spec != nil && !spec.RunID.IsZero() {
+		return requiredArtifactUUID(execCtx.Base, spec.RunID, "artifact_repo.run_id")
+	}
+	runID := strings.TrimSpace(execCtx.Request.Event.RunID)
+	if runID == "" {
+		if value, ok := execCtx.Base.Event.Lookup(paths.Parse("run_id")); ok {
+			runID = strings.TrimSpace(asString(value))
+		}
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", fmt.Errorf("artifact_repo_commit requires UUID run_id: %w", err)
+	}
+	return runID, nil
+}
+
+func requiredArtifactUUID(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
+	value, err := requiredArtifactString(base, expr, field)
+	if err != nil {
+		return "", err
+	}
+	if _, err := uuid.Parse(value); err != nil {
+		return "", fmt.Errorf("%s must resolve to UUID: %w", field, err)
+	}
+	return value, nil
+}
+
+func requiredArtifactString(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
+	value, ok, err := evalMailboxExpressionValue(base, expr)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", field, err)
+	}
+	if !ok {
+		return "", fmt.Errorf("%s resolved empty", field)
+	}
+	out := strings.TrimSpace(asString(value))
+	if out == "" {
+		return "", fmt.Errorf("%s resolved empty", field)
+	}
+	return out, nil
+}
+
+func optionalArtifactString(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue) string {
+	if expr.IsZero() {
+		return ""
+	}
+	value, ok, err := evalMailboxExpressionValue(base, expr)
+	if err != nil || !ok {
+		return ""
+	}
+	return strings.TrimSpace(asString(value))
+}
+
+func prepareArtifactRepoFiles(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec) ([]artifactRepoPreparedFile, string, error) {
+	if spec == nil {
+		return nil, "", fmt.Errorf("artifact_repo declaration is required")
+	}
+	allowed := map[string]struct{}{}
+	for _, raw := range spec.AllowedPaths {
+		cleaned, err := artifactRepoCleanPath(raw)
+		if err != nil {
+			return nil, "", fmt.Errorf("artifact_repo.allowed_paths %q: %w", raw, err)
+		}
+		allowed[cleaned] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return nil, "", fmt.Errorf("artifact_repo.allowed_paths is required")
+	}
+	if len(spec.Files) == 0 {
+		return nil, "", fmt.Errorf("artifact_repo.files is required")
+	}
+	files := make([]artifactRepoPreparedFile, 0, len(spec.Files))
+	seen := map[string]struct{}{}
+	total := 0
+	for i, file := range spec.Files {
+		rawPath, err := requiredArtifactString(base, file.Path, fmt.Sprintf("artifact_repo.files[%d].path", i))
+		if err != nil {
+			return nil, "", err
+		}
+		cleaned, err := artifactRepoCleanPath(rawPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("artifact_repo.files[%d].path: %w", i, err)
+		}
+		if _, ok := allowed[cleaned]; !ok {
+			return nil, "", fmt.Errorf("artifact_repo.files[%d].path %s is not allowlisted", i, cleaned)
+		}
+		if _, ok := seen[cleaned]; ok {
+			return nil, "", fmt.Errorf("artifact_repo.files duplicate canonical path %s", cleaned)
+		}
+		seen[cleaned] = struct{}{}
+		rawContent, err := requiredArtifactString(base, file.Content, fmt.Sprintf("artifact_repo.files[%d].content", i))
+		if err != nil {
+			return nil, "", err
+		}
+		contentType := strings.TrimSpace(file.ContentType)
+		normalized, err := normalizeArtifactContent(contentType, rawContent)
+		if err != nil {
+			return nil, "", fmt.Errorf("artifact_repo.files[%d].content: %w", i, err)
+		}
+		limit := artifactFileLimit(contentType, spec.Limits, file.MaxBytes)
+		if limit > 0 && len(normalized) > limit {
+			return nil, "", fmt.Errorf("artifact_repo.files[%d].content exceeds %d bytes", i, limit)
+		}
+		total += len(normalized)
+		files = append(files, artifactRepoPreparedFile{
+			Path:        cleaned,
+			Content:     normalized,
+			ContentType: contentType,
+			SHA256:      sha256Hex(normalized),
+			Size:        len(normalized),
+		})
+	}
+	maxRepo := spec.Limits.MaxRepoBytes
+	if maxRepo == 0 {
+		maxRepo = defaultRepoMaxBytes
+	}
+	if maxRepo > 0 && total > maxRepo {
+		return nil, "", fmt.Errorf("artifact_repo files exceed max repo bytes %d", maxRepo)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, artifactTreeHash(files), nil
+}
+
+func artifactFileLimit(contentType string, limits runtimecontracts.ArtifactRepoLimitsSpec, fileLimit int) int {
+	if fileLimit > 0 {
+		return fileLimit
+	}
+	switch contentType {
+	case "yaml":
+		if limits.MaxYAMLBytes > 0 {
+			return limits.MaxYAMLBytes
+		}
+		return defaultYAMLMaxBytes
+	case "markdown":
+		if limits.MaxMarkdownBytes > 0 {
+			return limits.MaxMarkdownBytes
+		}
+		return defaultMarkdownMaxBytes
+	default:
+		if limits.MaxTextBytes > 0 {
+			return limits.MaxTextBytes
+		}
+		return defaultTextMaxBytes
+	}
+}
+
+func normalizeArtifactContent(contentType, raw string) ([]byte, error) {
+	switch strings.TrimSpace(contentType) {
+	case "yaml":
+		var value any
+		if err := yaml.Unmarshal([]byte(raw), &value); err != nil {
+			return nil, err
+		}
+		out, err := yaml.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		return ensureTrailingNewline(out), nil
+	case "markdown", "text":
+		return ensureTrailingNewline([]byte(raw)), nil
+	default:
+		return nil, fmt.Errorf("unsupported content_type %q", contentType)
+	}
+}
+
+func artifactRepoCleanPath(raw string) (string, error) {
+	value := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	if value == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") {
+		return "", fmt.Errorf("path traversal is not allowed")
+	}
+	return cleaned, nil
+}
+
+func artifactRepoPath(root, runID, verticalID, businessSlug, repoID string) (string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", fmt.Errorf("artifact root is required")
+	}
+	for label, value := range map[string]string{"run_id": runID, "vertical_id": verticalID, "repo_id": repoID} {
+		if _, err := uuid.Parse(value); err != nil {
+			return "", fmt.Errorf("%s must be UUID: %w", label, err)
+		}
+	}
+	slug := sanitizeArtifactSlug(businessSlug)
+	if slug == "" {
+		slug = "artifact"
+	}
+	shortVertical := strings.ReplaceAll(verticalID, "-", "")
+	if len(shortVertical) > 8 {
+		shortVertical = shortVertical[:8]
+	}
+	repoPath := filepath.Join(root, "spec-repos", runID, slug+"-"+shortVertical, repoID+".git")
+	if !artifactPathWithinRoot(repoPath, root) {
+		return "", fmt.Errorf("artifact_repo path escaped artifact root")
+	}
+	return repoPath, nil
+}
+
+func sanitizeArtifactSlug(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range raw {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func ensureArtifactRepoInitialized(ctx context.Context, repoPath string, when time.Time) error {
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, ".git")); err == nil {
+		return nil
+	}
+	if _, err := runArtifactGit(ctx, repoPath, nil, "init"); err != nil {
+		return err
+	}
+	if _, err := runArtifactGit(ctx, repoPath, nil, "config", "user.name", "Swarm Artifact Repo"); err != nil {
+		return err
+	}
+	if _, err := runArtifactGit(ctx, repoPath, nil, "config", "user.email", "swarm-artifacts@localhost"); err != nil {
+		return err
+	}
+	if _, err := runArtifactGit(ctx, repoPath, gitCommitEnv(when), "commit", "--allow-empty", "-m", "chore: initialize artifact repo", "--no-gpg-sign"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeArtifactRepoFiles(repoPath string, files []artifactRepoPreparedFile) error {
+	for _, file := range files {
+		target := filepath.Join(repoPath, filepath.FromSlash(file.Path))
+		if !artifactPathWithinRoot(target, repoPath) {
+			return fmt.Errorf("artifact_repo path %s escaped repo root", file.Path)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if !artifactRealPathWithinRoot(filepath.Dir(target), repoPath) {
+			return fmt.Errorf("artifact_repo path %s escaped repo root through symlink", file.Path)
+		}
+		if info, err := os.Lstat(target); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("artifact_repo path %s targets a symlink", file.Path)
+		}
+		if err := os.WriteFile(target, file.Content, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artifactRepoPreparedFile, sourceEventID, requestID, author string, when time.Time) (string, error) {
+	if _, err := runArtifactGit(ctx, repoPath, nil, "add", "--all"); err != nil {
+		return "", err
+	}
+	if _, err := runArtifactGit(ctx, repoPath, nil, "diff", "--cached", "--quiet"); err == nil {
+		return artifactRepoHead(ctx, repoPath)
+	}
+	msg := fmt.Sprintf("artifact: commit request %s", requestID)
+	env := gitCommitEnv(when)
+	if author = strings.TrimSpace(author); author != "" {
+		env = append(env, "GIT_AUTHOR_NAME="+author, "GIT_AUTHOR_EMAIL=artifact-author@localhost")
+	}
+	if _, err := runArtifactGit(ctx, repoPath, env, "commit", "-m", msg, "--no-gpg-sign"); err != nil {
+		return "", err
+	}
+	return artifactRepoHead(ctx, repoPath)
+}
+
+func artifactRepoHead(ctx context.Context, repoPath string) (string, error) {
+	out, err := runArtifactGit(ctx, repoPath, nil, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(out)
+	if len(ref) != 40 {
+		return "", fmt.Errorf("artifact_repo commit ref %q is not a 40-character git SHA", ref)
+	}
+	return ref, nil
+}
+
+func runArtifactGit(ctx context.Context, dir string, extraEnv []string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func gitCommitEnv(when time.Time) []string {
+	when = commitTime(when)
+	stamp := when.UTC().Format(time.RFC3339)
+	return []string{
+		"GIT_AUTHOR_NAME=Swarm Artifact Repo",
+		"GIT_AUTHOR_EMAIL=swarm-artifacts@localhost",
+		"GIT_COMMITTER_NAME=Swarm Artifact Repo",
+		"GIT_COMMITTER_EMAIL=swarm-artifacts@localhost",
+		"GIT_AUTHOR_DATE=" + stamp,
+		"GIT_COMMITTER_DATE=" + stamp,
+	}
+}
+
+func commitTime(when time.Time) time.Time {
+	if when.IsZero() {
+		return time.Unix(0, 0).UTC()
+	}
+	return when.UTC()
+}
+
+func (pc *PipelineCoordinator) persistArtifactRepoResult(ctx context.Context, execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec, fields map[string]any) error {
+	if spec == nil {
+		return fmt.Errorf("artifact_repo output declaration is required")
+	}
+	metadata := cloneStringAnyMap(execCtx.Request.State.StateCarrier.Metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	for field, value := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		metadata[field] = value
+	}
+	mutation := runtimeengine.StateMutation{
+		StateCarrier: runtimeengine.NewStateCarrier(metadata, execCtx.Request.State.StateCarrier.Gates, execCtx.Request.State.StateCarrier.StateBuckets),
+	}
+	repo := pipelineEngineStateRepo{coordinator: pc}
+	return repo.SaveState(ctx, identity.NormalizeEntityID(execCtx.Request.EntityID.String()), mutation)
+}
+
+func artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash string, files []artifactRepoPreparedFile) map[string]any {
+	fileItems := make([]map[string]any, 0, len(files))
+	for _, file := range files {
+		fileItems = append(fileItems, map[string]any{
+			"path":         file.Path,
+			"content_type": file.ContentType,
+			"sha256":       file.SHA256,
+			"size_bytes":   file.Size,
+		})
+	}
+	return map[string]any{
+		"provider":                  artifactRepoProviderLocalGit,
+		"repo_id":                   repoID,
+		"run_id":                    runID,
+		"vertical_id":               verticalID,
+		"source_validation_case_id": sourceValidationCaseID,
+		"request_id":                requestID,
+		"source_event_id":           sourceEventID,
+		"repo_url":                  repoURL,
+		"ref":                       ref,
+		"tree_hash":                 treeHash,
+		"files":                     fileItems,
+	}
+}
+
+func artifactRepoFailurePayload(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec, repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID string, cause error) map[string]any {
+	out := map[string]any{}
+	if spec != nil {
+		for target, expr := range spec.FailurePayload {
+			target = strings.TrimSpace(target)
+			if target == "" {
+				continue
+			}
+			value, ok, err := evalMailboxExpressionValue(base, expr)
+			if err != nil || !ok {
+				continue
+			}
+			out[target] = value
+		}
+	}
+	out["repo_id"] = repoID
+	out["run_id"] = runID
+	out["vertical_id"] = verticalID
+	out["source_validation_case_id"] = sourceValidationCaseID
+	out["request_id"] = requestID
+	out["source_event_id"] = sourceEventID
+	out["failure_reason"] = cause.Error()
+	return out
+}
+
+func artifactTreeHash(files []artifactRepoPreparedFile) string {
+	h := sha256.New()
+	for _, file := range files {
+		h.Write([]byte(file.Path))
+		h.Write([]byte{0})
+		h.Write([]byte(file.SHA256))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func ensureTrailingNewline(data []byte) []byte {
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		return append(data, '\n')
+	}
+	return data
+}
+
+func artifactPathWithinRoot(value, root string) bool {
+	value = filepath.Clean(strings.TrimSpace(value))
+	root = filepath.Clean(strings.TrimSpace(root))
+	rel, err := filepath.Rel(root, value)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func artifactRealPathWithinRoot(value, root string) bool {
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	realValue, err := filepath.EvalSymlinks(value)
+	if err != nil {
+		return false
+	}
+	return artifactPathWithinRoot(realValue, realRoot)
+}

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -93,7 +93,7 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 		}
 		return err
 	}
-	if previous := strings.TrimSpace(asString(execCtx.Request.State.StateCarrier.Metadata[spec.Output.LastSourceEventID])); previous == sourceEventID {
+	if previous := strings.TrimSpace(asString(execCtx.Request.State.StateCarrier.Metadata[spec.Output.LastSourceEventID])); previous == sourceEventID && artifactRepoOutputsComplete(execCtx.Request.State.StateCarrier.Metadata, spec) {
 		return nil
 	}
 	files, treeHash, err := prepareArtifactRepoFiles(execCtx.Base, spec)
@@ -115,16 +115,31 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 	if err := ensureArtifactRepoInitialized(ctx, repoPath, commitTime(execCtx.Request.Event.CreatedAt)); err != nil {
 		return fail(err)
 	}
-	if previousTree, found, err := artifactRepoRequestTreeHash(ctx, repoPath, requestID); err != nil {
+	if previous, found, err := artifactRepoRequestRecord(ctx, repoPath, requestID); err != nil {
 		return fail(err)
 	} else if found {
-		if previousTree != treeHash {
-			return fail(fmt.Errorf("artifact_repo_commit request_id %s conflicts with previously committed tree %s", requestID, previousTree))
+		if previous.TreeHash != treeHash {
+			return fail(fmt.Errorf("artifact_repo_commit request_id %s conflicts with previously committed tree %s", requestID, previous.TreeHash))
 		}
-		return nil
+		repoURL := artifactRepoPublicScheme + repoID
+		manifest := artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, previous.Ref, treeHash, files)
+		return pc.persistArtifactRepoResult(ctx, execCtx, spec, map[string]any{
+			spec.Output.RepoURL:           repoURL,
+			spec.Output.CurrentRef:        previous.Ref,
+			spec.Output.FileManifest:      manifest,
+			spec.Output.Status:            "committed",
+			spec.Output.LastRequestID:     requestID,
+			spec.Output.LastSourceEventID: sourceEventID,
+			spec.Output.FailureReason:     "",
+		})
 	}
 	if err := writeArtifactRepoFiles(repoPath, files); err != nil {
 		return fail(err)
+	}
+	if size, err := artifactRepoProjectedTreeSize(ctx, repoPath, files); err != nil {
+		return fail(err)
+	} else if maxRepo := artifactRepoMaxBytes(spec.Limits); maxRepo > 0 && size > maxRepo {
+		return fail(fmt.Errorf("artifact_repo repository tree exceeds max repo bytes %d", maxRepo))
 	}
 	ref, err := commitArtifactRepoFiles(ctx, repoPath, files, sourceEventID, requestID, treeHash, optionalArtifactString(execCtx.Base, spec.Author), commitTime(execCtx.Request.Event.CreatedAt))
 	if err != nil {
@@ -151,6 +166,29 @@ func (pc *PipelineCoordinator) artifactRepoRoot() string {
 		return env
 	}
 	return defaultArtifactRoot
+}
+
+func artifactRepoOutputsComplete(metadata map[string]any, spec *runtimecontracts.ArtifactRepoSpec) bool {
+	if metadata == nil || spec == nil {
+		return false
+	}
+	if got := strings.TrimSpace(asString(metadata[spec.Output.Status])); got != "committed" {
+		return false
+	}
+	if strings.TrimSpace(asString(metadata[spec.Output.RepoURL])) == "" {
+		return false
+	}
+	if ref := strings.TrimSpace(asString(metadata[spec.Output.CurrentRef])); len(ref) != 40 {
+		return false
+	}
+	manifest, ok := metadata[spec.Output.FileManifest].(map[string]any)
+	if !ok || manifest == nil {
+		return false
+	}
+	if strings.TrimSpace(asString(manifest["tree_hash"])) == "" {
+		return false
+	}
+	return true
 }
 
 func artifactRunID(execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec) (string, error) {
@@ -248,7 +286,7 @@ func prepareArtifactRepoFiles(base runtimeengine.BaseContext, spec *runtimecontr
 			return nil, "", err
 		}
 		contentType := strings.TrimSpace(file.ContentType)
-		normalized, err := normalizeArtifactContent(contentType, rawContent)
+		normalized, err := normalizeArtifactContent(contentType, rawContent, file.Schema)
 		if err != nil {
 			return nil, "", fmt.Errorf("artifact_repo.files[%d].content: %w", i, err)
 		}
@@ -265,15 +303,18 @@ func prepareArtifactRepoFiles(base runtimeengine.BaseContext, spec *runtimecontr
 			Size:        len(normalized),
 		})
 	}
-	maxRepo := spec.Limits.MaxRepoBytes
-	if maxRepo == 0 {
-		maxRepo = defaultRepoMaxBytes
-	}
-	if maxRepo > 0 && total > maxRepo {
+	if maxRepo := artifactRepoMaxBytes(spec.Limits); maxRepo > 0 && total > maxRepo {
 		return nil, "", fmt.Errorf("artifact_repo files exceed max repo bytes %d", maxRepo)
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 	return files, artifactTreeHash(files), nil
+}
+
+func artifactRepoMaxBytes(limits runtimecontracts.ArtifactRepoLimitsSpec) int {
+	if limits.MaxRepoBytes > 0 {
+		return limits.MaxRepoBytes
+	}
+	return defaultRepoMaxBytes
 }
 
 func artifactFileLimit(contentType string, limits runtimecontracts.ArtifactRepoLimitsSpec, fileLimit int) int {
@@ -299,11 +340,14 @@ func artifactFileLimit(contentType string, limits runtimecontracts.ArtifactRepoL
 	}
 }
 
-func normalizeArtifactContent(contentType, raw string) ([]byte, error) {
+func normalizeArtifactContent(contentType, raw string, schema runtimecontracts.ArtifactRepoSchemaSpec) ([]byte, error) {
 	switch strings.TrimSpace(contentType) {
 	case "yaml":
-		var value any
+		var value map[string]any
 		if err := yaml.Unmarshal([]byte(raw), &value); err != nil {
+			return nil, err
+		}
+		if err := validateArtifactYAMLSchema(value, schema); err != nil {
 			return nil, err
 		}
 		out, err := yaml.Marshal(value)
@@ -316,6 +360,25 @@ func normalizeArtifactContent(contentType, raw string) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unsupported content_type %q", contentType)
 	}
+}
+
+func validateArtifactYAMLSchema(value map[string]any, schema runtimecontracts.ArtifactRepoSchemaSpec) error {
+	if strings.TrimSpace(schema.Type) != "object" {
+		return fmt.Errorf("yaml schema.type must be object")
+	}
+	if value == nil {
+		return fmt.Errorf("yaml content must be an object")
+	}
+	for _, field := range schema.RequiredFields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return fmt.Errorf("yaml schema.required_fields contains an empty field")
+		}
+		if _, ok := value[field]; !ok {
+			return fmt.Errorf("yaml content missing required field %s", field)
+		}
+	}
+	return nil
 }
 
 func artifactRepoCleanPath(raw string) (string, error) {
@@ -434,8 +497,9 @@ func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artif
 	if _, err := runArtifactGit(ctx, repoPath, nil, args...); err != nil {
 		return "", err
 	}
+	hasStagedDiff := true
 	if _, err := runArtifactGit(ctx, repoPath, nil, "diff", "--cached", "--quiet"); err == nil {
-		return artifactRepoHead(ctx, repoPath)
+		hasStagedDiff = false
 	}
 	if err := verifyArtifactRepoStagedPaths(ctx, repoPath, files); err != nil {
 		return "", err
@@ -445,7 +509,11 @@ func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artif
 	if author = strings.TrimSpace(author); author != "" {
 		env = append(env, "GIT_AUTHOR_NAME="+author, "GIT_AUTHOR_EMAIL=artifact-author@localhost")
 	}
-	if _, err := runArtifactGit(ctx, repoPath, env, "commit", "-m", msg, "--no-gpg-sign"); err != nil {
+	commitArgs := []string{"commit", "-m", msg, "--no-gpg-sign"}
+	if !hasStagedDiff {
+		commitArgs = append(commitArgs, "--allow-empty")
+	}
+	if _, err := runArtifactGit(ctx, repoPath, env, commitArgs...); err != nil {
 		return "", err
 	}
 	return artifactRepoHead(ctx, repoPath)
@@ -537,16 +605,72 @@ func (pc *PipelineCoordinator) persistArtifactRepoResult(ctx context.Context, ex
 	return repo.SaveState(ctx, identity.NormalizeEntityID(execCtx.Request.EntityID.String()), mutation)
 }
 
-func artifactRepoRequestTreeHash(ctx context.Context, repoPath, requestID string) (string, bool, error) {
+type artifactRepoHistoryRecord struct {
+	Ref      string
+	TreeHash string
+}
+
+func artifactRepoProjectedTreeSize(ctx context.Context, repoPath string, files []artifactRepoPreparedFile) (int, error) {
+	sizes := map[string]int{}
+	out, err := runArtifactGit(ctx, repoPath, nil, "ls-tree", "-r", "-l", "HEAD")
+	if err != nil {
+		return 0, err
+	}
+	for _, raw := range strings.Split(out, "\n") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		parts := strings.Fields(raw)
+		if len(parts) < 5 {
+			return 0, fmt.Errorf("artifact_repo cannot parse git tree entry %q", raw)
+		}
+		sizeValue := parts[3]
+		if sizeValue == "-" {
+			continue
+		}
+		var size int
+		if _, err := fmt.Sscanf(sizeValue, "%d", &size); err != nil {
+			return 0, fmt.Errorf("artifact_repo cannot parse git tree size %q: %w", sizeValue, err)
+		}
+		pathStart := strings.Index(raw, "\t")
+		if pathStart < 0 || pathStart+1 >= len(raw) {
+			return 0, fmt.Errorf("artifact_repo cannot parse git tree path %q", raw)
+		}
+		sizes[strings.TrimSpace(raw[pathStart+1:])] = size
+	}
+	for _, file := range files {
+		sizes[file.Path] = file.Size
+	}
+	total := 0
+	for _, size := range sizes {
+		total += size
+	}
+	return total, nil
+}
+
+func artifactRepoRequestRecord(ctx context.Context, repoPath, requestID string) (artifactRepoHistoryRecord, bool, error) {
 	requestID = strings.TrimSpace(requestID)
 	if requestID == "" {
-		return "", false, nil
+		return artifactRepoHistoryRecord{}, false, nil
 	}
-	out, err := runArtifactGit(ctx, repoPath, nil, "log", "--format=%B%x00")
+	out, err := runArtifactGit(ctx, repoPath, nil, "log", "--format=%H%x1f%B%x00")
 	if err != nil {
-		return "", false, err
+		return artifactRepoHistoryRecord{}, false, err
 	}
-	for _, message := range strings.Split(out, "\x00") {
+	for _, record := range strings.Split(out, "\x00") {
+		record = strings.Trim(record, "\n")
+		if strings.TrimSpace(record) == "" {
+			continue
+		}
+		ref, message, ok := strings.Cut(record, "\x1f")
+		if !ok {
+			return artifactRepoHistoryRecord{}, false, fmt.Errorf("artifact_repo cannot parse git history record")
+		}
+		ref = strings.TrimSpace(ref)
+		if len(ref) != 40 {
+			return artifactRepoHistoryRecord{}, false, fmt.Errorf("artifact_repo history ref %q is not a 40-character git SHA", ref)
+		}
 		foundRequest := ""
 		foundTree := ""
 		for _, line := range strings.Split(message, "\n") {
@@ -565,11 +689,11 @@ func artifactRepoRequestTreeHash(ctx context.Context, repoPath, requestID string
 			continue
 		}
 		if foundTree == "" {
-			return "", true, fmt.Errorf("artifact_repo_commit request_id %s has no recorded tree hash", requestID)
+			return artifactRepoHistoryRecord{}, true, fmt.Errorf("artifact_repo_commit request_id %s has no recorded tree hash", requestID)
 		}
-		return foundTree, true, nil
+		return artifactRepoHistoryRecord{Ref: ref, TreeHash: foundTree}, true, nil
 	}
-	return "", false, nil
+	return artifactRepoHistoryRecord{}, false, nil
 }
 
 func artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash string, files []artifactRepoPreparedFile) map[string]any {

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -115,10 +115,18 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 	if err := ensureArtifactRepoInitialized(ctx, repoPath, commitTime(execCtx.Request.Event.CreatedAt)); err != nil {
 		return fail(err)
 	}
+	if previousTree, found, err := artifactRepoRequestTreeHash(ctx, repoPath, requestID); err != nil {
+		return fail(err)
+	} else if found {
+		if previousTree != treeHash {
+			return fail(fmt.Errorf("artifact_repo_commit request_id %s conflicts with previously committed tree %s", requestID, previousTree))
+		}
+		return nil
+	}
 	if err := writeArtifactRepoFiles(repoPath, files); err != nil {
 		return fail(err)
 	}
-	ref, err := commitArtifactRepoFiles(ctx, repoPath, files, sourceEventID, requestID, optionalArtifactString(execCtx.Base, spec.Author), commitTime(execCtx.Request.Event.CreatedAt))
+	ref, err := commitArtifactRepoFiles(ctx, repoPath, files, sourceEventID, requestID, treeHash, optionalArtifactString(execCtx.Base, spec.Author), commitTime(execCtx.Request.Event.CreatedAt))
 	if err != nil {
 		return fail(err)
 	}
@@ -415,14 +423,24 @@ func writeArtifactRepoFiles(repoPath string, files []artifactRepoPreparedFile) e
 	return nil
 }
 
-func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artifactRepoPreparedFile, sourceEventID, requestID, author string, when time.Time) (string, error) {
-	if _, err := runArtifactGit(ctx, repoPath, nil, "add", "--all"); err != nil {
+func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artifactRepoPreparedFile, sourceEventID, requestID, treeHash, author string, when time.Time) (string, error) {
+	if _, err := runArtifactGit(ctx, repoPath, nil, "reset", "--"); err != nil {
+		return "", err
+	}
+	args := []string{"add", "--"}
+	for _, file := range files {
+		args = append(args, file.Path)
+	}
+	if _, err := runArtifactGit(ctx, repoPath, nil, args...); err != nil {
 		return "", err
 	}
 	if _, err := runArtifactGit(ctx, repoPath, nil, "diff", "--cached", "--quiet"); err == nil {
 		return artifactRepoHead(ctx, repoPath)
 	}
-	msg := fmt.Sprintf("artifact: commit request %s", requestID)
+	if err := verifyArtifactRepoStagedPaths(ctx, repoPath, files); err != nil {
+		return "", err
+	}
+	msg := fmt.Sprintf("artifact: commit request %s\n\nSwarm-Request-Id: %s\nSwarm-Source-Event-Id: %s\nSwarm-Tree-Hash: %s", requestID, requestID, sourceEventID, treeHash)
 	env := gitCommitEnv(when)
 	if author = strings.TrimSpace(author); author != "" {
 		env = append(env, "GIT_AUTHOR_NAME="+author, "GIT_AUTHOR_EMAIL=artifact-author@localhost")
@@ -431,6 +449,27 @@ func commitArtifactRepoFiles(ctx context.Context, repoPath string, files []artif
 		return "", err
 	}
 	return artifactRepoHead(ctx, repoPath)
+}
+
+func verifyArtifactRepoStagedPaths(ctx context.Context, repoPath string, files []artifactRepoPreparedFile) error {
+	out, err := runArtifactGit(ctx, repoPath, nil, "diff", "--cached", "--name-only")
+	if err != nil {
+		return err
+	}
+	allowed := map[string]struct{}{}
+	for _, file := range files {
+		allowed[file.Path] = struct{}{}
+	}
+	for _, raw := range strings.Split(out, "\n") {
+		staged := strings.TrimSpace(raw)
+		if staged == "" {
+			continue
+		}
+		if _, ok := allowed[staged]; !ok {
+			return fmt.Errorf("artifact_repo staged non-allowlisted path %s", staged)
+		}
+	}
+	return nil
 }
 
 func artifactRepoHead(ctx context.Context, repoPath string) (string, error) {
@@ -496,6 +535,41 @@ func (pc *PipelineCoordinator) persistArtifactRepoResult(ctx context.Context, ex
 	}
 	repo := pipelineEngineStateRepo{coordinator: pc}
 	return repo.SaveState(ctx, identity.NormalizeEntityID(execCtx.Request.EntityID.String()), mutation)
+}
+
+func artifactRepoRequestTreeHash(ctx context.Context, repoPath, requestID string) (string, bool, error) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return "", false, nil
+	}
+	out, err := runArtifactGit(ctx, repoPath, nil, "log", "--format=%B%x00")
+	if err != nil {
+		return "", false, err
+	}
+	for _, message := range strings.Split(out, "\x00") {
+		foundRequest := ""
+		foundTree := ""
+		for _, line := range strings.Split(message, "\n") {
+			key, value, ok := strings.Cut(line, ":")
+			if !ok {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "swarm-request-id":
+				foundRequest = strings.TrimSpace(value)
+			case "swarm-tree-hash":
+				foundTree = strings.TrimSpace(value)
+			}
+		}
+		if foundRequest != requestID {
+			continue
+		}
+		if foundTree == "" {
+			return "", true, fmt.Errorf("artifact_repo_commit request_id %s has no recorded tree hash", requestID)
+		}
+		return foundTree, true, nil
+	}
+	return "", false, nil
 }
 
 func artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash string, files []artifactRepoPreparedFile) map[string]any {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -56,6 +56,7 @@ type PipelineCoordinator struct {
 	timerScheduler          *Scheduler
 	timerScheduleStore      SchedulePersistence
 	eventReceiptsCapability func(context.Context) (bool, error)
+	artifactRoot            string
 
 	testSubscribeHook   func()
 	testEntityStateHook func(entityID, state string)
@@ -69,6 +70,7 @@ type PipelineCoordinatorOptions struct {
 	TimerScheduler          *Scheduler
 	TimerScheduleStore      SchedulePersistence
 	EventReceiptsCapability func(context.Context) (bool, error)
+	ArtifactRoot            string
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -90,6 +92,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		timerScheduler:          opts.TimerScheduler,
 		timerScheduleStore:      opts.TimerScheduleStore,
 		eventReceiptsCapability: opts.EventReceiptsCapability,
+		artifactRoot:            strings.TrimSpace(opts.ArtifactRoot),
 		entityLocks:             make(map[string]*sync.Mutex),
 	}
 }

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -760,6 +760,11 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 			return true, err
 		}
 		return true, nil
+	case "artifact_repo_commit":
+		if err := pc.commitArtifactRepo(ctx, action, execCtx); err != nil {
+			return true, err
+		}
+		return true, nil
 	default:
 		return false, nil
 	}

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -784,6 +784,25 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if got := strings.TrimSpace(asString(replayed.Metadata["current_ref"])); got != ref {
 		t.Fatalf("replay current_ref = %q, want %q", got, ref)
 	}
+
+	if err := os.MkdirAll(filepath.Join(repoPath, "notes"), 0o755); err != nil {
+		t.Fatalf("create extra dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "notes", "extra.txt"), []byte("should not be committed\n"), 0o644); err != nil {
+		t.Fatalf("write extra file: %v", err)
+	}
+	nextAction, nextCtx := testArtifactRepoActionAndContext(entityID, replayed.Metadata, "55555555-5555-5555-5555-555555555555", "66666666-6666-6666-6666-666666666666", "name: Demo\nrank: 3\n")
+	ok, err = pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx)
+	if !ok || err != nil {
+		t.Fatalf("next ExecuteAction ok=%v err=%v", ok, err)
+	}
+	tree, err := runArtifactGit(ctx, repoPath, nil, "ls-tree", "-r", "--name-only", "HEAD")
+	if err != nil {
+		t.Fatalf("git ls-tree: %v", err)
+	}
+	if strings.Contains(tree, "notes/extra.txt") {
+		t.Fatalf("non-allowlisted file was committed:\n%s", tree)
+	}
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAllowlist(t *testing.T) {
@@ -863,7 +882,16 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 		t.Fatalf("load workflow instance: %v", err)
 	}
 
-	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, instance.Metadata, "55555555-5555-5555-5555-555555555555", "44444444-4444-4444-4444-444444444444", "name: Changed\n")
+	nextAction, nextCtx := testArtifactRepoActionAndContext(entityID, instance.Metadata, "55555555-5555-5555-5555-555555555555", "66666666-6666-6666-6666-666666666666", "name: Next\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx); err != nil {
+		t.Fatalf("next ExecuteAction: %v", err)
+	}
+	afterNext, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance after next request: %v", err)
+	}
+
+	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, afterNext.Metadata, "77777777-7777-7777-7777-777777777777", "44444444-4444-4444-4444-444444444444", "name: Changed\n")
 	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
 	if !ok {
 		t.Fatal("expected artifact_repo_commit action to be claimed")

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -855,6 +855,45 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	}
 }
 
+func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMismatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "rank: 2\n")
+
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "missing required field name") {
+		t.Fatalf("ExecuteAction error = %v, want schema mismatch", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
+		t.Fatalf("status = %q, want failed", got)
+	}
+	if _, exists := instance.Metadata["current_ref"]; exists {
+		t.Fatalf("current_ref should not be persisted on failed commit: %#v", instance.Metadata["current_ref"])
+	}
+}
+
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentConflict(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
@@ -898,6 +937,173 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 	}
 	if err == nil || !strings.Contains(err.Error(), "conflicts with previously committed tree") {
 		t.Fatalf("ExecuteAction error = %v, want request conflict", err)
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistory(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx); err != nil {
+		t.Fatalf("initial ExecuteAction: %v", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	initialRef := strings.TrimSpace(asString(instance.Metadata["current_ref"]))
+
+	sameAction, sameCtx := testArtifactRepoActionAndContext(entityID, instance.Metadata, "55555555-5555-5555-5555-555555555555", "66666666-6666-6666-6666-666666666666", "name: Demo\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, sameAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, sameCtx); err != nil {
+		t.Fatalf("same-tree ExecuteAction: %v", err)
+	}
+	afterSame, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance after same-tree request: %v", err)
+	}
+	sameRef := strings.TrimSpace(asString(afterSame.Metadata["current_ref"]))
+	if sameRef == "" || sameRef == initialRef {
+		t.Fatalf("same-tree request current_ref = %q, initial ref = %q; want a durable operation commit", sameRef, initialRef)
+	}
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), testPipelineRunID, initial["vertical_id"].(string), initial["business_slug"].(string), initial["spec_repo_id"].(string))
+	if err != nil {
+		t.Fatalf("artifactRepoPath: %v", err)
+	}
+	if _, found, err := artifactRepoRequestRecord(ctx, repoPath, "66666666-6666-6666-6666-666666666666"); err != nil || !found {
+		t.Fatalf("artifactRepoRequestRecord found=%v err=%v, want recorded same-tree request", found, err)
+	}
+
+	nextAction, nextCtx := testArtifactRepoActionAndContext(entityID, afterSame.Metadata, "77777777-7777-7777-7777-777777777777", "88888888-8888-8888-8888-888888888888", "name: Next\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx); err != nil {
+		t.Fatalf("next ExecuteAction: %v", err)
+	}
+	afterNext, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance after next request: %v", err)
+	}
+
+	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, afterNext.Metadata, "99999999-9999-9999-9999-999999999999", "66666666-6666-6666-6666-666666666666", "name: Changed\n")
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "conflicts with previously committed tree") {
+		t.Fatalf("ExecuteAction error = %v, want same-tree request history conflict", err)
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitRepairsDBStateFromGitHistory(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx); err != nil {
+		t.Fatalf("initial ExecuteAction: %v", err)
+	}
+	committed, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load committed workflow instance: %v", err)
+	}
+	ref := strings.TrimSpace(asString(committed.Metadata["current_ref"]))
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("reset workflow instance to simulate DB/git split: %v", err)
+	}
+
+	repairAction, repairCtx := testArtifactRepoActionAndContext(entityID, initial, "55555555-5555-5555-5555-555555555555", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, repairAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, repairCtx)
+	if !ok || err != nil {
+		t.Fatalf("repair ExecuteAction ok=%v err=%v", ok, err)
+	}
+	repaired, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load repaired workflow instance: %v", err)
+	}
+	if got := strings.TrimSpace(asString(repaired.Metadata["current_ref"])); got != ref {
+		t.Fatalf("repaired current_ref = %q, want %q", got, ref)
+	}
+	if got := strings.TrimSpace(asString(repaired.Metadata["status"])); got != "committed" {
+		t.Fatalf("repaired status = %q, want committed", got)
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitEnforcesProjectedRepoSize(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	action.ArtifactRepo.Limits.MaxRepoBytes = 1024
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx); err != nil {
+		t.Fatalf("initial ExecuteAction: %v", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+
+	nextAction, nextCtx := testArtifactRepoActionAndContext(entityID, instance.Metadata, "55555555-5555-5555-5555-555555555555", "66666666-6666-6666-6666-666666666666", "name: unused\n")
+	nextAction.ArtifactRepo.AllowedPaths = append(nextAction.ArtifactRepo.AllowedPaths, "docs/extra.txt")
+	nextAction.ArtifactRepo.Files = []runtimecontracts.ArtifactRepoFileSpec{{
+		Path:        runtimecontracts.LiteralExpression("docs/extra.txt"),
+		Content:     runtimecontracts.LiteralExpression("xxxxxxxxxxxxxxxxxxxxxxxxx"),
+		ContentType: "text",
+	}}
+	nextAction.ArtifactRepo.Limits.MaxRepoBytes = 30
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "repository tree exceeds max repo bytes") {
+		t.Fatalf("ExecuteAction error = %v, want projected repo size failure", err)
 	}
 }
 
@@ -961,7 +1167,11 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 					Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
 					Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
 					ContentType: "yaml",
-					MaxBytes:    4096,
+					Schema: runtimecontracts.ArtifactRepoSchemaSpec{
+						Type:           "object",
+						RequiredFields: []string{"name"},
+					},
+					MaxBytes: 4096,
 				}},
 				Output: runtimecontracts.ArtifactRepoOutputSpec{
 					RepoURL:           "repo_url",

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -704,6 +706,268 @@ func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpr
 	if count != 0 {
 		t.Fatalf("mailbox row count = %d, want 0", count)
 	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	artifactRoot := t.TempDir()
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: artifactRoot}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\nrank: 2\n")
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err != nil {
+		t.Fatalf("ExecuteAction: %v", err)
+	}
+
+	instance, ok, err := store.Load(ctx, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load workflow instance ok=%v err=%v", ok, err)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["repo_url"])); got != "swarm-artifact://spec-repos/"+initial["spec_repo_id"].(string) {
+		t.Fatalf("repo_url = %q", got)
+	}
+	ref := strings.TrimSpace(asString(instance.Metadata["current_ref"]))
+	if len(ref) != 40 {
+		t.Fatalf("current_ref length = %d ref=%q", len(ref), ref)
+	}
+	manifest, ok := instance.Metadata["file_manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("file_manifest = %#v", instance.Metadata["file_manifest"])
+	}
+	if got := strings.TrimSpace(asString(manifest["source_event_id"])); got != execCtx.Request.Event.ID {
+		t.Fatalf("manifest source_event_id = %q", got)
+	}
+	files, ok := manifest["files"].([]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("manifest files = %#v", manifest["files"])
+	}
+	repoPath, err := artifactRepoPath(artifactRoot, testPipelineRunID, initial["vertical_id"].(string), initial["business_slug"].(string), initial["spec_repo_id"].(string))
+	if err != nil {
+		t.Fatalf("artifactRepoPath: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(repoPath, "specs", "mvp.yaml"))
+	if err != nil {
+		t.Fatalf("read artifact file: %v", err)
+	}
+	if got := string(raw); got != "name: Demo\nrank: 2\n" {
+		t.Fatalf("artifact file content = %q", got)
+	}
+
+	replayCtx := execCtx
+	replayCtx.Request.State.StateCarrier.Metadata = cloneStringAnyMap(instance.Metadata)
+	ok, err = pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, replayCtx)
+	if !ok || err != nil {
+		t.Fatalf("replay ExecuteAction ok=%v err=%v", ok, err)
+	}
+	replayed, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load replayed workflow instance: %v", err)
+	}
+	if got := strings.TrimSpace(asString(replayed.Metadata["current_ref"])); got != ref {
+		t.Fatalf("replay current_ref = %q, want %q", got, ref)
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAllowlist(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir(), bus: bus}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	action.ArtifactRepo.Files[0].Path = runtimecontracts.LiteralExpression("../escape.yaml")
+
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "path traversal is not allowed") {
+		t.Fatalf("ExecuteAction error = %v, want path traversal", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if _, exists := instance.Metadata["current_ref"]; exists {
+		t.Fatalf("current_ref should not be persisted on failed commit: %#v", instance.Metadata["current_ref"])
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
+		t.Fatalf("status = %q, want failed", got)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, "path traversal is not allowed") {
+		t.Fatalf("failure_reason = %q, want traversal detail", got)
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("failure event count = %d, want 1", got)
+	}
+	if got := string(bus.publishedEvent(0).Type); got != "spec_repo.commit_failed" {
+		t.Fatalf("failure event type = %q", got)
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentConflict(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "spec-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx); err != nil {
+		t.Fatalf("initial ExecuteAction: %v", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+
+	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, instance.Metadata, "55555555-5555-5555-5555-555555555555", "44444444-4444-4444-4444-444444444444", "name: Changed\n")
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "conflicts with previously committed tree") {
+		t.Fatalf("ExecuteAction error = %v, want request conflict", err)
+	}
+}
+
+func TestWriteArtifactRepoFilesRejectsSymlinkEscape(t *testing.T) {
+	repoPath := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repoPath, "specs")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	err := writeArtifactRepoFiles(repoPath, []artifactRepoPreparedFile{{
+		Path:    "specs/mvp.yaml",
+		Content: []byte("name: Demo\n"),
+	}})
+
+	if err == nil || !strings.Contains(err.Error(), "escaped repo root through symlink") {
+		t.Fatalf("writeArtifactRepoFiles error = %v, want symlink escape", err)
+	}
+}
+
+func testArtifactRepoEntityFields() map[string]any {
+	return map[string]any{
+		"spec_repo_id":              "11111111-1111-1111-1111-111111111111",
+		"vertical_id":               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		"source_validation_case_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+		"business_slug":             "Acme CRM",
+	}
+}
+
+func testArtifactRepoActionAndContext(entityID string, entity map[string]any, eventID, requestID, content string) (runtimecontracts.ActionSpec, runtimeengine.ExecutionContext) {
+	payload := map[string]any{
+		"request_id": requestID,
+		"mvp_yaml":   content,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	evt := events.Event{
+		ID:        eventID,
+		Type:      "spec_file.commit_requested",
+		RunID:     testPipelineRunID,
+		Payload:   payloadBytes,
+		CreatedAt: time.Unix(1_700_000_000, 0).UTC(),
+	}.WithEnvelope(events.EventEnvelope{EntityID: entityID})
+	base := values.NewContext()
+	base.Event = values.Wrap(evt.ContextMap("ready"))
+	base.Payload = values.Wrap(payload)
+	base.Entity = values.Wrap(entity)
+	stateMetadata := cloneStringAnyMap(entity)
+	return runtimecontracts.ActionSpec{
+			ID: "artifact_repo_commit",
+			ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
+				Provider:               "local_git",
+				RepoID:                 runtimecontracts.RefExpression("entity.spec_repo_id"),
+				RunID:                  runtimecontracts.RefExpression("event.run_id"),
+				VerticalID:             runtimecontracts.RefExpression("entity.vertical_id"),
+				BusinessSlug:           runtimecontracts.RefExpression("entity.business_slug"),
+				SourceValidationCaseID: runtimecontracts.RefExpression("entity.source_validation_case_id"),
+				RequestID:              runtimecontracts.RefExpression("payload.request_id"),
+				Author:                 runtimecontracts.LiteralExpression("validation-agent"),
+				AllowedPaths:           []string{"specs/mvp.yaml"},
+				Files: []runtimecontracts.ArtifactRepoFileSpec{{
+					Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
+					Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
+					ContentType: "yaml",
+					MaxBytes:    4096,
+				}},
+				Output: runtimecontracts.ArtifactRepoOutputSpec{
+					RepoURL:           "repo_url",
+					CurrentRef:        "current_ref",
+					FileManifest:      "file_manifest",
+					Status:            "status",
+					FailureReason:     "failure_reason",
+					LastRequestID:     "last_request_id",
+					LastSourceEventID: "last_source_event_id",
+				},
+				Limits: runtimecontracts.ArtifactRepoLimitsSpec{
+					MaxYAMLBytes: 4096,
+					MaxRepoBytes: 1048576,
+				},
+				FailureEvent: "spec_repo.commit_failed",
+				FailurePayload: map[string]runtimecontracts.ExpressionValue{
+					"request_id": runtimecontracts.RefExpression("payload.request_id"),
+				},
+			},
+		}, runtimeengine.ExecutionContext{
+			Base: base,
+			Request: runtimeengine.ExecutionRequest{
+				EntityID: identity.NormalizeEntityID(entityID),
+				NodeID:   identity.NormalizeNodeID("artifact-node"),
+				Event:    evt,
+				State: runtimeengine.StateSnapshot{
+					EntityID:        identity.NormalizeEntityID(entityID),
+					WorkflowName:    "spec-repo",
+					WorkflowVersion: "1.0.0",
+					CurrentState:    "ready",
+					StateCarrier:    runtimeengine.NewStateCarrier(stateMetadata, nil, nil),
+				},
+			},
+		}
 }
 
 func TestPipelineEngineEvaluator_ExposesAccumulatedScopeForCEL(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the Swarm V1 local-git artifact repository primitive approved for #699:

- new `artifact_repo_commit` handler action and strict `artifact_repo` declaration decoding
- bootverify validation for provider, required identities, allowlist/files/output fields, limits, and action/spec mismatches
- runtime local-git provider that writes allowlisted canonical files, commits them, persists opaque `swarm-artifact://...` URL plus 40-char ref/manifest/status, and fails closed on unsafe paths or idempotency conflicts
- authoritative `platform-spec.yaml` update for the action, operation state, failure event, idempotency, and testing requirements

Closes #699.

## Governing refs / context

- Binding issue/gate context: Swarm #699 Pre-Implementation Coverage Audit and independent gate outcome, approved as first slice.
- Authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`, under `handler_specification.handler_fields.action`, `compliance.runtime_enforcement`, `compliance.testing`, and `tool_model.access_control.handler_actions`.
- Adjacent existing contract context preserved: handler action vocabulary, native_tools/workspace boundaries, event lineage/idempotency, and fail-closed runtime semantics.

## Semantic migration

- New canonical owner: Swarm platform handler action `artifact_repo_commit` plus `artifact_repo` declaration, decoded in `internal/runtime/contracts`, verified in `internal/runtime/bootverify`, and executed in `internal/runtime/pipeline`.
- Old invalid paths: prompt-owned git/file writes, native_tools/file_io as durable service persistence, product-local `spec_repo_*` Swarm syntax, raw host `file://` paths as product truth, and arbitrary source-provided repo paths.
- Production paths checked for surviving old behavior: handler action vocabulary, strict action decoder, bootverify handler compliance, pipeline action runner, mailbox/create/select/record action precedents, native tool/workspace boundaries.
- Migration complete for Swarm V1 local-git artifact repo primitive. Empire #67/#64 remain separate consumers.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline`
- `go test ./...`
- `git diff --check`
