### PR TITLE
[agent-b][issue #753] Persist run bundle fingerprints

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -147,6 +147,10 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if _, err := s.initStateStores(ctx, s.stores, bundle); err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
+	bundleIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		return builderpkg.ProjectStatus{}, fmt.Errorf("derive project bundle identity: %w", err)
+	}
 	workspaces := s.newWorkspaces(s.stores, s.repoRoot, resolvedRoot, source)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		return builderpkg.ProjectStatus{}, err
@@ -162,6 +166,7 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		SelfCheck:          false,
 		WorkflowModule:     module,
 		WorkspaceLifecycle: workspaces,
+		BundleFingerprint:  bundleIdentity.Fingerprint,
 	})
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -136,6 +136,20 @@ func writeProjectRoot(t *testing.T) string {
 	return dir
 }
 
+func testBuilderSupervisorBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	dir := t.TempDir()
+	packagePath := filepath.Join(dir, "package.yaml")
+	if err := os.WriteFile(packagePath, []byte("name: test\nversion: 1.0.0\nflows: []\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	bundle := testWorkflowValidationBundle()
+	bundle.Paths.ProjectPackageFile = packagePath
+	bundle.Semantics.Name = "test"
+	bundle.Semantics.Version = "1.0.0"
+	return bundle
+}
+
 func newSupervisorForLoadProjectFailureTest(
 	t *testing.T,
 	projectRoot string,
@@ -143,7 +157,7 @@ func newSupervisorForLoadProjectFailureTest(
 	createRuntime func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error),
 ) *runtimeProjectSupervisor {
 	t.Helper()
-	bundle := testWorkflowValidationBundle()
+	bundle := testBuilderSupervisorBundle(t)
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
 	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), "", nil, nil, nil)
