### PR TITLE
[agent-d][issue #706] Generalize artifact repo identity

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1057,13 +1057,20 @@ handler_specification:
             product_surface: Consumers receive `swarm-artifact://...` URLs and 40-character git commit SHAs, not raw host paths.
           artifact_repo_fields:
             provider: string — must be local_git.
-            repo_id: expression value resolving to the service-owned repository UUID. Required.
-            run_id: optional expression value resolving to the run UUID. Defaults to the triggering event run_id.
-            vertical_id: expression value resolving to the vertical UUID. Required for deterministic path partitioning.
-            business_slug: optional expression value used only as a sanitized local path hint. Not authoritative identity.
-            source_validation_case_id: expression value resolving to the source validation case UUID. Required for provenance.
+            repo_id: expression value resolving to the service-owned repository UUID. Required. This is the authoritative
+              opaque repository identity; product concepts must not be encoded as platform identity fields.
+            namespace: optional expression value resolving to a product-neutral isolation namespace. Defaults to the triggering
+              event run_id when omitted. Only letters, digits, dash, underscore, and dot are allowed; traversal markers fail
+              closed. The namespace partitions provider storage but is not semantic product identity.
+            partition_key: optional expression value resolving to a product-neutral grouping key copied into the manifest.
+              It may be used by consumers for indexing/debugging, but the runtime does not interpret it.
+            display_slug: optional expression value resolving to a cosmetic debug label. It is sanitized for any provider path
+              hint and is never authoritative identity. Path separators, traversal markers, and values with no letters/digits
+              fail closed.
             request_id: expression value resolving to the business idempotency UUID. Required.
             author: optional expression value used for git author display only.
+            provenance: optional mapping of product-owned provenance keys to expression values. Keys are copied under a
+              manifest/failure `provenance` object and are not interpreted by the platform. Invalid keys fail closed.
             allowed_paths: list of repository-relative paths allowed for this service action. Required. Absolute paths and
               traversal are prohibited.
             files: list of `{path, content, content_type, schema, max_bytes}` entries. path and content are explicit expression
@@ -1074,14 +1081,17 @@ handler_specification:
               last_request_id, and last_source_event_id.
             failure_event: optional event name emitted when runtime execution fails after request/source identity resolution.
             failure_payload: optional mapping of additional failure event payload fields to expression values. Runtime always
-              includes repo_id, run_id, vertical_id, source_validation_case_id, request_id, source_event_id, and failure_reason.
+              includes repo_id, namespace, request_id, source_event_id, failure_reason, provenance, and optional partition_key
+              and display_slug when declared/resolved.
           behavior: The runtime normalizes file content, validates yaml content against the declared file schema, writes only
             allowlisted paths under the service-owned repo root, verifies the projected git tree stays within max_repo_bytes,
             commits staged files atomically, verifies the resulting ref is a 40-character git SHA, and persists only the declared
             output fields on the selected/owned entity. Duplicate replay for the same source_event_id is a no-op only when the
             contract-visible committed output state is already present. Reusing a request_id with different content fails closed
             even when that request is not the latest operation. Content hashes are diagnostic and do not replace request/source
-            idempotency.
+            idempotency. The public artifact URL is product-neutral (`swarm-artifact://repos/<repo_id>`). The local-git provider
+            path is product-neutral, collision-safe by repo_id, scoped below the runtime artifact root, and must not encode
+            product-specific path segments.
           operation_state: The selected/owned entity is the contract-visible operation/ref ledger surface for V1. The service
             contract must declare the output fields it wants persisted; status is committed or failed, failure_reason records
             runtime failure detail when available, and current_ref updates only after git commit/ref verification succeeds.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1064,9 +1064,9 @@ handler_specification:
               closed. The namespace partitions provider storage but is not semantic product identity.
             partition_key: optional expression value resolving to a product-neutral grouping key copied into the manifest.
               It may be used by consumers for indexing/debugging, but the runtime does not interpret it.
-            display_slug: optional expression value resolving to a cosmetic debug label. It is sanitized for any provider path
-              hint and is never authoritative identity. Path separators, traversal markers, and values with no letters/digits
-              fail closed.
+            display_slug: optional expression value resolving to a cosmetic debug label copied into the manifest/failure
+              payload. It is never authoritative identity and must not affect provider storage paths. Path separators, traversal
+              markers, and values with no letters/digits fail closed.
             request_id: expression value resolving to the business idempotency UUID. Required.
             author: optional expression value used for git author display only.
             provenance: optional mapping of product-owned provenance keys to expression values. Keys are copied under a

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -2294,13 +2294,34 @@ func validateArtifactRepoActionSpec(nodeID, eventType string, action runtimecont
 		findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo_commit provider %s is unsupported", provider)))
 	}
 	for label, expr := range map[string]runtimecontracts.ExpressionValue{
-		"repo_id":                   spec.RepoID,
-		"request_id":                spec.RequestID,
-		"vertical_id":               spec.VerticalID,
-		"source_validation_case_id": spec.SourceValidationCaseID,
+		"repo_id":    spec.RepoID,
+		"request_id": spec.RequestID,
 	} {
 		if expr.IsZero() {
 			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo_commit is missing artifact_repo.%s", label)))
+		}
+	}
+	for label, expr := range map[string]runtimecontracts.ExpressionValue{
+		"namespace":     spec.Namespace,
+		"partition_key": spec.PartitionKey,
+	} {
+		if value, ok := artifactRepoLiteralString(expr); ok {
+			if err := validateArtifactRepoSegment(value); err != nil {
+				findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.%s %q is invalid: %v", label, value, err)))
+			}
+		}
+	}
+	if value, ok := artifactRepoLiteralString(spec.DisplaySlug); ok {
+		if err := validateArtifactRepoDisplaySlug(value); err != nil {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.display_slug %q is invalid: %v", value, err)))
+		}
+	}
+	for key, expr := range spec.Provenance {
+		if err := validateArtifactRepoProvenanceKey(key); err != nil {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.provenance key %q is invalid: %v", key, err)))
+		}
+		if expr.IsZero() {
+			findings = append(findings, artifactRepoFinding(nodeID, eventType, fmt.Sprintf("artifact_repo.provenance.%s is missing value", strings.TrimSpace(key))))
 		}
 	}
 	if len(spec.AllowedPaths) == 0 {
@@ -2410,6 +2431,61 @@ func artifactRepoLiteralString(expr runtimecontracts.ExpressionValue) (string, b
 	}
 	value := strings.TrimSpace(fmt.Sprint(expr.Literal))
 	return value, value != ""
+}
+
+func validateArtifactRepoSegment(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fmt.Errorf("value is required")
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("only letters, digits, dash, underscore, and dot are allowed")
+	}
+	if value == "." || value == ".." || strings.Contains(value, "..") {
+		return fmt.Errorf("path traversal markers are not allowed")
+	}
+	return nil
+}
+
+func validateArtifactRepoProvenanceKey(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fmt.Errorf("key is required")
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("only letters, digits, dash, underscore, and dot are allowed")
+	}
+	return nil
+}
+
+func validateArtifactRepoDisplaySlug(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil
+	}
+	if strings.Contains(value, "\x00") || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	if value == "." || value == ".." || strings.Contains(value, "..") {
+		return fmt.Errorf("path traversal markers are not allowed")
+	}
+	hasAlphaNumeric := false
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			hasAlphaNumeric = true
+			break
+		}
+	}
+	if !hasAlphaNumeric {
+		return fmt.Errorf("must contain at least one letter or digit")
+	}
+	return nil
 }
 
 func validateArtifactRepoDeclaredPath(raw string) (string, error) {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -768,7 +768,7 @@ func TestRun_ReportsArtifactRepoCommitMissingSpec(t *testing.T) {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"artifact-node": {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"spec_file.commit_requested": {
+					"artifact.commit_requested": {
 						Action: runtimecontracts.ActionSpec{ID: "artifact_repo_commit"},
 					},
 				},
@@ -788,14 +788,18 @@ func TestRun_ReportsArtifactRepoCommitInvalidShape(t *testing.T) {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"artifact-node": {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"spec_file.commit_requested": {
+					"artifact.commit_requested": {
 						Action: runtimecontracts.ActionSpec{
 							ID: "artifact_repo_commit",
 							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
-								Provider:     "s3",
-								RepoID:       runtimecontracts.RefExpression("entity.spec_repo_id"),
-								RequestID:    runtimecontracts.RefExpression("payload.request_id"),
-								VerticalID:   runtimecontracts.RefExpression("entity.vertical_id"),
+								Provider:    "s3",
+								RepoID:      runtimecontracts.RefExpression("entity.repo_id"),
+								RequestID:   runtimecontracts.RefExpression("payload.request_id"),
+								Namespace:   runtimecontracts.LiteralExpression("../escape"),
+								DisplaySlug: runtimecontracts.LiteralExpression("../escape"),
+								Provenance: map[string]runtimecontracts.ExpressionValue{
+									"bad/key": {},
+								},
 								AllowedPaths: []string{"../escape.yaml"},
 								Files: []runtimecontracts.ArtifactRepoFileSpec{{
 									Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
@@ -819,8 +823,17 @@ func TestRun_ReportsArtifactRepoCommitInvalidShape(t *testing.T) {
 	if !reportContains(report.Errors(), "handler_field_compliance", "provider s3 is unsupported") {
 		t.Fatalf("expected unsupported provider error, got %#v", report.Errors())
 	}
-	if !reportContains(report.Errors(), "handler_field_compliance", "missing artifact_repo.source_validation_case_id") {
-		t.Fatalf("expected missing source_validation_case_id error, got %#v", report.Errors())
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo.namespace") {
+		t.Fatalf("expected invalid namespace error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo.display_slug") {
+		t.Fatalf("expected invalid display_slug error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo.provenance key") {
+		t.Fatalf("expected invalid provenance key error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "artifact_repo.provenance.bad/key is missing value") {
+		t.Fatalf("expected missing provenance value error, got %#v", report.Errors())
 	}
 	if !reportContains(report.Errors(), "handler_field_compliance", "path traversal is not allowed") {
 		t.Fatalf("expected traversal allowlist error, got %#v", report.Errors())
@@ -838,16 +851,15 @@ func TestRun_ReportsArtifactRepoCommitYAMLFileMissingSchema(t *testing.T) {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"artifact-node": {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"spec_file.commit_requested": {
+					"artifact.commit_requested": {
 						Action: runtimecontracts.ActionSpec{
 							ID: "artifact_repo_commit",
 							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
-								Provider:               "local_git",
-								RepoID:                 runtimecontracts.RefExpression("entity.spec_repo_id"),
-								RequestID:              runtimecontracts.RefExpression("payload.request_id"),
-								VerticalID:             runtimecontracts.RefExpression("entity.vertical_id"),
-								SourceValidationCaseID: runtimecontracts.RefExpression("entity.source_validation_case_id"),
-								AllowedPaths:           []string{"specs/mvp.yaml"},
+								Provider:     "local_git",
+								RepoID:       runtimecontracts.RefExpression("entity.repo_id"),
+								Namespace:    runtimecontracts.LiteralExpression("tenant.alpha"),
+								RequestID:    runtimecontracts.RefExpression("payload.request_id"),
+								AllowedPaths: []string{"specs/mvp.yaml"},
 								Files: []runtimecontracts.ArtifactRepoFileSpec{{
 									Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
 									Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
@@ -882,7 +894,7 @@ func TestRun_ReportsArtifactRepoDeclarationOnNonArtifactAction(t *testing.T) {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"artifact-node": {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"spec_file.commit_requested": {
+					"artifact.commit_requested": {
 						Action: runtimecontracts.ActionSpec{
 							ID: "record_evidence",
 							ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -332,20 +332,20 @@ type MailboxWriteSpec struct {
 }
 
 type ArtifactRepoSpec struct {
-	Provider               string                     `yaml:"provider"`
-	RepoID                 ExpressionValue            `yaml:"repo_id"`
-	RunID                  ExpressionValue            `yaml:"run_id"`
-	VerticalID             ExpressionValue            `yaml:"vertical_id"`
-	BusinessSlug           ExpressionValue            `yaml:"business_slug"`
-	SourceValidationCaseID ExpressionValue            `yaml:"source_validation_case_id"`
-	RequestID              ExpressionValue            `yaml:"request_id"`
-	Author                 ExpressionValue            `yaml:"author"`
-	AllowedPaths           []string                   `yaml:"allowed_paths"`
-	Files                  []ArtifactRepoFileSpec     `yaml:"files"`
-	Output                 ArtifactRepoOutputSpec     `yaml:"output"`
-	Limits                 ArtifactRepoLimitsSpec     `yaml:"limits"`
-	FailureEvent           string                     `yaml:"failure_event"`
-	FailurePayload         map[string]ExpressionValue `yaml:"failure_payload"`
+	Provider       string                     `yaml:"provider"`
+	RepoID         ExpressionValue            `yaml:"repo_id"`
+	Namespace      ExpressionValue            `yaml:"namespace"`
+	PartitionKey   ExpressionValue            `yaml:"partition_key"`
+	DisplaySlug    ExpressionValue            `yaml:"display_slug"`
+	RequestID      ExpressionValue            `yaml:"request_id"`
+	Author         ExpressionValue            `yaml:"author"`
+	Provenance     map[string]ExpressionValue `yaml:"provenance"`
+	AllowedPaths   []string                   `yaml:"allowed_paths"`
+	Files          []ArtifactRepoFileSpec     `yaml:"files"`
+	Output         ArtifactRepoOutputSpec     `yaml:"output"`
+	Limits         ArtifactRepoLimitsSpec     `yaml:"limits"`
+	FailureEvent   string                     `yaml:"failure_event"`
+	FailurePayload map[string]ExpressionValue `yaml:"failure_payload"`
 }
 
 type ArtifactRepoFileSpec struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -239,20 +239,20 @@ func (s *ArtifactRepoSpec) UnmarshalYAML(node *yaml.Node) error {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo must be a mapping")
 	}
 	allowed := map[string]struct{}{
-		"provider":                  {},
-		"repo_id":                   {},
-		"run_id":                    {},
-		"vertical_id":               {},
-		"business_slug":             {},
-		"source_validation_case_id": {},
-		"request_id":                {},
-		"author":                    {},
-		"allowed_paths":             {},
-		"files":                     {},
-		"output":                    {},
-		"limits":                    {},
-		"failure_event":             {},
-		"failure_payload":           {},
+		"provider":        {},
+		"repo_id":         {},
+		"namespace":       {},
+		"partition_key":   {},
+		"display_slug":    {},
+		"request_id":      {},
+		"author":          {},
+		"provenance":      {},
+		"allowed_paths":   {},
+		"files":           {},
+		"output":          {},
+		"limits":          {},
+		"failure_event":   {},
+		"failure_payload": {},
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -822,19 +823,22 @@ action:
   artifact_repo:
     provider: local_git
     repo_id:
-      ref: entity.spec_repo_id
-    run_id:
+      ref: entity.repo_id
+    namespace:
       ref: event.run_id
-    vertical_id:
-      ref: entity.vertical_id
-    business_slug:
-      ref: entity.business_slug
-    source_validation_case_id:
-      ref: entity.source_validation_case_id
+    partition_key:
+      ref: entity.project_id
+    display_slug:
+      ref: entity.display_slug
     request_id:
       ref: payload.request_id
     author:
-      literal: validation-agent
+      literal: artifact-writer
+    provenance:
+      scope:
+        literal: fixture
+      source_record_id:
+        ref: entity.source_record_id
     allowed_paths:
       - specs/mvp.yaml
     files:
@@ -859,7 +863,7 @@ action:
     limits:
       max_yaml_bytes: 4096
       max_repo_bytes: 1048576
-    failure_event: spec_repo.commit_failed
+    failure_event: artifact_repo.commit_failed
     failure_payload:
       request_id:
         ref: payload.request_id
@@ -875,6 +879,15 @@ action:
 	if got := handler.Action.ArtifactRepo.Provider; got != "local_git" {
 		t.Fatalf("ArtifactRepo.Provider = %q", got)
 	}
+	if got := handler.Action.ArtifactRepo.Namespace.Ref; got != "event.run_id" {
+		t.Fatalf("ArtifactRepo.Namespace = %#v", handler.Action.ArtifactRepo.Namespace)
+	}
+	if got := handler.Action.ArtifactRepo.PartitionKey.Ref; got != "entity.project_id" {
+		t.Fatalf("ArtifactRepo.PartitionKey = %#v", handler.Action.ArtifactRepo.PartitionKey)
+	}
+	if got := handler.Action.ArtifactRepo.Provenance["scope"].Literal; got != "fixture" {
+		t.Fatalf("ArtifactRepo.Provenance[scope] = %#v", handler.Action.ArtifactRepo.Provenance["scope"])
+	}
 	if got := handler.Action.ArtifactRepo.Files[0].Path.Literal; got != "specs/mvp.yaml" {
 		t.Fatalf("ArtifactRepo.Files[0].Path = %#v", got)
 	}
@@ -884,7 +897,7 @@ action:
 	if got := handler.Action.ArtifactRepo.Output.CurrentRef; got != "current_ref" {
 		t.Fatalf("ArtifactRepo.Output.CurrentRef = %q", got)
 	}
-	if got := handler.Action.ArtifactRepo.FailureEvent; got != "spec_repo.commit_failed" {
+	if got := handler.Action.ArtifactRepo.FailureEvent; got != "artifact_repo.commit_failed" {
 		t.Fatalf("ArtifactRepo.FailureEvent = %q", got)
 	}
 }
@@ -900,6 +913,25 @@ action:
 `), &handler)
 	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
 		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsLegacyArtifactRepoProductFields(t *testing.T) {
+	for _, field := range []string{"vertical_id", "source_validation_case_id", "business_slug", "spec_repo", "spec-repos"} {
+		t.Run(field, func(t *testing.T) {
+			var handler SystemNodeEventHandler
+			err := yaml.Unmarshal([]byte(fmt.Sprintf(`
+action:
+  id: artifact_repo_commit
+  artifact_repo:
+    provider: local_git
+    %s:
+      literal: old
+`, field)), &handler)
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf(`artifact_repo field "%s"`, field)) {
+				t.Fatalf("yaml.Unmarshal error = %v, want legacy product field rejection", err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	artifactRepoProviderLocalGit = "local_git"
-	artifactRepoPublicScheme     = "swarm-artifact://spec-repos/"
+	artifactRepoPublicScheme     = "swarm-artifact://repos/"
 	defaultArtifactRoot          = "/data/swarm/artifacts"
 	defaultYAMLMaxBytes          = 1 << 20
 	defaultMarkdownMaxBytes      = 5 << 20
@@ -62,15 +62,11 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 	if err != nil {
 		return err
 	}
-	runID, err := artifactRunID(execCtx, spec)
+	namespace, err := artifactNamespace(execCtx, spec)
 	if err != nil {
 		return err
 	}
-	verticalID, err := requiredArtifactUUID(execCtx.Base, spec.VerticalID, "artifact_repo.vertical_id")
-	if err != nil {
-		return err
-	}
-	sourceValidationCaseID, err := requiredArtifactUUID(execCtx.Base, spec.SourceValidationCaseID, "artifact_repo.source_validation_case_id")
+	partitionKey, err := optionalArtifactSegment(execCtx.Base, spec.PartitionKey, "artifact_repo.partition_key")
 	if err != nil {
 		return err
 	}
@@ -78,6 +74,8 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 	if err != nil {
 		return err
 	}
+	provenance := map[string]any{}
+	displaySlug := ""
 	fail := func(err error) error {
 		if err == nil {
 			return nil
@@ -89,9 +87,17 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			spec.Output.LastSourceEventID: sourceEventID,
 		})
 		if failureEvent := strings.TrimSpace(spec.FailureEvent); failureEvent != "" {
-			_ = pc.publish(ctx, failureEvent, execCtx.Request.EntityID.String(), artifactRepoFailurePayload(execCtx.Base, spec, repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, err))
+			_ = pc.publish(ctx, failureEvent, execCtx.Request.EntityID.String(), artifactRepoFailurePayload(execCtx.Base, spec, repoID, namespace, partitionKey, displaySlug, provenance, requestID, sourceEventID, err))
 		}
 		return err
+	}
+	displaySlug, err = optionalArtifactDisplaySlug(execCtx.Base, spec.DisplaySlug)
+	if err != nil {
+		return fail(err)
+	}
+	provenance, err = artifactRepoProvenance(execCtx.Base, spec)
+	if err != nil {
+		return fail(err)
 	}
 	if previous := strings.TrimSpace(asString(execCtx.Request.State.StateCarrier.Metadata[spec.Output.LastSourceEventID])); previous == sourceEventID && artifactRepoOutputsComplete(execCtx.Request.State.StateCarrier.Metadata, spec) {
 		return nil
@@ -107,8 +113,7 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			}
 		}
 	}
-	businessSlug := optionalArtifactString(execCtx.Base, spec.BusinessSlug)
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), runID, verticalID, businessSlug, repoID)
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), namespace, displaySlug, repoID)
 	if err != nil {
 		return fail(err)
 	}
@@ -122,7 +127,7 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			return fail(fmt.Errorf("artifact_repo_commit request_id %s conflicts with previously committed tree %s", requestID, previous.TreeHash))
 		}
 		repoURL := artifactRepoPublicScheme + repoID
-		manifest := artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, previous.Ref, treeHash, files)
+		manifest := artifactRepoManifest(repoID, namespace, partitionKey, displaySlug, provenance, requestID, sourceEventID, repoURL, previous.Ref, treeHash, files)
 		return pc.persistArtifactRepoResult(ctx, execCtx, spec, map[string]any{
 			spec.Output.RepoURL:           repoURL,
 			spec.Output.CurrentRef:        previous.Ref,
@@ -146,7 +151,7 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 		return fail(err)
 	}
 	repoURL := artifactRepoPublicScheme + repoID
-	manifest := artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash, files)
+	manifest := artifactRepoManifest(repoID, namespace, partitionKey, displaySlug, provenance, requestID, sourceEventID, repoURL, ref, treeHash, files)
 	return pc.persistArtifactRepoResult(ctx, execCtx, spec, map[string]any{
 		spec.Output.RepoURL:           repoURL,
 		spec.Output.CurrentRef:        ref,
@@ -191,20 +196,23 @@ func artifactRepoOutputsComplete(metadata map[string]any, spec *runtimecontracts
 	return true
 }
 
-func artifactRunID(execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec) (string, error) {
-	if spec != nil && !spec.RunID.IsZero() {
-		return requiredArtifactUUID(execCtx.Base, spec.RunID, "artifact_repo.run_id")
+func artifactNamespace(execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec) (string, error) {
+	if spec != nil && !spec.Namespace.IsZero() {
+		return requiredArtifactSegment(execCtx.Base, spec.Namespace, "artifact_repo.namespace")
 	}
-	runID := strings.TrimSpace(execCtx.Request.Event.RunID)
-	if runID == "" {
+	namespace := strings.TrimSpace(execCtx.Request.Event.RunID)
+	if namespace == "" {
 		if value, ok := execCtx.Base.Event.Lookup(paths.Parse("run_id")); ok {
-			runID = strings.TrimSpace(asString(value))
+			namespace = strings.TrimSpace(asString(value))
 		}
 	}
-	if _, err := uuid.Parse(runID); err != nil {
-		return "", fmt.Errorf("artifact_repo_commit requires UUID run_id: %w", err)
+	if namespace == "" {
+		return "", fmt.Errorf("artifact_repo_commit requires artifact_repo.namespace or event run_id")
 	}
-	return runID, nil
+	if err := validateArtifactRepoSegment(namespace); err != nil {
+		return "", fmt.Errorf("artifact_repo.namespace: %w", err)
+	}
+	return namespace, nil
 }
 
 func requiredArtifactUUID(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
@@ -233,6 +241,24 @@ func requiredArtifactString(base runtimeengine.BaseContext, expr runtimecontract
 	return out, nil
 }
 
+func requiredArtifactSegment(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
+	value, err := requiredArtifactString(base, expr, field)
+	if err != nil {
+		return "", err
+	}
+	if err := validateArtifactRepoSegment(value); err != nil {
+		return "", fmt.Errorf("%s: %w", field, err)
+	}
+	return value, nil
+}
+
+func optionalArtifactSegment(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue, field string) (string, error) {
+	if expr.IsZero() {
+		return "", nil
+	}
+	return requiredArtifactSegment(base, expr, field)
+}
+
 func optionalArtifactString(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue) string {
 	if expr.IsZero() {
 		return ""
@@ -242,6 +268,46 @@ func optionalArtifactString(base runtimeengine.BaseContext, expr runtimecontract
 		return ""
 	}
 	return strings.TrimSpace(asString(value))
+}
+
+func optionalArtifactDisplaySlug(base runtimeengine.BaseContext, expr runtimecontracts.ExpressionValue) (string, error) {
+	if expr.IsZero() {
+		return "", nil
+	}
+	value, ok, err := evalMailboxExpressionValue(base, expr)
+	if err != nil {
+		return "", fmt.Errorf("artifact_repo.display_slug: %w", err)
+	}
+	if !ok {
+		return "", nil
+	}
+	raw := strings.TrimSpace(asString(value))
+	if err := validateArtifactRepoDisplaySlug(raw); err != nil {
+		return "", fmt.Errorf("artifact_repo.display_slug: %w", err)
+	}
+	return raw, nil
+}
+
+func artifactRepoProvenance(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec) (map[string]any, error) {
+	out := map[string]any{}
+	if spec == nil {
+		return out, nil
+	}
+	for key, expr := range spec.Provenance {
+		key = strings.TrimSpace(key)
+		if err := validateArtifactRepoProvenanceKey(key); err != nil {
+			return nil, fmt.Errorf("artifact_repo.provenance key %q: %w", key, err)
+		}
+		value, ok, err := evalMailboxExpressionValue(base, expr)
+		if err != nil {
+			return nil, fmt.Errorf("artifact_repo.provenance.%s: %w", key, err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("artifact_repo.provenance.%s resolved empty", key)
+		}
+		out[key] = value
+	}
+	return out, nil
 }
 
 func prepareArtifactRepoFiles(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec) ([]artifactRepoPreparedFile, string, error) {
@@ -399,25 +465,74 @@ func artifactRepoCleanPath(raw string) (string, error) {
 	return cleaned, nil
 }
 
-func artifactRepoPath(root, runID, verticalID, businessSlug, repoID string) (string, error) {
+func validateArtifactRepoSegment(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fmt.Errorf("value is required")
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("only letters, digits, dash, underscore, and dot are allowed")
+	}
+	if value == "." || value == ".." || strings.Contains(value, "..") {
+		return fmt.Errorf("path traversal markers are not allowed")
+	}
+	return nil
+}
+
+func validateArtifactRepoProvenanceKey(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fmt.Errorf("key is required")
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("only letters, digits, dash, underscore, and dot are allowed")
+	}
+	return nil
+}
+
+func validateArtifactRepoDisplaySlug(raw string) error {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil
+	}
+	if strings.Contains(value, "\x00") || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	if value == "." || value == ".." || strings.Contains(value, "..") {
+		return fmt.Errorf("path traversal markers are not allowed")
+	}
+	if sanitizeArtifactSlug(value) == "" {
+		return fmt.Errorf("must contain at least one letter or digit")
+	}
+	return nil
+}
+
+func artifactRepoPath(root, namespace, displaySlug, repoID string) (string, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {
 		return "", fmt.Errorf("artifact root is required")
 	}
-	for label, value := range map[string]string{"run_id": runID, "vertical_id": verticalID, "repo_id": repoID} {
-		if _, err := uuid.Parse(value); err != nil {
-			return "", fmt.Errorf("%s must be UUID: %w", label, err)
-		}
+	if _, err := uuid.Parse(repoID); err != nil {
+		return "", fmt.Errorf("repo_id must be UUID: %w", err)
 	}
-	slug := sanitizeArtifactSlug(businessSlug)
-	if slug == "" {
-		slug = "artifact"
+	if err := validateArtifactRepoSegment(namespace); err != nil {
+		return "", fmt.Errorf("namespace: %w", err)
 	}
-	shortVertical := strings.ReplaceAll(verticalID, "-", "")
-	if len(shortVertical) > 8 {
-		shortVertical = shortVertical[:8]
+	if err := validateArtifactRepoDisplaySlug(displaySlug); err != nil {
+		return "", fmt.Errorf("display_slug: %w", err)
 	}
-	repoPath := filepath.Join(root, "spec-repos", runID, slug+"-"+shortVertical, repoID+".git")
+	parts := []string{root, "repos", namespace}
+	if slug := sanitizeArtifactSlug(displaySlug); slug != "" {
+		parts = append(parts, slug)
+	}
+	parts = append(parts, repoID+".git")
+	repoPath := filepath.Join(parts...)
 	if !artifactPathWithinRoot(repoPath, root) {
 		return "", fmt.Errorf("artifact_repo path escaped artifact root")
 	}
@@ -696,7 +811,7 @@ func artifactRepoRequestRecord(ctx context.Context, repoPath, requestID string) 
 	return artifactRepoHistoryRecord{}, false, nil
 }
 
-func artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID, repoURL, ref, treeHash string, files []artifactRepoPreparedFile) map[string]any {
+func artifactRepoManifest(repoID, namespace, partitionKey, displaySlug string, provenance map[string]any, requestID, sourceEventID, repoURL, ref, treeHash string, files []artifactRepoPreparedFile) map[string]any {
 	fileItems := make([]map[string]any, 0, len(files))
 	for _, file := range files {
 		fileItems = append(fileItems, map[string]any{
@@ -706,22 +821,31 @@ func artifactRepoManifest(repoID, runID, verticalID, sourceValidationCaseID, req
 			"size_bytes":   file.Size,
 		})
 	}
-	return map[string]any{
-		"provider":                  artifactRepoProviderLocalGit,
-		"repo_id":                   repoID,
-		"run_id":                    runID,
-		"vertical_id":               verticalID,
-		"source_validation_case_id": sourceValidationCaseID,
-		"request_id":                requestID,
-		"source_event_id":           sourceEventID,
-		"repo_url":                  repoURL,
-		"ref":                       ref,
-		"tree_hash":                 treeHash,
-		"files":                     fileItems,
+	if provenance == nil {
+		provenance = map[string]any{}
 	}
+	out := map[string]any{
+		"provider":        artifactRepoProviderLocalGit,
+		"repo_id":         repoID,
+		"namespace":       namespace,
+		"request_id":      requestID,
+		"source_event_id": sourceEventID,
+		"repo_url":        repoURL,
+		"ref":             ref,
+		"tree_hash":       treeHash,
+		"files":           fileItems,
+		"provenance":      provenance,
+	}
+	if strings.TrimSpace(partitionKey) != "" {
+		out["partition_key"] = partitionKey
+	}
+	if strings.TrimSpace(displaySlug) != "" {
+		out["display_slug"] = displaySlug
+	}
+	return out
 }
 
-func artifactRepoFailurePayload(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec, repoID, runID, verticalID, sourceValidationCaseID, requestID, sourceEventID string, cause error) map[string]any {
+func artifactRepoFailurePayload(base runtimeengine.BaseContext, spec *runtimecontracts.ArtifactRepoSpec, repoID, namespace, partitionKey, displaySlug string, provenance map[string]any, requestID, sourceEventID string, cause error) map[string]any {
 	out := map[string]any{}
 	if spec != nil {
 		for target, expr := range spec.FailurePayload {
@@ -737,9 +861,17 @@ func artifactRepoFailurePayload(base runtimeengine.BaseContext, spec *runtimecon
 		}
 	}
 	out["repo_id"] = repoID
-	out["run_id"] = runID
-	out["vertical_id"] = verticalID
-	out["source_validation_case_id"] = sourceValidationCaseID
+	out["namespace"] = namespace
+	if strings.TrimSpace(partitionKey) != "" {
+		out["partition_key"] = partitionKey
+	}
+	if strings.TrimSpace(displaySlug) != "" {
+		out["display_slug"] = displaySlug
+	}
+	if provenance == nil {
+		provenance = map[string]any{}
+	}
+	out["provenance"] = provenance
 	out["request_id"] = requestID
 	out["source_event_id"] = sourceEventID
 	out["failure_reason"] = cause.Error()

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -66,14 +66,11 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 	if err != nil {
 		return err
 	}
-	partitionKey, err := optionalArtifactSegment(execCtx.Base, spec.PartitionKey, "artifact_repo.partition_key")
-	if err != nil {
-		return err
-	}
 	requestID, err := requiredArtifactUUID(execCtx.Base, spec.RequestID, "artifact_repo.request_id")
 	if err != nil {
 		return err
 	}
+	partitionKey := ""
 	provenance := map[string]any{}
 	displaySlug := ""
 	fail := func(err error) error {
@@ -90,6 +87,10 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			_ = pc.publish(ctx, failureEvent, execCtx.Request.EntityID.String(), artifactRepoFailurePayload(execCtx.Base, spec, repoID, namespace, partitionKey, displaySlug, provenance, requestID, sourceEventID, err))
 		}
 		return err
+	}
+	partitionKey, err = optionalArtifactSegment(execCtx.Base, spec.PartitionKey, "artifact_repo.partition_key")
+	if err != nil {
+		return fail(err)
 	}
 	displaySlug, err = optionalArtifactDisplaySlug(execCtx.Base, spec.DisplaySlug)
 	if err != nil {
@@ -113,7 +114,7 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			}
 		}
 	}
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), namespace, displaySlug, repoID)
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), namespace, repoID)
 	if err != nil {
 		return fail(err)
 	}
@@ -513,7 +514,7 @@ func validateArtifactRepoDisplaySlug(raw string) error {
 	return nil
 }
 
-func artifactRepoPath(root, namespace, displaySlug, repoID string) (string, error) {
+func artifactRepoPath(root, namespace, repoID string) (string, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {
 		return "", fmt.Errorf("artifact root is required")
@@ -524,13 +525,7 @@ func artifactRepoPath(root, namespace, displaySlug, repoID string) (string, erro
 	if err := validateArtifactRepoSegment(namespace); err != nil {
 		return "", fmt.Errorf("namespace: %w", err)
 	}
-	if err := validateArtifactRepoDisplaySlug(displaySlug); err != nil {
-		return "", fmt.Errorf("display_slug: %w", err)
-	}
 	parts := []string{root, "repos", namespace}
-	if slug := sanitizeArtifactSlug(displaySlug); slug != "" {
-		parts = append(parts, slug)
-	}
 	parts = append(parts, repoID+".git")
 	repoPath := filepath.Join(parts...)
 	if !artifactPathWithinRoot(repoPath, root) {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -769,7 +769,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if !ok || len(files) != 1 {
 		t.Fatalf("manifest files = %#v", manifest["files"])
 	}
-	repoPath, err := artifactRepoPath(artifactRoot, initial["namespace"].(string), initial["display_slug"].(string), initial["repo_id"].(string))
+	repoPath, err := artifactRepoPath(artifactRoot, initial["namespace"].(string), initial["repo_id"].(string))
 	if err != nil {
 		t.Fatalf("artifactRepoPath: %v", err)
 	}
@@ -956,6 +956,8 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 	if err != nil {
 		t.Fatalf("load workflow instance after next request: %v", err)
 	}
+	// Display labels are cosmetic; request history must remain keyed by repo identity.
+	afterNext.Metadata["display_slug"] = "Renamed Artifact"
 
 	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, afterNext.Metadata, "77777777-7777-7777-7777-777777777777", "44444444-4444-4444-4444-444444444444", "name: Changed\n")
 	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
@@ -1007,7 +1009,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 	if sameRef == "" || sameRef == initialRef {
 		t.Fatalf("same-tree request current_ref = %q, initial ref = %q; want a durable operation commit", sameRef, initialRef)
 	}
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), initial["namespace"].(string), initial["display_slug"].(string), initial["repo_id"].(string))
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), initial["namespace"].(string), initial["repo_id"].(string))
 	if err != nil {
 		t.Fatalf("artifactRepoPath: %v", err)
 	}
@@ -1153,21 +1155,9 @@ func TestWriteArtifactRepoFilesRejectsSymlinkEscape(t *testing.T) {
 
 func TestArtifactRepoPathRejectsUnsafeGenericSegments(t *testing.T) {
 	repoID := "11111111-1111-1111-1111-111111111111"
-	for _, tc := range []struct {
-		name        string
-		namespace   string
-		displaySlug string
-		want        string
-	}{
-		{name: "namespace traversal", namespace: "../escape", displaySlug: "safe", want: "namespace"},
-		{name: "display traversal", namespace: "tenant-alpha", displaySlug: "../escape", want: "display_slug"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := artifactRepoPath(t.TempDir(), tc.namespace, tc.displaySlug, repoID)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("artifactRepoPath error = %v, want %s", err, tc.want)
-			}
-		})
+	_, err := artifactRepoPath(t.TempDir(), "../escape", repoID)
+	if err == nil || !strings.Contains(err.Error(), "namespace") {
+		t.Fatalf("artifactRepoPath error = %v, want namespace", err)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -720,7 +720,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -741,7 +741,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if err != nil || !ok {
 		t.Fatalf("load workflow instance ok=%v err=%v", ok, err)
 	}
-	if got := strings.TrimSpace(asString(instance.Metadata["repo_url"])); got != "swarm-artifact://spec-repos/"+initial["spec_repo_id"].(string) {
+	if got := strings.TrimSpace(asString(instance.Metadata["repo_url"])); got != "swarm-artifact://repos/"+initial["repo_id"].(string) {
 		t.Fatalf("repo_url = %q", got)
 	}
 	ref := strings.TrimSpace(asString(instance.Metadata["current_ref"]))
@@ -755,11 +755,21 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if got := strings.TrimSpace(asString(manifest["source_event_id"])); got != execCtx.Request.Event.ID {
 		t.Fatalf("manifest source_event_id = %q", got)
 	}
+	if _, exists := manifest["vertical_id"]; exists {
+		t.Fatalf("manifest contains product vertical_id: %#v", manifest)
+	}
+	provenance, ok := manifest["provenance"].(map[string]any)
+	if !ok {
+		t.Fatalf("manifest provenance = %#v", manifest["provenance"])
+	}
+	if got := strings.TrimSpace(asString(provenance["source_record_id"])); got != initial["source_record_id"].(string) {
+		t.Fatalf("manifest provenance source_record_id = %q", got)
+	}
 	files, ok := manifest["files"].([]any)
 	if !ok || len(files) != 1 {
 		t.Fatalf("manifest files = %#v", manifest["files"])
 	}
-	repoPath, err := artifactRepoPath(artifactRoot, testPipelineRunID, initial["vertical_id"].(string), initial["business_slug"].(string), initial["spec_repo_id"].(string))
+	repoPath, err := artifactRepoPath(artifactRoot, initial["namespace"].(string), initial["display_slug"].(string), initial["repo_id"].(string))
 	if err != nil {
 		t.Fatalf("artifactRepoPath: %v", err)
 	}
@@ -817,7 +827,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -850,8 +860,25 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	if got := bus.publishedCount(); got != 1 {
 		t.Fatalf("failure event count = %d, want 1", got)
 	}
-	if got := string(bus.publishedEvent(0).Type); got != "spec_repo.commit_failed" {
+	if got := string(bus.publishedEvent(0).Type); got != "artifact_repo.commit_failed" {
 		t.Fatalf("failure event type = %q", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.publishedEvent(0).Payload, &payload); err != nil {
+		t.Fatalf("failure event payload: %v", err)
+	}
+	if got := strings.TrimSpace(asString(payload["namespace"])); got != initial["namespace"].(string) {
+		t.Fatalf("failure payload namespace = %q", got)
+	}
+	if _, exists := payload["vertical_id"]; exists {
+		t.Fatalf("failure payload contains product vertical_id: %#v", payload)
+	}
+	provenance, ok := payload["provenance"].(map[string]any)
+	if !ok {
+		t.Fatalf("failure payload provenance = %#v", payload["provenance"])
+	}
+	if got := strings.TrimSpace(asString(provenance["source_record_id"])); got != initial["source_record_id"].(string) {
+		t.Fatalf("failure payload provenance source_record_id = %q", got)
 	}
 }
 
@@ -866,7 +893,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMis
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -905,7 +932,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -951,7 +978,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -980,7 +1007,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 	if sameRef == "" || sameRef == initialRef {
 		t.Fatalf("same-tree request current_ref = %q, initial ref = %q; want a durable operation commit", sameRef, initialRef)
 	}
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), testPipelineRunID, initial["vertical_id"].(string), initial["business_slug"].(string), initial["spec_repo_id"].(string))
+	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), initial["namespace"].(string), initial["display_slug"].(string), initial["repo_id"].(string))
 	if err != nil {
 		t.Fatalf("artifactRepoPath: %v", err)
 	}
@@ -1018,7 +1045,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRepairsDBStateFromGitHisto
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -1037,7 +1064,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRepairsDBStateFromGitHisto
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -1073,7 +1100,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitEnforcesProjectedRepoSize(
 	if err := store.Upsert(ctx, WorkflowInstance{
 		InstanceID:      entityID,
 		StorageRef:      entityID,
-		WorkflowName:    "spec-repo",
+		WorkflowName:    "artifact-repo",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "ready",
 		Metadata:        cloneStringAnyMap(initial),
@@ -1124,12 +1151,33 @@ func TestWriteArtifactRepoFilesRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestArtifactRepoPathRejectsUnsafeGenericSegments(t *testing.T) {
+	repoID := "11111111-1111-1111-1111-111111111111"
+	for _, tc := range []struct {
+		name        string
+		namespace   string
+		displaySlug string
+		want        string
+	}{
+		{name: "namespace traversal", namespace: "../escape", displaySlug: "safe", want: "namespace"},
+		{name: "display traversal", namespace: "tenant-alpha", displaySlug: "../escape", want: "display_slug"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := artifactRepoPath(t.TempDir(), tc.namespace, tc.displaySlug, repoID)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("artifactRepoPath error = %v, want %s", err, tc.want)
+			}
+		})
+	}
+}
+
 func testArtifactRepoEntityFields() map[string]any {
 	return map[string]any{
-		"spec_repo_id":              "11111111-1111-1111-1111-111111111111",
-		"vertical_id":               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-		"source_validation_case_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-		"business_slug":             "Acme CRM",
+		"repo_id":          "11111111-1111-1111-1111-111111111111",
+		"namespace":        "tenant-alpha",
+		"partition_key":    "project-42",
+		"display_slug":     "Demo Artifact",
+		"source_record_id": "record-123",
 	}
 }
 
@@ -1141,7 +1189,7 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 	payloadBytes, _ := json.Marshal(payload)
 	evt := events.Event{
 		ID:        eventID,
-		Type:      "spec_file.commit_requested",
+		Type:      "artifact_repo.commit_requested",
 		RunID:     testPipelineRunID,
 		Payload:   payloadBytes,
 		CreatedAt: time.Unix(1_700_000_000, 0).UTC(),
@@ -1154,15 +1202,18 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 	return runtimecontracts.ActionSpec{
 			ID: "artifact_repo_commit",
 			ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
-				Provider:               "local_git",
-				RepoID:                 runtimecontracts.RefExpression("entity.spec_repo_id"),
-				RunID:                  runtimecontracts.RefExpression("event.run_id"),
-				VerticalID:             runtimecontracts.RefExpression("entity.vertical_id"),
-				BusinessSlug:           runtimecontracts.RefExpression("entity.business_slug"),
-				SourceValidationCaseID: runtimecontracts.RefExpression("entity.source_validation_case_id"),
-				RequestID:              runtimecontracts.RefExpression("payload.request_id"),
-				Author:                 runtimecontracts.LiteralExpression("validation-agent"),
-				AllowedPaths:           []string{"specs/mvp.yaml"},
+				Provider:     "local_git",
+				RepoID:       runtimecontracts.RefExpression("entity.repo_id"),
+				Namespace:    runtimecontracts.RefExpression("entity.namespace"),
+				PartitionKey: runtimecontracts.RefExpression("entity.partition_key"),
+				DisplaySlug:  runtimecontracts.RefExpression("entity.display_slug"),
+				RequestID:    runtimecontracts.RefExpression("payload.request_id"),
+				Author:       runtimecontracts.LiteralExpression("artifact-writer"),
+				Provenance: map[string]runtimecontracts.ExpressionValue{
+					"artifact_type":    runtimecontracts.LiteralExpression("fixture"),
+					"source_record_id": runtimecontracts.RefExpression("entity.source_record_id"),
+				},
+				AllowedPaths: []string{"specs/mvp.yaml"},
 				Files: []runtimecontracts.ArtifactRepoFileSpec{{
 					Path:        runtimecontracts.LiteralExpression("specs/mvp.yaml"),
 					Content:     runtimecontracts.RefExpression("payload.mvp_yaml"),
@@ -1186,7 +1237,7 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 					MaxYAMLBytes: 4096,
 					MaxRepoBytes: 1048576,
 				},
-				FailureEvent: "spec_repo.commit_failed",
+				FailureEvent: "artifact_repo.commit_failed",
 				FailurePayload: map[string]runtimecontracts.ExpressionValue{
 					"request_id": runtimecontracts.RefExpression("payload.request_id"),
 				},
@@ -1199,7 +1250,7 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 				Event:    evt,
 				State: runtimeengine.StateSnapshot{
 					EntityID:        identity.NormalizeEntityID(entityID),
-					WorkflowName:    "spec-repo",
+					WorkflowName:    "artifact-repo",
 					WorkflowVersion: "1.0.0",
 					CurrentState:    "ready",
 					StateCarrier:    runtimeengine.NewStateCarrier(stateMetadata, nil, nil),


### PR DESCRIPTION
Closes #706

## Summary
- Generalizes `artifact_repo_commit` identity from Empire/product nouns to product-neutral `repo_id`, `namespace`, `partition_key`, `display_slug`, and declared `provenance`.
- Updates authoritative `platform-spec.yaml`, strict YAML decoding, bootverify, runtime path/URL/manifest/failure payload, and artifact repo tests.
- Preserves #699 local-git behavior: allowlisted writes, YAML schema validation, size limits, pinned refs, idempotency/history, recovery repair, symlink/path traversal rejection, and failure state/events.

## Governing refs/context
- Swarm #706 pre-audit and independent gate outcome: approved complete owner-cluster migration.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `handler_specification.handler_fields.action.artifact_repo_commit` is updated as the authoritative merge artifact.
- Swarm #699/#703 remains the behavior baseline for the primitive.
- Empire #67/#64 are downstream consumers and should map product concepts into generic Swarm fields/provenance.

## Semantic migration
- New canonical owner: Swarm `artifact_repo_commit` owner cluster across spec, contract type, strict decoder, bootverify, runtime, and tests.
- Old producer/reader/writer path now invalid: `vertical_id`, `source_validation_case_id`, `business_slug`, `spec_repo`, `spec-repos`, `swarm-artifact://spec-repos/<repo_id>`, and product-shaped top-level manifest/failure fields.
- Production paths checked for surviving old behavior: strict artifact repo YAML decode, bootverify artifact checks, runtime path/URL generation, manifest/failure payload, and pipeline artifact repo fixtures.
- Migration complete for the chosen Swarm class. Downstream Empire #67/#64 mapping remains separate.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline -run 'ArtifactRepo|artifact_repo|TestRun_ReportsArtifactRepo|TestSystemNodeEventHandlerDecode_.*ArtifactRepo' -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline -count=1`
- `go test ./...`
- `git diff --check`
