### PR TITLE
[agent-b][issue #721] Implement v1 agent controls

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -12,6 +12,7 @@ import (
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeingress "swarm/internal/runtime/ingress"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -301,26 +302,26 @@ type dashboardDynamicAgentControl struct {
 	supervisor *runtimeProjectSupervisor
 }
 
-func (c dashboardDynamicAgentControl) RestartAgent(agentID string) error {
+func (c dashboardDynamicAgentControl) Restart(ctx context.Context, req runtimeagentcontrol.RestartRequest) (runtimeagentcontrol.RestartResult, error) {
 	rt := c.supervisor.CurrentRuntime()
 	if rt == nil || rt.Manager == nil {
-		return fmt.Errorf("runtime manager unavailable")
+		return runtimeagentcontrol.RestartResult{}, fmt.Errorf("runtime manager unavailable")
 	}
-	return rt.Manager.RestartAgent(agentID)
+	return rt.Manager.Restart(ctx, req)
 }
 
-func (c dashboardDynamicAgentControl) ReplayAgentBacklog(ctx context.Context, agentID string) error {
+func (c dashboardDynamicAgentControl) ReplayBacklog(ctx context.Context, req runtimeagentcontrol.ReplayBacklogRequest) (runtimeagentcontrol.ReplayBacklogResult, error) {
 	rt := c.supervisor.CurrentRuntime()
 	if rt == nil || rt.Manager == nil {
-		return fmt.Errorf("runtime manager unavailable")
+		return runtimeagentcontrol.ReplayBacklogResult{}, fmt.Errorf("runtime manager unavailable")
 	}
-	return rt.Manager.ReplayAgentBacklog(ctx, agentID)
+	return rt.Manager.ReplayBacklog(ctx, req)
 }
 
-func (c dashboardDynamicAgentControl) ChatWithAgent(ctx context.Context, agentID, directive string, killPrevious bool) (string, error) {
+func (c dashboardDynamicAgentControl) SendDirective(ctx context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
 	rt := c.supervisor.CurrentRuntime()
 	if rt == nil || rt.Manager == nil {
-		return "", fmt.Errorf("runtime manager unavailable")
+		return runtimeagentcontrol.SendDirectiveResult{}, fmt.Errorf("runtime manager unavailable")
 	}
-	return rt.Manager.ChatWithAgent(ctx, agentID, directive, killPrevious)
+	return rt.Manager.SendDirective(ctx, req)
 }

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -13,6 +13,7 @@ import (
 	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -269,13 +270,13 @@ func TestDashboardDynamicAgentControl_DeniesWhenRuntimeShutdownAdmissionClosed(t
 	}
 	control := dashboardDynamicAgentControl{supervisor: supervisor}
 
-	if err := control.RestartAgent(agent.id); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
-		t.Fatalf("RestartAgent err = %v, want runtime shutting down", err)
+	if _, err := control.Restart(context.Background(), runtimeagentcontrol.RestartRequest{AgentID: agent.id}); err == nil || !strings.Contains(err.Error(), "agent not running") {
+		t.Fatalf("Restart err = %v, want agent not running", err)
 	}
-	if err := control.ReplayAgentBacklog(context.Background(), agent.id); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
-		t.Fatalf("ReplayAgentBacklog err = %v, want runtime shutting down", err)
+	if _, err := control.ReplayBacklog(context.Background(), runtimeagentcontrol.ReplayBacklogRequest{AgentID: agent.id}); err == nil || !strings.Contains(err.Error(), "agent not running") {
+		t.Fatalf("ReplayBacklog err = %v, want agent not running", err)
 	}
-	if _, err := control.ChatWithAgent(context.Background(), agent.id, "run corpus", false); err == nil || !strings.Contains(err.Error(), "runtime shutting down") {
-		t.Fatalf("ChatWithAgent err = %v, want runtime shutting down", err)
+	if _, err := control.SendDirective(context.Background(), runtimeagentcontrol.SendDirectiveRequest{AgentID: agent.id, Directive: "run corpus"}); err == nil || !strings.Contains(err.Error(), "agent not running") {
+		t.Fatalf("SendDirective err = %v, want agent not running", err)
 	}
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -199,6 +199,7 @@ func main() {
 		Observability:         stores.Postgres,
 		Entities:              apiEntities,
 		AgentConversations:    apiAgentConversations,
+		AgentControl:          dashboardDynamicAgentControl{supervisor: supervisor},
 		Mailbox:               stores.Postgres,
 		Idempotency:           stores.Postgres,
 		Events:                rt.Bus,

--- a/internal/apiv1/operator_agent_control.go
+++ b/internal/apiv1/operator_agent_control.go
@@ -1,0 +1,236 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	"swarm/internal/store"
+)
+
+const agentControlIdempotencyTTL = 24 * time.Hour
+
+type AgentControlController interface {
+	runtimeagentcontrol.Controller
+}
+
+type agentDirectiveResult struct {
+	OK       bool   `json:"ok"`
+	Response string `json:"response,omitempty"`
+}
+
+type agentReplayBacklogResult struct {
+	OK            bool `json:"ok"`
+	ReplayedCount int  `json:"replayed_count"`
+}
+
+func OperatorAgentControlHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.AgentControl == nil || opts.Idempotency == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"agent.send_directive": func(ctx context.Context, req Request) (any, error) {
+			return executeAgentSendDirective(ctx, req, opts, now().UTC())
+		},
+		"agent.restart": func(ctx context.Context, req Request) (any, error) {
+			return executeAgentRestart(ctx, req, opts, now().UTC())
+		},
+		"agent.replay_backlog": func(ctx context.Context, req Request) (any, error) {
+			return executeAgentReplayBacklog(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	agentID, err := requiredStringParam(req.Params, "agent_id")
+	if err != nil {
+		return nil, err
+	}
+	directive, err := requiredStringParam(req.Params, "directive")
+	if err != nil {
+		return nil, err
+	}
+	killPrevious, err := optionalBoolParam(req.Params, "kill_previous")
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     agentID,
+		TTL:            agentControlIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := opts.AgentControl.SendDirective(ctx, runtimeagentcontrol.SendDirectiveRequest{
+			AgentID:      agentID,
+			Directive:    directive,
+			KillPrevious: killPrevious,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+		}
+		response, err := json.Marshal(agentDirectiveResult{OK: true, Response: result.Response})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, agentControlError(agentID, err)
+	}
+	var stored agentDirectiveResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode %s idempotency response: %w", req.Method, err)
+		}
+		return nil, fmt.Errorf("decode %s response: %w", req.Method, err)
+	}
+	return stored, nil
+}
+
+func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	agentID, err := requiredStringParam(req.Params, "agent_id")
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     agentID,
+		TTL:            agentControlIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := opts.AgentControl.Restart(ctx, runtimeagentcontrol.RestartRequest{AgentID: agentID})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+		}
+		response, err := json.Marshal(okResult{OK: true})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, agentControlError(agentID, err)
+	}
+	var stored okResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode %s idempotency response: %w", req.Method, err)
+		}
+		return nil, fmt.Errorf("decode %s response: %w", req.Method, err)
+	}
+	return stored, nil
+}
+
+func executeAgentReplayBacklog(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	agentID, err := requiredStringParam(req.Params, "agent_id")
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     agentID,
+		TTL:            agentControlIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := opts.AgentControl.ReplayBacklog(ctx, runtimeagentcontrol.ReplayBacklogRequest{AgentID: agentID})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+		}
+		response, err := json.Marshal(agentReplayBacklogResult{OK: true, ReplayedCount: result.ReplayedCount})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, agentControlError(agentID, err)
+	}
+	var stored agentReplayBacklogResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode %s idempotency response: %w", req.Method, err)
+		}
+		return nil, fmt.Errorf("decode %s response: %w", req.Method, err)
+	}
+	return stored, nil
+}
+
+func optionalBoolParam(params map[string]any, name string) (bool, error) {
+	raw, ok := params[name]
+	if !ok || isEmptyParam(raw) {
+		return false, nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return false, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be a boolean"})
+	}
+	return value, nil
+}
+
+func agentControlError(agentID string, err error) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	var stateErr *runtimeagentcontrol.StateError
+	if errors.As(err, &stateErr) && stateErr != nil {
+		if candidate := stateErr.AgentID; candidate != "" {
+			agentID = candidate
+		}
+		switch {
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotFound):
+			return NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotRunning):
+			return NewApplicationError(AgentNotRunningCode, false, map[string]any{
+				"agent_id":       agentID,
+				"current_status": stateErr.CurrentStatus,
+			})
+		}
+	}
+	switch {
+	case errors.Is(err, runtimeagentcontrol.ErrAgentNotFound):
+		return NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+	case errors.Is(err, runtimeagentcontrol.ErrAgentNotRunning):
+		return NewApplicationError(AgentNotRunningCode, false, map[string]any{
+			"agent_id":       agentID,
+			"current_status": runtimeagentcontrol.StatusTerminated,
+		})
+	default:
+		return err
+	}
+}

