### PR TITLE
[agent-b][issue #713] Implement v1 WebSocket subscriptions

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -190,27 +190,29 @@ func main() {
 		apiEntities = stores.Postgres
 		apiAgentConversations = stores.Postgres
 	}
+	apiReadOptions := apiv1.OperatorReadOptions{
+		Ready: func() bool {
+			return ready.Load()
+		},
+		Database:              stores.Postgres,
+		Runs:                  stores.Postgres,
+		Observability:         stores.Postgres,
+		Entities:              apiEntities,
+		AgentConversations:    apiAgentConversations,
+		Mailbox:               stores.Postgres,
+		Idempotency:           stores.Postgres,
+		Events:                rt.Bus,
+		RunControl:            rt.RunControl,
+		RuntimeIngress:        rt.RuntimeIngress,
+		Source:                source,
+		MailboxApprovalRoutes: mailboxApprovalRoutes,
+		Bundle:                bootBundleIdentity,
+	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
 		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
-		Handlers: apiv1.OperatorReadHandlers(apiv1.OperatorReadOptions{
-			Ready: func() bool {
-				return ready.Load()
-			},
-			Database:              stores.Postgres,
-			Runs:                  stores.Postgres,
-			Observability:         stores.Postgres,
-			Entities:              apiEntities,
-			AgentConversations:    apiAgentConversations,
-			Mailbox:               stores.Postgres,
-			Idempotency:           stores.Postgres,
-			Events:                rt.Bus,
-			RunControl:            rt.RunControl,
-			RuntimeIngress:        rt.RuntimeIngress,
-			Source:                source,
-			MailboxApprovalRoutes: mailboxApprovalRoutes,
-			Bundle:                bootBundleIdentity,
-		}),
+		Handlers:         apiv1.OperatorReadHandlers(apiReadOptions),
+		Subscriptions:    apiv1.OperatorSubscriptions(apiReadOptions),
 	})
 	if err != nil {
 		log.Fatalf("init v1 api: %v", err)

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -34,6 +35,7 @@ type Handler struct {
 	tokens   map[string]struct{}
 	handlers map[string]MethodHandler
 	upgrader websocket.Upgrader
+	subs     *SubscriptionRuntime
 }
 
 type MethodHandler func(context.Context, Request) (any, error)
@@ -43,6 +45,7 @@ type Options struct {
 	Registry         *Registry
 	AuthTokens       []string
 	Handlers         map[string]MethodHandler
+	Subscriptions    *SubscriptionRuntime
 }
 
 type Request struct {
@@ -119,6 +122,7 @@ func NewHandler(opts Options) (*Handler, error) {
 		tokens:   tokenSet(opts.AuthTokens),
 		handlers: handlers,
 		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		subs:     opts.Subscriptions.withDefaults(),
 	}, nil
 }
 
@@ -182,38 +186,41 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer conn.Close()
-	for {
-		_, raw, err := conn.ReadMessage()
-		if err != nil {
-			return
-		}
-		resp := h.dispatch(r.Context(), raw, "websocket", requestCorrelationID(r, nil), actorTokenID(token))
-		if err := conn.WriteJSON(resp); err != nil {
-			return
-		}
-	}
+	session := newWebSocketSession(h, conn, r.Context(), requestCorrelationID(r, nil), actorTokenID(token))
+	session.run()
 }
 
 func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackCorrelationID, actorTokenID string) rpcResponse {
+	req, failure := h.prepareRequest(raw, transport, fallbackCorrelationID, actorTokenID)
+	if failure != nil {
+		return *failure
+	}
+	return h.dispatchPrepared(ctx, req)
+}
+
+func (h *Handler) prepareRequest(raw []byte, transport, fallbackCorrelationID, actorTokenID string) (Request, *rpcResponse) {
 	req, id, correlationID, rpcErr := h.parseRequest(raw, fallbackCorrelationID)
 	if rpcErr != nil {
-		return rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Error: rpcErr}
+		return Request{}, &rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Error: rpcErr}
 	}
 	req.Transport = transport
 	req.ActorTokenID = strings.TrimSpace(actorTokenID)
 	req.RequestHash = requestBodyHash(req.Method, req.Params)
 	if method, ok := h.registry.Method(req.Method); ok {
 		if rpcErr := validateParams(method, req.Params, req.CorrelationID); rpcErr != nil {
-			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
+			return Request{}, &rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
 		}
 	} else {
-		return rpcResponse{
+		return Request{}, &rpcResponse{
 			JSONRPC: jsonRPCVersion,
 			ID:      req.ID,
 			Error:   h.standardError(codeMethodNotFound, "method not found", correlationID, map[string]any{"method": req.Method}),
 		}
 	}
+	return req, nil
+}
+
+func (h *Handler) dispatchPrepared(ctx context.Context, req Request) rpcResponse {
 	handler := h.handlers[req.Method]
 	if handler == nil {
 		return rpcResponse{
@@ -225,6 +232,10 @@ func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackC
 		}
 	}
 	result, err := handler(ctx, req)
+	return h.responseFromResult(req, result, err)
+}
+
+func (h *Handler) responseFromResult(req Request, result any, err error) rpcResponse {
 	if err != nil {
 		var appErr *ApplicationError
 		if errors.As(err, &appErr) && appErr != nil {
@@ -237,6 +248,167 @@ func (h *Handler) dispatch(ctx context.Context, raw []byte, transport, fallbackC
 		return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: h.standardError(codeInternalError, "internal error", req.CorrelationID, map[string]any{"error": err.Error()})}
 	}
 	return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: result}
+}
+
+type webSocketSession struct {
+	handler               *Handler
+	conn                  *websocket.Conn
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	out                   chan any
+	fallbackCorrelationID string
+	actorTokenID          string
+	mu                    sync.Mutex
+	subs                  map[string]context.CancelFunc
+}
+
+func newWebSocketSession(handler *Handler, conn *websocket.Conn, parent context.Context, fallbackCorrelationID, actorTokenID string) *webSocketSession {
+	ctx, cancel := context.WithCancel(parent)
+	queueSize := defaultSubscriptionQueueSize
+	if handler != nil && handler.subs != nil && handler.subs.queueSize > 0 {
+		queueSize = handler.subs.queueSize
+	}
+	return &webSocketSession{
+		handler:               handler,
+		conn:                  conn,
+		ctx:                   ctx,
+		cancel:                cancel,
+		out:                   make(chan any, queueSize),
+		fallbackCorrelationID: strings.TrimSpace(fallbackCorrelationID),
+		actorTokenID:          strings.TrimSpace(actorTokenID),
+		subs:                  map[string]context.CancelFunc{},
+	}
+}
+
+func (s *webSocketSession) run() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.writeLoop()
+	}()
+	defer func() {
+		s.cancel()
+		s.cancelAllSubscriptions()
+		_ = s.conn.Close()
+		wg.Wait()
+	}()
+	for {
+		_, raw, err := s.conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		if !s.handleRaw(raw) {
+			return
+		}
+	}
+}
+
+func (s *webSocketSession) writeLoop() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case msg := <-s.out:
+			if err := s.conn.WriteJSON(msg); err != nil {
+				s.cancel()
+				_ = s.conn.Close()
+				return
+			}
+		}
+	}
+}
+
+func (s *webSocketSession) handleRaw(raw []byte) bool {
+	req, failure := s.handler.prepareRequest(raw, "websocket", s.fallbackCorrelationID, s.actorTokenID)
+	if failure != nil {
+		return s.enqueue(*failure)
+	}
+	switch req.Method {
+	case "health.subscribe", "event.subscribe", "run.subscribe_trace":
+		if s.handler.subs == nil {
+			return s.enqueue(s.handler.dispatchPrepared(s.ctx, req))
+		}
+		plan, err := s.handler.subs.prepare(s, req)
+		resp := s.handler.responseFromResult(req, plan.Result, err)
+		if !s.enqueue(resp) {
+			if plan.Cancel != nil {
+				plan.Cancel()
+			}
+			return false
+		}
+		if err == nil && plan.Start != nil {
+			plan.Start()
+		}
+		return true
+	case "rpc.unsubscribe":
+		subscriptionID := stringParam(req.Params, "subscription_id")
+		s.cancelSubscription(subscriptionID)
+		return s.enqueue(rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: map[string]any{"ok": true}})
+	default:
+		return s.enqueue(s.handler.dispatchPrepared(s.ctx, req))
+	}
+}
+
+func (s *webSocketSession) enqueue(msg any) bool {
+	select {
+	case <-s.ctx.Done():
+		return false
+	case s.out <- msg:
+		return true
+	default:
+		s.cancel()
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
+		return false
+	}
+}
+
+func (s *webSocketSession) notify(subscriptionID string, result any) bool {
+	return s.enqueue(rpcSubscriptionNotification{
+		JSONRPC: jsonRPCVersion,
+		Method:  "rpc.subscription",
+		Params: rpcSubscriptionParams{
+			Subscription: subscriptionID,
+			Result:       result,
+		},
+	})
+}
+
+func (s *webSocketSession) registerSubscription(subscriptionID string, cancel context.CancelFunc) {
+	if s == nil || cancel == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subs[subscriptionID] = cancel
+}
+
+func (s *webSocketSession) cancelSubscription(subscriptionID string) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	s.mu.Lock()
+	cancel := s.subs[subscriptionID]
+	delete(s.subs, subscriptionID)
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *webSocketSession) cancelAllSubscriptions() {
+	s.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(s.subs))
+	for subscriptionID, cancel := range s.subs {
+		delete(s.subs, subscriptionID)
+		cancels = append(cancels, cancel)
+	}
+	s.mu.Unlock()
+	for _, cancel := range cancels {
+		if cancel != nil {
+			cancel()
+		}
+	}
 }
 
 func (h *Handler) parseRequest(raw []byte, fallbackCorrelationID string) (Request, any, string, *rpcError) {

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -311,8 +311,7 @@ func (s *webSocketSession) writeLoop() {
 			return
 		case msg := <-s.out:
 			if err := s.conn.WriteJSON(msg); err != nil {
-				s.cancel()
-				_ = s.conn.Close()
+				s.close()
 				return
 			}
 		}
@@ -357,11 +356,18 @@ func (s *webSocketSession) enqueue(msg any) bool {
 	case s.out <- msg:
 		return true
 	default:
-		s.cancel()
-		if s.conn != nil {
-			_ = s.conn.Close()
-		}
+		s.close()
 		return false
+	}
+}
+
+func (s *webSocketSession) close() {
+	if s == nil {
+		return
+	}
+	s.cancel()
+	if s.conn != nil {
+		_ = s.conn.Close()
 	}
 }
 

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -162,15 +162,24 @@ type fakeObservabilityReadStore struct {
 	incidents []store.OperatorRuntimeIncident
 
 	lastEventList   store.OperatorEventListOptions
+	lastTrace       store.RunDebugTraceQueryOptions
 	lastRuntimeLogs store.OperatorRuntimeLogListOptions
 	lastIncidents   store.OperatorRuntimeIncidentListOptions
 }
 