@@ -241,6 +255,33 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesRuntimeStartFailure(t *te
 	}
 	if supervisor.CurrentRuntime() != nil {
 		t.Fatalf("CurrentRuntime = %p after start failure, want nil", supervisor.CurrentRuntime())
+	}
+}
+
+func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	expectedIdentity, err := runtimecontracts.BootBundleIdentity(testBuilderSupervisorBundle(t))
+	if err != nil {
+		t.Fatalf("BootBundleIdentity: %v", err)
+	}
+
+	var gotFingerprint string
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(_ context.Context, _ *config.Config, _ runtimepkg.Stores, opts runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
+		gotFingerprint = opts.BundleFingerprint
+		return &runtimepkg.Runtime{}, nil
+	})
+	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+
+	status, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	if !status.Loaded {
+		t.Fatalf("status.Loaded = false, want true")
+	}
+	if gotFingerprint != expectedIdentity.Fingerprint {
+		t.Fatalf("BundleFingerprint = %q, want %q", gotFingerprint, expectedIdentity.Fingerprint)
 	}
 }
 

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -82,6 +82,15 @@ func newServeCommand(ctx context.Context, repo string) *cobra.Command {
 		Use:   "serve",
 		Short: "Start the Swarm runtime, API, health, and MCP surfaces.",
 		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("require-bundle-match") && cmd.Flags().Changed("no-require-bundle-match") && opts.RequireBundleMatch && opts.NoRequireBundleMatch {
+				return fmt.Errorf("--require-bundle-match and --no-require-bundle-match cannot both be set")
+			}
+			if opts.NoRequireBundleMatch {
+				opts.RequireBundleMatch = false
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			code := runServeRuntime(ctx, repo, opts)
 			if code != 0 {
@@ -96,6 +105,8 @@ func newServeCommand(ctx context.Context, repo string) *cobra.Command {
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Store mode: postgres")
 	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", opts.HealthAddr, "HTTP bind address for health checks")
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
+	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs belong to a different non-NULL bundle fingerprint")
+	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs belong to a different bundle fingerprint")
 	return cmd
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -80,20 +80,23 @@ func main() {
 }
 
 type serveOptions struct {
-	ConfigPath       string
-	ContractsPath    string
-	PlatformSpecPath string
-	StoreMode        string
-	HealthAddr       string
-	SelfCheck        bool
+	ConfigPath           string
+	ContractsPath        string
+	PlatformSpecPath     string
+	StoreMode            string
+	HealthAddr           string
+	SelfCheck            bool
+	RequireBundleMatch   bool
+	NoRequireBundleMatch bool
 }
 
 func defaultServeOptions() serveOptions {
 	return serveOptions{
-		PlatformSpecPath: defaultPlatformSpecPath,
-		StoreMode:        "postgres",
-		HealthAddr:       defaultHealthAddr,
-		SelfCheck:        true,
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		HealthAddr:         defaultHealthAddr,
+		SelfCheck:          true,
+		RequireBundleMatch: true,
 	}
 }
 
@@ -138,6 +141,10 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("initialize state stores", "error", err)
 		return 1
 	}
+	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, bootBundleIdentity.Fingerprint, opts.RequireBundleMatch); err != nil {
+		slog.Error("bundle match admission failed", "error", err)
+		return 3
+	}
 	workspaces := configuredWorkspaceLifecycle(stores.SQLDB, repo, contractsRoot, source)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
@@ -175,6 +182,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		WorkspaceLifecycle: workspaces,
 		EnableToolGateway:  true,
 		ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
+		BundleFingerprint:  bootBundleIdentity.Fingerprint,
 		Credentials:        credentialStore,
 	})
 	if err != nil {
@@ -1355,6 +1363,32 @@ func buildStores(ctx context.Context, storeMode string, cfg *config.Config) (sto
 	default:
 		return storeBundle{}, fmt.Errorf("store mode %q is unsupported; postgres is required", strings.TrimSpace(storeMode))
 	}
+}
+
+func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresStore, bootFingerprint string, requireMatch bool) error {
+	bootFingerprint = strings.TrimSpace(bootFingerprint)
+	if !requireMatch {
+		log.Printf("bundle match admission disabled by --no-require-bundle-match; active run bundle fingerprints will not block startup")
+		return nil
+	}
+	if bootFingerprint == "" {
+		return fmt.Errorf("boot bundle fingerprint is required")
+	}
+	if pg == nil {
+		return nil
+	}
+	mismatches, err := pg.ActiveRunBundleMismatches(ctx, bootFingerprint)
+	if err != nil {
+		return err
+	}
+	if len(mismatches) == 0 {
+		return nil
+	}
+	details := make([]string, 0, len(mismatches))
+	for _, mismatch := range mismatches {
+		details = append(details, fmt.Sprintf("%s status=%s bundle_fingerprint=%s", mismatch.RunID, mismatch.Status, mismatch.BundleFingerprint))
+	}
+	return fmt.Errorf("active run bundle mismatch: boot bundle %s does not match %d active run(s): %s", bootFingerprint, len(mismatches), strings.Join(details, "; "))
 }
 
 func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -154,10 +154,72 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestServeBundleMatchAdmissionRejectsActiveMismatches(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	bootFingerprint := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	mismatchFingerprint := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	runID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', $2, now())
+	`, runID, mismatchFingerprint); err != nil {
+		t.Fatalf("seed active mismatched run: %v", err)
+	}
+
+	err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true)
+	if err == nil {
+		t.Fatal("enforceServeBundleMatchAdmission error = nil, want mismatch")
+	}
+	if got := err.Error(); !strings.Contains(got, "active run bundle mismatch") || !strings.Contains(got, runID) || !strings.Contains(got, mismatchFingerprint) {
+		t.Fatalf("admission error = %q, want run/fingerprint detail", got)
+	}
+}
+
+func TestServeBundleMatchAdmissionAllowsMatchingNullAndDisabled(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	bootFingerprint := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	mismatchFingerprint := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	for _, seed := range []struct {
+		runID       string
+		status      string
+		fingerprint sql.NullString
+	}{
+		{runID: uuid.NewString(), status: "running", fingerprint: sql.NullString{String: bootFingerprint, Valid: true}},
+		{runID: uuid.NewString(), status: "paused", fingerprint: sql.NullString{}},
+		{runID: uuid.NewString(), status: "completed", fingerprint: sql.NullString{String: mismatchFingerprint, Valid: true}},
+	} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+			VALUES ($1::uuid, $2, $3, now())
+		`, seed.runID, seed.status, seed.fingerprint); err != nil {
+			t.Fatalf("seed run %s: %v", seed.runID, err)
+		}
+	}
+	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true); err != nil {
+		t.Fatalf("enforceServeBundleMatchAdmission matching/null/completed: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', $2, now())
+	`, uuid.NewString(), mismatchFingerprint); err != nil {
+		t.Fatalf("seed disabled mismatch: %v", err)
+	}
+	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, false); err != nil {
+		t.Fatalf("enforceServeBundleMatchAdmission disabled: %v", err)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3413,7 +3413,7 @@ platform_tables:
         their parent via forked_from_run_id and forked_from_event_id.'
       ddl: "CREATE TABLE runs (\n    run_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    status            TEXT\
         \ NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'paused', 'completed', 'failed', 'cancelled', 'forked')),\n\
-        \    trigger_event_id  UUID,\n    trigger_event_type TEXT,\n    forked_from_run_id UUID REFERENCES runs(run_id),\n\
+        \    bundle_fingerprint TEXT,\n    trigger_event_id  UUID,\n    trigger_event_type TEXT,\n    forked_from_run_id UUID REFERENCES runs(run_id),\n\
         \    forked_from_event_id UUID,\n    entity_count      INTEGER NOT NULL DEFAULT 0,\n    event_count       INTEGER\
         \ NOT NULL DEFAULT 0,\n    error_summary     TEXT,\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n\
         \    ended_at          TIMESTAMPTZ,\n    INDEX idx_runs_status (status, started_at),\n    INDEX idx_runs_fork\
@@ -3430,6 +3430,11 @@ platform_tables:
         When a handler emits a new event, the child event inherits run_id from the parent event.
         External events (API, webhook, admin CLI) start a new run or join an existing one
         based on the ingress configuration.'
+      bundle_fingerprint: 'Optional boot bundle fingerprint pinned when the run row is first created.
+        New v1 run.start-created rows persist the orchestrator boot fingerprint after bundle_ref
+        validation. UPSERT/reopen paths must not overwrite an existing non-NULL fingerprint, but may
+        fill an unknown NULL fingerprint when a canonical boot-owned writer supplies one. Legacy NULL
+        values mean unknown bundle and are allowed by serve bundle-match admission.'
     entity_mutations:
       description: 'Append-only mutation log for entity_state changes. Every write to entity_state.fields,
         entity_state.current_state, entity_state.gates, or entity_state.accumulator produces a row.
@@ -5182,6 +5187,15 @@ cli_specification:
       command: swarm serve
       status: must_have
       behavior: starts current runtime, process probes, /v1/rpc, /v1/ws, and MCP surfaces
+      bundle_match_admission:
+        default: require-bundle-match
+        flags:
+        - --require-bundle-match
+        - --no-require-bundle-match
+        rule: After loading the boot bundle and ensuring platform schema, serve refuses startup before runtime start/readiness when
+          any active run has a non-NULL `runs.bundle_fingerprint` different from the boot bundle fingerprint. Legacy NULL fingerprints
+          mean unknown bundle and do not block startup. `--no-require-bundle-match` disables this admission gate for operator-approved
+          recovery/dev workflows.
     verify:
       command: swarm verify
       status: must_have

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimerunstart "swarm/internal/runtime/runstart"
 	"swarm/internal/store"
 )
@@ -57,6 +58,8 @@ func runStartConfigured(opts OperatorReadOptions) bool {
 }
 
 func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	bootFingerprint := strings.TrimSpace(opts.Bundle.Fingerprint)
+	ctx = runtimecorrelation.WithBundleFingerprint(ctx, bootFingerprint)
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return nil, err
@@ -69,7 +72,7 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 		TTL:            runStartIDempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		params, err := runStartParamsFromRequest(req, opts.Bundle.Fingerprint)
+		params, err := runStartParamsFromRequest(req, bootFingerprint)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -42,7 +42,7 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count = %d, want 1", count)
 	}
-	assertRunStartPersistence(t, db, runID, "scan.requested")
+	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
 	if count := countAPIIdempotencyRows(t, db); count != 1 {
 		t.Fatalf("api_idempotency rows = %d, want 1", count)
 	}
@@ -89,6 +89,24 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 	}
 }
 
+func TestOperatorRunStartHandlersPersistBootFingerprintWhenBundleRefOmitted(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := runStartTestHandler(t, pg, bus, source)
+	runID := uuid.NewString()
+
+	started := rpcCall(t, handler, runStartBodyWithoutBundle(runID, "scan.requested", `{"topic":"medicine"}`, "idem-start-no-bundle"))
+	if started.Error != nil {
+		t.Fatalf("run.start error = %#v", started.Error)
+	}
+	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
+}
+
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	t.Run("bundle mismatch", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
@@ -107,6 +125,27 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		}
 		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
 			t.Fatalf("bundle mismatch data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("invalid bundle fingerprint", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, "sha256:not-lower-64-hex", "scan.requested", `{"topic":"medicine"}`, "idem-invalid-bundle"))
+		if resp.Error == nil {
+			t.Fatal("run.start invalid bundle fingerprint error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleRefCode {
+			t.Fatalf("unsupported bundle ref data = %#v", data)
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
@@ -290,6 +329,16 @@ func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string)
 	)
 }
 
+func runStartBodyWithoutBundle(runID, eventName, payload, idempotencyKey string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		eventName,
+		payload,
+		runID,
+		idempotencyKey,
+	)
+}
+
 func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
 	t.Helper()
 	if resp.Error == nil {
@@ -303,14 +352,17 @@ func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
 	}
 }
 
-func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName string) {
+func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, bundleFingerprint string) {
 	t.Helper()
-	var runStatus, triggerType string
-	if err := db.QueryRow(`SELECT status, trigger_event_type FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType); err != nil {
+	var runStatus, triggerType, persistedFingerprint string
+	if err := db.QueryRow(`SELECT status, trigger_event_type, COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType, &persistedFingerprint); err != nil {
 		t.Fatalf("load run row: %v", err)
 	}
 	if runStatus != "running" || triggerType != eventName {
 		t.Fatalf("run row status=%q trigger=%q, want running/%s", runStatus, triggerType, eventName)
+	}
+	if persistedFingerprint != bundleFingerprint {
+		t.Fatalf("run row bundle_fingerprint=%q, want %q", persistedFingerprint, bundleFingerprint)
 	}
 	var entityID, producedBy string
 	var payload json.RawMessage

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -43,6 +43,7 @@ type EventBus struct {
 	recipientPlanGuard          PublishRecipientPlanGuard
 	runtimeIngressDispatchGate  RuntimeIngressDispatchGate
 	runDispatchGate             RunDispatchGate
+	bundleFingerprint           string
 	outboxSweeperActive         bool
 	inFlightPublishes           atomic.Int64
 }
@@ -76,6 +77,7 @@ type EventBusOptions struct {
 	RecipientPlanGuard          PublishRecipientPlanGuard
 	RuntimeIngressDispatchGate  RuntimeIngressDispatchGate
 	RunDispatchGate             RunDispatchGate
+	BundleFingerprint           string
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -142,6 +144,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		recipientPlanGuard:          opts.RecipientPlanGuard,
 		runtimeIngressDispatchGate:  opts.RuntimeIngressDispatchGate,
 		runDispatchGate:             opts.RunDispatchGate,
+		bundleFingerprint:           strings.TrimSpace(opts.BundleFingerprint),
 	}
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -131,6 +131,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
+	ctx = eb.withBundleFingerprint(ctx)
 	eb.inFlightPublishes.Add(1)
 	defer eb.inFlightPublishes.Add(-1)
 	start := time.Now()
@@ -237,6 +238,7 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
+	ctx = eb.withBundleFingerprint(ctx)
 	if tx == nil {
 		return errors.New("publish tx is required")
 	}
@@ -310,6 +312,16 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 		return fmt.Errorf("persist pipeline receipt: %w", err)
 	}
 	return nil
+}
+
+func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {
+	if ctx == nil || eb == nil {
+		return ctx
+	}
+	if runtimecorrelation.BundleFingerprintFromContext(ctx) != "" {
+		return ctx
+	}
+	return runtimecorrelation.WithBundleFingerprint(ctx, eb.bundleFingerprint)
 }
 
 func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, error) {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -933,6 +933,36 @@ func TestEventBusPublishTransactional_PersistsInboundEventBeforeInterceptorsRun(
 	}
 }
 
+func TestEventBusPublish_PersistsBootBundleFingerprintThroughRunLifecycleOwner(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	runID := uuid.NewString()
+	fingerprint := "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		BundleFingerprint: fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.Publish(context.Background(), events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("scan.requested"),
+		SourceAgent: "test",
+		CreatedAt:   time.Now().UTC(),
+		Payload:     []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	var got string
+	if err := db.QueryRowContext(context.Background(), `SELECT COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
+		t.Fatalf("load run bundle fingerprint: %v", err)
+	}
+	if got != fingerprint {
+		t.Fatalf("bundle_fingerprint = %q, want %q", got, fingerprint)
+	}
+}
+
 func TestEventBusPublishDeferred_PersistsInboundEventBeforeInterceptorsRun(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/correlation/context.go
+++ b/internal/runtime/correlation/context.go
@@ -12,6 +12,7 @@ type inboundEventContextKey struct{}
 type runIDContextKey struct{}
 type handlerIDContextKey struct{}
 type runtimeLineageContextKey struct{}
+type bundleFingerprintContextKey struct{}
 
 type RuntimeLineageRowCategory string
 
@@ -206,6 +207,25 @@ func HandlerIDFromContext(ctx context.Context) string {
 	}
 	handlerID, _ := ctx.Value(handlerIDContextKey{}).(string)
 	return strings.TrimSpace(handlerID)
+}
+
+func WithBundleFingerprint(ctx context.Context, fingerprint string) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, bundleFingerprintContextKey{}, fingerprint)
+}
+
+func BundleFingerprintFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	fingerprint, _ := ctx.Value(bundleFingerprintContextKey{}).(string)
+	return strings.TrimSpace(fingerprint)
 }
 
 func CorrelateEvent(ctx context.Context, evt events.Event) (context.Context, events.Event) {

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -14,7 +14,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
@@ -24,6 +24,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 		InterceptorProvider: interceptorProvider,
 		ContractBundle:      source,
 		PayloadValidator:    payloadValidator,
+		BundleFingerprint:   bundleFingerprint,
 	})
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,6 +64,7 @@ type RuntimeOptions struct {
 	WorkspaceLifecycle workspace.Lifecycle
 	EnableToolGateway  bool
 	ToolGatewayToken   string
+	BundleFingerprint  string
 	WorkflowModule     runtimepipeline.WorkflowModule
 	LLMRuntime         llm.Runtime
 	Credentials        runtimecredentials.Store
@@ -264,7 +265,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if binder, ok := stores.InboundStore.(eventPayloadValidationBinder); ok && binder != nil {
 		binder.SetEventPayloadValidator(payloadValidator)
 	}
-	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, func() []runtimebus.EventInterceptor {
+	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, strings.TrimSpace(opts.BundleFingerprint), func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil
 		}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -898,6 +898,7 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	}
 	opts := runLifecycleOptions(caps)
 	opts.ReopenCompleted = reopenCompleted
