### PR TITLE
[agent-b][issue #741] Add v1 CLI diagnostics reads

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -67,6 +67,8 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newVerifyCommand(ctx, repo),
 		newVersionCommand(),
 		newCompletionCommand(),
+		newRunsCommand(opts),
+		newInvestigateCommand(opts),
 		newControlCommand(opts),
 		newRetiredStatusCommand(),
 		newRetiredForkCommand(),

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -92,6 +92,25 @@ type diagnosticRunTraceRow struct {
 	TurnTriggerEventType string `json:"turn_trigger_event_type,omitempty"`
 }
 
+var diagnosticValidRunStatuses = map[string]struct{}{
+	"running":   {},
+	"paused":    {},
+	"completed": {},
+	"failed":    {},
+	"cancelled": {},
+	"forked":    {},
+}
+
+var diagnosticValidOperationalStates = map[string]struct{}{
+	"running":   {},
+	"stalled":   {},
+	"paused":    {},
+	"completed": {},
+	"failed":    {},
+	"cancelled": {},
+	"forked":    {},
+}
+
 func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 	runOpts := diagnosticRunListOptions{apiOptions: opts}
 	cmd := &cobra.Command{
@@ -386,8 +405,15 @@ func validateDiagnosticRunDiagnosis(result diagnosticRunDiagnosisResult) error {
 	if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
 		return err
 	}
-	if result.OperationalState == nil || strings.TrimSpace(*result.OperationalState) == "" {
+	if result.OperationalState == nil {
 		return fmt.Errorf("malformed run.diagnose result: operational_state is required")
+	}
+	operationalState := strings.TrimSpace(*result.OperationalState)
+	if operationalState == "" {
+		return fmt.Errorf("malformed run.diagnose result: operational_state is required")
+	}
+	if _, ok := diagnosticValidOperationalStates[operationalState]; !ok {
+		return fmt.Errorf("malformed run.diagnose result: operational_state=%q is not a valid OperationalState", operationalState)
 	}
 	if result.BlockingLayer == nil {
 		return fmt.Errorf("malformed run.diagnose result: blocking_layer is required")
@@ -448,8 +474,12 @@ func validateDiagnosticRunHeader(prefix string, run diagnosticRunHeader) error {
 	if strings.TrimSpace(run.RunID) == "" {
 		return fmt.Errorf("malformed run header: %s.run_id is required", prefix)
 	}
-	if strings.TrimSpace(run.Status) == "" {
+	status := strings.TrimSpace(run.Status)
+	if status == "" {
 		return fmt.Errorf("malformed run header: %s.status is required", prefix)
+	}
+	if _, ok := diagnosticValidRunStatuses[status]; !ok {
+		return fmt.Errorf("malformed run header: %s.status=%q is not a valid RunStatus", prefix, status)
 	}
 	if strings.TrimSpace(run.TriggerEventType) == "" {
 		return fmt.Errorf("malformed run header: %s.trigger_event_type is required", prefix)

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -41,9 +41,9 @@ type diagnosticRunGetResult struct {
 
 type diagnosticRunDiagnosisResult struct {
 	Run              diagnosticRunHeader `json:"run"`
-	OperationalState string              `json:"operational_state"`
-	BlockingLayer    string              `json:"blocking_layer"`
-	BlockingReason   string              `json:"blocking_reason"`
+	OperationalState *string             `json:"operational_state"`
+	BlockingLayer    *string             `json:"blocking_layer"`
+	BlockingReason   *string             `json:"blocking_reason"`
 	Heuristics       []string            `json:"heuristics"`
 }
 
@@ -61,9 +61,9 @@ type diagnosticHealthCheckResult struct {
 }
 
 type diagnosticBundleIdentity struct {
-	WorkflowName    string `json:"workflow_name"`
-	WorkflowVersion string `json:"workflow_version"`
-	Fingerprint     string `json:"fingerprint"`
+	WorkflowName    *string `json:"workflow_name"`
+	WorkflowVersion *string `json:"workflow_version"`
+	Fingerprint     string  `json:"fingerprint"`
 }
 
 type diagnosticRunHeader struct {
@@ -386,8 +386,17 @@ func validateDiagnosticRunDiagnosis(result diagnosticRunDiagnosisResult) error {
 	if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
 		return err
 	}
-	if strings.TrimSpace(result.OperationalState) == "" {
+	if result.OperationalState == nil || strings.TrimSpace(*result.OperationalState) == "" {
 		return fmt.Errorf("malformed run.diagnose result: operational_state is required")
+	}
+	if result.BlockingLayer == nil {
+		return fmt.Errorf("malformed run.diagnose result: blocking_layer is required")
+	}
+	if result.BlockingReason == nil {
+		return fmt.Errorf("malformed run.diagnose result: blocking_reason is required")
+	}
+	if result.Heuristics == nil {
+		return fmt.Errorf("malformed run.diagnose result: heuristics is required")
 	}
 	return nil
 }
@@ -425,6 +434,12 @@ func validateDiagnosticHealthCheck(result diagnosticHealthCheckResult) error {
 	}
 	if strings.TrimSpace(result.Bundle.Fingerprint) == "" {
 		return fmt.Errorf("malformed health.check result: bundle.fingerprint is required")
+	}
+	if result.Bundle.WorkflowName == nil {
+		return fmt.Errorf("malformed health.check result: bundle.workflow_name is required")
+	}
+	if result.Bundle.WorkflowVersion == nil {
+		return fmt.Errorf("malformed health.check result: bundle.workflow_version is required")
 	}
 	return nil
 }
@@ -530,9 +545,9 @@ func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisRes
 	}
 	writeDiagnosticRunHeader(out, result.Run)
 	fmt.Fprintf(out, "operational_state=%s blocking_layer=%s blocking_reason=%s\n",
-		result.OperationalState,
-		result.BlockingLayer,
-		result.BlockingReason,
+		stringPointerValue(result.OperationalState),
+		stringPointerValue(result.BlockingLayer),
+		stringPointerValue(result.BlockingReason),
 	)
 	if len(result.Heuristics) == 0 {
 		fmt.Fprintln(out, "heuristics=none")
@@ -578,8 +593,8 @@ func writeDiagnosticHealth(out io.Writer, result diagnosticHealthCheckResult) {
 	fmt.Fprintf(out, "alive=%t ready=%t db_ok=%t runtime_ok=%t\n", boolPointerValue(result.Alive), boolPointerValue(result.Ready), boolPointerValue(result.DBOK), boolPointerValue(result.RuntimeOK))
 	fmt.Fprintf(out, "bundle fingerprint=%s workflow_name=%s workflow_version=%s\n",
 		result.Bundle.Fingerprint,
-		emptyDash(result.Bundle.WorkflowName),
-		emptyDash(result.Bundle.WorkflowVersion),
+		emptyDash(stringPointerValue(result.Bundle.WorkflowName)),
+		emptyDash(stringPointerValue(result.Bundle.WorkflowVersion)),
 	)
 }
 
@@ -592,6 +607,13 @@ func intPointerValue(value *int) int {
 
 func boolPointerValue(value *bool) bool {
 	return value != nil && *value
+}
+
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func emptyDash(value string) string {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -1,0 +1,612 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type diagnosticRunListOptions struct {
+	apiOptions rootCommandOptions
+	status     string
+	since      string
+	until      string
+	limit      int
+	cursor     string
+}
+
+type diagnosticTraceOptions struct {
+	apiOptions rootCommandOptions
+	limit      int
+	cursor     string
+}
+
+type diagnosticRunOptions struct {
+	apiOptions rootCommandOptions
+	noDiagnose bool
+}
+
+type diagnosticRunListResult struct {
+	Runs       []diagnosticRunHeader `json:"runs"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+type diagnosticRunGetResult struct {
+	Run diagnosticRunHeader `json:"run"`
+}
+
+type diagnosticRunDiagnosisResult struct {
+	Run              diagnosticRunHeader `json:"run"`
+	OperationalState string              `json:"operational_state"`
+	BlockingLayer    string              `json:"blocking_layer"`
+	BlockingReason   string              `json:"blocking_reason"`
+	Heuristics       []string            `json:"heuristics"`
+}
+
+type diagnosticRunTraceResult struct {
+	Trace      []diagnosticRunTraceRow `json:"trace"`
+	NextCursor string                  `json:"next_cursor,omitempty"`
+}
+
+type diagnosticHealthCheckResult struct {
+	Alive     *bool                    `json:"alive"`
+	Ready     *bool                    `json:"ready"`
+	DBOK      *bool                    `json:"db_ok"`
+	RuntimeOK *bool                    `json:"runtime_ok"`
+	Bundle    diagnosticBundleIdentity `json:"bundle"`
+}
+
+type diagnosticBundleIdentity struct {
+	WorkflowName    string `json:"workflow_name"`
+	WorkflowVersion string `json:"workflow_version"`
+	Fingerprint     string `json:"fingerprint"`
+}
+
+type diagnosticRunHeader struct {
+	RunID            string `json:"run_id"`
+	Status           string `json:"status"`
+	TriggerEventType string `json:"trigger_event_type"`
+	TriggerEventID   string `json:"trigger_event_id"`
+	EntityCount      *int   `json:"entity_count"`
+	EventCount       *int   `json:"event_count"`
+	StartedAt        string `json:"started_at"`
+	EndedAt          string `json:"ended_at,omitempty"`
+	ForkedFromRunID  string `json:"forked_from_run_id,omitempty"`
+	ErrorSummary     string `json:"error_summary,omitempty"`
+}
+
+type diagnosticRunTraceRow struct {
+	EventID              string `json:"event_id"`
+	EventName            string `json:"event_name"`
+	EventCreatedAt       string `json:"event_created_at"`
+	EntityID             string `json:"entity_id,omitempty"`
+	DeliveryStatus       string `json:"delivery_status,omitempty"`
+	SubscriberType       string `json:"subscriber_type,omitempty"`
+	SubscriberID         string `json:"subscriber_id,omitempty"`
+	SessionID            string `json:"session_id,omitempty"`
+	TurnID               string `json:"turn_id,omitempty"`
+	TurnTriggerEventType string `json:"turn_trigger_event_type,omitempty"`
+}
+
+func newRunsCommand(opts rootCommandOptions) *cobra.Command {
+	runOpts := diagnosticRunListOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List runs through the v1 RPC read owner.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
+				return fmt.Errorf("--limit must be between 1 and 500")
+			}
+			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), runOpts)
+		},
+	}
+	bindDiagnosticRunListFlags(cmd, &runOpts)
+	return cmd
+}
+
+func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "investigate",
+		Short: "Inspect runtime state through v1 RPC read owners.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newInvestigateRunsCommand(opts),
+		newInvestigateRunCommand(opts),
+		newInvestigateTraceCommand(opts),
+		newInvestigateHealthCommand(opts),
+	)
+	return cmd
+}
+
+func newInvestigateRunsCommand(opts rootCommandOptions) *cobra.Command {
+	runOpts := diagnosticRunListOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List runs through the same v1 RPC path as swarm runs.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
+				return fmt.Errorf("--limit must be between 1 and 500")
+			}
+			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), runOpts)
+		},
+	}
+	bindDiagnosticRunListFlags(cmd, &runOpts)
+	return cmd
+}
+
+func newInvestigateRunCommand(opts rootCommandOptions) *cobra.Command {
+	runOpts := diagnosticRunOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "run [run-id]",
+		Short: "Diagnose one run through v1 RPC.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runID := ""
+			if len(args) == 1 {
+				runID = args[0]
+			}
+			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), runOpts, runID)
+		},
+	}
+	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
+	return cmd
+}
+
+func newInvestigateTraceCommand(opts rootCommandOptions) *cobra.Command {
+	traceOpts := diagnosticTraceOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "trace [run-id]",
+		Short: "Print a snapshot run trace through v1 RPC.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("limit") && traceOpts.limit == 0 {
+				return fmt.Errorf("--limit must be between 1 and 2000")
+			}
+			runID := ""
+			if len(args) == 1 {
+				runID = args[0]
+			}
+			return runDiagnosticTraceCommand(cmd.Context(), cmd.OutOrStdout(), traceOpts, runID)
+		},
+	}
+	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Optional page size, 1-2000")
+	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Optional pagination cursor")
+	return cmd
+}
+
+func newInvestigateHealthCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "health",
+		Short: "Print structured operator health through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+}
+
+func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptions) {
+	cmd.Flags().StringVar(&opts.status, "status", "", "Optional run status filter")
+	cmd.Flags().StringVar(&opts.since, "since", "", "Optional RFC3339 lower started_at bound")
+	cmd.Flags().StringVar(&opts.until, "until", "", "Optional RFC3339 upper started_at bound")
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Optional page size, 1-500")
+	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "Optional pagination cursor")
+}
+
+func runDiagnosticRunListCommand(ctx context.Context, out io.Writer, opts diagnosticRunListOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return err
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	result, err := fetchDiagnosticRunList(ctx, client, params)
+	if err != nil {
+		return err
+	}
+	writeDiagnosticRunList(out, result)
+	return nil
+}
+
+func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnosticRunOptions, runID string) error {
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		runID, err = latestDiagnosticRunID(ctx, client)
+		if err != nil {
+			return err
+		}
+	}
+	if opts.noDiagnose {
+		var result diagnosticRunGetResult
+		if err := client.call(ctx, "run.get", map[string]any{"run_id": runID}, &result); err != nil {
+			return err
+		}
+		if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
+			return err
+		}
+		writeDiagnosticRunHeader(out, result.Run)
+		return nil
+	}
+	var result diagnosticRunDiagnosisResult
+	if err := client.call(ctx, "run.diagnose", map[string]any{"run_id": runID}, &result); err != nil {
+		return err
+	}
+	if err := validateDiagnosticRunDiagnosis(result); err != nil {
+		return err
+	}
+	writeDiagnosticRunDiagnosis(out, result)
+	return nil
+}
+
+func runDiagnosticTraceCommand(ctx context.Context, out io.Writer, opts diagnosticTraceOptions, runID string) error {
+	params, err := opts.params()
+	if err != nil {
+		return err
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		runID, err = latestDiagnosticRunID(ctx, client)
+		if err != nil {
+			return err
+		}
+	}
+	params["run_id"] = runID
+	var result diagnosticRunTraceResult
+	if err := client.call(ctx, "run.trace", params, &result); err != nil {
+		return err
+	}
+	if err := validateDiagnosticRunTraceResult(result); err != nil {
+		return err
+	}
+	writeDiagnosticRunTrace(out, runID, result)
+	return nil
+}
+
+func runDiagnosticHealthCommand(ctx context.Context, out io.Writer, opts rootCommandOptions) error {
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return err
+	}
+	var result diagnosticHealthCheckResult
+	if err := client.call(ctx, "health.check", map[string]any{}, &result); err != nil {
+		return err
+	}
+	if err := validateDiagnosticHealthCheck(result); err != nil {
+		return err
+	}
+	writeDiagnosticHealth(out, result)
+	return nil
+}
+
+func fetchDiagnosticRunList(ctx context.Context, client *cliAPIClient, params map[string]any) (diagnosticRunListResult, error) {
+	var result diagnosticRunListResult
+	if err := client.call(ctx, "run.list", params, &result); err != nil {
+		return diagnosticRunListResult{}, err
+	}
+	if err := validateDiagnosticRunListResult(result); err != nil {
+		return diagnosticRunListResult{}, err
+	}
+	return result, nil
+}
+
+func latestDiagnosticRunID(ctx context.Context, client *cliAPIClient) (string, error) {
+	result, err := fetchDiagnosticRunList(ctx, client, map[string]any{"limit": 1})
+	if err != nil {
+		return "", err
+	}
+	if len(result.Runs) == 0 {
+		return "", fmt.Errorf("no runs found; pass a run id explicitly")
+	}
+	return result.Runs[0].RunID, nil
+}
+
+func (o diagnosticRunListOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if status := strings.ToLower(strings.TrimSpace(o.status)); status != "" {
+		params["status"] = status
+	}
+	if cursor := strings.TrimSpace(o.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	if o.limit != 0 {
+		if o.limit < 1 || o.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = o.limit
+	}
+	if since := strings.TrimSpace(o.since); since != "" {
+		if err := validateRFC3339Flag("--since", since); err != nil {
+			return nil, err
+		}
+		params["since"] = since
+	}
+	if until := strings.TrimSpace(o.until); until != "" {
+		if err := validateRFC3339Flag("--until", until); err != nil {
+			return nil, err
+		}
+		params["until"] = until
+	}
+	return params, nil
+}
+
+func (o diagnosticTraceOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if cursor := strings.TrimSpace(o.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	if o.limit != 0 {
+		if o.limit < 1 || o.limit > 2000 {
+			return nil, fmt.Errorf("--limit must be between 1 and 2000")
+		}
+		params["limit"] = o.limit
+	}
+	return params, nil
+}
+
+func validateRFC3339Flag(name, value string) error {
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("%s must be an RFC3339 timestamp: %w", name, err)
+	}
+	return nil
+}
+
+func validateDiagnosticRunListResult(result diagnosticRunListResult) error {
+	if result.Runs == nil {
+		return fmt.Errorf("malformed run.list result: runs is required")
+	}
+	for i, run := range result.Runs {
+		if err := validateDiagnosticRunHeader(fmt.Sprintf("runs[%d]", i), run); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDiagnosticRunDiagnosis(result diagnosticRunDiagnosisResult) error {
+	if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
+		return err
+	}
+	if strings.TrimSpace(result.OperationalState) == "" {
+		return fmt.Errorf("malformed run.diagnose result: operational_state is required")
+	}
+	return nil
+}
+
+func validateDiagnosticRunTraceResult(result diagnosticRunTraceResult) error {
+	if result.Trace == nil {
+		return fmt.Errorf("malformed run.trace result: trace is required")
+	}
+	for i, row := range result.Trace {
+		if strings.TrimSpace(row.EventID) == "" {
+			return fmt.Errorf("malformed run.trace result: trace[%d].event_id is required", i)
+		}
+		if strings.TrimSpace(row.EventName) == "" {
+			return fmt.Errorf("malformed run.trace result: trace[%d].event_name is required", i)
+		}
+		if err := validateRequiredTimestamp(fmt.Sprintf("trace[%d].event_created_at", i), row.EventCreatedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDiagnosticHealthCheck(result diagnosticHealthCheckResult) error {
+	if result.Alive == nil {
+		return fmt.Errorf("malformed health.check result: alive is required")
+	}
+	if result.Ready == nil {
+		return fmt.Errorf("malformed health.check result: ready is required")
+	}
+	if result.DBOK == nil {
+		return fmt.Errorf("malformed health.check result: db_ok is required")
+	}
+	if result.RuntimeOK == nil {
+		return fmt.Errorf("malformed health.check result: runtime_ok is required")
+	}
+	if strings.TrimSpace(result.Bundle.Fingerprint) == "" {
+		return fmt.Errorf("malformed health.check result: bundle.fingerprint is required")
+	}
+	return nil
+}
+
+func validateDiagnosticRunHeader(prefix string, run diagnosticRunHeader) error {
+	if strings.TrimSpace(run.RunID) == "" {
+		return fmt.Errorf("malformed run header: %s.run_id is required", prefix)
+	}
+	if strings.TrimSpace(run.Status) == "" {
+		return fmt.Errorf("malformed run header: %s.status is required", prefix)
+	}
+	if strings.TrimSpace(run.TriggerEventType) == "" {
+		return fmt.Errorf("malformed run header: %s.trigger_event_type is required", prefix)
+	}
+	if strings.TrimSpace(run.TriggerEventID) == "" {
+		return fmt.Errorf("malformed run header: %s.trigger_event_id is required", prefix)
+	}
+	if run.EntityCount == nil {
+		return fmt.Errorf("malformed run header: %s.entity_count is required", prefix)
+	}
+	if *run.EntityCount < 0 {
+		return fmt.Errorf("malformed run header: %s.entity_count must be non-negative", prefix)
+	}
+	if run.EventCount == nil {
+		return fmt.Errorf("malformed run header: %s.event_count is required", prefix)
+	}
+	if *run.EventCount < 0 {
+		return fmt.Errorf("malformed run header: %s.event_count must be non-negative", prefix)
+	}
+	if err := validateRequiredTimestamp(prefix+".started_at", run.StartedAt); err != nil {
+		return err
+	}
+	if endedAt := strings.TrimSpace(run.EndedAt); endedAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, endedAt); err != nil {
+			return fmt.Errorf("malformed run header: %s.ended_at must be an RFC3339 timestamp: %w", prefix, err)
+		}
+	}
+	return nil
+}
+
+func validateRequiredTimestamp(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("malformed result: %s is required", field)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("malformed result: %s must be an RFC3339 timestamp: %w", field, err)
+	}
+	return nil
+}
+
+func writeDiagnosticRunList(out io.Writer, result diagnosticRunListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Runs) == 0 {
+		fmt.Fprintln(out, "no runs")
+	} else {
+		fmt.Fprintln(out, "RUN ID\tSTATUS\tSTARTED\tEVENTS\tENTITIES\tTRIGGER")
+		for _, run := range result.Runs {
+			fmt.Fprintf(out, "%s\t%s\t%s\t%d\t%d\t%s\n",
+				run.RunID,
+				run.Status,
+				run.StartedAt,
+				intPointerValue(run.EventCount),
+				intPointerValue(run.EntityCount),
+				run.TriggerEventType,
+			)
+		}
+	}
+	if result.NextCursor != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeDiagnosticRunHeader(out io.Writer, run diagnosticRunHeader) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Run: %s\n", run.RunID)
+	fmt.Fprintf(out, "status=%s started_at=%s events=%d entities=%d trigger=%s trigger_event_id=%s\n",
+		run.Status,
+		run.StartedAt,
+		intPointerValue(run.EventCount),
+		intPointerValue(run.EntityCount),
+		run.TriggerEventType,
+		run.TriggerEventID,
+	)
+	if run.EndedAt != "" {
+		fmt.Fprintf(out, "ended_at=%s\n", run.EndedAt)
+	}
+	if run.ForkedFromRunID != "" {
+		fmt.Fprintf(out, "forked_from_run_id=%s\n", run.ForkedFromRunID)
+	}
+	if run.ErrorSummary != "" {
+		fmt.Fprintf(out, "error_summary=%s\n", run.ErrorSummary)
+	}
+}
+
+func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisResult) {
+	if out == nil {
+		return
+	}
+	writeDiagnosticRunHeader(out, result.Run)
+	fmt.Fprintf(out, "operational_state=%s blocking_layer=%s blocking_reason=%s\n",
+		result.OperationalState,
+		result.BlockingLayer,
+		result.BlockingReason,
+	)
+	if len(result.Heuristics) == 0 {
+		fmt.Fprintln(out, "heuristics=none")
+		return
+	}
+	fmt.Fprintln(out, "heuristics:")
+	for _, item := range result.Heuristics {
+		fmt.Fprintf(out, "- %s\n", item)
+	}
+}
+
+func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTraceResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "run trace: run_id=%s\n", runID)
+	if len(result.Trace) == 0 {
+		fmt.Fprintln(out, "no trace rows")
+	} else {
+		fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY\tSUBSCRIBER\tSESSION\tTURN")
+		for _, row := range result.Trace {
+			fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s/%s\t%s\t%s\n",
+				row.EventCreatedAt,
+				row.EventName,
+				row.EventID,
+				emptyDash(row.DeliveryStatus),
+				emptyDash(row.SubscriberType),
+				emptyDash(row.SubscriberID),
+				emptyDash(row.SessionID),
+				emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
+			)
+		}
+	}
+	if result.NextCursor != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeDiagnosticHealth(out io.Writer, result diagnosticHealthCheckResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "alive=%t ready=%t db_ok=%t runtime_ok=%t\n", boolPointerValue(result.Alive), boolPointerValue(result.Ready), boolPointerValue(result.DBOK), boolPointerValue(result.RuntimeOK))
+	fmt.Fprintf(out, "bundle fingerprint=%s workflow_name=%s workflow_version=%s\n",
+		result.Bundle.Fingerprint,
+		emptyDash(result.Bundle.WorkflowName),
+		emptyDash(result.Bundle.WorkflowVersion),
+	)
+}
+
+func intPointerValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func boolPointerValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func emptyDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -1,0 +1,516 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunsAndInvestigateRunsUseRunListV1RPC(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantParams map[string]any
+	}{
+		{
+			name: "swarm runs",
+			args: []string{"runs", "--status", "RUNNING", "--limit", "2", "--cursor", "cur-1", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T11:00:00Z"},
+			wantParams: map[string]any{
+				"status": "running",
+				"limit":  float64(2),
+				"cursor": "cur-1",
+				"since":  "2026-05-13T10:00:00Z",
+				"until":  "2026-05-13T11:00:00Z",
+			},
+		},
+		{
+			name:       "swarm investigate runs",
+			args:       []string{"investigate", "runs", "--limit", "1"},
+			wantParams: map[string]any{"limit": float64(1)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != "run.list" {
+					t.Fatalf("method = %q, want run.list", req.Method)
+				}
+				return map[string]any{
+					"runs":        []any{validDiagnosticRunHeader("run-1")},
+					"next_cursor": "next-1",
+				}
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if len(*requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(*requests))
+			}
+			if !reflect.DeepEqual((*requests)[0].Params, tc.wantParams) {
+				t.Fatalf("params = %#v, want %#v", (*requests)[0].Params, tc.wantParams)
+			}
+			for _, want := range []string{"RUN ID", "run-1", "running", "scan.requested", "next_cursor=next-1"} {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestInvestigateRunUsesDiagnoseAndRunGet(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantMethod string
+		wantOutput []string
+		notOutput  string
+	}{
+		{
+			name:       "diagnose default",
+			args:       []string{"investigate", "run", "run-1"},
+			wantMethod: "run.diagnose",
+			wantOutput: []string{"Run: run-1", "operational_state=stalled", "blocking_layer=delivery_lifecycle", "dead letters exist"},
+		},
+		{
+			name:       "header only",
+			args:       []string{"investigate", "run", "run-1", "--no-diagnose"},
+			wantMethod: "run.get",
+			wantOutput: []string{"Run: run-1", "status=running", "trigger=scan.requested"},
+			notOutput:  "operational_state=",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != tc.wantMethod {
+					t.Fatalf("method = %q, want %s", req.Method, tc.wantMethod)
+				}
+				if got := req.Params["run_id"]; got != "run-1" {
+					t.Fatalf("run_id param = %#v, want run-1", got)
+				}
+				if tc.wantMethod == "run.get" {
+					return map[string]any{"run": validDiagnosticRunHeader("run-1")}
+				}
+				return map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "stalled",
+					"blocking_layer":    "delivery_lifecycle",
+					"blocking_reason":   "no_active_deliveries",
+					"heuristics":        []any{"dead letters exist for this run"},
+				}
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if len(*requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(*requests))
+			}
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+			if tc.notOutput != "" && strings.Contains(stdout.String(), tc.notOutput) {
+				t.Fatalf("stdout contains %q, want absent:\n%s", tc.notOutput, stdout.String())
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestInvestigateRunAndTraceResolveLatestRunThroughRunList(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		args         []string
+		secondMethod string
+		wantOutput   string
+	}{
+		{name: "run", args: []string{"investigate", "run"}, secondMethod: "run.diagnose", wantOutput: "Run: latest-run"},
+		{name: "trace", args: []string{"investigate", "trace"}, secondMethod: "run.trace", wantOutput: "run trace: run_id=latest-run"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
+				switch callIndex {
+				case 0:
+					if req.Method != "run.list" {
+						t.Fatalf("first method = %q, want run.list", req.Method)
+					}
+					if got := req.Params["limit"]; got != float64(1) {
+						t.Fatalf("latest run limit = %#v, want 1", got)
+					}
+					return map[string]any{"runs": []any{validDiagnosticRunHeader("latest-run")}}
+				case 1:
+					if req.Method != tc.secondMethod {
+						t.Fatalf("second method = %q, want %s", req.Method, tc.secondMethod)
+					}
+					if got := req.Params["run_id"]; got != "latest-run" {
+						t.Fatalf("second run_id = %#v, want latest-run", got)
+					}
+					if tc.secondMethod == "run.trace" {
+						return map[string]any{
+							"trace": []any{map[string]any{
+								"event_id":         "event-1",
+								"event_name":       "scan.requested",
+								"event_created_at": "2026-05-13T10:00:01Z",
+							}},
+						}
+					}
+					return map[string]any{
+						"run":               validDiagnosticRunHeader("latest-run"),
+						"operational_state": "running",
+						"blocking_layer":    "",
+						"blocking_reason":   "",
+						"heuristics":        []any{},
+					}
+				default:
+					t.Fatalf("unexpected request %d: %s", callIndex+1, req.Method)
+				}
+				return nil
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if len(*requests) != 2 {
+				t.Fatalf("requests = %d, want 2", len(*requests))
+			}
+			if !strings.Contains(stdout.String(), tc.wantOutput) {
+				t.Fatalf("stdout missing %q:\n%s", tc.wantOutput, stdout.String())
+			}
+		})
+	}
+}
+
+func TestInvestigateTraceUsesRunTraceSnapshot(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+		if req.Method != "run.trace" {
+			t.Fatalf("method = %q, want run.trace", req.Method)
+		}
+		wantParams := map[string]any{"run_id": "run-1", "limit": float64(5), "cursor": "trace-cur"}
+		if !reflect.DeepEqual(req.Params, wantParams) {
+			t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
+		}
+		return map[string]any{
+			"trace": []any{map[string]any{
+				"event_id":         "event-1",
+				"event_name":       "scan.requested",
+				"event_created_at": "2026-05-13T10:00:01Z",
+				"delivery_status":  "delivered",
+				"subscriber_type":  "agent",
+				"subscriber_id":    "agent-1",
+				"session_id":       "session-1",
+				"turn_id":          "turn-1",
+			}},
+			"next_cursor": "trace-next",
+		}
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "trace", "run-1", "--limit", "5", "--cursor", "trace-cur"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*requests))
+	}
+	for _, want := range []string{"run trace: run_id=run-1", "event-1", "scan.requested", "agent/agent-1", "next_cursor=trace-next"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestInvestigateHealthUsesHealthCheck(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+		if req.Method != "health.check" {
+			t.Fatalf("method = %q, want health.check", req.Method)
+		}
+		if len(req.Params) != 0 {
+			t.Fatalf("params = %#v, want empty", req.Params)
+		}
+		return map[string]any{
+			"alive":      true,
+			"ready":      true,
+			"db_ok":      true,
+			"runtime_ok": true,
+			"bundle": map[string]any{
+				"fingerprint":      "sha256:abc",
+				"workflow_name":    "workflow",
+				"workflow_version": "v1",
+			},
+		}
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "health"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*requests))
+	}
+	for _, want := range []string{"alive=true", "ready=true", "db_ok=true", "runtime_ok=true", "fingerprint=sha256:abc", "workflow_name=workflow"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "runs invalid limit", args: []string{"runs", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "runs invalid since", args: []string{"runs", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "trace invalid limit", args: []string{"investigate", "trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
+		{name: "trace follow unsupported", args: []string{"investigate", "trace", "run-1", "--follow"}, wantStderr: "unknown flag"},
+		{name: "run extra arg", args: []string{"investigate", "run", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if calls.Load() != before {
+				t.Fatalf("server calls changed from %d to %d, want no request", before, calls.Load())
+			}
+		})
+	}
+}
+
+func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestInvestigateOmittedRunFailsClosedWhenNoRunsExist(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+		if req.Method != "run.list" {
+			t.Fatalf("method = %q, want run.list", req.Method)
+		}
+		return map[string]any{"runs": []any{}}
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "run"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(*requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*requests))
+	}
+	if !strings.Contains(stderr.String(), "no runs found") {
+		t.Fatalf("stderr = %q, want no-runs error", stderr.String())
+	}
+}
+
+func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			args: []string{"runs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "json rpc run not found",
+			args: []string{"investigate", "run", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				w.Header().Set("content-type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      req.ID,
+					"error": map[string]any{
+						"code":    -32017,
+						"message": "Application error: RUN_NOT_FOUND",
+						"data": map[string]any{
+							"code":           "RUN_NOT_FOUND",
+							"details":        map[string]any{"run_id": "missing"},
+							"retryable":      false,
+							"correlation_id": "corr-1",
+						},
+					},
+				})
+			},
+			wantStderr: "RUN_NOT_FOUND",
+		},
+		{
+			name: "run list missing runs",
+			args: []string{"runs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantStderr: "runs is required",
+		},
+		{
+			name: "run get missing required run id",
+			args: []string{"investigate", "run", "run-1", "--no-diagnose"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				run := validDiagnosticRunHeader("run-1")
+				delete(run, "run_id")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"run": run})
+			},
+			wantStderr: "run.run_id is required",
+		},
+		{
+			name: "trace missing trace",
+			args: []string{"investigate", "trace", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantStderr: "trace is required",
+		},
+		{
+			name: "health missing bundle fingerprint",
+			args: []string{"investigate", "health"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"alive":      true,
+					"ready":      true,
+					"db_ok":      true,
+					"runtime_ok": true,
+					"bundle":     map[string]any{},
+				})
+			},
+			wantStderr: "bundle.fingerprint is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func newDiagnosticSuccessServer(t *testing.T, responder func(jsonRPCRequest, int) map[string]any) (*httptest.Server, *[]jsonRPCRequest) {
+	t.Helper()
+	requests := []jsonRPCRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		callIndex := len(requests)
+		result := responder(req, callIndex)
+		requests = append(requests, req)
+		writeJSONRPCResult(t, w, req.ID, result)
+	}))
+	return server, &requests
+}
+
+func validDiagnosticRunHeader(runID string) map[string]any {
+	return map[string]any{
+		"run_id":             runID,
+		"status":             "running",
+		"trigger_event_type": "scan.requested",
+		"trigger_event_id":   "event-root",
+		"entity_count":       2,
+		"event_count":        3,
+		"started_at":         "2026-05-13T10:00:00Z",
+	}
+}

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -435,6 +435,30 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			wantStderr: "run.run_id is required",
 		},
 		{
+			name: "run list invalid run status",
+			args: []string{"runs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				run := validDiagnosticRunHeader("run-1")
+				run["status"] = "waiting"
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{run}})
+			},
+			wantStderr: `runs[0].status="waiting" is not a valid RunStatus`,
+		},
+		{
+			name: "run get invalid run status",
+			args: []string{"investigate", "run", "run-1", "--no-diagnose"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				run := validDiagnosticRunHeader("run-1")
+				run["status"] = "waiting"
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"run": run})
+			},
+			wantStderr: `run.status="waiting" is not a valid RunStatus`,
+		},
+		{
 			name: "run diagnose missing blocking layer",
 			args: []string{"investigate", "run", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -448,6 +472,22 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				})
 			},
 			wantStderr: "blocking_layer is required",
+		},
+		{
+			name: "run diagnose invalid operational state",
+			args: []string{"investigate", "run", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "blocked",
+					"blocking_layer":    "",
+					"blocking_reason":   "",
+					"heuristics":        []any{},
+				})
+			},
+			wantStderr: `operational_state="blocked" is not a valid OperationalState`,
 		},
 		{
 			name: "run diagnose missing blocking reason",

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -435,6 +435,51 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			wantStderr: "run.run_id is required",
 		},
 		{
+			name: "run diagnose missing blocking layer",
+			args: []string{"investigate", "run", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "running",
+					"blocking_reason":   "",
+					"heuristics":        []any{},
+				})
+			},
+			wantStderr: "blocking_layer is required",
+		},
+		{
+			name: "run diagnose missing blocking reason",
+			args: []string{"investigate", "run", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "running",
+					"blocking_layer":    "",
+					"heuristics":        []any{},
+				})
+			},
+			wantStderr: "blocking_reason is required",
+		},
+		{
+			name: "run diagnose missing heuristics",
+			args: []string{"investigate", "run", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "running",
+					"blocking_layer":    "",
+					"blocking_reason":   "",
+				})
+			},
+			wantStderr: "heuristics is required",
+		},
+		{
 			name: "trace missing trace",
 			args: []string{"investigate", "trace", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -459,6 +504,44 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				})
 			},
 			wantStderr: "bundle.fingerprint is required",
+		},
+		{
+			name: "health missing workflow name",
+			args: []string{"investigate", "health"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"alive":      true,
+					"ready":      true,
+					"db_ok":      true,
+					"runtime_ok": true,
+					"bundle": map[string]any{
+						"fingerprint":      "sha256:abc",
+						"workflow_version": "v1",
+					},
+				})
+			},
+			wantStderr: "bundle.workflow_name is required",
+		},
+		{
+			name: "health missing workflow version",
+			args: []string{"investigate", "health"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"alive":      true,
+					"ready":      true,
+					"db_ok":      true,
+					"runtime_ok": true,
+					"bundle": map[string]any{
+						"fingerprint":   "sha256:abc",
+						"workflow_name": "workflow",
+					},
+				})
+			},
+			wantStderr: "bundle.workflow_version is required",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5138,6 +5138,51 @@ cli_specification:
       command: swarm verify
       status: must_have
       behavior: local contract-file validation carve-out
+    runs:
+      command: swarm runs
+      status: must_have
+      owner: /v1/rpc run.list
+      behavior: List runs through the canonical v1 run.list read owner; no direct DB/store/runtime-state reads.
+    investigate:
+      command: swarm investigate
+      status: must_have
+      behavior: Runtime diagnosis command group. Subcommands consume v1 API read owners only.
+    investigate_runs:
+      command: swarm investigate runs
+      status: must_have
+      owner: /v1/rpc run.list
+      behavior: Same client and renderer path as `swarm runs`.
+    investigate_run:
+      command: swarm investigate run [run-id]
+      status: must_have
+      owner: /v1/rpc run.diagnose by default; /v1/rpc run.get when --no-diagnose is set
+      behavior: If run-id is omitted, resolve the latest run through run.list({limit:1}); do not call local run-debug/store helpers.
+    investigate_trace:
+      command: swarm investigate trace [run-id]
+      status: must_have
+      owner: /v1/rpc run.trace
+      behavior: Snapshot trace only. If run-id is omitted, resolve the latest run through run.list({limit:1}).
+      split_tail: Live follow mode is not part of this command; it requires run.subscribe_trace over /v1/ws.
+    investigate_health:
+      command: swarm investigate health
+      status: must_have
+      owner: /v1/rpc health.check
+      behavior: Structured authenticated operator health; do not consume /healthz, /readyz, or retired dashboard aliases.
+    control_mailbox_approve:
+      command: swarm control mailbox approve <mailbox-item-id>
+      status: must_have
+      owner: /v1/rpc mailbox.approve
+      behavior: Mailbox approval action through canonical v1 API owner; no direct DB/store/mailbox writes.
+    control_mailbox_reject:
+      command: swarm control mailbox reject <mailbox-item-id>
+      status: must_have
+      owner: /v1/rpc mailbox.reject
+      behavior: Mailbox rejection action through canonical v1 API owner; no direct DB/store/mailbox writes.
+    control_mailbox_defer:
+      command: swarm control mailbox defer <mailbox-item-id>
+      status: must_have
+      owner: /v1/rpc mailbox.defer
+      behavior: Mailbox defer action through canonical v1 API owner; no direct DB/store/mailbox writes.
     status:
       command: swarm status
       status: retired
@@ -5149,18 +5194,19 @@ cli_specification:
       exit_code: 2
       message: "ERROR: `swarm fork` was removed in v1. Forking is a mutating control action; use `swarm control run fork <run-id>` once that command ships. For v1, manual run forking goes through the API owner and the API spec."
   parent_tail:
-    not_implemented_in_first_slice:
-    - swarm run
+    implemented_after_first_slice:
+    - swarm control mailbox approve
+    - swarm control mailbox reject
+    - swarm control mailbox defer
     - swarm runs
     - swarm investigate runs
     - swarm investigate run
     - swarm investigate trace
     - swarm investigate health
-    - swarm control mailbox approve
-    - swarm control mailbox reject
-    - swarm control mailbox defer
+    remaining_not_implemented:
+    - swarm run
     - swarm control run/runtime/agent
-    rule: 'These commands require separate gates and must consume v1 API owners; they MUST NOT resurrect local DB/store/runtime-state readers.'
+    rule: 'Remaining commands require separate gates and must consume v1 API owners; they MUST NOT resurrect local DB/store/runtime-state readers.'
 
 api_specification:
   description: "Single canonical user-facing API for the Swarm platform. JSON-RPC 2.0 over\nHTTP for request/response, JSON-RPC\


### PR DESCRIPTION
## Summary

Closes #741.
Part of #735.

Implements the approved #741 first-slice CLI diagnostics class:

- `swarm runs` -> `/v1/rpc` `run.list`
- `swarm investigate runs` -> same `run.list` client/renderer path as `swarm runs`
- `swarm investigate run [run-id]` -> `run.diagnose` by default
- `swarm investigate run [run-id] --no-diagnose` -> `run.get`
- `swarm investigate trace [run-id]` -> snapshot `run.trace`
- `swarm investigate health` -> `health.check`

Optional run IDs resolve through `run.list({limit:1})` only. `trace --follow`, `swarm run`, event/entity/agent/conversation drill-down, runtime logs/incidents, and mutating run/runtime/agent control remain split.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification`: CLI command topology, Cobra owner, runtime-state CLI consumes v1 API, `verify` local carve-out.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.cli_consumption_rule`: `swarm investigate` must not reach directly into internal runtime packages.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` method catalog: `health.check`, `run.list`, `run.get`, `run.diagnose`, `run.trace`, and split `run.subscribe_trace`.
- `docs/specs/swarm-platform/platform/contracts/openrpc.json`: generated method registry artifact.
- Binding issue/gate context: #741 pre-audit and independent gate comment approved this as a first slice.

## Semantic Migration

- New CLI canonical owners consumed: v1 `/v1/rpc` methods `health.check`, `run.list`, `run.get`, `run.diagnose`, and `run.trace`.
- Old producer/reader path now invalid for this CLI class: local `cmd/swarm/main.go` store/debug helpers, direct DB/store reads, retired `swarm status`, retired `/api/*` and `/rpc` aliases, and process probes `/healthz`/`/readyz` for structured operator health.
- Production paths checked for surviving old behavior: new diagnostics code only calls the shared CLI API client; grep proof found no direct `internal/store`, `database/sql`, `LoadRunDebugReport`, `LoadRunDebugTrace`, `LoadRunDebugTracePage`, `ResolveLatestRunDebugRunID`, `ProjectRunOperationalStatus`, `ListRunHeaders`, or `LoadRunHeader` use in the new CLI diagnostics code.
- Migration completeness: complete for #741 snapshot read-only runtime diagnostics CLI. Parent #735 remains open for other CLI children.

## Proof Run

- `go test ./cmd/swarm -run 'TestCLI|TestInvestigate|TestRuns|TestDiagnostics' -count=1`
- `go test ./cmd/swarm -run 'TestCLI|TestControlMailbox|TestInvestigate|TestRuns|TestDiagnostics' -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `rg -n "internal/store|database/sql|LoadRunDebugReport|LoadRunDebugTrace|LoadRunDebugTracePage|ResolveLatestRunDebugRunID|ProjectRunOperationalStatus|ListRunHeaders|LoadRunHeader" cmd/swarm/diagnostics.go cmd/swarm/diagnostics_test.go cmd/swarm/cli.go || true` returned no matches.
