### PR TITLE
[agent-d][issue #747] Move artifact repos off read-only data mount

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1155,7 +1155,8 @@ handler_specification:
             may publish failure_event when declared. Content hashes are diagnostic and do not replace request/source idempotency.
             The public artifact URL is product-neutral
             (`swarm-artifact://repos/<repo_id>`). The local-git provider path is product-neutral, collision-safe by repo_id,
-            scoped below the runtime artifact root, and must not encode product-specific path segments.
+            scoped below the runtime artifact root defined by `runtime_storage.artifact_root`, and must not encode
+            product-specific path segments.
           operation_state: The selected/owned entity is the contract-visible operation/ref ledger surface for V1. The service
             contract must declare the output fields it wants persisted; status is committed or failed, failure_reason records
             runtime failure detail when available, and current_ref updates only after git commit/ref verification succeeds.
@@ -4679,6 +4680,28 @@ observation_model:
     Agent emissions are NOT part of the entity emission chain — they are independent events that enter the event loop separately.
     An agent emitting ticket.classified creates a new event in the events table that is then delivered to subscribers. The
     agent emission does not appear in the triggering handler's emitted_events list.
+runtime_storage:
+  description: Runtime-owned writable host storage for service state. These paths are not part of the agent workspace model,
+    are not mounted into agent sessions, and must never be exposed to agents as raw host paths. Agents and product contracts
+    consume runtime-owned artifacts only through typed platform surfaces such as `swarm-artifact://...` URLs and immutable refs.
+  artifact_root:
+    description: Root directory for local-git repositories materialized by `artifact_repo_commit`.
+    default: /var/lib/swarm/artifacts
+    env_override: SWARM_ARTIFACT_ROOT
+    resolution_order:
+    - Explicit runtime coordinator option, when supplied by an embedding runtime.
+    - SWARM_ARTIFACT_ROOT environment variable, when non-empty.
+    - Platform default `/var/lib/swarm/artifacts`.
+    requirements:
+    - The resolved path MUST be an absolute runtime-private host path.
+    - The resolved path MUST be writable by the runtime process when `artifact_repo_commit` executes.
+    - The resolved path MUST persist across runtime restarts.
+    - The resolved path MUST NOT be `/workspace`, `/data`, `/opt/swarm/contracts`, or any descendant of those agent-visible
+      mounts.
+    - If the resolved path or its existing parent prefix resolves through symlinks under an agent-visible mount, startup/runtime
+      validation MUST fail closed before git writes.
+    - Product contracts and agents MUST NOT rely on the raw host path. The stable product surface remains the opaque
+      `swarm-artifact://repos/<repo_id>` URL plus immutable commit ref.
 workspace_model:
   description: Defines the filesystem contract for agent sessions. The platform provides three standard mount points and a
     scoping model. Products define workspace classes that map agent roles to specific scope configurations. If a product declares

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -82,7 +82,10 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-if [ "$count" -gt 1 ]; then
+# Branch on the actual tool-result payload, not the process invocation count.
+# Extra startup/probe/fallback invocations should not make the first real turn
+# skip the provider-native Read tool call.
+if grep -q '"name":"read_file"' "$captured"; then
   printf '%s\n' '{"type":"result","result":"done"}'
 else
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -27,12 +27,14 @@ import (
 const (
 	artifactRepoProviderLocalGit = "local_git"
 	artifactRepoPublicScheme     = "swarm-artifact://repos/"
-	defaultArtifactRoot          = "/data/swarm/artifacts"
+	defaultArtifactRoot          = "/var/lib/swarm/artifacts"
 	defaultYAMLMaxBytes          = 1 << 20
 	defaultMarkdownMaxBytes      = 5 << 20
 	defaultTextMaxBytes          = 1 << 20
 	defaultRepoMaxBytes          = 50 << 20
 )
+
+var invalidArtifactRootMounts = []string{"/workspace", "/data", "/opt/swarm/contracts"}
 
 type artifactRepoPreparedFile struct {
 	Path        string
@@ -107,7 +109,11 @@ func (pc *PipelineCoordinator) commitArtifactRepo(ctx context.Context, action ru
 			}
 		}
 	}
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), namespace, repoID)
+	artifactRoot, err := pc.artifactRepoRoot()
+	if err != nil {
+		return fail(err)
+	}
+	repoPath, err := artifactRepoPath(artifactRoot, namespace, repoID)
 	if err != nil {
 		return fail(err)
 	}