+	opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
 	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
 }
 
@@ -962,10 +963,11 @@ func (s *PostgresStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context
 
 func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {
 	return storerunlifecycle.EnsureActiveOptions{
-		HasStartedAtCol: caps.Events.RunStartedAt,
-		HasTriggerCols:  caps.Events.RunTriggerColumns,
-		HasCounterCols:  caps.Events.RunCounterColumns,
-		HasTerminalCols: caps.Events.RunTerminalFields,
+		HasStartedAtCol:         caps.Events.RunStartedAt,
+		HasTriggerCols:          caps.Events.RunTriggerColumns,
+		HasCounterCols:          caps.Events.RunCounterColumns,
+		HasTerminalCols:         caps.Events.RunTerminalFields,
+		HasBundleFingerprintCol: caps.Events.RunBundleFingerprint,
 	}
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -153,6 +153,15 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
 		return err
 	}
+	if catalog.hasTable("runs") && !catalog.hasColumns("runs", "bundle_fingerprint") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE runs ADD COLUMN IF NOT EXISTS bundle_fingerprint TEXT`); err != nil {
+			return fmt.Errorf("ensure runs.bundle_fingerprint column: %w", err)
+		}
+		catalog, err = loadSchemaColumnCatalog(ctx, s.DB)
+		if err != nil {
+			return err
+		}
+	}
 	if !catalog.hasTable("entity_state") {
 		return nil
 	}

--- a/internal/store/run_bundle_fingerprint.go
+++ b/internal/store/run_bundle_fingerprint.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ActiveRunBundleMismatch struct {
+	RunID             string
+	Status            string
+	BundleFingerprint string
+}
+
+func (s *PostgresStore) ActiveRunBundleMismatches(ctx context.Context, bootFingerprint string) ([]ActiveRunBundleMismatch, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	bootFingerprint = strings.TrimSpace(bootFingerprint)
+	if bootFingerprint == "" {
+		return nil, fmt.Errorf("boot bundle fingerprint is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !caps.Events.HasRuns || !caps.Events.RunBundleFingerprint {
+		return nil, nil
+	}
+	orderBy := "run_id"
+	if caps.Events.RunStartedAt {
+		orderBy = "started_at ASC, run_id"
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT run_id::text, COALESCE(status, ''), COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE lower(COALESCE(status, '')) IN ('running', 'paused')
+		  AND NULLIF(bundle_fingerprint, '') IS NOT NULL
+		  AND bundle_fingerprint <> $1
+		ORDER BY `+orderBy, bootFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("load active run bundle mismatches: %w", err)
+	}
+	defer rows.Close()
+
+	var mismatches []ActiveRunBundleMismatch
+	for rows.Next() {
+		var mismatch ActiveRunBundleMismatch
+		if err := rows.Scan(&mismatch.RunID, &mismatch.Status, &mismatch.BundleFingerprint); err != nil {
+			return nil, fmt.Errorf("scan active run bundle mismatch: %w", err)
+		}
+		mismatch.RunID = strings.TrimSpace(mismatch.RunID)
+		mismatch.Status = strings.TrimSpace(mismatch.Status)
+		mismatch.BundleFingerprint = strings.TrimSpace(mismatch.BundleFingerprint)
+		mismatches = append(mismatches, mismatch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active run bundle mismatches: %w", err)
+	}
+	return mismatches, nil
+}

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/testutil"
+)
+
+const (
+	testBootBundleFingerprint  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testOtherBundleFingerprint = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+func TestPostgresStore_RunBundleFingerprintPersistsAtRunCreationAndNeverOverwrites(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
+	runID := uuid.NewString()
+
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "scan.requested",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(first): %v", err)
+	}
+	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+
+	changedCtx := runtimecorrelation.WithBundleFingerprint(context.Background(), testOtherBundleFingerprint)
+	if err := pg.AppendEvent(changedCtx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "scan.followup",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(second): %v", err)
+	}
+	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+}
+
+func TestPostgresStore_RunBundleFingerprintAllowsUnknownLegacyRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	runID := uuid.NewString()
+
+	if err := pg.AppendEvent(context.Background(), events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "legacy.requested",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	assertRunBundleFingerprint(t, db, runID, "")
+}
+
+func TestPostgresStore_RunBundleFingerprintFillsUnknownWithoutOverwritingKnown(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed unknown run: %v", err)
+	}
+
+	bootCtx := runtimecorrelation.WithBundleFingerprint(ctx, testBootBundleFingerprint)
+	if err := pg.AppendEvent(bootCtx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "legacy.filled",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(fill): %v", err)
+	}
+	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+
+	changedCtx := runtimecorrelation.WithBundleFingerprint(ctx, testOtherBundleFingerprint)
+	if err := pg.AppendEvent(changedCtx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "legacy.followup",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(followup): %v", err)
+	}
+	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+}
+
+func TestPostgresStore_ActiveRunBundleMismatches(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	matchingRunID := uuid.NewString()
+	mismatchedRunID := uuid.NewString()
+	legacyRunID := uuid.NewString()
+	completedMismatchRunID := uuid.NewString()
+
+	for _, seed := range []struct {
+		runID       string
+		status      string
+		fingerprint sql.NullString
+	}{
+		{runID: matchingRunID, status: "running", fingerprint: sql.NullString{String: testBootBundleFingerprint, Valid: true}},
+		{runID: mismatchedRunID, status: "paused", fingerprint: sql.NullString{String: testOtherBundleFingerprint, Valid: true}},
+		{runID: legacyRunID, status: "running", fingerprint: sql.NullString{}},
+		{runID: completedMismatchRunID, status: "completed", fingerprint: sql.NullString{String: testOtherBundleFingerprint, Valid: true}},
+	} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO runs (run_id, status, bundle_fingerprint)
+			VALUES ($1::uuid, $2, $3)
+		`, seed.runID, seed.status, seed.fingerprint); err != nil {
+			t.Fatalf("seed run %s: %v", seed.runID, err)
+		}
+	}
+
+	mismatches, err := pg.ActiveRunBundleMismatches(ctx, testBootBundleFingerprint)
+	if err != nil {
+		t.Fatalf("ActiveRunBundleMismatches: %v", err)
+	}
+	if len(mismatches) != 1 {
+		t.Fatalf("mismatches = %#v, want one", mismatches)
+	}
+	if got := mismatches[0]; got.RunID != mismatchedRunID || got.Status != "paused" || got.BundleFingerprint != testOtherBundleFingerprint {
+		t.Fatalf("mismatch = %#v, want paused mismatched run", got)
+	}
+}
+
+func assertRunBundleFingerprint(t *testing.T, db *sql.DB, runID, want string) {
+	t.Helper()
+	var got sql.NullString
+	if err := db.QueryRow(`SELECT bundle_fingerprint FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
+		t.Fatalf("load run bundle fingerprint: %v", err)
+	}
+	if want == "" {
+		if got.Valid {
+			t.Fatalf("bundle_fingerprint = %q, want NULL", got.String)
+		}
+		return
+	}
+	if !got.Valid || got.String != want {
+		t.Fatalf("bundle_fingerprint = %q valid=%v, want %q", got.String, got.Valid, want)
+	}
+}

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/mutationlog"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 const (
@@ -80,6 +81,10 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 	if err := s.requireRunForkMaterializerCapabilities(ctx); err != nil {
 		return RunForkMaterialization{}, err
 	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
 	var selection *RunForkContractSelection
 	if req.ContractSelection != nil {
 		normalized, err := normalizeRunForkSelectedContractSelection(*req.ContractSelection)
@@ -129,16 +134,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 		return RunForkMaterialization{}, err
 	}
 	now := time.Now().UTC()
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO runs (
-			run_id, status, forked_from_run_id, forked_from_event_id,
-			entity_count, event_count, started_at
-		)
-		VALUES (
-			$1::uuid, $2, $3::uuid, $4::uuid,
-			$5, 0, $6
-		)
-	`, forkRunID, RunForkMaterializedStatus, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
+	if err := insertRunForkRun(ctx, tx, catalog, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("insert fork run: %w", err)
 	}
 
@@ -196,6 +192,41 @@ func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRu
 		return fmt.Errorf("check existing fork materialization: %w", err)
 	}
 	return fmt.Errorf("fork materialization already exists for source run %s at event %s: %s", sourceRunID, forkEventID, existing)
+}
+
+func insertRunForkRun(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID, sourceRunID, forkEventID string, entityCount int, startedAt time.Time) error {
+	opts := storerunlifecycle.InsertForkOptions{
+		HasBundleFingerprintCol: catalog.hasColumns("runs", "bundle_fingerprint"),
+	}
+	if catalog.hasColumns("runs", "bundle_fingerprint") {
+		fingerprint, err := runForkBundleFingerprintForInsert(ctx, tx, sourceRunID)
+		if err != nil {
+			return err
+		}
+		opts.BundleFingerprint = fingerprint
+	}
+	return storerunlifecycle.InsertFork(ctx, tx, forkRunID, RunForkMaterializedStatus, sourceRunID, forkEventID, entityCount, startedAt, opts)
+}
+
+func runForkBundleFingerprintForInsert(ctx context.Context, tx *sql.Tx, sourceRunID string) (string, error) {
+	if fingerprint := runtimecorrelation.BundleFingerprintFromContext(ctx); fingerprint != "" {
+		return fingerprint, nil
+	}
+	var source sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT bundle_fingerprint
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, sourceRunID).Scan(&source); err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("source run %s not found", sourceRunID)
+		}
+		return "", fmt.Errorf("load source run bundle fingerprint: %w", err)
+	}
+	if !source.Valid {
+		return "", nil
+	}
+	return strings.TrimSpace(source.String), nil
 }
 
 func loadRunForkEntityMetadata(plan RunForkPlan) (map[string]runForkEntityMetadata, error) {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -29,8 +29,8 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	fieldOnlyAt := at.Add(30 * time.Second)
 	afterAt := at.Add(time.Minute)
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES ($1::uuid, 'running', $2)
+		INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', 'bundle-source-fingerprint', $2)
 	`, sourceRunID, at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed source run: %v", err)
 	}
