### PR TITLE
[agent-b][issue #727] Route run-clear run.start through v1 RPC

### DIFF
--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -203,7 +203,7 @@ for _ in $(seq 1 "${START_TIMEOUT}"); do
     -H "Authorization: Bearer ${SWARM_API_TOKEN}" \
     --data-binary "${api_health_body}" || true)"
   if [[ "${health_code}" == "200" && "${ready_code}" == "200" && "${api_code}" == "200" ]]; then
-    bundle_fingerprint="$(ruby -rjson -e 'doc = JSON.parse(File.read(ARGV[0])); abort("health.check returned error") if doc["error"]; fingerprint = doc.dig("result", "bundle", "fingerprint").to_s; abort("health.check missing bundle fingerprint") if fingerprint.empty?; print fingerprint' /tmp/swarm-api-health.json 2>/dev/null || true)"
+    bundle_fingerprint="$(ruby -rjson -e 'doc = JSON.parse(File.read(ARGV[0])); abort("health.check returned error") if doc["error"]; result = doc["result"] || {}; abort("health.check not ready") unless result["ready"] == true && result["db_ok"] == true && result["runtime_ok"] == true; fingerprint = result.dig("bundle", "fingerprint").to_s; abort("health.check missing bundle fingerprint") if fingerprint.empty?; print fingerprint' /tmp/swarm-api-health.json 2>/dev/null || true)"
     if [[ -n "${bundle_fingerprint}" ]]; then
       ready=1
       break

--- a/scripts/run_clear.sh
+++ b/scripts/run_clear.sh
@@ -14,7 +14,7 @@ fi
 HOST_HTTP_ADDR="${HEALTH_HOST}:${HEALTH_PORT}"
 HEALTH_URL="http://${HOST_HTTP_ADDR}/healthz"
 READY_URL="http://${HOST_HTTP_ADDR}/readyz"
-API_HEALTH_URL="http://${HOST_HTTP_ADDR}/api/health"
+API_RPC_URL="http://${HOST_HTTP_ADDR}/v1/rpc"
 
 SWARM_DB_HOST="${SWARM_DB_HOST:-127.0.0.1}"
 SWARM_DB_PORT="${SWARM_DB_PORT:-5432}"
@@ -188,6 +188,8 @@ launcher_exited_before_ready() {
 }
 
 ready=0
+bundle_fingerprint=""
+api_health_body='{"jsonrpc":"2.0","id":"run-clear-health","method":"health.check","params":{}}'
 for _ in $(seq 1 "${START_TIMEOUT}"); do
   if launcher_exited_before_ready "${launcher_pid}" "${launcher_identity}"; then
     echo "Swarm exited before becoming ready. Current log:"
@@ -196,11 +198,16 @@ for _ in $(seq 1 "${START_TIMEOUT}"); do
   fi
   health_code="$(curl -s -o /tmp/swarm-healthz.json -w '%{http_code}' "${HEALTH_URL}" || true)"
   ready_code="$(curl -s -o /tmp/swarm-readyz.json -w '%{http_code}' "${READY_URL}" || true)"
-  api_code="$(curl -s -o /tmp/swarm-api-health.json -w '%{http_code}' "${API_HEALTH_URL}" \
-    -H "Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}" || true)"
+  api_code="$(curl -s -o /tmp/swarm-api-health.json -w '%{http_code}' "${API_RPC_URL}" \
+    -H 'content-type: application/json' \
+    -H "Authorization: Bearer ${SWARM_API_TOKEN}" \
+    --data-binary "${api_health_body}" || true)"
   if [[ "${health_code}" == "200" && "${ready_code}" == "200" && "${api_code}" == "200" ]]; then
-    ready=1
-    break
+    bundle_fingerprint="$(ruby -rjson -e 'doc = JSON.parse(File.read(ARGV[0])); abort("health.check returned error") if doc["error"]; fingerprint = doc.dig("result", "bundle", "fingerprint").to_s; abort("health.check missing bundle fingerprint") if fingerprint.empty?; print fingerprint' /tmp/swarm-api-health.json 2>/dev/null || true)"
+    if [[ -n "${bundle_fingerprint}" ]]; then
+      ready=1
+      break
+    fi
   fi
   sleep 1
 done