-func (s *fakeObservabilityReadStore) LoadRunDebugTracePage(_ context.Context, runID string, _ store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, string, error) {
+func (s *fakeObservabilityReadStore) LoadRunDebugTracePage(_ context.Context, runID string, opts store.RunDebugTraceQueryOptions) ([]store.RunDebugTraceRow, string, error) {
+	s.lastTrace = opts
 	if s.traceErr != nil {
 		return nil, "", s.traceErr
 	}
-	return s.traceRows[runID], "", nil
+	rows := []store.RunDebugTraceRow{}
+	for _, row := range s.traceRows[runID] {
+		if opts.Since != nil && !row.EventCreatedAt.After(opts.Since.UTC()) {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, "", nil
 }
 
 func (s *fakeObservabilityReadStore) ListOperatorEvents(_ context.Context, opts store.OperatorEventListOptions) (store.OperatorEventListResult, error) {
@@ -180,6 +189,18 @@ func (s *fakeObservabilityReadStore) ListOperatorEvents(_ context.Context, opts 
 	}
 	out := make([]store.OperatorEventFull, 0, len(s.events))
 	for _, event := range s.events {
+		if opts.Since != nil && !event.CreatedAt.After(opts.Since.UTC()) {
+			continue
+		}
+		if opts.Filter.RunID != "" && event.RunID != opts.Filter.RunID {
+			continue
+		}
+		if opts.Filter.EntityID != "" && event.EntityID != opts.Filter.EntityID {
+			continue
+		}
+		if opts.Filter.EventName != "" && event.EventName != opts.Filter.EventName {
+			continue
+		}
 		out = append(out, event)
 	}
 	return store.OperatorEventListResult{Events: out}, nil

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -640,13 +640,24 @@ func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter,
 	if !ok {
 		return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter", "reason": "must be an object"})
 	}
+	for name := range filter {
+		if _, ok := eventListFilterFields[name]; !ok {
+			return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter." + name, "reason": "unknown parameter"})
+		}
+	}
 	out := store.OperatorEventListFilter{}
 	var err error
 	if out.RunID, _, err = optionalStringParam(filter, "run_id"); err != nil {
 		return store.OperatorEventListFilter{}, err
 	}
+	if out.RunID != "" && !opaqueIDPattern.MatchString(out.RunID) {
+		return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.run_id", "reason": "must match OpaqueId pattern"})
+	}
 	if out.EntityID, _, err = optionalStringParam(filter, "entity_id"); err != nil {
 		return store.OperatorEventListFilter{}, err
+	}
+	if out.EntityID != "" && !opaqueIDPattern.MatchString(out.EntityID) {
+		return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.entity_id", "reason": "must match OpaqueId pattern"})
 	}
 	if out.EventName, _, err = optionalStringParam(filter, "event_name"); err != nil {
 		return store.OperatorEventListFilter{}, err
@@ -654,11 +665,21 @@ func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter,
 	if out.DeliveryStatus, _, err = optionalStringParam(filter, "delivery_status"); err != nil {
 		return store.OperatorEventListFilter{}, err
 	}
+	if out.DeliveryStatus != "" {
+		if _, ok := eventListDeliveryStatuses[out.DeliveryStatus]; !ok {
+			return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.delivery_status", "reason": "must be a valid DeliveryStatus"})
+		}
+	}
 	if out.SubscriberID, _, err = optionalStringParam(filter, "subscriber_id"); err != nil {
 		return store.OperatorEventListFilter{}, err
 	}
 	if out.SubscriberType, _, err = optionalStringParam(filter, "subscriber_type"); err != nil {
 		return store.OperatorEventListFilter{}, err
+	}
+	if out.SubscriberType != "" {
+		if _, ok := eventListSubscriberTypes[out.SubscriberType]; !ok {
+			return store.OperatorEventListFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.subscriber_type", "reason": "must be a valid SubscriberType"})
+		}
 	}
 	if out.ReasonCode, _, err = optionalStringParam(filter, "reason_code"); err != nil {
 		return store.OperatorEventListFilter{}, err
@@ -671,6 +692,30 @@ func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter,
 		out.HasDeadLetter = &value
 	}
 	return out, nil
+}
+
+var eventListFilterFields = map[string]struct{}{
+	"run_id":          {},
+	"entity_id":       {},
+	"event_name":      {},
+	"delivery_status": {},
+	"subscriber_id":   {},
+	"subscriber_type": {},
+	"reason_code":     {},
+	"has_dead_letter": {},
+}
+
+var eventListDeliveryStatuses = map[string]struct{}{
+	"pending":     {},
+	"in_progress": {},
+	"delivered":   {},
+	"failed":      {},
+	"dead_letter": {},
+}
+
+var eventListSubscriberTypes = map[string]struct{}{
+	"node":  {},
+	"agent": {},
 }
 
 func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.OperatorRuntimeLogListOptions, error) {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -121,18 +121,7 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 			return healthPingResult{OK: true, TS: now().UTC().Format(time.RFC3339Nano)}, nil
 		},
 		"health.check": func(ctx context.Context, _ Request) (any, error) {
-			runtimeOK := ready()
-			dbOK := false
-			if opts.Database != nil {
-				dbOK = opts.Database.Ping(ctx) == nil
-			}
-			return healthCheckResult{
-				Alive:     true,
-				Ready:     runtimeOK && dbOK,
-				DBOK:      dbOK,
-				RuntimeOK: runtimeOK,
-				Bundle:    opts.Bundle,
-			}, nil
+			return operatorHealthSnapshot(ctx, ready, opts.Database, opts.Bundle), nil
 		},
 		"run.get": func(ctx context.Context, req Request) (any, error) {
 			runs, err := requireRunReadStore(opts.Runs)

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -241,7 +241,7 @@ func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, sessio
 			Order:  "asc",
 		})
 		if err != nil {
-			session.cancel()
+			session.close()
 			return false
 		}
 		for _, event := range result.Events {
@@ -263,7 +263,7 @@ func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, sessio
 			return true
 		}
 	}
-	session.cancel()
+	session.close()
 	return false
 }
 
