### PR TITLE
[agent-b][issue #755] Add directive run targeting

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -328,5 +328,8 @@ func (c dashboardDynamicAgentControl) SendDirective(ctx context.Context, req run
 	if rt == nil || rt.Manager == nil {
 		return runtimeagentcontrol.SendDirectiveResult{}, fmt.Errorf("runtime manager unavailable")
 	}
+	if req.Source == "" {
+		req.Source = runtimeagentcontrol.DirectiveSourceBuilderRuntime
+	}
 	return rt.Manager.SendDirective(ctx, req)
 }

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -293,7 +293,9 @@ func (builderControlTestAgent) Subscriptions() []events.EventType { return nil }
 func (builderControlTestAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
 	return nil, nil
 }
-func (builderControlTestAgent) BoardStep(context.Context, string) (string, error) { return "ok", nil }
+func (builderControlTestAgent) BoardStep(context.Context, runtimeagentcontrol.BoardDirective) (string, error) {
+	return "ok", nil
+}
 
 func TestDashboardDynamicAgentControl_DeniesWhenRuntimeShutdownAdmissionClosed(t *testing.T) {
 	agent := builderControlTestAgent{id: "agent-1"}

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -192,7 +192,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -318,7 +318,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -380,7 +380,7 @@
     },
     {
       "name": "agent.send_directive",
-      "description": "Send a directive (free-form instruction) to a running agent. Optionally kills the previous turn first.",
+      "description": "Send a directive (free-form instruction) to a running agent. The runtime resolves the target run before execution: explicit run_id targets an existing nonterminal run; with no run_id, zero active sessions allocate a new run_id, one active session uses that session's run_id, and multiple active sessions fail closed with AMBIGUOUS_RUN_TARGET. The runtime persists platform.agent_directive before BoardStep and all child emissions inherit the resolved run_id.",
       "params": [
         {
           "name": "agent_id",
@@ -398,8 +398,17 @@
           }
         },
         {
+          "name": "run_id",
+          "required": false,
+          "description": "Optional explicit nonterminal run target. If omitted, the runtime resolves from active sessions or allocates a new run_id.",
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
           "name": "kill_previous",
           "required": false,
+          "description": "Legacy turn-cancellation flag. It is evaluated only after run target validation succeeds; explicit run_id plus kill_previous is fail-closed if it would create dual target semantics.",
           "schema": {
             "default": false,
             "type": "boolean"
@@ -419,6 +428,13 @@
         "schema": {
           "additionalProperties": false,
           "properties": {
+            "directive_event_id": {
+              "$ref": "#/components/schemas/OpaqueId"
+            },
+            "directive_event_type": {
+              "const": "platform.agent_directive",
+              "type": "string"
+            },
             "ok": {
               "const": true,
               "type": "boolean"
@@ -426,10 +442,25 @@
             "response": {
               "description": "Optional acknowledgement or error from the agent.",
               "type": "string"
+            },
+            "run_id": {
+              "$ref": "#/components/schemas/OpaqueId"
+            },
+            "run_id_resolution": {
+              "enum": [
+                "specified",
+                "inferred_from_active_session",
+                "new_run_allocated"
+              ],
+              "type": "string"
             }
           },
           "required": [
-            "ok"
+            "ok",
+            "run_id",
+            "run_id_resolution",
+            "directive_event_id",
+            "directive_event_type"
           ],
           "type": "object"
         }
@@ -516,7 +547,148 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32018,
+          "message": "Application error: RUN_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "RUN_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "run_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32017,
+          "message": "Application error: RUN_ALREADY_TERMINAL",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "RUN_ALREADY_TERMINAL",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "current_status": {
+                    "$ref": "#/components/schemas/RunStatus"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "run_id",
+                  "current_status"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32002,
+          "message": "Application error: AMBIGUOUS_RUN_TARGET",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "AMBIGUOUS_RUN_TARGET",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "active_sessions": {
+                    "description": "Active sessions that prevent implicit target resolution. A session without run_id is reported without a run_id field and still fail-closes implicit resolution.",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "run_id": {
+                          "$ref": "#/components/schemas/OpaqueId"
+                        },
+                        "session_id": {
+                          "$ref": "#/components/schemas/OpaqueId"
+                        }
+                      },
+                      "required": [
+                        "session_id"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "agent_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId",
+                    "description": "Present when ambiguity was caused by an explicit run target combined with incompatible legacy targeting flags."
+                  }
+                },
+                "required": [
+                  "agent_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -665,7 +837,7 @@
       },
       "errors": [
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -828,7 +1000,7 @@
       },
       "errors": [
         {
-          "code": -32003,
+          "code": -32004,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -961,7 +1133,7 @@
       },
       "errors": [
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1181,7 +1353,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1219,7 +1391,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -1271,7 +1443,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -1313,7 +1485,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1408,7 +1580,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1446,7 +1618,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -1498,7 +1670,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -1543,7 +1715,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1624,7 +1796,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1779,7 +1951,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1817,7 +1989,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -1869,7 +2041,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1977,7 +2149,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2015,7 +2187,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2057,7 +2229,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2138,7 +2310,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2207,7 +2379,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2340,7 +2512,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2378,7 +2550,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2420,7 +2592,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -2458,7 +2630,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2582,7 +2754,7 @@
       },
       "errors": [
         {
-          "code": -32002,
+          "code": -32003,
           "message": "Application error: BUNDLE_MISMATCH",
           "data": {
             "additionalProperties": false,
@@ -2624,7 +2796,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2659,7 +2831,7 @@
           }
         },
         {
-          "code": -32004,
+          "code": -32005,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -2703,7 +2875,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2761,7 +2933,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2849,7 +3021,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2887,7 +3059,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2929,7 +3101,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3018,7 +3190,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3095,7 +3267,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3330,7 +3502,7 @@
       },
       "errors": [
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3361,7 +3533,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3442,7 +3614,7 @@
       },
       "errors": [
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3473,7 +3645,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4871,8 +5043,69 @@
           "type": "object"
         }
       },
-      "BUNDLE_MISMATCH": {
+      "AMBIGUOUS_RUN_TARGET": {
         "code": -32002,
+        "message": "Application error: AMBIGUOUS_RUN_TARGET",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "AMBIGUOUS_RUN_TARGET",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "active_sessions": {
+                  "description": "Active sessions that prevent implicit target resolution. A session without run_id is reported without a run_id field and still fail-closes implicit resolution.",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "run_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      },
+                      "session_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "session_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "agent_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                },
+                "run_id": {
+                  "$ref": "#/components/schemas/OpaqueId",
+                  "description": "Present when ambiguity was caused by an explicit run target combined with incompatible legacy targeting flags."
+                }
+              },
+              "required": [
+                "agent_id"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "BUNDLE_MISMATCH": {
+        "code": -32003,
         "message": "Application error: BUNDLE_MISMATCH",
         "data": {
           "additionalProperties": false,
@@ -4914,7 +5147,7 @@
         }
       },
       "ENTITY_NOT_FOUND": {
-        "code": -32003,
+        "code": -32004,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -4952,7 +5185,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32004,
+        "code": -32005,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -4996,7 +5229,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32005,
+        "code": -32006,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5034,7 +5267,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32006,
+        "code": -32007,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -5093,7 +5326,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32007,
+        "code": -32008,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -5138,7 +5371,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -5190,7 +5423,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -5232,7 +5465,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5270,7 +5503,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -5308,7 +5541,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -5366,7 +5599,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5397,7 +5630,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5428,7 +5661,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5466,7 +5699,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -5508,7 +5741,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5546,7 +5779,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -5588,7 +5821,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -5626,7 +5859,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4542,6 +4542,7 @@ platform_events:
         agent_id: string
         directive_text: string
         kill_previous: boolean
+        mode: string (directive)
         run_id: string
         run_id_resolution: string (specified | inferred_from_active_session | new_run_allocated)
         source: string

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4533,6 +4533,21 @@ platform_events:
         resumed_by: string
         timestamp: string (ISO 8601)
       produced_by_type: platform
+    platform.agent_directive:
+      description: Operator-issued directive accepted by the runtime for an agent. This is the authoritative persisted root
+        event for directive-started or directive-targeted work; BoardStep and all child emissions inherit this event's run_id
+        and source_event_id. It is persisted before agent execution and is not defined by the legacy board.directive helper.
+      scope: global
+      payload:
+        agent_id: string
+        directive_text: string
+        kill_previous: boolean
+        run_id: string
+        run_id_resolution: string (specified | inferred_from_active_session | new_run_allocated)
+        source: string
+        operator_id: string (nullable)
+        timestamp: string (ISO 8601)
+      produced_by_type: platform
     platform.agent_started:
       description: Agent session created and ready to process events.
       scope: flow
@@ -4580,9 +4595,9 @@ platform_events:
       platform.paused, platform.resumed, platform.boot, platform.recovery_failed, platform.agent_started, platform.budget_threshold_crossed.
       Products can subscribe to these.'
     diagnostic_events: 'Platform events that bypass the event loop and are persisted directly to the events table:
-      platform.runtime_log, platform.inbound_recorded. These are high-frequency diagnostic records. Routing them through the
-      event loop would cause recursive emission loops (a runtime_log about routing generates another runtime_log). They are
-      persisted for queryability but not routed to subscribers.'
+      platform.runtime_log, platform.inbound_recorded, platform.agent_directive. These are high-frequency diagnostic records
+      or operator-control root records. Routing them through the event loop would cause recursive emission loops or duplicate
+      control execution. They are persisted for queryability and causality but not routed to subscribers.'
   go_source_rule:
     description: Every hardcoded event name in Go runtime source must appear in this catalog. CI should enforce this — grep
       Go source for event name literals, verify each exists in platform_events.catalog or is a product event loaded from contracts.
@@ -6752,6 +6767,32 @@ api_specification:
             $ref: '#/components/schemas/OpaqueId'
           current_status:
             $ref: '#/components/schemas/RunStatus'
+      AMBIGUOUS_RUN_TARGET:
+        type: object
+        additionalProperties: false
+        required:
+        - agent_id
+        properties:
+          agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Present when ambiguity was caused by an explicit run target combined with incompatible legacy targeting
+              flags.
+          active_sessions:
+            type: array
+            description: Active sessions that prevent implicit target resolution. A session without run_id is reported without
+              a run_id field and still fail-closes implicit resolution.
+            items:
+              type: object
+              additionalProperties: false
+              required:
+              - session_id
+              properties:
+                session_id:
+                  $ref: '#/components/schemas/OpaqueId'
+                run_id:
+                  $ref: '#/components/schemas/OpaqueId'
       RUN_NOT_PAUSED:
         type: object
         additionalProperties: false
@@ -7679,7 +7720,10 @@ api_specification:
       - AGENT_NOT_FOUND
     agent.send_directive:
       tier: should_have
-      description: Send a directive (free-form instruction) to a running agent. Optionally kills the previous turn first.
+      description: "Send a directive (free-form instruction) to a running agent. The runtime resolves the target run before\
+        \ execution: explicit run_id targets an existing nonterminal run; with no run_id, zero active sessions allocate a\
+        \ new run_id, one active session uses that session's run_id, and multiple active sessions fail closed with AMBIGUOUS_RUN_TARGET.\
+        \ The runtime persists platform.agent_directive before BoardStep and all child emissions inherit the resolved run_id."
       scope:
         required:
         - control:agents
@@ -7694,11 +7738,19 @@ api_specification:
         schema:
           type: string
           minLength: 1
+      - name: run_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+        description: Optional explicit nonterminal run target. If omitted, the runtime resolves from active sessions or allocates
+          a new run_id.
       - name: kill_previous
         required: false
         schema:
           type: boolean
           default: false
+        description: Legacy turn-cancellation flag. It is evaluated only after run target validation succeeds; explicit run_id
+          plus kill_previous is fail-closed if it would create dual target semantics.
       - name: idempotency_key
         required: false
         schema:
@@ -7711,6 +7763,10 @@ api_specification:
           additionalProperties: false
           required:
           - ok
+          - run_id
+          - run_id_resolution
+          - directive_event_id
+          - directive_event_type
           properties:
             ok:
               type: boolean
@@ -7718,9 +7774,25 @@ api_specification:
             response:
               type: string
               description: Optional acknowledgement or error from the agent.
+            run_id:
+              $ref: '#/components/schemas/OpaqueId'
+            run_id_resolution:
+              type: string
+              enum:
+              - specified
+              - inferred_from_active_session
+              - new_run_allocated
+            directive_event_id:
+              $ref: '#/components/schemas/OpaqueId'
+            directive_event_type:
+              type: string
+              const: platform.agent_directive
       errors:
       - AGENT_NOT_FOUND
       - AGENT_NOT_RUNNING
+      - RUN_NOT_FOUND
+      - RUN_ALREADY_TERMINAL
+      - AMBIGUOUS_RUN_TARGET
       - IDEMPOTENCY_CONFLICT
     agent.restart:
       tier: should_have

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -22,8 +22,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 49 {
 		t.Fatalf("schema count = %d, want 49", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 21 {
-		t.Fatalf("error code count = %d, want 21", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 22 {
+		t.Fatalf("error code count = %d, want 22", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 12 {
 		t.Fatalf("mutating method count = %d, want 12", report.MutatingMethodCount)
@@ -67,8 +67,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 49 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 49", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 21 {
-		t.Fatalf("generated OpenRPC errors = %d, want 21", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 22 {
+		t.Fatalf("generated OpenRPC errors = %d, want 22", len(doc.Components.Errors))
 	}
 }
 

--- a/internal/apiv1/operator_agent_control.go
+++ b/internal/apiv1/operator_agent_control.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
@@ -18,8 +19,12 @@ type AgentControlController interface {
 }
 
 type agentDirectiveResult struct {
-	OK       bool   `json:"ok"`
-	Response string `json:"response,omitempty"`
+	OK                 bool   `json:"ok"`
+	Response           string `json:"response,omitempty"`
+	RunID              string `json:"run_id"`
+	RunIDResolution    string `json:"run_id_resolution"`
+	DirectiveEventID   string `json:"directive_event_id"`
+	DirectiveEventType string `json:"directive_event_type"`
 }
 
 type agentReplayBacklogResult struct {
@@ -61,6 +66,10 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 	if err != nil {
 		return nil, err
 	}
+	runID, _, err := optionalStringParam(req.Params, "run_id")
+	if err != nil {
+		return nil, err
+	}
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return nil, err
@@ -78,11 +87,21 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 			AgentID:      agentID,
 			Directive:    directive,
 			KillPrevious: killPrevious,
+			RunID:        runID,
+			Source:       runtimeagentcontrol.DirectiveSourceV1RPC,
+			OperatorID:   req.ActorTokenID,
 		})
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, agentControlError(req.Method, agentID, err)
 		}
-		response, err := json.Marshal(agentDirectiveResult{OK: true, Response: result.Response})
+		response, err := json.Marshal(agentDirectiveResult{
+			OK:                 true,
+			Response:           result.Response,
+			RunID:              result.RunID,
+			RunIDResolution:    result.RunIDResolution,
+			DirectiveEventID:   result.DirectiveEventID,
+			DirectiveEventType: result.DirectiveEventType,
+		})
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
@@ -220,6 +239,22 @@ func agentControlError(method, agentID string, err error) error {
 				"agent_id":       agentID,
 				"current_status": stateErr.CurrentStatus,
 			})
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrRunNotFound) && method == "agent.send_directive":
+			return NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": stateErr.RunID})
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrRunAlreadyTerminal) && method == "agent.send_directive":
+			return NewApplicationError(RunAlreadyTerminalCode, false, map[string]any{
+				"run_id":         stateErr.RunID,
+				"current_status": stateErr.CurrentStatus,
+			})
+		case errors.Is(stateErr.Err, runtimeagentcontrol.ErrAmbiguousRunTarget) && method == "agent.send_directive":
+			details := map[string]any{
+				"agent_id":        agentID,
+				"active_sessions": activeSessionDetails(stateErr.ActiveSessions),
+			}
+			if runID := strings.TrimSpace(stateErr.RunID); runID != "" {
+				details["run_id"] = runID
+			}
+			return NewApplicationError(AmbiguousRunTargetCode, false, details)
 		}
 	}
 	switch {
@@ -230,7 +265,30 @@ func agentControlError(method, agentID string, err error) error {
 			"agent_id":       agentID,
 			"current_status": runtimeagentcontrol.StatusTerminated,
 		})
+	case errors.Is(err, runtimeagentcontrol.ErrRunNotFound) && method == "agent.send_directive":
+		return NewApplicationError(RunNotFoundCode, false, nil)
+	case errors.Is(err, runtimeagentcontrol.ErrRunAlreadyTerminal) && method == "agent.send_directive":
+		return NewApplicationError(RunAlreadyTerminalCode, false, nil)
+	case errors.Is(err, runtimeagentcontrol.ErrAmbiguousRunTarget) && method == "agent.send_directive":
+		return NewApplicationError(AmbiguousRunTargetCode, false, map[string]any{"agent_id": agentID})
 	default:
 		return err
 	}
+}
+
+func activeSessionDetails(sessions []runtimeagentcontrol.ActiveSessionTarget) []map[string]any {
+	out := make([]map[string]any, 0, len(sessions))
+	for _, session := range sessions {
+		item := map[string]any{}
+		if sessionID := strings.TrimSpace(session.SessionID); sessionID != "" {
+			item["session_id"] = sessionID
+		}
+		if runID := strings.TrimSpace(session.RunID); runID != "" {
+			item["run_id"] = runID
+		}
+		if len(item) > 0 {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -2,11 +2,16 @@ package apiv1
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
 
+	"swarm/internal/events"
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
 )
@@ -28,15 +33,16 @@ func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.
 		}),
 	})
 
-	directiveBody := agentDirectiveBody("agent-1", "run corpus", true, "idem-directive")
+	directiveRunID := "00000000-0000-0000-0000-000000000901"
+	directiveBody := agentDirectiveBodyWithRun("agent-1", directiveRunID, "run corpus", true, "idem-directive")
 	directive := rpcCall(t, handler, directiveBody)
 	if directive.Error != nil {
 		t.Fatalf("agent.send_directive error = %#v", directive.Error)
 	}
-	if result := asMap(t, directive.Result); result["ok"] != true || result["response"] != "accepted" {
+	if result := asMap(t, directive.Result); result["ok"] != true || result["response"] != "accepted" || result["run_id"] != directiveRunID || result["run_id_resolution"] != runtimeagentcontrol.RunResolutionSpecified {
 		t.Fatalf("agent.send_directive result = %#v", result)
 	}
-	if controller.directiveCalls != 1 || !controller.lastDirective.KillPrevious || controller.lastDirective.Directive != "run corpus" {
+	if controller.directiveCalls != 1 || !controller.lastDirective.KillPrevious || controller.lastDirective.Directive != "run corpus" || controller.lastDirective.RunID != directiveRunID || controller.lastDirective.Source != runtimeagentcontrol.DirectiveSourceV1RPC {
 		t.Fatalf("directive call count/request = %d/%#v, want owner request", controller.directiveCalls, controller.lastDirective)
 	}
 	directiveReplay := rpcCall(t, handler, directiveBody)
@@ -46,7 +52,7 @@ func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.
 	if controller.directiveCalls != 1 {
 		t.Fatalf("directive calls after replay = %d, want 1", controller.directiveCalls)
 	}
-	directiveConflict := rpcCall(t, handler, agentDirectiveBody("agent-1", "different", true, "idem-directive"))
+	directiveConflict := rpcCall(t, handler, agentDirectiveBodyWithRun("agent-1", directiveRunID, "different", true, "idem-directive"))
 	if directiveConflict.Error == nil {
 		t.Fatal("agent.send_directive idempotency conflict error = nil")
 	}
@@ -139,6 +145,115 @@ func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
 	}
 }
 
+func TestOperatorAgentSendDirectiveRunTargetErrors(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	missingRunID := "00000000-0000-0000-0000-000000000404"
+	terminalRunID := "00000000-0000-0000-0000-000000000405"
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Idempotency: pg,
+			AgentControl: &fakeAgentControlController{
+				errs: map[string]error{
+					"missing": &runtimeagentcontrol.StateError{
+						Err:     runtimeagentcontrol.ErrRunNotFound,
+						AgentID: "agent-1",
+						RunID:   missingRunID,
+					},
+					"terminal": &runtimeagentcontrol.StateError{
+						Err:           runtimeagentcontrol.ErrRunAlreadyTerminal,
+						AgentID:       "agent-1",
+						RunID:         terminalRunID,
+						CurrentStatus: "completed",
+					},
+					"ambiguous": &runtimeagentcontrol.StateError{
+						Err:     runtimeagentcontrol.ErrAmbiguousRunTarget,
+						AgentID: "agent-1",
+						ActiveSessions: []runtimeagentcontrol.ActiveSessionTarget{{
+							SessionID: "00000000-0000-0000-0000-000000000501",
+							RunID:     "00000000-0000-0000-0000-000000000601",
+						}},
+					},
+				},
+			},
+		}),
+	})
+
+	cases := []struct {
+		name string
+		body string
+		code string
+	}{
+		{"missing", agentDirectiveBodyWithRun("agent-1", missingRunID, "missing", false, ""), RunNotFoundCode},
+		{"terminal", agentDirectiveBodyWithRun("agent-1", terminalRunID, "terminal", false, ""), RunAlreadyTerminalCode},
+		{"ambiguous", agentDirectiveBody("agent-1", "ambiguous", false, ""), AmbiguousRunTargetCode},
+	}
+	for _, tc := range cases {
+		resp := rpcCall(t, handler, tc.body)
+		if resp.Error == nil {
+			t.Fatalf("%s error = nil", tc.name)
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != tc.code {
+			t.Fatalf("%s data = %#v, want %s", tc.name, data, tc.code)
+		}
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 0 {
+		t.Fatalf("idempotency rows after run target errors = %d, want 0", count)
+	}
+}
+
+func TestOperatorAgentSendDirectivePersistsDirectiveEventOnceOnReplay(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	agent := &directiveIntegrationAgent{id: "agent-1"}
+	manager := runtimemanager.NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return agent, nil
+	}, pg)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Idempotency:  pg,
+			AgentControl: manager,
+		}),
+	})
+
+	body := agentDirectiveBody("agent-1", "run corpus", false, "idem-directive-integration")
+	first := rpcCall(t, handler, body)
+	if first.Error != nil {
+		t.Fatalf("first directive error = %#v", first.Error)
+	}
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("replay directive error = %#v", replay.Error)
+	}
+	if agent.calls != 1 {
+		t.Fatalf("BoardStep calls = %d, want 1", agent.calls)
+	}
+	if count := countDirectiveEvents(t, db); count != 1 {
+		t.Fatalf("platform.agent_directive rows = %d, want 1", count)
+	}
+	conflict := rpcCall(t, handler, agentDirectiveBody("agent-1", "different", false, "idem-directive-integration"))
+	if conflict.Error == nil {
+		t.Fatal("conflict error = nil")
+	}
+	if agent.calls != 1 {
+		t.Fatalf("BoardStep calls after conflict = %d, want 1", agent.calls)
+	}
+	if count := countDirectiveEvents(t, db); count != 1 {
+		t.Fatalf("platform.agent_directive rows after conflict = %d, want 1", count)
+	}
+}
+
 func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -203,13 +318,50 @@ type fakeAgentControlController struct {
 	lastDirective     runtimeagentcontrol.SendDirectiveRequest
 }
 