--- a/internal/apiv1/operator_agent_control.go
+++ b/internal/apiv1/operator_agent_control.go
@@ -80,7 +80,7 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 			KillPrevious: killPrevious,
 		})
 		if err != nil {
-			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+			return store.APIIdempotencyCompletion{}, agentControlError(req.Method, agentID, err)
 		}
 		response, err := json.Marshal(agentDirectiveResult{OK: true, Response: result.Response})
 		if err != nil {
@@ -89,7 +89,7 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
 	})
 	if err != nil {
-		return nil, agentControlError(agentID, err)
+		return nil, agentControlError(req.Method, agentID, err)
 	}
 	var stored agentDirectiveResult
 	if err := json.Unmarshal(completion.Response, &stored); err != nil {
@@ -121,7 +121,7 @@ func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOpti
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
 		result, err := opts.AgentControl.Restart(ctx, runtimeagentcontrol.RestartRequest{AgentID: agentID})
 		if err != nil {
-			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+			return store.APIIdempotencyCompletion{}, agentControlError(req.Method, agentID, err)
 		}
 		response, err := json.Marshal(okResult{OK: true})
 		if err != nil {
@@ -130,7 +130,7 @@ func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOpti
 		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
 	})
 	if err != nil {
-		return nil, agentControlError(agentID, err)
+		return nil, agentControlError(req.Method, agentID, err)
 	}
 	var stored okResult
 	if err := json.Unmarshal(completion.Response, &stored); err != nil {
@@ -162,7 +162,7 @@ func executeAgentReplayBacklog(ctx context.Context, req Request, opts OperatorRe
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
 		result, err := opts.AgentControl.ReplayBacklog(ctx, runtimeagentcontrol.ReplayBacklogRequest{AgentID: agentID})
 		if err != nil {
-			return store.APIIdempotencyCompletion{}, agentControlError(agentID, err)
+			return store.APIIdempotencyCompletion{}, agentControlError(req.Method, agentID, err)
 		}
 		response, err := json.Marshal(agentReplayBacklogResult{OK: true, ReplayedCount: result.ReplayedCount})
 		if err != nil {
@@ -171,7 +171,7 @@ func executeAgentReplayBacklog(ctx context.Context, req Request, opts OperatorRe
 		return store.APIIdempotencyCompletion{ResourceID: result.AgentID, Response: response}, nil
 	})
 	if err != nil {
-		return nil, agentControlError(agentID, err)
+		return nil, agentControlError(req.Method, agentID, err)
 	}
 	var stored agentReplayBacklogResult
 	if err := json.Unmarshal(completion.Response, &stored); err != nil {
@@ -195,7 +195,7 @@ func optionalBoolParam(params map[string]any, name string) (bool, error) {
 	return value, nil
 }
 
-func agentControlError(agentID string, err error) error {
+func agentControlError(method, agentID string, err error) error {
 	var conflict *store.APIIdempotencyConflictError
 	if errors.As(err, &conflict) {
 		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
@@ -215,7 +215,7 @@ func agentControlError(agentID string, err error) error {
 		switch {
 		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotFound):
 			return NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotRunning):
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotRunning) && method == "agent.send_directive":
 			return NewApplicationError(AgentNotRunningCode, false, map[string]any{
 				"agent_id":       agentID,
 				"current_status": stateErr.CurrentStatus,
@@ -225,7 +225,7 @@ func agentControlError(agentID string, err error) error {
 	switch {
 	case errors.Is(err, runtimeagentcontrol.ErrAgentNotFound):
 		return NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-	case errors.Is(err, runtimeagentcontrol.ErrAgentNotRunning):
+	case errors.Is(err, runtimeagentcontrol.ErrAgentNotRunning) && method == "agent.send_directive":
 		return NewApplicationError(AgentNotRunningCode, false, map[string]any{
 			"agent_id":       agentID,
 			"current_status": runtimeagentcontrol.StatusTerminated,

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -139,6 +139,46 @@ func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
 	}
 }
 
+func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Idempotency: pg,
+			AgentControl: &fakeAgentControlController{
+				errs: map[string]error{
+					"agent.restart": &runtimeagentcontrol.StateError{
+						Err:           runtimeagentcontrol.ErrAgentNotRunning,
+						AgentID:       "agent-1",
+						CurrentStatus: runtimeagentcontrol.StatusTerminated,
+					},
+					"agent.replay_backlog": &runtimeagentcontrol.StateError{
+						Err:           runtimeagentcontrol.ErrAgentNotRunning,
+						AgentID:       "agent-1",
+						CurrentStatus: runtimeagentcontrol.StatusTerminated,
+					},
+				},
+			},
+		}),
+	})
+
+	for _, method := range []string{"agent.restart", "agent.replay_backlog"} {
+		resp := rpcCall(t, handler, agentControlBody(method, "agent-1", ""))
+		if resp.Error == nil {
+			t.Fatalf("%s not-running error = nil", method)
+		}
+		if resp.Error.Code != codeInternalError {
+			t.Fatalf("%s error code = %d, want %d", method, resp.Error.Code, codeInternalError)
+		}
+		data := asMap(t, resp.Error.Data)
+		if data["code"] == AgentNotRunningCode {
+			t.Fatalf("%s returned undocumented application code %s", method, AgentNotRunningCode)
+		}
+	}
+}
+
 func TestOperatorAgentControlHandlersRequireOwner(t *testing.T) {
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -1,0 +1,203 @@
+package apiv1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	controller := &fakeAgentControlController{
+		directiveResponse: "accepted",
+		replayedCount:     7,
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:          func() time.Time { return time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC) },
+			Idempotency:  pg,
+			AgentControl: controller,
+		}),
+	})
+
+	directiveBody := agentDirectiveBody("agent-1", "run corpus", true, "idem-directive")
+	directive := rpcCall(t, handler, directiveBody)
+	if directive.Error != nil {
+		t.Fatalf("agent.send_directive error = %#v", directive.Error)
+	}
+	if result := asMap(t, directive.Result); result["ok"] != true || result["response"] != "accepted" {
+		t.Fatalf("agent.send_directive result = %#v", result)
+	}
+	if controller.directiveCalls != 1 || !controller.lastDirective.KillPrevious || controller.lastDirective.Directive != "run corpus" {
+		t.Fatalf("directive call count/request = %d/%#v, want owner request", controller.directiveCalls, controller.lastDirective)
+	}
+	directiveReplay := rpcCall(t, handler, directiveBody)
+	if directiveReplay.Error != nil {
+		t.Fatalf("agent.send_directive replay error = %#v", directiveReplay.Error)
+	}
+	if controller.directiveCalls != 1 {
+		t.Fatalf("directive calls after replay = %d, want 1", controller.directiveCalls)
+	}
+	directiveConflict := rpcCall(t, handler, agentDirectiveBody("agent-1", "different", true, "idem-directive"))
+	if directiveConflict.Error == nil {
+		t.Fatal("agent.send_directive idempotency conflict error = nil")
+	}
+	if data := asMap(t, directiveConflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("directive conflict data = %#v, want %s", data, IdempotencyConflictCode)
+	}
+
+	restartBody := agentControlBody("agent.restart", "agent-1", "idem-restart")
+	restarted := rpcCall(t, handler, restartBody)
+	if restarted.Error != nil {
+		t.Fatalf("agent.restart error = %#v", restarted.Error)
+	}
+	if result := asMap(t, restarted.Result); result["ok"] != true {
+		t.Fatalf("agent.restart result = %#v", result)
+	}
+	restartReplay := rpcCall(t, handler, restartBody)
+	if restartReplay.Error != nil {
+		t.Fatalf("agent.restart replay error = %#v", restartReplay.Error)
+	}
+	if controller.restartCalls != 1 {
+		t.Fatalf("restart calls after replay = %d, want 1", controller.restartCalls)
+	}
+
+	replayBody := agentControlBody("agent.replay_backlog", "agent-1", "idem-replay")
+	replayed := rpcCall(t, handler, replayBody)
+	if replayed.Error != nil {
+		t.Fatalf("agent.replay_backlog error = %#v", replayed.Error)
+	}
+	if result := asMap(t, replayed.Result); result["ok"] != true || result["replayed_count"] != float64(7) {
+		t.Fatalf("agent.replay_backlog result = %#v", result)
+	}
+	replayAgain := rpcCall(t, handler, replayBody)
+	if replayAgain.Error != nil {
+		t.Fatalf("agent.replay_backlog idempotent replay error = %#v", replayAgain.Error)
+	}
+	if controller.replayCalls != 1 {
+		t.Fatalf("replay calls after idempotent replay = %d, want 1", controller.replayCalls)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 3 {
+		t.Fatalf("api_idempotency rows = %d, want 3", count)
+	}
+}
+
+func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Idempotency: pg,
+			AgentControl: &fakeAgentControlController{
+				errs: map[string]error{
+					"agent.send_directive": &runtimeagentcontrol.StateError{
+						Err:           runtimeagentcontrol.ErrAgentNotRunning,
+						AgentID:       "agent-1",
+						CurrentStatus: runtimeagentcontrol.StatusTerminated,
+					},
+					"agent.restart": &runtimeagentcontrol.StateError{
+						Err:     runtimeagentcontrol.ErrAgentNotFound,
+						AgentID: "missing-agent",
+					},
+					"agent.replay_backlog": &runtimeagentcontrol.StateError{
+						Err:     runtimeagentcontrol.ErrAgentNotFound,
+						AgentID: "missing-agent",
+					},
+				},
+			},
+		}),
+	})
+
+	notRunning := rpcCall(t, handler, agentDirectiveBody("agent-1", "run corpus", false, ""))
+	if notRunning.Error == nil {
+		t.Fatal("agent.send_directive not-running error = nil")
+	}
+	if data := asMap(t, notRunning.Error.Data); data["code"] != AgentNotRunningCode {
+		t.Fatalf("not-running data = %#v, want %s", data, AgentNotRunningCode)
+	} else if details := asMap(t, data["details"]); details["current_status"] != runtimeagentcontrol.StatusTerminated {
+		t.Fatalf("not-running details = %#v, want terminated", details)
+	}
+
+	for _, method := range []string{"agent.restart", "agent.replay_backlog"} {
+		resp := rpcCall(t, handler, agentControlBody(method, "missing-agent", ""))
+		if resp.Error == nil {
+			t.Fatalf("%s missing-agent error = nil", method)
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != AgentNotFoundCode {
+			t.Fatalf("%s data = %#v, want %s", method, data, AgentNotFoundCode)
+		}
+	}
+}
+
+func TestOperatorAgentControlHandlersRequireOwner(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers:   OperatorReadHandlers(OperatorReadOptions{}),
+	})
+	resp := rpcCall(t, handler, agentControlBody("agent.restart", "agent-1", ""))
+	if resp.Error == nil {
+		t.Fatal("agent.restart without owner error = nil")
+	}
+	if data := asMap(t, resp.Error.Data); data["code"] != MethodUnavailableCode {
+		t.Fatalf("agent.restart without owner data = %#v, want %s", data, MethodUnavailableCode)
+	}
+}
+
+type fakeAgentControlController struct {
+	directiveResponse string
+	replayedCount     int
+	errs              map[string]error
+	directiveCalls    int
+	restartCalls      int
+	replayCalls       int
+	lastDirective     runtimeagentcontrol.SendDirectiveRequest
+}
+
+func (c *fakeAgentControlController) SendDirective(_ context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
+	c.directiveCalls++
+	c.lastDirective = req
+	if err := c.errs["agent.send_directive"]; err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
+	return runtimeagentcontrol.SendDirectiveResult{AgentID: req.AgentID, Response: c.directiveResponse}, nil
+}
+
+func (c *fakeAgentControlController) Restart(_ context.Context, req runtimeagentcontrol.RestartRequest) (runtimeagentcontrol.RestartResult, error) {
+	c.restartCalls++
+	if err := c.errs["agent.restart"]; err != nil {
+		return runtimeagentcontrol.RestartResult{}, err
+	}
+	return runtimeagentcontrol.RestartResult{AgentID: req.AgentID}, nil
+}
+
+func (c *fakeAgentControlController) ReplayBacklog(_ context.Context, req runtimeagentcontrol.ReplayBacklogRequest) (runtimeagentcontrol.ReplayBacklogResult, error) {
+	c.replayCalls++
+	if err := c.errs["agent.replay_backlog"]; err != nil {
+		return runtimeagentcontrol.ReplayBacklogResult{}, err
+	}
+	return runtimeagentcontrol.ReplayBacklogResult{AgentID: req.AgentID, ReplayedCount: c.replayedCount}, nil
+}
+
+func agentControlBody(method, agentID, idempotencyKey string) string {
+	if idempotencyKey == "" {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-control","method":%q,"params":{"agent_id":%q}}`, method, agentID)
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-control","method":%q,"params":{"agent_id":%q,"idempotency_key":%q}}`, method, agentID, idempotencyKey)
+}
+
+func agentDirectiveBody(agentID, directive string, killPrevious bool, idempotencyKey string) string {
+	if idempotencyKey == "" {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"directive":%q,"kill_previous":%t}}`, agentID, directive, killPrevious)
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"directive":%q,"kill_previous":%t,"idempotency_key":%q}}`, agentID, directive, killPrevious, idempotencyKey)
+}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -53,6 +53,7 @@ type OperatorReadOptions struct {
 	Observability         ObservabilityReadStore
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
+	AgentControl          AgentControlController
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
 	Events                EventPublisher
@@ -208,6 +209,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorAgentConversationHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorAgentControlHandlers(opts) {
 		handlers[name] = handler
 	}
 	return handlers

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -18,6 +18,7 @@ const (
 	EventNotFoundCode                    = "EVENT_NOT_FOUND"
 	EntityNotFoundCode                   = "ENTITY_NOT_FOUND"
 	AgentNotFoundCode                    = "AGENT_NOT_FOUND"
+	AgentNotRunningCode                  = "AGENT_NOT_RUNNING"
 	SessionNotFoundCode                  = "SESSION_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimetools "swarm/internal/runtime/tools"
@@ -189,9 +190,7 @@ type RunTraceReader interface {
 }
 
 type AgentController interface {
-	RestartAgent(agentID string) error
-	ReplayAgentBacklog(ctx context.Context, agentID string) error
-	ChatWithAgent(ctx context.Context, agentID, directive string, killPrevious bool) (string, error)
+	runtimeagentcontrol.Controller
 }
 
 type RuntimeController interface {
@@ -484,12 +483,16 @@ func (h *Handler) handleAgentDirective(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, errors.New("message is required"))
 		return
 	}
-	resp, err := h.agentControl.ChatWithAgent(r.Context(), id, req.Message, req.KillPrevious)
+	resp, err := h.agentControl.SendDirective(r.Context(), runtimeagentcontrol.SendDirectiveRequest{
+		AgentID:      id,
+		Directive:    req.Message,
+		KillPrevious: req.KillPrevious,
+	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, controlResult{OK: true, Message: strings.TrimSpace(resp)})
+	writeJSON(w, http.StatusOK, controlResult{OK: true, Message: strings.TrimSpace(resp.Response)})
 }
 
 func (h *Handler) handleAgentRestart(w http.ResponseWriter, r *http.Request) {
@@ -502,7 +505,7 @@ func (h *Handler) handleAgentRestart(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, errors.New("agent id is required"))
 		return
 	}
-	if err := h.agentControl.RestartAgent(id); err != nil {
+	if _, err := h.agentControl.Restart(r.Context(), runtimeagentcontrol.RestartRequest{AgentID: id}); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -519,7 +522,7 @@ func (h *Handler) handleAgentReplay(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, errors.New("agent id is required"))
 		return
 	}
-	if err := h.agentControl.ReplayAgentBacklog(r.Context(), id); err != nil {
+	if _, err := h.agentControl.ReplayBacklog(r.Context(), runtimeagentcontrol.ReplayBacklogRequest{AgentID: id}); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	builderpkg "swarm/internal/builder"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimeagents "swarm/internal/runtime/agents"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -813,13 +814,27 @@ func (s stubObservability) ListIncidents(context.Context, IncidentFilter) ([]inc
 	return s.incidents, nil
 }
 
-type stubAgentControl struct{ lastKillPrevious bool }
+type stubAgentControl struct {
+	lastDirective    runtimeagentcontrol.SendDirectiveRequest
+	restartCalls     int
+	replayCalls      int
+	lastKillPrevious bool
+}
 
-func (stubAgentControl) RestartAgent(string) error                        { return nil }
-func (stubAgentControl) ReplayAgentBacklog(context.Context, string) error { return nil }
-func (s *stubAgentControl) ChatWithAgent(_ context.Context, _, _ string, killPrevious bool) (string, error) {
-	s.lastKillPrevious = killPrevious
-	return "ok", nil
+func (s *stubAgentControl) Restart(_ context.Context, req runtimeagentcontrol.RestartRequest) (runtimeagentcontrol.RestartResult, error) {
+	s.restartCalls++
+	return runtimeagentcontrol.RestartResult{AgentID: req.AgentID}, nil
+}
+
+func (s *stubAgentControl) ReplayBacklog(_ context.Context, req runtimeagentcontrol.ReplayBacklogRequest) (runtimeagentcontrol.ReplayBacklogResult, error) {
+	s.replayCalls++
+	return runtimeagentcontrol.ReplayBacklogResult{AgentID: req.AgentID, ReplayedCount: 3}, nil
+}
+
+func (s *stubAgentControl) SendDirective(_ context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
+	s.lastDirective = req
+	s.lastKillPrevious = req.KillPrevious
+	return runtimeagentcontrol.SendDirectiveResult{AgentID: req.AgentID, Response: "ok"}, nil
 }
 
 type directiveSurfaceRuntime struct {
@@ -1178,6 +1193,9 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("agent restart status=%d body=%s", rec.Code, rec.Body.String())
 	}
+	if agentCtl.restartCalls != 1 {
+		t.Fatalf("restart calls = %d, want 1", agentCtl.restartCalls)
+	}
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/agents/agent-1/actions/directive", strings.NewReader(`{"message":"hello","kill_previous":true}`))
@@ -1188,6 +1206,20 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 	}
 	if !agentCtl.lastKillPrevious {
 		t.Fatal("expected kill_previous to be forwarded to agent control")
+	}
+	if agentCtl.lastDirective.AgentID != "agent-1" || agentCtl.lastDirective.Directive != "hello" {
+		t.Fatalf("directive request = %#v, want legacy payload adapted", agentCtl.lastDirective)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/agents/agent-1/actions/replay", strings.NewReader(`{}`))
+	setOperatorAuth(req)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("agent replay status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if agentCtl.replayCalls != 1 {
+		t.Fatalf("replay calls = %d, want 1", agentCtl.replayCalls)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/runtime/agentcontrol/control.go
+++ b/internal/runtime/agentcontrol/control.go
@@ -1,0 +1,86 @@
+package agentcontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	StatusIdle       = "idle"
+	StatusRunning    = "running"
+	StatusPaused     = "paused"
+	StatusFailed     = "failed"
+	StatusTerminated = "terminated"
+)
+
+var (
+	ErrAgentNotFound   = errors.New("agent not found")
+	ErrAgentNotRunning = errors.New("agent not running")
+)
+
+type StateError struct {
+	Err           error
+	AgentID       string
+	CurrentStatus string
+}
+
+func (e *StateError) Error() string {
+	if e == nil {
+		return ""
+	}
+	agentID := strings.TrimSpace(e.AgentID)
+	status := strings.TrimSpace(e.CurrentStatus)
+	switch {
+	case errors.Is(e.Err, ErrAgentNotFound) && agentID != "":
+		return fmt.Sprintf("agent not found: %s", agentID)
+	case errors.Is(e.Err, ErrAgentNotRunning) && agentID != "" && status != "":
+		return fmt.Sprintf("agent not running: %s current_status=%s", agentID, status)
+	case e.Err != nil:
+		return e.Err.Error()
+	default:
+		return "agent control state error"
+	}
+}
+
+func (e *StateError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type SendDirectiveRequest struct {
+	AgentID      string
+	Directive    string
+	KillPrevious bool
+}
+
+type SendDirectiveResult struct {
+	AgentID  string
+	Response string
+}
+
+type RestartRequest struct {
+	AgentID string
+}
+
+type RestartResult struct {
+	AgentID string
+}
+
+type ReplayBacklogRequest struct {
+	AgentID string
+}
+
+type ReplayBacklogResult struct {
+	AgentID       string
+	ReplayedCount int
+}
+
+type Controller interface {
+	SendDirective(context.Context, SendDirectiveRequest) (SendDirectiveResult, error)
+	Restart(context.Context, RestartRequest) (RestartResult, error)
+	ReplayBacklog(context.Context, ReplayBacklogRequest) (ReplayBacklogResult, error)
+}

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
@@ -560,6 +561,34 @@ func TestReplayAgentBacklog_DoesNotEmitStartupAftermathOutsideStartupRecovery(t 
 	}
 	if !foundLegacyFailure {
 		t.Fatalf("runtime logs = %#v, want legacy pending_replay_event_failed outside startup recovery", bus.runtimeLogs)
+	}
+}
+
+func TestReplayBacklogReportsDirectReplayCount(t *testing.T) {
+	now := time.Now().UTC()
+	store := &startupReplayTestStore{
+		pending: map[string][]events.Event{
+			"agent-a": {
+				{ID: "evt-1", Type: events.EventType("system.recover.ok"), CreatedAt: now.Add(-2 * time.Minute)},
+				{ID: "evt-2", Type: events.EventType("system.recover.ok"), CreatedAt: now.Add(-time.Minute)},
+			},
+		},
+	}
+	am := NewAgentManager(nil, func(cfg models.AgentConfig) (Agent, error) {
+		return startupReplayTestAgent{id: cfg.ID}, nil
+	}, store)
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: models.AgentConfig{ID: "agent-a"},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	result, err := am.ReplayBacklog(context.Background(), runtimeagentcontrol.ReplayBacklogRequest{AgentID: "agent-a"})
+	if err != nil {
+		t.Fatalf("ReplayBacklog: %v", err)
+	}
+	if result.ReplayedCount != 2 {
+		t.Fatalf("ReplayBacklog replayed_count = %d, want 2", result.ReplayedCount)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -31,14 +32,23 @@ type runCanceller interface {
 var errRuntimeShuttingDown = errors.New("runtime shutting down")
 
 func (am *AgentManager) RestartAgent(agentID string) error {
+	_, err := am.Restart(context.Background(), runtimeagentcontrol.RestartRequest{AgentID: agentID})
+	return legacyAgentControlError(err)
+}
+
+func (am *AgentManager) Restart(_ context.Context, req runtimeagentcontrol.RestartRequest) (runtimeagentcontrol.RestartResult, error) {
 	if am.shutdownAdmissionClosed() {
-		return errRuntimeShuttingDown
+		return runtimeagentcontrol.RestartResult{}, agentControlNotRunning(req.AgentID, runtimeagentcontrol.StatusTerminated)
+	}
+	agentID := strings.TrimSpace(req.AgentID)
+	if agentID == "" {
+		return runtimeagentcontrol.RestartResult{}, errors.New("agent id is required")
 	}
 	am.mu.RLock()
 	agent, ok := am.agents[agentID]
 	am.mu.RUnlock()
 	if !ok {
-		return fmt.Errorf("agent not found: %s", agentID)
+		return runtimeagentcontrol.RestartResult{}, agentControlNotFound(agentID)
 	}
 
 	am.runMu.Lock()
@@ -53,7 +63,7 @@ func (am *AgentManager) RestartAgent(agentID string) error {
 	if running {
 		am.startAgentLoop(ctx, agent)
 	}
-	return nil
+	return runtimeagentcontrol.RestartResult{AgentID: agentID}, nil
 }
 
 func (am *AgentManager) Shutdown() error {
@@ -314,29 +324,45 @@ func (am *AgentManager) safeProcessEvent(ctx context.Context, agent Agent, evt e
 }
 
 func (am *AgentManager) ChatWithAgent(ctx context.Context, agentID, directive string, killPrevious bool) (string, error) {
-	if am.shutdownAdmissionClosed() {
-		return "", errRuntimeShuttingDown
+	result, err := am.SendDirective(ctx, runtimeagentcontrol.SendDirectiveRequest{
+		AgentID:      agentID,
+		Directive:    directive,
+		KillPrevious: killPrevious,
+	})
+	if err != nil {
+		return "", legacyAgentControlError(err)
 	}
-	agentID = strings.TrimSpace(agentID)
+	return result.Response, nil
+}
+
+func (am *AgentManager) SendDirective(ctx context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
+	if am.shutdownAdmissionClosed() {
+		return runtimeagentcontrol.SendDirectiveResult{}, agentControlNotRunning(req.AgentID, runtimeagentcontrol.StatusTerminated)
+	}
+	agentID := strings.TrimSpace(req.AgentID)
 	if agentID == "" {
-		return "", errors.New("agent id is required")
+		return runtimeagentcontrol.SendDirectiveResult{}, errors.New("agent id is required")
 	}
 	am.mu.RLock()
 	agent, ok := am.agents[agentID]
 	am.mu.RUnlock()
 	if !ok {
-		return "", fmt.Errorf("agent not found: %s", agentID)
+		return runtimeagentcontrol.SendDirectiveResult{}, agentControlNotFound(agentID)
 	}
 	chatAgent, ok := agent.(BoardInteractiveAgent)
 	if !ok {
-		return "", fmt.Errorf("agent does not support board chat: %s", agentID)
+		return runtimeagentcontrol.SendDirectiveResult{}, agentControlNotRunning(agentID, runtimeagentcontrol.StatusIdle)
 	}
-	if killPrevious {
+	if req.KillPrevious {
 		if err := am.killPreviousRuns(ctx, agentID); err != nil {
-			return "", err
+			return runtimeagentcontrol.SendDirectiveResult{}, err
 		}
 	}
-	return chatAgent.BoardStep(ctx, directive)
+	response, err := chatAgent.BoardStep(ctx, req.Directive)
+	if err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
+	return runtimeagentcontrol.SendDirectiveResult{AgentID: agentID, Response: response}, nil
 }
 
 func (am *AgentManager) killPreviousRuns(ctx context.Context, producerID string) error {
@@ -739,14 +765,25 @@ func (am *AgentManager) replayPendingEventsDetailed(ctx context.Context) (Startu
 }
 
 func (am *AgentManager) ReplayAgentBacklog(ctx context.Context, agentID string) error {
-	_, err := am.replayAgentBacklogDetailed(ctx, agentID)
-	return err
+	_, err := am.ReplayBacklog(ctx, runtimeagentcontrol.ReplayBacklogRequest{AgentID: agentID})
+	return legacyAgentControlError(err)
+}
+
+func (am *AgentManager) ReplayBacklog(ctx context.Context, req runtimeagentcontrol.ReplayBacklogRequest) (runtimeagentcontrol.ReplayBacklogResult, error) {
+	summary, err := am.replayAgentBacklogDetailed(ctx, req.AgentID)
+	if err != nil {
+		return runtimeagentcontrol.ReplayBacklogResult{}, err
+	}
+	return runtimeagentcontrol.ReplayBacklogResult{
+		AgentID:       strings.TrimSpace(req.AgentID),
+		ReplayedCount: summary.ReplayedCount,
+	}, nil
 }
 
 func (am *AgentManager) replayAgentBacklogDetailed(ctx context.Context, agentID string) (StartupReplaySummary, error) {
 	summary := StartupReplaySummary{}
 	if am.shutdownAdmissionClosed() {
-		return summary, errRuntimeShuttingDown
+		return summary, agentControlNotRunning(agentID, runtimeagentcontrol.StatusTerminated)
 	}
 	if am.store == nil {
 		return summary, fmt.Errorf("manager store unavailable")
@@ -767,7 +804,7 @@ func (am *AgentManager) replayAgentBacklogDetailed(ctx context.Context, agentID 
 	}
 	am.mu.RUnlock()
 	if !ok || agent == nil {
-		return summary, fmt.Errorf("agent not found: %s", agentID)
+		return summary, agentControlNotFound(agentID)
 	}
 	pending, err := am.pendingEventsForAgent(ctx, agentID, cfg, agent, since)
 	if err != nil {
@@ -789,8 +826,8 @@ func (am *AgentManager) replayAgentBacklogDetailed(ctx context.Context, agentID 
 			return summary, nil
 		}
 		result := am.processEventDetailed(ctx, agent, evt)
+		summary.observe(result.record)
 		if startupManagerReplayDiagnosticsEnabled(ctx) {
-			summary.observe(result.record)
 			logStartupManagerReplayAftermath(ctx, am.bus, result.record)
 		}
 		if result.err != nil {
@@ -814,6 +851,41 @@ func (am *AgentManager) replayAgentBacklogDetailed(ctx context.Context, agentID 
 		}
 	}
 	return summary, nil
+}
+
+func agentControlNotFound(agentID string) error {
+	return &runtimeagentcontrol.StateError{
+		Err:     runtimeagentcontrol.ErrAgentNotFound,
+		AgentID: strings.TrimSpace(agentID),
+	}
+}
+
+func agentControlNotRunning(agentID, currentStatus string) error {
+	status := strings.TrimSpace(currentStatus)
+	if status == "" {
+		status = runtimeagentcontrol.StatusTerminated
+	}
+	return &runtimeagentcontrol.StateError{
+		Err:           runtimeagentcontrol.ErrAgentNotRunning,
+		AgentID:       strings.TrimSpace(agentID),
+		CurrentStatus: status,
+	}
+}
+
+func legacyAgentControlError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var stateErr *runtimeagentcontrol.StateError
+	if errors.As(err, &stateErr) && stateErr != nil {
+		switch {
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotFound):
+			return fmt.Errorf("agent not found: %s", strings.TrimSpace(stateErr.AgentID))
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAgentNotRunning) && strings.TrimSpace(stateErr.CurrentStatus) == runtimeagentcontrol.StatusTerminated:
+			return errRuntimeShuttingDown
+		}
+	}
+	return err
 }
 
 func (am *AgentManager) pendingEventsForAgent(


### PR DESCRIPTION
## Summary

Part of #721
Part of #665

Implements the approved #721 first slice:

- Adds a typed `internal/runtime/agentcontrol` owner for `agent.send_directive`, `agent.restart`, and `agent.replay_backlog`.
- Wires `/v1/rpc` handlers for all three methods with existing API idempotency and application error mapping.
- Converts dashboard REST agent action aliases to adapter-only consumers of the same typed owner.
- Preserves legacy runtime manager helper methods as compatibility wrappers over the typed owner.
- Exposes real direct backlog replay count from runtime manager replay execution instead of returning a placeholder.

## Governing Refs / Context

Exact governing spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` API specification.

Binding sections/provisions used:

- `api_specification.namespaces.entries.agent`: `agent.*` owns agent registry/current status/control actions.
- Mutating-method idempotency convention for `agent.send_directive`, `agent.restart`, `agent.replay_backlog`.
- Error schemas: `AGENT_NOT_FOUND`, `AGENT_NOT_RUNNING`, `IDEMPOTENCY_CONFLICT`.
- Method specs: `agent.send_directive`, `agent.restart`, `agent.replay_backlog`.
- Legacy REST transition map: `POST /api/agents/{id}/actions/directive|restart|replay` map to the corresponding v1 methods.

Approved gate: #721 independent gate comment approved first slice: canonical v1 agent-control owner plus dashboard REST aliases as adapters. CLI/helper migration remains split.

## Semantic Migration

New canonical owner:

- `internal/runtime/agentcontrol` typed control contract.
- `internal/runtime/manager.AgentManager` implements the typed owner while preserving legacy helper wrappers.
- `internal/apiv1` consumes the owner and owns JSON-RPC idempotency/error/result envelope mapping.
- `internal/dashboard/server` consumes the same owner as a deprecated REST adapter surface.

Old producer / reader / writer paths now invalid as semantic owners:

- Dashboard `AgentController.ChatWithAgent`, `RestartAgent`, and `ReplayAgentBacklog` no longer define public semantics independently.
- `cmd/swarm` dashboard dynamic agent control no longer calls legacy manager helpers; it calls the typed owner methods.
- Runtime manager `ReplayAgentBacklog` no longer hides direct replay summary from the canonical owner path.

Production paths checked for surviving old behavior:

- `/v1/rpc` catalog methods now have business handlers instead of `METHOD_UNAVAILABLE`.
- Dashboard `/api/agents/{id}/actions/directive|restart|replay` now routes through the typed owner.
- `scripts/run_clear.sh` still posts to the legacy directive alias, intentionally split by the gate; it benefits indirectly because the alias is now adapter-only.
- `swarm investigate` / future `swarm control` migration remains split from this PR.

Migration completeness:

- Complete for the approved first-slice class: v1 agent controls plus dashboard REST same-concept adapters.
- Not complete for full #665 Slice 8 CLI/helper migration tail, which remains split.

## Verification

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'TestRegistryMethodNamesMatchGeneratedOpenRPC|TestOperatorAgentControl' -count=1`
- `go test ./internal/dashboard/server -run 'Test.*Agent.*(Directive|Restart|Replay)|TestHandler_AgentDirectiveSurface|TestHandler_DashboardRoutesRequireAuthentication' -count=1`
- `go test ./internal/runtime/manager -run 'TestAgentManager_ChatWithAgent|TestReplayAgentBacklog|TestReplayBacklogReportsDirectReplayCount|TestRestartAgent' -count=1`
- `go test ./cmd/swarm -run TestDashboardDynamicAgentControl -count=1`
- `go test ./internal/apiv1 ./internal/dashboard/server ./internal/runtime/manager ./cmd/swarm -count=1`
- `go test ./... -count=1`