@@ -295,7 +295,7 @@ func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, sessio
 			Since:  since,
 		})
 		if err != nil {
-			session.cancel()
+			session.close()
 			return false
 		}
 		for _, row := range rows {
@@ -314,7 +314,7 @@ func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, sessio
 			return true
 		}
 	}
-	session.cancel()
+	session.close()
 	return false
 }
 

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -1,0 +1,367 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+)
+
+const (
+	defaultSubscriptionQueueSize     = 64
+	defaultSubscriptionPollInterval  = time.Second
+	defaultSubscriptionHealthCadence = 5 * time.Second
+	subscriptionBatchLimit           = 1000
+	subscriptionMaxPages             = 10
+)
+
+type SubscriptionRuntimeOptions struct {
+	PollInterval   time.Duration
+	HealthInterval time.Duration
+	QueueSize      int
+}
+
+type SubscriptionRuntime struct {
+	now            func() time.Time
+	ready          func() bool
+	database       Pinger
+	observability  ObservabilityReadStore
+	bundle         runtimecontracts.BundleIdentity
+	pollInterval   time.Duration
+	healthInterval time.Duration
+	queueSize      int
+}
+
+type subscriptionIDResult struct {
+	SubscriptionID string `json:"subscription_id"`
+}
+
+type rpcSubscriptionNotification struct {
+	JSONRPC string                `json:"jsonrpc"`
+	Method  string                `json:"method"`
+	Params  rpcSubscriptionParams `json:"params"`
+}
+
+type rpcSubscriptionParams struct {
+	Subscription string `json:"subscription"`
+	Result       any    `json:"result"`
+}
+
+type subscriptionPlan struct {
+	Result subscriptionIDResult
+	Start  func()
+	Cancel context.CancelFunc
+}
+
+func OperatorSubscriptions(opts OperatorReadOptions, overrides ...SubscriptionRuntimeOptions) *SubscriptionRuntime {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	ready := opts.Ready
+	if ready == nil {
+		ready = func() bool { return false }
+	}
+	out := &SubscriptionRuntime{
+		now:           now,
+		ready:         ready,
+		database:      opts.Database,
+		observability: opts.Observability,
+		bundle:        opts.Bundle,
+	}
+	if len(overrides) > 0 {
+		out.pollInterval = overrides[0].PollInterval
+		out.healthInterval = overrides[0].HealthInterval
+		out.queueSize = overrides[0].QueueSize
+	}
+	return out.withDefaults()
+}
+
+func (r *SubscriptionRuntime) withDefaults() *SubscriptionRuntime {
+	if r == nil {
+		return nil
+	}
+	if r.now == nil {
+		r.now = func() time.Time { return time.Now().UTC() }
+	}
+	if r.ready == nil {
+		r.ready = func() bool { return false }
+	}
+	if r.pollInterval <= 0 {
+		r.pollInterval = defaultSubscriptionPollInterval
+	}
+	if r.healthInterval <= 0 {
+		r.healthInterval = defaultSubscriptionHealthCadence
+	}
+	if r.queueSize <= 0 {
+		r.queueSize = defaultSubscriptionQueueSize
+	}
+	return r
+}
+
+func (r *SubscriptionRuntime) prepare(session *webSocketSession, req Request) (subscriptionPlan, error) {
+	if r == nil {
+		return subscriptionPlan{}, fmt.Errorf("subscription runtime is required")
+	}
+	switch req.Method {
+	case "health.subscribe":
+		return r.prepareHealthSubscription(session), nil
+	case "event.subscribe":
+		return r.prepareEventSubscription(session, req)
+	case "run.subscribe_trace":
+		return r.prepareRunTraceSubscription(session, req)
+	default:
+		return subscriptionPlan{}, NewApplicationError(MethodUnavailableCode, false, map[string]any{"method": req.Method})
+	}
+}
+
+func (r *SubscriptionRuntime) prepareHealthSubscription(session *webSocketSession) subscriptionPlan {
+	id, ctx, cancel := session.newSubscriptionContext("health")
+	return subscriptionPlan{
+		Result: subscriptionIDResult{SubscriptionID: id},
+		Start: func() {
+			go r.runHealthSubscription(ctx, session, id)
+		},
+		Cancel: cancel,
+	}
+}
+
+func (r *SubscriptionRuntime) prepareEventSubscription(session *webSocketSession, req Request) (subscriptionPlan, error) {
+	reads, err := requireObservabilityReadStore(r.observability)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	filter, err := eventListFilterParam(req.Params)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	replaySince, err := timestampParam(req.Params, "replay_since")
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	id, ctx, cancel := session.newSubscriptionContext("event")
+	return subscriptionPlan{
+		Result: subscriptionIDResult{SubscriptionID: id},
+		Start: func() {
+			go r.runEventSubscription(ctx, session, id, reads, filter, subscriptionBaseSince(replaySince, r.now()))
+		},
+		Cancel: cancel,
+	}, nil
+}
+
+func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSession, req Request) (subscriptionPlan, error) {
+	reads, err := requireObservabilityReadStore(r.observability)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	runID, err := requiredStringParam(req.Params, "run_id")
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	replaySince, err := timestampParam(req.Params, "replay_since")
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	baseSince := subscriptionBaseSince(replaySince, r.now())
+	if _, _, err := reads.LoadRunDebugTracePage(session.ctx, runID, store.RunDebugTraceQueryOptions{Limit: 1, Since: baseSince}); errors.Is(err, store.ErrRunNotFound) {
+		return subscriptionPlan{}, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
+	} else if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+		return subscriptionPlan{}, NewInvalidParamsError(map[string]any{"field": "replay_since", "reason": "invalid run trace replay watermark"})
+	} else if err != nil {
+		return subscriptionPlan{}, err
+	}
+	id, ctx, cancel := session.newSubscriptionContext("run-trace")
+	return subscriptionPlan{
+		Result: subscriptionIDResult{SubscriptionID: id},
+		Start: func() {
+			go r.runTraceSubscription(ctx, session, id, reads, runID, baseSince)
+		},
+		Cancel: cancel,
+	}, nil
+}
+
+func (s *webSocketSession) newSubscriptionContext(prefix string) (string, context.Context, context.CancelFunc) {
+	subscriptionID := strings.Trim(strings.TrimSpace(prefix)+"-"+uuid.NewString(), "-")
+	ctx, cancel := context.WithCancel(s.ctx)
+	s.registerSubscription(subscriptionID, cancel)
+	return subscriptionID, ctx, cancel
+}
+
+func (r *SubscriptionRuntime) runHealthSubscription(ctx context.Context, session *webSocketSession, subscriptionID string) {
+	if !session.notify(subscriptionID, operatorHealthSnapshot(ctx, r.ready, r.database, r.bundle)) {
+		return
+	}
+	ticker := time.NewTicker(r.healthInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !session.notify(subscriptionID, operatorHealthSnapshot(ctx, r.ready, r.database, r.bundle)) {
+				return
+			}
+		}
+	}
+}
+
+func (r *SubscriptionRuntime) runEventSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, filter store.OperatorEventListFilter, since *time.Time) {
+	seen := map[string]string{}
+	if !r.emitEventNotifications(ctx, session, subscriptionID, reads, filter, since, seen) {
+		return
+	}
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !r.emitEventNotifications(ctx, session, subscriptionID, reads, filter, since, seen) {
+				return
+			}
+		}
+	}
+}
+
+func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, filter store.OperatorEventListFilter, since *time.Time, seen map[string]string) bool {
+	cursor := ""
+	for page := 0; page < subscriptionMaxPages; page++ {
+		result, err := reads.ListOperatorEvents(ctx, store.OperatorEventListOptions{
+			Filter: filter,
+			Since:  since,
+			Limit:  subscriptionBatchLimit,
+			Cursor: cursor,
+			Order:  "asc",
+		})
+		if err != nil {
+			session.cancel()
+			return false
+		}
+		for _, event := range result.Events {
+			key := strings.TrimSpace(event.EventID)
+			if key == "" {
+				key = subscriptionPayloadFingerprint(event)
+			}
+			fingerprint := subscriptionPayloadFingerprint(event)
+			if seen[key] == fingerprint {
+				continue
+			}
+			seen[key] = fingerprint
+			if !session.notify(subscriptionID, event) {
+				return false
+			}
+		}
+		cursor = strings.TrimSpace(result.NextCursor)
+		if cursor == "" {
+			return true
+		}
+	}
+	session.cancel()
+	return false
+}
+
+func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time) {
+	seen := map[string]string{}
+	if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, seen) {
+		return
+	}
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, seen) {
+				return
+			}
+		}
+	}
+}
+
+func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, seen map[string]string) bool {
+	cursor := ""
+	for page := 0; page < subscriptionMaxPages; page++ {
+		rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{
+			Limit:  subscriptionBatchLimit,
+			Cursor: cursor,
+			Since:  since,
+		})
+		if err != nil {
+			session.cancel()
+			return false
+		}
+		for _, row := range rows {
+			key := runTraceSubscriptionKey(row)
+			fingerprint := subscriptionPayloadFingerprint(row)
+			if seen[key] == fingerprint {
+				continue
+			}
+			seen[key] = fingerprint
+			if !session.notify(subscriptionID, row) {
+				return false
+			}
+		}
+		cursor = strings.TrimSpace(nextCursor)
+		if cursor == "" {
+			return true
+		}
+	}
+	session.cancel()
+	return false
+}
+
+func operatorHealthSnapshot(ctx context.Context, ready func() bool, database Pinger, bundle runtimecontracts.BundleIdentity) healthCheckResult {
+	runtimeOK := false
+	if ready != nil {
+		runtimeOK = ready()
+	}
+	dbOK := false
+	if database != nil {
+		dbOK = database.Ping(ctx) == nil
+	}
+	return healthCheckResult{
+		Alive:     true,
+		Ready:     runtimeOK && dbOK,
+		DBOK:      dbOK,
+		RuntimeOK: runtimeOK,
+		Bundle:    bundle,
+	}
+}
+
+func subscriptionBaseSince(replaySince *time.Time, now time.Time) *time.Time {
+	if replaySince != nil {
+		value := replaySince.UTC()
+		return &value
+	}
+	value := now.UTC()
+	return &value
+}
+
+func runTraceSubscriptionKey(row store.RunDebugTraceRow) string {
+	parts := []string{
+		strings.TrimSpace(row.EventID),
+		strings.TrimSpace(row.DeliveryID),
+		strings.TrimSpace(row.TurnID),
+	}
+	key := strings.Join(parts, "\x00")
+	if strings.Trim(key, "\x00") != "" {
+		return key
+	}
+	return subscriptionPayloadFingerprint(row)
+}
+
+func subscriptionPayloadFingerprint(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%#v", value)
+	}
+	return string(raw)
+}

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -1,0 +1,310 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+)
+
+func TestHandlerWebSocketHealthSubscribeAndUnsubscribe(t *testing.T) {
+	now := time.Unix(1700001000, 0).UTC()
+	readOpts := OperatorReadOptions{
+		Now:      func() time.Time { return now },
+		Ready:    func() bool { return true },
+		Database: fakePinger{err: nil},
+		Bundle: runtimecontracts.BundleIdentity{
+			WorkflowName:    "review",
+			WorkflowVersion: "1.2.3",
+			Fingerprint:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Handlers:      OperatorReadHandlers(readOpts),
+		Subscriptions: OperatorSubscriptions(readOpts, SubscriptionRuntimeOptions{HealthInterval: time.Hour, QueueSize: 4}),
+	})
+
+	health := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"health","method":"health.check","params":{}}`)
+	if health.Error != nil {
+		t.Fatalf("health.check error = %#v", health.Error)
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-health",
+		"method":  "health.subscribe",
+		"params":  map[string]any{},
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("health.subscribe error = %#v", subscribe.Error)
+	}
+	subscriptionID, ok := asMap(t, subscribe.Result)["subscription_id"].(string)
+	if !ok || subscriptionID == "" {
+		t.Fatalf("health.subscribe result = %#v, want subscription_id", subscribe.Result)
+	}
+
+	notification := readWSNotification(t, conn)
+	if notification.Method != "rpc.subscription" || notification.Params.Subscription != subscriptionID {
+		t.Fatalf("notification = %#v, want rpc.subscription for %s", notification, subscriptionID)
+	}
+	if got, want := asMap(t, notification.Params.Result), asMap(t, health.Result); !sameJSON(got, want) {
+		t.Fatalf("health notification = %#v, want health.check result %#v", got, want)
+	}
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "unsub-health",
+		"method":  "rpc.unsubscribe",
+		"params": map[string]any{
+			"subscription_id": subscriptionID,
+		},
+	})
+	unsubscribe := readWSResponse(t, conn)
+	if unsubscribe.Error != nil || asMap(t, unsubscribe.Result)["ok"] != true {
+		t.Fatalf("rpc.unsubscribe response = %#v", unsubscribe)
+	}
+}
+
+func TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay(t *testing.T) {
+	base := time.Unix(1700001100, 0).UTC()
+	hasDeadLetter := false
+	observability := &fakeObservabilityReadStore{
+		events: map[string]store.OperatorEventFull{
+			"evt-1": {
+				EventID:     "evt-1",
+				EventName:   "scan.requested",
+				RunID:       "run-1",
+				EntityID:    "entity-1",
+				CreatedAt:   base.Add(time.Second),
+				Source:      "runtime",
+				Payload:     map[string]any{"ok": true},
+				Deliveries:  []store.OperatorEventDelivery{},
+				DeadLetters: []store.OperatorDeadLetterRecord{},
+			},
+		},
+	}
+	readOpts := OperatorReadOptions{
+		Now:           func() time.Time { return base.Add(10 * time.Second) },
+		Observability: observability,
+	}
+	handler := testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Subscriptions: OperatorSubscriptions(readOpts, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-events",
+		"method":  "event.subscribe",
+		"params": map[string]any{
+			"filter": map[string]any{
+				"run_id":          "run-1",
+				"entity_id":       "entity-1",
+				"event_name":      "scan.requested",
+				"has_dead_letter": hasDeadLetter,
+			},
+			"replay_since": base.Format(time.RFC3339Nano),
+		},
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("event.subscribe error = %#v", subscribe.Error)
+	}
+	subscriptionID := asMap(t, subscribe.Result)["subscription_id"].(string)
+	notification := readWSNotification(t, conn)
+	if notification.Params.Subscription != subscriptionID {
+		t.Fatalf("event notification subscription = %q, want %q", notification.Params.Subscription, subscriptionID)
+	}
+	if got := asMap(t, notification.Params.Result)["event_id"]; got != "evt-1" {
+		t.Fatalf("event notification result = %#v, want evt-1", notification.Params.Result)
+	}
+	if observability.lastEventList.Filter.RunID != "run-1" ||
+		observability.lastEventList.Filter.EntityID != "entity-1" ||
+		observability.lastEventList.Filter.EventName != "scan.requested" ||
+		observability.lastEventList.Filter.HasDeadLetter == nil ||
+		*observability.lastEventList.Filter.HasDeadLetter != hasDeadLetter {
+		t.Fatalf("event.subscribe filter = %#v", observability.lastEventList.Filter)
+	}
+	if observability.lastEventList.Since == nil || !observability.lastEventList.Since.Equal(base) {
+		t.Fatalf("event.subscribe since = %#v, want %s", observability.lastEventList.Since, base)
+	}
+	if observability.lastEventList.Order != "asc" {
+		t.Fatalf("event.subscribe order = %q, want asc", observability.lastEventList.Order)
+	}
+}
+
+func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testing.T) {
+	base := time.Unix(1700001200, 0).UTC()
+	missing := &fakeObservabilityReadStore{traceErr: store.ErrRunNotFound}
+	missingHandler := testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{Observability: missing}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	missingServer := httptest.NewServer(missingHandler)
+	defer missingServer.Close()
+	missingConn := dialTestWS(t, missingServer.URL)
+	defer missingConn.Close()
+	writeWSRequest(t, missingConn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "missing-trace",
+		"method":  "run.subscribe_trace",
+		"params": map[string]any{
+			"run_id":       "missing-run",
+			"replay_since": base.Format(time.RFC3339Nano),
+		},
+	})
+	missingResp := readWSResponse(t, missingConn)
+	if missingResp.Error == nil || asMap(t, missingResp.Error.Data)["code"] != RunNotFoundCode {
+		t.Fatalf("missing run response = %#v, want RUN_NOT_FOUND", missingResp)
+	}
+
+	observability := &fakeObservabilityReadStore{
+		traceRows: map[string][]store.RunDebugTraceRow{
+			"run-1": {{
+				EventID:        "evt-1",
+				EventName:      "scan.requested",
+				EventCreatedAt: base.Add(time.Second),
+			}},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{Observability: observability}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-trace",
+		"method":  "run.subscribe_trace",
+		"params": map[string]any{
+			"run_id":       "run-1",
+			"replay_since": base.Format(time.RFC3339Nano),
+		},
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("run.subscribe_trace error = %#v", subscribe.Error)
+	}
+	notification := readWSNotification(t, conn)
+	if got := asMap(t, notification.Params.Result)["event_id"]; got != "evt-1" {
+		t.Fatalf("trace notification result = %#v, want evt-1", notification.Params.Result)
+	}
+	if observability.lastTrace.Since == nil || !observability.lastTrace.Since.Equal(base) {
+		t.Fatalf("run.subscribe_trace since = %#v, want %s", observability.lastTrace.Since, base)
+	}
+}
+
+func TestWebSocketSessionBackpressureAndUnsubscribeCancelState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &webSocketSession{
+		ctx:    ctx,
+		cancel: cancel,
+		out:    make(chan any, 1),
+		subs:   map[string]context.CancelFunc{},
+	}
+	if !session.enqueue(rpcResponse{JSONRPC: jsonRPCVersion, ID: "first", Result: map[string]any{"ok": true}}) {
+		t.Fatal("first enqueue unexpectedly failed")
+	}
+	if session.enqueue(rpcResponse{JSONRPC: jsonRPCVersion, ID: "second", Result: map[string]any{"ok": true}}) {
+		t.Fatal("second enqueue succeeded, want bounded backpressure cancellation")
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("session context was not canceled on backpressure")
+	}
+
+	subCtx, subCancel := context.WithCancel(context.Background())
+	session.registerSubscription("sub-1", subCancel)
+	session.cancelSubscription("sub-1")
+	select {
+	case <-subCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("subscription context was not canceled by unsubscribe")
+	}
+}
+
+func dialTestWS(t *testing.T, serverURL string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/v1/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer " + testToken}})
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	return conn
+}
+
+func writeWSRequest(t *testing.T, conn *websocket.Conn, request map[string]any) {
+	t.Helper()
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("write websocket request: %v", err)
+	}
+}
+
+func readWSResponse(t *testing.T, conn *websocket.Conn) rpcResponse {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer conn.SetReadDeadline(time.Time{})
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket response: %v", err)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode websocket response envelope: %v raw=%s", err, raw)
+	}
+	if envelope["method"] == "rpc.subscription" {
+		t.Fatalf("got notification before response: %s", raw)
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode websocket response: %v raw=%s", err, raw)
+	}
+	return resp
+}
+
+func readWSNotification(t *testing.T, conn *websocket.Conn) rpcSubscriptionNotification {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer conn.SetReadDeadline(time.Time{})
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket notification: %v", err)
+	}
+	var notification rpcSubscriptionNotification
+	if err := json.Unmarshal(raw, &notification); err != nil {
+		t.Fatalf("decode websocket notification: %v raw=%s", err, raw)
+	}
+	if notification.Method != "rpc.subscription" {
+		t.Fatalf("websocket notification = %s, want rpc.subscription", raw)
+	}
+	return notification
+}
+
+func sameJSON(a, b any) bool {
+	rawA, errA := json.Marshal(a)
+	rawB, errB := json.Marshal(b)
+	return errA == nil && errB == nil && string(rawA) == string(rawB)
+}

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -148,6 +149,107 @@ func TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay(t *testing.T) {
 	}
 	if observability.lastEventList.Order != "asc" {
 		t.Fatalf("event.subscribe order = %q, want asc", observability.lastEventList.Order)
+	}
+}
+
+func TestEventListFilterValidationCoversListAndSubscribe(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Observability: &fakeObservabilityReadStore{},
+		}),
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Observability: &fakeObservabilityReadStore{},
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+
+	listUnknown := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list-unknown","method":"event.list","params":{"filter":{"event_nmae":"typo"}}}`)
+	if listUnknown.Error == nil || listUnknown.Error.Code != codeInvalidParams {
+		t.Fatalf("event.list unknown filter error = %#v, want invalid params", listUnknown.Error)
+	}
+	if details := asMap(t, asMap(t, listUnknown.Error.Data)["details"]); details["field"] != "filter.event_nmae" {
+		t.Fatalf("event.list unknown filter details = %#v", details)
+	}
+
+	listEnum := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list-enum","method":"event.list","params":{"filter":{"delivery_status":"done"}}}`)
+	if listEnum.Error == nil || listEnum.Error.Code != codeInvalidParams {
+		t.Fatalf("event.list enum error = %#v, want invalid params", listEnum.Error)
+	}
+	if details := asMap(t, asMap(t, listEnum.Error.Data)["details"]); details["field"] != "filter.delivery_status" {
+		t.Fatalf("event.list enum details = %#v", details)
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-unknown",
+		"method":  "event.subscribe",
+		"params": map[string]any{
+			"filter": map[string]any{"event_nmae": "typo"},
+		},
+	})
+	subUnknown := readWSResponse(t, conn)
+	if subUnknown.Error == nil || subUnknown.Error.Code != codeInvalidParams {
+		t.Fatalf("event.subscribe unknown filter error = %#v, want invalid params", subUnknown.Error)
+	}
+	if details := asMap(t, asMap(t, subUnknown.Error.Data)["details"]); details["field"] != "filter.event_nmae" {
+		t.Fatalf("event.subscribe unknown filter details = %#v", details)
+	}
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-enum",
+		"method":  "event.subscribe",
+		"params": map[string]any{
+			"filter": map[string]any{"subscriber_type": "system"},
+		},
+	})
+	subEnum := readWSResponse(t, conn)
+	if subEnum.Error == nil || subEnum.Error.Code != codeInvalidParams {
+		t.Fatalf("event.subscribe enum error = %#v, want invalid params", subEnum.Error)
+	}
+	if details := asMap(t, asMap(t, subEnum.Error.Data)["details"]); details["field"] != "filter.subscriber_type" {
+		t.Fatalf("event.subscribe enum details = %#v", details)
+	}
+}
+
+func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
+	observability := &fakeObservabilityReadStore{listErr: errors.New("store unavailable")}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Observability: observability,
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-events",
+		"method":  "event.subscribe",
+		"params":  map[string]any{},
+	})
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer conn.SetReadDeadline(time.Time{})
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return
+	}
+	var subscribe rpcResponse
+	if err := json.Unmarshal(raw, &subscribe); err != nil {
+		t.Fatalf("decode event.subscribe response before close: %v raw=%s", err, raw)
+	}
+	if subscribe.Error != nil {
+		t.Fatalf("event.subscribe response error = %#v", subscribe.Error)
+	}
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("websocket stayed open after owner read error, want fail-closed disconnect")
 	}
 }
 

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -33,6 +33,7 @@ type OperatorEventListOptions struct {
 	Until              *time.Time
 	Limit              int
 	Cursor             string
+	Order              string
 	ExcludeRuntimeLogs bool
 }
 
