### PR TITLE
[agent-b][issue #704] Add agent conversation read owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -185,8 +185,10 @@ func main() {
 		log.Fatalf("load v1 api mailbox approval routes: %v", err)
 	}
 	var apiEntities apiv1.EntityReadStore
+	var apiAgentConversations apiv1.AgentConversationReadStore
 	if stores.Postgres != nil {
 		apiEntities = stores.Postgres
+		apiAgentConversations = stores.Postgres
 	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
@@ -199,6 +201,7 @@ func main() {
 			Runs:                  stores.Postgres,
 			Observability:         stores.Postgres,
 			Entities:              apiEntities,
+			AgentConversations:    apiAgentConversations,
 			Mailbox:               stores.Postgres,
 			Idempotency:           stores.Postgres,
 			Events:                rt.Bus,

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -1,0 +1,183 @@
+package apiv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarm/internal/store"
+)
+
+type fakeAgentConversationReadStore struct {
+	listAgentsResult           store.OperatorAgentListResult
+	listAgentsErr              error
+	agentResult                store.OperatorAgentDetail
+	agentErr                   error
+	listConversationsResult    store.OperatorConversationListResult
+	listConversationsErr       error
+	conversationResult         store.OperatorConversationDetail
+	conversationErr            error
+	currentConversationResult  *store.OperatorConversationDetail
+	currentConversationErr     error
+	lastAgentList              store.OperatorAgentListOptions
+	lastConversationList       store.OperatorConversationListOptions
+	lastAgentID                string
+	lastConversationSessionID  string
+	lastCurrentConversationFor string
+}
+
+func (s *fakeAgentConversationReadStore) ListOperatorAgents(_ context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error) {
+	s.lastAgentList = opts
+	return s.listAgentsResult, s.listAgentsErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorAgent(_ context.Context, agentID string) (store.OperatorAgentDetail, error) {
+	s.lastAgentID = agentID
+	return s.agentResult, s.agentErr
+}
+
+func (s *fakeAgentConversationReadStore) ListOperatorConversations(_ context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error) {
+	s.lastConversationList = opts
+	return s.listConversationsResult, s.listConversationsErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorConversation(_ context.Context, sessionID string) (store.OperatorConversationDetail, error) {
+	s.lastConversationSessionID = sessionID
+	return s.conversationResult, s.conversationErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadCurrentOperatorConversationForAgent(_ context.Context, agentID string) (*store.OperatorConversationDetail, error) {
+	s.lastCurrentConversationFor = agentID
+	return s.currentConversationResult, s.currentConversationErr
+}
+
+func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	reads := &fakeAgentConversationReadStore{
+		listAgentsResult: store.OperatorAgentListResult{Agents: []store.OperatorAgentSummary{{
+			AgentID:          "agent-1",
+			Role:             "researcher",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: "session",
+			SessionScope:     "global",
+			Status:           "running",
+		}}},
+		agentResult: store.OperatorAgentDetail{Agent: store.OperatorAgentSummary{AgentID: "agent-1", Role: "researcher"}},
+		listConversationsResult: store.OperatorConversationListResult{
+			Conversations: []store.OperatorConversationSummary{{
+				SessionID:    "sess-1",
+				AgentID:      "agent-1",
+				RunID:        "run-1",
+				StartedAt:    now,
+				TurnCount:    1,
+				MessageCount: 2,
+				Status:       "active",
+			}},
+			NextCursor: "next",
+		},
+		conversationResult: store.OperatorConversationDetail{
+			Conversation: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", StartedAt: now, Status: "active"},
+			Turns:        []store.OperatorConversationTurn{{TurnID: "turn-1", TriggerEventID: "evt-1", TriggerEventType: "task.started", ParseOK: true}},
+		},
+		currentConversationResult: &store.OperatorConversationDetail{
+			Conversation: store.OperatorConversationSummary{SessionID: "sess-current", AgentID: "agent-1", StartedAt: now, Status: "active"},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	listAgents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agents","method":"agent.list","params":{"flow":"flow/a","role":"researcher"}}`)
+	if listAgents.Error != nil {
+		t.Fatalf("agent.list error = %#v", listAgents.Error)
+	}
+	if reads.lastAgentList.Flow != "flow/a" || reads.lastAgentList.Role != "researcher" {
+		t.Fatalf("agent.list options = %#v", reads.lastAgentList)
+	}
+
+	getAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent","method":"agent.get","params":{"agent_id":"agent-1"}}`)
+	if getAgent.Error != nil {
+		t.Fatalf("agent.get error = %#v", getAgent.Error)
+	}
+	if reads.lastAgentID != "agent-1" {
+		t.Fatalf("agent.get id = %q", reads.lastAgentID)
+	}
+
+	listConversations := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"convs","method":"conversation.list","params":{"agent_id":"agent-1","run_id":"11111111-1111-1111-1111-111111111111","limit":10,"cursor":"abc"}}`)
+	if listConversations.Error != nil {
+		t.Fatalf("conversation.list error = %#v", listConversations.Error)
+	}
+	if reads.lastConversationList.AgentID != "agent-1" || reads.lastConversationList.RunID == "" || reads.lastConversationList.Limit != 10 || reads.lastConversationList.Cursor != "abc" {
+		t.Fatalf("conversation.list options = %#v", reads.lastConversationList)
+	}
+
+	getConversation := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"sess-1"}}`)
+	if getConversation.Error != nil {
+		t.Fatalf("conversation.get error = %#v", getConversation.Error)
+	}
+	if reads.lastConversationSessionID != "sess-1" {
+		t.Fatalf("conversation.get session = %q", reads.lastConversationSessionID)
+	}
+
+	current := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"current","method":"conversation.current_for_agent","params":{"agent_id":"agent-1"}}`)
+	if current.Error != nil {
+		t.Fatalf("conversation.current_for_agent error = %#v", current.Error)
+	}
+	if reads.lastCurrentConversationFor != "agent-1" {
+		t.Fatalf("current_for_agent id = %q", reads.lastCurrentConversationFor)
+	}
+}
+
+func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		body    string
+		reads   *fakeAgentConversationReadStore
+		wantApp string
+	}{
+		{
+			name:    "agent missing",
+			method:  "agent.get",
+			body:    `{"jsonrpc":"2.0","id":"agent","method":"agent.get","params":{"agent_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{agentErr: store.ErrAgentNotFound},
+			wantApp: AgentNotFoundCode,
+		},
+		{
+			name:    "conversation missing",
+			method:  "conversation.get",
+			body:    `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{conversationErr: store.ErrSessionNotFound},
+			wantApp: SessionNotFoundCode,
+		},
+		{
+			name:    "current unknown agent",
+			method:  "conversation.current_for_agent",
+			body:    `{"jsonrpc":"2.0","id":"current","method":"conversation.current_for_agent","params":{"agent_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{currentConversationErr: store.ErrAgentNotFound},
+			wantApp: AgentNotFoundCode,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					AgentConversations: tc.reads,
+				}),
+			})
+			resp := rpcCall(t, handler, tc.body)
+			if resp.Error == nil {
+				t.Fatalf("%s returned no error", tc.method)
+			}
+			data := asMap(t, resp.Error.Data)
+			if data["code"] != tc.wantApp {
+				t.Fatalf("error code = %#v, want %s", data["code"], tc.wantApp)
+			}
+		})
+	}
+}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -37,6 +37,14 @@ type EntityReadStore interface {
 	AggregateOperatorEntities(context.Context, store.OperatorEntityAggregateOptions) (store.OperatorEntityAggregateResult, error)
 }
 
+type AgentConversationReadStore interface {
+	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
+	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
+	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
+	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
+	LoadCurrentOperatorConversationForAgent(context.Context, string) (*store.OperatorConversationDetail, error)
+}
+
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
@@ -44,6 +52,7 @@ type OperatorReadOptions struct {
 	Runs                  RunReadStore
 	Observability         ObservabilityReadStore
 	Entities              EntityReadStore
+	AgentConversations    AgentConversationReadStore
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
@@ -209,6 +218,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorEntityHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorAgentConversationHandlers(opts) {
+		handlers[name] = handler
+	}
 	return handlers
 }
 
@@ -231,6 +243,111 @@ func requireEntityReadStore(reads EntityReadStore) (EntityReadStore, error) {
 		return nil, fmt.Errorf("entity read store is required")
 	}
 	return reads, nil
