### PR TITLE
[agent-d] Stabilize tier12 fork CI test

### DIFF
--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -465,12 +465,12 @@ func selectedContractSourceRunCounts(t testing.TB, db *sql.DB, runID string) map
 	return selectedContractRunCounts(t, db, runID, true)
 }
 
-func selectedContractRunCounts(t testing.TB, db *sql.DB, runID string, ignoreRuntimeLogEvents bool) map[string]int {
+func selectedContractRunCounts(t testing.TB, db *sql.DB, runID string, ignoreRuntimeDiagnosticEvents bool) map[string]int {
 	t.Helper()
 	ctx := context.Background()
 	eventFilter := ""
-	if ignoreRuntimeLogEvents {
-		eventFilter = " AND event_name <> 'platform.runtime_log'"
+	if ignoreRuntimeDiagnosticEvents {
+		eventFilter = " AND event_name NOT IN ('platform.runtime_log', 'platform.agent_started')"
 	}
 	queries := map[string]string{
 		"runs":                                 `SELECT COUNT(*) FROM runs WHERE run_id = $1::uuid`,


### PR DESCRIPTION
## Summary
- Treat asynchronous platform agent-start diagnostics like runtime logs in source-run isolation count accounting.
- Keep semantic source-row freeze assertions intact while removing timing sensitivity from the cleanup probe.

## Proof
- go test ./internal/runtime/cataloge2e -run TestTier12RuntimeFork_SelectedContractForkExecutionFixture -count=20
- go test ./...

## Context
Fixes the CI flake observed in run 25807648811 where TestTier12RuntimeFork_SelectedContractForkExecutionFixture saw an extra source-run events row after the cleanup probe because platform.agent_started landed asynchronously.