+type directiveIntegrationAgent struct {
+	id    string
+	calls int
+}
+
+func (a *directiveIntegrationAgent) ID() string                      { return a.id }
+func (*directiveIntegrationAgent) Type() string                      { return "stub" }
+func (*directiveIntegrationAgent) Subscriptions() []events.EventType { return nil }
+func (*directiveIntegrationAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	return nil, nil
+}
+func (a *directiveIntegrationAgent) BoardStep(_ context.Context, directive runtimeagentcontrol.BoardDirective) (string, error) {
+	a.calls++
+	if err := runtimeagentcontrol.ValidateBoardDirective(directive); err != nil {
+		return "", err
+	}
+	return "accepted", nil
+}
+
 func (c *fakeAgentControlController) SendDirective(_ context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
 	c.directiveCalls++
 	c.lastDirective = req
+	if err := c.errs[req.Directive]; err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
 	if err := c.errs["agent.send_directive"]; err != nil {
 		return runtimeagentcontrol.SendDirectiveResult{}, err
 	}
-	return runtimeagentcontrol.SendDirectiveResult{AgentID: req.AgentID, Response: c.directiveResponse}, nil
+	runID := req.RunID
+	if runID == "" {
+		runID = "00000000-0000-0000-0000-000000000902"
+	}
+	mode := runtimeagentcontrol.RunResolutionSpecified
+	if req.RunID == "" {
+		mode = runtimeagentcontrol.RunResolutionNewRunAllocated
+	}
+	return runtimeagentcontrol.SendDirectiveResult{
+		AgentID:            req.AgentID,
+		Response:           c.directiveResponse,
+		RunID:              runID,
+		RunIDResolution:    mode,
+		DirectiveEventID:   "00000000-0000-0000-0000-000000000903",
+		DirectiveEventType: runtimeagentcontrol.DirectiveEventType,
+	}, nil
 }
 
 func (c *fakeAgentControlController) Restart(_ context.Context, req runtimeagentcontrol.RestartRequest) (runtimeagentcontrol.RestartResult, error) {
@@ -240,4 +392,20 @@ func agentDirectiveBody(agentID, directive string, killPrevious bool, idempotenc
 		return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"directive":%q,"kill_previous":%t}}`, agentID, directive, killPrevious)
 	}
 	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"directive":%q,"kill_previous":%t,"idempotency_key":%q}}`, agentID, directive, killPrevious, idempotencyKey)