+}
+
+func requireAgentConversationReadStore(reads AgentConversationReadStore) (AgentConversationReadStore, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("agent/conversation read store is required")
+	}
+	return reads, nil
+}
+
+func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.AgentConversations == nil {
+		return nil
+	}
+	return map[string]MethodHandler{
+		"agent.list": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorAgentListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorAgents(ctx, listOpts)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"agent.get": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			agentID, err := requiredStringParam(req.Params, "agent_id")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorAgent(ctx, agentID)
+			if errors.Is(err, store.ErrAgentNotFound) {
+				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"conversation.list": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := operatorConversationListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListOperatorConversations(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidConversationCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid conversation list cursor"})
+			}
+			if paramErr := entityReadParamError(err); paramErr != nil {
+				return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"conversation.get": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			sessionID, err := requiredStringParam(req.Params, "session_id")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorConversation(ctx, sessionID)
+			if errors.Is(err, store.ErrSessionNotFound) {
+				return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"conversation.current_for_agent": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			agentID, err := requiredStringParam(req.Params, "agent_id")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadCurrentOperatorConversationForAgent(ctx, agentID)
+			if errors.Is(err, store.ErrAgentNotFound) {
+				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	}
 }
 
 func OperatorEntityHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -454,6 +571,40 @@ func operatorEntityAggregateOptionsFromParams(params map[string]any) (store.Oper
 	return out, nil
 }
 
+func operatorAgentListOptionsFromParams(params map[string]any) (store.OperatorAgentListOptions, error) {
+	out := store.OperatorAgentListOptions{}
+	var err error
+	if out.Flow, _, err = optionalStringParam(params, "flow"); err != nil {
+		return store.OperatorAgentListOptions{}, err
+	}
+	if out.Role, _, err = optionalStringParam(params, "role"); err != nil {
+		return store.OperatorAgentListOptions{}, err
+	}
+	return out, nil
+}
+
+func operatorConversationListOptionsFromParams(params map[string]any) (store.OperatorConversationListOptions, error) {
+	out := store.OperatorConversationListOptions{}
+	var err error
+	if out.AgentID, _, err = optionalStringParam(params, "agent_id"); err != nil {
+		return store.OperatorConversationListOptions{}, err
+	}
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorConversationListOptions{}, err
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.OperatorConversationListOptions{}, err
+	}
+	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
+		limit, ok := integerParam(raw)
+		if !ok || limit < 1 || limit > 500 {
+			return store.OperatorConversationListOptions{}, NewInvalidParamsError(map[string]any{"field": "limit", "reason": "must be an integer from 1 to 500"})
+		}
+		out.Limit = limit
+	}
+	return out, nil
+}
+
 func entityReadParamError(err error) *store.EntityReadParamError {
 	if err == nil {
 		return nil
@@ -657,6 +808,17 @@ func optionalStringParam(params map[string]any, name string) (string, bool, erro
 		return "", true, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be a string"})
 	}
 	return strings.TrimSpace(text), true, nil
+}
+
+func requiredStringParam(params map[string]any, name string) (string, error) {
+	value, present, err := optionalStringParam(params, name)
+	if err != nil {
+		return "", err
+	}
+	if !present || value == "" {
+		return "", NewInvalidParamsError(map[string]any{"field": name, "reason": "is required"})
+	}
+	return value, nil
 }
 
 func stringParam(params map[string]any, name string) string {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -17,6 +17,8 @@ const (
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
 	EventNotFoundCode                    = "EVENT_NOT_FOUND"
 	EntityNotFoundCode                   = "ENTITY_NOT_FOUND"
+	AgentNotFoundCode                    = "AGENT_NOT_FOUND"
+	SessionNotFoundCode                  = "SESSION_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -3,103 +3,78 @@ package server
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 	"strings"
 	"time"
 
 	runtimemanager "swarm/internal/runtime/manager"
-	runtimesessions "swarm/internal/runtime/sessions"
 	"swarm/internal/store"
 )
 
 type SQLAgentReader struct {
-	db        *sql.DB
-	base      AgentReader
-	turnLimit int
+	source *dashboardAgentReadSource
+	owner  *store.OperatorAgentConversationReadSurface
 }
 
-func NewSQLAgentReader(db *sql.DB, base AgentReader, turnLimit int) *SQLAgentReader {
-	if db == nil && base == nil {
+func NewSQLAgentReader(db *sql.DB, source any, turnLimit int) *SQLAgentReader {
+	adapter := &dashboardAgentReadSource{source: source}
+	owner := store.NewOperatorAgentConversationReadSurface(db, adapter, turnLimit)
+	if owner == nil {
 		return nil
 	}
-	return &SQLAgentReader{
-		db:        db,
-		base:      base,
-		turnLimit: turnLimit,
-	}
+	return &SQLAgentReader{source: adapter, owner: owner}
 }
 
 func (r *SQLAgentReader) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
-	if r == nil || r.base == nil {
+	if r == nil || r.source == nil {
 		return nil, nil
 	}
-	return r.base.LoadAgents(ctx)
+	return r.source.LoadAgents(ctx)
+}
+
+func (r *SQLAgentReader) ListOperatorAgents(ctx context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error) {
+	if r == nil || r.owner == nil {
+		return store.OperatorAgentListResult{}, nil
+	}
+	return r.owner.ListOperatorAgents(ctx, opts)
+}
+
+func (r *SQLAgentReader) LoadOperatorAgent(ctx context.Context, agentID string) (store.OperatorAgentDetail, error) {
+	if r == nil || r.owner == nil {
+		return store.OperatorAgentDetail{}, store.ErrAgentNotFound
+	}
+	return r.owner.LoadOperatorAgent(ctx, agentID)
 }
 
 func (r *SQLAgentReader) ListGenericAgents(ctx context.Context) ([]genericAgent, error) {
-	baseRows, err := r.LoadAgents(ctx)
+	result, err := r.ListOperatorAgents(ctx, store.OperatorAgentListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	items := make([]genericAgent, 0, len(baseRows))
-	for _, row := range baseRows {
-		items = append(items, toGenericAgent(row))
-	}
-	if r == nil || r.db == nil || len(items) == 0 {
-		return items, nil
-	}
-	projections, err := r.loadOperatorProjections(ctx)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]genericAgent, 0, len(items))
-	for _, item := range items {
-		projection, ok := projections[item.ID]
-		if !ok {
-			return nil, fmt.Errorf("missing agent operator projection: %s", strings.TrimSpace(item.ID))
-		}
-		applyOperatorProjection(&item, projection, r.turnLimit)
-		out = append(out, item)
+	out := make([]genericAgent, 0, len(result.Agents))
+	for _, item := range result.Agents {
+		out = append(out, genericAgentFromOperatorSummary(item))
 	}
 	return out, nil
 }
 
 func (r *SQLAgentReader) GetGenericAgent(ctx context.Context, id string) (genericAgent, bool, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
+	item, err := r.LoadOperatorAgent(ctx, strings.TrimSpace(id))
+	if errors.Is(err, store.ErrAgentNotFound) {
 		return genericAgent{}, false, nil
 	}
-	rows, err := r.ListGenericAgents(ctx)
 	if err != nil {
 		return genericAgent{}, false, err
 	}
-	for _, row := range rows {
-		if row.ID == id {
-			return row, true, nil
-		}
-	}
-	return genericAgent{}, false, nil
+	return genericAgentFromOperatorSummary(item.Agent), true, nil
 }
 
-type agentOperatorProjection struct {
-	Status              string
-	LifecycleState      string
-	BlockingLayer       string
-	PendingEvents       int
-	OldestPendingAgeSec int
-	LockOwner           string
-	LockExpiresAt       time.Time
-	InFlightTurn        bool
-	InFlightSeconds     int
-	Failures24h         int
-	DeadLetters24h      int
-	TurnCount           int
-	Turns24h            int
-	SessionID           string
-	ProviderSessionID   string
-	CurrentTaskID       string
-	LastTool            *AgentLastTool
-	LiveTurn            *OperatorLiveTurn
+type dashboardAgentReadSource struct {
+	source any
+}
+
+type dashboardLoadAgentsSource interface {
+	LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error)
 }
 
 type pendingAgentDeliveryFactSource interface {
@@ -110,247 +85,34 @@ type agentLifecycleFactSource interface {
 	ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error)
 }
 
-func (r *SQLAgentReader) loadOperatorProjections(ctx context.Context) (map[string]agentOperatorProjection, error) {
-	caps, err := r.resolveCapabilities(ctx)
-	if err != nil {
-		return nil, err
+func (s *dashboardAgentReadSource) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
+	source, ok := s.source.(dashboardLoadAgentsSource)
+	if !ok || source == nil {
+		return nil, nil
 	}
-	if err := requireAgentOperatorProjectionCapabilities(caps); err != nil {
-		return nil, err
-	}
-	latestTurnBlocksExpr := `'[]'::jsonb`
-	if caps.Conversations.TurnBlocks {
-		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
-	}
-	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT
-			a.agent_id,
-			COALESCE(a.status, 'active'),
-			COALESCE(sess.session_id::text, ''),
-			COALESCE(sess.turn_count, 0),
-			COALESCE(sess.lease_holder, ''),
-			sess.lease_expires_at,
-			COALESCE(sess.runtime_state, '{}'::jsonb),
-			0,
-			0,
-			COALESCE(f.failures_24h, 0),
-			COALESCE(f.dead_letters_24h, 0),
-			0,
-			COALESCE(latest_turn.turn_id, ''),
-			COALESCE(latest_turn.task_id, ''),
-			COALESCE(latest_turn.parse_ok, false),
-			COALESCE(latest_turn.turn_blocks, '[]'::jsonb)
-		FROM agents a
-		LEFT JOIN LATERAL (
-			SELECT
-				session_id,
-				turn_count,
-				lease_holder,
-				lease_expires_at,
-				runtime_state
-			FROM agent_sessions
-			WHERE agent_id = a.agent_id
-			  AND status = 'active'
-			  AND runtime_mode IN ($1, $2)
-			ORDER BY updated_at DESC, created_at DESC
-			LIMIT 1
-		) sess ON true
-		LEFT JOIN LATERAL (
-			SELECT
-				turn_id::text AS turn_id,
-				COALESCE(task_id, '') AS task_id,
-				parse_ok,
-				%s AS turn_blocks
-			FROM agent_turns
-			WHERE agent_id = a.agent_id
-			  AND sess.session_id IS NOT NULL
-			  AND session_id = sess.session_id
-			ORDER BY created_at DESC, turn_id DESC
-			LIMIT 1
-		) latest_turn ON true
-		LEFT JOIN LATERAL (
-			SELECT
-				COUNT(*) FILTER (WHERE status = 'failed')::int AS failures_24h,
-				COUNT(*) FILTER (WHERE status = 'dead_letter')::int AS dead_letters_24h
-			FROM event_deliveries
-			WHERE subscriber_type = 'agent'
-			  AND subscriber_id = a.agent_id
-			  AND COALESCE(delivered_at, created_at) >= now() - interval '24 hours'
-		) f ON true
-		WHERE a.status NOT IN ('terminated', 'ephemeral')
-		ORDER BY a.created_at ASC, a.agent_id ASC
-	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
-	if err != nil {
-		return nil, fmt.Errorf("query agent operator projections: %w", err)
-	}
-	defer rows.Close()
-
-	out := map[string]agentOperatorProjection{}
-	agentIDs := make([]string, 0)
-	for rows.Next() {
-		var (
-			id              string
-			projection      agentOperatorProjection
-			lockExpiresAt   sql.NullTime
-			runtimeStateRaw []byte
-			latestTurnID    string
-			latestTaskID    string
-			latestParseOK   bool
-			latestTurnRaw   []byte
-		)
-		if err := rows.Scan(
-			&id,
-			&projection.Status,
-			&projection.SessionID,
-			&projection.TurnCount,
-			&projection.LockOwner,
-			&lockExpiresAt,
-			&runtimeStateRaw,
-			&projection.PendingEvents,
-			&projection.OldestPendingAgeSec,
-			&projection.Failures24h,
-			&projection.DeadLetters24h,
-			&projection.Turns24h,
-			&latestTurnID,
-			&latestTaskID,
-			&latestParseOK,
-			&latestTurnRaw,
-		); err != nil {
-			return nil, fmt.Errorf("scan agent operator projection: %w", err)
-		}
-		if lockExpiresAt.Valid {
-			projection.LockExpiresAt = lockExpiresAt.Time
-			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(projection.LockOwner) != "" {
-				projection.InFlightTurn = true
-			}
-		}
-		if err := enrichAgentOperatorProjectionFromLatestTurn(&projection, runtimeStateRaw, latestTurnID, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
-			return nil, err
-		}
-		id = strings.TrimSpace(id)
-		out[id] = projection
-		agentIDs = append(agentIDs, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read agent operator projection rows: %w", err)
-	}
-	factSource, ok := r.base.(pendingAgentDeliveryFactSource)
-	if !ok || factSource == nil {
-		return nil, fmt.Errorf("missing pending agent delivery fact source")
-	}
-	factsByAgent, err := factSource.ListPendingAgentDeliveryFacts(ctx, agentIDs, time.Time{})
-	if err != nil {
-		return nil, err
-	}
-	lifecycleSource, ok := r.base.(agentLifecycleFactSource)
-	if !ok || lifecycleSource == nil {
-		return nil, fmt.Errorf("missing agent lifecycle fact source")
-	}
-	lifecycleByAgent, err := lifecycleSource.ListAgentLifecycleFacts(ctx, agentIDs)
-	if err != nil {
-		return nil, err
-	}
-	for agentID, facts := range factsByAgent {
-		projection := out[strings.TrimSpace(agentID)]
-		projection.PendingEvents = facts.PendingCount
-		projection.OldestPendingAgeSec = facts.OldestPendingAgeSec
-		out[strings.TrimSpace(agentID)] = projection
-	}
-	for agentID, facts := range lifecycleByAgent {
-		projection := out[strings.TrimSpace(agentID)]
-		projection.LifecycleState = strings.TrimSpace(facts.CurrentState)
-		projection.BlockingLayer = strings.TrimSpace(facts.BlockingLayer)
-		out[strings.TrimSpace(agentID)] = projection
-	}
-	return out, nil
+	return source.LoadAgents(ctx)
 }
 
-func (r *SQLAgentReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
-	if r != nil {
-		if source, ok := r.base.(schemaCapabilitySource); ok && source != nil {
-			return source.ResolveSchemaCapabilities(ctx)
-		}
+func (s *dashboardAgentReadSource) ResolveSchemaCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
+	source, ok := s.source.(schemaCapabilitySource)
+	if !ok || source == nil {
+		return store.StoreSchemaCapabilities{}, missingDashboardCapabilityOwner("agent reader")
 	}
-	return store.StoreSchemaCapabilities{}, missingDashboardCapabilityOwner("agent reader")
+	return source.ResolveSchemaCapabilities(ctx)
 }
 
-func applyOperatorProjection(agent *genericAgent, projection agentOperatorProjection, turnLimit int) {
-	if agent == nil {
-		return
+func (s *dashboardAgentReadSource) ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]store.PendingAgentDeliveryFacts, error) {
+	source, ok := s.source.(pendingAgentDeliveryFactSource)
+	if !ok || source == nil {
+		return nil, errors.New("missing pending agent delivery fact source")
 	}
-	agent.Status = strings.TrimSpace(projection.Status)
-	agent.BlockingLayer = projection.blockingLayer()
-	agent.PendingEvents = projection.PendingEvents
-	agent.OldestPendingAgeSec = projection.OldestPendingAgeSec
-	agent.LockOwner = strings.TrimSpace(projection.LockOwner)
-	agent.LockExpiresAt = formatTime(projection.LockExpiresAt)
-	agent.InFlightTurn = projection.InFlightTurn
-	agent.InFlightSeconds = projection.InFlightSeconds
-	agent.Failures24h = projection.Failures24h
-	agent.DeadLetters24h = projection.DeadLetters24h
-	agent.TurnCount = projection.TurnCount
-	agent.TurnLimit = maxInt(turnLimit, 0)
-	agent.Turns24h = maxInt(projection.Turns24h, 0)
-	agent.SessionID = strings.TrimSpace(projection.SessionID)
-	agent.ProviderSessionID = strings.TrimSpace(projection.ProviderSessionID)
-	agent.CurrentTaskID = strings.TrimSpace(projection.CurrentTaskID)
-	agent.LastTool = projection.LastTool
-	agent.LiveTurn = projection.LiveTurn
-	if agent.TurnLimit > 0 {
-		agent.NearBreaker = agent.TurnCount*100 >= agent.TurnLimit*85
-	}
-	agent.State = projection.state()
+	return source.ListPendingAgentDeliveryFacts(ctx, agentIDs, since)
 }
 
-func (p agentOperatorProjection) state() string {
-	status := strings.ToLower(strings.TrimSpace(p.Status))
-	if status == "terminated" {
-		return "terminated"
+func (s *dashboardAgentReadSource) ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error) {
+	source, ok := s.source.(agentLifecycleFactSource)
+	if !ok || source == nil {
+		return nil, errors.New("missing agent lifecycle fact source")
 	}
-	if state := strings.TrimSpace(p.LifecycleState); state != "" {
-		return state
-	}
-	if p.InFlightTurn {
-		return "active"
-	}
-	return "idle"
-}
-
-func (p agentOperatorProjection) blockingLayer() string {
-	if layer := strings.TrimSpace(p.BlockingLayer); layer != "" {
-		return layer
-	}
-	if p.InFlightTurn {
-		return "session_execution"
-	}
-	return ""
-}
-
-func enrichAgentOperatorProjectionFromLatestTurn(projection *agentOperatorProjection, runtimeStateRaw []byte, turnID, taskID string, parseOK bool, turnBlocksRaw []byte) error {
-	if projection == nil {
-		return nil
-	}
-	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
-	if err != nil {
-		return fmt.Errorf("decode latest agent session runtime_state: %w", err)
-	}
-	projection.ProviderSessionID = strings.TrimSpace(runtimeState.ProviderSessionID)
-	projection.LiveTurn, err = projectLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
-	if err != nil {
-		return fmt.Errorf("decode latest agent turn live_turn: %w", err)
-	}
-	if projection.LiveTurn != nil {
-		projection.CurrentTaskID = strings.TrimSpace(projection.LiveTurn.TaskID)
-		projection.LastTool = projection.LiveTurn.LastTool
-		return nil
-	}
-	projection.CurrentTaskID = strings.TrimSpace(taskID)
-	return nil
-}
-
-func maxInt(v, floor int) int {
-	if v < floor {
-		return floor
-	}
-	return v
+	return source.ListAgentLifecycleFacts(ctx, agentIDs)
 }

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -3,12 +3,9 @@ package server
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
-	"time"
 
-	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
 )
 
@@ -20,13 +17,38 @@ const (
 type SQLConversationReader struct {
 	db        *sql.DB
 	capSource schemaCapabilitySource
+	owner     *store.OperatorAgentConversationReadSurface
 }
 
 func NewSQLConversationReader(db *sql.DB, capSource schemaCapabilitySource) *SQLConversationReader {
 	if db == nil {
 		return nil
 	}
-	return &SQLConversationReader{db: db, capSource: capSource}
+	return &SQLConversationReader{
+		db:        db,
+		capSource: capSource,
+		owner:     store.NewOperatorConversationReadSurface(db, capSource),
+	}
+}
+
+func (r *SQLConversationReader) ListOperatorConversations(ctx context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error) {
+	if r == nil || r.owner == nil {
+		if _, err := r.resolveCapabilities(ctx); err != nil {
+			return store.OperatorConversationListResult{}, err
+		}
+		return store.OperatorConversationListResult{}, errors.New("conversation reader is not configured")
+	}
+	return r.owner.ListOperatorConversations(ctx, opts)
+}
+
+func (r *SQLConversationReader) LoadOperatorConversation(ctx context.Context, sessionID string) (store.OperatorConversationDetail, error) {
+	if r == nil || r.owner == nil {
+		if _, err := r.resolveCapabilities(ctx); err != nil {
+			return store.OperatorConversationDetail{}, err
+		}
+		return store.OperatorConversationDetail{}, store.ErrSessionNotFound
+	}
+	return r.owner.LoadOperatorConversation(ctx, sessionID)
 }
 
 func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]ConversationSummary, error) {
@@ -46,60 +68,13 @@ func (r *SQLConversationReader) List(ctx context.Context, limit int) ([]Conversa
 	if err := requireConversationTurnCapabilities(caps); err != nil {
 		return nil, err
 	}
-	sources := conversationQuerySources(caps)
-	latestTurnBlocksExpr := `'[]'::jsonb`
-	if caps.Conversations.TurnBlocks {
-		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
-	}
-	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT
-			conversations.session_id,
-			conversations.agent_id,
-			conversations.kind,
-			COALESCE(conversations.scope_key, ''),
-			COALESCE(conversations.scope, ''),
-			COALESCE(conversations.runtime_mode, ''),
-			COALESCE(conversations.status, ''),
-			COALESCE(conversations.turn_count, 0),
-			COALESCE(conversations.runtime_state, '{}'::jsonb),
-			COALESCE(latest_turn.turn_id, ''),
-			COALESCE(latest_turn.task_id, ''),
-			COALESCE(latest_turn.parse_ok, false),
-			COALESCE(latest_turn.turn_blocks, '[]'::jsonb),
-			conversations.updated_at
-		FROM (
-			%s
-		) conversations
-		LEFT JOIN LATERAL (
-			SELECT
-				turn_id::text AS turn_id,
-				COALESCE(task_id, '') AS task_id,
-				parse_ok,
-				%s AS turn_blocks
-			FROM agent_turns
-			WHERE agent_id = conversations.agent_id
-			  AND session_id::text = conversations.session_id
-			ORDER BY created_at DESC, turn_id DESC
-			LIMIT 1
-		) latest_turn ON true
-		ORDER BY updated_at DESC, agent_id ASC
-		LIMIT $1
-	`, strings.Join(sources, "\nUNION ALL\n"), latestTurnBlocksExpr), limit)
+	rows, err := r.owner.ListDashboardOperatorConversations(ctx, limit)
 	if err != nil {
-		return nil, fmt.Errorf("list conversations: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
-
-	out := []ConversationSummary{}
-	for rows.Next() {
-		item, err := scanConversationSummary(rows)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("list conversations rows: %w", err)
+	out := make([]ConversationSummary, 0, len(rows))
+	for _, item := range rows {
+		out = append(out, conversationSummaryFromOperator(item))
 	}
 	return out, nil
 }
@@ -119,272 +94,14 @@ func (r *SQLConversationReader) Get(ctx context.Context, sessionID string) (Conv
 	if err := requireConversationSurfaceCapabilities(caps); err != nil {
 		return ConversationDetail{}, false, err
 	}
-	sources := conversationQuerySources(caps)
-
-	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT
-			session_id,
-			agent_id,
-			kind,
-			COALESCE(scope_key, ''),
-			COALESCE(scope, ''),
-			COALESCE(runtime_mode, ''),
-			COALESCE(status, ''),
-			COALESCE(turn_count, 0),
-			COALESCE(runtime_state, '{}'::jsonb),
-			COALESCE(conversation, '[]'::jsonb),
-			updated_at
-		FROM (
-			%s
-		) conversations
-		WHERE session_id = $1
-		LIMIT 1
-	`, strings.Join(sources, "\nUNION ALL\n")), sessionID)
-
-	item, err := scanConversationDetail(row)
-	if err == sql.ErrNoRows {
-		return ConversationDetail{}, false, nil
-	}
+	item, ok, err := r.owner.LoadDashboardOperatorConversation(ctx, sessionID)
 	if err != nil {
-		return ConversationDetail{}, false, fmt.Errorf("get conversation: %w", err)
-	}
-	item.Turns, err = r.loadConversationTurns(ctx, item.AgentID, item.SessionID)
-	if err != nil {
-		return ConversationDetail{}, false, fmt.Errorf("load conversation turns: %w", err)
-	}
-	return item, true, nil
-}
-
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
-func scanConversationSummary(scanner rowScanner) (ConversationSummary, error) {
-	var (
-		item            ConversationSummary
-		runtimeStateRaw []byte
-		turnID          string
-		taskID          string
-		parseOK         bool
-		turnBlocksRaw   []byte
-	)
-	if err := scanner.Scan(
-		&item.SessionID,
-		&item.AgentID,
-		&item.Kind,
-		&item.ScopeKey,
-		&item.Scope,
-		&item.RuntimeMode,
-		&item.Status,
-		&item.TurnCount,
-		&runtimeStateRaw,
-		&turnID,
-		&taskID,
-		&parseOK,
-		&turnBlocksRaw,
-		&item.UpdatedAt,
-	); err != nil {
-		return ConversationSummary{}, err
-	}
-	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
-	if err != nil {
-		return ConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
-	}
-	item.Summary = runtimeState.Summary
-	item.Metadata = projectConversationSummaryMetadata(runtimeState)
-	item.Metadata.LiveTurn, err = projectLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
-	if err != nil {
-		return ConversationSummary{}, fmt.Errorf("decode conversation live_turn: %w", err)
-	}
-	return item, nil
-}
-
-func scanConversationDetail(scanner rowScanner) (ConversationDetail, error) {
-	var (
-		item            ConversationDetail
-		runtimeStateRaw []byte
-		messagesRaw     []byte
-	)
-	if err := scanner.Scan(
-		&item.SessionID,
-		&item.AgentID,
-		&item.Kind,
-		&item.ScopeKey,
-		&item.Scope,
-		&item.RuntimeMode,
-		&item.Status,
-		&item.TurnCount,
-		&runtimeStateRaw,
-		&messagesRaw,
-		&item.UpdatedAt,
-	); err != nil {
-		return ConversationDetail{}, err
-	}
-	runtimeState, err := store.DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
-	if err != nil {
-		return ConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
-	}
-	item.Summary = runtimeState.Summary
-	item.RuntimeState = projectConversationRuntimeState(runtimeState)
-	item.Messages, err = decodeJSONArray[ConversationMessage](messagesRaw)
-	if err != nil {
-		return ConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)
-	}
-	if item.Messages == nil {
-		item.Messages = []ConversationMessage{}
-	}
-	return item, nil
-}
-
-func decodeJSONObjectRaw(raw []byte) (json.RawMessage, error) {
-	if len(raw) == 0 {
-		return json.RawMessage(`{}`), nil
-	}
-	var out map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return append(json.RawMessage(nil), raw...), nil
-}
-
-func decodeJSONMap(raw []byte) (map[string]any, error) {
-	if len(raw) == 0 {
-		return map[string]any{}, nil
-	}
-	out := map[string]any{}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func decodeJSONArray[T any](raw []byte) ([]T, error) {
-	if len(raw) == 0 {
-		return []T{}, nil
-	}
-	out := []T{}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func decodeJSONStringMap(raw []byte) (map[string]string, error) {
-	if len(raw) == 0 {
-		return map[string]string{}, nil
-	}
-	out := map[string]string{}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (r *SQLConversationReader) loadConversationTurns(ctx context.Context, agentID, sessionID string) ([]ConversationTurn, error) {
-	if r == nil || r.db == nil {
-		return nil, nil
-	}
-	agentID = strings.TrimSpace(agentID)
-	sessionID = strings.TrimSpace(sessionID)
-	if agentID == "" || sessionID == "" {
-		return []ConversationTurn{}, nil
-	}
-	caps, err := r.resolveCapabilities(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err := requireConversationTurnCapabilities(caps); err != nil {
-		return nil, err
-	}
-	query := `
-		SELECT
-			turn_id::text,
-			agent_id,
-			session_id::text,
-			COALESCE(runtime_mode, ''),
-			COALESCE(scope_key, ''),
-			COALESCE(entity_id::text, ''),
-			COALESCE(trigger_event_id::text, ''),
-			COALESCE(trigger_event_type, ''),
-			COALESCE(task_id, ''),
-			COALESCE(available_tools, '[]'::jsonb),
-			COALESCE(tool_calls, '[]'::jsonb),
-			COALESCE(emitted_events, '[]'::jsonb),
-			COALESCE(mcp_servers, '{}'::jsonb),
-			COALESCE(mcp_tools_listed, '[]'::jsonb),
-			COALESCE(mcp_tools_visible, '[]'::jsonb),
-			COALESCE(request_payload, '{}'::jsonb),
-			COALESCE(response_payload, '{}'::jsonb),
-			COALESCE(turn_blocks, '[]'::jsonb),
-			parse_ok,
-			COALESCE(latency_ms, 0),
-			COALESCE(retry_count, 0),
-			COALESCE(error, ''),
-			created_at
-		FROM agent_turns
-		WHERE agent_id = $1
-		  AND session_id = $2::uuid
-		ORDER BY created_at ASC, turn_id ASC
-	`
-	if !caps.Conversations.TurnBlocks {
-		query = `
-		SELECT
-			turn_id::text,
-			agent_id,
-			session_id::text,
-			COALESCE(runtime_mode, ''),
-			COALESCE(scope_key, ''),
-			COALESCE(entity_id::text, ''),
-			COALESCE(trigger_event_id::text, ''),
-			COALESCE(trigger_event_type, ''),
-			COALESCE(task_id, ''),
-			COALESCE(available_tools, '[]'::jsonb),
-			COALESCE(tool_calls, '[]'::jsonb),
-			COALESCE(emitted_events, '[]'::jsonb),
-			COALESCE(mcp_servers, '{}'::jsonb),
-			COALESCE(mcp_tools_listed, '[]'::jsonb),
-			COALESCE(mcp_tools_visible, '[]'::jsonb),
-			COALESCE(request_payload, '{}'::jsonb),
-			COALESCE(response_payload, '{}'::jsonb),
-			'[]'::jsonb AS turn_blocks,
-			parse_ok,
-			COALESCE(latency_ms, 0),
-			COALESCE(retry_count, 0),
-			COALESCE(error, ''),
-			created_at
-		FROM agent_turns
-		WHERE agent_id = $1
-		  AND session_id = $2::uuid
-		ORDER BY created_at ASC, turn_id ASC
-		`
-	}
-	rows, err := r.db.QueryContext(ctx, query, agentID, sessionID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	out := []ConversationTurn{}
-	for rows.Next() {
-		item, err := scanConversationTurn(rows)
-		if err != nil {
-			return nil, err
+		if turnErr := requireConversationTurnCapabilities(caps); turnErr != nil {
+			return ConversationDetail{}, false, turnErr
 		}
-		assistantText, outcome, reasoning, progress, toolResults, err := summarizeConversationTurnBlocks(item.TurnBlocks)
-		if err != nil {
-			return nil, fmt.Errorf("summarize conversation turn blocks: %w", err)
-		}
-		item.AssistantVisibleOutput = assistantText
-		item.Outcome = outcome
-		item.ReasoningBlocks = reasoning
-		item.ProgressUpdates = progress
-		item.ToolResults = toolResults
-		out = append(out, item)
+		return ConversationDetail{}, false, err
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return out, nil
+	return conversationDetailFromOperator(item), ok, nil
 }
 
 func (r *SQLConversationReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
@@ -394,146 +111,193 @@ func (r *SQLConversationReader) resolveCapabilities(ctx context.Context) (store.
 	return r.capSource.ResolveSchemaCapabilities(ctx)
 }
 
-func conversationQuerySources(caps store.StoreSchemaCapabilities) []string {
-	sources := []string{}
-	if caps.Conversations.Sessions == store.SchemaFlavorCanonical {
-		sources = append(sources, `
-			SELECT
-				session_id::text AS session_id,
-				agent_id,
-				'live_session' AS kind,
-				scope_key,
-				scope,
-				runtime_mode,
-				status,
-				turn_count,
-				runtime_state,
-				conversation,
-				updated_at,
-				created_at
-			FROM agent_sessions
-			WHERE status = 'active'
-			  AND runtime_mode IN ('session', 'session_per_entity')
-		`)
+func conversationSummaryFromOperator(item store.OperatorConversationSummary) ConversationSummary {
+	return ConversationSummary{
+		SessionID:   strings.TrimSpace(item.SessionID),
+		AgentID:     strings.TrimSpace(item.AgentID),
+		Kind:        strings.TrimSpace(item.Kind),
+		ScopeKey:    strings.TrimSpace(item.ScopeKey),
+		Scope:       strings.TrimSpace(item.Scope),
+		RuntimeMode: strings.TrimSpace(item.RuntimeMode),
+		Status:      strings.TrimSpace(item.Status),
+		TurnCount:   item.TurnCount,
+		Summary:     strings.TrimSpace(item.Summary),
+		UpdatedAt:   formatTime(item.UpdatedAt),
+		Metadata:    conversationMetadataFromOperator(item.Metadata),
 	}
-	if taskSource := store.CanonicalTaskConversationVisibilitySourceSQL(caps.Conversations); taskSource != "" {
-		sources = append(sources, fmt.Sprintf(`
-			SELECT
-				session_id,
-				agent_id,
-				'turn_audit' AS kind,
-				scope_key,
-				scope,
-				runtime_mode,
-				status,
-				turn_count,
-				runtime_state,
-				conversation,
-				updated_at,
-				created_at
-			FROM (
-				%s
-			) task_conversations
-		`, taskSource))
-	}
-	return sources
 }
 
-func scanConversationTurn(scanner rowScanner) (ConversationTurn, error) {
-	var (
-		item                                  ConversationTurn
-		availableToolsRaw, toolCallsRaw       []byte
-		emittedEventsRaw, mcpServersRaw       []byte
-		mcpToolsListedRaw, mcpToolsVisibleRaw []byte
-		requestPayloadRaw, responsePayloadRaw []byte
-		turnBlocksRaw                         []byte
-		createdAt                             time.Time
-	)
-	if err := scanner.Scan(
-		&item.TurnID,
-		&item.AgentID,
-		&item.SessionID,
-		&item.RuntimeMode,
-		&item.ScopeKey,
-		&item.EntityID,
-		&item.TriggerEventID,
-		&item.TriggerEventType,
-		&item.TaskID,
-		&availableToolsRaw,
-		&toolCallsRaw,
-		&emittedEventsRaw,
-		&mcpServersRaw,
-		&mcpToolsListedRaw,
-		&mcpToolsVisibleRaw,
-		&requestPayloadRaw,
-		&responsePayloadRaw,
-		&turnBlocksRaw,
-		&item.ParseOK,
-		&item.LatencyMS,
-		&item.RetryCount,
-		&item.Error,
-		&createdAt,
-	); err != nil {
-		return ConversationTurn{}, err
+func conversationDetailFromOperator(item store.OperatorConversationDetail) ConversationDetail {
+	out := ConversationDetail{
+		AgentID:      strings.TrimSpace(item.Conversation.AgentID),
+		SessionID:    strings.TrimSpace(item.Conversation.SessionID),
+		Kind:         strings.TrimSpace(item.Conversation.Kind),
+		ScopeKey:     strings.TrimSpace(item.Conversation.ScopeKey),
+		Scope:        strings.TrimSpace(item.Conversation.Scope),
+		RuntimeMode:  strings.TrimSpace(item.Conversation.RuntimeMode),
+		Status:       strings.TrimSpace(item.Conversation.Status),
+		TurnCount:    item.Conversation.TurnCount,
+		Summary:      strings.TrimSpace(item.Conversation.Summary),
+		UpdatedAt:    formatTime(item.Conversation.UpdatedAt),
+		Messages:     conversationMessagesFromOperator(item.Messages),
+		RuntimeState: conversationStateFromOperator(item.RuntimeState),
 	}
-	item.CreatedAt = createdAt.Format(time.RFC3339Nano)
-	var err error
-	summary, hasSummary, err := decodeTurnSummaryProjection(turnBlocksRaw)
-	if err != nil {
-		return ConversationTurn{}, err
+	out.Turns = make([]ConversationTurn, 0, len(item.Turns))
+	for _, turn := range item.Turns {
+		out.Turns = append(out.Turns, conversationTurnFromOperator(turn))
 	}
-	if item.AvailableTools, err = decodeJSONArray[string](availableToolsRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn available_tools: %w", err)
+	if out.Messages == nil {
+		out.Messages = []ConversationMessage{}
 	}
-	if item.ToolCalls, err = decodeJSONArray[ConversationToolCall](toolCallsRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn tool_calls: %w", err)
-	}
-	if item.EmittedEvents, err = decodeJSONArray[string](emittedEventsRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn emitted_events: %w", err)
-	}
-	if item.MCPToolsListed, err = decodeJSONArray[string](mcpToolsListedRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn mcp_tools_listed: %w", err)
-	}
-	if item.MCPToolsVisible, err = decodeJSONArray[string](mcpToolsVisibleRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn mcp_tools_visible: %w", err)
-	}
-	if item.MCPServers, err = decodeJSONStringMap(mcpServersRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn mcp_servers: %w", err)
-	}
-	if item.RequestPayload, err = decodeJSONObjectRaw(requestPayloadRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn request_payload: %w", err)
-	}
-	if item.ResponsePayload, err = decodeJSONObjectRaw(responsePayloadRaw); err != nil {
-		return ConversationTurn{}, fmt.Errorf("decode turn response_payload: %w", err)
-	}
-	if len(turnBlocksRaw) > 0 {
-		if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocksJSON(turnBlocksRaw); err != nil {
-			return ConversationTurn{}, fmt.Errorf("decode canonical runtime_log turn_blocks: %w", err)
-		}
-		if item.TurnBlocks, err = decodeJSONArray[ConversationTurnBlock](turnBlocksRaw); err != nil {
-			return ConversationTurn{}, fmt.Errorf("decode turn turn_blocks: %w", err)
-		}
-	}
-	if hasSummary {
-		item.AssistantVisibleOutput, item.Outcome, item.ReasoningBlocks, item.ProgressUpdates, item.ToolResults = projectedTurnSummaryConversationFields(summary)
-	}
-	return item, nil
+	return out
 }
 
-func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, string, []string, []string, []ConversationToolResult, error) {
-	raw, err := json.Marshal(blocks)
-	if err != nil {
-		return "", "", nil, nil, nil, err
+func conversationMetadataFromOperator(item store.OperatorConversationSummaryMetadata) ConversationSummaryMetadata {
+	return ConversationSummaryMetadata{
+		ProviderSessionID:    strings.TrimSpace(item.ProviderSessionID),
+		RetryReason:          strings.TrimSpace(item.RetryReason),
+		RetriesFromSessionID: strings.TrimSpace(item.RetriesFromSessionID),
+		Watchdog:             conversationWatchdogFromOperator(item.Watchdog),
+		LiveTurn:             dashboardLiveTurn(item.LiveTurn),
 	}
-	summary, ok, err := decodeTurnSummaryProjection(raw)
-	if err != nil {
-		return "", "", nil, nil, nil, err
+}
+
+func conversationStateFromOperator(item store.OperatorConversationState) ConversationRuntimeState {
+	out := ConversationRuntimeState{
+		Summary:              strings.TrimSpace(item.Summary),
+		ProviderSessionID:    strings.TrimSpace(item.ProviderSessionID),
+		RetryReason:          strings.TrimSpace(item.RetryReason),
+		RetriesFromSessionID: strings.TrimSpace(item.RetriesFromSessionID),
+		Watchdog:             conversationWatchdogFromOperator(item.Watchdog),
 	}
-	if !ok {
-		return "", "", nil, nil, nil, nil
+	if item.LastTurn != nil {
+		out.LastTurn = &ConversationRuntimeLastTurn{
+			TaskID:  strings.TrimSpace(item.LastTurn.TaskID),
+			ParseOK: item.LastTurn.ParseOK,
+		}
 	}
-	assistant, outcome, reasoning, progress, toolResults := projectedTurnSummaryConversationFields(summary)
-	return assistant, outcome, reasoning, progress, toolResults, nil
+	return out
+}
+
+func conversationWatchdogFromOperator(item *store.OperatorConversationWatchdog) *ConversationRuntimeWatchdog {
+	if item == nil {
+		return nil
+	}
+	return &ConversationRuntimeWatchdog{
+		State:         strings.TrimSpace(item.State),
+		BlockingLayer: strings.TrimSpace(item.BlockingLayer),
+		Action:        strings.TrimSpace(item.Action),
+		Outcome:       strings.TrimSpace(item.Outcome),
+		LastOutputAt:  strings.TrimSpace(item.LastOutputAt),
+		RecordedAt:    strings.TrimSpace(item.RecordedAt),
+	}
+}
+
+func conversationMessagesFromOperator(items []store.OperatorConversationMessage) []ConversationMessage {
+	if len(items) == 0 {
+		return []ConversationMessage{}
+	}
+	out := make([]ConversationMessage, 0, len(items))
+	for _, item := range items {
+		out = append(out, ConversationMessage{Role: strings.TrimSpace(item.Role), Content: item.Content})
+	}
+	return out
+}
+
+func conversationTurnFromOperator(item store.OperatorConversationTurn) ConversationTurn {
+	return ConversationTurn{
+		TurnID:                 strings.TrimSpace(item.TurnID),
+		AgentID:                strings.TrimSpace(item.AgentID),
+		SessionID:              strings.TrimSpace(item.SessionID),
+		RuntimeMode:            strings.TrimSpace(item.RuntimeMode),
+		ScopeKey:               strings.TrimSpace(item.ScopeKey),
+		EntityID:               strings.TrimSpace(item.EntityID),
+		TriggerEventID:         strings.TrimSpace(item.TriggerEventID),
+		TriggerEventType:       strings.TrimSpace(item.TriggerEventType),
+		TaskID:                 strings.TrimSpace(item.TaskID),
+		AvailableTools:         append([]string(nil), item.AvailableTools...),
+		ToolCalls:              conversationToolCallsFromOperator(item.ToolCalls),
+		ToolResults:            conversationToolResultsFromOperator(item.ToolResults),
+		TurnBlocks:             conversationTurnBlocksFromOperator(item.TurnBlocks),
+		EmittedEvents:          append([]string(nil), item.EmittedEvents...),
+		MCPServers:             cloneStringMap(item.MCPServers),
+		MCPToolsListed:         append([]string(nil), item.MCPToolsListed...),
+		MCPToolsVisible:        append([]string(nil), item.MCPToolsVisible...),
+		RequestPayload:         appendJSONRaw(item.RequestPayload),
+		ResponsePayload:        appendJSONRaw(item.ResponsePayload),
+		AssistantVisibleOutput: strings.TrimSpace(item.AssistantVisibleOutput),
+		ReasoningBlocks:        append([]string(nil), item.ReasoningBlocks...),
+		ProgressUpdates:        append([]string(nil), item.ProgressUpdates...),
+		Outcome:                strings.TrimSpace(item.Outcome),
+		ParseOK:                item.ParseOK,
+		LatencyMS:              item.LatencyMS,
+		RetryCount:             item.RetryCount,
+		Error:                  strings.TrimSpace(item.Error),
+		CreatedAt:              formatTime(item.CreatedAt),
+	}
+}
+
+func conversationToolCallsFromOperator(items []store.OperatorConversationToolCall) []ConversationToolCall {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ConversationToolCall, 0, len(items))
+	for _, item := range items {
+		out = append(out, ConversationToolCall{Name: strings.TrimSpace(item.Name), Arguments: appendJSONRaw(item.Arguments)})
+	}
+	return out
+}
+
+func conversationToolResultsFromOperator(items []store.OperatorConversationToolResult) []ConversationToolResult {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ConversationToolResult, 0, len(items))
+	for _, item := range items {
+		out = append(out, ConversationToolResult{
+			ToolName:  strings.TrimSpace(item.ToolName),
+			ToolUseID: strings.TrimSpace(item.ToolUseID),
+			Output:    appendJSONRaw(item.Output),
+		})
+	}
+	return out
+}
+
+func conversationTurnBlocksFromOperator(items []store.OperatorConversationTurnBlock) []ConversationTurnBlock {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ConversationTurnBlock, 0, len(items))
+	for _, item := range items {
+		out = append(out, ConversationTurnBlock{
+			Kind:     strings.TrimSpace(item.Kind),
+			Title:    strings.TrimSpace(item.Title),
+			Text:     item.Text,
+			ToolName: strings.TrimSpace(item.ToolName),
+			Input:    appendJSONRaw(item.Input),
+			Output:   appendJSONRaw(item.Output),
+			Data:     appendJSONRaw(item.Data),
+		})
+	}
+	return out
+}
+
+func appendJSONRaw(in []byte) []byte {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]byte(nil), in...)
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func readString(value any) string {

--- a/internal/dashboard/server/read_model_projection.go
+++ b/internal/dashboard/server/read_model_projection.go
@@ -94,6 +94,22 @@ func projectedTurnSummaryConversationFields(p runtimellm.TurnSummaryTurnBlockDat
 	return p.AssistantVisibleOutput, p.Outcome, cloneStringSlice(p.ReasoningBlocks), cloneStringSlice(p.ProgressUpdates), projectedTurnSummaryToolResultsTransport(p)
 }
 
+func summarizeConversationTurnBlocks(blocks []ConversationTurnBlock) (string, string, []string, []string, []ConversationToolResult, error) {
+	raw, err := json.Marshal(blocks)
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	summary, ok, err := decodeTurnSummaryProjection(raw)
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	if !ok {
+		return "", "", nil, nil, nil, nil
+	}
+	assistant, outcome, reasoning, progress, toolResults := projectedTurnSummaryConversationFields(summary)
+	return assistant, outcome, reasoning, progress, toolResults, nil
+}
+
 func projectedTurnSummaryToolResultsTransport(p runtimellm.TurnSummaryTurnBlockData) []ConversationToolResult {
 	if len(p.ToolResults) == 0 {
 		return nil

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -23,6 +23,11 @@ type AgentReader interface {
 	LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error)
 }
 
+type canonicalAgentReader interface {
+	ListOperatorAgents(ctx context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
+	LoadOperatorAgent(ctx context.Context, agentID string) (store.OperatorAgentDetail, error)
+}
+
 type MailboxReader interface {
 	ListMailboxItems(ctx context.Context, status string, limit int) ([]runtimetools.MailboxItem, error)
 	GetMailboxItem(ctx context.Context, id string) (runtimetools.MailboxItem, error)
@@ -165,6 +170,11 @@ type ConversationTurnBlock struct {
 type ConversationReader interface {
 	List(ctx context.Context, limit int) ([]ConversationSummary, error)
 	Get(ctx context.Context, sessionID string) (ConversationDetail, bool, error)
+}
+
+type canonicalConversationReader interface {
+	ListOperatorConversations(ctx context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
+	LoadOperatorConversation(ctx context.Context, sessionID string) (store.OperatorConversationDetail, error)
 }
 
 type ObservabilityReader interface {
@@ -411,33 +421,29 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleAgents(w http.ResponseWriter, r *http.Request) {
-	if h.agents == nil {
+	reader, ok := h.agents.(canonicalAgentReader)
+	if h.agents == nil || !ok {
 		writeJSONError(w, http.StatusNotImplemented, errors.New("agents reader is not configured"))
 		return
 	}
-	if richer, ok := h.agents.(genericAgentProvider); ok {
-		rows, err := richer.ListGenericAgents(r.Context())
-		if err != nil {
-			writeJSONError(w, http.StatusInternalServerError, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]any{"agents": rows})
-		return
-	}
-	rows, err := h.agents.LoadAgents(r.Context())
+	result, err := reader.ListOperatorAgents(r.Context(), store.OperatorAgentListOptions{
+		Flow: strings.TrimSpace(r.URL.Query().Get("flow")),
+		Role: strings.TrimSpace(r.URL.Query().Get("role")),
+	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}
-	out := make([]genericAgent, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, toGenericAgent(row))
+	out := make([]genericAgent, 0, len(result.Agents))
+	for _, row := range result.Agents {
+		out = append(out, genericAgentFromOperatorSummary(row))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"agents": out})
 }
 
 func (h *Handler) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
-	if h.agents == nil {
+	reader, ok := h.agents.(canonicalAgentReader)
+	if h.agents == nil || !ok {
 		writeJSONError(w, http.StatusNotImplemented, errors.New("agents reader is not configured"))
 		return
 	}
@@ -446,32 +452,16 @@ func (h *Handler) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, errors.New("agent id is required"))
 		return
 	}
-	if richer, ok := h.agents.(genericAgentProvider); ok {
-		row, ok, err := richer.GetGenericAgent(r.Context(), id)
-		if err != nil {
-			writeJSONError(w, http.StatusInternalServerError, err)
-			return
-		}
-		if !ok {
+	row, err := reader.LoadOperatorAgent(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrAgentNotFound) {
 			writeJSONError(w, http.StatusNotFound, errors.New("agent not found"))
 			return
 		}
-		writeJSON(w, http.StatusOK, row)
-		return
-	}
-	rows, err := h.agents.LoadAgents(r.Context())
-	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}
-	for _, row := range rows {
-		if strings.TrimSpace(row.Config.ID) != id {
-			continue
-		}
-		writeJSON(w, http.StatusOK, toGenericAgent(row))
-		return
-	}
-	writeJSONError(w, http.StatusNotFound, errors.New("agent not found"))
+	writeJSON(w, http.StatusOK, genericAgentFromOperatorSummary(row.Agent))
 }
 
 func (h *Handler) handleAgentDirective(w http.ResponseWriter, r *http.Request) {
@@ -537,21 +527,31 @@ func (h *Handler) handleAgentReplay(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleConversations(w http.ResponseWriter, r *http.Request) {
-	if h.conversations == nil {
+	reader, ok := h.conversations.(canonicalConversationReader)
+	if h.conversations == nil || !ok {
 		writeJSONError(w, http.StatusNotImplemented, errors.New("conversation reader is not configured"))
 		return
 	}
-	limit := intQuery(r, "limit", 100)
-	rows, err := h.conversations.List(r.Context(), limit)
+	result, err := reader.ListOperatorConversations(r.Context(), store.OperatorConversationListOptions{
+		AgentID: strings.TrimSpace(r.URL.Query().Get("agent_id")),
+		RunID:   strings.TrimSpace(r.URL.Query().Get("run_id")),
+		Cursor:  strings.TrimSpace(r.URL.Query().Get("cursor")),
+		Limit:   intQuery(r, "limit", 100),
+	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
+	}
+	rows := make([]ConversationSummary, 0, len(result.Conversations))
+	for _, item := range result.Conversations {
+		rows = append(rows, conversationSummaryFromOperator(item))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"conversations": rows})
 }
 
 func (h *Handler) handleConversationDetail(w http.ResponseWriter, r *http.Request) {
-	if h.conversations == nil {
+	reader, ok := h.conversations.(canonicalConversationReader)
+	if h.conversations == nil || !ok {
 		writeJSONError(w, http.StatusNotImplemented, errors.New("conversation reader is not configured"))
 		return
 	}
@@ -560,16 +560,20 @@ func (h *Handler) handleConversationDetail(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusBadRequest, errors.New("session id is required"))
 		return
 	}
-	row, ok, err := h.conversations.Get(r.Context(), sessionID)
+	row, err := reader.LoadOperatorConversation(r.Context(), sessionID)
 	if err != nil {
+		if errors.Is(err, store.ErrSessionNotFound) {
+			writeJSONError(w, http.StatusNotFound, errors.New("conversation not found"))
+			return
+		}
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if !ok {
+	if strings.TrimSpace(row.Conversation.SessionID) == "" {
 		writeJSONError(w, http.StatusNotFound, errors.New("conversation not found"))
 		return
 	}
-	writeJSON(w, http.StatusOK, row)
+	writeJSON(w, http.StatusOK, conversationDetailFromOperator(row))
 }
 
 func (h *Handler) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -1045,6 +1049,71 @@ func toGenericAgent(row runtimemanager.PersistedAgent) genericAgent {
 		Subscriptions:   append([]string(nil), row.Config.Subscriptions...),
 		Permissions:     append([]string(nil), row.Config.Permissions...),
 		StartedAt:       formatTime(row.StartedAt),
+	}
+}
+
+func genericAgentFromOperatorSummary(row store.OperatorAgentSummary) genericAgent {
+	return genericAgent{
+		ID:                  strings.TrimSpace(row.AgentID),
+		Type:                strings.TrimSpace(row.Type),
+		Role:                strings.TrimSpace(row.Role),
+		Mode:                strings.TrimSpace(row.Mode),
+		Status:              firstString(strings.TrimSpace(row.DashboardStatus), strings.TrimSpace(row.Status)),
+		State:               strings.TrimSpace(row.DashboardState),
+		BlockingLayer:       strings.TrimSpace(row.BlockingLayer),
+		EntityID:            strings.TrimSpace(row.EntityID),
+		ParentAgentID:       strings.TrimSpace(row.ParentAgentID),
+		CoordinatorID:       strings.TrimSpace(row.CoordinatorID),
+		HiredBy:             strings.TrimSpace(row.HiredBy),
+		TemplateVersion:     strings.TrimSpace(row.TemplateVersion),
+		BudgetEnvelope:      row.BudgetEnvelope,
+		Subscriptions:       append([]string(nil), row.Subscriptions...),
+		Permissions:         append([]string(nil), row.Permissions...),
+		PendingEvents:       row.PendingEvents,
+		OldestPendingAgeSec: row.OldestPendingAgeSec,
+		InFlightTurn:        row.InFlightTurn,
+		InFlightSeconds:     row.InFlightSeconds,
+		LockOwner:           strings.TrimSpace(row.LockOwner),
+		LockExpiresAt:       formatTime(row.LockExpiresAt),
+		Failures24h:         row.Failures24h,
+		DeadLetters24h:      row.DeadLetters24h,
+		TurnCount:           row.TurnCount,
+		TurnLimit:           row.TurnLimit,
+		Turns24h:            row.Turns24h,
+		NearBreaker:         row.NearBreaker,
+		SessionID:           strings.TrimSpace(row.SessionID),
+		ProviderSessionID:   strings.TrimSpace(row.ProviderSessionID),
+		CurrentTaskID:       strings.TrimSpace(row.CurrentTaskID),
+		LastTool:            dashboardAgentLastTool(row.LastTool),
+		LiveTurn:            dashboardLiveTurn(row.LiveTurn),
+		StartedAt:           formatTime(row.StartedAt),
+	}
+}
+
+func dashboardAgentLastTool(item *store.OperatorAgentTool) *AgentLastTool {
+	if item == nil {
+		return nil
+	}
+	return &AgentLastTool{
+		Name:      strings.TrimSpace(item.Name),
+		ToolUseID: strings.TrimSpace(item.ToolUseID),
+		OK:        item.OK,
+		Result:    append(json.RawMessage(nil), item.Result...),
+	}
+}
+
+func dashboardLiveTurn(item *store.OperatorLiveTurn) *OperatorLiveTurn {
+	if item == nil {
+		return nil
+	}
+	return &OperatorLiveTurn{
+		TurnID:                 strings.TrimSpace(item.TurnID),
+		TaskID:                 strings.TrimSpace(item.TaskID),
+		ParseOK:                item.ParseOK,
+		AssistantVisibleOutput: strings.TrimSpace(item.AssistantVisibleOutput),
+		Outcome:                strings.TrimSpace(item.Outcome),
+		ProgressUpdates:        append([]string(nil), item.ProgressUpdates...),
+		LastTool:               dashboardAgentLastTool(item.LastTool),
 	}
 }
 

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -55,6 +55,11 @@ func asString(v any) string {
 
 func ptrTime(v time.Time) *time.Time { return &v }
 
+func parseTestTime(raw string) time.Time {
+	ts, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	return ts
+}
+
 func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 	return store.StoreSchemaCapabilities{
 		Events: store.EventSchemaCapabilities{
@@ -81,6 +86,51 @@ type stubAgents struct {
 
 func (s stubAgents) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
 	return s.rows, nil
+}
+
+func (s stubAgents) ListOperatorAgents(_ context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error) {
+	out := store.OperatorAgentListResult{Agents: []store.OperatorAgentSummary{}}
+	for _, row := range s.rows {
+		if opts.Role != "" && row.Config.Role != opts.Role {
+			continue
+		}
+		item := store.OperatorAgentSummary{
+			AgentID:          row.Config.ID,
+			Role:             row.Config.Role,
+			Type:             row.Config.Type,
+			ModelTier:        row.Config.ModelTier,
+			ConversationMode: row.Config.ConversationMode,
+			SessionScope:     row.Config.SessionScope,
+			Status:           row.Status,
+			Mode:             row.Config.Mode,
+			EntityID:         row.Config.EffectiveEntityID(),
+			ParentAgentID:    row.ParentAgentID,
+			CoordinatorID:    row.CoordinatorID,
+			HiredBy:          row.HiredBy,
+			TemplateVersion:  row.TemplateVersion,
+			BudgetEnvelope:   row.Config.BudgetEnvelope,
+			Subscriptions:    append([]string(nil), row.Config.Subscriptions...),
+			Permissions:      append([]string(nil), row.Config.Permissions...),
+			StartedAt:        row.StartedAt,
+			DashboardStatus:  row.Status,
+			DashboardState:   row.Status,
+		}
+		out.Agents = append(out.Agents, item)
+	}
+	return out, nil
+}
+
+func (s stubAgents) LoadOperatorAgent(ctx context.Context, agentID string) (store.OperatorAgentDetail, error) {
+	result, err := s.ListOperatorAgents(ctx, store.OperatorAgentListOptions{})
+	if err != nil {
+		return store.OperatorAgentDetail{}, err
+	}
+	for _, row := range result.Agents {
+		if row.AgentID == agentID {
+			return store.OperatorAgentDetail{Agent: row}, nil
+		}
+	}
+	return store.OperatorAgentDetail{}, store.ErrAgentNotFound
 }
 
 type stubMailbox struct {
@@ -182,6 +232,86 @@ func (s stubConversations) List(context.Context, int) ([]ConversationSummary, er
 func (s stubConversations) Get(_ context.Context, sessionID string) (ConversationDetail, bool, error) {
 	item, ok := s.bySession[sessionID]
 	return item, ok, nil
+}
+
+func (s stubConversations) ListOperatorConversations(_ context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error) {
+	limit := opts.Limit
+	if limit <= 0 || limit > len(s.list) {
+		limit = len(s.list)
+	}
+	out := store.OperatorConversationListResult{Conversations: []store.OperatorConversationSummary{}}
+	for _, row := range s.list[:limit] {
+		out.Conversations = append(out.Conversations, store.OperatorConversationSummary{
+			SessionID:   row.SessionID,
+			AgentID:     row.AgentID,
+			Kind:        row.Kind,
+			ScopeKey:    row.ScopeKey,
+			Scope:       row.Scope,
+			RuntimeMode: row.RuntimeMode,
+			Status:      row.Status,
+			TurnCount:   row.TurnCount,
+			Summary:     row.Summary,
+			UpdatedAt:   parseTestTime(row.UpdatedAt),
+			Metadata: store.OperatorConversationSummaryMetadata{
+				ProviderSessionID:    row.Metadata.ProviderSessionID,
+				RetryReason:          row.Metadata.RetryReason,
+				RetriesFromSessionID: row.Metadata.RetriesFromSessionID,
+			},
+		})
+	}
+	return out, nil
+}
+
+func (s stubConversations) LoadOperatorConversation(_ context.Context, sessionID string) (store.OperatorConversationDetail, error) {
+	item, ok := s.bySession[sessionID]
+	if !ok {
+		return store.OperatorConversationDetail{}, store.ErrSessionNotFound
+	}
+	out := store.OperatorConversationDetail{
+		Conversation: store.OperatorConversationSummary{
+			SessionID:   item.SessionID,
+			AgentID:     item.AgentID,
+			Kind:        item.Kind,
+			ScopeKey:    item.ScopeKey,
+			Scope:       item.Scope,
+			RuntimeMode: item.RuntimeMode,
+			Status:      item.Status,
+			TurnCount:   item.TurnCount,
+			Summary:     item.Summary,
+			UpdatedAt:   parseTestTime(item.UpdatedAt),
+		},
+		Messages: []store.OperatorConversationMessage{},
+		Turns:    []store.OperatorConversationTurn{},
+		RuntimeState: store.OperatorConversationState{
+			Summary: item.RuntimeState.Summary,
+		},
+	}
+	for _, msg := range item.Messages {
+		out.Messages = append(out.Messages, store.OperatorConversationMessage{Role: msg.Role, Content: msg.Content})
+	}
+	for _, turn := range item.Turns {
+		out.Turns = append(out.Turns, store.OperatorConversationTurn{
+			TurnID:                 turn.TurnID,
+			AgentID:                turn.AgentID,
+			SessionID:              turn.SessionID,
+			AssistantVisibleOutput: turn.AssistantVisibleOutput,
+			ParseOK:                turn.ParseOK,
+		})
+	}
+	if item.RuntimeState.LastTurn != nil {
+		out.RuntimeState.LastTurn = &store.OperatorConversationLastTurn{TaskID: item.RuntimeState.LastTurn.TaskID, ParseOK: item.RuntimeState.LastTurn.ParseOK}
+	}
+	if item.RuntimeState.Watchdog != nil {
+		out.RuntimeState.Watchdog = &store.OperatorConversationWatchdog{
+			State:         item.RuntimeState.Watchdog.State,
+			BlockingLayer: item.RuntimeState.Watchdog.BlockingLayer,
+			Action:        item.RuntimeState.Watchdog.Action,
+			Outcome:       item.RuntimeState.Watchdog.Outcome,
+			LastOutputAt:  item.RuntimeState.Watchdog.LastOutputAt,
+			RecordedAt:    item.RuntimeState.Watchdog.RecordedAt,
+		}
+	}
+	return out, nil
 }
 
 type stubObservability struct {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -76,6 +76,13 @@ func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 	}
 }
 
+func canonicalAgentProjectionColumns() []string {
+	return []string{
+		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+		"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+	}
+}
+
 func setOperatorAuth(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+testOperatorAuthToken)
 }
@@ -1368,10 +1375,8 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	]`
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(turnBlocksPayload)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1432,10 +1437,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
@@ -1467,10 +1470,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
@@ -1503,10 +1504,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResul
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
 		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
@@ -1545,10 +1544,8 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-7", 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, 0, "turn-7", "task-7", false, []byte(`[]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, 0, "turn-7", "task-7", false, "", time.Now(), []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1608,10 +1605,8 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -1662,10 +1657,8 @@ func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenD
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "sess-1", 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1710,10 +1703,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutOperatorProjection(t
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent operator projection") {
 		t.Fatalf("expected missing agent operator projection error, got %v", err)
@@ -1832,10 +1822,8 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
-		WillReturnRows(sqlmock.NewRows([]string{
-			"agent_id", "status", "session_id", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-			"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "turn_blocks",
-		}).AddRow("agent-1", "active", "", 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, []byte(`[]`)))
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
 		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -14,9 +14,15 @@ var ErrInvalidObservabilityCursor = errors.New("store: invalid observability cur
 
 var ErrEntityNotFound = errors.New("store: entity not found")
 
+var ErrAgentNotFound = errors.New("store: agent not found")
+
+var ErrSessionNotFound = errors.New("store: session not found")
+
 var ErrAmbiguousEntityRunID = errors.New("store: ambiguous entity run_id")
 
 var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")
+
+var ErrInvalidConversationCursor = errors.New("store: invalid conversation cursor")
 
 var ErrInvalidEntityReadParam = errors.New("store: invalid entity read parameter")
 

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -1,0 +1,1655 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimellm "swarm/internal/runtime/llm"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimesessions "swarm/internal/runtime/sessions"
+)
+
+type OperatorAgentConversationReadSource interface {
+	OperatorConversationReadSource
+	LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error)
+	ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]PendingAgentDeliveryFacts, error)
+	ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]AgentLifecycleFacts, error)
+}
+
+type OperatorConversationReadSource interface {
+	ResolveSchemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error)
+}
+
+type OperatorAgentConversationReadSurface struct {
+	db        *sql.DB
+	source    OperatorAgentConversationReadSource
+	capSource OperatorConversationReadSource
+	turnLimit int
+}
+
+func NewOperatorAgentConversationReadSurface(db *sql.DB, source OperatorAgentConversationReadSource, turnLimit int) *OperatorAgentConversationReadSurface {
+	if db == nil || source == nil {
+		return nil
+	}
+	return &OperatorAgentConversationReadSurface{db: db, source: source, capSource: source, turnLimit: maxStoreInt(turnLimit, 0)}
+}
+
+func NewOperatorConversationReadSurface(db *sql.DB, source OperatorConversationReadSource) *OperatorAgentConversationReadSurface {
+	if db == nil || source == nil {
+		return nil
+	}
+	return &OperatorAgentConversationReadSurface{db: db, capSource: source}
+}
+
+type OperatorAgentListOptions struct {
+	Flow string
+	Role string
+}
+
+type OperatorAgentListResult struct {
+	Agents []OperatorAgentSummary `json:"agents"`
+}
+
+type OperatorAgentSummary struct {
+	AgentID          string `json:"agent_id"`
+	Role             string `json:"role"`
+	Type             string `json:"type"`
+	ModelTier        string `json:"model_tier"`
+	ConversationMode string `json:"conversation_mode"`
+	SessionScope     string `json:"session_scope"`
+	Status           string `json:"status"`
+
+	Mode                string              `json:"-"`
+	FlowInstance        string              `json:"-"`
+	EntityID            string              `json:"-"`
+	ParentAgentID       string              `json:"-"`
+	CoordinatorID       string              `json:"-"`
+	HiredBy             string              `json:"-"`
+	TemplateVersion     string              `json:"-"`
+	BudgetEnvelope      float64             `json:"-"`
+	Subscriptions       []string            `json:"-"`
+	Permissions         []string            `json:"-"`
+	PendingEvents       int                 `json:"-"`
+	OldestPendingAgeSec int                 `json:"-"`
+	InFlightTurn        bool                `json:"-"`
+	InFlightSeconds     int                 `json:"-"`
+	LockOwner           string              `json:"-"`
+	LockExpiresAt       time.Time           `json:"-"`
+	Failures24h         int                 `json:"-"`
+	DeadLetters24h      int                 `json:"-"`
+	TurnCount           int                 `json:"-"`
+	TurnLimit           int                 `json:"-"`
+	Turns24h            int                 `json:"-"`
+	NearBreaker         bool                `json:"-"`
+	SessionID           string              `json:"-"`
+	ProviderSessionID   string              `json:"-"`
+	CurrentTaskID       string              `json:"-"`
+	LastTool            *OperatorAgentTool  `json:"-"`
+	LiveTurn            *OperatorLiveTurn   `json:"-"`
+	StartedAt           time.Time           `json:"-"`
+	DashboardStatus     string              `json:"-"`
+	DashboardState      string              `json:"-"`
+	BlockingLayer       string              `json:"-"`
+	CurrentSessionRef   *OperatorSessionRef `json:"-"`
+	LastTurnRef         *OperatorTurnRef    `json:"-"`
+}
+
+type OperatorSessionRef struct {
+	SessionID string    `json:"session_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+type OperatorTurnRef struct {
+	TurnID      string    `json:"turn_id"`
+	CompletedAt time.Time `json:"completed_at"`
+	ParseOK     bool      `json:"parse_ok"`
+	Error       string    `json:"error,omitempty"`
+}
+
+type OperatorAgentDetail struct {
+	Agent             OperatorAgentSummary `json:"agent"`
+	CurrentSessionRef *OperatorSessionRef  `json:"current_session_ref,omitempty"`
+	LastTurnRef       *OperatorTurnRef     `json:"last_turn_ref,omitempty"`
+}
+
+type OperatorAgentTool struct {
+	Name      string          `json:"name"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	OK        bool            `json:"ok"`
+	Result    json.RawMessage `json:"result,omitempty"`
+}
+
+type OperatorLiveTurn struct {
+	TurnID                 string             `json:"turn_id,omitempty"`
+	TaskID                 string             `json:"task_id,omitempty"`
+	ParseOK                bool               `json:"parse_ok"`
+	AssistantVisibleOutput string             `json:"assistant_visible_output,omitempty"`
+	Outcome                string             `json:"outcome,omitempty"`
+	ProgressUpdates        []string           `json:"progress_updates,omitempty"`
+	LastTool               *OperatorAgentTool `json:"last_tool,omitempty"`
+}
+
+type OperatorConversationListOptions struct {
+	AgentID string
+	RunID   string
+	Limit   int
+	Cursor  string
+}
+
+type OperatorConversationListResult struct {
+	Conversations []OperatorConversationSummary `json:"conversations"`
+	NextCursor    string                        `json:"next_cursor,omitempty"`
+}
+
+type OperatorConversationSummary struct {
+	SessionID    string     `json:"session_id"`
+	AgentID      string     `json:"agent_id"`
+	RunID        string     `json:"run_id,omitempty"`
+	StartedAt    time.Time  `json:"started_at"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	TurnCount    int        `json:"turn_count"`
+	MessageCount int        `json:"message_count"`
+	Status       string     `json:"status"`
+
+	Kind        string                              `json:"-"`
+	ScopeKey    string                              `json:"-"`
+	Scope       string                              `json:"-"`
+	RuntimeMode string                              `json:"-"`
+	Summary     string                              `json:"-"`
+	UpdatedAt   time.Time                           `json:"-"`
+	Metadata    OperatorConversationSummaryMetadata `json:"-"`
+}
+
+type OperatorConversationSummaryMetadata struct {
+	ProviderSessionID    string                        `json:"provider_session_id,omitempty"`
+	RetryReason          string                        `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string                        `json:"retries_from_session_id,omitempty"`
+	Watchdog             *OperatorConversationWatchdog `json:"watchdog,omitempty"`
+	LiveTurn             *OperatorLiveTurn             `json:"live_turn,omitempty"`
+}
+
+type OperatorConversationDetail struct {
+	Conversation OperatorConversationSummary `json:"conversation"`
+	Turns        []OperatorConversationTurn  `json:"turns"`
+
+	Messages     []OperatorConversationMessage `json:"-"`
+	RuntimeState OperatorConversationState     `json:"-"`
+}
+
+type OperatorConversationMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type OperatorConversationState struct {
+	Summary              string                        `json:"summary,omitempty"`
+	LastTurn             *OperatorConversationLastTurn `json:"last_turn,omitempty"`
+	ProviderSessionID    string                        `json:"provider_session_id,omitempty"`
+	RetryReason          string                        `json:"retry_reason,omitempty"`
+	RetriesFromSessionID string                        `json:"retries_from_session_id,omitempty"`
+	Watchdog             *OperatorConversationWatchdog `json:"watchdog,omitempty"`
+}
+
+type OperatorConversationLastTurn struct {
+	TaskID  string `json:"task_id,omitempty"`
+	ParseOK bool   `json:"parse_ok"`
+}
+
+type OperatorConversationWatchdog struct {
+	State         string `json:"state,omitempty"`
+	BlockingLayer string `json:"blocking_layer,omitempty"`
+	Action        string `json:"action,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	LastOutputAt  string `json:"last_output_at,omitempty"`
+	RecordedAt    string `json:"recorded_at,omitempty"`
+}
+
+type OperatorConversationTurn struct {
+	TurnID           string                          `json:"turn_id"`
+	TriggerEventID   string                          `json:"trigger_event_id"`
+	TriggerEventType string                          `json:"trigger_event_type"`
+	RequestPayload   json.RawMessage                 `json:"request_payload,omitempty"`
+	ResponsePayload  json.RawMessage                 `json:"response_payload,omitempty"`
+	ToolCalls        []OperatorConversationToolCall  `json:"tool_calls,omitempty"`
+	TurnBlocks       []OperatorConversationTurnBlock `json:"turn_blocks,omitempty"`
+	ParseOK          bool                            `json:"parse_ok"`
+	LatencyMS        int                             `json:"latency_ms"`
+	Error            string                          `json:"error,omitempty"`
+
+	AgentID                string                           `json:"-"`
+	SessionID              string                           `json:"-"`
+	RuntimeMode            string                           `json:"-"`
+	ScopeKey               string                           `json:"-"`
+	EntityID               string                           `json:"-"`
+	TaskID                 string                           `json:"-"`
+	AvailableTools         []string                         `json:"-"`
+	EmittedEvents          []string                         `json:"-"`
+	MCPServers             map[string]string                `json:"-"`
+	MCPToolsListed         []string                         `json:"-"`
+	MCPToolsVisible        []string                         `json:"-"`
+	AssistantVisibleOutput string                           `json:"-"`
+	ReasoningBlocks        []string                         `json:"-"`
+	ProgressUpdates        []string                         `json:"-"`
+	Outcome                string                           `json:"-"`
+	ToolResults            []OperatorConversationToolResult `json:"-"`
+	RetryCount             int                              `json:"-"`
+	CreatedAt              time.Time                        `json:"-"`
+}
+
+type OperatorConversationToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type OperatorConversationToolResult struct {
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
+}
+
+type OperatorConversationTurnBlock struct {
+	Kind     string          `json:"kind"`
+	Title    string          `json:"title,omitempty"`
+	Text     string          `json:"text,omitempty"`
+	ToolName string          `json:"tool_name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+	Output   json.RawMessage `json:"output,omitempty"`
+	Data     json.RawMessage `json:"data,omitempty"`
+}
+
+type operatorAgentProjection struct {
+	Status              string
+	LifecycleState      string
+	BlockingLayer       string
+	PendingEvents       int
+	OldestPendingAgeSec int
+	LockOwner           string
+	LockExpiresAt       time.Time
+	InFlightTurn        bool
+	InFlightSeconds     int
+	Failures24h         int
+	DeadLetters24h      int
+	TurnCount           int
+	Turns24h            int
+	SessionID           string
+	SessionStartedAt    time.Time
+	ProviderSessionID   string
+	CurrentTaskID       string
+	LastTool            *OperatorAgentTool
+	LiveTurn            *OperatorLiveTurn
+	LastTurnRef         *OperatorTurnRef
+}
+
+type conversationPositionCursor struct {
+	Kind      string `json:"kind"`
+	UpdatedAt string `json:"updated_at"`
+	SessionID string `json:"session_id"`
+}
+
+type operatorRowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (s *PostgresStore) ListOperatorAgents(ctx context.Context, opts OperatorAgentListOptions) (OperatorAgentListResult, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).ListOperatorAgents(ctx, opts)
+}
+
+func (s *PostgresStore) LoadOperatorAgent(ctx context.Context, agentID string) (OperatorAgentDetail, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgent(ctx, agentID)
+}
+
+func (s *PostgresStore) ListOperatorConversations(ctx context.Context, opts OperatorConversationListOptions) (OperatorConversationListResult, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).ListOperatorConversations(ctx, opts)
+}
+
+func (s *PostgresStore) LoadOperatorConversation(ctx context.Context, sessionID string) (OperatorConversationDetail, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorConversation(ctx, sessionID)
+}
+
+func (s *PostgresStore) LoadCurrentOperatorConversationForAgent(ctx context.Context, agentID string) (*OperatorConversationDetail, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadCurrentOperatorConversationForAgent(ctx, agentID)
+}
+
+func (r *OperatorAgentConversationReadSurface) ListOperatorAgents(ctx context.Context, opts OperatorAgentListOptions) (OperatorAgentListResult, error) {
+	if err := r.requireAgentCapabilities(ctx); err != nil {
+		return OperatorAgentListResult{}, err
+	}
+	opts.Flow = strings.Trim(strings.TrimSpace(opts.Flow), "/")
+	opts.Role = strings.TrimSpace(opts.Role)
+	baseRows, err := r.source.LoadAgents(ctx)
+	if err != nil {
+		return OperatorAgentListResult{}, err
+	}
+	projections, err := r.loadAgentOperatorProjections(ctx)
+	if err != nil {
+		return OperatorAgentListResult{}, err
+	}
+	agents := make([]OperatorAgentSummary, 0, len(baseRows))
+	for _, row := range baseRows {
+		if opts.Role != "" && strings.TrimSpace(row.Config.Role) != opts.Role {
+			continue
+		}
+		if opts.Flow != "" && !operatorAgentFlowMatches(row.Config.CanonicalFlowPath(), opts.Flow) {
+			continue
+		}
+		id := strings.TrimSpace(row.Config.ID)
+		projection, ok := projections[id]
+		if !ok {
+			return OperatorAgentListResult{}, fmt.Errorf("missing agent operator projection: %s", id)
+		}
+		agents = append(agents, operatorAgentSummaryFromPersisted(row, projection, r.turnLimit))
+	}
+	if agents == nil {
+		agents = []OperatorAgentSummary{}
+	}
+	return OperatorAgentListResult{Agents: agents}, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorAgent(ctx context.Context, agentID string) (OperatorAgentDetail, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return OperatorAgentDetail{}, ErrAgentNotFound
+	}
+	result, err := r.ListOperatorAgents(ctx, OperatorAgentListOptions{})
+	if err != nil {
+		return OperatorAgentDetail{}, err
+	}
+	for _, agent := range result.Agents {
+		if strings.TrimSpace(agent.AgentID) == agentID {
+			return OperatorAgentDetail{
+				Agent:             agent,
+				CurrentSessionRef: agent.CurrentSessionRef,
+				LastTurnRef:       agent.LastTurnRef,
+			}, nil
+		}
+	}
+	return OperatorAgentDetail{}, ErrAgentNotFound
+}
+
+func (r *OperatorAgentConversationReadSurface) ListOperatorConversations(ctx context.Context, opts OperatorConversationListOptions) (OperatorConversationListResult, error) {
+	if err := r.requireConversationCapabilities(ctx); err != nil {
+		return OperatorConversationListResult{}, err
+	}
+	opts, err := defaultOperatorConversationListOptions(opts)
+	if err != nil {
+		return OperatorConversationListResult{}, err
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return OperatorConversationListResult{}, err
+	}
+	if opts.RunID != "" && !caps.Conversations.SessionRunID && !caps.Conversations.AuditRunID {
+		return OperatorConversationListResult{}, fmt.Errorf("operator conversation read surface requires conversation run_id columns for run_id filtering")
+	}
+	sources := operatorConversationQuerySources(caps)
+	if len(sources) == 0 {
+		return OperatorConversationListResult{Conversations: []OperatorConversationSummary{}}, nil
+	}
+	args := make([]any, 0, 8)
+	where := []string{"TRUE"}
+	add := func(value any) int {
+		args = append(args, value)
+		return len(args)
+	}
+	if opts.AgentID != "" {
+		n := add(opts.AgentID)
+		where = append(where, fmt.Sprintf("conversations.agent_id = $%d", n))
+	}
+	if opts.RunID != "" {
+		n := add(opts.RunID)
+		where = append(where, fmt.Sprintf("conversations.run_id = $%d", n))
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeConversationPositionCursor(opts.Cursor, "conversation.list")
+		if err != nil {
+			return OperatorConversationListResult{}, err
+		}
+		updatedAt, err := time.Parse(time.RFC3339Nano, cursor.UpdatedAt)
+		if err != nil || strings.TrimSpace(cursor.SessionID) == "" {
+			return OperatorConversationListResult{}, ErrInvalidConversationCursor
+		}
+		nTime := add(updatedAt.UTC())
+		nSession := add(cursor.SessionID)
+		where = append(where, fmt.Sprintf(`(
+			conversations.updated_at < $%d
+			OR (conversations.updated_at = $%d AND conversations.session_id > $%d)
+		)`, nTime, nTime, nSession))
+	}
+	limitArg := add(opts.Limit + 1)
+	latestTurnBlocksExpr := `'[]'::jsonb`
+	if caps.Conversations.TurnBlocks {
+		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			conversations.session_id,
+			conversations.agent_id,
+			conversations.run_id,
+			conversations.kind,
+			COALESCE(conversations.scope_key, ''),
+			COALESCE(conversations.scope, ''),
+			COALESCE(conversations.runtime_mode, ''),
+			COALESCE(conversations.status, ''),
+			COALESCE(conversations.turn_count, 0),
+			COALESCE(conversations.message_count, 0),
+			COALESCE(conversations.runtime_state, '{}'::jsonb),
+			COALESCE(latest_turn.turn_id, ''),
+			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.turn_blocks, '[]'::jsonb),
+			conversations.started_at,
+			conversations.ended_at,
+			conversations.updated_at
+		FROM (
+			%s
+		) conversations
+		LEFT JOIN LATERAL (
+			SELECT
+				turn_id::text AS turn_id,
+				COALESCE(task_id, '') AS task_id,
+				parse_ok,
+				%s AS turn_blocks
+			FROM agent_turns
+			WHERE agent_id = conversations.agent_id
+			  AND session_id::text = conversations.session_id
+			ORDER BY created_at DESC, turn_id DESC
+			LIMIT 1
+		) latest_turn ON true
+		WHERE %s
+		ORDER BY conversations.updated_at DESC, conversations.session_id ASC
+		LIMIT $%d
+	`, strings.Join(sources, "\nUNION ALL\n"), latestTurnBlocksExpr, strings.Join(where, " AND "), limitArg), args...)
+	if err != nil {
+		return OperatorConversationListResult{}, fmt.Errorf("list operator conversations: %w", err)
+	}
+	defer rows.Close()
+	conversations := []OperatorConversationSummary{}
+	for rows.Next() {
+		item, err := scanOperatorConversationSummary(rows)
+		if err != nil {
+			return OperatorConversationListResult{}, err
+		}
+		conversations = append(conversations, item)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorConversationListResult{}, fmt.Errorf("read operator conversations: %w", err)
+	}
+	nextCursor := ""
+	if len(conversations) > opts.Limit {
+		conversations = conversations[:opts.Limit]
+		last := conversations[len(conversations)-1]
+		nextCursor = encodeConversationPositionCursor(conversationPositionCursor{
+			Kind:      "conversation.list",
+			UpdatedAt: last.UpdatedAt.UTC().Format(time.RFC3339Nano),
+			SessionID: last.SessionID,
+		})
+	}
+	if conversations == nil {
+		conversations = []OperatorConversationSummary{}
+	}
+	return OperatorConversationListResult{Conversations: conversations, NextCursor: nextCursor}, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorConversation(ctx context.Context, sessionID string) (OperatorConversationDetail, error) {
+	if err := r.requireConversationCapabilities(ctx); err != nil {
+		return OperatorConversationDetail{}, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return OperatorConversationDetail{}, ErrSessionNotFound
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return OperatorConversationDetail{}, err
+	}
+	sources := operatorConversationQuerySources(caps)
+	if len(sources) == 0 {
+		return OperatorConversationDetail{}, ErrSessionNotFound
+	}
+	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT
+			session_id,
+			agent_id,
+			run_id,
+			kind,
+			COALESCE(scope_key, ''),
+			COALESCE(scope, ''),
+			COALESCE(runtime_mode, ''),
+			COALESCE(status, ''),
+			COALESCE(turn_count, 0),
+			COALESCE(message_count, 0),
+			COALESCE(runtime_state, '{}'::jsonb),
+			COALESCE(conversation, '[]'::jsonb),
+			started_at,
+			ended_at,
+			updated_at
+		FROM (
+			%s
+		) conversations
+		WHERE session_id = $1
+		LIMIT 1
+	`, strings.Join(sources, "\nUNION ALL\n")), sessionID)
+	item, err := scanOperatorConversationDetail(row)
+	if err == sql.ErrNoRows {
+		return OperatorConversationDetail{}, ErrSessionNotFound
+	}
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("load operator conversation: %w", err)
+	}
+	item.Turns, err = r.loadConversationTurns(ctx, item.Conversation.AgentID, item.Conversation.SessionID)
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("load operator conversation turns: %w", err)
+	}
+	if item.Turns == nil {
+		item.Turns = []OperatorConversationTurn{}
+	}
+	return item, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) ListDashboardOperatorConversations(ctx context.Context, limit int) ([]OperatorConversationSummary, error) {
+	if err := r.requireConversationCapabilities(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sources := dashboardOperatorConversationQuerySources(caps)
+	latestTurnBlocksExpr := `'[]'::jsonb`
+	if caps.Conversations.TurnBlocks {
+		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			conversations.session_id,
+			conversations.agent_id,
+			conversations.kind,
+			COALESCE(conversations.scope_key, ''),
+			COALESCE(conversations.scope, ''),
+			COALESCE(conversations.runtime_mode, ''),
+			COALESCE(conversations.status, ''),
+			COALESCE(conversations.turn_count, 0),
+			COALESCE(conversations.runtime_state, '{}'::jsonb),
+			COALESCE(latest_turn.turn_id, ''),
+			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.turn_blocks, '[]'::jsonb),
+			conversations.updated_at
+		FROM (
+			%s
+		) conversations
+		LEFT JOIN LATERAL (
+			SELECT
+				turn_id::text AS turn_id,
+				COALESCE(task_id, '') AS task_id,
+				parse_ok,
+				%s AS turn_blocks
+			FROM agent_turns
+			WHERE agent_id = conversations.agent_id
+			  AND session_id::text = conversations.session_id
+			ORDER BY created_at DESC, turn_id DESC
+			LIMIT 1
+		) latest_turn ON true
+		ORDER BY updated_at DESC, agent_id ASC
+		LIMIT $1
+	`, strings.Join(sources, "\nUNION ALL\n"), latestTurnBlocksExpr), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list dashboard operator conversations: %w", err)
+	}
+	defer rows.Close()
+
+	out := []OperatorConversationSummary{}
+	for rows.Next() {
+		item, err := scanDashboardOperatorConversationSummary(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list dashboard operator conversations rows: %w", err)
+	}
+	return out, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadDashboardOperatorConversation(ctx context.Context, sessionID string) (OperatorConversationDetail, bool, error) {
+	if err := r.requireDashboardConversationSurfaceCapabilities(ctx); err != nil {
+		return OperatorConversationDetail{}, false, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return OperatorConversationDetail{}, false, nil
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return OperatorConversationDetail{}, false, err
+	}
+	sources := dashboardOperatorConversationQuerySources(caps)
+	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT
+			session_id,
+			agent_id,
+			kind,
+			COALESCE(scope_key, ''),
+			COALESCE(scope, ''),
+			COALESCE(runtime_mode, ''),
+			COALESCE(status, ''),
+			COALESCE(turn_count, 0),
+			COALESCE(runtime_state, '{}'::jsonb),
+			COALESCE(conversation, '[]'::jsonb),
+			updated_at
+		FROM (
+			%s
+		) conversations
+		WHERE session_id = $1
+		LIMIT 1
+	`, strings.Join(sources, "\nUNION ALL\n")), sessionID)
+
+	item, err := scanDashboardOperatorConversationDetail(row)
+	if err == sql.ErrNoRows {
+		return OperatorConversationDetail{}, false, nil
+	}
+	if err != nil {
+		return OperatorConversationDetail{}, false, fmt.Errorf("get dashboard operator conversation: %w", err)
+	}
+	item.Turns, err = r.loadConversationTurns(ctx, item.Conversation.AgentID, item.Conversation.SessionID)
+	if err != nil {
+		return OperatorConversationDetail{}, false, fmt.Errorf("load dashboard operator conversation turns: %w", err)
+	}
+	return item, true, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) requireDashboardConversationSurfaceCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil || r.capSource == nil {
+		return fmt.Errorf("operator conversation read surface requires postgres store")
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical && caps.Conversations.Audits != SchemaFlavorCanonical {
+		if caps.Conversations.Audits != SchemaFlavorUnavailable {
+			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
+		}
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadCurrentOperatorConversationForAgent(ctx context.Context, agentID string) (*OperatorConversationDetail, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, ErrAgentNotFound
+	}
+	if _, err := r.LoadOperatorAgent(ctx, agentID); err != nil {
+		return nil, err
+	}
+	result, err := r.ListOperatorConversations(ctx, OperatorConversationListOptions{AgentID: agentID, Limit: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Conversations) == 0 {
+		return nil, nil
+	}
+	detail, err := r.LoadOperatorConversation(ctx, result.Conversations[0].SessionID)
+	if err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) requireAgentCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil || r.source == nil {
+		return fmt.Errorf("operator agent read surface requires postgres store")
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
+	}
+	return RequireCanonicalPendingAgentDeliveryCapabilities(caps)
+}
+
+func (r *OperatorAgentConversationReadSurface) requireConversationCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil || r.capSource == nil {
+		return fmt.Errorf("operator conversation read surface requires postgres store")
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical && caps.Conversations.Audits != SchemaFlavorCanonical {
+		if caps.Conversations.Audits != SchemaFlavorUnavailable {
+			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
+		}
+		return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) resolveConversationCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
+	if r == nil || r.capSource == nil {
+		return StoreSchemaCapabilities{}, fmt.Errorf("operator conversation read surface requires schema capabilities")
+	}
+	return r.capSource.ResolveSchemaCapabilities(ctx)
+}
+
+func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx context.Context) (map[string]operatorAgentProjection, error) {
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	latestTurnBlocksExpr := `'[]'::jsonb`
+	if caps.Conversations.TurnBlocks {
+		latestTurnBlocksExpr = `COALESCE(turn_blocks, '[]'::jsonb)`
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			a.agent_id,
+			COALESCE(a.status, 'active'),
+			COALESCE(sess.session_id::text, ''),
+			COALESCE(sess.turn_count, 0),
+			COALESCE(sess.lease_holder, ''),
+			sess.lease_expires_at,
+			COALESCE(sess.runtime_state, '{}'::jsonb),
+			0,
+			0,
+			COALESCE(f.failures_24h, 0),
+			COALESCE(f.dead_letters_24h, 0),
+			0,
+			COALESCE(latest_turn.turn_id, ''),
+			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.turn_blocks, '[]'::jsonb)
+		FROM agents a
+		LEFT JOIN LATERAL (
+			SELECT
+				session_id,
+				turn_count,
+				lease_holder,
+				lease_expires_at,
+				runtime_state
+			FROM agent_sessions
+			WHERE agent_id = a.agent_id
+			  AND status = 'active'
+			  AND runtime_mode IN ($1, $2)
+			ORDER BY updated_at DESC, created_at DESC
+			LIMIT 1
+		) sess ON true
+		LEFT JOIN LATERAL (
+			SELECT
+				turn_id::text AS turn_id,
+				COALESCE(task_id, '') AS task_id,
+				parse_ok,
+				%s AS turn_blocks
+			FROM agent_turns
+			WHERE agent_id = a.agent_id
+			  AND sess.session_id IS NOT NULL
+			  AND session_id = sess.session_id
+			ORDER BY created_at DESC, turn_id DESC
+			LIMIT 1
+		) latest_turn ON true
+		LEFT JOIN LATERAL (
+			SELECT
+				COUNT(*) FILTER (WHERE status = 'failed')::int AS failures_24h,
+				COUNT(*) FILTER (WHERE status = 'dead_letter')::int AS dead_letters_24h
+			FROM event_deliveries
+			WHERE subscriber_type = 'agent'
+			  AND subscriber_id = a.agent_id
+			  AND COALESCE(delivered_at, created_at) >= now() - interval '24 hours'
+		) f ON true
+		WHERE a.status NOT IN ('terminated', 'ephemeral')
+		ORDER BY a.created_at ASC, a.agent_id ASC
+	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
+	if err != nil {
+		return nil, fmt.Errorf("query agent operator projections: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]operatorAgentProjection{}
+	agentIDs := make([]string, 0)
+	for rows.Next() {
+		var (
+			id              string
+			projection      operatorAgentProjection
+			lockExpiresAt   sql.NullTime
+			runtimeStateRaw []byte
+			latestTurnID    string
+			latestTaskID    string
+			latestParseOK   bool
+			latestTurnRaw   []byte
+		)
+		if err := rows.Scan(
+			&id,
+			&projection.Status,
+			&projection.SessionID,
+			&projection.TurnCount,
+			&projection.LockOwner,
+			&lockExpiresAt,
+			&runtimeStateRaw,
+			&projection.PendingEvents,
+			&projection.OldestPendingAgeSec,
+			&projection.Failures24h,
+			&projection.DeadLetters24h,
+			&projection.Turns24h,
+			&latestTurnID,
+			&latestTaskID,
+			&latestParseOK,
+			&latestTurnRaw,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent operator projection: %w", err)
+		}
+		if lockExpiresAt.Valid {
+			projection.LockExpiresAt = lockExpiresAt.Time
+			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(projection.LockOwner) != "" {
+				projection.InFlightTurn = true
+			}
+		}
+		if err := enrichOperatorAgentProjectionFromLatestTurn(&projection, runtimeStateRaw, latestTurnID, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
+			return nil, err
+		}
+		id = strings.TrimSpace(id)
+		out[id] = projection
+		agentIDs = append(agentIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read agent operator projection rows: %w", err)
+	}
+	factsByAgent, err := r.source.ListPendingAgentDeliveryFacts(ctx, agentIDs, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	lifecycleByAgent, err := r.source.ListAgentLifecycleFacts(ctx, agentIDs)
+	if err != nil {
+		return nil, err
+	}
+	for agentID, facts := range factsByAgent {
+		projection := out[strings.TrimSpace(agentID)]
+		projection.PendingEvents = facts.PendingCount
+		projection.OldestPendingAgeSec = facts.OldestPendingAgeSec
+		out[strings.TrimSpace(agentID)] = projection
+	}
+	for agentID, facts := range lifecycleByAgent {
+		projection := out[strings.TrimSpace(agentID)]
+		projection.LifecycleState = strings.TrimSpace(facts.CurrentState)
+		projection.BlockingLayer = strings.TrimSpace(facts.BlockingLayer)
+		out[strings.TrimSpace(agentID)] = projection
+	}
+	return out, nil
+}
+
+func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projection operatorAgentProjection, turnLimit int) OperatorAgentSummary {
+	mode := strings.TrimSpace(row.Config.ConversationMode)
+	if mode == "" {
+		mode = runtimesessions.RuntimeModeTask.String()
+	}
+	scope := strings.TrimSpace(row.Config.SessionScope)
+	if scope == "" {
+		scope = runtimesessions.SessionScopeGlobal.String()
+	}
+	out := OperatorAgentSummary{
+		AgentID:             strings.TrimSpace(row.Config.ID),
+		Role:                strings.TrimSpace(row.Config.Role),
+		Type:                agentPersistedType(row.Config, agentModelTier(row.Config)),
+		ModelTier:           agentModelTier(row.Config),
+		ConversationMode:    mode,
+		SessionScope:        scope,
+		Status:              projection.v1Status(),
+		Mode:                strings.TrimSpace(row.Config.Mode),
+		FlowInstance:        strings.TrimSpace(row.Config.CanonicalFlowPath()),
+		EntityID:            strings.TrimSpace(row.Config.EffectiveEntityID()),
+		ParentAgentID:       strings.TrimSpace(row.ParentAgentID),
+		CoordinatorID:       strings.TrimSpace(row.CoordinatorID),
+		HiredBy:             strings.TrimSpace(row.HiredBy),
+		TemplateVersion:     strings.TrimSpace(row.TemplateVersion),
+		BudgetEnvelope:      row.Config.BudgetEnvelope,
+		Subscriptions:       append([]string(nil), row.Config.Subscriptions...),
+		Permissions:         append([]string(nil), row.Config.Permissions...),
+		PendingEvents:       projection.PendingEvents,
+		OldestPendingAgeSec: projection.OldestPendingAgeSec,
+		InFlightTurn:        projection.InFlightTurn,
+		InFlightSeconds:     projection.InFlightSeconds,
+		LockOwner:           strings.TrimSpace(projection.LockOwner),
+		LockExpiresAt:       projection.LockExpiresAt,
+		Failures24h:         projection.Failures24h,
+		DeadLetters24h:      projection.DeadLetters24h,
+		TurnCount:           projection.TurnCount,
+		TurnLimit:           maxStoreInt(turnLimit, 0),
+		Turns24h:            maxStoreInt(projection.Turns24h, 0),
+		SessionID:           strings.TrimSpace(projection.SessionID),
+		ProviderSessionID:   strings.TrimSpace(projection.ProviderSessionID),
+		CurrentTaskID:       strings.TrimSpace(projection.CurrentTaskID),
+		LastTool:            projection.LastTool,
+		LiveTurn:            projection.LiveTurn,
+		StartedAt:           row.StartedAt,
+		DashboardStatus:     strings.TrimSpace(projection.Status),
+		DashboardState:      projection.dashboardState(),
+		BlockingLayer:       projection.dashboardBlockingLayer(),
+		CurrentSessionRef:   projection.currentSessionRef(),
+		LastTurnRef:         projection.LastTurnRef,
+	}
+	if out.TurnLimit > 0 {
+		out.NearBreaker = out.TurnCount*100 >= out.TurnLimit*85
+	}
+	return out
+}
+
+func (p operatorAgentProjection) currentSessionRef() *OperatorSessionRef {
+	if strings.TrimSpace(p.SessionID) == "" || p.SessionStartedAt.IsZero() {
+		return nil
+	}
+	return &OperatorSessionRef{SessionID: strings.TrimSpace(p.SessionID), StartedAt: p.SessionStartedAt}
+}
+
+func (p operatorAgentProjection) dashboardState() string {
+	status := strings.ToLower(strings.TrimSpace(p.Status))
+	if status == "terminated" {
+		return "terminated"
+	}
+	if state := strings.TrimSpace(p.LifecycleState); state != "" {
+		return state
+	}
+	if p.InFlightTurn {
+		return "active"
+	}
+	return "idle"
+}
+
+func (p operatorAgentProjection) dashboardBlockingLayer() string {
+	if layer := strings.TrimSpace(p.BlockingLayer); layer != "" {
+		return layer
+	}
+	if p.InFlightTurn {
+		return "session_execution"
+	}
+	return ""
+}
+
+func (p operatorAgentProjection) v1Status() string {
+	switch strings.TrimSpace(p.Status) {
+	case "terminated":
+		return "terminated"
+	case "paused":
+		return "paused"
+	}
+	switch strings.TrimSpace(p.LifecycleState) {
+	case "active", "launching", "retrying":
+		return "running"
+	case "exhausted":
+		return "failed"
+	}
+	if p.InFlightTurn {
+		return "running"
+	}
+	return "idle"
+}
+
+func enrichOperatorAgentProjectionFromLatestTurn(projection *operatorAgentProjection, runtimeStateRaw []byte, turnID, taskID string, parseOK bool, turnBlocksRaw []byte) error {
+	if projection == nil {
+		return nil
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return fmt.Errorf("decode latest agent session runtime_state: %w", err)
+	}
+	projection.ProviderSessionID = strings.TrimSpace(runtimeState.ProviderSessionID)
+	projection.LiveTurn, err = projectOperatorLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
+	if err != nil {
+		return fmt.Errorf("decode latest agent turn live_turn: %w", err)
+	}
+	if projection.LiveTurn != nil {
+		projection.CurrentTaskID = strings.TrimSpace(projection.LiveTurn.TaskID)
+		projection.LastTool = projection.LiveTurn.LastTool
+		return nil
+	}
+	projection.CurrentTaskID = strings.TrimSpace(taskID)
+	return nil
+}
+
+func operatorAgentFlowMatches(agentFlow, filter string) bool {
+	agentFlow = strings.Trim(strings.TrimSpace(agentFlow), "/")
+	filter = strings.Trim(strings.TrimSpace(filter), "/")
+	return filter == "" || agentFlow == filter || strings.HasPrefix(agentFlow, filter+"/")
+}
+
+func defaultOperatorConversationListOptions(opts OperatorConversationListOptions) (OperatorConversationListOptions, error) {
+	opts.AgentID = strings.TrimSpace(opts.AgentID)
+	opts.RunID = strings.TrimSpace(opts.RunID)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.RunID != "" {
+		if _, err := uuid.Parse(opts.RunID); err != nil {
+			return OperatorConversationListOptions{}, fmt.Errorf("%w: run_id must be a UUID", ErrInvalidEntityReadParam)
+		}
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts, nil
+}
+
+func operatorConversationQuerySources(caps StoreSchemaCapabilities) []string {
+	sources := []string{}
+	if caps.Conversations.Sessions == SchemaFlavorCanonical {
+		sessionRunID := "''"
+		if caps.Conversations.SessionRunID {
+			sessionRunID = "COALESCE(run_id::text, '')"
+		}
+		sources = append(sources, fmt.Sprintf(`
+			SELECT
+				session_id::text AS session_id,
+				agent_id,
+				%s AS run_id,
+				'live_session' AS kind,
+				scope_key,
+				scope,
+				runtime_mode,
+				CASE WHEN status = 'terminated' THEN 'terminated' ELSE 'active' END AS status,
+				turn_count,
+				jsonb_array_length(COALESCE(conversation, '[]'::jsonb)) AS message_count,
+				runtime_state,
+				conversation,
+				created_at AS started_at,
+				CASE WHEN status = 'terminated' THEN terminated_at ELSE NULL END AS ended_at,
+				updated_at,
+				created_at
+			FROM agent_sessions
+			WHERE status IN ('active', 'terminated')
+			  AND runtime_mode IN ('session', 'session_per_entity')
+		`, sessionRunID))
+	}
+	if caps.Conversations.Audits == SchemaFlavorCanonical {
+		auditRunID := "''"
+		if caps.Conversations.AuditRunID {
+			auditRunID = "COALESCE(run_id::text, '')"
+		}
+		sources = append(sources, fmt.Sprintf(`
+			SELECT
+				session_id::text AS session_id,
+				agent_id,
+				%s AS run_id,
+				'turn_audit' AS kind,
+				COALESCE(scope_key, '') AS scope_key,
+				COALESCE(scope, '') AS scope,
+				COALESCE(runtime_mode, '') AS runtime_mode,
+				CASE WHEN status = 'terminated' THEN 'terminated' ELSE 'active' END AS status,
+				COALESCE(turn_count, 0) AS turn_count,
+				jsonb_array_length(COALESCE(conversation, '[]'::jsonb)) AS message_count,
+				COALESCE(runtime_state, '{}'::jsonb) AS runtime_state,
+				COALESCE(conversation, '[]'::jsonb) AS conversation,
+				created_at AS started_at,
+				NULL::timestamptz AS ended_at,
+				updated_at,
+				created_at
+			FROM (
+				%s
+			) task_conversations
+		`, auditRunID, CanonicalTaskConversationVisibilitySourceSQL(caps.Conversations)))
+	}
+	return sources
+}
+
+func dashboardOperatorConversationQuerySources(caps StoreSchemaCapabilities) []string {
+	sources := []string{}
+	if caps.Conversations.Sessions == SchemaFlavorCanonical {
+		sources = append(sources, `
+			SELECT
+				session_id::text AS session_id,
+				agent_id,
+				'live_session' AS kind,
+				scope_key,
+				scope,
+				runtime_mode,
+				status,
+				turn_count,
+				runtime_state,
+				conversation,
+				updated_at,
+				created_at
+			FROM agent_sessions
+			WHERE status = 'active'
+			  AND runtime_mode IN ('session', 'session_per_entity')
+		`)
+	}
+	if taskSource := CanonicalTaskConversationVisibilitySourceSQL(caps.Conversations); taskSource != "" {
+		sources = append(sources, fmt.Sprintf(`
+			SELECT
+				session_id,
+				agent_id,
+				'turn_audit' AS kind,
+				scope_key,
+				scope,
+				runtime_mode,
+				status,
+				turn_count,
+				runtime_state,
+				conversation,
+				updated_at,
+				created_at
+			FROM (
+				%s
+			) task_conversations
+		`, taskSource))
+	}
+	return sources
+}
+
+func scanDashboardOperatorConversationSummary(scanner operatorRowScanner) (OperatorConversationSummary, error) {
+	var (
+		item            OperatorConversationSummary
+		runtimeStateRaw []byte
+		turnID          string
+		taskID          string
+		parseOK         bool
+		turnBlocksRaw   []byte
+	)
+	if err := scanner.Scan(
+		&item.SessionID,
+		&item.AgentID,
+		&item.Kind,
+		&item.ScopeKey,
+		&item.Scope,
+		&item.RuntimeMode,
+		&item.Status,
+		&item.TurnCount,
+		&runtimeStateRaw,
+		&turnID,
+		&taskID,
+		&parseOK,
+		&turnBlocksRaw,
+		&item.UpdatedAt,
+	); err != nil {
+		return OperatorConversationSummary{}, err
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return OperatorConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
+	}
+	item.Summary = runtimeState.Summary
+	item.Metadata = projectOperatorConversationSummaryMetadata(runtimeState)
+	item.Metadata.LiveTurn, err = projectOperatorLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
+	if err != nil {
+		return OperatorConversationSummary{}, fmt.Errorf("decode conversation live_turn: %w", err)
+	}
+	return item, nil
+}
+
+func scanDashboardOperatorConversationDetail(scanner operatorRowScanner) (OperatorConversationDetail, error) {
+	var (
+		item            OperatorConversationDetail
+		runtimeStateRaw []byte
+		messagesRaw     []byte
+	)
+	if err := scanner.Scan(
+		&item.Conversation.SessionID,
+		&item.Conversation.AgentID,
+		&item.Conversation.Kind,
+		&item.Conversation.ScopeKey,
+		&item.Conversation.Scope,
+		&item.Conversation.RuntimeMode,
+		&item.Conversation.Status,
+		&item.Conversation.TurnCount,
+		&runtimeStateRaw,
+		&messagesRaw,
+		&item.Conversation.UpdatedAt,
+	); err != nil {
+		return OperatorConversationDetail{}, err
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
+	}
+	item.Conversation.Summary = runtimeState.Summary
+	item.RuntimeState = projectOperatorConversationState(runtimeState)
+	item.Messages, err = decodeStoreJSONArray[OperatorConversationMessage](messagesRaw)
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)
+	}
+	if item.Messages == nil {
+		item.Messages = []OperatorConversationMessage{}
+	}
+	return item, nil
+}
+
+func scanOperatorConversationSummary(scanner operatorRowScanner) (OperatorConversationSummary, error) {
+	var (
+		item            OperatorConversationSummary
+		runtimeStateRaw []byte
+		turnID          string
+		taskID          string
+		parseOK         bool
+		turnBlocksRaw   []byte
+		endedAt         sql.NullTime
+	)
+	if err := scanner.Scan(
+		&item.SessionID,
+		&item.AgentID,
+		&item.RunID,
+		&item.Kind,
+		&item.ScopeKey,
+		&item.Scope,
+		&item.RuntimeMode,
+		&item.Status,
+		&item.TurnCount,
+		&item.MessageCount,
+		&runtimeStateRaw,
+		&turnID,
+		&taskID,
+		&parseOK,
+		&turnBlocksRaw,
+		&item.StartedAt,
+		&endedAt,
+		&item.UpdatedAt,
+	); err != nil {
+		return OperatorConversationSummary{}, err
+	}
+	if endedAt.Valid {
+		ended := endedAt.Time
+		item.EndedAt = &ended
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return OperatorConversationSummary{}, fmt.Errorf("decode conversation runtime_state: %w", err)
+	}
+	item.Summary = runtimeState.Summary
+	item.Metadata = projectOperatorConversationSummaryMetadata(runtimeState)
+	item.Metadata.LiveTurn, err = projectOperatorLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
+	if err != nil {
+		return OperatorConversationSummary{}, fmt.Errorf("decode conversation live_turn: %w", err)
+	}
+	return item, nil
+}
+
+func scanOperatorConversationDetail(scanner operatorRowScanner) (OperatorConversationDetail, error) {
+	var (
+		item            OperatorConversationDetail
+		runtimeStateRaw []byte
+		messagesRaw     []byte
+		endedAt         sql.NullTime
+	)
+	if err := scanner.Scan(
+		&item.Conversation.SessionID,
+		&item.Conversation.AgentID,
+		&item.Conversation.RunID,
+		&item.Conversation.Kind,
+		&item.Conversation.ScopeKey,
+		&item.Conversation.Scope,
+		&item.Conversation.RuntimeMode,
+		&item.Conversation.Status,
+		&item.Conversation.TurnCount,
+		&item.Conversation.MessageCount,
+		&runtimeStateRaw,
+		&messagesRaw,
+		&item.Conversation.StartedAt,
+		&endedAt,
+		&item.Conversation.UpdatedAt,
+	); err != nil {
+		return OperatorConversationDetail{}, err
+	}
+	if endedAt.Valid {
+		ended := endedAt.Time
+		item.Conversation.EndedAt = &ended
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(runtimeStateRaw)
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("decode conversation runtime_state: %w", err)
+	}
+	item.Conversation.Summary = runtimeState.Summary
+	item.Conversation.Metadata = projectOperatorConversationSummaryMetadata(runtimeState)
+	item.RuntimeState = projectOperatorConversationState(runtimeState)
+	item.Messages, err = decodeStoreJSONArray[OperatorConversationMessage](messagesRaw)
+	if err != nil {
+		return OperatorConversationDetail{}, fmt.Errorf("decode conversation messages: %w", err)
+	}
+	if item.Messages == nil {
+		item.Messages = []OperatorConversationMessage{}
+	}
+	return item, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) loadConversationTurns(ctx context.Context, agentID, sessionID string) ([]OperatorConversationTurn, error) {
+	agentID = strings.TrimSpace(agentID)
+	sessionID = strings.TrimSpace(sessionID)
+	if agentID == "" || sessionID == "" {
+		return []OperatorConversationTurn{}, nil
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return nil, unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
+	}
+	query := `
+		SELECT
+			turn_id::text,
+			agent_id,
+			session_id::text,
+			COALESCE(runtime_mode, ''),
+			COALESCE(scope_key, ''),
+			COALESCE(entity_id::text, ''),
+			COALESCE(trigger_event_id::text, ''),
+			COALESCE(trigger_event_type, ''),
+			COALESCE(task_id, ''),
+			COALESCE(available_tools, '[]'::jsonb),
+			COALESCE(tool_calls, '[]'::jsonb),
+			COALESCE(emitted_events, '[]'::jsonb),
+			COALESCE(mcp_servers, '{}'::jsonb),
+			COALESCE(mcp_tools_listed, '[]'::jsonb),
+			COALESCE(mcp_tools_visible, '[]'::jsonb),
+			COALESCE(request_payload, '{}'::jsonb),
+			COALESCE(response_payload, '{}'::jsonb),
+			COALESCE(turn_blocks, '[]'::jsonb),
+			parse_ok,
+			COALESCE(latency_ms, 0),
+			COALESCE(retry_count, 0),
+			COALESCE(error, ''),
+			created_at
+		FROM agent_turns
+		WHERE agent_id = $1
+		  AND session_id = $2::uuid
+		ORDER BY created_at ASC, turn_id ASC
+	`
+	if !caps.Conversations.TurnBlocks {
+		query = strings.Replace(query, "COALESCE(turn_blocks, '[]'::jsonb),", "'[]'::jsonb AS turn_blocks,", 1)
+	}
+	rows, err := r.db.QueryContext(ctx, query, agentID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []OperatorConversationTurn{}
+	for rows.Next() {
+		item, err := scanOperatorConversationTurn(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func scanOperatorConversationTurn(scanner operatorRowScanner) (OperatorConversationTurn, error) {
+	var (
+		item                                  OperatorConversationTurn
+		availableToolsRaw, toolCallsRaw       []byte
+		emittedEventsRaw, mcpServersRaw       []byte
+		mcpToolsListedRaw, mcpToolsVisibleRaw []byte
+		requestPayloadRaw, responsePayloadRaw []byte
+		turnBlocksRaw                         []byte
+	)
+	if err := scanner.Scan(
+		&item.TurnID,
+		&item.AgentID,
+		&item.SessionID,
+		&item.RuntimeMode,
+		&item.ScopeKey,
+		&item.EntityID,
+		&item.TriggerEventID,
+		&item.TriggerEventType,
+		&item.TaskID,
+		&availableToolsRaw,
+		&toolCallsRaw,
+		&emittedEventsRaw,
+		&mcpServersRaw,
+		&mcpToolsListedRaw,
+		&mcpToolsVisibleRaw,
+		&requestPayloadRaw,
+		&responsePayloadRaw,
+		&turnBlocksRaw,
+		&item.ParseOK,
+		&item.LatencyMS,
+		&item.RetryCount,
+		&item.Error,
+		&item.CreatedAt,
+	); err != nil {
+		return OperatorConversationTurn{}, err
+	}
+	summary, hasSummary, err := decodeOperatorTurnSummaryProjection(turnBlocksRaw)
+	if err != nil {
+		return OperatorConversationTurn{}, err
+	}
+	if item.AvailableTools, err = decodeStoreJSONArray[string](availableToolsRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn available_tools: %w", err)
+	}
+	if item.ToolCalls, err = decodeStoreJSONArray[OperatorConversationToolCall](toolCallsRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn tool_calls: %w", err)
+	}
+	if item.EmittedEvents, err = decodeStoreJSONArray[string](emittedEventsRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn emitted_events: %w", err)
+	}
+	if item.MCPToolsListed, err = decodeStoreJSONArray[string](mcpToolsListedRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn mcp_tools_listed: %w", err)
+	}
+	if item.MCPToolsVisible, err = decodeStoreJSONArray[string](mcpToolsVisibleRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn mcp_tools_visible: %w", err)
+	}
+	if item.MCPServers, err = decodeStoreJSONStringMap(mcpServersRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn mcp_servers: %w", err)
+	}
+	if item.RequestPayload, err = decodeStoreJSONObjectRaw(requestPayloadRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn request_payload: %w", err)
+	}
+	if item.ResponsePayload, err = decodeStoreJSONObjectRaw(responsePayloadRaw); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("decode turn response_payload: %w", err)
+	}
+	if len(turnBlocksRaw) > 0 {
+		if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocksJSON(turnBlocksRaw); err != nil {
+			return OperatorConversationTurn{}, fmt.Errorf("decode canonical runtime_log turn_blocks: %w", err)
+		}
+		if item.TurnBlocks, err = decodeStoreJSONArray[OperatorConversationTurnBlock](turnBlocksRaw); err != nil {
+			return OperatorConversationTurn{}, fmt.Errorf("decode turn turn_blocks: %w", err)
+		}
+	}
+	if hasSummary {
+		item.AssistantVisibleOutput, item.Outcome, item.ReasoningBlocks, item.ProgressUpdates, item.ToolResults = projectedOperatorTurnSummaryConversationFields(summary)
+	}
+	return item, nil
+}
+
+func projectOperatorConversationSummaryMetadata(p ConversationRuntimeStateDescriptor) OperatorConversationSummaryMetadata {
+	meta := OperatorConversationSummaryMetadata{
+		ProviderSessionID:    p.ProviderSessionID,
+		RetryReason:          p.RetryReason,
+		RetriesFromSessionID: p.RetriesFromSessionID,
+	}
+	if p.Watchdog != nil {
+		meta.Watchdog = &OperatorConversationWatchdog{
+			State:         p.Watchdog.State,
+			BlockingLayer: p.Watchdog.BlockingLayer,
+			Action:        p.Watchdog.Action,
+			Outcome:       p.Watchdog.Outcome,
+			LastOutputAt:  p.Watchdog.LastOutputAt,
+			RecordedAt:    p.Watchdog.RecordedAt,
+		}
+	}
+	return meta
+}
+
+func projectOperatorConversationState(p ConversationRuntimeStateDescriptor) OperatorConversationState {
+	state := OperatorConversationState{
+		Summary:              p.Summary,
+		ProviderSessionID:    p.ProviderSessionID,
+		RetryReason:          p.RetryReason,
+		RetriesFromSessionID: p.RetriesFromSessionID,
+	}
+	if p.LastTurn != nil {
+		state.LastTurn = &OperatorConversationLastTurn{TaskID: p.LastTurn.TaskID, ParseOK: p.LastTurn.ParseOK}
+	}
+	if p.Watchdog != nil {
+		state.Watchdog = &OperatorConversationWatchdog{
+			State:         p.Watchdog.State,
+			BlockingLayer: p.Watchdog.BlockingLayer,
+			Action:        p.Watchdog.Action,
+			Outcome:       p.Watchdog.Outcome,
+			LastOutputAt:  p.Watchdog.LastOutputAt,
+			RecordedAt:    p.Watchdog.RecordedAt,
+		}
+	}
+	return state
+}
+
+func projectOperatorLatestTurn(taskID string, parseOK bool, turnID string, turnBlocksRaw []byte) (*OperatorLiveTurn, error) {
+	taskID = strings.TrimSpace(taskID)
+	turnID = strings.TrimSpace(turnID)
+	summary, ok, err := decodeOperatorTurnSummaryProjection(turnBlocksRaw)
+	if err != nil {
+		return nil, err
+	}
+	if !ok && taskID == "" && turnID == "" {
+		return nil, nil
+	}
+	out := &OperatorLiveTurn{TurnID: turnID, TaskID: taskID, ParseOK: parseOK}
+	if ok {
+		out.AssistantVisibleOutput = summary.AssistantVisibleOutput
+		out.Outcome = summary.Outcome
+		out.ProgressUpdates = cloneStoreStringSlice(summary.ProgressUpdates)
+		out.LastTool, err = projectedOperatorTurnSummaryLastTool(summary, parseOK)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func decodeOperatorTurnSummaryProjection(raw []byte) (runtimellm.TurnSummaryTurnBlockData, bool, error) {
+	summary, ok, err := runtimellm.DecodeCanonicalTurnSummaryJSON(raw)
+	if err != nil {
+		return runtimellm.TurnSummaryTurnBlockData{}, false, err
+	}
+	return summary, ok, nil
+}
+
+func projectedOperatorTurnSummaryConversationFields(p runtimellm.TurnSummaryTurnBlockData) (string, string, []string, []string, []OperatorConversationToolResult) {
+	return p.AssistantVisibleOutput, p.Outcome, cloneStoreStringSlice(p.ReasoningBlocks), cloneStoreStringSlice(p.ProgressUpdates), projectedOperatorTurnSummaryToolResults(p)
+}
+
+func projectedOperatorTurnSummaryToolResults(p runtimellm.TurnSummaryTurnBlockData) []OperatorConversationToolResult {
+	if len(p.ToolResults) == 0 {
+		return nil
+	}
+	out := make([]OperatorConversationToolResult, 0, len(p.ToolResults))
+	for _, item := range p.ToolResults {
+		row := OperatorConversationToolResult{ToolName: item.ToolName}
+		if item.ToolUseID != "" {
+			row.ToolUseID = item.ToolUseID
+		}
+		if item.Output != nil {
+			row.Output = append(json.RawMessage(nil), item.Output...)
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func projectedOperatorTurnSummaryLastTool(p runtimellm.TurnSummaryTurnBlockData, parseOK bool) (*OperatorAgentTool, error) {
+	if len(p.ToolResults) == 0 {
+		return nil, nil
+	}
+	last := p.ToolResults[len(p.ToolResults)-1]
+	if last.ToolName == "" {
+		return nil, fmt.Errorf("latest canonical tool_result is missing tool_name")
+	}
+	out := &OperatorAgentTool{Name: last.ToolName, OK: parseOK}
+	if last.ToolUseID != "" {
+		out.ToolUseID = last.ToolUseID
+	}
+	if last.Output != nil {
+		trimmed := bytes.TrimSpace(last.Output)
+		if len(trimmed) == 0 {
+			return nil, fmt.Errorf("latest canonical tool_result output is empty")
+		}
+		if !json.Valid(trimmed) {
+			return nil, fmt.Errorf("latest canonical tool_result output is invalid JSON")
+		}
+		out.Result = append(json.RawMessage(nil), trimmed...)
+	}
+	return out, nil
+}
+
+func encodeConversationPositionCursor(cursor conversationPositionCursor) string {
+	raw, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeConversationPositionCursor(raw string, kind string) (conversationPositionCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return conversationPositionCursor{}, ErrInvalidConversationCursor
+	}
+	var cursor conversationPositionCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return conversationPositionCursor{}, ErrInvalidConversationCursor
+	}
+	if strings.TrimSpace(cursor.Kind) != kind {
+		return conversationPositionCursor{}, ErrInvalidConversationCursor
+	}
+	return cursor, nil
+}
+
+func decodeStoreJSONObjectRaw(raw []byte) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return append(json.RawMessage(nil), raw...), nil
+}
+
+func decodeStoreJSONArray[T any](raw []byte) ([]T, error) {
+	if len(raw) == 0 {
+		return []T{}, nil
+	}
+	out := []T{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeStoreJSONStringMap(raw []byte) (map[string]string, error) {
+	if len(raw) == 0 {
+		return map[string]string{}, nil
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func cloneStoreStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]string(nil), in...)
+}
+
+func maxStoreInt(v, floor int) int {
+	if v < floor {
+		return floor
+	}
+	return v
+}

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -694,18 +694,7 @@ func (r *OperatorAgentConversationReadSurface) LoadCurrentOperatorConversationFo
 	if _, err := r.LoadOperatorAgent(ctx, agentID); err != nil {
 		return nil, err
 	}
-	result, err := r.ListOperatorConversations(ctx, OperatorConversationListOptions{AgentID: agentID, Limit: 1})
-	if err != nil {
-		return nil, err
-	}
-	if len(result.Conversations) == 0 {
-		return nil, nil
-	}
-	detail, err := r.LoadOperatorConversation(ctx, result.Conversations[0].SessionID)
-	if err != nil {
-		return nil, err
-	}
-	return &detail, nil
+	return r.loadCurrentActiveOperatorConversationForAgent(ctx, agentID)
 }
 
 func (r *OperatorAgentConversationReadSurface) requireAgentCapabilities(ctx context.Context) error {
@@ -742,6 +731,62 @@ func (r *OperatorAgentConversationReadSurface) requireConversationCapabilities(c
 	return nil
 }
 
+func (r *OperatorAgentConversationReadSurface) loadCurrentActiveOperatorConversationForAgent(ctx context.Context, agentID string) (*OperatorConversationDetail, error) {
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical {
+		return nil, unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return nil, unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
+	}
+	sessionRunID := "''"
+	if caps.Conversations.SessionRunID {
+		sessionRunID = "COALESCE(run_id::text, '')"
+	}
+	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT
+			session_id::text,
+			agent_id,
+			%s AS run_id,
+			'live_session' AS kind,
+			COALESCE(scope_key, ''),
+			COALESCE(scope, ''),
+			COALESCE(runtime_mode, ''),
+			COALESCE(status, ''),
+			COALESCE(turn_count, 0),
+			jsonb_array_length(COALESCE(conversation, '[]'::jsonb)) AS message_count,
+			COALESCE(runtime_state, '{}'::jsonb),
+			COALESCE(conversation, '[]'::jsonb),
+			created_at AS started_at,
+			NULL::timestamptz AS ended_at,
+			updated_at
+		FROM agent_sessions
+		WHERE agent_id = $1
+		  AND status = 'active'
+		  AND runtime_mode IN ($2, $3)
+		ORDER BY updated_at DESC, created_at DESC, session_id ASC
+		LIMIT 1
+	`, sessionRunID), agentID, runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
+	item, err := scanOperatorConversationDetail(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load current operator conversation: %w", err)
+	}
+	item.Turns, err = r.loadConversationTurns(ctx, item.Conversation.AgentID, item.Conversation.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("load current operator conversation turns: %w", err)
+	}
+	if item.Turns == nil {
+		item.Turns = []OperatorConversationTurn{}
+	}
+	return &item, nil
+}
+
 func (r *OperatorAgentConversationReadSurface) resolveConversationCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
 	if r == nil || r.capSource == nil {
 		return StoreSchemaCapabilities{}, fmt.Errorf("operator conversation read surface requires schema capabilities")
@@ -763,6 +808,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			a.agent_id,
 			COALESCE(a.status, 'active'),
 			COALESCE(sess.session_id::text, ''),
+			sess.created_at,
 			COALESCE(sess.turn_count, 0),
 			COALESCE(sess.lease_holder, ''),
 			sess.lease_expires_at,
@@ -775,11 +821,14 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			COALESCE(latest_turn.turn_id, ''),
 			COALESCE(latest_turn.task_id, ''),
 			COALESCE(latest_turn.parse_ok, false),
+			COALESCE(latest_turn.error, ''),
+			latest_turn.created_at,
 			COALESCE(latest_turn.turn_blocks, '[]'::jsonb)
 		FROM agents a
 		LEFT JOIN LATERAL (
 			SELECT
 				session_id,
+				created_at,
 				turn_count,
 				lease_holder,
 				lease_expires_at,
@@ -796,6 +845,8 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 				turn_id::text AS turn_id,
 				COALESCE(task_id, '') AS task_id,
 				parse_ok,
+				COALESCE(error, '') AS error,
+				created_at,
 				%s AS turn_blocks
 			FROM agent_turns
 			WHERE agent_id = a.agent_id
@@ -825,19 +876,23 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 	agentIDs := make([]string, 0)
 	for rows.Next() {
 		var (
-			id              string
-			projection      operatorAgentProjection
-			lockExpiresAt   sql.NullTime
-			runtimeStateRaw []byte
-			latestTurnID    string
-			latestTaskID    string
-			latestParseOK   bool
-			latestTurnRaw   []byte
+			id               string
+			projection       operatorAgentProjection
+			lockExpiresAt    sql.NullTime
+			sessionStartedAt sql.NullTime
+			runtimeStateRaw  []byte
+			latestTurnID     string
+			latestTaskID     string
+			latestParseOK    bool
+			latestError      string
+			latestCompleted  sql.NullTime
+			latestTurnRaw    []byte
 		)
 		if err := rows.Scan(
 			&id,
 			&projection.Status,
 			&projection.SessionID,
+			&sessionStartedAt,
 			&projection.TurnCount,
 			&projection.LockOwner,
 			&lockExpiresAt,
@@ -850,14 +905,27 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			&latestTurnID,
 			&latestTaskID,
 			&latestParseOK,
+			&latestError,
+			&latestCompleted,
 			&latestTurnRaw,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent operator projection: %w", err)
+		}
+		if sessionStartedAt.Valid {
+			projection.SessionStartedAt = sessionStartedAt.Time
 		}
 		if lockExpiresAt.Valid {
 			projection.LockExpiresAt = lockExpiresAt.Time
 			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(projection.LockOwner) != "" {
 				projection.InFlightTurn = true
+			}
+		}
+		if latestCompleted.Valid && strings.TrimSpace(latestTurnID) != "" {
+			projection.LastTurnRef = &OperatorTurnRef{
+				TurnID:      strings.TrimSpace(latestTurnID),
+				CompletedAt: latestCompleted.Time,
+				ParseOK:     latestParseOK,
+				Error:       strings.TrimSpace(latestError),
 			}
 		}
 		if err := enrichOperatorAgentProjectionFromLatestTurn(&projection, runtimeStateRaw, latestTurnID, latestTaskID, latestParseOK, latestTurnRaw); err != nil {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimesessions "swarm/internal/runtime/sessions"
 )
 
 type fakeConversationCapabilitySource struct {
@@ -15,6 +18,87 @@ type fakeConversationCapabilitySource struct {
 
 func (s fakeConversationCapabilitySource) ResolveSchemaCapabilities(context.Context) (StoreSchemaCapabilities, error) {
 	return s.caps, s.err
+}
+
+type fakeAgentConversationReadSource struct {
+	caps      StoreSchemaCapabilities
+	agents    []runtimemanager.PersistedAgent
+	pending   map[string]PendingAgentDeliveryFacts
+	lifecycle map[string]AgentLifecycleFacts
+	err       error
+}
+
+func (s fakeAgentConversationReadSource) ResolveSchemaCapabilities(context.Context) (StoreSchemaCapabilities, error) {
+	return s.caps, s.err
+}
+
+func (s fakeAgentConversationReadSource) LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error) {
+	return s.agents, s.err
+}
+
+func (s fakeAgentConversationReadSource) ListPendingAgentDeliveryFacts(_ context.Context, agentIDs []string, _ time.Time) (map[string]PendingAgentDeliveryFacts, error) {
+	out := make(map[string]PendingAgentDeliveryFacts, len(agentIDs))
+	for _, agentID := range agentIDs {
+		out[agentID] = s.pending[agentID]
+	}
+	return out, s.err
+}
+
+func (s fakeAgentConversationReadSource) ListAgentLifecycleFacts(_ context.Context, agentIDs []string) (map[string]AgentLifecycleFacts, error) {
+	out := make(map[string]AgentLifecycleFacts, len(agentIDs))
+	for _, agentID := range agentIDs {
+		out[agentID] = s.lifecycle[agentID]
+	}
+	return out, s.err
+}
+
+func canonicalAgentConversationReadCaps() StoreSchemaCapabilities {
+	return StoreSchemaCapabilities{
+		Events: EventSchemaCapabilities{
+			Log:        SchemaFlavorCanonical,
+			Deliveries: SchemaFlavorCanonical,
+			Receipts:   SchemaFlavorCanonical,
+		},
+		Conversations: ConversationSchemaCapabilities{
+			Sessions:     SchemaFlavorCanonical,
+			Turns:        SchemaFlavorCanonical,
+			TurnBlocks:   true,
+			SessionRunID: true,
+		},
+	}
+}
+
+func operatorAgentProjectionColumns() []string {
+	return []string{
+		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
+		"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+	}
+}
+
+func operatorConversationDetailColumns() []string {
+	return []string{
+		"session_id", "agent_id", "run_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "message_count", "runtime_state", "conversation", "started_at", "ended_at", "updated_at",
+	}
+}
+
+func operatorConversationTurnColumns() []string {
+	return []string{
+		"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id", "available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible", "request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+	}
+}
+
+func testOperatorAgent(agentID string) runtimemanager.PersistedAgent {
+	return runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               agentID,
+			Role:             "researcher",
+			Type:             "managed",
+			ConversationMode: runtimesessions.RuntimeModeSession.String(),
+			SessionScope:     runtimesessions.SessionScopeGlobal.String(),
+		},
+		Status:    "active",
+		StartedAt: time.Date(2026, 5, 12, 8, 0, 0, 0, time.UTC),
+	}
 }
 
 func TestOperatorConversationReadSurfaceListUsesCanonicalProjection(t *testing.T) {
@@ -55,6 +139,122 @@ func TestOperatorConversationReadSurfaceListUsesCanonicalProjection(t *testing.T
 	row := result.Conversations[0]
 	if row.SessionID != "sess-1" || row.AgentID != "agent-1" || row.RunID != runID || row.MessageCount != 4 || row.Summary != "brief" {
 		t.Fatalf("unexpected conversation row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	turnID := "22222222-2222-2222-2222-222222222222"
+	sessionStartedAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", false, "model error", turnCompletedAt, []byte(`[]`)))
+
+	detail, err := reader.LoadOperatorAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("LoadOperatorAgent: %v", err)
+	}
+	if detail.CurrentSessionRef == nil || detail.CurrentSessionRef.SessionID != sessionID || !detail.CurrentSessionRef.StartedAt.Equal(sessionStartedAt) {
+		t.Fatalf("current_session_ref = %#v", detail.CurrentSessionRef)
+	}
+	if detail.LastTurnRef == nil || detail.LastTurnRef.TurnID != turnID || !detail.LastTurnRef.CompletedAt.Equal(turnCompletedAt) || detail.LastTurnRef.ParseOK || detail.LastTurnRef.Error != "model error" {
+		t.Fatalf("last_turn_ref = %#v", detail.LastTurnRef)
+	}
+	if detail.Agent.CurrentSessionRef == nil || detail.Agent.LastTurnRef == nil {
+		t.Fatalf("agent summary refs not populated: %+v", detail.Agent)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessionOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	runID := "33333333-3333-3333-3333-333333333333"
+	now := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
+			AddRow(sessionID, "agent-1", runID, "live_session", "global", "global", "session", "active", 2, 1, []byte(`{"summary":"active session"}`), []byte(`[{"role":"assistant","content":"ready"}]`), now.Add(-time.Hour), nil, now))
+	mock.ExpectQuery("(?s)SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationTurnColumns()))
+
+	detail, err := reader.LoadCurrentOperatorConversationForAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("LoadCurrentOperatorConversationForAgent: %v", err)
+	}
+	if detail == nil {
+		t.Fatal("expected active conversation")
+	}
+	if detail.Conversation.SessionID != sessionID || detail.Conversation.Kind != "live_session" || detail.Conversation.Status != "active" {
+		t.Fatalf("conversation = %+v", detail.Conversation)
+	}
+	if detail.Conversation.Summary != "active session" {
+		t.Fatalf("summary = %q", detail.Conversation.Summary)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveLiveSession(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()))
+
+	detail, err := reader.LoadCurrentOperatorConversationForAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("LoadCurrentOperatorConversationForAgent: %v", err)
+	}
+	if detail != nil {
+		t.Fatalf("expected nil current conversation without active live session, got %+v", detail)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+type fakeConversationCapabilitySource struct {
+	caps StoreSchemaCapabilities
+	err  error
+}
+
+func (s fakeConversationCapabilitySource) ResolveSchemaCapabilities(context.Context) (StoreSchemaCapabilities, error) {
+	return s.caps, s.err
+}
+
+func TestOperatorConversationReadSurfaceListUsesCanonicalProjection(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	runID := "11111111-1111-1111-1111-111111111111"
+	now := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	reader := NewOperatorConversationReadSurface(db, fakeConversationCapabilitySource{caps: StoreSchemaCapabilities{
+		Conversations: ConversationSchemaCapabilities{
+			Sessions:     SchemaFlavorCanonical,
+			Turns:        SchemaFlavorCanonical,
+			TurnBlocks:   true,
+			SessionRunID: true,
+		},
+	}})
+
+	mock.ExpectQuery("SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.run_id,.*FROM \\(").
+		WithArgs("agent-1", runID, 3).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "run_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "message_count", "runtime_state", "turn_id", "task_id", "parse_ok", "turn_blocks", "started_at", "ended_at", "updated_at",
+		}).AddRow("sess-1", "agent-1", runID, "live_session", "global", "global", "session", "active", 2, 4, []byte(`{"summary":"brief"}`), "turn-1", "task-1", true, []byte(`[]`), now, nil, now))
+
+	result, err := reader.ListOperatorConversations(context.Background(), OperatorConversationListOptions{
+		AgentID: "agent-1",
+		RunID:   runID,
+		Limit:   2,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorConversations: %v", err)
+	}
+	if len(result.Conversations) != 1 {
+		t.Fatalf("conversation count = %d", len(result.Conversations))
+	}
+	row := result.Conversations[0]
+	if row.SessionID != "sess-1" || row.AgentID != "agent-1" || row.RunID != runID || row.MessageCount != 4 || row.Summary != "brief" {
+		t.Fatalf("unexpected conversation row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a shared `internal/store` agent/conversation operator read owner for `agent.list`, `agent.get`, `conversation.list`, `conversation.get`, and `conversation.current_for_agent`.
- Wire v1 JSON-RPC handlers to that owner with typed `AGENT_NOT_FOUND` / `SESSION_NOT_FOUND` behavior and conversation filter/cursor parsing.
- Demote dashboard `/api/agents*` and `/api/conversations*` to adapters over the shared owner; dashboard endpoint files no longer contain direct agent/conversation SQL ownership.

Closes #704
Part of #665
Part of #694

## Governing refs/context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.agent.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.agent.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.current_for_agent`
- `components.schemas.AgentSummary`, `AgentDetail`, `ConversationSummary`, `ConversationDetail`
- #704 pre-audit and approved gate comment

## Semantic migration accounting
- New canonical owner: `internal/store/operator_agent_conversation_read_surface.go`.
- Old non-authoritative producer/reader path invalidated: dashboard-local agent/conversation endpoint projection ownership in `internal/dashboard/server/agents_sql.go`, `internal/dashboard/server/conversations_sql.go`, and fallback handler scans.
- Production paths checked for surviving old behavior: v1 handler registry, dashboard `/api/agents*`, dashboard `/api/conversations*`, Builder/CLI/script reads, and dashboard SQL reader files.
- Migration complete for #704: yes, for the approved agent/conversation read-model child only. Subscriptions, agent control/mutation, CLI migration, and #677/#683 control tail remain outside this closure claim.

## Tests
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server -count=1`
- `go test ./... -count=1`