@@ -102,16 +102,19 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		)
 	}
 
-	var forkStatus, forkedFromRun, forkedFromEvent string
+	var forkStatus, forkedFromRun, forkedFromEvent, forkBundleFingerprint string
 	if err := db.QueryRowContext(ctx, `
-		SELECT status, forked_from_run_id::text, forked_from_event_id::text
+		SELECT status, forked_from_run_id::text, forked_from_event_id::text, COALESCE(bundle_fingerprint, '')
 		FROM runs
 		WHERE run_id = $1::uuid
-	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent); err != nil {
+	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent, &forkBundleFingerprint); err != nil {
 		t.Fatalf("load fork run: %v", err)
 	}
 	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != secondEventID {
 		t.Fatalf("fork run = status:%s from:%s event:%s", forkStatus, forkedFromRun, forkedFromEvent)
+	}
+	if forkBundleFingerprint != "bundle-source-fingerprint" {
+		t.Fatalf("fork bundle_fingerprint = %q, want source fingerprint", forkBundleFingerprint)
 	}
 	var sourceStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -207,16 +207,7 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		return RunForkMaterialization{}, err
 	}
 	now := time.Now().UTC()
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO runs (
-			run_id, status, forked_from_run_id, forked_from_event_id,
-			entity_count, event_count, started_at
-		)
-		VALUES (
-			$1::uuid, $2, $3::uuid, $4::uuid,
-			$5, 0, $6
-		)
-	`, forkRunID, RunForkMaterializedStatus, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
+	if err := insertRunForkRun(ctx, tx, catalog, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID, len(plan.Entities), now); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("insert selected-contract fork run: %w", err)
 	}
 

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -20,6 +20,13 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	eventID := uuid.NewString()
 	at := time.Unix(1700002400, 0).UTC()
 	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET bundle_fingerprint = 'selected-source-fingerprint'
