### PR TITLE
[agent-a][issue #707] Add selected-contract fork readiness classifier

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -582,6 +582,14 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 		return 1
 	}
 	if contracts := strings.TrimSpace(*contractsPath); contracts != "" {
+		replayAdmission := store.RunForkSelectedContractReplayResumeAdmission(plan)
+		if len(plan.ReplayResumeAdmission.Dispositions) > 0 || len(plan.ReplayResumeAdmission.UnsupportedBlockers) > 0 {
+			plan.UnsupportedBlockers = replayAdmission.UnsupportedBlockers
+			plan.UnsupportedBlockerCount = len(replayAdmission.UnsupportedBlockers)
+		}
+		plan.ReplayResumeAdmission = replayAdmission
+		plan.ExecutionReady = replayAdmission.StateOnlyExecutionReady || replayAdmission.DeliveryEventReplayReady
+
 		contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, contracts))
 		if err != nil {
 			if out != nil {
@@ -641,8 +649,20 @@ func runForkCommand(ctx context.Context, repo string, args []string, out io.Writ
 			}
 			return 1
 		}
+		readiness, err := runtimerunforkexecution.BuildSelectedContractReadinessClassifier(runtimerunforkexecution.SelectedContractReadinessClassifierRequest{
+			Plan:                      plan,
+			ContractFrontierAdmission: admission,
+			SelectedContractExecution: executionModel,
+		})
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: classify selected contract readiness: %v\n", err)
+			}
+			return 1
+		}
 		plan.ContractFrontierAdmission = &admission
 		plan.SelectedContractExecution = &executionModel
