### PR TITLE
[agent-b][issue #739] Implement mailbox control CLI

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -25,7 +25,11 @@ func (e commandExitError) Error() string {
 }
 
 func executeRootCommand(ctx context.Context, repo string, args []string, out, errOut io.Writer) int {
-	cmd := newRootCommand(ctx, repo, out, errOut)
+	return executeRootCommandWithOptions(ctx, repo, args, out, errOut, defaultRootCommandOptions())
+}
+
+func executeRootCommandWithOptions(ctx context.Context, repo string, args []string, out, errOut io.Writer, opts rootCommandOptions) int {
+	cmd := newRootCommandWithOptions(ctx, repo, out, errOut, opts)
 	cmd.SetArgs(args)
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		if exit, ok := err.(commandExitError); ok {
@@ -40,6 +44,10 @@ func executeRootCommand(ctx context.Context, repo string, args []string, out, er
 }
 
 func newRootCommand(ctx context.Context, repo string, out, errOut io.Writer) *cobra.Command {
+	return newRootCommandWithOptions(ctx, repo, out, errOut, defaultRootCommandOptions())
+}
+
+func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.Writer, opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "swarm",
 		Short:         "Run and inspect Swarm workflows.",
@@ -59,6 +67,7 @@ func newRootCommand(ctx context.Context, repo string, out, errOut io.Writer) *co
 		newVerifyCommand(ctx, repo),
 		newVersionCommand(),
 		newCompletionCommand(),
+		newControlCommand(opts),
 		newRetiredStatusCommand(),
 		newRetiredForkCommand(),
 	)

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const defaultCLIAPIEndpoint = "http://127.0.0.1:8081/v1/rpc"
+
+type rootCommandOptions struct {
+	apiEndpoint string
+	httpClient  *http.Client
+}
+
+func defaultRootCommandOptions() rootCommandOptions {
+	return rootCommandOptions{
+		apiEndpoint: defaultCLIAPIEndpoint,
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type cliAPIClient struct {
+	endpoint   string
+	token      string
+	httpClient *http.Client
+}
+
+func newCLIAPIClient(opts rootCommandOptions) (*cliAPIClient, error) {
+	endpoint := strings.TrimSpace(opts.apiEndpoint)
+	if endpoint == "" {
+		endpoint = defaultCLIAPIEndpoint
+	}
+	token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN"))
+	if token == "" {
+		return nil, fmt.Errorf("SWARM_API_TOKEN is required for runtime-state CLI commands")
+	}
+	client := opts.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &cliAPIClient{endpoint: endpoint, token: token, httpClient: client}, nil
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      string         `json:"id"`
+	Method  string         `json:"method"`
+	Params  map[string]any `json:"params"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *jsonRPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if code := applicationErrorCode(e.Data); code != "" {
+		return fmt.Sprintf("%s: %s", code, e.Message)
+	}
+	return e.Message
+}
+
+func applicationErrorCode(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var data struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(data.Code)
+}
+
+func (c *cliAPIClient) call(ctx context.Context, method string, params map[string]any, result any) error {
+	body, err := json.Marshal(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      "swarm-cli:" + method,
+		Method:  method,
+		Params:  params,
+	})
+	if err != nil {
+		return fmt.Errorf("encode JSON-RPC request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build v1 RPC request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("v1 RPC request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read v1 RPC response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		message := strings.TrimSpace(string(raw))
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("v1 RPC HTTP %d: %s", resp.StatusCode, message)
+	}
+
+	var envelope jsonRPCResponse
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode JSON-RPC response: %w", err)
+	}
+	if envelope.JSONRPC != "2.0" {
+		return fmt.Errorf("malformed JSON-RPC response: jsonrpc=%q", envelope.JSONRPC)
+	}
+	if envelope.Error != nil {
+		return envelope.Error
+	}
+	if len(envelope.Result) == 0 || string(envelope.Result) == "null" {
+		return fmt.Errorf("JSON-RPC response missing result")
+	}
+	if result == nil {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Result, result); err != nil {
+		return fmt.Errorf("decode JSON-RPC result: %w", err)
+	}
+	return nil
+}

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -92,9 +92,10 @@ func applicationErrorCode(raw json.RawMessage) string {
 }
 
 func (c *cliAPIClient) call(ctx context.Context, method string, params map[string]any, result any) error {
+	requestID := "swarm-cli:" + method
 	body, err := json.Marshal(jsonRPCRequest{
 		JSONRPC: "2.0",
-		ID:      "swarm-cli:" + method,
+		ID:      requestID,
 		Method:  method,
 		Params:  params,
 	})
@@ -133,6 +134,10 @@ func (c *cliAPIClient) call(ctx context.Context, method string, params map[strin
 	if envelope.JSONRPC != "2.0" {
 		return fmt.Errorf("malformed JSON-RPC response: jsonrpc=%q", envelope.JSONRPC)
 	}
+	responseID, ok := envelope.ID.(string)
+	if !ok || responseID != requestID {
+		return fmt.Errorf("malformed JSON-RPC response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+	}
 	if envelope.Error != nil {
 		return envelope.Error
 	}
@@ -146,4 +151,14 @@ func (c *cliAPIClient) call(ctx context.Context, method string, params map[strin
 		return fmt.Errorf("decode JSON-RPC result: %w", err)
 	}
 	return nil
+}
+
+func formatJSONRPCID(id any) string {
+	if id == nil {
+		return "<missing>"
+	}
+	if value, ok := id.(string); ok {
+		return fmt.Sprintf("%q", value)
+	}
+	return fmt.Sprintf("%v", id)
 }

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -132,14 +132,14 @@ func runMailboxDecisionCommand(ctx context.Context, out io.Writer, opts mailboxD
 	if err := client.call(ctx, opts.method, params, &result); err != nil {
 		return err
 	}
-	if err := validateMailboxDecisionResult(result); err != nil {
+	if err := validateMailboxDecisionResult(opts.action, result); err != nil {
 		return err
 	}
 	writeMailboxDecisionResult(out, opts.action, mailboxID, result)
 	return nil
 }
 
-func validateMailboxDecisionResult(result mailboxDecisionResult) error {
+func validateMailboxDecisionResult(action string, result mailboxDecisionResult) error {
 	if !result.OK {
 		return fmt.Errorf("malformed mailbox decision result: ok must be true")
 	}
@@ -149,7 +149,25 @@ func validateMailboxDecisionResult(result mailboxDecisionResult) error {
 	if strings.TrimSpace(result.Status) == "" {
 		return fmt.Errorf("malformed mailbox decision result: status is required")
 	}
+	expectedStatus, err := expectedMailboxDecisionStatus(action)
+	if err != nil {
+		return err
+	}
+	if result.Status != expectedStatus {
+		return fmt.Errorf("malformed mailbox decision result: status=%q, want %q for mailbox %s", result.Status, expectedStatus, action)
+	}
 	return nil
+}
+
+func expectedMailboxDecisionStatus(action string) (string, error) {
+	switch action {
+	case "approve", "reject":
+		return "decided", nil
+	case "defer":
+		return "deferred", nil
+	default:
+		return "", fmt.Errorf("unsupported mailbox action %q", action)
+	}
 }
 
 func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any, error) {

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type mailboxDecisionResult struct {
+	OK                bool   `json:"ok"`
+	MailboxDecisionID string `json:"mailbox_decision_id"`
+	DownstreamEventID string `json:"downstream_event_id,omitempty"`
+	Status            string `json:"status"`
+}
+
+type mailboxDecisionCommandOptions struct {
+	apiOptions          rootCommandOptions
+	action              string
+	method              string
+	reason              string
+	until               string
+	idempotencyKey      string
+	decisionPayloadJSON string
+}
+
+func newControlCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "control",
+		Short: "Run supported v1 operator control actions.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newControlMailboxCommand(opts))
+	return cmd
+}
+
+func newControlMailboxCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mailbox",
+		Short: "Approve, reject, or defer mailbox items through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newControlMailboxApproveCommand(opts),
+		newControlMailboxRejectCommand(opts),
+		newControlMailboxDeferCommand(opts),
+	)
+	return cmd
+}
+
+func newControlMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
+	actionOpts := mailboxDecisionCommandOptions{
+		apiOptions: opts,
+		action:     "approve",
+		method:     "mailbox.approve",
+	}
+	cmd := &cobra.Command{
+		Use:   "approve <mailbox-item-id>",
+		Short: "Approve a pending mailbox item through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&actionOpts.decisionPayloadJSON, "decision-payload-json", "", "Optional JSON object attached to the approval event")
+	return cmd
+}
+
+func newControlMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
+	actionOpts := mailboxDecisionCommandOptions{
+		apiOptions: opts,
+		action:     "reject",
+		method:     "mailbox.reject",
+	}
+	cmd := &cobra.Command{
+		Use:   "reject <mailbox-item-id>",
+		Short: "Reject a pending mailbox item through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&actionOpts.reason, "reason", "", "Required rejection reason")
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func newControlMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
+	actionOpts := mailboxDecisionCommandOptions{
+		apiOptions: opts,
+		action:     "defer",
+		method:     "mailbox.defer",
+	}
+	cmd := &cobra.Command{
+		Use:   "defer <mailbox-item-id>",
+		Short: "Defer a pending mailbox item through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&actionOpts.until, "until", "", "Required RFC3339 timestamp")
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runMailboxDecisionCommand(ctx context.Context, out io.Writer, opts mailboxDecisionCommandOptions, mailboxID string) error {
+	mailboxID = strings.TrimSpace(mailboxID)
+	if mailboxID == "" {
+		return fmt.Errorf("mailbox item id is required")
+	}
+	params, err := opts.params(mailboxID)
+	if err != nil {
+		return err
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	var result mailboxDecisionResult
+	if err := client.call(ctx, opts.method, params, &result); err != nil {
+		return err
+	}
+	if err := validateMailboxDecisionResult(result); err != nil {
+		return err
+	}
+	writeMailboxDecisionResult(out, opts.action, mailboxID, result)
+	return nil
+}
+
+func validateMailboxDecisionResult(result mailboxDecisionResult) error {
+	if !result.OK {
+		return fmt.Errorf("malformed mailbox decision result: ok must be true")
+	}
+	if strings.TrimSpace(result.MailboxDecisionID) == "" {
+		return fmt.Errorf("malformed mailbox decision result: mailbox_decision_id is required")
+	}
+	if strings.TrimSpace(result.Status) == "" {
+		return fmt.Errorf("malformed mailbox decision result: status is required")
+	}
+	return nil
+}
+
+func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any, error) {
+	params := map[string]any{"mailbox_id": mailboxID}
+	if key := strings.TrimSpace(o.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	switch o.action {
+	case "approve":
+		payload, ok, err := parseOptionalDecisionPayload(o.decisionPayloadJSON)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			params["decision_payload"] = payload
+		}
+	case "reject":
+		reason := strings.TrimSpace(o.reason)
+		if reason == "" {
+			return nil, fmt.Errorf("--reason is required for mailbox reject")
+		}
+		params["reason"] = reason
+	case "defer":
+		until := strings.TrimSpace(o.until)
+		if until == "" {
+			return nil, fmt.Errorf("--until is required for mailbox defer")
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, until)
+		if err != nil {
+			return nil, fmt.Errorf("--until must be an RFC3339 timestamp: %w", err)
+		}
+		params["until"] = parsed.UTC().Format(time.RFC3339Nano)
+	default:
+		return nil, fmt.Errorf("unsupported mailbox action %q", o.action)
+	}
+	return params, nil
+}
+
+func parseOptionalDecisionPayload(raw string) (map[string]any, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, false, nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, false, fmt.Errorf("--decision-payload-json must be a JSON object: %w", err)
+	}
+	if payload == nil {
+		return nil, false, fmt.Errorf("--decision-payload-json must be a JSON object")
+	}
+	return payload, true, nil
+}
+
+func writeMailboxDecisionResult(out io.Writer, action, mailboxID string, result mailboxDecisionResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "mailbox %s ok: mailbox_id=%s status=%s decision_id=%s", action, mailboxID, result.Status, result.MailboxDecisionID)
+	if result.DownstreamEventID != "" {
+		fmt.Fprintf(out, " downstream_event_id=%s", result.DownstreamEventID)
+	}
+	fmt.Fprintln(out)
+}

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -273,6 +273,60 @@ func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 	}
 }
 
+func TestControlMailboxRejectsMalformedStatusByAction(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		status string
+		want   string
+	}{
+		{
+			name:   "approve invalid enum status",
+			args:   []string{"control", "mailbox", "approve", "mailbox-1"},
+			status: "garbage",
+			want:   `status="garbage", want "decided" for mailbox approve`,
+		},
+		{
+			name:   "reject wrong action status",
+			args:   []string{"control", "mailbox", "reject", "mailbox-1", "--reason", "not enough evidence"},
+			status: "deferred",
+			want:   `status="deferred", want "decided" for mailbox reject`,
+		},
+		{
+			name:   "defer wrong action status",
+			args:   []string{"control", "mailbox", "defer", "mailbox-1", "--until", "2026-05-13T12:30:00Z"},
+			status: "decided",
+			want:   `status="decided", want "deferred" for mailbox defer`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"ok":                  true,
+					"mailbox_decision_id": "decision-1",
+					"status":              tc.status,
+				})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
 func testRootCommandOptions(server *httptest.Server) rootCommandOptions {
 	opts := defaultRootCommandOptions()
 	opts.apiEndpoint = server.URL + "/v1/rpc"

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantMethod string
+		wantParams map[string]any
+		wantOutput []string
+	}{
+		{
+			name:       "approve",
+			args:       []string{"control", "mailbox", "approve", "mailbox-1", "--idempotency-key", "idem-approve", "--decision-payload-json", `{"approved":true}`},
+			wantMethod: "mailbox.approve",
+			wantParams: map[string]any{
+				"mailbox_id":       "mailbox-1",
+				"idempotency_key":  "idem-approve",
+				"decision_payload": map[string]any{"approved": true},
+			},
+			wantOutput: []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "downstream_event_id=event-1"},
+		},
+		{
+			name:       "reject",
+			args:       []string{"control", "mailbox", "reject", "mailbox-2", "--reason", "not enough evidence", "--idempotency-key", "idem-reject"},
+			wantMethod: "mailbox.reject",
+			wantParams: map[string]any{
+				"mailbox_id":      "mailbox-2",
+				"reason":          "not enough evidence",
+				"idempotency_key": "idem-reject",
+			},
+			wantOutput: []string{"mailbox reject ok:", "mailbox_id=mailbox-2", "status=decided", "decision_id=decision-1"},
+		},
+		{
+			name:       "defer",
+			args:       []string{"control", "mailbox", "defer", "mailbox-3", "--until", "2026-05-13T12:30:00Z", "--idempotency-key", "idem-defer"},
+			wantMethod: "mailbox.defer",
+			wantParams: map[string]any{
+				"mailbox_id":      "mailbox-3",
+				"until":           "2026-05-13T12:30:00Z",
+				"idempotency_key": "idem-defer",
+			},
+			wantOutput: []string{"mailbox defer ok:", "mailbox_id=mailbox-3", "status=deferred", "decision_id=decision-1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/rpc" {
+					t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+					t.Errorf("Authorization = %q, want bearer token", got)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				status := "decided"
+				downstream := ""
+				if tc.name == "defer" {
+					status = "deferred"
+				}
+				if tc.name == "approve" {
+					downstream = "event-1"
+				}
+				writeJSONRPCResult(t, w, captured.ID, map[string]any{
+					"ok":                  true,
+					"mailbox_decision_id": "decision-1",
+					"downstream_event_id": downstream,
+					"status":              status,
+				})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.JSONRPC != "2.0" || captured.Method != tc.wantMethod {
+				t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, tc.wantMethod)
+			}
+			if !reflect.DeepEqual(captured.Params, tc.wantParams) {
+				t.Fatalf("params = %#v, want %#v", captured.Params, tc.wantParams)
+			}
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestControlMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name        string
+		args        []string
+		wantStderr  string
+		wantNoCalls bool
+	}{
+		{name: "approve missing id", args: []string{"control", "mailbox", "approve"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "approve extra arg", args: []string{"control", "mailbox", "approve", "mailbox-1", "extra"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "approve unsupported flag", args: []string{"control", "mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
+		{name: "approve malformed payload", args: []string{"control", "mailbox", "approve", "mailbox-1", "--decision-payload-json", "{"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "approve non-object payload", args: []string{"control", "mailbox", "approve", "mailbox-1", "--decision-payload-json", "[]"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "reject missing reason", args: []string{"control", "mailbox", "reject", "mailbox-1"}, wantStderr: "--reason is required", wantNoCalls: true},
+		{name: "reject blank reason", args: []string{"control", "mailbox", "reject", "mailbox-1", "--reason", "  "}, wantStderr: "--reason is required", wantNoCalls: true},
+		{name: "defer missing until", args: []string{"control", "mailbox", "defer", "mailbox-1"}, wantStderr: "--until is required", wantNoCalls: true},
+		{name: "defer invalid until", args: []string{"control", "mailbox", "defer", "mailbox-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp", wantNoCalls: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if tc.wantNoCalls && calls.Load() != before {
+				t.Fatalf("server calls changed from %d to %d, want no request", before, calls.Load())
+			}
+		})
+	}
+}
+
+func TestControlMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "malformed response",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{`))
+			},
+			wantStderr: "decode JSON-RPC response",
+		},
+		{
+			name: "malformed result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true})
+			},
+			wantStderr: "mailbox_decision_id is required",
+		},
+		{
+			name: "json rpc application error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      req.ID,
+					"error": map[string]any{
+						"code":    -32010,
+						"message": "Application error: MAILBOX_NOT_FOUND",
+						"data": map[string]any{
+							"code":           "MAILBOX_NOT_FOUND",
+							"details":        map[string]any{"mailbox_id": "missing"},
+							"retryable":      false,
+							"correlation_id": "corr-1",
+						},
+					},
+				})
+			},
+			wantStderr: "MAILBOX_NOT_FOUND",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func testRootCommandOptions(server *httptest.Server) rootCommandOptions {
+	opts := defaultRootCommandOptions()
+	opts.apiEndpoint = server.URL + "/v1/rpc"
+	opts.httpClient = server.Client()
+	return opts
+}
+
+func writeJSONRPCResult(t *testing.T, w http.ResponseWriter, id string, result map[string]any) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -205,6 +205,32 @@ func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 			wantStderr: "mailbox_decision_id is required",
 		},
 		{
+			name: "mismatched json rpc id",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSONRPCResult(t, w, "swarm-cli:mailbox.reject", map[string]any{
+					"ok":                  true,
+					"mailbox_decision_id": "decision-1",
+					"status":              "decided",
+				})
+			},
+			wantStderr: "malformed JSON-RPC response: id",
+		},
+		{
+			name: "missing json rpc id",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("content-type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"result": map[string]any{
+						"ok":                  true,
+						"mailbox_decision_id": "decision-1",
+						"status":              "decided",
+					},
+				})
+			},
+			wantStderr: "malformed JSON-RPC response: id=<missing>",
+		},
+		{
 			name: "json rpc application error",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest


### PR DESCRIPTION
## Summary

Closes #739.

- Adds `swarm control mailbox approve|reject|defer` under the existing Cobra command tree.
- Adds a minimal transport-only v1 JSON-RPC CLI client for these runtime-state commands.
- Sends `mailbox.approve`, `mailbox.reject`, and `mailbox.defer` to `/v1/rpc` with `SWARM_API_TOKEN` bearer auth.
- Fails closed for bad command shape, missing required flags, malformed payloads/timestamps, missing token, HTTP failures, JSON-RPC errors, and malformed success results.

## Governing Refs / Context

- `platform-spec.yaml` `cli_specification`: Cobra is the command owner, runtime-state CLI commands consume v1 API, and `swarm control mailbox approve|reject|defer` are gated parent-tail commands.
- `platform-spec.yaml` `api_specification.foundations.cli_consumption_rule`: future `swarm control` consumes `/v1/rpc`; `swarm verify` is the only local carve-out.
- `platform-spec.yaml` method catalog and generated `openrpc.json`: `mailbox.approve`, `mailbox.reject`, `mailbox.defer` params/results/errors/idempotency.
- #739 pre-audit and independent gate: approved as first slice.

## Semantic Migration / Ownership

- New CLI consumer: `cmd/swarm` Cobra `control mailbox` subtree.
- Canonical mailbox decision owner remains v1 API + `internal/apiv1/operator_mailbox.go` + `store.DecideV1MailboxItem`.
- Old invalid path for this CLI child: any direct CLI call to SQL, `internal/mailbox`, `DecideMailboxItem`, or `DecideV1MailboxItem`.
- Production paths checked: new command/client files contain no direct mailbox/store/runtime owner calls; sibling CLI commands remain split under #735.
- Migration complete for #739; #735 remains open for `swarm run`, `swarm runs`, `swarm investigate *`, and other deferred controls.

## Proof

- `go test ./cmd/swarm -run 'TestCLI|TestControlMailbox' -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "internal/mailbox|DecideMailboxItem|DecideV1MailboxItem|database/sql|MailboxAPIStore|MailboxV1Decision|store\." cmd/swarm/cli.go cmd/swarm/cli_api.go cmd/swarm/control_mailbox.go cmd/swarm/control_mailbox_test.go` returned no matches.