+		WHERE run_id = $1::uuid
+	`, sourceRunID); err != nil {
+		t.Fatalf("seed source bundle fingerprint: %v", err)
+	}
 
 	_, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
@@ -41,6 +48,17 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	}
 	if materialized.ForkRunID == "" || materialized.SelectedContractBinding == nil || !materialized.DeliveryResumeBlocked {
 		t.Fatalf("materialization = %#v", materialized)
+	}
+	var forkBundleFingerprint string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&forkBundleFingerprint); err != nil {
+		t.Fatalf("load selected fork bundle fingerprint: %v", err)
+	}
+	if forkBundleFingerprint != "selected-source-fingerprint" {
+		t.Fatalf("selected fork bundle_fingerprint = %q, want source fingerprint", forkBundleFingerprint)
 	}
 	var replayRows int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, materialized.ForkRunID).Scan(&replayRows); err != nil {

--- a/internal/store/runlifecycle/fork.go
+++ b/internal/store/runlifecycle/fork.go
@@ -1,0 +1,57 @@
+package runlifecycle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type InsertForkOptions struct {
+	HasBundleFingerprintCol bool
+	BundleFingerprint       string
+}
+
+func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, forkEventID string, entityCount int, startedAt time.Time, opts InsertForkOptions) error {
+	if db == nil {
+		return fmt.Errorf("run lifecycle database is required")
+	}
+	forkRunID = strings.TrimSpace(forkRunID)
+	status = strings.TrimSpace(status)
+	sourceRunID = strings.TrimSpace(sourceRunID)
+	forkEventID = strings.TrimSpace(forkEventID)
+	if forkRunID == "" {
+		return fmt.Errorf("fork run_id is required")
+	}
+	if status == "" {
+		return fmt.Errorf("fork run status is required")
+	}
+	if sourceRunID == "" {
+		return fmt.Errorf("source run_id is required")
+	}
+	if forkEventID == "" {
+		return fmt.Errorf("fork event_id is required")
+	}
+
+	cols := []string{
+		"run_id",
+		"status",
+		"forked_from_run_id",
+		"forked_from_event_id",
+		"entity_count",
+		"event_count",
+		"started_at",
+	}
+	values := []string{"$1::uuid", "$2", "$3::uuid", "$4::uuid", "$5", "0", "$6"}
+	args := []any{forkRunID, status, sourceRunID, forkEventID, entityCount, startedAt}
+	if opts.HasBundleFingerprintCol {
+		args = append(args, strings.TrimSpace(opts.BundleFingerprint))
+		cols = append(cols, "bundle_fingerprint")
+		values = append(values, fmt.Sprintf("NULLIF($%d, '')", len(args)))
+	}
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO runs (`+strings.Join(cols, ", ")+`)
+		VALUES (`+strings.Join(values, ", ")+`)
+	`, args...)
+	return err
+}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -24,11 +24,13 @@ type Snapshot struct {
 }
 
 type EnsureActiveOptions struct {
-	ReopenCompleted bool
-	HasStartedAtCol bool
-	HasTriggerCols  bool
-	HasCounterCols  bool
-	HasTerminalCols bool
+	ReopenCompleted         bool
+	HasStartedAtCol         bool
+	HasTriggerCols          bool
+	HasCounterCols          bool
+	HasTerminalCols         bool
+	HasBundleFingerprintCol bool
+	BundleFingerprint       string
 }
 
 func CanonicalTerminalStatus(raw string) (string, error) {
@@ -56,6 +58,7 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	}
 	triggerEventID = strings.TrimSpace(triggerEventID)
 	triggerEventType = strings.TrimSpace(triggerEventType)