@@ -257,22 +258,33 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 		if err != nil {
 			return OperatorEventListResult{}, err
 		}
+		if cursor.Order != "" && cursor.Order != opts.Order {
+			return OperatorEventListResult{}, ErrInvalidObservabilityCursor
+		}
 		createdAt, err := time.Parse(time.RFC3339Nano, cursor.CreatedAt)
 		if err != nil || strings.TrimSpace(cursor.ID) == "" {
 			return OperatorEventListResult{}, ErrInvalidObservabilityCursor
 		}
 		nTime := add(createdAt.UTC())
 		nID := add(cursor.ID)
-		where = append(where, fmt.Sprintf("(e.created_at < $%d OR (e.created_at = $%d AND e.event_id::text < $%d))", nTime, nTime, nID))
+		if opts.Order == "asc" {
+			where = append(where, fmt.Sprintf("(e.created_at > $%d OR (e.created_at = $%d AND e.event_id::text > $%d))", nTime, nTime, nID))
+		} else {
+			where = append(where, fmt.Sprintf("(e.created_at < $%d OR (e.created_at = $%d AND e.event_id::text < $%d))", nTime, nTime, nID))
+		}
 	}
 	limitArg := add(opts.Limit + 1)
+	orderSQL := "DESC"
+	if opts.Order == "asc" {
+		orderSQL = "ASC"
+	}
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT e.event_id::text
 		FROM events e
 		WHERE `+strings.Join(where, " AND ")+fmt.Sprintf(`