@@ -227,13 +234,13 @@ if [[ -z "${RUN_CLEAR_INPUT_PAYLOAD_JSON}" ]]; then
   fi
   RUN_CLEAR_INPUT_PAYLOAD_JSON="$(ruby -rjson -e 'print JSON.generate({request: {geography: ARGV[0]}, corpus_path: ARGV[1]})' "${CORPUS_GEOGRAPHY}" "${CORPUS_PATH}")"
 fi
-run_start_body="$(ruby -rjson -e 'print JSON.generate({jsonrpc: "2.0", id: "run-clear", method: "run.start", params: {run_id: ARGV[0], inputs: {ARGV[1] => JSON.parse(ARGV[2])}}})' "${run_id}" "${RUN_CLEAR_INPUT_EVENT}" "${RUN_CLEAR_INPUT_PAYLOAD_JSON}")"
-run_response="$(curl -sS "http://${HOST_HTTP_ADDR}/api/rpc" \
+run_start_body="$(ruby -rjson -e 'print JSON.generate({jsonrpc: "2.0", id: "run-clear", method: "run.start", params: {run_id: ARGV[0], event_name: ARGV[1], payload: JSON.parse(ARGV[2]), bundle_ref: {fingerprint: ARGV[3]}, idempotency_key: "run-clear:#{ARGV[0]}"}})' "${run_id}" "${RUN_CLEAR_INPUT_EVENT}" "${RUN_CLEAR_INPUT_PAYLOAD_JSON}" "${bundle_fingerprint}")"
+run_response="$(curl -sS "${API_RPC_URL}" \
   -H 'content-type: application/json' \
-  -H "Authorization: Bearer ${SWARM_BUILDER_AUTH_TOKEN}" \
+  -H "Authorization: Bearer ${SWARM_API_TOKEN}" \
   --data-binary "${run_start_body}")"
 echo "${run_response}"
-if ! grep -q '"status":"started"' <<<"${run_response}"; then
+if ! ruby -rjson -e 'doc = JSON.parse(STDIN.read); exit 1 if doc["error"]; result = doc["result"] || {}; exit(result["run_id"].to_s == ARGV[0] && result["status"].to_s == "running" ? 0 : 1)' "${run_id}" <<<"${run_response}"; then
   echo "Corpus run failed to start. Current log:"
   tail -n 200 "${LOG_FILE}"
   exit 1

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 )
 