+}
+
+func agentDirectiveBodyWithRun(agentID, runID, directive string, killPrevious bool, idempotencyKey string) string {
+	if idempotencyKey == "" {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"run_id":%q,"directive":%q,"kill_previous":%t}}`, agentID, runID, directive, killPrevious)
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-directive","method":"agent.send_directive","params":{"agent_id":%q,"run_id":%q,"directive":%q,"kill_previous":%t,"idempotency_key":%q}}`, agentID, runID, directive, killPrevious, idempotencyKey)
+}
+
+func countDirectiveEvents(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = 'platform.agent_directive'`).Scan(&count); err != nil {
+		t.Fatalf("count directive events: %v", err)
+	}
+	return count
 }

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -254,6 +254,57 @@ func TestOperatorAgentSendDirectivePersistsDirectiveEventOnceOnReplay(t *testing
 	}
 }
 
+func TestOperatorAgentSendDirectivePersistsRunBundleFingerprint(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	bootFingerprint := "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	existingFingerprint := "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		BundleFingerprint: bootFingerprint,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	agent := &directiveIntegrationAgent{id: "agent-1"}
+	manager := runtimemanager.NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return agent, nil
+	}, pg)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Idempotency:  pg,
+			AgentControl: manager,
+		}),
+	})
+
+	first := rpcCall(t, handler, agentDirectiveBody("agent-1", "new run", false, "idem-directive-bundle-new"))
+	if first.Error != nil {
+		t.Fatalf("new-run directive error = %#v", first.Error)
+	}
+	newRunID, _ := asMap(t, first.Result)["run_id"].(string)
+	if newRunID == "" {
+		t.Fatalf("new-run directive result = %#v", first.Result)
+	}
+	assertRunBundleFingerprint(t, db, newRunID, bootFingerprint)
+
+	existingRunID := "00000000-0000-0000-0000-000000000755"
+	if _, err := db.Exec(`
+		INSERT INTO runs (run_id, status, bundle_fingerprint)
+		VALUES ($1::uuid, 'running', $2)
+	`, existingRunID, existingFingerprint); err != nil {
+		t.Fatalf("seed existing run: %v", err)
+	}
+	explicit := rpcCall(t, handler, agentDirectiveBodyWithRun("agent-1", existingRunID, "existing run", false, "idem-directive-bundle-existing"))
+	if explicit.Error != nil {
+		t.Fatalf("existing-run directive error = %#v", explicit.Error)
+	}
+	assertRunBundleFingerprint(t, db, existingRunID, existingFingerprint)
+}
+
 func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -408,4 +459,15 @@ func countDirectiveEvents(t *testing.T, db *sql.DB) int {
 		t.Fatalf("count directive events: %v", err)
 	}
 	return count
+}
+
+func assertRunBundleFingerprint(t *testing.T, db *sql.DB, runID, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow(`SELECT COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
+		t.Fatalf("load run bundle fingerprint: %v", err)
+	}
+	if got != want {
+		t.Fatalf("run %s bundle_fingerprint = %q, want %q", runID, got, want)
+	}
 }

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -23,6 +23,7 @@ const (
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"
+	AmbiguousRunTargetCode               = "AMBIGUOUS_RUN_TARGET"
 	RunNotPausedCode                     = "RUN_NOT_PAUSED"
 	RunAlreadyPausedCode                 = "RUN_ALREADY_PAUSED"
 	MailboxNotFoundCode                  = "MAILBOX_NOT_FOUND"

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -450,6 +450,7 @@ func (h *Handler) handleAgentDirective(w http.ResponseWriter, r *http.Request) {
 		AgentID:      id,
 		Directive:    req.Message,
 		KillPrevious: req.KillPrevious,
+		Source:       runtimeagentcontrol.DirectiveSourceDashboardLegacy,
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err)

--- a/internal/runtime/agentcontrol/control.go
+++ b/internal/runtime/agentcontrol/control.go
@@ -2,9 +2,14 @@ package agentcontrol
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
 )
 
 const (
@@ -16,14 +21,19 @@ const (
 )
 
 var (
-	ErrAgentNotFound   = errors.New("agent not found")
-	ErrAgentNotRunning = errors.New("agent not running")
+	ErrAgentNotFound      = errors.New("agent not found")
+	ErrAgentNotRunning    = errors.New("agent not running")
+	ErrRunNotFound        = errors.New("run not found")
+	ErrRunAlreadyTerminal = errors.New("run already terminal")
+	ErrAmbiguousRunTarget = errors.New("ambiguous run target")
 )
 
 type StateError struct {
-	Err           error
-	AgentID       string
-	CurrentStatus string
+	Err            error
+	AgentID        string
+	RunID          string
+	CurrentStatus  string
+	ActiveSessions []ActiveSessionTarget
 }
 
 func (e *StateError) Error() string {
@@ -37,6 +47,15 @@ func (e *StateError) Error() string {
 		return fmt.Sprintf("agent not found: %s", agentID)
 	case errors.Is(e.Err, ErrAgentNotRunning) && agentID != "" && status != "":
 		return fmt.Sprintf("agent not running: %s current_status=%s", agentID, status)
+	case errors.Is(e.Err, ErrRunNotFound) && strings.TrimSpace(e.RunID) != "":
+		return fmt.Sprintf("run not found: %s", strings.TrimSpace(e.RunID))
+	case errors.Is(e.Err, ErrRunAlreadyTerminal) && strings.TrimSpace(e.RunID) != "":
+		if status != "" {
+			return fmt.Sprintf("run already terminal: %s current_status=%s", strings.TrimSpace(e.RunID), status)
+		}
+		return fmt.Sprintf("run already terminal: %s", strings.TrimSpace(e.RunID))
+	case errors.Is(e.Err, ErrAmbiguousRunTarget) && agentID != "":
+		return fmt.Sprintf("ambiguous run target for agent %s", agentID)
 	case e.Err != nil:
 		return e.Err.Error()
 	default:
@@ -51,15 +70,140 @@ func (e *StateError) Unwrap() error {
 	return e.Err
 }
 
+const (
+	DirectiveEventType = "platform.agent_directive"
+
+	RunResolutionSpecified         = "specified"
+	RunResolutionActiveSession     = "inferred_from_active_session"
+	RunResolutionNewRunAllocated   = "new_run_allocated"
+	DirectiveSourceV1RPC           = "v1_rpc"
+	DirectiveSourceDashboardLegacy = "dashboard_legacy_adapter"
+	DirectiveSourceBuilderRuntime  = "builder_runtime_adapter"
+)
+
+type ActiveSessionTarget struct {
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id,omitempty"`
+}
+
+type RunTargetResolution struct {
+	RunID          string
+	Mode           string
+	ActiveSessions []ActiveSessionTarget
+}
+
+func (r RunTargetResolution) Normalized() RunTargetResolution {
+	r.RunID = strings.TrimSpace(r.RunID)
+	r.Mode = strings.TrimSpace(r.Mode)
+	if r.Mode == "" {
+		r.Mode = RunResolutionNewRunAllocated
+	}
+	out := make([]ActiveSessionTarget, 0, len(r.ActiveSessions))
+	for _, session := range r.ActiveSessions {
+		session.SessionID = strings.TrimSpace(session.SessionID)
+		session.RunID = strings.TrimSpace(session.RunID)
+		if session.SessionID == "" && session.RunID == "" {
+			continue
+		}
+		out = append(out, session)
+	}
+	r.ActiveSessions = out
+	return r
+}
+
 type SendDirectiveRequest struct {
 	AgentID      string
 	Directive    string
 	KillPrevious bool
+	RunID        string
+	Source       string
+	OperatorID   string
 }
 
 type SendDirectiveResult struct {
-	AgentID  string
-	Response string
+	AgentID            string
+	Response           string
+	RunID              string
+	RunIDResolution    string
+	DirectiveEventID   string
+	DirectiveEventType string
+}
+
+type BoardDirective struct {
+	Directive       string
+	Event           events.Event
+	RunIDResolution string
+	OperatorID      string
+	Source          string
+}
+
+func NewDirectiveEvent(req SendDirectiveRequest, target RunTargetResolution, now time.Time) (events.Event, error) {
+	agentID := strings.TrimSpace(req.AgentID)
+	directive := strings.TrimSpace(req.Directive)
+	target = target.Normalized()
+	if agentID == "" {
+		return events.Event{}, errors.New("agent id is required")
+	}
+	if directive == "" {
+		return events.Event{}, errors.New("directive is required")
+	}
+	if target.RunID == "" {
+		return events.Event{}, errors.New("run_id is required")
+	}
+	if _, err := uuid.Parse(target.RunID); err != nil {
+		return events.Event{}, fmt.Errorf("run_id must be a UUID: %w", err)
+	}
+	source := strings.TrimSpace(req.Source)
+	if source == "" {
+		source = DirectiveSourceBuilderRuntime
+	}
+	operatorID := strings.TrimSpace(req.OperatorID)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	payload := map[string]any{
+		"agent_id":          agentID,
+		"directive_text":    directive,
+		"kill_previous":     req.KillPrevious,
+		"run_id":            target.RunID,
+		"run_id_resolution": target.Mode,
+		"source":            source,
+		"timestamp":         now.Format(time.RFC3339Nano),
+	}
+	if operatorID != "" {
+		payload["operator_id"] = operatorID
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return events.Event{}, err
+	}
+	return events.Event{
+		ID:          uuid.NewString(),
+		Type:        events.EventType(DirectiveEventType),
+		SourceAgent: "runtime",
+		RunID:       target.RunID,
+		Payload:     raw,
+		CreatedAt:   now,
+	}, nil
+}
+
+func ValidateBoardDirective(d BoardDirective) error {
+	if strings.TrimSpace(d.Directive) == "" {
+		return errors.New("directive is required")
+	}
+	evt := d.Event
+	if strings.TrimSpace(evt.ID) == "" {
+		return errors.New("directive event id is required")
+	}
+	if strings.TrimSpace(string(evt.Type)) != DirectiveEventType {
+		return fmt.Errorf("directive event type = %q, want %s", strings.TrimSpace(string(evt.Type)), DirectiveEventType)
+	}
+	if strings.TrimSpace(evt.RunID) == "" {
+		return errors.New("directive event run_id is required")
+	}
+	return nil
 }
 
 type RestartRequest struct {

--- a/internal/runtime/agentcontrol/control.go
+++ b/internal/runtime/agentcontrol/control.go
@@ -72,6 +72,7 @@ func (e *StateError) Unwrap() error {
 
 const (
 	DirectiveEventType = "platform.agent_directive"
+	DirectiveEventMode = "directive"
 
 	RunResolutionSpecified         = "specified"
 	RunResolutionActiveSession     = "inferred_from_active_session"
@@ -167,6 +168,7 @@ func NewDirectiveEvent(req SendDirectiveRequest, target RunTargetResolution, now
 		"agent_id":          agentID,
 		"directive_text":    directive,
 		"kill_previous":     req.KillPrevious,
+		"mode":              DirectiveEventMode,
 		"run_id":            target.RunID,
 		"run_id_resolution": target.Mode,
 		"source":            source,

--- a/internal/runtime/agentcontrol/control_test.go
+++ b/internal/runtime/agentcontrol/control_test.go
@@ -1,0 +1,32 @@
+package agentcontrol
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewDirectiveEventPayloadPreservesDirectiveMode(t *testing.T) {
+	evt, err := NewDirectiveEvent(SendDirectiveRequest{
+		AgentID:      "agent-1",
+		Directive:    "run corpus",
+		KillPrevious: true,
+		Source:       DirectiveSourceV1RPC,
+	}, RunTargetResolution{
+		RunID: "00000000-0000-0000-0000-000000000701",
+		Mode:  RunResolutionSpecified,
+	}, time.Date(2026, 5, 14, 3, 10, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewDirectiveEvent: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["mode"] != DirectiveEventMode {
+		t.Fatalf("mode = %#v, want %q", payload["mode"], DirectiveEventMode)
+	}
+	if payload["directive_text"] != "run corpus" || payload["run_id"] != evt.RunID {
+		t.Fatalf("payload = %#v", payload)
+	}
+}

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimeauthority "swarm/internal/runtime/authority"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -489,11 +490,15 @@ func (a *LLMAgent) injectHumanTaskToolResult(ctx context.Context, evt events.Eve
 	return a.conversation.InjectAsyncToolResult(ctx, "human_task_request", ok, result, errText)
 }
 
-func (a *LLMAgent) BoardStep(ctx context.Context, directive string) (string, error) {
+func (a *LLMAgent) BoardStep(ctx context.Context, directive runtimeagentcontrol.BoardDirective) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	evt := boardDirectiveEvent(strings.TrimSpace(directive))
+	if err := runtimeagentcontrol.ValidateBoardDirective(directive); err != nil {
+		return "", err
+	}
+	directiveText := strings.TrimSpace(directive.Directive)
+	evt := directive.Event
 	a.applyPromptForEvent(evt)
 	a.resetConversationScopeIfNeeded(evt)
 
@@ -513,7 +518,7 @@ func (a *LLMAgent) BoardStep(ctx context.Context, directive string) (string, err
 	}
 
 	beforeRemediation := len(a.conversation.Messages)
-	resp, err = a.conversation.Step(ctx, boardDirectiveRemediationPrompt(directive, strings.TrimSpace(resp.Message.Content)))
+	resp, err = a.conversation.Step(ctx, boardDirectiveRemediationPrompt(directiveText, strings.TrimSpace(resp.Message.Content)))
 	if err != nil {
 		return "", err
 	}
@@ -551,19 +556,6 @@ func boardDirectiveRemediationPrompt(directive, assistantText string) string {
 		b.WriteString(assistantText)
 	}
 	return b.String()
-}
-
-func boardDirectiveEvent(directive string) events.Event {
-	payload := map[string]any{
-		"directive_text": strings.TrimSpace(directive),
-		"mode":           "directive",
-	}
-	raw, _ := json.Marshal(payload)
-	return events.Event{
-		Type:        events.EventType("board.directive"),
-		SourceAgent: "dashboard",
-		Payload:     raw,
-	}
 }
 
 func toolMessageHasSuccessfulResult(raw string) bool {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -32,7 +32,7 @@ func testBoardDirective(text string) runtimeagentcontrol.BoardDirective {
 			Type:        events.EventType(runtimeagentcontrol.DirectiveEventType),
 			SourceAgent: "runtime",
 			RunID:       "00000000-0000-0000-0000-000000000201",
-			Payload:     []byte(`{"directive_text":"` + text + `","run_id":"00000000-0000-0000-0000-000000000201","run_id_resolution":"new_run_allocated","source":"test"}`),
+			Payload:     []byte(`{"directive_text":"` + text + `","mode":"directive","run_id":"00000000-0000-0000-0000-000000000201","run_id_resolution":"new_run_allocated","source":"test"}`),
 		},
 		RunIDResolution: runtimeagentcontrol.RunResolutionNewRunAllocated,
 		Source:          "test",

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimeauthority "swarm/internal/runtime/authority"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -22,6 +23,21 @@ import (
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 )
+
+func testBoardDirective(text string) runtimeagentcontrol.BoardDirective {
+	return runtimeagentcontrol.BoardDirective{
+		Directive: text,
+		Event: events.Event{
+			ID:          "00000000-0000-0000-0000-000000000101",
+			Type:        events.EventType(runtimeagentcontrol.DirectiveEventType),
+			SourceAgent: "runtime",
+			RunID:       "00000000-0000-0000-0000-000000000201",
+			Payload:     []byte(`{"directive_text":"` + text + `","run_id":"00000000-0000-0000-0000-000000000201","run_id_resolution":"new_run_allocated","source":"test"}`),
+		},
+		RunIDResolution: runtimeagentcontrol.RunResolutionNewRunAllocated,
+		Source:          "test",
+	}
+}
 
 func TestFormatEventForAgent_UsesPostCompositionToolSurface(t *testing.T) {
 	cfg := models.AgentConfig{
@@ -587,7 +603,7 @@ func TestBoardStep_ReturnsErrorWhenDirectiveDoesNotAct(t *testing.T) {
 		nil,
 	)
 
-	_, err := agent.BoardStep(context.Background(), "start a corpus run")
+	_, err := agent.BoardStep(context.Background(), testBoardDirective("start a corpus run"))
 	if err == nil {
 		t.Fatal("expected directive without action to fail")
 	}
@@ -615,7 +631,7 @@ func TestBoardStep_RemediatesAndSucceedsWhenDirectiveEmits(t *testing.T) {
 		[]llm.ToolDefinition{{Name: "emit_scan_requested"}},
 	)
 
-	got, err := agent.BoardStep(context.Background(), "start a corpus run")
+	got, err := agent.BoardStep(context.Background(), testBoardDirective("start a corpus run"))
 	if err != nil {
 		t.Fatalf("BoardStep: %v", err)
 	}
@@ -749,7 +765,8 @@ type directiveFactoryPublishBus struct {
 	events []events.Event
 }
 
-func (b *directiveFactoryPublishBus) Publish(_ context.Context, evt events.Event) error {
+func (b *directiveFactoryPublishBus) Publish(ctx context.Context, evt events.Event) error {
+	_, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
 	b.events = append(b.events, evt)
 	return nil
 }
@@ -820,7 +837,7 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 		},
 	})
 
-	got, err := agent.BoardStep(context.Background(), "start a corpus run")
+	got, err := agent.BoardStep(context.Background(), testBoardDirective("start a corpus run"))
 	if err != nil {
 		t.Fatalf("BoardStep: %v", err)
 	}
@@ -835,6 +852,9 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 	}
 	if len(bus.events) != 1 || string(bus.events[0].Type) != "scan.requested" {
 		t.Fatalf("published events = %#v, want one scan.requested event", bus.events)
+	}
+	if bus.events[0].RunID != "00000000-0000-0000-0000-000000000201" || bus.events[0].ParentEventID != "00000000-0000-0000-0000-000000000101" {
+		t.Fatalf("published event lineage = run:%q parent:%q", bus.events[0].RunID, bus.events[0].ParentEventID)
 	}
 }
 
@@ -882,7 +902,7 @@ func TestBoardStep_FactoryCreatedDirectiveRemediationPreservesFlowScopedEmitTool
 		},
 	})
 
-	got, err := agent.BoardStep(context.Background(), "start a corpus run")
+	got, err := agent.BoardStep(context.Background(), testBoardDirective("start a corpus run"))
 	if err != nil {
 		t.Fatalf("BoardStep: %v", err)
 	}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -324,6 +324,10 @@ func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {
 	return runtimecorrelation.WithBundleFingerprint(ctx, eb.bundleFingerprint)
 }
 
+func (eb *EventBus) WithBundleFingerprint(ctx context.Context) context.Context {
+	return eb.withBundleFingerprint(ctx)
+}
+
 func (eb *EventBus) pipelineTransitionCapability() func(context.Context) (bool, error) {
 	if eb == nil || eb.store == nil {
 		return nil

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -33,6 +33,10 @@ type agentDirectiveRunTargetResolver interface {
 	ResolveAgentDirectiveRunTarget(ctx context.Context, agentID, explicitRunID string) (runtimeagentcontrol.RunTargetResolution, error)
 }
 
+type bundleFingerprintContextOwner interface {
+	WithBundleFingerprint(context.Context) context.Context
+}
+
 var errRuntimeShuttingDown = errors.New("runtime shutting down")
 
 func (am *AgentManager) RestartAgent(agentID string) error {
@@ -445,6 +449,9 @@ func (am *AgentManager) publishAgentDirectiveEvent(ctx context.Context, evt even
 		return nil
 	}
 	eventCtx := runtimecorrelation.WithRunID(am.runtimePlatformControlEventContext(ctx), strings.TrimSpace(evt.RunID))
+	if owner, ok := am.bus.(bundleFingerprintContextOwner); ok && owner != nil {
+		eventCtx = owner.WithBundleFingerprint(eventCtx)
+	}
 	eventStore := am.bus.Store()
 	if eventStore == nil {
 		return errors.New("event store is required for agent directive persistence")

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -29,6 +29,10 @@ type runCanceller interface {
 	CancelActiveRunWorkByProducer(ctx context.Context, producerID string) ([]runtimedelivery.Transition, error)
 }
 
+type agentDirectiveRunTargetResolver interface {
+	ResolveAgentDirectiveRunTarget(ctx context.Context, agentID, explicitRunID string) (runtimeagentcontrol.RunTargetResolution, error)
+}
+
 var errRuntimeShuttingDown = errors.New("runtime shutting down")
 
 func (am *AgentManager) RestartAgent(agentID string) error {
@@ -336,12 +340,21 @@ func (am *AgentManager) ChatWithAgent(ctx context.Context, agentID, directive st
 }
 
 func (am *AgentManager) SendDirective(ctx context.Context, req runtimeagentcontrol.SendDirectiveRequest) (runtimeagentcontrol.SendDirectiveResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if am.shutdownAdmissionClosed() {
 		return runtimeagentcontrol.SendDirectiveResult{}, agentControlNotRunning(req.AgentID, runtimeagentcontrol.StatusTerminated)
 	}
 	agentID := strings.TrimSpace(req.AgentID)
+	req.AgentID = agentID
+	req.Directive = strings.TrimSpace(req.Directive)
+	req.RunID = strings.TrimSpace(req.RunID)
 	if agentID == "" {
 		return runtimeagentcontrol.SendDirectiveResult{}, errors.New("agent id is required")
+	}
+	if req.Directive == "" {
+		return runtimeagentcontrol.SendDirectiveResult{}, errors.New("directive is required")
 	}
 	am.mu.RLock()
 	agent, ok := am.agents[agentID]
@@ -353,16 +366,108 @@ func (am *AgentManager) SendDirective(ctx context.Context, req runtimeagentcontr
 	if !ok {
 		return runtimeagentcontrol.SendDirectiveResult{}, agentControlNotRunning(agentID, runtimeagentcontrol.StatusIdle)
 	}
+	target, err := am.resolveAgentDirectiveRunTarget(ctx, agentID, req.RunID)
+	if err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
+	if req.KillPrevious && req.RunID != "" {
+		return runtimeagentcontrol.SendDirectiveResult{}, &runtimeagentcontrol.StateError{
+			Err:     runtimeagentcontrol.ErrAmbiguousRunTarget,
+			AgentID: agentID,
+			RunID:   target.RunID,
+		}
+	}
 	if req.KillPrevious {
 		if err := am.killPreviousRuns(ctx, agentID); err != nil {
 			return runtimeagentcontrol.SendDirectiveResult{}, err
 		}
 	}
-	response, err := chatAgent.BoardStep(ctx, req.Directive)
+	directiveEvent, err := runtimeagentcontrol.NewDirectiveEvent(req, target, time.Now().UTC())
 	if err != nil {
 		return runtimeagentcontrol.SendDirectiveResult{}, err
 	}
-	return runtimeagentcontrol.SendDirectiveResult{AgentID: agentID, Response: response}, nil
+	if err := am.publishAgentDirectiveEvent(ctx, directiveEvent); err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
+	directiveCtx := runtimecorrelation.WithRunID(ctx, strings.TrimSpace(directiveEvent.RunID))
+	directiveCtx = runtimebus.WithInboundEvent(directiveCtx, directiveEvent)
+	response, err := chatAgent.BoardStep(directiveCtx, runtimeagentcontrol.BoardDirective{
+		Directive:       req.Directive,
+		Event:           directiveEvent,
+		RunIDResolution: target.Mode,
+		OperatorID:      strings.TrimSpace(req.OperatorID),
+		Source:          strings.TrimSpace(req.Source),
+	})
+	if err != nil {
+		return runtimeagentcontrol.SendDirectiveResult{}, err
+	}
+	return runtimeagentcontrol.SendDirectiveResult{
+		AgentID:            agentID,
+		Response:           response,
+		RunID:              strings.TrimSpace(directiveEvent.RunID),
+		RunIDResolution:    target.Mode,
+		DirectiveEventID:   strings.TrimSpace(directiveEvent.ID),
+		DirectiveEventType: string(directiveEvent.Type),
+	}, nil
+}
+
+func (am *AgentManager) resolveAgentDirectiveRunTarget(ctx context.Context, agentID, explicitRunID string) (runtimeagentcontrol.RunTargetResolution, error) {
+	agentID = strings.TrimSpace(agentID)
+	explicitRunID = strings.TrimSpace(explicitRunID)
+	if resolver, ok := am.store.(agentDirectiveRunTargetResolver); ok && resolver != nil {
+		target, err := resolver.ResolveAgentDirectiveRunTarget(ctx, agentID, explicitRunID)
+		if err != nil {
+			return runtimeagentcontrol.RunTargetResolution{}, err
+		}
+		return target.Normalized(), nil
+	}
+	if explicitRunID != "" {
+		return runtimeagentcontrol.RunTargetResolution{}, &runtimeagentcontrol.StateError{
+			Err:     runtimeagentcontrol.ErrRunNotFound,
+			AgentID: agentID,
+			RunID:   explicitRunID,
+		}
+	}
+	return runtimeagentcontrol.RunTargetResolution{
+		RunID: uuid.NewString(),
+		Mode:  runtimeagentcontrol.RunResolutionNewRunAllocated,
+	}, nil
+}
+
+func (am *AgentManager) publishAgentDirectiveEvent(ctx context.Context, evt events.Event) error {
+	if strings.TrimSpace(evt.RunID) == "" {
+		return errors.New("directive event run_id is required")
+	}
+	if am.bus == nil {
+		if am.store != nil {
+			return errors.New("event bus is required for agent directive persistence")
+		}
+		return nil
+	}
+	eventCtx := runtimecorrelation.WithRunID(am.runtimePlatformControlEventContext(ctx), strings.TrimSpace(evt.RunID))
+	eventStore := am.bus.Store()
+	if eventStore == nil {
+		return errors.New("event store is required for agent directive persistence")
+	}
+	if atomicStore, ok := eventStore.(runtimebus.AtomicEventReplayScopePersistence); ok && atomicStore != nil {
+		return atomicStore.PersistEventWithDeliveriesAndScope(eventCtx, evt, nil, runtimereplayclaim.CommittedReplayScopeDirect)
+	}
+	if atomicStore, ok := eventStore.(runtimebus.AtomicEventPersistence); ok && atomicStore != nil {
+		if err := atomicStore.PersistEventWithDeliveries(eventCtx, evt, nil); err != nil {
+			return err
+		}
+		if scopeWriter, ok := eventStore.(runtimebus.EventReplayScopePersistence); ok && scopeWriter != nil {
+			return scopeWriter.UpsertCommittedReplayScope(eventCtx, evt.ID, runtimereplayclaim.CommittedReplayScopeDirect)
+		}
+		return nil
+	}
+	if err := eventStore.AppendEvent(eventCtx, evt); err != nil {
+		return err
+	}
+	if scopeWriter, ok := eventStore.(runtimebus.EventReplayScopePersistence); ok && scopeWriter != nil {
+		return scopeWriter.UpsertCommittedReplayScope(eventCtx, evt.ID, runtimereplayclaim.CommittedReplayScopeDirect)
+	}
+	return nil
 }
 
 func (am *AgentManager) killPreviousRuns(ctx context.Context, producerID string) error {

--- a/internal/runtime/manager/runtime_chat_test.go
+++ b/internal/runtime/manager/runtime_chat_test.go
@@ -6,13 +6,20 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimedelivery "swarm/internal/runtime/deliverylifecycle"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
 type chatTestAgent struct {
-	id        string
-	directive string
-	calls     int
+	id              string
+	directive       string
+	runID           string
+	directiveEvent  string
+	directiveSource string
+	calls           int
 }
 
 func (a *chatTestAgent) ID() string                        { return a.id }
@@ -21,9 +28,12 @@ func (a *chatTestAgent) Subscriptions() []events.EventType { return nil }
 func (a *chatTestAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
 	return nil, nil
 }
-func (a *chatTestAgent) BoardStep(_ context.Context, directive string) (string, error) {
+func (a *chatTestAgent) BoardStep(_ context.Context, directive runtimeagentcontrol.BoardDirective) (string, error) {
 	a.calls++
-	a.directive = directive
+	a.directive = directive.Directive
+	a.runID = directive.Event.RunID
+	a.directiveEvent = directive.Event.ID
+	a.directiveSource = string(directive.Event.Type)
 	return "ok", nil
 }
 
@@ -54,10 +64,71 @@ func (s *chatTestStore) CancelActiveRunWorkByProducer(_ context.Context, produce
 	return append([]runtimedelivery.Transition(nil), s.transitions...), nil
 }
 
+type directiveTargetStore struct {
+	chatTestStore
+	target runtimeagentcontrol.RunTargetResolution
+	err    error
+	calls  int
+}
+
+func (s *directiveTargetStore) ResolveAgentDirectiveRunTarget(context.Context, string, string) (runtimeagentcontrol.RunTargetResolution, error) {
+	s.calls++
+	if s.err != nil {
+		return runtimeagentcontrol.RunTargetResolution{}, s.err
+	}
+	return s.target, nil
+}
+
+type directiveTestBus struct {
+	direct []events.Event
+	store  *directiveEventStore
+}
+
+func (b *directiveTestBus) Publish(_ context.Context, evt events.Event) error {
+	return nil
+}
+func (b *directiveTestBus) PublishDirect(_ context.Context, evt events.Event, _ []string) error {
+	b.direct = append(b.direct, evt)
+	return nil
+}
+func (b *directiveTestBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
+func (b *directiveTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+func (b *directiveTestBus) Unsubscribe(string) {}
+func (b *directiveTestBus) Store() runtimebus.EventStore {
+	if b.store == nil {
+		b.store = &directiveEventStore{}
+	}
+	return b.store
+}
+func (b *directiveTestBus) ResetInMemoryState() error { return nil }
+func (b *directiveTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
+	return nil
+}
+
+type directiveEventStore struct {
+	events []events.Event
+}
+
+func (s *directiveEventStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.events = append(s.events, evt)
+	return nil
+}
+func (*directiveEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*directiveEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, runtimereplayclaim.ErrAuthoritativeRecipientManifestUnavailable
+}
+func (*directiveEventStore) SupportsPersistedReplay() bool { return false }
+
 func TestAgentManager_ChatWithAgent_KillPreviousCancelsBeforeBoardStep(t *testing.T) {
 	store := &chatTestStore{}
 	agent := &chatTestAgent{id: "campaign-coordinator"}
-	am := NewAgentManager(nil, nil, store)
+	am := NewAgentManager(&directiveTestBus{}, nil, store)
 	am.agents[agent.id] = agent
 
 	got, err := am.ChatWithAgent(context.Background(), agent.id, "run corpus", true)
@@ -73,12 +144,94 @@ func TestAgentManager_ChatWithAgent_KillPreviousCancelsBeforeBoardStep(t *testin
 	if agent.calls != 1 || agent.directive != "run corpus" {
 		t.Fatalf("board step calls=%d directive=%q", agent.calls, agent.directive)
 	}
+	if agent.runID == "" || agent.directiveEvent == "" || agent.directiveSource != runtimeagentcontrol.DirectiveEventType {
+		t.Fatalf("board directive event = run:%q event:%q type:%q", agent.runID, agent.directiveEvent, agent.directiveSource)
+	}
+}
+
+func TestAgentManager_SendDirectivePersistsCanonicalDirectiveEventBeforeBoardStep(t *testing.T) {
+	runID := "00000000-0000-0000-0000-000000000701"
+	bus := &directiveTestBus{}
+	store := &directiveTargetStore{
+		target: runtimeagentcontrol.RunTargetResolution{
+			RunID: runID,
+			Mode:  runtimeagentcontrol.RunResolutionActiveSession,
+			ActiveSessions: []runtimeagentcontrol.ActiveSessionTarget{{
+				SessionID: "00000000-0000-0000-0000-000000000801",
+				RunID:     runID,
+			}},
+		},
+	}
+	agent := &chatTestAgent{id: "campaign-coordinator"}
+	am := NewAgentManager(bus, nil, store)
+	am.agents[agent.id] = agent
+
+	result, err := am.SendDirective(context.Background(), runtimeagentcontrol.SendDirectiveRequest{
+		AgentID:    agent.id,
+		Directive:  "run corpus",
+		Source:     runtimeagentcontrol.DirectiveSourceV1RPC,
+		OperatorID: "operator-token",
+	})
+	if err != nil {
+		t.Fatalf("SendDirective: %v", err)
+	}
+	if result.RunID != runID || result.RunIDResolution != runtimeagentcontrol.RunResolutionActiveSession || result.DirectiveEventID == "" {
+		t.Fatalf("directive result = %#v", result)
+	}
+	if store.calls != 1 {
+		t.Fatalf("target resolver calls = %d, want 1", store.calls)
+	}
+	eventCount := 0
+	if bus.store != nil {
+		eventCount = len(bus.store.events)
+	}
+	if eventCount != 1 {
+		t.Fatalf("persisted directive events = %d, want 1", eventCount)
+	}
+	evt := bus.store.events[0]
+	if string(evt.Type) != runtimeagentcontrol.DirectiveEventType || evt.RunID != runID || evt.ID == "" {
+		t.Fatalf("directive event = %#v", evt)
+	}
+	if agent.calls != 1 || agent.runID != runID || agent.directiveEvent != evt.ID {
+		t.Fatalf("board step saw calls=%d run=%q event=%q, want event %q", agent.calls, agent.runID, agent.directiveEvent, evt.ID)
+	}
+}
+
+func TestAgentManager_SendDirectiveTargetErrorFailsBeforeKillPreviousAndBoardStep(t *testing.T) {
+	bus := &directiveTestBus{}
+	store := &directiveTargetStore{
+		err: &runtimeagentcontrol.StateError{
+			Err:     runtimeagentcontrol.ErrRunNotFound,
+			AgentID: "campaign-coordinator",
+			RunID:   "00000000-0000-0000-0000-000000000404",
+		},
+	}
+	agent := &chatTestAgent{id: "campaign-coordinator"}
+	am := NewAgentManager(bus, nil, store)
+	am.agents[agent.id] = agent
+
+	_, err := am.SendDirective(context.Background(), runtimeagentcontrol.SendDirectiveRequest{
+		AgentID:      agent.id,
+		Directive:    "run corpus",
+		RunID:        "00000000-0000-0000-0000-000000000404",
+		KillPrevious: true,
+	})
+	if err == nil {
+		t.Fatal("SendDirective error = nil")
+	}
+	eventCount := 0
+	if bus.store != nil {
+		eventCount = len(bus.store.events)
+	}
+	if store.cancelCalls != 0 || agent.calls != 0 || eventCount != 0 {
+		t.Fatalf("side effects after target error: cancel=%d board=%d events=%d", store.cancelCalls, agent.calls, eventCount)
+	}
 }
 
 func TestAgentManager_ChatWithAgent_WithoutKillPreviousSkipsCancellation(t *testing.T) {
 	store := &chatTestStore{}
 	agent := &chatTestAgent{id: "campaign-coordinator"}
-	am := NewAgentManager(nil, nil, store)
+	am := NewAgentManager(&directiveTestBus{}, nil, store)
 	am.agents[agent.id] = agent
 
 	if _, err := am.ChatWithAgent(context.Background(), agent.id, "run corpus", false); err != nil {

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"swarm/internal/events"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
@@ -24,7 +25,7 @@ type Agent interface {
 }
 
 type BoardInteractiveAgent interface {
-	BoardStep(ctx context.Context, directive string) (string, error)
+	BoardStep(ctx context.Context, directive runtimeagentcontrol.BoardDirective) (string, error)
 }
 
 type AgentFactory func(cfg models.AgentConfig) (Agent, error)

--- a/internal/store/agent_directive_run_target.go
+++ b/internal/store/agent_directive_run_target.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+)
+
+type agentDirectiveActiveSession struct {
+	SessionID string
+	RunID     string
+}
+
+func (s *PostgresStore) ResolveAgentDirectiveRunTarget(ctx context.Context, agentID, explicitRunID string) (runtimeagentcontrol.RunTargetResolution, error) {
+	agentID = strings.TrimSpace(agentID)
+	explicitRunID = strings.TrimSpace(explicitRunID)
+	if s == nil || s.DB == nil {
+		return runtimeagentcontrol.RunTargetResolution{}, fmt.Errorf("postgres store is required")
+	}
+	if agentID == "" {
+		return runtimeagentcontrol.RunTargetResolution{}, fmt.Errorf("agent_id is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimeagentcontrol.RunTargetResolution{}, err
+	}
+	if !caps.Events.HasRuns {
+		return runtimeagentcontrol.RunTargetResolution{}, unsupportedSchemaCapability("runs", SchemaFlavorUnavailable)
+	}
+	if explicitRunID != "" {
+		if err := validateDirectiveRunTarget(ctx, s.DB, agentID, explicitRunID); err != nil {
+			return runtimeagentcontrol.RunTargetResolution{}, err
+		}
+		return runtimeagentcontrol.RunTargetResolution{
+			RunID: explicitRunID,
+			Mode:  runtimeagentcontrol.RunResolutionSpecified,
+		}, nil
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
+		return runtimeagentcontrol.RunTargetResolution{}, unsupportedSchemaCapability("agent_sessions.run_id", caps.Conversations.Sessions)
+	}
+	sessions, err := listActiveDirectiveSessions(ctx, s.DB, agentID)
+	if err != nil {
+		return runtimeagentcontrol.RunTargetResolution{}, err
+	}
+	switch len(sessions) {
+	case 0:
+		return runtimeagentcontrol.RunTargetResolution{
+			RunID: uuid.NewString(),
+			Mode:  runtimeagentcontrol.RunResolutionNewRunAllocated,
+		}, nil
+	case 1:
+		session := sessions[0]
+		if strings.TrimSpace(session.RunID) == "" {
+			return runtimeagentcontrol.RunTargetResolution{}, ambiguousDirectiveRunTarget(agentID, sessions)
+		}
+		if err := validateDirectiveRunTarget(ctx, s.DB, agentID, session.RunID); err != nil {
+			return runtimeagentcontrol.RunTargetResolution{}, err
+		}
+		return runtimeagentcontrol.RunTargetResolution{
+			RunID: session.RunID,
+			Mode:  runtimeagentcontrol.RunResolutionActiveSession,
+			ActiveSessions: []runtimeagentcontrol.ActiveSessionTarget{{
+				SessionID: session.SessionID,
+				RunID:     session.RunID,
+			}},
+		}, nil
+	default:
+		return runtimeagentcontrol.RunTargetResolution{}, ambiguousDirectiveRunTarget(agentID, sessions)
+	}
+}
+
+func listActiveDirectiveSessions(ctx context.Context, db *sql.DB, agentID string) ([]agentDirectiveActiveSession, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			session_id::text,
+			COALESCE(run_id::text, '')
+		FROM agent_sessions
+		WHERE agent_id = $1
+		  AND status = 'active'
+		ORDER BY updated_at DESC, created_at DESC, session_id ASC
+	`, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("list active directive sessions: %w", err)
+	}
+	defer rows.Close()
+
+	out := []agentDirectiveActiveSession{}
+	for rows.Next() {
+		var rec agentDirectiveActiveSession
+		if err := rows.Scan(&rec.SessionID, &rec.RunID); err != nil {
+			return nil, fmt.Errorf("scan active directive session: %w", err)
+		}
+		rec.SessionID = strings.TrimSpace(rec.SessionID)
+		rec.RunID = strings.TrimSpace(rec.RunID)
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active directive sessions: %w", err)
+	}
+	return out, nil
+}
+
+func validateDirectiveRunTarget(ctx context.Context, db *sql.DB, agentID, runID string) error {
+	runID = strings.TrimSpace(runID)
+	if _, err := uuid.Parse(runID); err != nil {
+		return &runtimeagentcontrol.StateError{
+			Err:     runtimeagentcontrol.ErrRunNotFound,
+			AgentID: agentID,
+			RunID:   runID,
+		}
+	}
+	var status string
+	err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+		LIMIT 1
+	`, runID).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &runtimeagentcontrol.StateError{
+			Err:     runtimeagentcontrol.ErrRunNotFound,
+			AgentID: agentID,
+			RunID:   runID,
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("load directive run target: %w", err)
+	}
+	status = strings.TrimSpace(strings.ToLower(status))
+	switch status {
+	case "running", "paused":
+		return nil
+	default:
+		return &runtimeagentcontrol.StateError{
+			Err:           runtimeagentcontrol.ErrRunAlreadyTerminal,
+			AgentID:       agentID,
+			RunID:         runID,
+			CurrentStatus: status,
+		}
+	}
+}
+
+func ambiguousDirectiveRunTarget(agentID string, sessions []agentDirectiveActiveSession) error {
+	targets := make([]runtimeagentcontrol.ActiveSessionTarget, 0, len(sessions))
+	for _, session := range sessions {
+		targets = append(targets, runtimeagentcontrol.ActiveSessionTarget{
+			SessionID: session.SessionID,
+			RunID:     session.RunID,
+		})
+	}
+	return &runtimeagentcontrol.StateError{
+		Err:            runtimeagentcontrol.ErrAmbiguousRunTarget,
+		AgentID:        strings.TrimSpace(agentID),
+		ActiveSessions: targets,
+	}
+}

--- a/internal/store/agent_directive_run_target_test.go
+++ b/internal/store/agent_directive_run_target_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStoreResolveAgentDirectiveRunTarget(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+	pg := &PostgresStore{DB: db}
+	createDirectiveRunTargetTables(t, ctx, pg)
+
+	runA := "00000000-0000-0000-0000-0000000000a1"
+	runB := "00000000-0000-0000-0000-0000000000b1"
+	runDone := "00000000-0000-0000-0000-0000000000c1"
+	insertDirectiveRun(t, ctx, pg, runA, "running")
+	insertDirectiveRun(t, ctx, pg, runB, "paused")
+	insertDirectiveRun(t, ctx, pg, runDone, "completed")
+
+	explicit, err := pg.ResolveAgentDirectiveRunTarget(ctx, "agent-a", runA)
+	if err != nil {
+		t.Fatalf("explicit target: %v", err)
+	}
+	if explicit.RunID != runA || explicit.Mode != runtimeagentcontrol.RunResolutionSpecified {
+		t.Fatalf("explicit target = %#v", explicit)
+	}
+
+	missingID := "00000000-0000-0000-0000-000000000404"
+	_, err = pg.ResolveAgentDirectiveRunTarget(ctx, "agent-a", missingID)
+	if !errors.Is(err, runtimeagentcontrol.ErrRunNotFound) {
+		t.Fatalf("missing target err = %v, want run not found", err)
+	}
+
+	_, err = pg.ResolveAgentDirectiveRunTarget(ctx, "agent-a", runDone)
+	if !errors.Is(err, runtimeagentcontrol.ErrRunAlreadyTerminal) {
+		t.Fatalf("terminal target err = %v, want run already terminal", err)
+	}
+
+	allocated, err := pg.ResolveAgentDirectiveRunTarget(ctx, "agent-empty", "")
+	if err != nil {
+		t.Fatalf("zero active target: %v", err)
+	}
+	if allocated.RunID == "" || allocated.Mode != runtimeagentcontrol.RunResolutionNewRunAllocated {
+		t.Fatalf("zero active target = %#v", allocated)
+	}
+
+	insertDirectiveSession(t, ctx, pg, "00000000-0000-0000-0000-000000000101", "agent-one", runB)
+	active, err := pg.ResolveAgentDirectiveRunTarget(ctx, "agent-one", "")
+	if err != nil {
+		t.Fatalf("one active target: %v", err)
+	}
+	if active.RunID != runB || active.Mode != runtimeagentcontrol.RunResolutionActiveSession || len(active.ActiveSessions) != 1 {
+		t.Fatalf("one active target = %#v", active)
+	}
+
+	insertDirectiveSession(t, ctx, pg, "00000000-0000-0000-0000-000000000201", "agent-many", runA)
+	insertDirectiveSession(t, ctx, pg, "00000000-0000-0000-0000-000000000202", "agent-many", runB)
+	_, err = pg.ResolveAgentDirectiveRunTarget(ctx, "agent-many", "")
+	if !errors.Is(err, runtimeagentcontrol.ErrAmbiguousRunTarget) {
+		t.Fatalf("many active err = %v, want ambiguous", err)
+	}
+
+	insertDirectiveSession(t, ctx, pg, "00000000-0000-0000-0000-000000000301", "agent-null", "")
+	_, err = pg.ResolveAgentDirectiveRunTarget(ctx, "agent-null", "")
+	if !errors.Is(err, runtimeagentcontrol.ErrAmbiguousRunTarget) {
+		t.Fatalf("null run active err = %v, want ambiguous", err)
+	}
+}
+
+func createDirectiveRunTargetTables(t *testing.T, ctx context.Context, pg *PostgresStore) {
+	t.Helper()
+	if _, err := pg.DB.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE; DROP TABLE IF EXISTS runs CASCADE;`); err != nil {
+		t.Fatalf("drop directive target tables: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		CREATE TABLE runs (
+			run_id UUID PRIMARY KEY,
+			status TEXT NOT NULL,
+			started_at TIMESTAMPTZ,
+			trigger_event_id UUID,
+			trigger_event_type TEXT,
+			event_count INTEGER NOT NULL DEFAULT 0,
+			entity_count INTEGER NOT NULL DEFAULT 0,
+			error_summary TEXT,
+			ended_at TIMESTAMPTZ,
+			bundle_fingerprint TEXT
+		);
+		CREATE TABLE agent_sessions (
+			session_id UUID PRIMARY KEY,
+			run_id UUID REFERENCES runs(run_id),
+			agent_id TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			scope_key TEXT NOT NULL,
+			scope TEXT NOT NULL DEFAULT 'global',
+			conversation JSONB NOT NULL DEFAULT '[]'::jsonb,
+			turn_count INTEGER NOT NULL DEFAULT 0,
+			runtime_mode TEXT NOT NULL DEFAULT 'session',
+			runtime_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+			lease_holder TEXT,
+			lease_expires_at TIMESTAMPTZ,
+			status TEXT NOT NULL DEFAULT 'active',
+			termination_reason TEXT,
+			termination_detail TEXT,
+			successor_session_id UUID,
+			terminated_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+	`); err != nil {
+		t.Fatalf("create directive target tables: %v", err)
+	}
+}
+
+func insertDirectiveRun(t *testing.T, ctx context.Context, pg *PostgresStore, runID, status string) {
+	t.Helper()
+	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, $2)`, runID, status); err != nil {
+		t.Fatalf("insert run %s: %v", runID, err)
+	}
+}
+
+func insertDirectiveSession(t *testing.T, ctx context.Context, pg *PostgresStore, sessionID, agentID, runID string) {
+	t.Helper()
+	if runID == "" {
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO agent_sessions (session_id, agent_id, scope_key, scope, runtime_mode, status)
+			VALUES ($1::uuid, $2, 'global', 'global', 'session', 'active')
+		`, sessionID, agentID); err != nil {
+			t.Fatalf("insert session %s: %v", sessionID, err)
+		}
+		return
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO agent_sessions (session_id, run_id, agent_id, scope_key, scope, runtime_mode, status)
+		VALUES ($1::uuid, $2::uuid, $3, 'global', 'global', 'session', 'active')
+	`, sessionID, runID, agentID); err != nil {
+		t.Fatalf("insert session %s: %v", sessionID, err)
+	}
+}


### PR DESCRIPTION
Closes #755
Part of #750

Governing refs/context:
- #755 Pre-Implementation Coverage Audit and lead gate outcome: approved as first slice for agent.send_directive.run_id targeting, active-session resolution, AMBIGUOUS_RUN_TARGET, persisted platform.agent_directive, and BoardStep/run causality propagation.
- Authoritative spec updated in docs/specs/swarm-platform/platform/contracts/platform-spec.yaml: platform_events.catalog platform.agent_directive, api_specification.components.errors.AMBIGUOUS_RUN_TARGET, and method_catalog agent.send_directive.
- Generated OpenRPC updated in docs/specs/swarm-platform/platform/contracts/openrpc.json.

Semantic migration:
- New canonical owner: runtime AgentManager.SendDirective plus PostgresStore.ResolveAgentDirectiveRunTarget and the canonical event store persistence path for platform.agent_directive.
- Old producer/interpreter now invalid: LLMAgent BoardStep no longer creates a local board.directive event or relies on empty runtimecorrelation fallback run identity.
- Checked production consumers: v1 agent.send_directive, dashboard /api/agents/{id}/actions/directive adapter, builder dynamic agent control adapter, ChatWithAgent helper path, and scripts/run_clear.sh directive consumer.
- Migration complete for this child: run_clear refactor, kill_previous removal, runtime.nuke, #748 batch, and serve shutdown/dev cleanup remain outside #755 by gate.

Proof run:
- go test ./internal/runtime/manager ./internal/runtime/agents ./internal/apiv1 -count=1
- go test ./internal/store ./cmd/swarm -count=1
- go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1
- go run ./cmd/swarm-openrpc-gen --check
- git diff --check
- rg -n 'board\.directive' internal cmd scripts || true