-		ORDER BY e.created_at DESC, e.event_id::text DESC
+		ORDER BY e.created_at %s, e.event_id::text %s
 		LIMIT $%d
-	`, limitArg), args...)
+	`, orderSQL, orderSQL, limitArg), args...)
 	if err != nil {
 		return OperatorEventListResult{}, fmt.Errorf("list operator events: %w", err)
 	}
@@ -304,6 +316,7 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 			Kind:      "event.list",
 			CreatedAt: last.CreatedAt.UTC().Format(time.RFC3339Nano),
 			ID:        last.EventID,
+			Order:     opts.Order,
 		})
 	}
 	if events == nil {
@@ -716,6 +729,13 @@ func defaultOperatorEventListOptions(opts OperatorEventListOptions) OperatorEven
 	opts.Filter.ReasonCode = strings.TrimSpace(opts.Filter.ReasonCode)
 	opts.Source = strings.TrimSpace(opts.Source)
 	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	opts.Order = strings.ToLower(strings.TrimSpace(opts.Order))
+	if opts.Order == "" {
+		opts.Order = "desc"
+	}
+	if opts.Order != "asc" && opts.Order != "desc" {
+		opts.Order = "desc"
+	}
 	if opts.Limit <= 0 {
 		opts.Limit = 100
 	}

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -84,6 +84,20 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 	if len(page2.Events) != 1 || page2.Events[0].EventID != olderEventID {
 		t.Fatalf("page2 = %#v", page2)
 	}
+	ascPage1, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 1, Order: "asc"})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents asc page1: %v", err)
+	}
+	if len(ascPage1.Events) != 1 || ascPage1.Events[0].EventID != olderEventID || ascPage1.NextCursor == "" {
+		t.Fatalf("asc page1 = %#v", ascPage1)
+	}
+	ascPage2, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 1, Order: "asc", Cursor: ascPage1.NextCursor})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents asc page2: %v", err)
+	}
+	if len(ascPage2.Events) != 1 || ascPage2.Events[0].EventID != newerEventID {
+		t.Fatalf("asc page2 = %#v", ascPage2)
+	}
 	sinceBase := base
 	afterBase, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{
 		Filter: OperatorEventListFilter{RunID: runID},
@@ -269,6 +283,13 @@ func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	}
 	if len(page2) != 1 || page2[0].EventID != secondEvent {
 		t.Fatalf("trace page2 = %#v", page2)
+	}
+	sinceRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &base})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage since: %v", err)
+	}
+	if len(sinceRows) != 1 || sinceRows[0].EventID != secondEvent {
+		t.Fatalf("trace since rows = %#v, want only second event", sinceRows)
 	}
 	if _, _, err := pg.LoadRunDebugTracePage(ctx, uuid.NewString(), RunDebugTraceQueryOptions{}); !errors.Is(err, ErrRunNotFound) {
 		t.Fatalf("missing run error = %v, want ErrRunNotFound", err)

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -653,7 +653,15 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 	sinceWhere := ""
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
-		sinceWhere = fmt.Sprintf(" AND e.created_at > $%d::timestamptz", len(args))
+		sinceWhere = fmt.Sprintf(`
+		  AND GREATEST(
+			e.created_at,
+			COALESCE(d.created_at, '-infinity'::timestamptz),
+			COALESCE(d.started_at, '-infinity'::timestamptz),
+			COALESCE(d.delivered_at, '-infinity'::timestamptz),
+			COALESCE(sess.updated_at, '-infinity'::timestamptz),
+			COALESCE(t.created_at, '-infinity'::timestamptz)
+		  ) > $%d::timestamptz`, len(args))
 	}
 	args = append(args, opts.Limit+1)
 	limitArg := len(args)

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -130,6 +130,7 @@ type RunDebugReport struct {
 type RunDebugTraceQueryOptions struct {
 	Limit  int
 	Cursor string
+	Since  *time.Time
 }
 
 type RunDebugTraceRow struct {
@@ -649,6 +650,11 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			2, 3, 4, 5, 6, 7,
 		)
 	}
