### PR TITLE
[agent-b][issue #761] Add event.publish canonical workflow creation

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1230,6 +1230,385 @@
       }
     },
     {
+      "name": "event.publish",
+      "description": "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger, and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nThe method consumes the same canonical EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start remains only\nas a deprecated wrapper for older callers.\n",
+      "params": [
+        {
+          "name": "bundle_ref",
+          "required": false,
+          "description": "Optional assertion that the server is running the expected boot bundle fingerprint.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleRef"
+          }
+        },
+        {
+          "name": "event_name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "payload",
+          "required": true,
+          "schema": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        {
+          "name": "run_id",
+          "required": false,
+          "description": "Existing nonterminal run to inject into; if omitted, runtime allocates and starts a new run.",
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "emitter",
+          "required": false,
+          "description": "Optional producer identifier. Defaults to cli-publish:\u003cactor_token_id\u003e.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/EventPublishResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32003,
+          "message": "Application error: BUNDLE_MISMATCH",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_MISMATCH",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "boot_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "provided_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  }
+                },
+                "required": [
+                  "provided_fingerprint",
+                  "boot_fingerprint"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32021,
+          "message": "Application error: UNSUPPORTED_BUNDLE_REF",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "UNSUPPORTED_BUNDLE_REF",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32005,
+          "message": "Application error: EVENT_NOT_DECLARED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_NOT_DECLARED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "declared_events": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "event_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "event_name"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32013,
+          "message": "Application error: PAYLOAD_VALIDATION_FAILED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "PAYLOAD_VALIDATION_FAILED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "violations": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "field_path": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "rule": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "field_path",
+                        "rule",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "violations"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32018,
+          "message": "Application error: RUN_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "RUN_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "run_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32017,
+          "message": "Application error: RUN_ALREADY_TERMINAL",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "RUN_ALREADY_TERMINAL",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "current_status": {
+                    "$ref": "#/components/schemas/RunStatus"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "run_id",
+                  "current_status"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "event.subscribe",
       "description": "Live event stream with the same filter shape as event.list. Filter\nparity is required by the conventions section. Pagination params\n(limit, cursor) and the time-window `until` are NOT accepted here\n— subscriptions deliver everything matching the filter live.\n",
       "params": [
@@ -2683,7 +3062,8 @@
     },
     {
       "name": "run.start",
-      "description": "Start a new run by injecting an event into the runtime bus.\nOptionally declares a bundle_ref by fingerprint; v1 runtime\nrequires the fingerprint to match the orchestrator's boot-time\nbundle (or the bundle_ref to be omitted, in which case the\nboot-time bundle is used). Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle).\n",
+      "deprecated": true,
+      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares a bundle_ref by fingerprint; v1 runtime\nrequires the fingerprint to match the orchestrator's boot-time\nbundle (or the bundle_ref to be omitted, in which case the\nboot-time bundle is used). Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle).\n",
       "params": [
         {
           "name": "bundle_ref",
@@ -3790,7 +4170,7 @@
       },
       "BundleRef": {
         "additionalProperties": false,
-        "description": "Bundle reference passed by callers to assert \"I expect the server\nto be running this bundle.\" Identified by content fingerprint,\nNOT server-local filesystem paths — paths cannot be safely\nreferenced by external Phase-2 consumers, and the runtime's\nactual identity check is fingerprint comparison.\n\nv1 runtime requires the fingerprint to match the orchestrator's\nboot-time loaded bundle, or the call fails with BUNDLE_MISMATCH.\nPer-run dynamic bundle loading (a content-addressable bundle\nuploaded or referenced by registry coordinate) is part of the\ndeferred bundle_lifecycle namespace; v1 BundleRef carries\nfingerprint only.\n\nA typical caller flow: call health.check first to read the\nserver's current bundle.fingerprint, then pass the same\nfingerprint in run.start.bundle_ref to assert continuity.\n",
+        "description": "Bundle reference passed by callers to assert \"I expect the server\nto be running this bundle.\" Identified by content fingerprint,\nNOT server-local filesystem paths — paths cannot be safely\nreferenced by external Phase-2 consumers, and the runtime's\nactual identity check is fingerprint comparison.\n\nv1 runtime requires the fingerprint to match the orchestrator's\nboot-time loaded bundle, or the call fails with BUNDLE_MISMATCH.\nPer-run dynamic bundle loading (a content-addressable bundle\nuploaded or referenced by registry coordinate) is part of the\ndeferred bundle_lifecycle namespace; v1 BundleRef carries\nfingerprint only.\n\nA typical caller flow: call health.check first to read the\nserver's current bundle.fingerprint, then pass the same\nfingerprint in event.publish.bundle_ref or run.start.bundle_ref to assert continuity.\n",
         "properties": {
           "fingerprint": {
             "$ref": "#/components/schemas/Sha256Fingerprint"
@@ -4064,6 +4444,9 @@
           "reason_code": {
             "type": "string"
           },
+          "session_id": {
+            "type": "string"
+          },
           "status": {
             "$ref": "#/components/schemas/DeliveryStatus"
           },
@@ -4160,6 +4543,58 @@
             "$ref": "#/components/schemas/SubscriberType"
           }
         },
+        "type": "object"
+      },
+      "EventPublishDelivery": {
+        "additionalProperties": false,
+        "properties": {
+          "attempt": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeliveryStatus"
+          },
+          "subscriber_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscriber_id",
+          "status",
+          "attempt"
+        ],
+        "type": "object"
+      },
+      "EventPublishResult": {
+        "additionalProperties": false,
+        "properties": {
+          "deliveries": {
+            "description": "Canonical persisted delivery rows for the published event; empty when the declared event has no subscribers.",
+            "items": {
+              "$ref": "#/components/schemas/EventPublishDelivery"
+            },
+            "type": "array"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "new_run_created": {
+            "type": "boolean"
+          },
+          "run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        "required": [
+          "event_id",
+          "run_id",
+          "new_run_created",
+          "deliveries"
+        ],
         "type": "object"
       },
       "HealthCheckResult": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5539,7 +5539,7 @@ api_specification:
         description: External webhook/provider events are queueable. While paused, valid signed ingress is persisted as events
           and deduplicated normally, but dispatch is gated until resume.
       - surface: api.event_producing_methods
-        description: Event-producing API/admin surfaces such as run.start and future explicit event-publish APIs are queueable.
+        description: Event-producing API/admin surfaces such as event.publish and deprecated run.start wrapper calls are queueable.
           While paused, they may persist canonical root/input events and lifecycle rows but must not dispatch subscriber work until
           resume.
       - surface: timer.fire
@@ -5595,6 +5595,7 @@ api_specification:
         '
       ttl: 24 hours after first completed response stored.
       mutating_methods:
+      - event.publish
       - run.start
       - run.stop
       - run.pause
@@ -5668,7 +5669,8 @@ api_specification:
         where content is identical.
       algorithm_migration: If a future version migrates to a different hash algorithm, the prefix changes (e.g., `blake3:<hex>`).
         v1 commits to sha256 only.
-      role_in_v1: "fingerprint is the load-bearing bundle identity in v1. BundleRef\n(passed by callers in run.start) carries\
+      role_in_v1: "fingerprint is the load-bearing bundle identity in v1. BundleRef\n(passed by callers in event.publish\
+        \ or deprecated run.start) carries\
         \ fingerprint only \u2014 no\nfilesystem paths. BundleIdentity (returned by health.check)\ncarries fingerprint + workflow_name\
         \ + workflow_version, again\nwithout paths. This makes every API surface that touches bundle\nidentity safely callable\
         \ by external Phase-2 consumers without\nleaking server deployment internals.\n"
@@ -5734,7 +5736,7 @@ api_specification:
           Per-run dynamic bundle loading (a content-addressable bundle\nuploaded or referenced by registry coordinate) is\
           \ part of the\ndeferred bundle_lifecycle namespace; v1 BundleRef carries\nfingerprint only.\n\nA typical caller\
           \ flow: call health.check first to read the\nserver's current bundle.fingerprint, then pass the same\nfingerprint\
-          \ in run.start.bundle_ref to assert continuity.\n"
+          \ in event.publish.bundle_ref or run.start.bundle_ref to assert continuity.\n"
         type: object
         additionalProperties: false
         required:
@@ -6033,12 +6035,51 @@ api_specification:
             $ref: '#/components/schemas/SubscriberType'
           subscriber_id:
             type: string
+          session_id:
+            type: string
           status:
             $ref: '#/components/schemas/DeliveryStatus'
           reason_code:
             type: string
           last_error:
             type: string
+      EventPublishDelivery:
+        type: object
+        additionalProperties: false
+        required:
+        - subscriber_id
+        - status
+        - attempt
+        properties:
+          subscriber_id:
+            type: string
+          session_id:
+            type: string
+          status:
+            $ref: '#/components/schemas/DeliveryStatus'
+          attempt:
+            type: integer
+            minimum: 1
+      EventPublishResult:
+        type: object
+        additionalProperties: false
+        required:
+        - event_id
+        - run_id
+        - new_run_created
+        - deliveries
+        properties:
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          new_run_created:
+            type: boolean
+          deliveries:
+            type: array
+            description: Canonical persisted delivery rows for the published event; empty when the declared event has no subscribers.
+            items:
+              $ref: '#/components/schemas/EventPublishDelivery'
       DeadLetterRecord:
         type: object
         additionalProperties: false
@@ -6999,9 +7040,68 @@ api_specification:
         schema:
           $ref: '#/components/schemas/OkResult'
       errors: []
+    event.publish:
+      tier: should_have
+      description: "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into\
+        \ the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger,\
+        \ and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing\
+        \ or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nThe method consumes the same canonical\
+        \ EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted\
+        \ event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start\
+        \ remains only\nas a deprecated wrapper for older callers.\n"
+      scope:
+        required:
+        - write:runs
+      idempotency: per the convention.
+      params:
+      - name: bundle_ref
+        required: false
+        description: Optional assertion that the server is running the expected boot bundle fingerprint.
+        schema:
+          $ref: '#/components/schemas/BundleRef'
+      - name: event_name
+        required: true
+        schema:
+          type: string
+      - name: payload
+        required: true
+        schema:
+          type: object
+          additionalProperties: true
+      - name: run_id
+        required: false
+        description: Existing nonterminal run to inject into; if omitted, runtime allocates and starts a new run.
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: emitter
+        required: false
+        description: Optional producer identifier. Defaults to cli-publish:<actor_token_id>.
+        schema:
+          type: string
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventPublishResult'
+      errors:
+      - BUNDLE_MISMATCH
+      - UNSUPPORTED_BUNDLE_REF
+      - EVENT_NOT_DECLARED
+      - PAYLOAD_VALIDATION_FAILED
+      - RUN_NOT_FOUND
+      - RUN_ALREADY_TERMINAL
+      - IDEMPOTENCY_CONFLICT
     run.start:
       tier: must_have
-      description: 'Start a new run by injecting an event into the runtime bus.
+      deprecated: true
+      description: 'Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call
+        event.publish directly.
+
+        Start a new run by injecting an event into the runtime bus.
 
         Optionally declares a bundle_ref by fingerprint; v1 runtime
 
@@ -8150,8 +8250,9 @@ api_specification:
       - bundle.open
       - bundle.reload
       - bundle.close
-      rationale: "Per-run dynamic bundle loading is deferred. v1 runtime uses\nboot-time bundle configuration; run.start may\
-        \ carry a bundle_ref\nwhose fingerprint must match the boot-time fingerprint, or the\nbundle_ref may be omitted entirely.\
+      rationale: "Per-run dynamic bundle loading is deferred. v1 runtime uses\nboot-time bundle configuration; event.publish\
+        \ and deprecated run.start may\ncarry a bundle_ref whose fingerprint must match the boot-time fingerprint,\nor the\
+        \ bundle_ref may be omitted entirely.\
         \ When dynamic loading lands,\nBundleRef likely gains content-addressable forms (registry\ncoordinate, uploaded content\
         \ hash) \u2014 additive change to the\nBundleRef schema, not a breaking one.\n"
     verify:
@@ -8223,7 +8324,8 @@ api_specification:
         \ auth surface, one token."
     cli_consumer_migration:
       make_run_clear: 'Migrates from legacy `/api/rpc` run.start payloads with builder-token auth to `curl /v1/rpc
-        {method: run.start, params: {bundle_ref?, event_name, payload, idempotency_key?}}` with the unified token.'
+        {method: run.start, params: {bundle_ref?, event_name, payload, idempotency_key?}}` with the unified token. run.start
+        is now a deprecated wrapper over event.publish until the helper moves to the canonical event.publish method.'
       swarm_investigate: "First-slice subcommands map to v1 methods:\n  swarm investigate runs   \u2192 run.list\n  swarm\
         \ investigate run    \u2192 run.diagnose (default), run.get (--no-diagnose)\n  swarm investigate trace  \u2192 run.trace\n\
         \  swarm investigate health \u2192 health.check\nFollow-on subcommands map to event.*, runtime.logs, runtime.incidents,\

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -55,6 +55,7 @@ type MailboxApprovalEventRoute struct {
 
 type Method struct {
 	Tier               string              `yaml:"tier" json:"tier,omitempty"`
+	Deprecated         bool                `yaml:"deprecated,omitempty" json:"deprecated,omitempty"`
 	Description        string              `yaml:"description" json:"description,omitempty"`
 	Scope              Scope               `yaml:"scope" json:"scope"`
 	Idempotency        any                 `yaml:"idempotency,omitempty" json:"idempotency,omitempty"`
@@ -104,6 +105,7 @@ type OpenRPCServer struct {
 
 type OpenRPCMethod struct {
 	Name        string              `json:"name"`
+	Deprecated  bool                `json:"deprecated,omitempty"`
 	Description string              `json:"description,omitempty"`
 	Params      []ContentDescriptor `json:"params"`
 	Result      *ContentDescriptor  `json:"result,omitempty"`
@@ -279,6 +281,7 @@ func GenerateOpenRPC(api *APISpecification) ([]byte, error) {
 		}
 		methods = append(methods, OpenRPCMethod{
 			Name:        methodName,
+			Deprecated:  method.Deprecated,
 			Description: method.Description,
 			Params:      normalizeDescriptors(method.Params),
 			Result:      normalizeDescriptorPointer(method.Result),

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,17 +16,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 36 {
-		t.Fatalf("method count = %d, want 36", report.MethodCount)
+	if report.MethodCount != 37 {
+		t.Fatalf("method count = %d, want 37", report.MethodCount)
 	}
-	if report.SchemaCount != 49 {
-		t.Fatalf("schema count = %d, want 49", report.SchemaCount)
+	if report.SchemaCount != 51 {
+		t.Fatalf("schema count = %d, want 51", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 22 {
 		t.Fatalf("error code count = %d, want 22", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 12 {
-		t.Fatalf("mutating method count = %d, want 12", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 13 {
+		t.Fatalf("mutating method count = %d, want 13", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 3 {
 		t.Fatalf("subscription method count = %d, want 3", report.SubscriptionMethodCnt)
@@ -61,14 +61,24 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 36 {
-		t.Fatalf("generated OpenRPC methods = %d, want 36", len(doc.Methods))
+	if len(doc.Methods) != 37 {
+		t.Fatalf("generated OpenRPC methods = %d, want 37", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 49 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 49", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 51 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 51", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 22 {
 		t.Fatalf("generated OpenRPC errors = %d, want 22", len(doc.Components.Errors))
+	}
+	methods := map[string]OpenRPCMethod{}
+	for _, method := range doc.Methods {
+		methods[method.Name] = method
+	}
+	if _, ok := methods["event.publish"]; !ok {
+		t.Fatal("generated OpenRPC missing event.publish")
+	}
+	if !methods["run.start"].Deprecated {
+		t.Fatal("generated OpenRPC run.start deprecated flag = false, want true")
 	}
 }
 

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 36 {
-		t.Fatalf("method count = %d, want 36", len(openRPCNames))
+	if len(openRPCNames) != 37 {
+		t.Fatalf("method count = %d, want 37", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -79,23 +79,12 @@ func executeEventPublish(ctx context.Context, req Request, opts OperatorReadOpti
 		requireExistingExplicitRun:     true,
 		injectRunIDEntityIDWhenMissing: true,
 		injectRunIDEntityIDOnlyNewRun:  true,
-		buildCompletion: func(ctx context.Context, opts OperatorReadOptions, params eventPublicationParams) (any, string, error) {
-			event, err := opts.Observability.LoadOperatorEvent(ctx, params.EventID)
-			if errors.Is(err, store.ErrEventNotFound) {
-				return nil, "", fmt.Errorf("load published event %s: %w", params.EventID, err)
-			}
-			if err != nil {
-				return nil, "", err
-			}
-			runID := strings.TrimSpace(event.RunID)
-			if runID == "" {
-				runID = params.RunID
-			}
+		buildCompletion: func(_ context.Context, _ OperatorReadOptions, params eventPublicationParams) (any, string, error) {
 			return eventPublishResult{
 				EventID:       params.EventID,
-				RunID:         runID,
+				RunID:         params.RunID,
 				NewRunCreated: params.NewRunCreated,
-				Deliveries:    eventPublishDeliveries(event.Deliveries),
+				Deliveries:    []eventPublishDelivery{},
 			}, params.EventID, nil
 		},
 	}
@@ -103,14 +92,50 @@ func executeEventPublish(ctx context.Context, req Request, opts OperatorReadOpti
 	if err != nil {
 		return nil, runStartIdempotencyError(err)
 	}
-	var stored eventPublishResult
-	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+	stored, err := eventPublishStoredResult(completion)
+	if err != nil {
 		if replay {
 			return nil, fmt.Errorf("decode event.publish idempotency response: %w", err)
 		}
 		return nil, fmt.Errorf("decode event.publish response: %w", err)
 	}
+	result, err := eventPublishResultFromStore(ctx, opts, completion, stored)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func eventPublishStoredResult(completion store.APIIdempotencyCompletion) (eventPublishResult, error) {
+	var stored eventPublishResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		return eventPublishResult{}, err
+	}
 	return stored, nil
+}
+
+func eventPublishResultFromStore(ctx context.Context, opts OperatorReadOptions, completion store.APIIdempotencyCompletion, stored eventPublishResult) (eventPublishResult, error) {
+	eventID := strings.TrimSpace(completion.ResourceID)
+	if eventID == "" {
+		eventID = strings.TrimSpace(stored.EventID)
+	}
+	event, err := opts.Observability.LoadOperatorEvent(ctx, eventID)
+	if errors.Is(err, store.ErrEventNotFound) {
+		return eventPublishResult{}, fmt.Errorf("load published event %s: %w", eventID, err)
+	}
+	if err != nil {
+		return eventPublishResult{}, err
+	}
+	runID := strings.TrimSpace(event.RunID)
+	if runID == "" {
+		runID = strings.TrimSpace(stored.RunID)
+	}
+	return eventPublishResult{
+		EventID:       strings.TrimSpace(event.EventID),
+		RunID:         runID,
+		NewRunCreated: stored.NewRunCreated,
+		Deliveries:    eventPublishDeliveries(event.Deliveries),
+	}, nil
 }
 
 func executeOperatorEventPublication(

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -1,0 +1,370 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimerunstart "swarm/internal/runtime/runstart"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+)
+
+type eventPublishResult struct {
+	EventID       string                 `json:"event_id"`
+	RunID         string                 `json:"run_id"`
+	NewRunCreated bool                   `json:"new_run_created"`
+	Deliveries    []eventPublishDelivery `json:"deliveries"`
+}
+
+type eventPublishDelivery struct {
+	SubscriberID string `json:"subscriber_id"`
+	SessionID    string `json:"session_id,omitempty"`
+	Status       string `json:"status"`
+	Attempt      int    `json:"attempt"`
+}
+
+type eventPublicationParams struct {
+	BundleFingerprint string
+	EventID           string
+	EventName         string
+	Payload           json.RawMessage
+	EntityID          string
+	RunID             string
+	IdempotencyKey    string
+	Emitter           string
+	NewRunCreated     bool
+}
+
+type eventPublicationConfig struct {
+	sourceAgent                    func(Request) string
+	allowEmitterParam              bool
+	rootInputOnly                  bool
+	requireExistingExplicitRun     bool
+	injectRunIDEntityIDWhenMissing bool
+	injectRunIDEntityIDOnlyNewRun  bool
+	buildCompletion                func(context.Context, OperatorReadOptions, eventPublicationParams) (any, string, error)
+}
+
+func OperatorEventPublishHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if !eventPublishConfigured(opts) {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"event.publish": func(ctx context.Context, req Request) (any, error) {
+			return executeEventPublish(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func eventPublishConfigured(opts OperatorReadOptions) bool {
+	return runStartConfigured(opts) && opts.Runs != nil && opts.Observability != nil
+}
+
+func executeEventPublish(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	cfg := eventPublicationConfig{
+		sourceAgent:                    eventPublishSourceAgent,
+		allowEmitterParam:              true,
+		requireExistingExplicitRun:     true,
+		injectRunIDEntityIDWhenMissing: true,
+		injectRunIDEntityIDOnlyNewRun:  true,
+		buildCompletion: func(ctx context.Context, opts OperatorReadOptions, params eventPublicationParams) (any, string, error) {
+			event, err := opts.Observability.LoadOperatorEvent(ctx, params.EventID)
+			if errors.Is(err, store.ErrEventNotFound) {
+				return nil, "", fmt.Errorf("load published event %s: %w", params.EventID, err)
+			}
+			if err != nil {
+				return nil, "", err
+			}
+			runID := strings.TrimSpace(event.RunID)
+			if runID == "" {
+				runID = params.RunID
+			}
+			return eventPublishResult{
+				EventID:       params.EventID,
+				RunID:         runID,
+				NewRunCreated: params.NewRunCreated,
+				Deliveries:    eventPublishDeliveries(event.Deliveries),
+			}, params.EventID, nil
+		},
+	}
+	completion, replay, err := executeOperatorEventPublication(ctx, req, opts, now, cfg)
+	if err != nil {
+		return nil, runStartIdempotencyError(err)
+	}
+	var stored eventPublishResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode event.publish idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode event.publish response: %w", err)
+	}
+	return stored, nil
+}
+
+func executeOperatorEventPublication(
+	ctx context.Context,
+	req Request,
+	opts OperatorReadOptions,
+	now time.Time,
+	cfg eventPublicationConfig,
+) (store.APIIdempotencyCompletion, bool, error) {
+	bootFingerprint := strings.TrimSpace(opts.Bundle.Fingerprint)
+	ctx = runtimecorrelation.WithBundleFingerprint(ctx, bootFingerprint)
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return store.APIIdempotencyCompletion{}, false, err
+	}
+	return opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		TTL:            runStartIDempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		params, err := eventPublicationParamsFromRequest(req, bootFingerprint, cfg)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		if err := validateEventPublication(ctx, opts, params, cfg); err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		if err := opts.Events.Publish(ctx, events.Event{
+			ID:          params.EventID,
+			RunID:       params.RunID,
+			Type:        events.EventType(params.EventName),
+			SourceAgent: params.Emitter,
+			Payload:     params.Payload,
+			CreatedAt:   now,
+		}.WithEntityID(params.EntityID)); err != nil {
+			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
+		}
+		result, resourceID, err := cfg.buildCompletion(ctx, opts, params)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		response, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: resourceID,
+			Response:   response,
+		}, nil
+	})
+}
+
+func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg eventPublicationConfig) (eventPublicationParams, error) {
+	eventName := stringParam(req.Params, "event_name")
+	if eventName == "" {
+		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
+	}
+	fingerprint, err := bundleFingerprintParam(req.Params)
+	if err != nil {
+		return eventPublicationParams{}, err
+	}
+	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
+		return eventPublicationParams{}, NewApplicationError(BundleMismatchCode, false, map[string]any{
+			"provided_fingerprint": fingerprint,
+			"boot_fingerprint":     strings.TrimSpace(bootFingerprint),
+		})
+	}
+	runID, _, err := optionalStringParam(req.Params, "run_id")
+	if err != nil {
+		return eventPublicationParams{}, err
+	}
+	newRun := false
+	if runID == "" {
+		runID = uuid.NewString()
+		newRun = true
+	} else if parsed, err := uuid.Parse(runID); err != nil {
+		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "must be a UUID"})
+	} else {
+		runID = parsed.String()
+	}
+	injectEntityID := cfg.injectRunIDEntityIDWhenMissing && (!cfg.injectRunIDEntityIDOnlyNewRun || newRun)
+	payload, entityID, err := eventPublicationPayload(req.Params, runID, injectEntityID)
+	if err != nil {
+		return eventPublicationParams{}, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return eventPublicationParams{}, err
+	}
+	emitter := ""
+	if cfg.allowEmitterParam {
+		emitter, _, err = optionalStringParam(req.Params, "emitter")
+		if err != nil {
+			return eventPublicationParams{}, err
+		}
+	}
+	if emitter == "" && cfg.sourceAgent != nil {
+		emitter = cfg.sourceAgent(req)
+	}
+	return eventPublicationParams{
+		BundleFingerprint: fingerprint,
+		EventID:           uuid.NewString(),
+		EventName:         eventName,
+		Payload:           payload,
+		EntityID:          entityID,
+		RunID:             runID,
+		IdempotencyKey:    idempotencyKey,
+		Emitter:           emitter,
+		NewRunCreated:     newRun,
+	}, nil
+}
+
+func eventPublicationPayload(params map[string]any, runID string, injectRunIDEntityID bool) (json.RawMessage, string, error) {
+	if params == nil {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
+	}
+	raw, ok := params["payload"]
+	if !ok || isEmptyParam(raw) {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
+	}
+	payload, ok := raw.(map[string]any)
+	if !ok {
+		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "must be an object"})
+	}
+	cloned := make(map[string]any, len(payload)+1)
+	for key, value := range payload {
+		cloned[key] = value
+	}
+	entityID, supplied, err := runStartPayloadEntityID(cloned["entity_id"])
+	if err != nil {
+		return nil, "", err
+	}
+	switch {
+	case supplied:
+		cloned["entity_id"] = entityID
+	case injectRunIDEntityID:
+		entityID = strings.TrimSpace(runID)
+		cloned["entity_id"] = entityID
+	}
+	encoded, err := json.Marshal(cloned)
+	if err != nil {
+		return nil, "", err
+	}
+	return encoded, entityID, nil
+}
+
+func validateEventPublication(ctx context.Context, opts OperatorReadOptions, params eventPublicationParams, cfg eventPublicationConfig) error {
+	if cfg.rootInputOnly {
+		set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
+		if err != nil {
+			return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+				"event_name":      params.EventName,
+				"declared_events": set.Declared,
+			})
+		}
+		return nil
+	}
+	if !eventDeclared(opts.Source, params.EventName) {
+		return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+			"event_name":      params.EventName,
+			"declared_events": declaredEventNames(opts.Source),
+		})
+	}
+	if cfg.requireExistingExplicitRun && !params.NewRunCreated {
+		runs, err := requireRunReadStore(opts.Runs)
+		if err != nil {
+			return err
+		}
+		header, err := runs.LoadRunHeader(ctx, params.RunID)
+		if errors.Is(err, store.ErrRunNotFound) {
+			return NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": params.RunID})
+		}
+		if err != nil {
+			return err
+		}
+		status := strings.TrimSpace(strings.ToLower(header.Status))
+		if status != "running" && status != "paused" {
+			return NewApplicationError(RunAlreadyTerminalCode, false, map[string]any{
+				"run_id":         params.RunID,
+				"current_status": status,
+			})
+		}
+	}
+	return nil
+}
+
+func eventPublishSourceAgent(req Request) string {
+	actor := strings.TrimSpace(req.ActorTokenID)
+	if actor == "" {
+		actor = "anonymous"
+	}
+	return "cli-publish:" + actor
+}
+
+func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDelivery {
+	out := make([]eventPublishDelivery, 0, len(in))
+	for _, delivery := range in {
+		if strings.TrimSpace(delivery.SubscriberID) == "__runtime_replay_scope__" {
+			continue
+		}
+		attempt := delivery.RetryCount + 1
+		if attempt < 1 {
+			attempt = 1
+		}
+		out = append(out, eventPublishDelivery{
+			SubscriberID: strings.TrimSpace(delivery.SubscriberID),
+			SessionID:    strings.TrimSpace(delivery.SessionID),
+			Status:       strings.TrimSpace(delivery.Status),
+			Attempt:      attempt,
+		})
+	}
+	return out
+}
+
+func eventDeclared(source semanticview.Source, eventName string) bool {
+	eventName = strings.TrimSpace(eventName)
+	if source == nil || eventName == "" {
+		return false
+	}
+	if _, ok := source.EventEntry(eventName); ok {
+		return true
+	}
+	for name := range source.ResolvedEventCatalog() {
+		if strings.TrimSpace(name) == eventName {
+			return true
+		}
+	}
+	return false
+}
+
+func declaredEventNames(source semanticview.Source) []string {
+	if source == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for name := range source.EventEntries() {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	for name := range source.ResolvedEventCatalog() {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -1,0 +1,416 @@
+package apiv1
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeingress "swarm/internal/runtime/ingress"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	seedActiveAPIV1RuntimeBusAgent(t, context.Background(), pg, "scan-orchestrator")
+	ch := bus.Subscribe("scan-orchestrator", events.EventType("scan.requested"))
+	defer bus.Unsubscribe("scan-orchestrator")
+	handler := eventPublishTestHandler(t, pg, bus, source)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish")
+
+	published := rpcCall(t, handler, body)
+	if published.Error != nil {
+		t.Fatalf("event.publish error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	runID := stringValue(t, result["run_id"], "run_id")
+	if _, err := uuid.Parse(eventID); err != nil {
+		t.Fatalf("event_id = %q, want UUID", eventID)
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		t.Fatalf("run_id = %q, want UUID", runID)
+	}
+	if result["new_run_created"] != true {
+		t.Fatalf("new_run_created = %#v, want true", result["new_run_created"])
+	}
+	deliveries := asSlice(t, result["deliveries"])
+	if len(deliveries) != 1 {
+		t.Fatalf("deliveries = %#v, want one persisted delivery", deliveries)
+	}
+	delivery := asMap(t, deliveries[0])
+	if delivery["subscriber_id"] != "scan-orchestrator" || delivery["status"] != "pending" || delivery["attempt"] != float64(1) {
+		t.Fatalf("delivery = %#v, want scan-orchestrator pending attempt 1", delivery)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count = %d, want 1", count)
+	}
+	assertEventPublishPersistence(t, db, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows = %d, want 1", count)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event.publish delivery")
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("event.publish replay error = %#v", replay.Error)
+	}
+	replayResult := asMap(t, replay.Result)
+	if replayResult["event_id"] != eventID || replayResult["run_id"] != runID {
+		t.Fatalf("event.publish replay result = %#v, want original event/run", replayResult)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
+	}
+
+	conflict := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"changed"}`, "", "idem-publish"))
+	if conflict.Error == nil {
+		t.Fatal("event.publish idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("event.publish conflict data = %#v", data)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after conflict = %d, want 1", count)
+	}
+}
+
+func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	seedActiveAPIV1RuntimeBusAgent(t, context.Background(), pg, "scan-orchestrator")
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	initial := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"first"}`, "", "idem-new-run"))
+	if initial.Error != nil {
+		t.Fatalf("initial event.publish error = %#v", initial.Error)
+	}
+	runID := stringValue(t, asMap(t, initial.Result)["run_id"], "run_id")
+
+	targeted := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"second"}`, "operator-test", "idem-existing-run"))
+	if targeted.Error != nil {
+		t.Fatalf("targeted event.publish error = %#v", targeted.Error)
+	}
+	targetedResult := asMap(t, targeted.Result)
+	if targetedResult["run_id"] != runID || targetedResult["new_run_created"] != false {
+		t.Fatalf("targeted result = %#v, want existing run", targetedResult)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
+		t.Fatalf("scan.requested events after targeted publish = %d, want 2", count)
+	}
+
+	missingRunID := uuid.NewString()
+	missing := rpcCall(t, handler, eventPublishBody(missingRunID, runStartTestFingerprint, "scan.requested", `{"topic":"missing"}`, "", "idem-missing-run"))
+	if missing.Error == nil {
+		t.Fatal("missing run event.publish error = nil")
+	}
+	if data := asMap(t, missing.Error.Data); data["code"] != RunNotFoundCode {
+		t.Fatalf("missing run data = %#v, want %s", data, RunNotFoundCode)
+	}
+
+	if _, err := db.Exec(`UPDATE runs SET status = 'completed', ended_at = now() WHERE run_id = $1::uuid`, runID); err != nil {
+		t.Fatalf("mark run terminal: %v", err)
+	}
+	terminal := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"terminal"}`, "", "idem-terminal-run"))
+	if terminal.Error == nil {
+		t.Fatal("terminal run event.publish error = nil")
+	}
+	if data := asMap(t, terminal.Error.Data); data["code"] != RunAlreadyTerminalCode {
+		t.Fatalf("terminal run data = %#v, want %s", data, RunAlreadyTerminalCode)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
+		t.Fatalf("scan.requested events after failed targets = %d, want 2", count)
+	}
+}
+
+func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
+	t.Run("bundle mismatch", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBody("", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "", "idem-event-mismatch"))
+		if resp.Error == nil {
+			t.Fatal("event.publish bundle mismatch error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
+			t.Fatalf("bundle mismatch data = %#v", data)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+
+	t.Run("undeclared event", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.missing", `{"topic":"medicine"}`, "", "idem-event-missing"))
+		if resp.Error == nil {
+			t.Fatal("event.publish undeclared event error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != EventNotDeclaredCode {
+			t.Fatalf("undeclared event data = %#v", data)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+
+	t.Run("payload validation", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+			ContractBundle: source,
+			PayloadValidator: func(eventType string, payload []byte) error {
+				if eventType != "scan.requested" {
+					return fmt.Errorf("unexpected event type %q", eventType)
+				}
+				return errors.New("schema violation")
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-event-invalid-payload"))
+		if resp.Error == nil {
+			t.Fatal("event.publish payload validation error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != PayloadValidationFailedCode {
+			t.Fatalf("payload validation data = %#v", data)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+
+	t.Run("invalid run id", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBody("abc", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-event-invalid-run-id"))
+		if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+			t.Fatalf("event.publish invalid run_id error = %#v, want invalid params", resp.Error)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+}
+
+func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	ctx := context.Background()
+	agentID := "scan-orchestrator"
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, agentID)
+	ch := bus.Subscribe(agentID, events.EventType("scan.requested"))
+	defer bus.Unsubscribe(agentID)
+
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+		Now:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	handler := eventPublishTestHandler(t, pg, bus, source)
+	published := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"paused"}`, "", "idem-paused-publish"))
+	if published.Error != nil {
+		t.Fatalf("paused event.publish error = %#v", published.Error)
+	}
+	eventID := stringValue(t, asMap(t, published.Result)["event_id"], "event_id")
+	if got := len(asSlice(t, asMap(t, published.Result)["deliveries"])); got != 1 {
+		t.Fatalf("paused event.publish deliveries = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		t.Fatalf("paused event.publish delivered event %s before resume", got.ID)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("paused event deliveries = %d, want 1", got)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("paused pipeline receipts = %d, want 0", got)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+		Now:          time.Now().UTC().Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("released event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for queued event.publish release")
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
+	}
+}
+
+func eventPublishTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source) *Handler {
+	t.Helper()
+	return testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:           func() time.Time { return time.Now().UTC() },
+			Ready:         func() bool { return true },
+			Database:      fakePinger{},
+			Runs:          pg,
+			Observability: pg,
+			Idempotency:   pg,
+			Events:        bus,
+			Source:        source,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     runStartTestFingerprint,
+			},
+		}),
+	})
+}
+
+func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
+	parts := []string{
+		fmt.Sprintf(`"bundle_ref":{"fingerprint":%q}`, fingerprint),
+		fmt.Sprintf(`"event_name":%q`, eventName),
+		fmt.Sprintf(`"payload":%s`, payload),
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(runID) != "" {
+		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
+	}
+	if strings.TrimSpace(emitter) != "" {
+		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
+}
+
+func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eventName, producedBy string) {
+	t.Helper()
+	var runStatus, triggerType, triggerID, persistedFingerprint string
+	if err := db.QueryRow(`SELECT status, trigger_event_type, trigger_event_id::text, COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType, &triggerID, &persistedFingerprint); err != nil {
+		t.Fatalf("load event.publish run row: %v", err)
+	}
+	if runStatus != "running" || triggerType != eventName || triggerID != eventID {
+		t.Fatalf("run row status=%q trigger=%q/%q, want running/%s/%s", runStatus, triggerType, triggerID, eventName, eventID)
+	}
+	if persistedFingerprint != runStartTestFingerprint {
+		t.Fatalf("run row bundle_fingerprint=%q, want %q", persistedFingerprint, runStartTestFingerprint)
+	}
+	var entityID, gotProducedBy string
+	var payload json.RawMessage
+	if err := db.QueryRow(`
+		SELECT entity_id::text, produced_by, payload
+		FROM events
+		WHERE event_id = $1::uuid
+	`, eventID).Scan(&entityID, &gotProducedBy, &payload); err != nil {
+		t.Fatalf("load event.publish event row: %v", err)
+	}
+	if entityID != runID {
+		t.Fatalf("event entity_id = %q, want run_id %q", entityID, runID)
+	}
+	if gotProducedBy != producedBy {
+		t.Fatalf("event produced_by = %q, want %q", gotProducedBy, producedBy)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode event.publish payload: %v", err)
+	}
+	if decoded["entity_id"] != runID || decoded["topic"] != "medicine" {
+		t.Fatalf("event.publish payload = %#v", decoded)
+	}
+}
+
+func assertNoEventPublishPersistence(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if count := countAllRunRows(t, db); count != 0 {
+		t.Fatalf("run rows = %d, want 0", count)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 0 {
+		t.Fatalf("scan.requested event rows = %d, want 0", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 0 {
+		t.Fatalf("api_idempotency rows = %d, want 0", count)
+	}
+}
+
+func stringValue(t *testing.T, value any, field string) string {
+	t.Helper()
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		t.Fatalf("%s = %#v, want non-empty string", field, value)
+	}
+	return strings.TrimSpace(text)
+}
+
+func asSlice(t *testing.T, value any) []any {
+	t.Helper()
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want []any", value)
+	}
+	return items
+}

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -98,6 +98,61 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	}
 }
 
+func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	seedActiveAPIV1RuntimeBusAgent(t, context.Background(), pg, "scan-orchestrator")
+	ch := bus.Subscribe("scan-orchestrator", events.EventType("scan.requested"))
+	defer bus.Unsubscribe("scan-orchestrator")
+	observability := &failOnceEventReadStore{
+		ObservabilityReadStore: pg,
+		err:                    errors.New("transient event readback failure"),
+	}
+	handler := eventPublishTestHandlerWithObservability(t, pg, bus, source, observability)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-readback")
+
+	first := rpcCall(t, handler, body)
+	if first.Error == nil || !strings.Contains(fmt.Sprintf("%#v", first.Error.Data), "transient event readback failure") {
+		t.Fatalf("first event.publish error = %#v, want transient readback failure", first.Error)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after readback failure = %d, want 1", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after readback failure = %d, want 1", count)
+	}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event delivery after readback failure")
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("event.publish replay after readback recovery error = %#v", replay.Error)
+	}
+	replayResult := asMap(t, replay.Result)
+	eventID := stringValue(t, replayResult["event_id"], "event_id")
+	runID := stringValue(t, replayResult["run_id"], "run_id")
+	if _, err := uuid.Parse(eventID); err != nil {
+		t.Fatalf("event_id = %q, want UUID", eventID)
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		t.Fatalf("run_id = %q, want UUID", runID)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
+	}
+	if got := len(asSlice(t, replayResult["deliveries"])); got != 1 {
+		t.Fatalf("replay deliveries = %d, want persisted delivery result", got)
+	}
+}
+
 func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -312,6 +367,11 @@ func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
 
 func eventPublishTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source) *Handler {
 	t.Helper()
+	return eventPublishTestHandlerWithObservability(t, pg, bus, source, pg)
+}
+
+func eventPublishTestHandlerWithObservability(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source, observability ObservabilityReadStore) *Handler {
+	t.Helper()
 	return testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
@@ -319,7 +379,7 @@ func eventPublishTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtime
 			Ready:         func() bool { return true },
 			Database:      fakePinger{},
 			Runs:          pg,
-			Observability: pg,
+			Observability: observability,
 			Idempotency:   pg,
 			Events:        bus,
 			Source:        source,
@@ -330,6 +390,20 @@ func eventPublishTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtime
 			},
 		}),
 	})
+}
+
+type failOnceEventReadStore struct {
+	ObservabilityReadStore
+	err error
+}
+
+func (s *failOnceEventReadStore) LoadOperatorEvent(ctx context.Context, eventID string) (store.OperatorEventFull, error) {
+	if s.err != nil {
+		err := s.err
+		s.err = nil
+		return store.OperatorEventFull{}, err
+	}
+	return s.ObservabilityReadStore.LoadOperatorEvent(ctx, eventID)
 }
 
 func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -196,6 +196,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorRunStartHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorEventPublishHandlers(opts) {
+		handlers[name] = handler
+	}
 	for name, handler := range OperatorRunControlHandlers(opts) {
 		handlers[name] = handler
 	}

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -10,10 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
-	runtimecorrelation "swarm/internal/runtime/correlation"
-	runtimerunstart "swarm/internal/runtime/runstart"
 	"swarm/internal/store"
 )
 
@@ -24,15 +21,6 @@ var sha256FingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 type runStartResult struct {
 	RunID  string `json:"run_id"`
 	Status string `json:"status"`
-}
-
-type runStartParams struct {
-	BundleFingerprint string
-	EventName         string
-	Payload           json.RawMessage
-	EntityID          string
-	RunID             string
-	IdempotencyKey    string
 }
 
 func OperatorRunStartHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -58,51 +46,15 @@ func runStartConfigured(opts OperatorReadOptions) bool {
 }
 
 func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
-	bootFingerprint := strings.TrimSpace(opts.Bundle.Fingerprint)
-	ctx = runtimecorrelation.WithBundleFingerprint(ctx, bootFingerprint)
-	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
-	if err != nil {
-		return nil, err
+	cfg := eventPublicationConfig{
+		sourceAgent:                    func(Request) string { return "api.v1" },
+		rootInputOnly:                  true,
+		injectRunIDEntityIDWhenMissing: true,
+		buildCompletion: func(_ context.Context, _ OperatorReadOptions, params eventPublicationParams) (any, string, error) {
+			return runStartResult{RunID: params.RunID, Status: "running"}, params.RunID, nil
+		},
 	}
-	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
-		Method:         req.Method,
-		ActorTokenID:   req.ActorTokenID,
-		IdempotencyKey: idempotencyKey,
-		RequestHash:    req.RequestHash,
-		TTL:            runStartIDempotencyTTL,
-		Now:            now,
-	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		params, err := runStartParamsFromRequest(req, bootFingerprint)
-		if err != nil {
-			return store.APIIdempotencyCompletion{}, err
-		}
-		set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
-		if err != nil {
-			return store.APIIdempotencyCompletion{}, NewApplicationError(EventNotDeclaredCode, false, map[string]any{
-				"event_name":      params.EventName,
-				"declared_events": set.Declared,
-			})
-		}
-		result := runStartResult{RunID: params.RunID, Status: "running"}
-		if err := opts.Events.Publish(ctx, events.Event{
-			ID:          uuid.NewString(),
-			RunID:       params.RunID,
-			Type:        events.EventType(params.EventName),
-			SourceAgent: "api.v1",
-			Payload:     params.Payload,
-			CreatedAt:   now,
-		}.WithEntityID(params.EntityID)); err != nil {
-			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
-		}
-		response, err := json.Marshal(result)
-		if err != nil {
-			return store.APIIdempotencyCompletion{}, err
-		}
-		return store.APIIdempotencyCompletion{
-			ResourceID: params.RunID,
-			Response:   response,
-		}, nil
-	})
+	completion, replay, err := executeOperatorEventPublication(ctx, req, opts, now, cfg)
 	if err != nil {
 		return nil, runStartIdempotencyError(err)
 	}
@@ -114,50 +66,6 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 		return nil, fmt.Errorf("decode run.start response: %w", err)
 	}
 	return stored, nil
-}
-
-func runStartParamsFromRequest(req Request, bootFingerprint string) (runStartParams, error) {
-	eventName := stringParam(req.Params, "event_name")
-	if eventName == "" {
-		return runStartParams{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
-	}
-	fingerprint, err := bundleFingerprintParam(req.Params)
-	if err != nil {
-		return runStartParams{}, err
-	}
-	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
-		return runStartParams{}, NewApplicationError(BundleMismatchCode, false, map[string]any{
-			"provided_fingerprint": fingerprint,
-			"boot_fingerprint":     strings.TrimSpace(bootFingerprint),
-		})
-	}
-	runID, _, err := optionalStringParam(req.Params, "run_id")
-	if err != nil {
-		return runStartParams{}, err
-	}
-	if runID == "" {
-		runID = uuid.NewString()
-	} else if parsed, err := uuid.Parse(runID); err != nil {
-		return runStartParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "must be a UUID"})
-	} else {
-		runID = parsed.String()
-	}
-	payload, entityID, err := runStartPayload(req.Params, runID)
-	if err != nil {
-		return runStartParams{}, err
-	}
-	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
-	if err != nil {
-		return runStartParams{}, err
-	}
-	return runStartParams{
-		BundleFingerprint: fingerprint,
-		EventName:         eventName,
-		Payload:           payload,
-		EntityID:          entityID,
-		RunID:             runID,
-		IdempotencyKey:    idempotencyKey,
-	}, nil
 }
 
 func bundleFingerprintParam(params map[string]any) (string, error) {
@@ -184,39 +92,6 @@ func bundleFingerprintParam(params map[string]any) (string, error) {
 		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref.fingerprint must be sha256:<64 lowercase hex>"})
 	}
 	return fingerprint, nil
-}
-
-func runStartPayload(params map[string]any, runID string) (json.RawMessage, string, error) {
-	if params == nil {
-		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
-	}
-	raw, ok := params["payload"]
-	if !ok || isEmptyParam(raw) {
-		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "required parameter is missing"})
-	}
-	payload, ok := raw.(map[string]any)
-	if !ok {
-		return nil, "", NewInvalidParamsError(map[string]any{"field": "payload", "reason": "must be an object"})
-	}
-	cloned := make(map[string]any, len(payload)+1)
-	for key, value := range payload {
-		cloned[key] = value
-	}
-	entityID, supplied, err := runStartPayloadEntityID(cloned["entity_id"])
-	if err != nil {
-		return nil, "", err
-	}
-	if !supplied {
-		entityID = strings.TrimSpace(runID)
-		cloned["entity_id"] = entityID
-	} else {
-		cloned["entity_id"] = entityID
-	}
-	encoded, err := json.Marshal(cloned)
-	if err != nil {
-		return nil, "", err
-	}
-	return encoded, entityID, nil
 }
 
 func runStartPayloadEntityID(value any) (string, bool, error) {

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -447,6 +447,9 @@ func runStartTestBundle(eventName string) *runtimecontracts.WorkflowContractBund
 	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
 	return &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{Name: "review", Version: "1.0.0"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			eventName: {},
+		},
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"scan-orchestrator": flow.Nodes["scan-orchestrator"],
 		},

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -58,6 +58,7 @@ type OperatorEventDelivery struct {
 	DeliveryID     string `json:"delivery_id"`
 	SubscriberType string `json:"subscriber_type"`
 	SubscriberID   string `json:"subscriber_id"`
+	SessionID      string `json:"session_id,omitempty"`
 	Status         string `json:"status"`
 	ReasonCode     string `json:"reason_code,omitempty"`
 	LastError      string `json:"last_error,omitempty"`
@@ -173,7 +174,7 @@ func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Con
 		},
 		"event_deliveries": {
 			"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id",
-			"status", "retry_count", "reason_code", "last_error", "created_at",
+			"status", "retry_count", "reason_code", "last_error", "active_session_id", "created_at",
 		},
 		"dead_letters": {
 			"dead_letter_id", "original_event_id", "failure_type", "error_message",
@@ -391,6 +392,7 @@ func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID
 			d.delivery_id::text,
 			COALESCE(d.subscriber_type, ''),
 			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.active_session_id::text, ''),
 			COALESCE(d.status, ''),
 			COALESCE(d.reason_code, ''),
 			COALESCE(d.last_error, ''),
@@ -406,7 +408,7 @@ func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID
 	out := []OperatorEventDelivery{}
 	for rows.Next() {
 		var item OperatorEventDelivery
-		if err := rows.Scan(&item.DeliveryID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.LastError, &item.RetryCount); err != nil {
+		if err := rows.Scan(&item.DeliveryID, &item.SubscriberType, &item.SubscriberID, &item.SessionID, &item.Status, &item.ReasonCode, &item.LastError, &item.RetryCount); err != nil {
 			return nil, fmt.Errorf("scan operator event delivery: %w", err)
 		}
 		out = append(out, item)


### PR DESCRIPTION
## Summary
- Adds canonical `/v1/rpc` `event.publish` for declared event publication and new-run creation.
- Refactors v1 `run.start` into a deprecated wrapper over the shared event-publication owner.
- Updates authoritative `platform-spec.yaml`, generated `openrpc.json`, and OpenRPC deprecated-field generation.

Closes #761
Part of #748

## Governing refs / context
- Issue #761 approved gate boundary: implement `event.publish` plus v1 `run.start` wrapper/deprecation as the first slice under #748.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` API specification: `event.publish`, deprecated `run.start`, queueable event-producing ingress, idempotency, BundleRef.
- Root review context: `docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux-v2.yaml` `api_dependencies.proposed_api_extensions.event.publish` and q8 run.start deprecation staging.

## Semantic migration
- New canonical owner: v1 `event.publish` handler backed by the existing runtime EventBus/store event-publication owner and persisted delivery read owner.
- Old producer / reader / writer path now invalid: v1 `run.start` direct API-level event interpretation is removed; it now calls the shared event-publication path and is marked deprecated in OpenRPC.
- Production paths checked for surviving old behavior: v1 `operator_run_start.go`, v1 method registry/OpenRPC generation, run_clear caller path, Builder legacy run.start split, event delivery read owner.
- Migration completeness: complete for the approved #761 child. Legacy Builder transport and script caller migration remain explicitly outside this child.

## Proof
- `go test ./internal/apiv1 -run 'TestOperatorEventPublish|TestOperatorRunStartHandlers|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/store -run TestOperatorObservability -count=1`
- `go test ./internal/runtime/bus -run TestEventBusRuntimeIngressPauseQueuesAndResumeReleases -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`