+const runClearTestBundleFingerprint = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 type runClearConfig struct {
 	apiToken         string
 	operatorToken    string
@@ -25,72 +27,134 @@ type runClearConfig struct {
 	readyCode        string
 	apiHealthCode    string
 	startTimeout     string
+	inputEvent       string
+	inputPayloadJSON string
 }
 
-func TestRunClear_ProvisionsBuilderAuthTokenAndUsesBearerForRPC(t *testing.T) {
+func TestRunClear_UsesV1RPCHealthCheckAndRunStart(t *testing.T) {
 	result := runRunClear(t, runClearConfig{})
 
 	if strings.TrimSpace(result.operatorToken) == "" {
 		t.Fatal("expected helper to provision SWARM_OPERATOR_AUTH_TOKEN")
 	}
+	if got, want := strings.TrimSpace(result.apiToken), strings.TrimSpace(result.operatorToken); got != want {
+		t.Fatalf("api token = %q, want operator fallback %q", got, want)
+	}
 	if strings.TrimSpace(result.builderToken) == "" {
 		t.Fatal("expected helper to provision SWARM_BUILDER_AUTH_TOKEN")
 	}
-	wantOperatorHeader := "Authorization: Bearer " + result.operatorToken
-	if !strings.Contains(result.healthHeaders, wantOperatorHeader) {
-		t.Fatalf("api health headers = %q, want %q", result.healthHeaders, wantOperatorHeader)
+	wantAPIHeader := "Authorization: Bearer " + result.apiToken
+	if !strings.Contains(result.healthHeaders, wantAPIHeader) {
+		t.Fatalf("health.check headers = %q, want %q", result.healthHeaders, wantAPIHeader)
 	}
-	if got := strings.TrimSpace(result.healthURL); got != "http://127.0.0.1:8081/api/health" {
-		t.Fatalf("api health url = %q, want helper /api/health readiness gate", got)
+	if got := strings.TrimSpace(result.healthURL); got != "http://127.0.0.1:8081/v1/rpc" {
+		t.Fatalf("health.check url = %q, want v1 rpc endpoint", got)
 	}
-	wantHeader := "Authorization: Bearer " + result.builderToken
-	if !strings.Contains(result.rpcHeaders, wantHeader) {
-		t.Fatalf("rpc headers = %q, want %q", result.rpcHeaders, wantHeader)
+	health := decodeJSONRPCBody(t, result.healthBody)
+	if health.Method != "health.check" {
+		t.Fatalf("health body = %#v, want health.check", health)
 	}
-	if got := strings.TrimSpace(result.rpcURL); got != "http://127.0.0.1:8081/api/rpc" {
-		t.Fatalf("rpc url = %q, want helper /api/rpc alias", got)
+	if !strings.Contains(result.rpcHeaders, wantAPIHeader) {
+		t.Fatalf("run.start headers = %q, want %q", result.rpcHeaders, wantAPIHeader)
 	}
-	if !strings.Contains(result.rpcBody, `"method":"run.start"`) {
-		t.Fatalf("rpc body = %q, want run.start request", result.rpcBody)
+	if strings.Contains(result.rpcHeaders, result.builderToken) && result.builderToken != result.apiToken {
+		t.Fatalf("run.start headers = %q, want no builder-token auth", result.rpcHeaders)
 	}
-	if !strings.Contains(result.rpcBody, `"scan.corpus_file_requested"`) {
-		t.Fatalf("rpc body = %q, want typed corpus root input", result.rpcBody)
+	if got := strings.TrimSpace(result.rpcURL); got != "http://127.0.0.1:8081/v1/rpc" {
+		t.Fatalf("run.start url = %q, want v1 rpc endpoint", got)
+	}
+	start := decodeJSONRPCBody(t, result.rpcBody)
+	if start.JSONRPC != "2.0" || start.ID != "run-clear" || start.Method != "run.start" {
+		t.Fatalf("run.start body = %#v, want JSON-RPC run.start envelope", start)
+	}
+	if start.Params["run_id"] != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("run.start params = %#v, want run_id", start.Params)
+	}
+	if start.Params["event_name"] != "scan.corpus_file_requested" {
+		t.Fatalf("run.start params = %#v, want typed corpus root input", start.Params)
+	}
+	if _, ok := start.Params["inputs"]; ok {
+		t.Fatalf("run.start params = %#v, want no legacy inputs envelope", start.Params)
+	}
+	bundleRef := mapParam(t, start.Params, "bundle_ref")
+	if bundleRef["fingerprint"] != runClearTestBundleFingerprint {
+		t.Fatalf("bundle_ref = %#v, want health.check fingerprint", bundleRef)
+	}
+	if start.Params["idempotency_key"] != "run-clear:11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("run.start params = %#v, want per-run idempotency key", start.Params)
+	}
+	payload := mapParam(t, start.Params, "payload")
+	request := mapParam(t, payload, "request")
+	if request["geography"] != "US" {
+		t.Fatalf("payload = %#v, want typed request geography", payload)
+	}
+	if payload["corpus_path"] != "/data/test-signals-25.jsonl" {
+		t.Fatalf("payload = %#v, want corpus_path", payload)
 	}
 	if strings.Contains(result.rpcBody, `"scan.requested"`) {
-		t.Fatalf("rpc body = %q, want no retired scan.requested input", result.rpcBody)
+		t.Fatalf("run.start body = %q, want no retired scan.requested input", result.rpcBody)
 	}
-	if !strings.Contains(result.rpcBody, `"request":{"geography":"US"}`) {
-		t.Fatalf("rpc body = %q, want typed request geography", result.rpcBody)
+	if !strings.Contains(result.stdout, `"status":"running"`) {
+		t.Fatalf("stdout = %q, want v1 running response", result.stdout)
 	}
-	if !strings.Contains(result.rpcBody, `"corpus_path":"/data/test-signals-25.jsonl"`) {
-		t.Fatalf("rpc body = %q, want corpus_path payload", result.rpcBody)
-	}
-	if !strings.Contains(result.stdout, `"status":"started"`) {
-		t.Fatalf("stdout = %q, want started response", result.stdout)
+	if strings.Contains(result.stdout, `"status":"started"`) {
+		t.Fatalf("stdout = %q, want no legacy started response", result.stdout)
 	}
 }
 
-func TestRunClear_UsesConfiguredBuilderAuthTokenForRPC(t *testing.T) {
+func TestRunClear_UsesConfiguredAPITokenForHealthCheckAndRunStart(t *testing.T) {
+	const explicitAPIToken = "api-explicit-token"
 	const explicitOperatorToken = "operator-explicit-token"
 	const explicitBuilderToken = "builder-explicit-token"
 	result := runRunClear(t, runClearConfig{
+		apiToken:      explicitAPIToken,
 		operatorToken: explicitOperatorToken,
 		builderToken:  explicitBuilderToken,
 	})
 
+	if got := strings.TrimSpace(result.apiToken); got != explicitAPIToken {
+		t.Fatalf("api token = %q, want %q", got, explicitAPIToken)
+	}
 	if got := strings.TrimSpace(result.operatorToken); got != explicitOperatorToken {
 		t.Fatalf("operator token = %q, want %q", got, explicitOperatorToken)
 	}
 	if got := strings.TrimSpace(result.builderToken); got != explicitBuilderToken {
 		t.Fatalf("builder token = %q, want %q", got, explicitBuilderToken)
 	}
-	wantOperatorHeader := "Authorization: Bearer " + explicitOperatorToken
-	if !strings.Contains(result.healthHeaders, wantOperatorHeader) {
-		t.Fatalf("api health headers = %q, want %q", result.healthHeaders, wantOperatorHeader)
+	wantAPIHeader := "Authorization: Bearer " + explicitAPIToken
+	if !strings.Contains(result.healthHeaders, wantAPIHeader) {
+		t.Fatalf("health.check headers = %q, want %q", result.healthHeaders, wantAPIHeader)
 	}
-	wantBuilderHeader := "Authorization: Bearer " + explicitBuilderToken
-	if !strings.Contains(result.rpcHeaders, wantBuilderHeader) {
-		t.Fatalf("rpc headers = %q, want %q", result.rpcHeaders, wantBuilderHeader)
+	if !strings.Contains(result.rpcHeaders, wantAPIHeader) {
+		t.Fatalf("run.start headers = %q, want %q", result.rpcHeaders, wantAPIHeader)
+	}
+	if strings.Contains(result.rpcHeaders, explicitBuilderToken) || strings.Contains(result.healthHeaders, explicitBuilderToken) {
+		t.Fatalf("headers used builder token: health=%q run=%q", result.healthHeaders, result.rpcHeaders)
+	}
+}
+
+func TestRunClear_MapsConfiguredInputEventAndPayloadToV1RunStart(t *testing.T) {
+	result := runRunClear(t, runClearConfig{
+		inputEvent:       "scan.signals_requested",
+		inputPayloadJSON: `{"source":"manual","count":2}`,
+	})
+
+	start := decodeJSONRPCBody(t, result.rpcBody)
+	if start.Method != "run.start" {
+		t.Fatalf("run.start body = %#v, want run.start", start)
+	}
+	if start.Params["event_name"] != "scan.signals_requested" {
+		t.Fatalf("run.start params = %#v, want configured event_name", start.Params)
+	}
+	if _, ok := start.Params["inputs"]; ok {
+		t.Fatalf("run.start params = %#v, want no legacy inputs envelope", start.Params)
+	}
+	payload := mapParam(t, start.Params, "payload")
+	if payload["source"] != "manual" {
+		t.Fatalf("payload = %#v, want configured source", payload)
+	}
+	if payload["count"] != float64(2) {
+		t.Fatalf("payload = %#v, want configured count", payload)
 	}
 }
 
@@ -120,7 +184,7 @@ func TestRunClear_DoesNotTreatLauncherStateChangeAsStartupFailure(t *testing.T) 
 	if !strings.Contains(result.stdout, "Swarm ready at http://127.0.0.1:8081") {
 		t.Fatalf("stdout = %q, want readiness success", result.stdout)
 	}
-	if !strings.Contains(result.stdout, `"status":"started"`) {
+	if !strings.Contains(result.stdout, `"status":"running"`) {
 		t.Fatalf("stdout = %q, want run.start request after readiness", result.stdout)
 	}
 }
@@ -243,6 +307,7 @@ type runClearResult struct {
 	launchedBinaryPath  string
 	launchedHealthAddr  string
 	healthHeaders       string
+	healthBody          string
 	healthURL           string
 	rpcHeaders          string
 	rpcBody             string
@@ -278,6 +343,7 @@ func runRunClearResult(t *testing.T, cfg runClearConfig) (runClearResult, error)
 	pythonHealthAddrSink := filepath.Join(t.TempDir(), "python-health-addr.txt")
 	psStateCountSink := filepath.Join(t.TempDir(), "ps-state-count.txt")
 	healthHeadersSink := filepath.Join(t.TempDir(), "api-health-headers.txt")
+	healthBodySink := filepath.Join(t.TempDir(), "api-health-body.txt")
 	healthURLSink := filepath.Join(t.TempDir(), "api-health-url.txt")
 	rpcHeadersSink := filepath.Join(t.TempDir(), "rpc-headers.txt")
 	bodySink := filepath.Join(t.TempDir(), "rpc-body.txt")
@@ -458,20 +524,10 @@ if [[ "$url" == *"/api/health" ]]; then
   else
     : > "${CURL_API_HEALTH_HEADERS_SINK}"
   fi
-  want="Authorization: Bearer ${SWARM_OPERATOR_AUTH_TOKEN}"
-  for header in "${headers[@]}"; do
-    if [[ "$header" == "$want" ]]; then
-      if [[ -n "$out" ]]; then
-        printf '{}' > "$out"
-      fi
-      printf '%s' "${CURL_API_HEALTH_CODE:-200}"
-      exit 0
-    fi
-  done
   if [[ -n "$out" ]]; then
-    printf '{"error":"operator authentication is not configured"}' > "$out"
+    printf '{"error":"legacy api health is not canonical"}' > "$out"
   fi
-  printf '401'
+  printf '500'
   exit 0
 fi
 if [[ "$url" == *"/api/rpc" ]]; then
@@ -482,17 +538,52 @@ if [[ "$url" == *"/api/rpc" ]]; then
     : > "${CURL_HEADERS_SINK}"
   fi
   printf '%s' "$body" > "${CURL_BODY_SINK}"
-  want="Authorization: Bearer ${SWARM_BUILDER_AUTH_TOKEN}"
-  for header in "${headers[@]}"; do
-    if [[ "$header" == "$want" ]]; then
-      printf '{"jsonrpc":"2.0","id":"run-clear","result":{"status":"started"}}'
-      exit 0
-    fi
-  done
-  printf '{"jsonrpc":"2.0","id":"run-clear","error":{"message":"missing authorization bearer token"}}'
+  printf '{"jsonrpc":"2.0","id":"run-clear","error":{"message":"legacy /api/rpc run.start is not canonical"}}'
   exit 0
 fi
 if [[ "$url" == *"/v1/rpc" ]]; then
+  if [[ "$body" == *'"method":"health.check"'* ]]; then
+    printf '%s' "$url" > "${CURL_API_HEALTH_URL_SINK}"
+    printf '%s' "$body" > "${CURL_API_HEALTH_BODY_SINK}"
+    if ((${#headers[@]})); then
+      printf '%s\n' "${headers[@]}" > "${CURL_API_HEALTH_HEADERS_SINK}"
+    else
+      : > "${CURL_API_HEALTH_HEADERS_SINK}"
+    fi
+    want="Authorization: Bearer ${SWARM_API_TOKEN}"
+    for header in "${headers[@]}"; do
+      if [[ "$header" == "$want" ]]; then
+        if [[ -n "$out" ]]; then
+          printf '{"jsonrpc":"2.0","id":"run-clear-health","result":{"alive":true,"ready":true,"db_ok":true,"runtime_ok":true,"bundle":{"workflow_name":"empire","workflow_version":"test","fingerprint":"%s"}}}' "${RUN_CLEAR_TEST_BUNDLE_FINGERPRINT}" > "$out"
+        fi
+        printf '%s' "${CURL_API_HEALTH_CODE:-200}"
+        exit 0
+      fi
+    done
+    if [[ -n "$out" ]]; then
+      printf '{"jsonrpc":"2.0","id":"run-clear-health","error":{"code":-32000,"message":"missing authorization bearer token","data":{"code":"UNAUTHORIZED"}}}' > "$out"
+    fi
+    printf '401'
+    exit 0
+  fi
+  if [[ "$body" == *'"method":"run.start"'* ]]; then
+    printf '%s' "$url" > "${CURL_URL_SINK}"
+    if ((${#headers[@]})); then
+      printf '%s\n' "${headers[@]}" > "${CURL_HEADERS_SINK}"
+    else
+      : > "${CURL_HEADERS_SINK}"
+    fi
+    printf '%s' "$body" > "${CURL_BODY_SINK}"
+    want="Authorization: Bearer ${SWARM_API_TOKEN}"
+    for header in "${headers[@]}"; do
+      if [[ "$header" == "$want" ]]; then
+        printf '{"jsonrpc":"2.0","id":"run-clear","result":{"run_id":"11111111-1111-1111-1111-111111111111","status":"running"}}'
+        exit 0
+      fi
+    done
+    printf '{"jsonrpc":"2.0","id":"run-clear","error":{"code":-32000,"message":"missing authorization bearer token","data":{"code":"UNAUTHORIZED"}}}'
+    exit 0
+  fi
   printf '%s' "$url" > "${CURL_DIRECTIVE_URL_SINK}"
   if ((${#headers[@]})); then
     printf '%s\n' "${headers[@]}" > "${CURL_DIRECTIVE_HEADERS_SINK}"
@@ -537,10 +628,12 @@ printf '{}'
 		"PS_MODE=" + defaultString(cfg.psMode, "real"),
 		"PS_STATE_COUNT_SINK=" + psStateCountSink,
 		"CURL_API_HEALTH_HEADERS_SINK=" + healthHeadersSink,
+		"CURL_API_HEALTH_BODY_SINK=" + healthBodySink,
 		"CURL_API_HEALTH_URL_SINK=" + healthURLSink,
 		"CURL_HEALTHZ_CODE=200",
 		"CURL_READYZ_CODE=" + defaultString(cfg.readyCode, "200"),
 		"CURL_API_HEALTH_CODE=" + defaultString(cfg.apiHealthCode, "200"),
+		"RUN_CLEAR_TEST_BUNDLE_FINGERPRINT=" + runClearTestBundleFingerprint,
 		"CURL_HEADERS_SINK=" + rpcHeadersSink,
 		"CURL_BODY_SINK=" + bodySink,
 		"CURL_URL_SINK=" + urlSink,
@@ -569,6 +662,12 @@ printf '{}'
 	if cfg.directiveMessage != "" {
 		cmd.Env = append(cmd.Env, "DIRECTIVE_MESSAGE="+cfg.directiveMessage)
 	}
+	if cfg.inputEvent != "" {
+		cmd.Env = append(cmd.Env, "RUN_CLEAR_INPUT_EVENT="+cfg.inputEvent)
+	}
+	if cfg.inputPayloadJSON != "" {
+		cmd.Env = append(cmd.Env, "RUN_CLEAR_INPUT_PAYLOAD_JSON="+cfg.inputPayloadJSON)
+	}
 	if cfg.hostGatewayURL != "" {
 		cmd.Env = append(cmd.Env, "SWARM_TOOL_GATEWAY_URL="+cfg.hostGatewayURL)
 	}
@@ -592,6 +691,7 @@ printf '{}'
 		launchedBinaryPath:  readFileTrimmed(t, pythonBinaryPathSink),
 		launchedHealthAddr:  readFileTrimmed(t, pythonHealthAddrSink),
 		healthHeaders:       readFileTrimmedOptional(t, healthHeadersSink),
+		healthBody:          readFileTrimmedOptional(t, healthBodySink),
 		healthURL:           readFileTrimmedOptional(t, healthURLSink),
 		rpcHeaders:          readFileTrimmedOptional(t, rpcHeadersSink),
 		rpcBody:             readFileTrimmedOptional(t, bodySink),
@@ -600,6 +700,38 @@ printf '{}'
 		directiveBody:       readFileTrimmedOptional(t, directiveBodySink),
 		directiveURL:        readFileTrimmedOptional(t, directiveURLSink),
 	}, err
+}
+
+type jsonRPCRequestBody struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      string         `json:"id"`
+	Method  string         `json:"method"`
+	Params  map[string]any `json:"params"`
+}
+
+func decodeJSONRPCBody(t *testing.T, raw string) jsonRPCRequestBody {
+	t.Helper()
+	var body jsonRPCRequestBody
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode JSON-RPC body %q: %v", raw, err)
+	}
+	if body.Params == nil {
+		body.Params = map[string]any{}
+	}
+	return body
+}
+
+func mapParam(t *testing.T, values map[string]any, name string) map[string]any {
+	t.Helper()
+	value, ok := values[name]
+	if !ok {
+		t.Fatalf("missing %s in %#v", name, values)
+	}
+	mapped, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", name, value)
+	}
+	return mapped
 }
 
 func filteredEnv(removeKeys ...string) []string {

--- a/scripts/run_clear_test.go
+++ b/scripts/run_clear_test.go
@@ -26,6 +26,9 @@ type runClearConfig struct {
 	psMode           string
 	readyCode        string
 	apiHealthCode    string
+	apiHealthReady   string
+	apiHealthDBOK    string
+	apiHealthRuntime string
 	startTimeout     string
 	inputEvent       string
 	inputPayloadJSON string
@@ -155,6 +158,28 @@ func TestRunClear_MapsConfiguredInputEventAndPayloadToV1RunStart(t *testing.T) {
 	}
 	if payload["count"] != float64(2) {
 		t.Fatalf("payload = %#v, want configured count", payload)
+	}
+}
+
+func TestRunClear_DoesNotStartRunWhenHealthCheckIsNotReady(t *testing.T) {
+	result, err := runRunClearResult(t, runClearConfig{
+		apiHealthReady:   "false",
+		apiHealthDBOK:    "false",
+		apiHealthRuntime: "true",
+		startTimeout:     "1",
+	})
+
+	if err == nil {
+		t.Fatal("expected helper to fail readiness when health.check is not ready")
+	}
+	if got := strings.TrimSpace(result.rpcBody); got != "" {
+		t.Fatalf("run.start body = %q, want no run.start when health.check is not ready", got)
+	}
+	if got := strings.TrimSpace(result.rpcURL); got != "" {
+		t.Fatalf("run.start url = %q, want no run.start when health.check is not ready", got)
+	}
+	if !strings.Contains(result.stdout, "Swarm failed to become ready. Current log:") {
+		t.Fatalf("stdout = %q, want readiness failure", result.stdout)
 	}
 }
 
@@ -554,7 +579,7 @@ if [[ "$url" == *"/v1/rpc" ]]; then
     for header in "${headers[@]}"; do
       if [[ "$header" == "$want" ]]; then
         if [[ -n "$out" ]]; then
-          printf '{"jsonrpc":"2.0","id":"run-clear-health","result":{"alive":true,"ready":true,"db_ok":true,"runtime_ok":true,"bundle":{"workflow_name":"empire","workflow_version":"test","fingerprint":"%s"}}}' "${RUN_CLEAR_TEST_BUNDLE_FINGERPRINT}" > "$out"
+          printf '{"jsonrpc":"2.0","id":"run-clear-health","result":{"alive":true,"ready":%s,"db_ok":%s,"runtime_ok":%s,"bundle":{"workflow_name":"empire","workflow_version":"test","fingerprint":"%s"}}}' "${RUN_CLEAR_TEST_HEALTH_READY}" "${RUN_CLEAR_TEST_HEALTH_DB_OK}" "${RUN_CLEAR_TEST_HEALTH_RUNTIME_OK}" "${RUN_CLEAR_TEST_BUNDLE_FINGERPRINT}" > "$out"
         fi
         printf '%s' "${CURL_API_HEALTH_CODE:-200}"
         exit 0
@@ -633,6 +658,9 @@ printf '{}'
 		"CURL_HEALTHZ_CODE=200",
 		"CURL_READYZ_CODE=" + defaultString(cfg.readyCode, "200"),
 		"CURL_API_HEALTH_CODE=" + defaultString(cfg.apiHealthCode, "200"),
+		"RUN_CLEAR_TEST_HEALTH_READY=" + defaultString(cfg.apiHealthReady, "true"),
+		"RUN_CLEAR_TEST_HEALTH_DB_OK=" + defaultString(cfg.apiHealthDBOK, "true"),
+		"RUN_CLEAR_TEST_HEALTH_RUNTIME_OK=" + defaultString(cfg.apiHealthRuntime, "true"),
 		"RUN_CLEAR_TEST_BUNDLE_FINGERPRINT=" + runClearTestBundleFingerprint,
 		"CURL_HEADERS_SINK=" + rpcHeadersSink,
 		"CURL_BODY_SINK=" + bodySink,


### PR DESCRIPTION
## Summary
- Migrate `scripts/run_clear.sh` run admission from legacy `/api/rpc run.start` to `/v1/rpc run.start`.
- Use `/v1/rpc health.check` to read the boot bundle fingerprint for `run.start.bundle_ref.fingerprint`.
- Preserve `RUN_CLEAR_INPUT_EVENT`, `RUN_CLEAR_INPUT_PAYLOAD_JSON`, startup/readiness probes, cleanup behavior, and the existing v1 directive path.
- Update focused script tests so legacy `/api/rpc run.start` is a fail-closed sentinel, not an accepted helper path.

Closes #727
Part of #665

## Governing Refs / Context
Exact governing spec references exist in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
- `api_specification` `/v1/rpc` JSON-RPC transport and `/healthz`/`/readyz` process probes.
- Single bearer-token auth model and CLI/helper API consumption rule.
- Idempotency convention for mutating methods.
- `BundleRef` / `BundleIdentity` caller flow: read `health.check` and pass `bundle.fingerprint` to `run.start.bundle_ref.fingerprint`.
- `health.check` and `run.start` method descriptors.
- Migration/auth disposition for `make_run_clear` and deprecated `/api/rpc run.start`.

Binding tracker context:
- #727 Pre-Implementation Coverage Audit and independent gate review.
- #665 parent API migration tracker.
- #679 v1 `run.start` owner proof.
- #725/#726 `run_clear` agent-directive consumer proof.

## Semantic Migration
New canonical owner consumed by this helper:
- `/v1/rpc run.start`, implemented in `internal/apiv1/operator_run_start.go`.
- `/v1/rpc health.check`, implemented by the v1 read handlers and backed by boot `BundleIdentity`.
- API idempotency remains owned by the v1 idempotency store path.

Old path now invalid for this chosen class:
- `scripts/run_clear.sh` no longer posts `run.start` to `/api/rpc`.
- `scripts/run_clear.sh` no longer uses `SWARM_BUILDER_AUTH_TOKEN` for run-start admission.
- `scripts/run_clear.sh` no longer sends legacy `{inputs:{event:payload}}` or expects `status:"started"`.

Production paths checked for surviving old behavior:
- `scripts/run_clear.sh`
- `scripts/run_clear_test.go`
- repo grep for `/api/rpc`, `/api/health`, `run.start`, `health.check`, `bundle_ref`, `idempotency_key`, `SWARM_BUILDER_AUTH_TOKEN`, and `SWARM_API_TOKEN`

Migration completeness:
- Complete for the chosen #727 class: `run_clear` run-start v1 migration.
- Parent #665 remains open for Builder/dashboard adapters, future CLI UX, run/runtime control siblings, and deprecation headers.

## Proof Run
- `bash -n scripts/run_clear.sh`
- `go test ./scripts -run 'TestRunClear_.*RunStart|TestRunClear_UsesV1RPCForAgentDirective' -count=1`
- `go test ./scripts -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorRunStart|TestOperatorReadHandlersHealthCheck' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`

OpenRPC check output: `api spec valid: methods=36 schemas=49 errors=21 mutating=12 subscriptions=3`.