+	sinceWhere := ""
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		sinceWhere = fmt.Sprintf(" AND e.created_at > $%d::timestamptz", len(args))
+	}
 	args = append(args, opts.Limit+1)
 	limitArg := len(args)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
@@ -710,6 +716,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 		   )
 		WHERE e.run_id = $1::uuid
 		%s
+		%s
 		ORDER BY
 			e.created_at ASC,
 			e.event_id ASC,
@@ -718,7 +725,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			t.created_at ASC NULLS FIRST,
 			t.turn_id ASC NULLS FIRST
 		LIMIT $%d
-	`, sessionSources, cursorWhere, limitArg), args...)
+	`, sessionSources, cursorWhere, sinceWhere, limitArg), args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("load run debug trace: %w", err)
 	}

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -347,6 +347,90 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	}
 }
 
+func TestRunDebugReadSurface_LoadRunDebugTrace_SinceUsesRowMaterializationWatermark(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	sessionID := uuid.NewString()
+	turnID := uuid.NewString()
+	entityID := uuid.NewString()
+	base := time.Unix(1700000450, 0).UTC()
+	since := base.Add(time.Second)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, base.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'scan.requested', $3::uuid, 'entity', '{}'::jsonb, 'builder', 'platform', $4)
+	`, runID, eventID, entityID, base); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	seedRunDebugAgent(t, pg, ctx, "agent-late", entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-late', $3::uuid, 'flow-a', 'entity:' || $3::text, 'entity',
+			'[]'::jsonb, 1, 'session', '{}'::jsonb,
+			NULL, NULL, 'active', $4, $5
+		)
+	`, sessionID, runID, entityID, base.Add(2*time.Second), base.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, active_session_id, started_at, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-late', 'in_progress', 'session_started',
+			$4::uuid, $5, $5
+		)
+	`, deliveryID, runID, eventID, sessionID, base.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed late delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+			request_payload, response_payload, parse_ok, latency_ms, retry_count, error, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'agent-late', $3::uuid, 'session', 'entity:' || $4::text, $4::uuid,
+			$5::uuid, 'scan.requested', 'task-late', '[]'::jsonb, '[]'::jsonb,
+			'[]'::jsonb, '{}'::jsonb, '[]'::jsonb, '[]'::jsonb,
+			'{}'::jsonb, '{}'::jsonb, true, 12, 0, '', $6
+		)
+	`, turnID, runID, sessionID, entityID, eventID, base.Add(3*time.Second)); err != nil {
+		t.Fatalf("seed late turn: %v", err)
+	}
+
+	rows, err := pg.LoadRunDebugTrace(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &since})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTrace since: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("trace len = %d, want late composed row: %#v", len(rows), rows)
+	}
+	got := rows[0]
+	if got.EventID != eventID || got.DeliveryID != deliveryID || got.TurnID != turnID {
+		t.Fatalf("late materialized trace row = %#v", got)
+	}
+}
+
 func TestRunDebugReadSurface_LoadRunDebugTrace_UsesTaskAuditSessionWhenLiveSessionDoesNotExist(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary

Closes #713.
Part of #665.

Implements the approved Slice 7 first-slice boundary: the canonical v1 WebSocket subscription owner for `health.subscribe`, `event.subscribe`, `run.subscribe_trace`, and current-connection `rpc.unsubscribe`.

## Governing refs

Exact platform spec refs:

- `api_specification.foundations.transport.json_rpc_over_websocket`
- `api_specification.conventions.subscriptions`
- `api_specification.method_catalog.health.subscribe`
- `api_specification.method_catalog.event.subscribe`
- `api_specification.method_catalog.run.subscribe_trace`
- `api_specification.method_catalog.rpc.unsubscribe`
- `components.schemas.SubscriptionId`
- `components.schemas.RpcSubscriptionNotification`
- `components.schemas.HealthCheckResult`
- `components.schemas.EventListFilter`
- `components.schemas.EventFull`
- `components.schemas.RunTraceRow`
- API transition map entries for `GET /api/events/flow -> event.subscribe` and `GET /api/runs/{runID}/trace -> run.trace` plus `run.subscribe_trace` as the live variant.

Binding issue/gate context:

- #713 Pre-Implementation Coverage Audit.
- #713 independent gate outcome: approved as first slice.
- #696/#697, #700/#701, #704/#710 read-owner proof audits consumed as already-closed siblings.

## Semantic migration notes

- New canonical owner: `internal/apiv1` WebSocket subscription runtime and per-connection session registry.
- Data owners consumed: health snapshot shared with `health.check`; `store.ListOperatorEvents` / `LoadOperatorEvent` for event payload/filter truth; `store.LoadRunDebugTracePage` for trace payload/replay truth.
- Old WS path now invalid as semantic owner: global `rpc.unsubscribe` no-op for WebSocket subscription cancellation. It remains only as the existing HTTP protocol compatibility response; WS unsubscribe now cancels current-connection state.
- Production paths checked for surviving old behavior: `/v1/ws`, dashboard `/api/events/flow` and `/api/events?stream=true`, Builder `run:events:*`, EventBus subscriptions, and `cmd/swarm` v1 API wiring.
- Migration completeness: complete for #713 v1 subscription owner only. Dashboard SSE remains adapter-only over canonical event reads; Builder `run:events:*` and future CLI streams remain #665 residuals.

## Tests

- `go test ./internal/apiv1 -run 'TestHandlerWebSocket(HealthSubscribeAndUnsubscribe|EventSubscribeUsesOwnerFilterAndReplay|RunSubscribeTraceUsesOwnerReplayAndRunNotFound|AuthAndFrameValidation)|TestWebSocketSessionBackpressureAndUnsubscribeCancelState|TestEventListSubscribeFilterParity' -count=1`
- `go test ./internal/store -run 'TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor|TestRunDebugTracePageCursorAndRunNotFound' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 ./internal/store ./internal/dashboard/server ./internal/builder ./cmd/swarm -count=1`
- `go test ./... -count=1`