+		plan.SelectedContractReadiness = &readiness
 	}
 	if *asJSON {
 		enc := json.NewEncoder(out)
@@ -791,6 +811,15 @@ func printRunForkPlan(w io.Writer, plan store.RunForkPlan) {
 			model.NonMutating,
 			model.ExecutionSupported,
 			model.FutureExecutionOwner,
+		)
+	}
+	if plan.SelectedContractReadiness != nil {
+		readiness := plan.SelectedContractReadiness
+		fmt.Fprintf(w, "Selected Contract Readiness: owner=%s non_mutating=%t facts=%d future_owner=%s\n",
+			readiness.Owner,
+			readiness.NonMutating,
+			len(readiness.FactMatrix),
+			readiness.FutureExecutionOwner,
 		)
 	}
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -614,6 +614,56 @@ func TestRunForkCommand_DryRunContractsAddsContractFrontierAdmissionJSON(t *test
 	if !runForkPlanHasBlocker(model.UnsupportedBlockers, store.RunForkBlockerSelectedContractExecutionModelNonMutating) {
 		t.Fatalf("selected-contract execution blockers = %#v", model.UnsupportedBlockers)
 	}
+	readiness := plan.SelectedContractReadiness
+	if readiness == nil {
+		t.Fatalf("SelectedContractReadiness = nil; output=%s", buf.String())
+	}
+	if readiness.Owner != store.RunForkSelectedContractReadinessClassifierOwner ||
+		!readiness.NonMutating ||
+		readiness.PlannerOwner != store.RunForkPlanningOwner ||
+		readiness.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner ||
+		readiness.ContractFrontierAdmissionOwner != store.RunForkContractFrontierAdmissionOwner ||
+		readiness.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		readiness.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		readiness.SelectedExecutionModelOwner != store.RunForkSelectedContractExecutionModelOwner ||
+		readiness.FutureExecutionOwner != store.RunForkSelectedContractExecutionOwner {
+		t.Fatalf("selected-contract readiness = %#v", readiness)
+	}
+	if len(readiness.FactMatrix) != 20 {
+		t.Fatalf("readiness facts = %d, want complete matrix; facts=%#v", len(readiness.FactMatrix), readiness.FactMatrix)
+	}
+	for _, fact := range []string{
+		store.RunForkSelectedContractReadinessFactSourceEvents,
+		store.RunForkSelectedContractReadinessFactForkEvents,
+		store.RunForkSelectedContractReadinessFactSourceDeliveries,
+		store.RunForkSelectedContractReadinessFactForkDeliveries,
+		store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes,
+		store.RunForkSelectedContractReadinessFactTimers,
+		store.RunForkSelectedContractReadinessFactSessions,
+		store.RunForkSelectedContractReadinessFactTurns,
+		store.RunForkSelectedContractReadinessFactAudits,
+		store.RunForkSelectedContractReadinessFactCommittedReplayScopeMarkers,
+		store.RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics,
+		store.RunForkSelectedContractReadinessFactReceipts,
+		store.RunForkSelectedContractReadinessFactDeadLetters,
+		store.RunForkSelectedContractReadinessFactRetryIdempotency,
+		store.RunForkSelectedContractReadinessFactEmittedFollowUps,
+		store.RunForkSelectedContractReadinessFactSourcePostTFacts,
+		store.RunForkSelectedContractReadinessFactCurrentStateSnapshots,
+		store.RunForkSelectedContractReadinessFactNonAgentNodeSystemWork,
+		store.RunForkSelectedContractReadinessFactRestartRecovery,
+		store.RunForkSelectedContractReadinessFactOperatorConsumers,
+	} {
+		if !runForkReadinessFactHas(readiness.FactMatrix, fact) {
+			t.Fatalf("readiness fact %q missing from %#v", fact, readiness.FactMatrix)
+		}
+	}
+	if !runForkReadinessFactHasDisposition(readiness.FactMatrix, store.RunForkSelectedContractReadinessFactSourceDeliveries, store.RunForkSelectedContractReadinessDispositionFailClosedBlocker) {
+		t.Fatalf("source delivery readiness = %#v, want fail-closed blocker for source node delivery", readiness.FactMatrix)
+	}
+	if !runForkReadinessFactHasDisposition(readiness.FactMatrix, store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes, store.RunForkSelectedContractReadinessDispositionReconstructedForkState) {
+		t.Fatalf("route/recipient readiness = %#v, want reconstructed fork-local evidence", readiness.FactMatrix)
+	}
 }
 
 func TestRunForkCommand_ActivateWithContractsReachesSelectedActivationGate(t *testing.T) {
@@ -1244,6 +1294,24 @@ func runForkPlanHasString(values []string, want string) bool {
 func runForkPlanHasBoundary(values []store.RunForkSelectedContractExecutionBoundary, concept, disposition string) bool {
 	for _, value := range values {
 		if value.Concept == concept && value.Disposition == disposition {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkReadinessFactHas(values []store.RunForkSelectedContractReadinessFact, fact string) bool {
+	for _, value := range values {
+		if value.Fact == fact {
+			return true
+		}
+	}
+	return false
+}
+
+func runForkReadinessFactHasDisposition(values []store.RunForkSelectedContractReadinessFact, fact, disposition string) bool {
+	for _, value := range values {
+		if value.Fact == fact && value.Disposition == disposition {
 			return true
 		}
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3566,6 +3566,21 @@ run_model:
       receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime replay
       mutation. Full historical resume remains separately gated even when state-only activation or delivery/event replay
       is ready.'
+    selected_contract_readiness_classifier: 'Selected-contract timestamp-fork readiness explanation is owned by
+      runtime.run_fork.selected_contract_readiness_classifier. This owner is non-mutating and consumes the canonical
+      store planner, store.run_fork.replay_resume_admission, runtime.run_fork.contract_frontier_admission, selected
+      route admission/topology/dynamic topology, runtime.run_fork.selected_contract_recipient_planning, selected
+      execution model/admission evidence when present, current-state/materialization metadata, contract-swap admission,
+      historical replay admission, and fork-local runtime/platform lineage owners. It emits a complete read-only fact
+      matrix for selected-contract fork readiness with exactly one disposition for every source/fork fact family:
+      executable fork work, reconstructed fork-local state, lineage/no-action, branch-divergence evidence,
+      fail-closed blocker, or unsupported/split sibling. The classifier MUST NOT run handlers, create fork runs, write
+      fork-local events, event_deliveries, entity_state, sessions, turns, timers, audits, route recovery, replay rows,
+      receipts, dead letters, idempotency state, emitted follow-ups, or API/UI state. It MUST NOT copy source rows, use
+      source outcomes as fork suppressors, recompute historical fact-family semantics owned by historical replay
+      admission, recompute contract-swap readiness, or weaken materialization, execution, activation, or recovery
+      fail-closed gates. CLI, API, dashboard, and Builder are consumers only and may display the classifier output, but
+      they are not readiness owners.'
     selected_contract_execution_model: 'Selected-contract fork execution ownership is a non-mutating model until
       separately approved for runtime mutation. The canonical owner consumes contract_frontier_admission output only as
       prerequisite evidence, names the durable selected-contract binding owner that future execution must consume,
@@ -3925,6 +3940,16 @@ run_model:
         does not authorize replay directly from replay_resume_admission or RunForkPlan pending rows. Future runtime work uses the fork
         run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
         unsupported outside the gated delivery/event primitive.'
+      3b1_selected_contract_readiness_classifier: 'For selected-contract timestamp-fork dry-run/explain, the
+        runtime.run_fork.selected_contract_readiness_classifier owner consumes existing planner, replay taxonomy,
+        contract-frontier, route/topology, recipient-planning, selected-execution, current-state/materialization,
+        contract-swap, historical-replay, and fork-local runtime lineage owners to emit one read-only readiness matrix
+        before mutation. Every source/fork fact family must appear exactly once with owner, disposition, proof source,
+        and blocker or split tracker when applicable. The classifier is an explanation/read model only: it does not
+        authorize materialization, activation, selected execution, route recovery, historical replay, contract-swap
+        execution, restart recovery, or API/UI behavior. Mutation owners and activation gates must continue to consume
+        their own canonical owners and fail closed. CLI/API/dashboard/Builder surfaces may consume the matrix but MUST
+        NOT compute readiness semantics independently.'
       3c_selected_contract_source_advanced_branch: 'For selected-contract mutating fork execution, source advancement
         after the fork point is explicit branch divergence evidence when the selected execution owner can regenerate
         fork-local work under the fork run_id. The source run remains in its current status and is not frozen or rewound.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -353,6 +353,7 @@ nodes:
       - canonical timestamp-fork replay/resume owner must define which historical source-run facts are replayed, copied, reconstructed, lineage-only, or permanently blocked before execution starts
       - existing fork planner/materializer/activation owners are prerequisites and consumers, not the historical replay/resume owner
       - delivery, session/turn, timer, route, replay-scope, current-state, and mutation-log owners must either consume that owner or remain explicit blockers
+      - runtime.run_fork.selected_contract_readiness_classifier is the non-mutating selected-contract dry-run/explain matrix owner; it consumes existing planner/admission/execution owners and keeps CLI/API/dashboard/Builder as consumers only
     why_this_node_exists: activation-only forks can start a state-only fork context, but historical replay/resume is split across delivery rows, committed replay scope, sessions, turns, timers, routes, source-advanced checks, and planner blockers; local delivery redelivery or event-copy helpers would preserve semantic drift
     known_manifestations:
       - activation-only timestamp forks deliberately block historical replay and set historical replay as unsupported
@@ -395,6 +396,7 @@ nodes:
       - fork materialization needs runtime.run_fork.materialized_entity_snapshot_metadata to classify reconstructed entity_mutations candidates with source-at-T flow_instance/entity_type metadata before generic or selected-contract materializers write fork-local entity_state rows
       - selected-contract fork-local agent runtime materializer/executor needs runtime.run_fork.selected_contract_execution.fork_local_agent_runtime_materializer_executor to consume selected recipient planning, construct ephemeral fork-local handlers through factored static contract-agent semantics, and execute planned selected agent recipients under the fork run_id without persisting ordinary current-runtime agents or using source deliveries/outcomes/live subscriptions as execution truth
       - selected-contract fork-local runtime/platform control event lineage needs runtime.run_fork.selected_contract_execution.fork_local_runtime_platform_event_lineage_policy to classify fresh fork-run platform control outputs and platform.runtime_log diagnostics emitted by selected-fork runtime execution as lineage only through the selected fork event parent/source_event_id chain, with runtime-log diagnostics deriving persisted lineage from explicit parent_event_id or verified same-run subject event, while preserving fail-closed behavior for uncaused fork platform events, source platform.auth_required rows, current-state materialization, restart recovery, non-agent replay, and operator surfaces
+      - selected-contract fork readiness explanation needs runtime.run_fork.selected_contract_readiness_classifier to emit one owner-backed non-mutating matrix over source/fork events and deliveries, route/recipient evidence, timers, sessions/turns/audits, replay-scope markers, platform/runtime diagnostics, receipts/dead letters, retry/idempotency/follow-ups, source/post-T facts, current-state snapshots, non-agent work, restart/recovery, and operator consumers before mutation; it must consume existing owners rather than recompute them
     representative_issues:
       - 564
       - 565
@@ -432,6 +434,7 @@ nodes:
       - 681
       - 686
       - 690
+      - 707
     common_framing_mistakes:
       too_broad:
         - implement full fork replay, timers, sessions, routes, contract swap, and UI in one undifferentiated PR

--- a/internal/runtime/runforkexecution/readiness_classifier.go
+++ b/internal/runtime/runforkexecution/readiness_classifier.go
@@ -1,0 +1,471 @@
+package runforkexecution
+
+import (
+	"fmt"
+	"strings"
+
+	"swarm/internal/store"
+)
+
+type SelectedContractReadinessClassifierRequest struct {
+	Plan                      store.RunForkPlan
+	ContractFrontierAdmission store.RunForkContractFrontierAdmission
+	SelectedContractExecution store.RunForkSelectedContractExecution
+}
+
+func BuildSelectedContractReadinessClassifier(req SelectedContractReadinessClassifierRequest) (store.RunForkSelectedContractReadiness, error) {
+	plan := req.Plan
+	replayAdmission := plan.ReplayResumeAdmission
+	if strings.TrimSpace(replayAdmission.Owner) != store.RunForkReplayResumeAdmissionOwner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires %s; got %q", store.RunForkReplayResumeAdmissionOwner, replayAdmission.Owner)
+	}
+	frontier := req.ContractFrontierAdmission
+	if strings.TrimSpace(frontier.Owner) != store.RunForkContractFrontierAdmissionOwner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires %s; got %q", store.RunForkContractFrontierAdmissionOwner, frontier.Owner)
+	}
+	if !frontier.NonMutating {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires non-mutating frontier admission")
+	}
+	if frontier.HistoricalExecutionSupported {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier cannot consume mutating frontier admission")
+	}
+	model := req.SelectedContractExecution
+	if strings.TrimSpace(model.Owner) != store.RunForkSelectedContractExecutionModelOwner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires %s; got %q", store.RunForkSelectedContractExecutionModelOwner, model.Owner)
+	}
+	if !model.NonMutating {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires non-mutating selected execution model")
+	}
+	if model.ExecutionSupported {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier cannot consume mutating selected execution model")
+	}
+	if strings.TrimSpace(model.AdmissionOwner) != frontier.Owner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier frontier owner mismatch")
+	}
+	if err := validateSelectionMatches("readiness classifier", frontier.ContractSelection, model.ContractSelection); err != nil {
+		return store.RunForkSelectedContractReadiness{}, err
+	}
+	if model.RouteTopology == nil {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires route topology owner")
+	}
+	if model.RecipientPlanning == nil {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires recipient planning owner")
+	}
+	if strings.TrimSpace(model.RouteTopology.Owner) != store.RunForkSelectedContractRouteTopologyOwner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires %s; got %q", store.RunForkSelectedContractRouteTopologyOwner, model.RouteTopology.Owner)
+	}
+	if strings.TrimSpace(model.RecipientPlanning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
+		return store.RunForkSelectedContractReadiness{}, fmt.Errorf("selected-contract readiness classifier requires %s; got %q", store.RunForkSelectedContractRecipientPlanningOwner, model.RecipientPlanning.Owner)
+	}
+
+	historicalFacts := historicalReplayFactAdmissions(replayAdmission)
+	blockers := []store.RunForkUnsupportedBlocker{}
+	for _, blocker := range replayAdmission.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	for _, blocker := range frontier.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+	for _, blocker := range model.UnsupportedBlockers {
+		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
+	}
+
+	readiness := store.RunForkSelectedContractReadiness{
+		Owner:                          store.RunForkSelectedContractReadinessClassifierOwner,
+		NonMutating:                    true,
+		ContractSelection:              frontier.ContractSelection,
+		PlannerOwner:                   store.RunForkPlanningOwner,
+		ReplayResumeAdmissionOwner:     replayAdmission.Owner,
+		ContractFrontierAdmissionOwner: frontier.Owner,
+		RouteAdmissionOwner:            model.RouteTopology.RouteAdmissionOwner,
+		RouteTopologyOwner:             model.RouteTopology.Owner,
+		DynamicRouteTopologyOwner:      model.RouteTopology.DynamicTopologyOwner,
+		RecipientPlanningOwner:         model.RecipientPlanning.Owner,
+		SelectedExecutionModelOwner:    model.Owner,
+		FutureExecutionOwner:           model.FutureExecutionOwner,
+		FactMatrix:                     selectedContractReadinessFacts(plan, frontier, model, historicalFacts),
+		RequiredConsumers:              selectedContractReadinessRequiredConsumers(),
+		BlockedSiblings:                selectedContractReadinessBlockedSiblings(model),
+		InvalidPaths:                   selectedContractReadinessInvalidPaths(),
+		UnsupportedBlockers:            blockers,
+	}
+	if err := validateSelectedContractReadinessMatrix(readiness.FactMatrix); err != nil {
+		return store.RunForkSelectedContractReadiness{}, err
+	}
+	return readiness, nil
+}
+
+func selectedContractReadinessFacts(
+	plan store.RunForkPlan,
+	frontier store.RunForkContractFrontierAdmission,
+	model store.RunForkSelectedContractExecution,
+	historicalFacts []store.RunForkHistoricalReplayFactAdmission,
+) []store.RunForkSelectedContractReadinessFact {
+	return []store.RunForkSelectedContractReadinessFact{
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactSourceEvents, store.RunForkHistoricalReplayFactSourceEvents, historicalFacts),
+		readinessForkEvents(frontier),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactSourceDeliveries, store.RunForkHistoricalReplayFactEventDeliveries, historicalFacts),
+		readinessForkDeliveries(model),
+		readinessSelectedRecipientsRoutes(model),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactTimers, store.RunForkHistoricalReplayFactTimers, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactSessions, store.RunForkHistoricalReplayFactSessions, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactTurns, store.RunForkHistoricalReplayFactTurns, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactAudits, store.RunForkHistoricalReplayFactAudits, historicalFacts),
+		readinessReplayDispositionFact(plan.ReplayResumeAdmission, store.RunForkSelectedContractReadinessFactCommittedReplayScopeMarkers, store.RunForkReplayResumeFactCommittedReplayScope, "source committed replay-scope marker facts are classified by the canonical replay taxonomy and selected-contract marker policy; fork-local recovery proof must be freshly written by fork owners"),
+		readinessPlatformRuntimeFacts(frontier),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactReceipts, store.RunForkHistoricalReplayFactReceipts, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactDeadLetters, store.RunForkHistoricalReplayFactDeadLetters, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactRetryIdempotency, store.RunForkHistoricalReplayFactRetryIdempotency, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactEmittedFollowUps, store.RunForkHistoricalReplayFactEmittedFollowUps, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactSourcePostTFacts, store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts, historicalFacts),
+		readinessCurrentStateSnapshots(plan),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactNonAgentNodeSystemWork, store.RunForkHistoricalReplayFactNonAgentNodeSystemWork, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactRestartRecovery, store.RunForkHistoricalReplayFactRuntimeRestartRecovery, historicalFacts),
+		readinessHistoricalFact(store.RunForkSelectedContractReadinessFactOperatorConsumers, store.RunForkHistoricalReplayFactCLIApiDashboardOperator, historicalFacts),
+	}
+}
+
+func readinessHistoricalFact(readinessFact, historicalFact string, admissions []store.RunForkHistoricalReplayFactAdmission) store.RunForkSelectedContractReadinessFact {
+	for _, admission := range admissions {
+		if strings.TrimSpace(admission.Fact) != historicalFact {
+			continue
+		}
+		return store.RunForkSelectedContractReadinessFact{
+			Fact:        readinessFact,
+			Disposition: readinessDispositionFromHistoricalFact(readinessFact, admission),
+			Owner:       readinessOwnerFromHistorical(admission),
+			SourceOwner: admission.SourceOwner,
+			BlockerCode: admission.BlockerCode,
+			Tracker:     admission.Tracker,
+			Message:     admission.Message,
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        readinessFact,
+		Disposition: store.RunForkSelectedContractReadinessDispositionFailClosedBlocker,
+		Owner:       store.RunForkHistoricalReplayExecutionAdmissionOwner,
+		Message:     "fact is absent from the canonical historical replay admission matrix and must fail closed",
+	}
+}
+
+func readinessForkEvents(frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractReadinessFact {
+	if frontier.FrontierEventCount == 0 {
+		return store.RunForkSelectedContractReadinessFact{
+			Fact:        store.RunForkSelectedContractReadinessFactForkEvents,
+			Disposition: store.RunForkSelectedContractReadinessDispositionLineageNoAction,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			SourceOwner: frontier.Owner,
+			Message:     "no selected-contract frontier events require fork-local event minting at this fork point",
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        store.RunForkSelectedContractReadinessFactForkEvents,
+		Disposition: store.RunForkSelectedContractReadinessDispositionExecutableForkWork,
+		Owner:       store.RunForkSelectedContractExecutionOwner,
+		SourceOwner: frontier.Owner,
+		Evidence:    []string{store.RunForkSelectedContractExecutionModelOwner},
+		Message:     "selected execution may mint fresh fork-local events only through runtime.run_fork.selected_contract_execution; dry-run creates none",
+	}
+}
+
+func readinessForkDeliveries(model store.RunForkSelectedContractExecution) store.RunForkSelectedContractReadinessFact {
+	if model.RecipientPlanning == nil || len(model.RecipientPlanning.RecipientPlanEvents) == 0 {
+		return store.RunForkSelectedContractReadinessFact{
+			Fact:        store.RunForkSelectedContractReadinessFactForkDeliveries,
+			Disposition: store.RunForkSelectedContractReadinessDispositionLineageNoAction,
+			Owner:       store.RunForkSelectedContractExecutionOwner,
+			SourceOwner: store.RunForkSelectedContractRecipientPlanningOwner,
+			Message:     "no selected recipient plan requires fork-local delivery rows at this fork point",
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        store.RunForkSelectedContractReadinessFactForkDeliveries,
+		Disposition: store.RunForkSelectedContractReadinessDispositionExecutableForkWork,
+		Owner:       store.RunForkSelectedContractExecutionOwner,
+		SourceOwner: store.RunForkSelectedContractRecipientPlanningOwner,
+		Evidence:    []string{store.RunForkSelectedContractAuthoritativeAgentDeliveryMaterializationOwner},
+		Message:     "selected execution may write fork-local event_deliveries only from canonical recipient planning; source deliveries are not executable truth",
+	}
+}
+
+func readinessSelectedRecipientsRoutes(model store.RunForkSelectedContractExecution) store.RunForkSelectedContractReadinessFact {
+	if model.RouteTopology != nil {
+		for _, blocker := range model.RouteTopology.UnsupportedBlockers {
+			if strings.TrimSpace(blocker.Code) == store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven {
+				return store.RunForkSelectedContractReadinessFact{
+					Fact:        store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes,
+					Disposition: store.RunForkSelectedContractReadinessDispositionFailClosedBlocker,
+					Owner:       store.RunForkSelectedContractRouteTopologyOwner,
+					SourceOwner: store.RunForkSelectedContractRouteAdmissionOwner,
+					BlockerCode: blocker.Code,
+					Tracker:     "#615",
+					Message:     blocker.Message,
+				}
+			}
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes,
+		Disposition: store.RunForkSelectedContractReadinessDispositionReconstructedForkState,
+		Owner:       store.RunForkSelectedContractRecipientPlanningOwner,
+		SourceOwner: store.RunForkSelectedContractRouteTopologyOwner,
+		Evidence:    []string{store.RunForkSelectedContractRouteAdmissionOwner, store.RunForkSelectedContractRouteTopologyOwner},
+		Message:     "selected route topology and recipient planning are non-mutating fork-local evidence; route rows and source deliveries are not copied",
+	}
+}
+
+func readinessReplayDispositionFact(replay store.RunForkReplayResumeAdmission, fact, replayFact, fallbackMessage string) store.RunForkSelectedContractReadinessFact {
+	for _, disposition := range replay.Dispositions {
+		if strings.TrimSpace(disposition.Fact) != replayFact {
+			continue
+		}
+		return store.RunForkSelectedContractReadinessFact{
+			Fact:        fact,
+			Disposition: readinessDispositionFromReplay(disposition.Disposition),
+			Owner:       readinessReplayOwner(disposition),
+			SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+			BlockerCode: disposition.BlockerCode,
+			Message:     disposition.Message,
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        fact,
+		Disposition: store.RunForkSelectedContractReadinessDispositionLineageNoAction,
+		Owner:       store.RunForkReplayResumeAdmissionOwner,
+		SourceOwner: store.RunForkReplayResumeAdmissionOwner,
+		Message:     fallbackMessage,
+	}
+}
+
+func readinessPlatformRuntimeFacts(frontier store.RunForkContractFrontierAdmission) store.RunForkSelectedContractReadinessFact {
+	if len(frontier.LineageOnlyEvents) > 0 {
+		return store.RunForkSelectedContractReadinessFact{
+			Fact:        store.RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics,
+			Disposition: store.RunForkSelectedContractReadinessDispositionLineageNoAction,
+			Owner:       store.RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner,
+			SourceOwner: frontier.Owner,
+			Evidence:    []string{store.RunForkSelectedContractForkLocalRuntimePlatformEventLineagePolicyOwner},
+			Message:     "source diagnostic platform outcome facts are lineage/no-action only; fresh fork-local platform/runtime rows require selected-fork causal lineage",
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        store.RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics,
+		Disposition: store.RunForkSelectedContractReadinessDispositionUnsupportedSplitSibling,
+		Owner:       store.RunForkSelectedContractForkLocalRuntimePlatformEventLineagePolicyOwner,
+		SourceOwner: frontier.Owner,
+		Tracker:     "#702",
+		Message:     "fork-local runtime/platform diagnostic and control rows remain owned by selected-fork runtime platform-event lineage; unrelated platform rows fail closed",
+	}
+}
+
+func readinessCurrentStateSnapshots(plan store.RunForkPlan) store.RunForkSelectedContractReadinessFact {
+	disposition := store.RunForkSelectedContractReadinessDispositionReconstructedForkState
+	blockerCode := ""
+	for _, blocker := range plan.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == store.RunForkBlockerEntitySnapshotMetadataUnproven {
+			disposition = store.RunForkSelectedContractReadinessDispositionFailClosedBlocker
+			blockerCode = blocker.Code
+			break
+		}
+	}
+	return store.RunForkSelectedContractReadinessFact{
+		Fact:        store.RunForkSelectedContractReadinessFactCurrentStateSnapshots,
+		Disposition: disposition,
+		Owner:       store.RunForkMaterializedEntitySnapshotMetadataOwner,
+		SourceOwner: "entity_mutations",
+		BlockerCode: blockerCode,
+		Tracker:     "#681",
+		Message:     "fork-local current-state snapshots are reconstructed only from planner/entity-mutation evidence and materialized through the snapshot metadata owner; source current rows are not copied",
+	}
+}
+
+func readinessDispositionFromHistorical(admission string) string {
+	switch strings.TrimSpace(admission) {
+	case store.RunForkHistoricalReplayAdmissionExecutableForkWork:
+		return store.RunForkSelectedContractReadinessDispositionExecutableForkWork
+	case store.RunForkHistoricalReplayAdmissionReconstructedForkState:
+		return store.RunForkSelectedContractReadinessDispositionReconstructedForkState
+	case store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence:
+		return store.RunForkSelectedContractReadinessDispositionLineageNoAction
+	case store.RunForkHistoricalReplayAdmissionFailClosedBlocker:
+		return store.RunForkSelectedContractReadinessDispositionFailClosedBlocker
+	case store.RunForkHistoricalReplayAdmissionSplitSibling:
+		return store.RunForkSelectedContractReadinessDispositionUnsupportedSplitSibling
+	default:
+		return store.RunForkSelectedContractReadinessDispositionFailClosedBlocker
+	}
+}
+
+func readinessDispositionFromHistoricalFact(readinessFact string, admission store.RunForkHistoricalReplayFactAdmission) string {
+	if strings.TrimSpace(admission.Admission) == store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence {
+		switch readinessFact {
+		case store.RunForkSelectedContractReadinessFactSourcePostTFacts:
+			if strings.TrimSpace(admission.SourceOwner) == store.RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner {
+				return store.RunForkSelectedContractReadinessDispositionBranchDivergenceEvidence
+			}
+		case store.RunForkSelectedContractReadinessFactSourceDeliveries:
+			if strings.TrimSpace(admission.SourceOwner) == store.RunForkSelectedContractActiveSourceDeliveryConversationCouplingPolicyOwner {
+				return store.RunForkSelectedContractReadinessDispositionBranchDivergenceEvidence
+			}
+		}
+	}
+	return readinessDispositionFromHistorical(admission.Admission)
+}
+
+func readinessDispositionFromReplay(disposition string) string {
+	switch strings.TrimSpace(disposition) {
+	case store.RunForkReplayResumeDispositionForkReplay:
+		return store.RunForkSelectedContractReadinessDispositionExecutableForkWork
+	case store.RunForkReplayResumeDispositionReconstruct:
+		return store.RunForkSelectedContractReadinessDispositionReconstructedForkState
+	case store.RunForkReplayResumeDispositionLineageOnly, store.RunForkReplayResumeDispositionNoHistoricalAction:
+		return store.RunForkSelectedContractReadinessDispositionLineageNoAction
+	case store.RunForkReplayResumeDispositionFailClosedBlocker:
+		return store.RunForkSelectedContractReadinessDispositionFailClosedBlocker
+	case store.RunForkReplayResumeDispositionSplitSibling:
+		return store.RunForkSelectedContractReadinessDispositionUnsupportedSplitSibling
+	default:
+		return store.RunForkSelectedContractReadinessDispositionFailClosedBlocker
+	}
+}
+
+func readinessOwnerFromHistorical(admission store.RunForkHistoricalReplayFactAdmission) string {
+	switch strings.TrimSpace(admission.Admission) {
+	case store.RunForkHistoricalReplayAdmissionExecutableForkWork:
+		return store.RunForkHistoricalReplayExecutionOwner
+	case store.RunForkHistoricalReplayAdmissionReconstructedForkState:
+		if strings.TrimSpace(admission.SourceOwner) != "" {
+			return strings.TrimSpace(admission.SourceOwner)
+		}
+		return store.RunForkHistoricalReplayExecutionOwner
+	case store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence, store.RunForkHistoricalReplayAdmissionFailClosedBlocker:
+		if strings.TrimSpace(admission.SourceOwner) != "" {
+			return strings.TrimSpace(admission.SourceOwner)
+		}
+		return store.RunForkHistoricalReplayExecutionAdmissionOwner
+	case store.RunForkHistoricalReplayAdmissionSplitSibling:
+		return store.RunForkHistoricalReplayExecutionAdmissionOwner
+	default:
+		return store.RunForkHistoricalReplayExecutionAdmissionOwner
+	}
+}
+
+func readinessReplayOwner(disposition store.RunForkReplayResumeDisposition) string {
+	if strings.TrimSpace(disposition.Owner) != "" {
+		return strings.TrimSpace(disposition.Owner)
+	}
+	switch strings.TrimSpace(disposition.Disposition) {
+	case store.RunForkReplayResumeDispositionForkReplay:
+		return store.RunForkHistoricalReplayExecutionOwner
+	case store.RunForkReplayResumeDispositionReconstruct:
+		return store.RunForkHistoricalReplayExecutionOwner
+	default:
+		return store.RunForkReplayResumeAdmissionOwner
+	}
+}
+
+func selectedContractReadinessRequiredConsumers() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "cli_dry_run_explain_json",
+			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
+			Owner:       store.RunForkSelectedContractReadinessClassifierOwner,
+			Reason:      "supported explain output must consume the canonical readiness classifier and must not synthesize the matrix in CLI code",
+		},
+		{
+			Concept:     "future_api_dashboard_builder_consumers",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractReadinessClassifierOwner,
+			Reason:      "operator surfaces may display the classifier matrix later, but they cannot own readiness semantics",
+		},
+	}
+}
+
+func selectedContractReadinessBlockedSiblings(model store.RunForkSelectedContractExecution) []store.RunForkSelectedContractExecutionBoundary {
+	out := []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "typed_runtime_lineage",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractForkLocalRuntimePlatformEventLineagePolicyOwner,
+			Reason:      "#708 remains the typed-lineage architecture sibling; readiness explains current owner output without requiring that refactor",
+		},
+		{
+			Concept:     "fork_local_runtime_container",
+			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
+			Owner:       store.RunForkSelectedContractExecutionOwner + ".fork_local_runtime_container",
+			Reason:      "#709 remains the runtime-container architecture sibling; readiness is non-mutating explanation only",
+		},
+	}
+	out = append(out, model.BlockedSiblings...)
+	return out
+}
+
+func selectedContractReadinessInvalidPaths() []store.RunForkSelectedContractExecutionBoundary {
+	return []store.RunForkSelectedContractExecutionBoundary{
+		{
+			Concept:     "cli_owned_readiness",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "CLI/API/dashboard/Builder are consumers only and must not compute selected-contract fork readiness semantics",
+		},
+		{
+			Concept:     "source_row_copy_as_executable_truth",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source events, deliveries, receipts, dead letters, sessions, timers, and routes are lineage or blocker evidence; fork execution must mint fresh fork-local truth",
+		},
+		{
+			Concept:     "source_outcome_suppression",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "source outcomes cannot suppress fork-local selected execution or follow-up generation",
+		},
+		{
+			Concept:     "explain_output_authorizes_mutation",
+			Disposition: store.RunForkSelectedContractDispositionInvalid,
+			Reason:      "readiness explanation is non-mutating evidence and does not weaken materialization, execution, or activation fail-closed gates",
+		},
+	}
+}
+
+func validateSelectedContractReadinessMatrix(facts []store.RunForkSelectedContractReadinessFact) error {
+	required := []string{
+		store.RunForkSelectedContractReadinessFactSourceEvents,
+		store.RunForkSelectedContractReadinessFactForkEvents,
+		store.RunForkSelectedContractReadinessFactSourceDeliveries,
+		store.RunForkSelectedContractReadinessFactForkDeliveries,
+		store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes,
+		store.RunForkSelectedContractReadinessFactTimers,
+		store.RunForkSelectedContractReadinessFactSessions,
+		store.RunForkSelectedContractReadinessFactTurns,
+		store.RunForkSelectedContractReadinessFactAudits,
+		store.RunForkSelectedContractReadinessFactCommittedReplayScopeMarkers,
+		store.RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics,
+		store.RunForkSelectedContractReadinessFactReceipts,
+		store.RunForkSelectedContractReadinessFactDeadLetters,
+		store.RunForkSelectedContractReadinessFactRetryIdempotency,
+		store.RunForkSelectedContractReadinessFactEmittedFollowUps,
+		store.RunForkSelectedContractReadinessFactSourcePostTFacts,
+		store.RunForkSelectedContractReadinessFactCurrentStateSnapshots,
+		store.RunForkSelectedContractReadinessFactNonAgentNodeSystemWork,
+		store.RunForkSelectedContractReadinessFactRestartRecovery,
+		store.RunForkSelectedContractReadinessFactOperatorConsumers,
+	}
+	seen := map[string]struct{}{}
+	for _, fact := range facts {
+		name := strings.TrimSpace(fact.Fact)
+		if name == "" {
+			return fmt.Errorf("selected-contract readiness matrix contains unnamed fact")
+		}
+		if strings.TrimSpace(fact.Disposition) == "" {
+			return fmt.Errorf("selected-contract readiness fact %s has no disposition", name)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("selected-contract readiness matrix repeats fact %s", name)
+		}
+		seen[name] = struct{}{}
+	}
+	for _, requiredFact := range required {
+		if _, ok := seen[requiredFact]; !ok {
+			return fmt.Errorf("selected-contract readiness matrix missing fact %s", requiredFact)
+		}
+	}
+	return nil
+}

--- a/internal/runtime/runforkexecution/readiness_classifier_test.go
+++ b/internal/runtime/runforkexecution/readiness_classifier_test.go
@@ -1,0 +1,156 @@
+package runforkexecution
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/store"
+)
+
+func TestBuildSelectedContractReadinessClassifierEmitsCompleteOwnerMatrix(t *testing.T) {
+	frontier := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID: "source-event",
+			EventName:     "work.begin",
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "agent",
+				SubscriberID:   "worker",
+				Path:           "flow-a/worker",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	model := testSelectedContractExecutionModel(t, frontier)
+	plan := store.RunForkPlan{
+		SourceRunID: "source-run",
+		ForkPoint: store.RunForkPoint{
+			Input:     "source-event",
+			EventID:   "source-event",
+			EventName: "work.begin",
+			Timestamp: time.Unix(1700000707, 0).UTC(),
+		},
+		ReplayResumeAdmission: store.RunForkReplayResumeAdmission{
+			Owner:                    store.RunForkReplayResumeAdmissionOwner,
+			DeliveryEventReplayReady: true,
+			Dispositions: []store.RunForkReplayResumeDisposition{{
+				Fact:           store.RunForkReplayResumeFactDeliveryPendingHistory,
+				Disposition:    store.RunForkReplayResumeDispositionForkReplay,
+				Classification: store.RunForkPendingClassificationPending,
+				Message:        "pending delivery can be replayed",
+			}, {
+				Fact:        store.RunForkReplayResumeFactSourceAdvanced,
+				Disposition: store.RunForkReplayResumeDispositionLineageOnly,
+				Owner:       store.RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner,
+				Message:     "post-T source conversation history is branch divergence evidence",
+			}},
+		},
+	}
+
+	readiness, err := BuildSelectedContractReadinessClassifier(SelectedContractReadinessClassifierRequest{
+		Plan:                      plan,
+		ContractFrontierAdmission: frontier,
+		SelectedContractExecution: model,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractReadinessClassifier: %v", err)
+	}
+	if readiness.Owner != store.RunForkSelectedContractReadinessClassifierOwner ||
+		!readiness.NonMutating ||
+		readiness.ReplayResumeAdmissionOwner != store.RunForkReplayResumeAdmissionOwner ||
+		readiness.ContractFrontierAdmissionOwner != store.RunForkContractFrontierAdmissionOwner ||
+		readiness.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		readiness.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		readiness.SelectedExecutionModelOwner != store.RunForkSelectedContractExecutionModelOwner {
+		t.Fatalf("readiness ownership = %#v", readiness)
+	}
+	assertReadinessFactSet(t, readiness.FactMatrix)
+	assertReadinessFact(t, readiness.FactMatrix, store.RunForkSelectedContractReadinessFactSourceDeliveries, store.RunForkSelectedContractReadinessDispositionExecutableForkWork, store.RunForkHistoricalReplayExecutionOwner)
+	assertReadinessFact(t, readiness.FactMatrix, store.RunForkSelectedContractReadinessFactForkEvents, store.RunForkSelectedContractReadinessDispositionExecutableForkWork, store.RunForkSelectedContractExecutionOwner)
+	assertReadinessFact(t, readiness.FactMatrix, store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes, store.RunForkSelectedContractReadinessDispositionReconstructedForkState, store.RunForkSelectedContractRecipientPlanningOwner)
+	assertReadinessFact(t, readiness.FactMatrix, store.RunForkSelectedContractReadinessFactSourcePostTFacts, store.RunForkSelectedContractReadinessDispositionBranchDivergenceEvidence, store.RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner)
+	assertReadinessFact(t, readiness.FactMatrix, store.RunForkSelectedContractReadinessFactOperatorConsumers, store.RunForkSelectedContractReadinessDispositionUnsupportedSplitSibling, store.RunForkHistoricalReplayExecutionAdmissionOwner)
+	if !executionBoundaryHas(readiness.InvalidPaths, "explain_output_authorizes_mutation", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("invalid paths = %#v, want explain output non-authoritative", readiness.InvalidPaths)
+	}
+}
+
+func TestBuildSelectedContractReadinessClassifierRejectsLocalExecutionModel(t *testing.T) {
+	_, err := BuildSelectedContractReadinessClassifier(SelectedContractReadinessClassifierRequest{
+		Plan: store.RunForkPlan{
+			ReplayResumeAdmission: store.RunForkReplayResumeAdmission{Owner: store.RunForkReplayResumeAdmissionOwner},
+		},
+		ContractFrontierAdmission: store.RunForkContractFrontierAdmission{
+			Owner:       store.RunForkContractFrontierAdmissionOwner,
+			NonMutating: true,
+		},
+		SelectedContractExecution: store.RunForkSelectedContractExecution{
+			Owner:       "cmd.swarm.local_readiness",
+			NonMutating: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractExecutionModelOwner) {
+		t.Fatalf("error = %v, want canonical execution model owner failure", err)
+	}
+}
+
+func assertReadinessFactSet(t *testing.T, facts []store.RunForkSelectedContractReadinessFact) {
+	t.Helper()
+	required := []string{
+		store.RunForkSelectedContractReadinessFactSourceEvents,
+		store.RunForkSelectedContractReadinessFactForkEvents,
+		store.RunForkSelectedContractReadinessFactSourceDeliveries,
+		store.RunForkSelectedContractReadinessFactForkDeliveries,
+		store.RunForkSelectedContractReadinessFactSelectedRecipientsRoutes,
+		store.RunForkSelectedContractReadinessFactTimers,
+		store.RunForkSelectedContractReadinessFactSessions,
+		store.RunForkSelectedContractReadinessFactTurns,
+		store.RunForkSelectedContractReadinessFactAudits,
+		store.RunForkSelectedContractReadinessFactCommittedReplayScopeMarkers,
+		store.RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics,
+		store.RunForkSelectedContractReadinessFactReceipts,
+		store.RunForkSelectedContractReadinessFactDeadLetters,
+		store.RunForkSelectedContractReadinessFactRetryIdempotency,
+		store.RunForkSelectedContractReadinessFactEmittedFollowUps,
+		store.RunForkSelectedContractReadinessFactSourcePostTFacts,
+		store.RunForkSelectedContractReadinessFactCurrentStateSnapshots,
+		store.RunForkSelectedContractReadinessFactNonAgentNodeSystemWork,
+		store.RunForkSelectedContractReadinessFactRestartRecovery,
+		store.RunForkSelectedContractReadinessFactOperatorConsumers,
+	}
+	seen := map[string]struct{}{}
+	for _, fact := range facts {
+		if _, ok := seen[fact.Fact]; ok {
+			t.Fatalf("readiness fact %s repeated in %#v", fact.Fact, facts)
+		}
+		seen[fact.Fact] = struct{}{}
+	}
+	for _, fact := range required {
+		if _, ok := seen[fact]; !ok {
+			t.Fatalf("readiness fact %s missing from %#v", fact, facts)
+		}
+	}
+}
+
+func assertReadinessFact(t *testing.T, facts []store.RunForkSelectedContractReadinessFact, fact, disposition, owner string) {
+	t.Helper()
+	for _, item := range facts {
+		if item.Fact == fact {
+			if item.Disposition != disposition || item.Owner != owner {
+				t.Fatalf("readiness fact %s = %#v, want disposition=%s owner=%s", fact, item, disposition, owner)
+			}
+			return
+		}
+	}
+	t.Fatalf("readiness fact %s missing from %#v", fact, facts)
+}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -43,6 +43,7 @@ type RunForkPlan struct {
 	ReplayResumeAdmission     RunForkReplayResumeAdmission      `json:"replay_resume_admission"`
 	ContractFrontierAdmission *RunForkContractFrontierAdmission `json:"contract_frontier_admission,omitempty"`
 	SelectedContractExecution *RunForkSelectedContractExecution `json:"selected_contract_execution,omitempty"`
+	SelectedContractReadiness *RunForkSelectedContractReadiness `json:"selected_contract_readiness,omitempty"`
 	Entities                  []RunForkEntityState              `json:"entities,omitempty"`
 	PendingWork               []RunForkPendingWork              `json:"pending_work,omitempty"`
 	UnsupportedBlockers       []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`

--- a/internal/store/run_fork_selected_contract_readiness.go
+++ b/internal/store/run_fork_selected_contract_readiness.go
@@ -1,0 +1,69 @@
+package store
+
+const (
+	RunForkPlanningOwner                            = "store.run_fork.planning_owner"
+	RunForkSelectedContractReadinessClassifierOwner = "runtime.run_fork.selected_contract_readiness_classifier"
+)
+
+const (
+	RunForkSelectedContractReadinessDispositionExecutableForkWork       = "executable_fork_work"
+	RunForkSelectedContractReadinessDispositionLineageNoAction          = "lineage_no_action"
+	RunForkSelectedContractReadinessDispositionReconstructedForkState   = "reconstructed_fork_local_state"
+	RunForkSelectedContractReadinessDispositionBranchDivergenceEvidence = "branch_divergence_evidence"
+	RunForkSelectedContractReadinessDispositionFailClosedBlocker        = "fail_closed_blocker"
+	RunForkSelectedContractReadinessDispositionUnsupportedSplitSibling  = "unsupported_split_sibling"
+)
+
+const (
+	RunForkSelectedContractReadinessFactSourceEvents                = "source_events"
+	RunForkSelectedContractReadinessFactForkEvents                  = "fork_events"
+	RunForkSelectedContractReadinessFactSourceDeliveries            = "source_deliveries"
+	RunForkSelectedContractReadinessFactForkDeliveries              = "fork_deliveries"
+	RunForkSelectedContractReadinessFactSelectedRecipientsRoutes    = "selected_recipients_and_route_topology"
+	RunForkSelectedContractReadinessFactTimers                      = "timers"
+	RunForkSelectedContractReadinessFactSessions                    = "sessions"
+	RunForkSelectedContractReadinessFactTurns                       = "turns"
+	RunForkSelectedContractReadinessFactAudits                      = "audits"
+	RunForkSelectedContractReadinessFactCommittedReplayScopeMarkers = "committed_replay_scope_markers"
+	RunForkSelectedContractReadinessFactPlatformRuntimeDiagnostics  = "platform_runtime_diagnostic_control_rows"
+	RunForkSelectedContractReadinessFactReceipts                    = "receipts"
+	RunForkSelectedContractReadinessFactDeadLetters                 = "dead_letters"
+	RunForkSelectedContractReadinessFactRetryIdempotency            = "retry_idempotency"
+	RunForkSelectedContractReadinessFactEmittedFollowUps            = "emitted_follow_ups"
+	RunForkSelectedContractReadinessFactSourcePostTFacts            = "source_post_t_facts"
+	RunForkSelectedContractReadinessFactCurrentStateSnapshots       = "current_state_materialization_snapshots"
+	RunForkSelectedContractReadinessFactNonAgentNodeSystemWork      = "non_agent_node_system_work"
+	RunForkSelectedContractReadinessFactRestartRecovery             = "restart_recovery"
+	RunForkSelectedContractReadinessFactOperatorConsumers           = "cli_api_dashboard_builder_consumers"
+)
+
+type RunForkSelectedContractReadiness struct {
+	Owner                          string                                     `json:"owner"`
+	NonMutating                    bool                                       `json:"non_mutating"`
+	ContractSelection              RunForkContractSelection                   `json:"contract_selection"`
+	PlannerOwner                   string                                     `json:"planner_owner"`
+	ReplayResumeAdmissionOwner     string                                     `json:"replay_resume_admission_owner"`
+	ContractFrontierAdmissionOwner string                                     `json:"contract_frontier_admission_owner"`
+	RouteAdmissionOwner            string                                     `json:"route_admission_owner,omitempty"`
+	RouteTopologyOwner             string                                     `json:"route_topology_owner,omitempty"`
+	DynamicRouteTopologyOwner      string                                     `json:"dynamic_route_topology_owner,omitempty"`
+	RecipientPlanningOwner         string                                     `json:"recipient_planning_owner,omitempty"`
+	SelectedExecutionModelOwner    string                                     `json:"selected_execution_model_owner"`
+	FutureExecutionOwner           string                                     `json:"future_execution_owner"`
+	FactMatrix                     []RunForkSelectedContractReadinessFact     `json:"fact_matrix"`
+	RequiredConsumers              []RunForkSelectedContractExecutionBoundary `json:"required_consumers,omitempty"`
+	BlockedSiblings                []RunForkSelectedContractExecutionBoundary `json:"blocked_siblings,omitempty"`
+	InvalidPaths                   []RunForkSelectedContractExecutionBoundary `json:"invalid_paths,omitempty"`
+	UnsupportedBlockers            []RunForkUnsupportedBlocker                `json:"unsupported_blockers,omitempty"`
+}
+
+type RunForkSelectedContractReadinessFact struct {
+	Fact        string   `json:"fact"`
+	Disposition string   `json:"disposition"`
+	Owner       string   `json:"owner,omitempty"`
+	SourceOwner string   `json:"source_owner,omitempty"`
+	BlockerCode string   `json:"blocker_code,omitempty"`
+	Tracker     string   `json:"tracker,omitempty"`
+	Evidence    []string `json:"evidence,omitempty"`
+	Message     string   `json:"message"`
+}


### PR DESCRIPTION
## Summary

Closes #707.

Adds `runtime.run_fork.selected_contract_readiness_classifier` as the canonical non-mutating selected-contract timestamp-fork readiness/explain owner. The classifier consumes the existing planner, selected-contract replay admission wrapper, contract frontier, selected route/topology, recipient planning, selected execution model, historical replay admission fact matrix, current-state/materialization, and fork-local runtime/platform lineage owners, then emits a complete 20-row fact-family matrix in `swarm fork --contracts --dry-run --json`.

## Governing refs / context

- `platform-spec.yaml`: `run_model.fork.planning_owner`
- `platform-spec.yaml`: `run_model.fork.replay_resume_admission_taxonomy`
- `platform-spec.yaml`: `run_model.fork.selected_contract_readiness_classifier`
- `platform-spec.yaml`: `3b1_selected_contract_readiness_classifier`
- `platform-spec.yaml`: selected-contract route/topology/recipient-planning/execution owners
- Issue #707 pre-audit and independent gate outcome: `approved as first slice`
- Parent trackers: #695, #564, #549

## Semantic migration

- New canonical owner: `runtime.run_fork.selected_contract_readiness_classifier`
- Old non-authoritative path: CLI dry-run output only nested planner/frontier/route/model structs and did not own a complete readiness matrix.
- Production paths checked for surviving old behavior: `swarm fork --contracts --dry-run --json`, CLI text output, selected-contract replay admission wrapper, activation-gate admission path, historical replay admission fact matrix, selected execution model, and operator consumer watchlist.
- Migration completeness: complete for the supported CLI dry-run/explain surface. API/dashboard/Builder remain explicit consumers/split siblings until they consume this same matrix.

## Proof

Focused tests:

- `go test ./cmd/swarm -run 'DryRunContractsAddsContractFrontierAdmissionJSON|DryRunUsesCanonicalPlannerJSON|DryRunJSONReportsDeliveryEventReplayReady' -count=1`
- `go test ./internal/runtime/runforkexecution -run 'Readiness|SelectedContractExecutionModel|HistoricalReplay' -count=1`
- `go test ./internal/runtime/runforkexecution ./cmd/swarm ./internal/store -count=1`

Supported surface proof:

- Built `/tmp/swarm-707` from this branch.
- Ran selected-contract dry-run explain on `swarm_credentialed_post698_1778549716` for source run `38d9ba7e-683a-48ff-92d6-4fea71f25d36` at `validation/validation.package_ready` event `b5ba2fb5-a460-464e-8635-431969b7733d`.
- Ran selected-contract dry-run explain on the same source run at pre-OpCo `validation/vertical.ready_for_review` event `2c3116d1-3644-4ea5-88de-f60c4155131b`.
- Both emitted `selected_contract_readiness.owner=runtime.run_fork.selected_contract_readiness_classifier` with `20` fact rows.
- Non-mutation proof: before/after counts stayed unchanged for `runs=3`, `events=396`, `event_deliveries=45`, `entity_state=4`, `run_fork_selected_contract_bindings=1`, `run_fork_selected_contract_executions=1`, `run_fork_selected_contract_route_recoveries=1`, and `run_fork_delivery_event_replays=0`.