+	bundleFingerprint := strings.TrimSpace(opts.BundleFingerprint)
 	reopenStatus := "runs.status"
 	reopenErrorSummary := ""
 	reopenEndedAt := ""
@@ -69,15 +72,28 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 		reopenErrorSummary = "runs.error_summary"
 		reopenEndedAt = "runs.ended_at"
 	}
-	insertCols := "run_id, status"
-	insertVals := "$1::uuid, 'running'"
+	insertCols := []string{"run_id", "status"}
+	insertVals := []string{"$1::uuid", "'running'"}
+	args := []any{runID}
+	addParam := func(col, expr string, value any) {
+		args = append(args, value)
+		insertCols = append(insertCols, col)
+		insertVals = append(insertVals, fmt.Sprintf(expr, len(args)))
+	}
+	if opts.HasTriggerCols {
+		addParam("trigger_event_id", "NULLIF($%d,'')::uuid", triggerEventID)
+		addParam("trigger_event_type", "NULLIF($%d,'')", triggerEventType)
+	}
+	if opts.HasBundleFingerprintCol {
+		addParam("bundle_fingerprint", "NULLIF($%d,'')", bundleFingerprint)
+	}
 	if opts.HasStartedAtCol {
-		insertCols += ", started_at"
-		insertVals += ", now()"
+		insertCols = append(insertCols, "started_at")
+		insertVals = append(insertVals, "now()")
 	}
 	query := `
-		INSERT INTO runs (` + insertCols + `)
-		VALUES (` + insertVals + `)
+		INSERT INTO runs (` + strings.Join(insertCols, ", ") + `)
+		VALUES (` + strings.Join(insertVals, ", ") + `)
 		ON CONFLICT (run_id) DO UPDATE SET
 			status = ` + reopenStatus
 	if opts.HasTerminalCols {
@@ -85,34 +101,14 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 			error_summary = ` + reopenErrorSummary + `,
 			ended_at = ` + reopenEndedAt
 	}
-	args := []any{runID}
+	if opts.HasBundleFingerprintCol {
+		query += `,
+			bundle_fingerprint = COALESCE(runs.bundle_fingerprint, EXCLUDED.bundle_fingerprint)`
+	}
 	if opts.HasTriggerCols {
-		query = `
-		INSERT INTO runs (
-			run_id, status, trigger_event_id, trigger_event_type`
-		if opts.HasStartedAtCol {
-			query += `, started_at`
-		}
-		query += `
-		)
-		VALUES (
-			$1::uuid, 'running', NULLIF($2,'')::uuid, NULLIF($3,'')`
-		if opts.HasStartedAtCol {
-			query += `, now()`
-		}
-		query += `
-		)
-		ON CONFLICT (run_id) DO UPDATE SET
-			status = ` + reopenStatus
-		if opts.HasTerminalCols {
-			query += `,
-			error_summary = ` + reopenErrorSummary + `,
-			ended_at = ` + reopenEndedAt
-		}
 		query += `,
 			trigger_event_id = COALESCE(runs.trigger_event_id, NULLIF($2,'')::uuid),
 			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))`
-		args = append(args, triggerEventID, triggerEventType)
 	}
 	_, err := db.ExecContext(ctx, query, args...)
 	if err != nil {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -17,17 +17,18 @@ const (
 )
 
 type EventSchemaCapabilities struct {
-	Log               SchemaFlavor
-	Deliveries        SchemaFlavor
-	Receipts          SchemaFlavor
-	HasRuns           bool
-	RunStartedAt      bool
-	RunTriggerColumns bool
-	RunCounterColumns bool
-	RunTerminalFields bool
-	LogRunID          bool
-	DeliveryRunID     bool
-	LogIdempotencyKey bool
+	Log                  SchemaFlavor
+	Deliveries           SchemaFlavor
+	Receipts             SchemaFlavor
+	HasRuns              bool
+	RunStartedAt         bool
+	RunTriggerColumns    bool
+	RunCounterColumns    bool
+	RunTerminalFields    bool
+	RunBundleFingerprint bool
+	LogRunID             bool
+	DeliveryRunID        bool
+	LogIdempotencyKey    bool
 }
 
 type ConversationSchemaCapabilities struct {
@@ -172,14 +173,15 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 			},
 			[]string{"event_id", "agent_id", "processed_at", "status", "retry_count", "error"},
 		),
-		HasRuns:           catalog.hasColumns("runs", "run_id", "status"),
-		RunStartedAt:      catalog.hasColumns("runs", "started_at"),
-		RunTriggerColumns: catalog.hasColumns("runs", "trigger_event_id", "trigger_event_type"),
-		RunCounterColumns: catalog.hasColumns("runs", "event_count", "entity_count"),
-		RunTerminalFields: catalog.hasColumns("runs", "error_summary", "ended_at"),
-		LogRunID:          catalog.hasColumns("events", "run_id"),
-		DeliveryRunID:     catalog.hasColumns("event_deliveries", "run_id"),
-		LogIdempotencyKey: catalog.hasColumns("events", "idempotency_key"),
+		HasRuns:              catalog.hasColumns("runs", "run_id", "status"),
+		RunStartedAt:         catalog.hasColumns("runs", "started_at"),
+		RunTriggerColumns:    catalog.hasColumns("runs", "trigger_event_id", "trigger_event_type"),
+		RunCounterColumns:    catalog.hasColumns("runs", "event_count", "entity_count"),
+		RunTerminalFields:    catalog.hasColumns("runs", "error_summary", "ended_at"),
+		RunBundleFingerprint: catalog.hasColumns("runs", "bundle_fingerprint"),
+		LogRunID:             catalog.hasColumns("events", "run_id"),
+		DeliveryRunID:        catalog.hasColumns("event_deliveries", "run_id"),
+		LogIdempotencyKey:    catalog.hasColumns("events", "idempotency_key"),
 	}
 
 	caps.Conversations = ConversationSchemaCapabilities{

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -21,7 +21,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		}
 	}
 
-	addColumns("runs", "run_id", "status")
+	addColumns("runs", "run_id", "status", "bundle_fingerprint")
 	addColumns("agents",
 		"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
 		"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
@@ -84,7 +84,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	if caps.Agents != SchemaFlavorCanonical {
 		t.Fatalf("agents flavor = %s", caps.Agents)
 	}
-	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey {
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey || !caps.Events.RunBundleFingerprint {
 		t.Fatalf("events caps = %+v", caps.Events)
 	}
 	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -177,6 +177,37 @@ func TestPlatformSpecEntityStateUsesRunScopedIdentity(t *testing.T) {
 	}
 }
 
+func TestPlatformSpecRunsOwnsBundleFingerprint(t *testing.T) {
+	_, file, _, _ := stdruntime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	var runs SchemaTableDDL
+	for _, plan := range plans {
+		if plan.TableName == "runs" {
+			runs = plan
+			break
+		}
+	}
+	if runs.TableName == "" {
+		t.Fatal("runs ddl plan missing")
+	}
+	joined := strings.Join(runs.Statements, "\n")
+	if !strings.Contains(joined, "bundle_fingerprint TEXT") {
+		t.Fatalf("runs ddl missing bundle_fingerprint:\n%s", joined)
+	}
+}
+
 func TestGeneratePlatformTableDDLs_StripsDeprecatedEntitySubjectDDL(t *testing.T) {
 	var spec runtimecontracts.PlatformSpecDocument
 	spec.PlatformTables.Tables = map[string]struct {


### PR DESCRIPTION
## Summary

Closes #753
Part of #750

Implements the approved first-slice boundary only: persisted run bundle fingerprint ownership plus `swarm serve` bundle-match admission. This does not implement `--dev`, `--abandon-active-runs`, `--shutdown-grace`, extended `platform.boot`, directive targeting, `platform.agent_directive`, `AMBIGUOUS_RUN_TARGET`, or `runtime.nuke`.

## Governing refs / context

- #750 pre-audit: https://github.com/yazzaoui/Swarm/issues/750#issuecomment-4446508574
- #750 independent gate: https://github.com/yazzaoui/Swarm/issues/750#issuecomment-4446549261
- #753 child tracker: https://github.com/yazzaoui/Swarm/issues/753
- Authoritative spec updated: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `platform_tables.runs.ddl` now includes `bundle_fingerprint`.
  - `platform_tables.runs.bundle_fingerprint` defines persistence and non-overwrite semantics.
  - `cli_specification.command_catalog.serve.bundle_match_admission` defines default require-match behavior and the two supported flags.

## Semantic migration

- New canonical persisted owner: `runs.bundle_fingerprint`, written through `internal/store/runlifecycle.EnsureActive` for active run rows and `internal/store/runlifecycle.InsertFork` for fork materialization rows.
- New boot identity propagation: `runtimecorrelation.WithBundleFingerprint`, `RuntimeOptions.BundleFingerprint`, and `runtimebus.EventBusOptions.BundleFingerprint` carry the boot fingerprint into event/run persistence.
- Old producer/reader/writer path now invalid: handler-only `run.start` bundle validation without persisted run fingerprint; run-row creation that inserts active/fork rows without the lifecycle bundle owner.
- Production paths checked for surviving old behavior: `run.start`, EventBus `Publish`/`PublishTx`, store `ensureRunRow` consumers (`events`, `inbound`, `llm_store`), fork materialization, serve startup, Builder project reload runtime construction, `scripts/run_clear.sh`, and production route registrations.
- Migration completeness: complete for the approved #753 class. Parent #750 siblings remain open by gate decision.

## Proof

- `go test ./cmd/swarm -run 'TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime|TestRuntimeProjectSupervisorLoadProject|TestCLI_ServeOwnsRuntimeStartupFlags|TestServeBundleMatchAdmission' -count=1`
- `go test ./internal/store -run 'TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming|TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFrontier|TestPostgresStore_RunBundleFingerprint|TestPostgresStore_ActiveRunBundleMismatches|TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants|TestPlatformSpecRunsOwnsBundleFingerprint' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorRunStartHandlers|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusPublish_PersistsBootBundleFingerprintThroughRunLifecycleOwner' -count=1`
- `go test ./cmd/swarm -run 'TestCLI_ServeOwnsRuntimeStartupFlags|TestServeBundleMatchAdmission' -count=1`
- `go test ./internal/store ./internal/apiv1 ./internal/runtime/bus ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./... -count=1`
- Grep proof run: `rg -n "INSERT INTO runs|EnsureActive\(|InsertFork\(|ensureRunRow\(|/api/rpc|/rpc|/api/ws|/ws" internal cmd scripts -g '*.go' -g '*.sh' -g '!**/*_test.go'`
  - Production run-row inserts are confined to `internal/store/runlifecycle` owner functions plus the non-production `internal/runtime/cataloge2e/runtime_harness.go` test harness.
  - Production served operator routes remain `/v1/rpc` and `/v1/ws`; `scripts/run_clear.sh` uses `/v1/rpc`.