@@ -277,14 +283,78 @@ func normalizedArtifactRepoFlowInstance(value string) string {
 	return strings.Trim(strings.TrimSpace(value), "/")
 }
 
-func (pc *PipelineCoordinator) artifactRepoRoot() string {
+func (pc *PipelineCoordinator) artifactRepoRoot() (string, error) {
 	if pc != nil && strings.TrimSpace(pc.artifactRoot) != "" {
-		return strings.TrimSpace(pc.artifactRoot)
+		return ResolveArtifactRepoRoot(pc.artifactRoot)
+	}
+	return ResolveArtifactRepoRoot("")
+}
+
+// ResolveArtifactRepoRoot returns the validated runtime-private artifact root.
+// The explicit root has precedence over SWARM_ARTIFACT_ROOT, which has
+// precedence over the platform default.
+func ResolveArtifactRepoRoot(explicit string) (string, error) {
+	root := strings.TrimSpace(explicit)
+	if root != "" {
+		return validateArtifactRepoRoot(root)
 	}
 	if env := strings.TrimSpace(os.Getenv("SWARM_ARTIFACT_ROOT")); env != "" {
-		return env
+		return validateArtifactRepoRoot(env)
 	}
-	return defaultArtifactRoot
+	return validateArtifactRepoRoot(defaultArtifactRoot)
+}
+
+func validateArtifactRepoRoot(raw string) (string, error) {
+	root := strings.TrimSpace(raw)
+	if root == "" {
+		return "", fmt.Errorf("artifact root is required")
+	}
+	if strings.Contains(root, "\x00") {
+		return "", fmt.Errorf("artifact root contains NUL byte")
+	}
+	cleaned := filepath.Clean(root)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("artifact root %q must be an absolute runtime-private host path", root)
+	}
+	if mount, ok := artifactRootAgentMount(cleaned); ok {
+		return "", fmt.Errorf("artifact root %q cannot live under agent-visible mount %s", cleaned, mount)
+	}
+	if resolved, ok := artifactRootResolveExistingPrefix(cleaned); ok {
+		if mount, ok := artifactRootAgentMount(resolved); ok {
+			return "", fmt.Errorf("artifact root %q resolves under agent-visible mount %s", cleaned, mount)
+		}
+	}
+	return cleaned, nil
+}
+
+func artifactRootAgentMount(root string) (string, bool) {
+	for _, mount := range invalidArtifactRootMounts {
+		cleanMount := filepath.Clean(mount)
+		if artifactPathWithinRoot(root, cleanMount) {
+			return cleanMount, true
+		}
+	}
+	return "", false
+}
+
+func artifactRootResolveExistingPrefix(cleaned string) (string, bool) {
+	current := cleaned
+	remaining := []string{}
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(remaining) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, remaining[i])
+			}
+			return filepath.Clean(resolved), true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false
+		}
+		remaining = append(remaining, filepath.Base(current))
+		current = parent
+	}
 }
 
 func artifactRepoOutputsComplete(metadata map[string]any, spec *runtimecontracts.ArtifactRepoSpec) bool {
@@ -628,9 +698,10 @@ func validateArtifactRepoDisplaySlug(raw string) error {
 }
 
 func artifactRepoPath(root, namespace, repoID string) (string, error) {
-	root = strings.TrimSpace(root)
-	if root == "" {
-		return "", fmt.Errorf("artifact root is required")
+	var err error
+	root, err = validateArtifactRepoRoot(root)
+	if err != nil {
+		return "", err
 	}
 	if _, err := uuid.Parse(repoID); err != nil {
 		return "", fmt.Errorf("repo_id must be UUID: %w", err)

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -816,6 +816,111 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	}
 }
 
+func TestResolveArtifactRepoRootDefaultUsesRuntimePrivateRoot(t *testing.T) {
+	t.Setenv("SWARM_ARTIFACT_ROOT", "")
+
+	root, err := ResolveArtifactRepoRoot("")
+	if err != nil {
+		t.Fatalf("ResolveArtifactRepoRoot: %v", err)
+	}
+	if got, want := root, "/var/lib/swarm/artifacts"; got != want {
+		t.Fatalf("default artifact root = %q, want %q", got, want)
+	}
+}
+
+func TestResolveArtifactRepoRootExplicitOptionOverridesEnv(t *testing.T) {
+	t.Setenv("SWARM_ARTIFACT_ROOT", "/data/swarm/artifacts")
+	explicit := filepath.Join(t.TempDir(), "artifacts", "..", "repos")
+
+	root, err := ResolveArtifactRepoRoot(explicit)
+	if err != nil {
+		t.Fatalf("ResolveArtifactRepoRoot: %v", err)
+	}
+	if got, want := root, filepath.Clean(explicit); got != want {
+		t.Fatalf("explicit artifact root = %q, want %q", got, want)
+	}
+}
+
+func TestResolveArtifactRepoRootRejectsUnsafeRoots(t *testing.T) {
+	t.Setenv("SWARM_ARTIFACT_ROOT", "")
+	for _, tc := range []struct {
+		name string
+		root string
+		want string
+	}{
+		{name: "relative", root: "artifacts", want: "absolute runtime-private host path"},
+		{name: "data", root: "/data/swarm/artifacts", want: "agent-visible mount /data"},
+		{name: "workspace", root: "/workspace/artifacts", want: "agent-visible mount /workspace"},
+		{name: "contracts", root: "/opt/swarm/contracts/artifacts", want: "agent-visible mount /opt/swarm/contracts"},
+		{name: "prefix", root: "/database/swarm/artifacts", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveArtifactRepoRoot(tc.root)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("ResolveArtifactRepoRoot(%q): %v", tc.root, err)
+				}
+				if got != filepath.Clean(tc.root) {
+					t.Fatalf("ResolveArtifactRepoRoot(%q) = %q", tc.root, got)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ResolveArtifactRepoRoot(%q) error = %v, want %q", tc.root, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifactRoot(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: "/data/swarm/artifacts", bus: bus}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "artifact-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "agent-visible mount /data") {
+		t.Fatalf("ExecuteAction error = %v, want invalid /data artifact root", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
+		t.Fatalf("status = %q, want failed", got)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, "agent-visible mount /data") {
+		t.Fatalf("failure_reason = %q, want invalid root detail", got)
+	}
+	if _, exists := instance.Metadata["current_ref"]; exists {
+		t.Fatalf("current_ref should not be persisted on invalid artifact root: %#v", instance.Metadata["current_ref"])
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("failure event count = %d, want 1", got)
+	}
+	if got := string(bus.publishedEvent(0).Type); got != "artifact_repo.commit_failed" {
+		t.Fatalf("failure event type = %q", got)
+	}
+}
+
 func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEvent(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
@@ -1483,7 +1588,11 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 	if sameRef == "" || sameRef == initialRef {
 		t.Fatalf("same-tree request current_ref = %q, initial ref = %q; want a durable operation commit", sameRef, initialRef)
 	}
-	repoPath, err := artifactRepoPath(pc.artifactRepoRoot(), initial["namespace"].(string), initial["repo_id"].(string))
+	artifactRoot, err := pc.artifactRepoRoot()
+	if err != nil {
+		t.Fatalf("artifactRepoRoot: %v", err)
+	}
+	repoPath, err := artifactRepoPath(artifactRoot, initial["namespace"].(string), initial["repo_id"].(string))
 	if err != nil {
 		t.Fatalf("artifactRepoPath: %v", err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -312,6 +312,10 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		}
 	})
 	if stores.SQLDB != nil {
+		artifactRoot, err := runtimepipeline.ResolveArtifactRepoRoot("")
+		if err != nil {
+			return nil, fmt.Errorf("artifact repo root validation failed: %w", err)
+		}
 		rt.Pipeline = runtimepipeline.NewPipelineCoordinatorWithOptions(rt.Bus, stores.SQLDB, runtimepipeline.PipelineCoordinatorOptions{
 			Module: opts.WorkflowModule,
 			InstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
@@ -329,6 +333,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			TimerScheduler:          rt.Scheduler,
 			TimerScheduleStore:      stores.ScheduleStore,
 			EventReceiptsCapability: receiptCaps,
+			ArtifactRoot:            artifactRoot,
 		})
 		if rt.Pipeline != nil {
 			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -15,6 +15,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+	"swarm/internal/testutil"
 )
 
 type recoveryGuardManagerStore struct {
@@ -91,6 +92,24 @@ func testOperationalRuntimeConfig() *config.Config {
 		LLM: config.LLMConfig{
 			RuntimeMode: "api",
 		},
+	}
+}
+
+func TestNewRuntimeRejectsInvalidArtifactRootEnv(t *testing.T) {
+	t.Setenv("SWARM_ARTIFACT_ROOT", "/data/swarm/artifacts")
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	module := loadRuntimeOwnershipWorkflowModule(t)
+
+	_, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		SQLDB:      db,
+		EventStore: &minimalRuntimeEventStore{},
+	}, RuntimeOptions{
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "artifact repo root validation failed") || !strings.Contains(err.Error(), "agent-visible mount /data") {
+		t.Fatalf("NewRuntime error = %v, want invalid artifact root", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #747.

Moves the local-git `artifact_repo_commit` runtime storage root out of the agent-visible read-only `/data` mount and into a runtime-private root, with one shared validator for the default, `SWARM_ARTIFACT_ROOT`, and explicit coordinator option paths.

## Governing Context

- Swarm #747 pre-audit and independent gate outcome: approved.
- Authoritative spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `artifact_repo_commit`, `runtime_storage.artifact_root`, and `workspace_model.standard_mounts`.
- Binding gate boundary: product-neutral `artifact_repo_commit` storage root only; no change to agent workspace mounts, no raw host paths exposed to products/agents, no broader runtime-storage framework.

## Semantic Migration

- New canonical owner: `runtime_storage.artifact_root` in `platform-spec.yaml` plus `runtimepipeline.ResolveArtifactRepoRoot`.
- Old invalid producer: `/data/swarm/artifacts` default runtime artifact root.
- Old invalid interpreters: env/option roots under `/data`, `/workspace`, `/opt/swarm/contracts`, and relative CWD-dependent roots.
- Production paths checked: normal runtime construction, selected/fork pipeline use through the shared pipeline resolver, action-path `artifact_repo_commit`, non-test grep for `/data/swarm/artifacts`.
- Migration completeness: complete for the chosen #747 class; Empire #81 remains the downstream supported-run proof tracker.

## Proof

- `go test ./internal/runtime/pipeline -run 'TestResolveArtifactRepoRoot|TestPipelineEngineActionRunner_ArtifactRepoCommit'`
- `go test ./internal/runtime -run TestNewRuntimeRejectsInvalidArtifactRootEnv`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline`
- `go test ./...`
- `git diff --check`
- `rg -n '"/data/swarm/artifacts"|/data/swarm/artifacts' --glob '!**/*_test.go' .` returns no production matches.
