### PR TITLE
[agent-b][issue #725] Migrate run-clear directives to v1 RPC

### DIFF
--- a/docs/EPO_INVESTIGATION_SURFACES.md
+++ b/docs/EPO_INVESTIGATION_SURFACES.md
@@ -107,16 +107,19 @@ Use these for lightweight runtime inspection without attaching to the database f
 Common surfaces:
 - `/healthz`
 - `/readyz`
-- `/api/agents`
+- `/v1/rpc` `agent.list` / `agent.get`
 - `/api/runs`
 - `/api/rpc`
-- `POST /api/agents/{id}/actions/directive`
+- `/v1/rpc` `agent.send_directive`
 
 Best for:
 - readiness confirmation
 - active agent discovery
-- live directive-path reproduction
+- live directive-path reproduction through the canonical v1 owner
 - builder/operator surface mismatches
+
+Legacy dashboard `/api/agents*` routes are adapter surfaces for historical
+investigation only; they are not the canonical agent-control API.
 
 ### 6. Runtime Process Log
 

--- a/docs/SWARM_INVESTIGATE_COMMAND_DRAFT.md
+++ b/docs/SWARM_INVESTIGATE_COMMAND_DRAFT.md
@@ -154,11 +154,21 @@ They are real follow-on candidates for `swarm investigate`, not speculative futu
 
 ### Agent / Conversation / Entity / Instance Surfaces
 
-- `GET /api/agents`
-- `GET /api/agents/{id}`
-- `POST /api/agents/{id}/actions/directive`
-- `POST /api/agents/{id}/actions/restart`
-- `POST /api/agents/{id}/actions/replay`
+Canonical v1 agent-control/read methods:
+
+- `agent.list`
+- `agent.get`
+- `agent.send_directive`
+- `agent.restart`
+- `agent.replay_backlog`
+
+Legacy dashboard REST aliases remain available only as adapter surfaces:
+
+- `GET /api/agents` -> `agent.list`
+- `GET /api/agents/{id}` -> `agent.get`
+- `POST /api/agents/{id}/actions/directive` -> `agent.send_directive`
+- `POST /api/agents/{id}/actions/restart` -> `agent.restart`
+- `POST /api/agents/{id}/actions/replay` -> `agent.replay_backlog`
 
 - `GET /api/conversations`
 - `GET /api/conversations/{sessionID}`
@@ -179,7 +189,10 @@ These already provide operator-visible drill-down without querying:
 - `flow_instances`
 - `entity_state`
 
-Primary API owner: [server.go](/Users/youmew/dev/swarm/internal/dashboard/server/server.go#L241)
+Primary API owner: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
+`api_specification`, implemented by the v1 `/v1/rpc` handlers and shared
+operator read/control owners. Dashboard `server.go` routes are deprecated
+adapter surfaces, not semantic owners.
 
 Entity-oriented diagnosis is already stronger than a typical “future follow-on” category, even though the current APIs are still instance-shaped:
 

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -35,6 +35,7 @@ RUN_CLEAR_INPUT_EVENT="${RUN_CLEAR_INPUT_EVENT:-scan.corpus_file_requested}"
 RUN_CLEAR_INPUT_PAYLOAD_JSON="${RUN_CLEAR_INPUT_PAYLOAD_JSON:-}"
 SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+SWARM_API_TOKEN="${SWARM_API_TOKEN:-${SWARM_OPERATOR_AUTH_TOKEN}}"
 if [[ -n "${SWARM_TOOL_GATEWAY_URL:-}" && -n "${SWARM_TOOL_GATEWAY_CONTAINER_URL:-}" ]]; then
   SWARM_TOOL_GATEWAY_URL="${SWARM_TOOL_GATEWAY_URL}"
   SWARM_TOOL_GATEWAY_CONTAINER_URL="${SWARM_TOOL_GATEWAY_CONTAINER_URL}"
@@ -45,6 +46,7 @@ fi
 
 export SWARM_OPERATOR_AUTH_TOKEN
 export SWARM_BUILDER_AUTH_TOKEN
+export SWARM_API_TOKEN
 export SWARM_TOOL_GATEWAY_URL
 export SWARM_TOOL_GATEWAY_CONTAINER_URL
 
@@ -116,7 +118,7 @@ go build -o "${BINARY_PATH}" ./cmd/swarm
 echo "Starting Swarm with contracts ${CONTRACTS_ROOT}..."
 : > "${LOG_FILE}"
 launcher_pid="$(
-  LOG_FILE="${LOG_FILE}" BINARY_PATH="${BINARY_PATH}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN}" SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN}" python3 - <<'PY'
+  LOG_FILE="${LOG_FILE}" BINARY_PATH="${BINARY_PATH}" CONTRACTS_ROOT="${CONTRACTS_ROOT}" HEALTH_ADDR="${HEALTH_ADDR}" SWARM_API_TOKEN="${SWARM_API_TOKEN}" SWARM_OPERATOR_AUTH_TOKEN="${SWARM_OPERATOR_AUTH_TOKEN}" SWARM_BUILDER_AUTH_TOKEN="${SWARM_BUILDER_AUTH_TOKEN}" python3 - <<'PY'
 import os
 import subprocess
 import sys
@@ -239,10 +241,10 @@ fi
 
 if [[ -n "${DIRECTIVE_AGENT}" && -n "${DIRECTIVE_MESSAGE}" ]]; then
   echo "Sending directive to ${DIRECTIVE_AGENT}..."
-  ruby -rjson -e 'print JSON.generate({message: ARGV[0], kill_previous: true})' "${DIRECTIVE_MESSAGE}" | \
-    curl -sS "http://${HOST_HTTP_ADDR}/api/agents/${DIRECTIVE_AGENT}/actions/directive" \
-      -H 'content-type: application/json' \
-      -H "Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}" \
-      --data-binary @-
+  directive_body="$(ruby -rjson -e 'print JSON.generate({jsonrpc: "2.0", id: "run-clear-directive", method: "agent.send_directive", params: {agent_id: ARGV[0], directive: ARGV[1], kill_previous: true}})' "${DIRECTIVE_AGENT}" "${DIRECTIVE_MESSAGE}")"
+  curl -sS "http://${HOST_HTTP_ADDR}/v1/rpc" \
+    -H 'content-type: application/json' \
+    -H "Authorization: Bearer ${SWARM_API_TOKEN}" \
+    --data-binary "${directive_body}"
   echo
 fi

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -1,6 +1,7 @@
 package scripts
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 )
 
 type runClearConfig struct {
+	apiToken         string
 	operatorToken    string
 	builderToken     string
 	directiveAgent   string
@@ -123,26 +125,50 @@ func TestRunClear_DoesNotTreatLauncherStateChangeAsStartupFailure(t *testing.T) 
 	}
 }
 
-func TestRunClear_UsesOperatorBearerForDirective(t *testing.T) {
+func TestRunClear_UsesV1RPCForAgentDirective(t *testing.T) {
+	const explicitAPIToken = "api-explicit-token"
 	const explicitOperatorToken = "operator-explicit-token"
 	result := runRunClear(t, runClearConfig{
+		apiToken:         explicitAPIToken,
 		operatorToken:    explicitOperatorToken,
 		directiveAgent:   "agent-7",
 		directiveMessage: "hello from test",
 	})
 
-	wantHeader := "Authorization: Bearer " + explicitOperatorToken
+	if got := strings.TrimSpace(result.apiToken); got != explicitAPIToken {
+		t.Fatalf("api token = %q, want %q", got, explicitAPIToken)
+	}
+	wantHeader := "Authorization: Bearer " + explicitAPIToken
 	if !strings.Contains(result.directiveHeaders, wantHeader) {
 		t.Fatalf("directive headers = %q, want %q", result.directiveHeaders, wantHeader)
 	}
-	if got := strings.TrimSpace(result.directiveURL); got != "http://127.0.0.1:8081/api/agents/agent-7/actions/directive" {
-		t.Fatalf("directive url = %q, want helper directive endpoint", got)
+	if got := strings.TrimSpace(result.directiveURL); got != "http://127.0.0.1:8081/v1/rpc" {
+		t.Fatalf("directive url = %q, want v1 rpc endpoint", got)
 	}
-	if !strings.Contains(result.directiveBody, `"message":"hello from test"`) {
-		t.Fatalf("directive body = %q, want directive message payload", result.directiveBody)
+
+	var body struct {
+		JSONRPC string         `json:"jsonrpc"`
+		ID      string         `json:"id"`
+		Method  string         `json:"method"`
+		Params  map[string]any `json:"params"`
 	}
-	if !strings.Contains(result.directiveBody, `"kill_previous":true`) {
-		t.Fatalf("directive body = %q, want kill_previous payload", result.directiveBody)
+	if err := json.Unmarshal([]byte(result.directiveBody), &body); err != nil {
+		t.Fatalf("decode directive body %q: %v", result.directiveBody, err)
+	}
+	if body.JSONRPC != "2.0" || body.ID != "run-clear-directive" || body.Method != "agent.send_directive" {
+		t.Fatalf("directive body = %#v, want JSON-RPC agent.send_directive envelope", body)
+	}
+	if body.Params["agent_id"] != "agent-7" {
+		t.Fatalf("directive params = %#v, want agent_id", body.Params)
+	}
+	if body.Params["directive"] != "hello from test" {
+		t.Fatalf("directive params = %#v, want directive message", body.Params)
+	}
+	if body.Params["kill_previous"] != true {
+		t.Fatalf("directive params = %#v, want kill_previous true", body.Params)
+	}
+	if _, ok := body.Params["message"]; ok {
+		t.Fatalf("directive params = %#v, want no legacy message field", body.Params)
 	}
 }
 
@@ -208,6 +234,7 @@ func TestRunClear_FailsFastWhenSwarmExitsBeforeReady(t *testing.T) {
 
 type runClearResult struct {
 	stdout              string
+	apiToken            string
 	operatorToken       string
 	builderToken        string
 	hostGatewayURL      string
@@ -242,6 +269,7 @@ func runRunClearResult(t *testing.T, cfg runClearConfig) (runClearResult, error)
 	logFile := filepath.Join(t.TempDir(), "swarm.log")
 	pidFile := filepath.Join(t.TempDir(), "swarm.pid")
 	operatorTokenSink := filepath.Join(t.TempDir(), "operator-token.txt")
+	apiTokenSink := filepath.Join(t.TempDir(), "api-token.txt")
 	builderTokenSink := filepath.Join(t.TempDir(), "builder-token.txt")
 	hostGatewayURLSink := filepath.Join(t.TempDir(), "host-gateway-url.txt")
 	containerGatewayURLSink := filepath.Join(t.TempDir(), "container-gateway-url.txt")
@@ -360,6 +388,7 @@ chmod +x "$out"
 	writeExecutable(t, binDir, "python3", `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s' "${SWARM_OPERATOR_AUTH_TOKEN:-}" > "${PYTHON_OPERATOR_TOKEN_SINK}"
+printf '%s' "${SWARM_API_TOKEN:-}" > "${PYTHON_API_TOKEN_SINK}"
 printf '%s' "${SWARM_BUILDER_AUTH_TOKEN:-}" > "${PYTHON_ENV_SINK}"
 printf '%s' "${SWARM_TOOL_GATEWAY_URL:-}" > "${PYTHON_HOST_GATEWAY_URL_SINK}"
 printf '%s' "${SWARM_TOOL_GATEWAY_CONTAINER_URL:-}" > "${PYTHON_CONTAINER_GATEWAY_URL_SINK}"
@@ -463,7 +492,7 @@ if [[ "$url" == *"/api/rpc" ]]; then
   printf '{"jsonrpc":"2.0","id":"run-clear","error":{"message":"missing authorization bearer token"}}'
   exit 0
 fi
-if [[ "$url" == *"/api/agents/"*"/actions/directive" ]]; then
+if [[ "$url" == *"/v1/rpc" ]]; then
   printf '%s' "$url" > "${CURL_DIRECTIVE_URL_SINK}"
   if ((${#headers[@]})); then
     printf '%s\n' "${headers[@]}" > "${CURL_DIRECTIVE_HEADERS_SINK}"
@@ -471,14 +500,14 @@ if [[ "$url" == *"/api/agents/"*"/actions/directive" ]]; then
     : > "${CURL_DIRECTIVE_HEADERS_SINK}"
   fi
   printf '%s' "$body" > "${CURL_DIRECTIVE_BODY_SINK}"
-  want="Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}"
+  want="Authorization: Bearer ${SWARM_API_TOKEN}"
   for header in "${headers[@]}"; do
     if [[ "$header" == "$want" ]]; then
-      printf '{"status":"accepted"}'
+      printf '{"jsonrpc":"2.0","id":"run-clear-directive","result":{"ok":true,"response":"accepted"}}'
       exit 0
     fi
   done
-  printf '{"error":"missing authorization bearer token"}'
+  printf '{"jsonrpc":"2.0","id":"run-clear-directive","error":{"code":-32000,"message":"missing authorization bearer token","data":{"code":"UNAUTHORIZED"}}}'
   exit 0
 fi
 printf '{}'
@@ -487,6 +516,7 @@ printf '{}'
 	cmd := exec.Command("bash", filepath.Join(scriptDir, "run_clear.sh"))
 	cmd.Env = append(filteredEnv(
 		"SWARM_OPERATOR_AUTH_TOKEN",
+		"SWARM_API_TOKEN",
 		"SWARM_BUILDER_AUTH_TOKEN",
 		"SWARM_TOOL_GATEWAY_URL",
 		"SWARM_TOOL_GATEWAY_CONTAINER_URL",
@@ -495,6 +525,7 @@ printf '{}'
 	), []string{
 		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"PYTHON_OPERATOR_TOKEN_SINK=" + operatorTokenSink,
+		"PYTHON_API_TOKEN_SINK=" + apiTokenSink,
 		"PYTHON_ENV_SINK=" + builderTokenSink,
 		"PYTHON_HOST_GATEWAY_URL_SINK=" + hostGatewayURLSink,
 		"PYTHON_CONTAINER_GATEWAY_URL_SINK=" + containerGatewayURLSink,
@@ -526,6 +557,9 @@ printf '{}'
 	if cfg.operatorToken != "" {
 		cmd.Env = append(cmd.Env, "SWARM_OPERATOR_AUTH_TOKEN="+cfg.operatorToken)
 	}
+	if cfg.apiToken != "" {
+		cmd.Env = append(cmd.Env, "SWARM_API_TOKEN="+cfg.apiToken)
+	}
 	if cfg.builderToken != "" {
 		cmd.Env = append(cmd.Env, "SWARM_BUILDER_AUTH_TOKEN="+cfg.builderToken)
 	}
@@ -549,6 +583,7 @@ printf '{}'
 
 	return runClearResult{
 		stdout:              string(out),
+		apiToken:            readFileTrimmed(t, apiTokenSink),
 		operatorToken:       readFileTrimmed(t, operatorTokenSink),
 		builderToken:        readFileTrimmed(t, builderTokenSink),
 		hostGatewayURL:      readFileTrimmed(t, hostGatewayURLSink),


### PR DESCRIPTION
## Summary

Closes #725
Part of #721
Part of #665

Implements the approved #725 first slice only:

- Migrates `scripts/run_clear.sh` optional directive delivery from legacy `POST /api/agents/{id}/actions/directive` to `/v1/rpc` `agent.send_directive`.
- Uses `SWARM_API_TOKEN` for the v1 directive call, defaulting it to the existing operator token so current helper behavior remains usable while the v1 bearer token is available to the launched server.
- Updates `run_clear` tests to prove the JSON-RPC envelope, `agent_id` / `directive` / `kill_previous` params, `/v1/rpc` endpoint, and v1 bearer header.
- Cleans investigation docs so `/api/agents/{id}/actions/*` is described as deprecated/legacy adapter surface, not the canonical agent-control API owner.

Explicitly not included: `run_clear` `run.start` migration from `/api/rpc`, future `swarm investigate` / `swarm control` UX, dashboard REST implementation rewrites, or legacy endpoint deprecation headers.

## Governing Refs / Context

Exact governing spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification`.

Binding sections/provisions used:

- `api_specification` single user-facing API authority and `/v1/rpc` transport.
- `api_specification` bearer-token model, with `SWARM_API_TOKEN` canonical and legacy token fallbacks still accepted by `internal/apiv1.AuthTokensFromEnvironment`.
- `api_specification.namespaces.entries.agent`: `agent.*` owns agent registry/current status/control actions.
- `api_specification.method_catalog.agent.send_directive`.
- Legacy REST transition map: `POST /api/agents/{id}/actions/directive -> agent.send_directive`.
- CLI/API migration closure context for `swarm investigate` / future control commands and `make_run_clear` parent-tail notes.

Approved gate: #725 independent gate comment approved first slice for live helper agent-directive migration plus docs canonicality cleanup. The gate explicitly split future CLI UX, full `make run-clear` run-start migration, legacy endpoint deprecation headers, and dashboard REST rewrites.

## Semantic Migration

New canonical owner consumed:

- `/v1/rpc` `agent.send_directive` handler in `internal/apiv1/operator_agent_control.go`, backed by the typed `internal/runtime/agentcontrol` owner landed in #723.

Old producer / reader / writer path now invalid for this slice:

- `scripts/run_clear.sh` no longer posts agent directives to legacy `/api/agents/${DIRECTIVE_AGENT}/actions/directive` with `{message, kill_previous}`.
- `scripts/run_clear_test.go` no longer locks the helper to the legacy directive URL or legacy `message` payload shape.
- Docs no longer present dashboard `server.go` or `/api/agents/{id}/actions/*` as the primary/canonical agent-control API owner.

Production paths checked for surviving old behavior:

- `scripts/run_clear.sh` optional directive path now calls `/v1/rpc` `agent.send_directive`.
- `run_clear` `run.start` remains on `/api/rpc` by approved split boundary.
- Dashboard REST `/api/agents/{id}/actions/directive|restart|replay` remains adapter-only after #723 and is not rewritten here.
- No live `swarm investigate` or `swarm control` command exists in `cmd/swarm`; future CLI UX remains split.

Migration completeness:

- Complete for the approved #725 first-slice class: live helper agent-directive consumer migration plus docs canonicality cleanup.
- Not complete for full #721/#665 Slice 8, future CLI UX, full `make run-clear` v1 migration, or legacy endpoint deprecation headers.

## Verification

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./scripts -run TestRunClear_UsesV1RPCForAgentDirective -count=1`
- `go test ./scripts -count=1`
- `go test ./internal/apiv1 -run TestOperatorAgentControl -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_Agent.*(Directive|Restart|Replay)|TestHandler_AgentDirectiveSurface' -count=1`
- `git diff --check`
- `go test ./... -count=1`